### PR TITLE
Add sidebar navigation and unify theme

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -12,22 +12,6 @@ body.login-page {
   justify-content: center;
 }
 
-nav {
-  text-align: right;
-  margin-bottom: 1rem;
-}
-
-nav a {
-  color: #4a00e0;
-  margin-left: 1rem;
-  text-decoration: none;
-  font-weight: 600;
-}
-
-nav a:hover {
-  text-decoration: underline;
-}
-
 .container {
   background-color: #fff;
   padding: 2rem;
@@ -82,4 +66,59 @@ table td {
 table th {
   background-color: #f3f3f3;
   text-align: left;
+}
+
+.app-container {
+  display: flex;
+  width: 90vw;
+  margin: 0 auto;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background-color: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: 200px;
+  display: flex;
+  flex-direction: column;
+}
+
+.menu-link {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
+  background-color: #4a00e0;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.menu-link i {
+  margin-right: 0.5rem;
+}
+
+.menu-link:hover {
+  background-color: #3700b3;
+}
+
+.menu-link.logout {
+  margin-top: auto;
+  background-color: #e53935;
+}
+
+.menu-link.logout:hover {
+  background-color: #b71c1c;
+}
+
+.content {
+  flex: 1;
+  background-color: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  margin-left: 1rem;
 }

--- a/src/views/business.ejs
+++ b/src/views/business.ejs
@@ -1,23 +1,18 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>Business Info</title>
-  <link rel="stylesheet" href="/style.css">
-</head>
+  <%- include('partials/head', { title: 'Business Info' }) %>
 <body>
-  <div class="container">
-    <nav>
-      <a href="/">Business Info</a>
-      <a href="/licenses">Licenses</a>
-      <a href="/logout">Logout</a>
-    </nav>
-    <h1>Business Information</h1>
-    <% if (company) { %>
-      <p>Name: <%= company.name %></p>
-      <% if (company.address) { %>
-        <p>Address: <%= company.address %></p>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Business Information</h1>
+      <% if (company) { %>
+        <p>Name: <%= company.name %></p>
+        <% if (company.address) { %>
+          <p>Address: <%= company.address %></p>
+        <% } %>
       <% } %>
-    <% } %>
+    </div>
   </div>
 </body>
 </html>

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -1,39 +1,34 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>Licenses</title>
-  <link rel="stylesheet" href="/style.css">
-</head>
+  <%- include('partials/head', { title: 'Licenses' }) %>
 <body>
-  <div class="container">
-    <nav>
-      <a href="/">Business Info</a>
-      <a href="/licenses">Licenses</a>
-      <a href="/logout">Logout</a>
-    </nav>
-    <h1>Licenses</h1>
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Platform</th>
-          <th>Count</th>
-          <th>Expiry</th>
-          <th>Contract Term</th>
-        </tr>
-      </thead>
-      <tbody>
-      <% licenses.forEach(function(lic) { %>
-        <tr>
-          <td><%= lic.name %></td>
-          <td><%= lic.platform %></td>
-          <td><%= lic.count %></td>
-          <td><%= lic.expiry_date %></td>
-          <td><%= lic.contract_term %></td>
-        </tr>
-      <% }); %>
-      </tbody>
-    </table>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Licenses</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Platform</th>
+            <th>Count</th>
+            <th>Expiry</th>
+            <th>Contract Term</th>
+          </tr>
+        </thead>
+        <tbody>
+        <% licenses.forEach(function(lic) { %>
+          <tr>
+            <td><%= lic.name %></td>
+            <td><%= lic.platform %></td>
+            <td><%= lic.count %></td>
+            <td><%= lic.expiry_date %></td>
+            <td><%= lic.contract_term %></td>
+          </tr>
+        <% }); %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </body>
 </html>

--- a/src/views/login.ejs
+++ b/src/views/login.ejs
@@ -1,9 +1,6 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>Login</title>
-  <link rel="stylesheet" href="/style.css">
-</head>
+  <%- include('partials/head', { title: 'Login' }) %>
 <body class="login-page">
   <div class="login-container">
     <h1>Login</h1>

--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -1,0 +1,5 @@
+<head>
+  <title><%= title %></title>
+  <link rel="stylesheet" href="/style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnH1zqD+XzdzN7D8YGN9VOGZsv5nYeD1yfknhk+aoCA8DmF5asJ5AZt0fjOEtRjdbc/YWZL0w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -1,0 +1,5 @@
+<nav class="sidebar">
+  <a href="/" class="menu-link"><i class="fas fa-briefcase"></i> Business Info</a>
+  <a href="/licenses" class="menu-link"><i class="fas fa-file-contract"></i> Licenses</a>
+  <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
+</nav>

--- a/src/views/register.ejs
+++ b/src/views/register.ejs
@@ -1,18 +1,18 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>Register</title>
-</head>
+  <%- include('partials/head', { title: 'Register' }) %>
 <body>
-  <h1>Register</h1>
-  <% if (error) { %>
-    <p style="color:red"><%= error %></p>
-  <% } %>
-  <form method="post" action="/register">
-    <label>Company: <input type="text" name="company" required></label><br>
-    <label>Email: <input type="email" name="email" required></label><br>
-    <label>Password: <input type="password" name="password" required></label><br>
-    <button type="submit">Register</button>
-  </form>
+  <div class="container">
+    <h1>Register</h1>
+    <% if (error) { %>
+      <p class="error"><%= error %></p>
+    <% } %>
+    <form method="post" action="/register">
+      <label>Company:<br><input type="text" name="company" required></label><br><br>
+      <label>Email:<br><input type="email" name="email" required></label><br><br>
+      <label>Password:<br><input type="password" name="password" required></label><br><br>
+      <button type="submit">Register</button>
+    </form>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Apply shared head partial with global stylesheet and Font Awesome for consistent theming
- Style registration page to match logged-in view
- Add left sidebar navigation with button-style links and anchored logout; constrain app width to 90% of viewport

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689be7f495b8832d81ff033fb3ac64f1