### PR TITLE
Ensure web portal accessible over network

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -59,7 +59,9 @@ app.get('/licenses', ensureAuth, async (req, res) => {
   res.render('licenses', { licenses });
 });
 
-const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
+const port = parseInt(process.env.PORT || '3000', 10);
+const host = process.env.HOST || '0.0.0.0';
+
+app.listen(port, host, () => {
+  console.log(`Server running at http://${host}:${port}`);
 });


### PR DESCRIPTION
## Summary
- Bind Express server to all network interfaces by default so the portal can be reached externally.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689bdf42cc0c832db2736e16eaf5a8e8