### PR TITLE
Show allocated users per license

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -147,3 +147,27 @@ table th {
   height: calc(100vh - 80px - 4rem);
   border: none;
 }
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  max-width: 400px;
+  width: 90%;
+}
+
+.modal .close {
+  float: right;
+  cursor: pointer;
+}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -342,6 +342,19 @@ export async function unlinkStaffFromLicense(
   ]);
 }
 
+export async function getStaffForLicense(
+  licenseId: number
+): Promise<Staff[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT s.*
+     FROM staff s
+     JOIN staff_licenses sl ON s.id = sl.staff_id
+     WHERE sl.license_id = ?`,
+    [licenseId]
+  );
+  return rows as Staff[];
+}
+
 export async function createApiKey(
   apiKey: string,
   description: string,

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ import {
   unassignUserFromCompany,
   linkStaffToLicense,
   unlinkStaffFromLicense,
+  getStaffForLicense,
   getApiKeys,
   createApiKey,
   deleteApiKey,
@@ -237,6 +238,21 @@ app.get('/licenses', ensureAuth, ensureLicenseAccess, async (req, res) => {
     canManageStaff: current?.can_manage_staff ?? 0,
   });
 });
+
+app.get(
+  '/licenses/:id/allocated',
+  ensureAuth,
+  ensureLicenseAccess,
+  async (req, res) => {
+    const licenseId = parseInt(req.params.id, 10);
+    const license = await getLicenseById(licenseId);
+    if (!license || license.company_id !== req.session.companyId) {
+      return res.status(404).json({ error: 'License not found' });
+    }
+    const staff = await getStaffForLicense(licenseId);
+    res.json(staff);
+  }
+);
 
 app.get('/staff', ensureAuth, ensureStaffAccess, async (req, res) => {
   const companies = await getCompaniesForUser(req.session.userId!);

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -23,7 +23,7 @@
             <td><%= lic.name %></td>
             <td><%= lic.platform %></td>
             <td><%= lic.count %></td>
-            <td><%= lic.allocated %></td>
+            <td><a href="#" class="allocated-link" data-license-id="<%= lic.id %>"><%= lic.allocated %></a></td>
             <td><%= lic.expiry_date %></td>
             <td><%= lic.contract_term %></td>
           </tr>
@@ -32,5 +32,43 @@
       </table>
     </div>
   </div>
+
+  <div id="allocated-modal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <span id="allocated-close" class="close">&times;</span>
+      <h2>Allocated Users</h2>
+      <ul id="allocated-users"></ul>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.allocated-link').forEach(function (link) {
+      link.addEventListener('click', async function (e) {
+        e.preventDefault();
+        const id = this.dataset.licenseId;
+        const res = await fetch(`/licenses/${id}/allocated`);
+        if (!res.ok) return;
+        const users = await res.json();
+        const list = document.getElementById('allocated-users');
+        list.innerHTML = '';
+        if (users.length === 0) {
+          const li = document.createElement('li');
+          li.textContent = 'No users allocated';
+          list.appendChild(li);
+        } else {
+          users.forEach(function (u) {
+            const li = document.createElement('li');
+            li.textContent = `${u.first_name} ${u.last_name} (${u.email})`;
+            list.appendChild(li);
+          });
+        }
+        document.getElementById('allocated-modal').style.display = 'flex';
+      });
+    });
+
+    document.getElementById('allocated-close').addEventListener('click', function () {
+      document.getElementById('allocated-modal').style.display = 'none';
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow clicking allocated count on Licenses page to view assigned users
- add backend endpoint and query to retrieve staff for a license
- style and script modal popup for allocated users

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c0a4b29a8832db3ea7cf1a2a866d2