### PR TITLE
Add app pricing APIs and company price display

### DIFF
--- a/src/views/apps.ejs
+++ b/src/views/apps.ejs
@@ -39,6 +39,17 @@
           <input type="number" step="0.01" name="price" placeholder="Price" required>
           <button type="submit">Set Price</button>
         </form>
+        <h3>Existing Company Prices</h3>
+        <table>
+          <tr><th>Company</th><th>App</th><th>Price</th></tr>
+          <% companyPrices.forEach(function(p){ %>
+            <tr>
+              <td><%= p.company_name %></td>
+              <td><%= p.app_name %></td>
+              <td><%= p.price %></td>
+            </tr>
+          <% }); %>
+        </table>
       </div>
     </div>
   </body>


### PR DESCRIPTION
## Summary
- show existing company-specific app prices on Apps page
- add CRUD API endpoints for apps and company-specific pricing
- implement database helpers for app and company pricing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c495711cc832d9fe447f232c91e79