### PR TITLE
Reorganize sidebar navigation into top and bottom sections

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -104,6 +104,11 @@ table th {
   flex-direction: column;
 }
 
+.sidebar-bottom {
+  margin-top: auto;
+}
+
+
 .menu-link {
   display: flex;
   align-items: center;
@@ -125,7 +130,6 @@ table th {
 }
 
 .menu-link.logout {
-  margin-top: auto;
   background-color: #e53935;
 }
 

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -1,37 +1,43 @@
 <nav class="sidebar">
-  <% if (companies && companies.length > 1) { %>
-    <div class="company-switcher">
-      <h3>Select Company</h3>
-      <form action="/switch-company" method="post">
-        <select name="companyId" onchange="this.form.submit()">
-          <% companies.forEach(function(c) { %>
-            <option value="<%= c.company_id %>" <%= c.company_id === currentCompanyId ? 'selected' : '' %>><%= c.company_name %></option>
-          <% }); %>
-        </select>
-      </form>
-    </div>
-    <br>
-  <% } %>
-  <a href="/" class="menu-link"><i class="fas fa-briefcase"></i> Business Info</a>
-  <% if (canManageStaff) { %>
-    <a href="/staff" class="menu-link"><i class="fas fa-users"></i> Staff</a>
-  <% } %>
-  <% if (canManageLicenses) { %>
-    <a href="/licenses" class="menu-link"><i class="fas fa-file-contract"></i> Licenses</a>
-  <% } %>
-  <% if (canManageAssets) { %>
-    <a href="/assets" class="menu-link"><i class="fas fa-desktop"></i> Assets</a>
-  <% } %>
-  <% if (canManageInvoices) { %>
-    <a href="/invoices" class="menu-link"><i class="fas fa-file-invoice"></i> Invoices</a>
-  <% } %>
+  <div class="sidebar-top">
+    <% if (companies && companies.length > 1) { %>
+      <div class="company-switcher">
+        <h3>Select Company</h3>
+        <form action="/switch-company" method="post">
+          <select name="companyId" onchange="this.form.submit()">
+            <% companies.forEach(function(c) { %>
+              <option value="<%= c.company_id %>" <%= c.company_id === currentCompanyId ? 'selected' : '' %>><%= c.company_name %></option>
+            <% }); %>
+          </select>
+        </form>
+      </div>
+      <br>
+    <% } %>
+    <a href="/" class="menu-link"><i class="fas fa-briefcase"></i> Business Info</a>
+    <% if (canManageStaff) { %>
+      <a href="/staff" class="menu-link"><i class="fas fa-users"></i> Staff</a>
+    <% } %>
+    <% if (canManageLicenses) { %>
+      <a href="/licenses" class="menu-link"><i class="fas fa-file-contract"></i> Licenses</a>
+    <% } %>
+    <% if (canManageAssets) { %>
+      <a href="/assets" class="menu-link"><i class="fas fa-desktop"></i> Assets</a>
+    <% } %>
+    <% if (canManageInvoices) { %>
+      <a href="/invoices" class="menu-link"><i class="fas fa-file-invoice"></i> Invoices</a>
+    <% } %>
+  </div>
+  <div class="sidebar-bottom">
+    <% if (isSuperAdmin) { %>
+      <a href="/apps" class="menu-link"><i class="fas fa-th-large"></i> Apps</a>
+    <% } %>
     <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
       <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
     <% } %>
     <% if (isSuperAdmin) { %>
-      <a href="/apps" class="menu-link"><i class="fas fa-th-large"></i> Apps</a>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
       <a href="/external-apis" class="menu-link"><i class="fas fa-plug"></i> External APIs</a>
     <% } %>
-  <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
+    <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
+  </div>
 </nav>


### PR DESCRIPTION
## Summary
- Organize sidebar into distinct top and bottom sections
- Order navigation links to match new requirements
- Style new sidebar bottom container and adjust logout link styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c68ab8960832dac34e6eda2718008