### PR TITLE
Add admin-only API Docs page

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -141,3 +141,9 @@ table th {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   margin-left: 1rem;
 }
+
+.swagger-frame {
+  width: 100%;
+  height: 100vh;
+  border: none;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -91,7 +91,7 @@ const swaggerSpec = swaggerJSDoc({
 });
 
 app.use(
-  '/api-docs',
+  '/swagger',
   ensureAuth,
   ensureAdmin,
   swaggerUi.serve,
@@ -111,6 +111,18 @@ function ensureAdmin(req: express.Request, res: express.Response, next: express.
   }
   next();
 }
+
+app.get('/api-docs', ensureAuth, ensureAdmin, async (req, res) => {
+  const companies = await getCompaniesForUser(req.session.userId!);
+  const current = companies.find((c) => c.company_id === req.session.companyId);
+  res.render('api-docs', {
+    companies,
+    currentCompanyId: req.session.companyId,
+    isAdmin: true,
+    canManageLicenses: current?.can_manage_licenses ?? 0,
+    canManageStaff: current?.can_manage_staff ?? 0,
+  });
+});
 
 app.get('/login', async (req, res) => {
   const count = await getUserCount();

--- a/src/views/api-docs.ejs
+++ b/src/views/api-docs.ejs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'API Docs' }) %>
+  <body>
+    <div class="app-container">
+      <%- include('partials/sidebar') %>
+      <div class="content">
+        <iframe src="/swagger" class="swagger-frame"></iframe>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -21,6 +21,7 @@
   <% } %>
   <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
     <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
+    <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
   <% } %>
   <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
 </nav>


### PR DESCRIPTION
## Summary
- add sidebar link to API Docs for admin users only
- embed Swagger UI in new admin API docs page
- serve Swagger UI at `/swagger` for iframe embedding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c02bfcd34832d82df1f297dde8654