### PR TITLE
Add first-time registration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 MyPortal is a simple customer portal built with Node.js, TypeScript and MySQL. It allows users from a company to log in and view company information and allocated software licenses.
 
+There are no default login credentials; the first visit will prompt you to register.
+
 ## Features
 
 - Session-based authentication for multiple users
 - Business information summary tab to confirm the logged-in company
 - Licenses tab showing license name, platform, count, expiry date and contract term
+- First-time visit redirects to a registration page when no users exist
 
 ## Setup
 
@@ -16,16 +19,17 @@ MyPortal is a simple customer portal built with Node.js, TypeScript and MySQL. I
    ```
 2. Copy `.env.example` to `.env` and update the MySQL credentials and session secret.
 3. Create the database and tables using `schema.sql`.
-4. Run in development mode:
+4. On first run, visiting `/login` will redirect to a registration page to create the initial user and company.
+5. Run in development mode:
    ```bash
    npm run dev
    ```
-5. Build and start the application:
+6. Build and start the application:
    ```bash
    npm run build
    npm start
    ```
-6. Run type checks:
+7. Run type checks:
    ```bash
    npm test
    ```

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1,5 +1,5 @@
 import { pool } from './db';
-import { RowDataPacket } from 'mysql2';
+import { RowDataPacket, ResultSetHeader } from 'mysql2';
 
 export interface User {
   id: number;
@@ -37,4 +37,28 @@ export async function getCompanyById(id: number): Promise<Company | null> {
 export async function getLicensesByCompany(companyId: number): Promise<License[]> {
   const [rows] = await pool.query<RowDataPacket[]>('SELECT * FROM licenses WHERE company_id = ?', [companyId]);
   return rows as License[];
+}
+
+export async function getUserCount(): Promise<number> {
+  const [rows] = await pool.query<RowDataPacket[]>('SELECT COUNT(*) as count FROM users');
+  return (rows[0] as { count: number }).count;
+}
+
+export async function createCompany(name: string): Promise<number> {
+  const [result] = await pool.execute('INSERT INTO companies (name) VALUES (?)', [name]);
+  const insert = result as ResultSetHeader;
+  return insert.insertId;
+}
+
+export async function createUser(
+  email: string,
+  passwordHash: string,
+  companyId: number
+): Promise<number> {
+  const [result] = await pool.execute(
+    'INSERT INTO users (email, password_hash, company_id) VALUES (?, ?, ?)',
+    [email, passwordHash, companyId]
+  );
+  const insert = result as ResultSetHeader;
+  return insert.insertId;
 }

--- a/src/views/register.ejs
+++ b/src/views/register.ejs
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Register</title>
+</head>
+<body>
+  <h1>Register</h1>
+  <% if (error) { %>
+    <p style="color:red"><%= error %></p>
+  <% } %>
+  <form method="post" action="/register">
+    <label>Company: <input type="text" name="company" required></label><br>
+    <label>Email: <input type="email" name="email" required></label><br>
+    <label>Password: <input type="password" name="password" required></label><br>
+    <button type="submit">Register</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Redirect to registration page when no users exist and add `/register` routes
- Introduce user and company creation helpers in queries
- Document that no default credentials exist and update setup instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689be1eb1dd8832d995a94d320a90a48