### PR TITLE
Add sidebar navigation and adjust layout

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -12,19 +12,7 @@ body.login-page {
   justify-content: center;
 }
 
-.container {
-  background-color: #fff;
-  padding: 2rem;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  max-width: 800px;
-  margin: 0 auto;
-  height: 90vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
+.container,
 .login-container {
   background-color: #fff;
   padding: 2rem;
@@ -32,10 +20,7 @@ body.login-page {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   width: 100%;
   max-width: 400px;
-  height: 90vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+  margin: 0 auto;
 }
 
 h1 {
@@ -78,7 +63,7 @@ table th {
 
 .app-container {
   display: flex;
-  width: 90vw;
+  width: 90%;
   margin: 0 auto;
   min-height: 100vh;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -148,7 +148,7 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
   const companies = await getAllCompanies();
   const users = await getAllUsers();
   const assignments = await getUserCompanyAssignments();
-  res.render('admin', { companies, users, assignments });
+  res.render('admin', { companies, users, assignments, isAdmin: true });
 });
 
 app.post('/admin/company', ensureAuth, ensureAdmin, async (req, res) => {

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -1,75 +1,69 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>Admin</title>
-  <link rel="stylesheet" href="/style.css">
-</head>
+  <%- include('partials/head', { title: 'Admin' }) %>
 <body>
-  <div class="container">
-    <nav>
-      <a href="/">Business Info</a>
-      <a href="/licenses">Licenses</a>
-      <a href="/admin">Admin</a>
-      <a href="/logout">Logout</a>
-    </nav>
-    <h1>Admin</h1>
-    <section>
-      <h2>Add Company</h2>
-      <form action="/admin/company" method="post">
-        <input type="text" name="name" placeholder="Company Name" required>
-        <button type="submit">Add</button>
-      </form>
-    </section>
-    <section>
-      <h2>Add User</h2>
-      <form action="/admin/user" method="post">
-        <input type="email" name="email" placeholder="Email" required>
-        <input type="password" name="password" placeholder="Password" required>
-        <select name="companyId">
-          <% companies.forEach(function(c) { %>
-            <option value="<%= c.id %>"><%= c.name %></option>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Admin</h1>
+      <section>
+        <h2>Add Company</h2>
+        <form action="/admin/company" method="post">
+          <input type="text" name="name" placeholder="Company Name" required>
+          <button type="submit">Add</button>
+        </form>
+      </section>
+      <section>
+        <h2>Add User</h2>
+        <form action="/admin/user" method="post">
+          <input type="email" name="email" placeholder="Email" required>
+          <input type="password" name="password" placeholder="Password" required>
+          <select name="companyId">
+            <% companies.forEach(function(c) { %>
+              <option value="<%= c.id %>"><%= c.name %></option>
+            <% }); %>
+          </select>
+          <label><input type="checkbox" name="canManageLicenses">Can manage licenses</label>
+          <button type="submit">Add User</button>
+        </form>
+      </section>
+      <section>
+        <h2>Assign Existing User to Company</h2>
+        <form action="/admin/assign" method="post">
+          <select name="userId">
+            <% users.forEach(function(u) { %>
+              <option value="<%= u.id %>"><%= u.email %></option>
+            <% }); %>
+          </select>
+          <select name="companyId">
+            <% companies.forEach(function(c) { %>
+              <option value="<%= c.id %>"><%= c.name %></option>
+            <% }); %>
+          </select>
+          <label><input type="checkbox" name="canManageLicenses">Can manage licenses</label>
+          <button type="submit">Assign</button>
+        </form>
+      </section>
+      <section>
+        <h2>Current Assignments</h2>
+        <table>
+          <tr><th>User</th><th>Company</th><th>Licenses</th></tr>
+          <% assignments.forEach(function(a) { %>
+            <tr>
+              <td><%= a.email %></td>
+              <td><%= a.company_name %></td>
+              <td>
+                <form action="/admin/permission" method="post">
+                  <input type="hidden" name="userId" value="<%= a.user_id %>">
+                  <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                  <input type="checkbox" name="canManageLicenses" value="1" <%= a.can_manage_licenses ? 'checked' : '' %> onchange="this.form.submit()">
+                </form>
+              </td>
+            </tr>
           <% }); %>
-        </select>
-        <label><input type="checkbox" name="canManageLicenses">Can manage licenses</label>
-        <button type="submit">Add User</button>
-      </form>
-    </section>
-    <section>
-      <h2>Assign Existing User to Company</h2>
-      <form action="/admin/assign" method="post">
-        <select name="userId">
-          <% users.forEach(function(u) { %>
-            <option value="<%= u.id %>"><%= u.email %></option>
-          <% }); %>
-        </select>
-        <select name="companyId">
-          <% companies.forEach(function(c) { %>
-            <option value="<%= c.id %>"><%= c.name %></option>
-          <% }); %>
-        </select>
-        <label><input type="checkbox" name="canManageLicenses">Can manage licenses</label>
-        <button type="submit">Assign</button>
-      </form>
-    </section>
-    <section>
-      <h2>Current Assignments</h2>
-      <table>
-        <tr><th>User</th><th>Company</th><th>Licenses</th></tr>
-        <% assignments.forEach(function(a) { %>
-          <tr>
-            <td><%= a.email %></td>
-            <td><%= a.company_name %></td>
-            <td>
-              <form action="/admin/permission" method="post">
-                <input type="hidden" name="userId" value="<%= a.user_id %>">
-                <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                <input type="checkbox" name="canManageLicenses" value="1" <%= a.can_manage_licenses ? 'checked' : '' %> onchange="this.form.submit()">
-              </form>
-            </td>
-          </tr>
-        <% }); %>
-      </table>
-    </section>
+        </table>
+      </section>
+    </div>
   </div>
 </body>
 </html>

--- a/src/views/business.ejs
+++ b/src/views/business.ejs
@@ -2,29 +2,26 @@
 <html>
   <%- include('partials/head', { title: 'Business Info' }) %>
 <body>
-  <div class="container">
-    <nav>
-      <a href="/">Business Info</a>
-      <a href="/licenses">Licenses</a>
-      <% if (isAdmin) { %><a href="/admin">Admin</a><% } %>
-      <a href="/logout">Logout</a>
-    </nav>
-    <% if (companies && companies.length > 1) { %>
-      <form action="/switch-company" method="post">
-        <select name="companyId" onchange="this.form.submit()">
-          <% companies.forEach(function(c) { %>
-            <option value="<%= c.company_id %>" <%= c.company_id === currentCompanyId ? 'selected' : '' %>><%= c.company_name %></option>
-          <% }); %>
-        </select>
-      </form>
-    <% } %>
-    <h1>Business Information</h1>
-    <% if (company) { %>
-      <p>Name: <%= company.name %></p>
-      <% if (company.address) { %>
-        <p>Address: <%= company.address %></p>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <% if (companies && companies.length > 1) { %>
+        <form action="/switch-company" method="post">
+          <select name="companyId" onchange="this.form.submit()">
+            <% companies.forEach(function(c) { %>
+              <option value="<%= c.company_id %>" <%= c.company_id === currentCompanyId ? 'selected' : '' %>><%= c.company_name %></option>
+            <% }); %>
+          </select>
+        </form>
       <% } %>
-    <% } %>
+      <h1>Business Information</h1>
+      <% if (company) { %>
+        <p>Name: <%= company.name %></p>
+        <% if (company.address) { %>
+          <p>Address: <%= company.address %></p>
+        <% } %>
+      <% } %>
+    </div>
   </div>
-  </body>
+</body>
 </html>

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -2,36 +2,33 @@
 <html>
   <%- include('partials/head', { title: 'Licenses' }) %>
 <body>
-  <div class="container">
-    <nav>
-      <a href="/">Business Info</a>
-      <a href="/licenses">Licenses</a>
-      <% if (isAdmin) { %><a href="/admin">Admin</a><% } %>
-      <a href="/logout">Logout</a>
-    </nav>
-    <h1>Licenses</h1>
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Platform</th>
-          <th>Count</th>
-          <th>Expiry</th>
-          <th>Contract Term</th>
-        </tr>
-      </thead>
-      <tbody>
-      <% licenses.forEach(function(lic) { %>
-        <tr>
-          <td><%= lic.name %></td>
-          <td><%= lic.platform %></td>
-          <td><%= lic.count %></td>
-          <td><%= lic.expiry_date %></td>
-          <td><%= lic.contract_term %></td>
-        </tr>
-      <% }); %>
-      </tbody>
-    </table>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Licenses</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Platform</th>
+            <th>Count</th>
+            <th>Expiry</th>
+            <th>Contract Term</th>
+          </tr>
+        </thead>
+        <tbody>
+        <% licenses.forEach(function(lic) { %>
+          <tr>
+            <td><%= lic.name %></td>
+            <td><%= lic.platform %></td>
+            <td><%= lic.count %></td>
+            <td><%= lic.expiry_date %></td>
+            <td><%= lic.contract_term %></td>
+          </tr>
+        <% }); %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </body>
 </html>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -1,5 +1,8 @@
 <nav class="sidebar">
   <a href="/" class="menu-link"><i class="fas fa-briefcase"></i> Business Info</a>
   <a href="/licenses" class="menu-link"><i class="fas fa-file-contract"></i> Licenses</a>
+  <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
+    <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
+  <% } %>
   <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
 </nav>


### PR DESCRIPTION
## Summary
- Introduce left sidebar navigation with icons and logout anchored to bottom
- Narrow login/registration forms and center them on the page
- Wrap post-login pages in 90% width layout and expose admin link via sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689bebc7e2c8832d892f8208c545813a