### PR TITLE
Fix permission removal in admin assignments

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -249,6 +249,13 @@ app.post('/admin/assign', ensureAuth, ensureAdmin, async (req, res) => {
   res.redirect('/admin');
 });
 
+function parseCheckbox(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    value = value[value.length - 1];
+  }
+  return value === '1' || value === 'on' || value === true;
+}
+
 app.post('/admin/permission', ensureAuth, ensureAdmin, async (req, res) => {
   const { userId, companyId, canManageLicenses, canManageStaff } = req.body;
   const uid = parseInt(userId, 10);
@@ -258,7 +265,7 @@ app.post('/admin/permission', ensureAuth, ensureAdmin, async (req, res) => {
       uid,
       cid,
       'can_manage_licenses',
-      !!canManageLicenses
+      parseCheckbox(canManageLicenses)
     );
   }
   if (typeof canManageStaff !== 'undefined') {
@@ -266,7 +273,7 @@ app.post('/admin/permission', ensureAuth, ensureAdmin, async (req, res) => {
       uid,
       cid,
       'can_manage_staff',
-      !!canManageStaff
+      parseCheckbox(canManageStaff)
     );
   }
   res.redirect('/admin');

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -54,6 +54,7 @@
                 <form action="/admin/permission" method="post">
                   <input type="hidden" name="userId" value="<%= a.user_id %>">
                   <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                  <input type="hidden" name="canManageLicenses" value="0">
                   <input type="checkbox" name="canManageLicenses" value="1" <%= a.can_manage_licenses ? 'checked' : '' %> onchange="this.form.submit()">
                 </form>
               </td>
@@ -61,6 +62,7 @@
                 <form action="/admin/permission" method="post">
                   <input type="hidden" name="userId" value="<%= a.user_id %>">
                   <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                  <input type="hidden" name="canManageStaff" value="0">
                   <input type="checkbox" name="canManageStaff" value="1" <%= a.can_manage_staff ? 'checked' : '' %> onchange="this.form.submit()">
                 </form>
               </td>


### PR DESCRIPTION
## Summary
- Always send explicit values for permission checkboxes in admin UI
- Parse checkbox submissions to correctly update user-company permissions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689bf4c6e12c832db6c728b8ced1aa49