### PR TITLE
Display allocated staff counts on licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are no default login credentials; the first visit will prompt you to regis
 
 - Session-based authentication for multiple users
 - Business information summary tab to confirm the logged-in company
-- Licenses tab showing license name, platform, count, expiry date and contract term
+- Licenses tab showing license name, platform, count, allocated staff, expiry date and contract term
 - First-time visit redirects to a registration page when no users exist
 
 ## Setup

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -22,6 +22,7 @@ export interface License {
   count: number;
   expiry_date: string;
   contract_term: string;
+  allocated?: number;
 }
 
 export interface UserCompany {
@@ -61,17 +62,36 @@ export async function getCompanyById(id: number): Promise<Company | null> {
 }
 
 export async function getLicensesByCompany(companyId: number): Promise<License[]> {
-  const [rows] = await pool.query<RowDataPacket[]>('SELECT * FROM licenses WHERE company_id = ?', [companyId]);
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT l.*, COUNT(sl.staff_id) AS allocated
+     FROM licenses l
+     LEFT JOIN staff_licenses sl ON l.id = sl.license_id
+     WHERE l.company_id = ?
+     GROUP BY l.id`,
+    [companyId]
+  );
   return rows as License[];
 }
 
 export async function getAllLicenses(): Promise<License[]> {
-  const [rows] = await pool.query<RowDataPacket[]>('SELECT * FROM licenses');
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT l.*, COUNT(sl.staff_id) AS allocated
+     FROM licenses l
+     LEFT JOIN staff_licenses sl ON l.id = sl.license_id
+     GROUP BY l.id`
+  );
   return rows as License[];
 }
 
 export async function getLicenseById(id: number): Promise<License | null> {
-  const [rows] = await pool.query<RowDataPacket[]>('SELECT * FROM licenses WHERE id = ?', [id]);
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT l.*, COUNT(sl.staff_id) AS allocated
+     FROM licenses l
+     LEFT JOIN staff_licenses sl ON l.id = sl.license_id
+     WHERE l.id = ?
+     GROUP BY l.id`,
+    [id]
+  );
   return (rows as License[])[0] || null;
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -741,6 +741,8 @@ api.delete('/users/:id', async (req, res) => {
  *                     type: string
  *                   count:
  *                     type: integer
+ *                   allocated:
+ *                     type: integer
  *                   expiry_date:
  *                     type: string
  *                     format: date
@@ -838,6 +840,8 @@ api.post('/licenses', async (req, res) => {
  *                 platform:
  *                   type: string
  *                 count:
+ *                   type: integer
+ *                 allocated:
  *                   type: integer
  *                 expiry_date:
  *                   type: string

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -12,6 +12,7 @@
             <th>Name</th>
             <th>Platform</th>
             <th>Count</th>
+            <th>Allocated</th>
             <th>Expiry</th>
             <th>Contract Term</th>
           </tr>
@@ -22,6 +23,7 @@
             <td><%= lic.name %></td>
             <td><%= lic.platform %></td>
             <td><%= lic.count %></td>
+            <td><%= lic.allocated %></td>
             <td><%= lic.expiry_date %></td>
             <td><%= lic.contract_term %></td>
           </tr>


### PR DESCRIPTION
## Summary
- track number of staff assigned to each license via new `allocated` column
- show allocated counts in license list UI
- document allocated field in API docs and README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c08aa03e8832d82ab2ac7786701a7