### PR TITLE
Add sorting and filtering to all tables

### DIFF
--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -53,91 +53,99 @@
         </form>
       </section>
       <% } %>
-      <section>
-        <h2>Current Assignments</h2>
-        <table>
-          <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Assets</th><th>Invoices</th></tr>
-          <% assignments.forEach(function(a) { %>
-            <tr>
-              <td><%= a.email %></td>
-              <td><%= a.company_name %></td>
-              <td>
-                <form action="/admin/permission" method="post">
-                  <input type="hidden" name="userId" value="<%= a.user_id %>">
-                  <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                  <input type="hidden" name="isAdmin" value="0">
-                  <input type="checkbox" name="isAdmin" value="1" <%= a.is_admin ? 'checked' : '' %> onchange="this.form.submit()">
-                </form>
-              </td>
-              <td>
-                <form action="/admin/permission" method="post">
-                  <input type="hidden" name="userId" value="<%= a.user_id %>">
-                  <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                  <input type="hidden" name="canManageLicenses" value="0">
-                  <input type="checkbox" name="canManageLicenses" value="1" <%= a.can_manage_licenses ? 'checked' : '' %> onchange="this.form.submit()">
-                </form>
-              </td>
-              <td>
-                <form action="/admin/permission" method="post">
-                  <input type="hidden" name="userId" value="<%= a.user_id %>">
-                  <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                  <input type="hidden" name="canOrderLicenses" value="0">
-                  <input type="checkbox" name="canOrderLicenses" value="1" <%= a.can_order_licenses ? 'checked' : '' %> onchange="this.form.submit()">
-                </form>
-              </td>
-              <td>
-                <form action="/admin/permission" method="post">
-                  <input type="hidden" name="userId" value="<%= a.user_id %>">
-                  <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                  <input type="hidden" name="canManageStaff" value="0">
-                  <input type="checkbox" name="canManageStaff" value="1" <%= a.can_manage_staff ? 'checked' : '' %> onchange="this.form.submit()">
-                </form>
-              </td>
-              <td>
-                <form action="/admin/permission" method="post">
-                  <input type="hidden" name="userId" value="<%= a.user_id %>">
-                  <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                  <input type="hidden" name="canManageAssets" value="0">
-                  <input type="checkbox" name="canManageAssets" value="1" <%= a.can_manage_assets ? 'checked' : '' %> onchange="this.form.submit()">
-                </form>
-              </td>
-              <td>
-                <form action="/admin/permission" method="post">
-                  <input type="hidden" name="userId" value="<%= a.user_id %>">
-                  <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                  <input type="hidden" name="canManageInvoices" value="0">
-                  <input type="checkbox" name="canManageInvoices" value="1" <%= a.can_manage_invoices ? 'checked' : '' %> onchange="this.form.submit()">
-                </form>
-              </td>
-            </tr>
-          <% }); %>
-        </table>
-      </section>
+        <section>
+          <h2>Current Assignments</h2>
+          <table>
+            <thead>
+              <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Assets</th><th>Invoices</th></tr>
+            </thead>
+            <tbody>
+            <% assignments.forEach(function(a) { %>
+              <tr>
+                <td><%= a.email %></td>
+                <td><%= a.company_name %></td>
+                <td>
+                  <form action="/admin/permission" method="post">
+                    <input type="hidden" name="userId" value="<%= a.user_id %>">
+                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                    <input type="hidden" name="isAdmin" value="0">
+                    <input type="checkbox" name="isAdmin" value="1" <%= a.is_admin ? 'checked' : '' %> onchange="this.form.submit()">
+                  </form>
+                </td>
+                <td>
+                  <form action="/admin/permission" method="post">
+                    <input type="hidden" name="userId" value="<%= a.user_id %>">
+                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                    <input type="hidden" name="canManageLicenses" value="0">
+                    <input type="checkbox" name="canManageLicenses" value="1" <%= a.can_manage_licenses ? 'checked' : '' %> onchange="this.form.submit()">
+                  </form>
+                </td>
+                <td>
+                  <form action="/admin/permission" method="post">
+                    <input type="hidden" name="userId" value="<%= a.user_id %>">
+                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                    <input type="hidden" name="canOrderLicenses" value="0">
+                    <input type="checkbox" name="canOrderLicenses" value="1" <%= a.can_order_licenses ? 'checked' : '' %> onchange="this.form.submit()">
+                  </form>
+                </td>
+                <td>
+                  <form action="/admin/permission" method="post">
+                    <input type="hidden" name="userId" value="<%= a.user_id %>">
+                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                    <input type="hidden" name="canManageStaff" value="0">
+                    <input type="checkbox" name="canManageStaff" value="1" <%= a.can_manage_staff ? 'checked' : '' %> onchange="this.form.submit()">
+                  </form>
+                </td>
+                <td>
+                  <form action="/admin/permission" method="post">
+                    <input type="hidden" name="userId" value="<%= a.user_id %>">
+                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                    <input type="hidden" name="canManageAssets" value="0">
+                    <input type="checkbox" name="canManageAssets" value="1" <%= a.can_manage_assets ? 'checked' : '' %> onchange="this.form.submit()">
+                  </form>
+                </td>
+                <td>
+                  <form action="/admin/permission" method="post">
+                    <input type="hidden" name="userId" value="<%= a.user_id %>">
+                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                    <input type="hidden" name="canManageInvoices" value="0">
+                    <input type="checkbox" name="canManageInvoices" value="1" <%= a.can_manage_invoices ? 'checked' : '' %> onchange="this.form.submit()">
+                  </form>
+                </td>
+              </tr>
+            <% }); %>
+            </tbody>
+          </table>
+        </section>
       <% if (isSuperAdmin) { %>
-      <section>
-        <h2>API Keys</h2>
-        <form action="/admin/api-key" method="post">
-          <input type="text" name="description" placeholder="Description">
-          <input type="date" name="expiryDate">
-          <button type="submit">Add API Key</button>
-        </form>
-        <table>
-          <tr><th>Key</th><th>Description</th><th>Expiry</th><th></th></tr>
-          <% apiKeys.forEach(function(k) { %>
-            <tr>
-              <td><%= k.api_key %></td>
-              <td><%= k.description %></td>
-              <td><%= k.expiry_date || '' %></td>
-              <td>
-                <form action="/admin/api-key/delete" method="post">
-                  <input type="hidden" name="id" value="<%= k.id %>">
-                  <button type="submit">Delete</button>
-                </form>
-              </td>
-            </tr>
-          <% }); %>
-        </table>
-      </section>
+        <section>
+          <h2>API Keys</h2>
+          <form action="/admin/api-key" method="post">
+            <input type="text" name="description" placeholder="Description">
+            <input type="date" name="expiryDate">
+            <button type="submit">Add API Key</button>
+          </form>
+          <table>
+            <thead>
+              <tr><th>Key</th><th>Description</th><th>Expiry</th><th></th></tr>
+            </thead>
+            <tbody>
+            <% apiKeys.forEach(function(k) { %>
+              <tr>
+                <td><%= k.api_key %></td>
+                <td><%= k.description %></td>
+                <td><%= k.expiry_date || '' %></td>
+                <td>
+                  <form action="/admin/api-key/delete" method="post">
+                    <input type="hidden" name="id" value="<%= k.id %>">
+                    <button type="submit">Delete</button>
+                  </form>
+                </td>
+              </tr>
+            <% }); %>
+            </tbody>
+          </table>
+        </section>
       <% } %>
     </div>
   </div>

