### PR TITLE
Add assets and invoices management with external API settings

### DIFF
--- a/migrations/007_add_asset_invoice_permissions.sql
+++ b/migrations/007_add_asset_invoice_permissions.sql
@@ -1,0 +1,11 @@
+ALTER TABLE user_companies
+  ADD COLUMN IF NOT EXISTS can_manage_assets TINYINT(1),
+  ADD COLUMN IF NOT EXISTS can_manage_invoices TINYINT(1);
+
+UPDATE user_companies
+SET can_manage_assets = 1, can_manage_invoices = 1
+WHERE can_manage_assets IS NULL OR can_manage_invoices IS NULL;
+
+ALTER TABLE user_companies
+  MODIFY can_manage_assets TINYINT(1) DEFAULT 0 NOT NULL,
+  MODIFY can_manage_invoices TINYINT(1) DEFAULT 0 NOT NULL;

--- a/migrations/008_assets.sql
+++ b/migrations/008_assets.sql
@@ -1,0 +1,9 @@
+CREATE TABLE assets (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  company_id INT NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  type VARCHAR(255),
+  serial_number VARCHAR(255),
+  status VARCHAR(255),
+  FOREIGN KEY (company_id) REFERENCES companies(id)
+);

--- a/migrations/009_invoices.sql
+++ b/migrations/009_invoices.sql
@@ -1,0 +1,9 @@
+CREATE TABLE invoices (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  company_id INT NOT NULL,
+  invoice_number VARCHAR(255) NOT NULL,
+  amount DECIMAL(10,2) NOT NULL,
+  due_date DATE,
+  status VARCHAR(255),
+  FOREIGN KEY (company_id) REFERENCES companies(id)
+);

--- a/migrations/010_external_api_settings.sql
+++ b/migrations/010_external_api_settings.sql
@@ -1,0 +1,8 @@
+CREATE TABLE external_api_settings (
+  company_id INT PRIMARY KEY,
+  xero_endpoint VARCHAR(255),
+  xero_api_key VARCHAR(255),
+  syncro_endpoint VARCHAR(255),
+  syncro_api_key VARCHAR(255),
+  FOREIGN KEY (company_id) REFERENCES companies(id)
+);

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -46,7 +46,7 @@
       <section>
         <h2>Current Assignments</h2>
         <table>
-          <tr><th>User</th><th>Company</th><th>Licenses</th><th>Staff</th></tr>
+          <tr><th>User</th><th>Company</th><th>Licenses</th><th>Staff</th><th>Assets</th><th>Invoices</th></tr>
           <% assignments.forEach(function(a) { %>
             <tr>
               <td><%= a.email %></td>
@@ -65,6 +65,22 @@
                   <input type="hidden" name="companyId" value="<%= a.company_id %>">
                   <input type="hidden" name="canManageStaff" value="0">
                   <input type="checkbox" name="canManageStaff" value="1" <%= a.can_manage_staff ? 'checked' : '' %> onchange="this.form.submit()">
+                </form>
+              </td>
+              <td>
+                <form action="/admin/permission" method="post">
+                  <input type="hidden" name="userId" value="<%= a.user_id %>">
+                  <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                  <input type="hidden" name="canManageAssets" value="0">
+                  <input type="checkbox" name="canManageAssets" value="1" <%= a.can_manage_assets ? 'checked' : '' %> onchange="this.form.submit()">
+                </form>
+              </td>
+              <td>
+                <form action="/admin/permission" method="post">
+                  <input type="hidden" name="userId" value="<%= a.user_id %>">
+                  <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                  <input type="hidden" name="canManageInvoices" value="0">
+                  <input type="checkbox" name="canManageInvoices" value="1" <%= a.can_manage_invoices ? 'checked' : '' %> onchange="this.form.submit()">
                 </form>
               </td>
             </tr>

--- a/src/views/assets.ejs
+++ b/src/views/assets.ejs
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Assets' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Assets</h1>
+      <section>
+        <h2>Company Assets</h2>
+        <table>
+          <tr><th>Name</th><th>Type</th><th>Serial Number</th><th>Status</th></tr>
+          <% assets.forEach(function(a) { %>
+            <tr>
+              <td><%= a.name %></td>
+              <td><%= a.type %></td>
+              <td><%= a.serial_number %></td>
+              <td><%= a.status %></td>
+            </tr>
+          <% }); %>
+        </table>
+      </section>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/external-apis.ejs
+++ b/src/views/external-apis.ejs
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'External APIs' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>External API Settings</h1>
+      <form action="/external-apis" method="post">
+        <h2>Xero</h2>
+        <input type="text" name="xeroEndpoint" placeholder="Xero API Endpoint" value="<%= settings ? settings.xero_endpoint : '' %>">
+        <input type="text" name="xeroApiKey" placeholder="Xero API Key" value="<%= settings ? settings.xero_api_key : '' %>">
+        <h2>Syncro RMM</h2>
+        <input type="text" name="syncroEndpoint" placeholder="Syncro API Endpoint" value="<%= settings ? settings.syncro_endpoint : '' %>">
+        <input type="text" name="syncroApiKey" placeholder="Syncro API Key" value="<%= settings ? settings.syncro_api_key : '' %>">
+        <button type="submit">Save</button>
+      </form>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/invoices.ejs
+++ b/src/views/invoices.ejs
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Invoices' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Invoices</h1>
+      <section>
+        <h2>Company Invoices</h2>
+        <table>
+          <tr><th>Number</th><th>Amount</th><th>Due Date</th><th>Status</th></tr>
+          <% invoices.forEach(function(i) { %>
+            <tr>
+              <td><%= i.invoice_number %></td>
+              <td><%= i.amount %></td>
+              <td><%= i.due_date %></td>
+              <td><%= i.status %></td>
+            </tr>
+          <% }); %>
+        </table>
+      </section>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -19,9 +19,16 @@
   <% if (canManageLicenses) { %>
     <a href="/licenses" class="menu-link"><i class="fas fa-file-contract"></i> Licenses</a>
   <% } %>
+  <% if (canManageAssets) { %>
+    <a href="/assets" class="menu-link"><i class="fas fa-desktop"></i> Assets</a>
+  <% } %>
+  <% if (canManageInvoices) { %>
+    <a href="/invoices" class="menu-link"><i class="fas fa-file-invoice"></i> Invoices</a>
+  <% } %>
   <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
     <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
     <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
+    <a href="/external-apis" class="menu-link"><i class="fas fa-plug"></i> External APIs</a>
   <% } %>
   <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
 </nav>


### PR DESCRIPTION
## Summary
- Track asset and invoice permissions for company assignments and expose database tables
- Add Assets, Invoices, and External API configuration pages with navigation
- Provide API endpoints and Swagger docs to import assets/invoices and manage external API settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c0e188f8c832daec11e3c0c0cfb8b