### PR TITLE
feat: add app pricing and license ordering

### DIFF
--- a/migrations/012_apps.sql
+++ b/migrations/012_apps.sql
@@ -1,0 +1,30 @@
+CREATE TABLE apps (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  sku VARCHAR(255) NOT NULL UNIQUE,
+  name VARCHAR(255) NOT NULL,
+  default_price DECIMAL(10,2) NOT NULL,
+  contract_term VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE company_app_prices (
+  company_id INT NOT NULL,
+  app_id INT NOT NULL,
+  price DECIMAL(10,2) NOT NULL,
+  PRIMARY KEY (company_id, app_id),
+  FOREIGN KEY (company_id) REFERENCES companies(id),
+  FOREIGN KEY (app_id) REFERENCES apps(id)
+);
+
+ALTER TABLE user_companies
+  ADD COLUMN IF NOT EXISTS can_order_licenses TINYINT(1);
+
+UPDATE user_companies
+SET can_order_licenses = 1
+WHERE can_order_licenses IS NULL;
+
+ALTER TABLE user_companies
+  MODIFY can_order_licenses TINYINT(1) DEFAULT 0 NOT NULL;
+
+ALTER TABLE external_api_settings
+  ADD COLUMN IF NOT EXISTS webhook_url VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS webhook_api_key VARCHAR(255);

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -56,7 +56,7 @@
       <section>
         <h2>Current Assignments</h2>
         <table>
-          <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Staff</th><th>Assets</th><th>Invoices</th></tr>
+          <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Assets</th><th>Invoices</th></tr>
           <% assignments.forEach(function(a) { %>
             <tr>
               <td><%= a.email %></td>
@@ -75,6 +75,14 @@
                   <input type="hidden" name="companyId" value="<%= a.company_id %>">
                   <input type="hidden" name="canManageLicenses" value="0">
                   <input type="checkbox" name="canManageLicenses" value="1" <%= a.can_manage_licenses ? 'checked' : '' %> onchange="this.form.submit()">
+                </form>
+              </td>
+              <td>
+                <form action="/admin/permission" method="post">
+                  <input type="hidden" name="userId" value="<%= a.user_id %>">
+                  <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                  <input type="hidden" name="canOrderLicenses" value="0">
+                  <input type="checkbox" name="canOrderLicenses" value="1" <%= a.can_order_licenses ? 'checked' : '' %> onchange="this.form.submit()">
                 </form>
               </td>
               <td>

--- a/src/views/apps.ejs
+++ b/src/views/apps.ejs
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Apps' }) %>
+  <body>
+    <div class="app-container">
+      <%- include('partials/sidebar') %>
+      <div class="content">
+        <h1>Apps</h1>
+        <form action="/apps" method="post">
+          <input type="text" name="sku" placeholder="SKU" required>
+          <input type="text" name="name" placeholder="Name" required>
+          <input type="number" step="0.01" name="price" placeholder="Default Price" required>
+          <input type="text" name="contractTerm" placeholder="Contract Term" required>
+          <button type="submit">Add App</button>
+        </form>
+        <table>
+          <tr><th>SKU</th><th>Name</th><th>Default Price</th><th>Contract Term</th></tr>
+          <% apps.forEach(function(a){ %>
+            <tr>
+              <td><%= a.sku %></td>
+              <td><%= a.name %></td>
+              <td><%= a.default_price %></td>
+              <td><%= a.contract_term %></td>
+            </tr>
+          <% }); %>
+        </table>
+        <h2>Company Pricing</h2>
+        <form action="/apps/price" method="post">
+          <select name="appId">
+            <% apps.forEach(function(a){ %>
+              <option value="<%= a.id %>"><%= a.name %></option>
+            <% }); %>
+          </select>
+          <select name="companyId">
+            <% allCompanies.forEach(function(c){ %>
+              <option value="<%= c.id %>"><%= c.name %></option>
+            <% }); %>
+          </select>
+          <input type="number" step="0.01" name="price" placeholder="Price" required>
+          <button type="submit">Set Price</button>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/views/external-apis.ejs
+++ b/src/views/external-apis.ejs
@@ -13,6 +13,9 @@
         <h2>Syncro RMM</h2>
         <input type="text" name="syncroEndpoint" placeholder="Syncro API Endpoint" value="<%= settings ? settings.syncro_endpoint : '' %>">
         <input type="text" name="syncroApiKey" placeholder="Syncro API Key" value="<%= settings ? settings.syncro_api_key : '' %>">
+        <h2>License Orders Webhook</h2>
+        <input type="text" name="webhookUrl" placeholder="Webhook URL" value="<%= settings ? settings.webhook_url : '' %>">
+        <input type="text" name="webhookApiKey" placeholder="Webhook API Key" value="<%= settings ? settings.webhook_api_key : '' %>">
         <button type="submit">Save</button>
       </form>
     </div>

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -15,6 +15,7 @@
             <th>Allocated</th>
             <th>Expiry</th>
             <th>Contract Term</th>
+            <% if (canOrderLicenses) { %><th>Actions</th><% } %>
           </tr>
         </thead>
         <tbody>
@@ -26,6 +27,12 @@
             <td><a href="#" class="allocated-link" data-license-id="<%= lic.id %>"><%= lic.allocated %></a></td>
             <td><%= lic.expiry_date %></td>
             <td><%= lic.contract_term %></td>
+            <% if (canOrderLicenses) { %>
+              <td>
+                <button class="order-btn" data-license-id="<%= lic.id %>">Order More</button>
+                <button class="remove-btn" data-license-id="<%= lic.id %>">Request Removal</button>
+              </td>
+            <% } %>
           </tr>
         <% }); %>
         </tbody>
@@ -68,6 +75,32 @@
 
     document.getElementById('allocated-close').addEventListener('click', function () {
       document.getElementById('allocated-modal').style.display = 'none';
+    });
+
+    document.querySelectorAll('.order-btn').forEach(function (btn) {
+      btn.addEventListener('click', async function () {
+        const qty = prompt('How many licenses to order?');
+        if (!qty) return;
+        await fetch(`/licenses/${this.dataset.licenseId}/order`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ quantity: parseInt(qty, 10) }),
+        });
+        alert('Order submitted');
+      });
+    });
+
+    document.querySelectorAll('.remove-btn').forEach(function (btn) {
+      btn.addEventListener('click', async function () {
+        const qty = prompt('How many licenses to remove?');
+        if (!qty) return;
+        await fetch(`/licenses/${this.dataset.licenseId}/remove`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ quantity: parseInt(qty, 10) }),
+        });
+        alert('Removal requested');
+      });
     });
   </script>
 </body>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -29,6 +29,7 @@
       <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
     <% } %>
     <% if (isSuperAdmin) { %>
+      <a href="/apps" class="menu-link"><i class="fas fa-th-large"></i> Apps</a>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
       <a href="/external-apis" class="menu-link"><i class="fas fa-plug"></i> External APIs</a>
     <% } %>


### PR DESCRIPTION
## Summary
- manage default and company-specific app pricing
- allow admins to order or remove licenses and trigger webhook
- store license order webhook credentials in external API settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c402bbef4832d8e7630fe8fc63ce3