### PR TITLE
Fix missing can_manage_staff column

### DIFF
--- a/migrations/004_add_can_manage_staff.sql
+++ b/migrations/004_add_can_manage_staff.sql
@@ -1,0 +1,9 @@
+ALTER TABLE user_companies
+  ADD COLUMN IF NOT EXISTS can_manage_staff TINYINT(1);
+
+UPDATE user_companies
+SET can_manage_staff = 1
+WHERE can_manage_staff IS NULL;
+
+ALTER TABLE user_companies
+  MODIFY can_manage_staff TINYINT(1) DEFAULT 0 NOT NULL;


### PR DESCRIPTION
## Summary
- add migration to add `can_manage_staff` column to `user_companies`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689bf35f3910832db63aa00b5d0816f3