### PR TITLE
fix api docs double scrollbar

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -144,6 +144,6 @@ table th {
 
 .swagger-frame {
   width: 100%;
-  height: 100vh;
+  height: calc(100vh - 80px - 4rem);
   border: none;
 }


### PR DESCRIPTION
## Summary
- prevent API docs container from pushing page height beyond viewport to remove double scrollbars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c05db7444832dac31080b6cd30464