### PR TITLE
Position login button at bottom of sidebar

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -124,6 +124,10 @@ table th {
   background-color: #3700b3;
 }
 
+.menu-link.login {
+  margin-top: auto;
+}
+
 .menu-link.logout {
   margin-top: auto;
   background-color: #e53935;

--- a/src/server.ts
+++ b/src/server.ts
@@ -80,6 +80,11 @@ app.use(
   })
 );
 
+app.use((req, res, next) => {
+  res.locals.isLoggedIn = !!req.session.userId;
+  next();
+});
+
 const swaggerSpec = swaggerJSDoc({
   definition: {
     openapi: '3.0.0',

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -25,10 +25,14 @@
   <% if (canManageInvoices) { %>
     <a href="/invoices" class="menu-link"><i class="fas fa-file-invoice"></i> Invoices</a>
   <% } %>
-  <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
   <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
     <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
     <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
     <a href="/external-apis" class="menu-link"><i class="fas fa-plug"></i> External APIs</a>
+  <% } %>
+  <% if (isLoggedIn) { %>
+    <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
+  <% } else { %>
+    <a href="/login" class="menu-link login"><i class="fas fa-sign-in-alt"></i> Login</a>
   <% } %>
 </nav>


### PR DESCRIPTION
## Summary
- expose a login state to templates via middleware
- adjust sidebar to render login/logout link at the bottom
- add CSS to push login link to the sidebar's end

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c3c4e3b24832daaf02793674c91af