### PR TITLE
feat: add company SKU assignment

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -263,7 +263,7 @@ export async function createLicense(
   name: string,
   platform: string,
   count: number,
-  expiryDate: string,
+  expiryDate: string | null,
   contractTerm: string
 ): Promise<number> {
   const [result] = await pool.execute(

--- a/src/server.ts
+++ b/src/server.ts
@@ -571,6 +571,25 @@ app.post('/apps/price', ensureAuth, ensureSuperAdmin, async (req, res) => {
   res.redirect('/apps');
 });
 
+app.post('/apps/:appId/add', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  const appId = parseInt(req.params.appId, 10);
+  const { companyId, quantity } = req.body;
+  const appInfo = await getAppById(appId);
+  if (!appInfo) {
+    res.status(404).send('App not found');
+    return;
+  }
+  await createLicense(
+    parseInt(companyId, 10),
+    appInfo.name,
+    appInfo.sku,
+    parseInt(quantity, 10),
+    null,
+    appInfo.contract_term
+  );
+  res.status(204).end();
+});
+
 app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
   const isSuperAdmin = req.session.userId === 1;
   let allCompanies: Company[] = [];

--- a/src/views/apps.ejs
+++ b/src/views/apps.ejs
@@ -15,7 +15,7 @@
         </form>
         <table>
           <thead>
-            <tr><th>SKU</th><th>Name</th><th>Default Price</th><th>Contract Term</th></tr>
+            <tr><th>SKU</th><th>Name</th><th>Default Price</th><th>Contract Term</th><th>Actions</th></tr>
           </thead>
           <tbody>
           <% apps.forEach(function(a){ %>
@@ -24,6 +24,7 @@
               <td><%= a.name %></td>
               <td><%= a.default_price %></td>
               <td><%= a.contract_term %></td>
+              <td><button class="add-sku-default" data-app-id="<%= a.id %>" data-app-name="<%= a.name %>">Add to Company</button></td>
             </tr>
           <% }); %>
           </tbody>
@@ -46,7 +47,7 @@
           <h3>Existing Company Prices</h3>
           <table>
             <thead>
-              <tr><th>Company</th><th>SKU</th><th>App</th><th>Price</th></tr>
+              <tr><th>Company</th><th>SKU</th><th>App</th><th>Price</th><th>Actions</th></tr>
             </thead>
             <tbody>
             <% companyPrices.forEach(function(p){ %>
@@ -55,11 +56,47 @@
                 <td><%= p.sku %></td>
                 <td><%= p.app_name %></td>
                 <td><%= p.price %></td>
+                <td><button class="add-sku-company" data-app-id="<%= p.app_id %>" data-company-id="<%= p.company_id %>" data-company-name="<%= p.company_name %>">Add to Company</button></td>
               </tr>
             <% }); %>
             </tbody>
           </table>
       </div>
     </div>
+  <script>
+    const allCompanies = <%- JSON.stringify(allCompanies) %>;
+    document.querySelectorAll('.add-sku-default').forEach(function(btn){
+      btn.addEventListener('click', async function(){
+        const appId = this.dataset.appId;
+        const appName = this.dataset.appName;
+        const list = allCompanies.map(c => `${c.id}: ${c.name}`).join('\n');
+        const companyId = prompt(`Select company for ${appName}:\n${list}`);
+        if(!companyId) return;
+        const qty = prompt('Number of licenses purchased?');
+        if(!qty) return;
+        await fetch(`/apps/${appId}/add`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ companyId: parseInt(companyId,10), quantity: parseInt(qty,10) })
+        });
+        alert('App added to company');
+      });
+    });
+    document.querySelectorAll('.add-sku-company').forEach(function(btn){
+      btn.addEventListener('click', async function(){
+        const appId = this.dataset.appId;
+        const companyId = this.dataset.companyId;
+        const companyName = this.dataset.companyName;
+        const qty = prompt(`Number of licenses for ${companyName}?`);
+        if(!qty) return;
+        await fetch(`/apps/${appId}/add`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ companyId: parseInt(companyId,10), quantity: parseInt(qty,10) })
+        });
+        alert('App added to company');
+      });
+    });
+  </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- allow creating licenses from apps with optional expiry date
- add endpoint to attach app SKUs to companies and record purchased licenses
- add UI actions on Apps page for assigning SKUs to companies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c684e790c832db758499163b27f65