### PR TITLE
feat: add remember me option to login

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -116,12 +116,18 @@ app.get('/login', async (req, res) => {
 });
 
 app.post('/login', async (req, res) => {
-  const { email, password } = req.body;
+  const { email, password, remember } = req.body;
   const user = await getUserByEmail(email);
   if (user && (await bcrypt.compare(password, user.password_hash))) {
     req.session.userId = user.id;
     const companies = await getCompaniesForUser(user.id);
     req.session.companyId = companies[0]?.company_id;
+    if (remember === 'on') {
+      req.session.cookie.maxAge = 8 * 60 * 60 * 1000; // 8 hours
+    } else {
+      req.session.cookie.expires = undefined;
+      req.session.cookie.maxAge = undefined;
+    }
     res.redirect('/');
   } else {
     res.render('login', { error: 'Invalid credentials' });

--- a/src/views/login.ejs
+++ b/src/views/login.ejs
@@ -10,6 +10,7 @@
     <form method="post" action="/login">
       <label>Email:<br><input type="email" name="email" required></label><br><br>
       <label>Password:<br><input type="password" name="password" required></label><br><br>
+      <label><input type="checkbox" name="remember"> Remember Me</label><br><br>
       <button type="submit">Login</button>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- add "Remember Me" checkbox to login page
- persist user session for 8 hours when option is selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689bfe6889dc832dbbf21bc1e6ab8158