### PR TITLE
Handle already up-to-date in update script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -5,7 +5,21 @@ set -e
 cd "$(dirname "$0")"
 
 # Pull latest changes and rebuild the project
-git pull origin main
+git_output=$(git pull origin main 2>&1)
+git_status=$?
+echo "$git_output"
+
+# Exit if git pull failed
+if [ $git_status -ne 0 ]; then
+  exit $git_status
+fi
+
+# If repository already up to date, skip further steps
+if echo "$git_output" | grep -q "Already up to date."; then
+  echo "No updates found. Exiting."
+  exit 0
+fi
+
 npm install
 npm run build
 pm2 restart myportal


### PR DESCRIPTION
## Summary
- Skip npm rebuild and PM2 restart when `git pull` reports "Already up to date."

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c0927722c832d8045392abc4046a9