### PR TITLE
Add API key admin and REST management endpoints

### DIFF
--- a/migrations/005_api_keys.sql
+++ b/migrations/005_api_keys.sql
@@ -1,0 +1,6 @@
+CREATE TABLE api_keys (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  api_key VARCHAR(64) NOT NULL UNIQUE,
+  description VARCHAR(255),
+  expiry_date DATE
+);

--- a/migrations/006_staff_licenses.sql
+++ b/migrations/006_staff_licenses.sql
@@ -1,0 +1,7 @@
+CREATE TABLE staff_licenses (
+  staff_id INT NOT NULL,
+  license_id INT NOT NULL,
+  PRIMARY KEY (staff_id, license_id),
+  FOREIGN KEY (staff_id) REFERENCES staff(id),
+  FOREIGN KEY (license_id) REFERENCES licenses(id)
+);

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -70,6 +70,30 @@
           <% }); %>
         </table>
       </section>
+      <section>
+        <h2>API Keys</h2>
+        <form action="/admin/api-key" method="post">
+          <input type="text" name="description" placeholder="Description">
+          <input type="date" name="expiryDate">
+          <button type="submit">Add API Key</button>
+        </form>
+        <table>
+          <tr><th>Key</th><th>Description</th><th>Expiry</th><th></th></tr>
+          <% apiKeys.forEach(function(k) { %>
+            <tr>
+              <td><%= k.api_key %></td>
+              <td><%= k.description %></td>
+              <td><%= k.expiry_date || '' %></td>
+              <td>
+                <form action="/admin/api-key/delete" method="post">
+                  <input type="hidden" name="id" value="<%= k.id %>">
+                  <button type="submit">Delete</button>
+                </form>
+              </td>
+            </tr>
+          <% }); %>
+        </table>
+      </section>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- Add database tables for API keys and staff-license links
- Support CRUD operations and linking for users, companies, licenses, and staff through new REST API with API key auth
- Provide admin UI to create and delete API keys with descriptions and optional expirations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689bf6d08a40832db264eafa589b36f9