### PR TITLE
Move admin links to bottom of sidebar

### DIFF
--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -25,10 +25,10 @@
   <% if (canManageInvoices) { %>
     <a href="/invoices" class="menu-link"><i class="fas fa-file-invoice"></i> Invoices</a>
   <% } %>
+  <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
   <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
     <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
     <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
     <a href="/external-apis" class="menu-link"><i class="fas fa-plug"></i> External APIs</a>
   <% } %>
-  <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
 </nav>


### PR DESCRIPTION
## Summary
- Reorder Admin, API Docs, and External APIs links after logout so they appear at the bottom of the sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c33d36cb4832d8e1bdbbfa4b8a593