### PR TITLE
Fix missing closing EJS block in business view

### DIFF
--- a/src/views/business.ejs
+++ b/src/views/business.ejs
@@ -24,7 +24,7 @@
       <% if (company.address) { %>
         <p>Address: <%= company.address %></p>
       <% } %>
-    </div>
+    <% } %>
   </div>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Close outer `company` conditional in `business.ejs` and remove stray container closing
- Ensures EJS template compiles without syntax error

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689bea7fd52c832daf4009dc67a3d912