--- a/src/views/apps.ejs
+++ b/src/views/apps.ejs
@@ -14,7 +14,10 @@
           <button type="submit">Add App</button>
         </form>
         <table>
-          <tr><th>SKU</th><th>Name</th><th>Default Price</th><th>Contract Term</th></tr>
+          <thead>
+            <tr><th>SKU</th><th>Name</th><th>Default Price</th><th>Contract Term</th></tr>
+          </thead>
+          <tbody>
           <% apps.forEach(function(a){ %>
             <tr>
               <td><%= a.sku %></td>
@@ -23,6 +26,7 @@
               <td><%= a.contract_term %></td>
             </tr>
           <% }); %>
+          </tbody>
         </table>
         <h2>Company Pricing</h2>
         <form action="/apps/price" method="post">
@@ -41,7 +45,10 @@
         </form>
           <h3>Existing Company Prices</h3>
           <table>
-            <tr><th>Company</th><th>SKU</th><th>App</th><th>Price</th></tr>
+            <thead>
+              <tr><th>Company</th><th>SKU</th><th>App</th><th>Price</th></tr>
+            </thead>
+            <tbody>
             <% companyPrices.forEach(function(p){ %>
               <tr>
                 <td><%= p.company_name %></td>
@@ -50,6 +57,7 @@
                 <td><%= p.price %></td>
               </tr>
             <% }); %>
