### PR TITLE
Add staff management and refine admin UX

### DIFF
--- a/migrations/003_staff.sql
+++ b/migrations/003_staff.sql
@@ -1,0 +1,10 @@
+CREATE TABLE staff (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  company_id INT NOT NULL,
+  first_name VARCHAR(255) NOT NULL,
+  last_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  date_onboarded DATE,
+  enabled TINYINT(1) DEFAULT 1,
+  FOREIGN KEY (company_id) REFERENCES companies(id)
+);

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -32,6 +32,16 @@ export interface UserCompany {
   email?: string;
 }
 
+export interface Staff {
+  id: number;
+  company_id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+  date_onboarded: string;
+  enabled: number;
+}
+
 export async function getUserByEmail(email: string): Promise<User | null> {
   const [rows] = await pool.query<RowDataPacket[]>('SELECT * FROM users WHERE email = ?', [email]);
   return (rows as User[])[0] || null;
@@ -124,4 +134,36 @@ export async function updateUserCompanyPermission(
     'UPDATE user_companies SET can_manage_licenses = ? WHERE user_id = ? AND company_id = ?',
     [canManageLicenses ? 1 : 0, userId, companyId]
   );
+}
+
+export async function getStaffByCompany(companyId: number): Promise<Staff[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    'SELECT * FROM staff WHERE company_id = ?',
+    [companyId]
+  );
+  return rows as Staff[];
+}
+
+export async function addStaff(
+  companyId: number,
+  firstName: string,
+  lastName: string,
+  email: string,
+  dateOnboarded: string,
+  enabled: boolean
+): Promise<void> {
+  await pool.execute(
+    'INSERT INTO staff (company_id, first_name, last_name, email, date_onboarded, enabled) VALUES (?, ?, ?, ?, ?, ?)',
+    [companyId, firstName, lastName, email, dateOnboarded, enabled ? 1 : 0]
+  );
+}
+
+export async function updateStaffEnabled(
+  staffId: number,
+  enabled: boolean
+): Promise<void> {
+  await pool.execute('UPDATE staff SET enabled = ? WHERE id = ?', [
+    enabled ? 1 : 0,
+    staffId,
+  ]);
 }

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -19,11 +19,10 @@
           <input type="email" name="email" placeholder="Email" required>
           <input type="password" name="password" placeholder="Password" required>
           <select name="companyId">
-            <% companies.forEach(function(c) { %>
+            <% allCompanies.forEach(function(c) { %>
               <option value="<%= c.id %>"><%= c.name %></option>
             <% }); %>
           </select>
-          <label><input type="checkbox" name="canManageLicenses">Can manage licenses</label>
           <button type="submit">Add User</button>
         </form>
       </section>
@@ -36,11 +35,10 @@
             <% }); %>
           </select>
           <select name="companyId">
-            <% companies.forEach(function(c) { %>
+            <% allCompanies.forEach(function(c) { %>
               <option value="<%= c.id %>"><%= c.name %></option>
             <% }); %>
           </select>
-          <label><input type="checkbox" name="canManageLicenses">Can manage licenses</label>
           <button type="submit">Assign</button>
         </form>
       </section>

--- a/src/views/business.ejs
+++ b/src/views/business.ejs
@@ -5,15 +5,6 @@
   <div class="app-container">
     <%- include('partials/sidebar') %>
     <div class="content">
-      <% if (companies && companies.length > 1) { %>
-        <form action="/switch-company" method="post">
-          <select name="companyId" onchange="this.form.submit()">
-            <% companies.forEach(function(c) { %>
-              <option value="<%= c.company_id %>" <%= c.company_id === currentCompanyId ? 'selected' : '' %>><%= c.company_name %></option>
-            <% }); %>
-          </select>
-        </form>
-      <% } %>
       <h1>Business Information</h1>
       <% if (company) { %>
         <p>Name: <%= company.name %></p>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -1,5 +1,18 @@
 <nav class="sidebar">
+  <% if (companies && companies.length > 1) { %>
+    <div class="company-switcher">
+      <h3>Select Company</h3>
+      <form action="/switch-company" method="post">
+        <select name="companyId" onchange="this.form.submit()">
+          <% companies.forEach(function(c) { %>
+            <option value="<%= c.company_id %>" <%= c.company_id === currentCompanyId ? 'selected' : '' %>><%= c.company_name %></option>
+          <% }); %>
+        </select>
+      </form>
+    </div>
+  <% } %>
   <a href="/" class="menu-link"><i class="fas fa-briefcase"></i> Business Info</a>
+  <a href="/staff" class="menu-link"><i class="fas fa-users"></i> Staff</a>
   <a href="/licenses" class="menu-link"><i class="fas fa-file-contract"></i> Licenses</a>
   <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
     <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Staff' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Staff</h1>
+      <section>
+        <h2>Add Staff Member</h2>
+        <form action="/staff" method="post">
+          <input type="text" name="firstName" placeholder="First Name" required>
+          <input type="text" name="lastName" placeholder="Last Name" required>
+          <input type="email" name="email" placeholder="Email Address" required>
+          <input type="date" name="dateOnboarded" required>
+          <label><input type="checkbox" name="enabled" checked>Enabled</label>
+          <button type="submit">Add</button>
+        </form>
+      </section>
+      <section>
+        <h2>Current Staff</h2>
+        <table>
+          <tr><th>First Name</th><th>Last Name</th><th>Email</th><th>Date Onboarded</th><th>Enabled</th></tr>
+          <% staff.forEach(function(s) { %>
+            <tr>
+              <td><%= s.first_name %></td>
+              <td><%= s.last_name %></td>
+              <td><%= s.email %></td>
+              <td><%= s.date_onboarded %></td>
+              <td>
+                <form action="/staff/enabled" method="post">
+                  <input type="hidden" name="staffId" value="<%= s.id %>">
+                  <input type="checkbox" name="enabled" value="1" <%= s.enabled ? 'checked' : '' %> onchange="this.form.submit()">
+                </form>
+              </td>
+            </tr>
+          <% }); %>
+        </table>
+      </section>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Move company switcher to sidebar with "Select Company" heading and new Staff link
- Streamline admin user assignment by removing license checkbox; permission toggled in assignments table
- Introduce staff management page backed by new database table and routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689bee40f06c832d930fe4f1e171f27b