### PR TITLE
Center forms vertically and set 90vh height

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -18,7 +18,11 @@ body.login-page {
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   max-width: 800px;
-  margin: 2rem auto;
+  margin: 0 auto;
+  height: 90vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .login-container {
@@ -28,6 +32,10 @@ body.login-page {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   width: 100%;
   max-width: 400px;
+  height: 90vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 h1 {

--- a/src/views/register.ejs
+++ b/src/views/register.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <%- include('partials/head', { title: 'Register' }) %>
-<body>
+<body class="login-page">
   <div class="container">
     <h1>Register</h1>
     <% if (error) { %>


### PR DESCRIPTION
## Summary
- Make login and registration containers 90% of viewport height and vertically center their contents
- Apply shared flex centering to the registration page body

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689be9f2c86c832d948749b3e211a904