+            </tbody>
           </table>
       </div>
     </div>

--- a/src/views/assets.ejs
+++ b/src/views/assets.ejs
@@ -9,7 +9,10 @@
       <section>
         <h2>Company Assets</h2>
         <table>
-          <tr><th>Name</th><th>Type</th><th>Serial Number</th><th>Status</th></tr>
+          <thead>
+            <tr><th>Name</th><th>Type</th><th>Serial Number</th><th>Status</th></tr>
+          </thead>
+          <tbody>
           <% assets.forEach(function(a) { %>
             <tr>
               <td><%= a.name %></td>
@@ -18,6 +21,7 @@
               <td><%= a.status %></td>
             </tr>
           <% }); %>
+          </tbody>
         </table>
       </section>
     </div>

--- a/src/views/invoices.ejs
+++ b/src/views/invoices.ejs
@@ -9,7 +9,10 @@
       <section>
         <h2>Company Invoices</h2>
         <table>
-          <tr><th>Number</th><th>Amount</th><th>Due Date</th><th>Status</th></tr>
+          <thead>
+            <tr><th>Number</th><th>Amount</th><th>Due Date</th><th>Status</th></tr>
+          </thead>
+          <tbody>
           <% invoices.forEach(function(i) { %>
             <tr>
               <td><%= i.invoice_number %></td>
@@ -18,6 +21,7 @@
               <td><%= i.status %></td>
             </tr>
           <% }); %>
+          </tbody>
         </table>
       </section>
     </div>

--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -2,4 +2,12 @@
   <title><%= title %></title>
   <link rel="stylesheet" href="/style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnH1zqD+XzdzN7D8YGN9VOGZsv5nYeD1yfknhk+aoCA8DmF5asJ5AZt0fjOEtRjdbc/YWZL0w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script>
+    $(function() {
+      $('table').DataTable();
+    });
+  </script>
 </head>

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -9,7 +9,10 @@
       <section>
         <h2>Current Staff</h2>
         <table>
-          <tr><th>First Name</th><th>Last Name</th><th>Email</th><th>Date Onboarded</th><th>Enabled</th></tr>
+          <thead>
+            <tr><th>First Name</th><th>Last Name</th><th>Email</th><th>Date Onboarded</th><th>Enabled</th></tr>
+          </thead>
+          <tbody>
           <% staff.forEach(function(s) { %>
             <tr>
               <td><%= s.first_name %></td>
@@ -24,6 +27,7 @@
               </td>
             </tr>
           <% }); %>
+          </tbody>
         </table>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- enable DataTables across the app for instant sorting and filtering
- ensure table markup uses `<thead>`/`<tbody>` for proper initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c6404f500832daa4029f4cd1ebd19