### PR TITLE
feat: add shop with product management

### DIFF
--- a/migrations/013_shop.sql
+++ b/migrations/013_shop.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS shop_products (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  description TEXT,
+  price DECIMAL(10,2) NOT NULL,
+  stock INT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS shop_orders (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  company_id INT NOT NULL,
+  product_id INT NOT NULL,
+  quantity INT NOT NULL,
+  order_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (product_id) REFERENCES shop_products(id)
+);
+
+ALTER TABLE user_companies
+  ADD COLUMN IF NOT EXISTS can_access_shop TINYINT(1);
+
+UPDATE user_companies
+SET can_access_shop = 1
+WHERE can_access_shop IS NULL;
+
+ALTER TABLE user_companies
+  MODIFY can_access_shop TINYINT(1) DEFAULT 0 NOT NULL;

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -57,7 +57,7 @@
           <h2>Current Assignments</h2>
           <table>
             <thead>
-              <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Assets</th><th>Invoices</th></tr>
+              <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Assets</th><th>Invoices</th><th>Shop</th></tr>
             </thead>
             <tbody>
             <% assignments.forEach(function(a) { %>
@@ -110,6 +110,14 @@
                     <input type="hidden" name="companyId" value="<%= a.company_id %>">
                     <input type="hidden" name="canManageInvoices" value="0">
                     <input type="checkbox" name="canManageInvoices" value="1" <%= a.can_manage_invoices ? 'checked' : '' %> onchange="this.form.submit()">
+                  </form>
+                </td>
+                <td>
+                  <form action="/admin/permission" method="post">
+                    <input type="hidden" name="userId" value="<%= a.user_id %>">
+                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                    <input type="hidden" name="canAccessShop" value="0">
+                    <input type="checkbox" name="canAccessShop" value="1" <%= a.can_access_shop ? 'checked' : '' %> onchange="this.form.submit()">
                   </form>
                 </td>
               </tr>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -26,6 +26,9 @@
     <% if (canManageInvoices) { %>
       <a href="/invoices" class="menu-link"><i class="fas fa-file-invoice"></i> Invoices</a>
     <% } %>
+    <% if (canAccessShop) { %>
+      <a href="/shop" class="menu-link"><i class="fas fa-shopping-cart"></i> Shop</a>
+    <% } %>
   </div>
   <div class="sidebar-bottom">
     <% if (isSuperAdmin) { %>
@@ -37,6 +40,7 @@
     <% if (isSuperAdmin) { %>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
       <a href="/external-apis" class="menu-link"><i class="fas fa-plug"></i> External APIs</a>
+      <a href="/shop/admin" class="menu-link"><i class="fas fa-cogs"></i> Shop Admin</a>
     <% } %>
     <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
   </div>

--- a/src/views/shop-admin.ejs
+++ b/src/views/shop-admin.ejs
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Shop Admin' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Shop Admin</h1>
+      <section>
+        <h2>Add Product</h2>
+        <form action="/shop/admin/product" method="post">
+          <input type="text" name="name" placeholder="Name" required>
+          <input type="text" name="description" placeholder="Description">
+          <input type="number" step="0.01" name="price" placeholder="Price" required>
+          <input type="number" name="stock" placeholder="Stock" required>
+          <button type="submit">Add</button>
+        </form>
+      </section>
+      <section>
+        <h2>Products</h2>
+        <ul>
+          <% products.forEach(function(p){ %>
+            <li>
+              <form action="/shop/admin/product/<%= p.id %>" method="post" style="display:inline-block">
+                <input type="text" name="name" value="<%= p.name %>">
+                <input type="text" name="description" value="<%= p.description %>">
+                <input type="number" step="0.01" name="price" value="<%= p.price %>">
+                <input type="number" name="stock" value="<%= p.stock %>">
+                <button type="submit">Update</button>
+              </form>
+              <form action="/shop/admin/product/<%= p.id %>/delete" method="post" style="display:inline-block">
+                <button type="submit">Delete</button>
+              </form>
+            </li>
+          <% }) %>
+        </ul>
+      </section>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/shop.ejs
+++ b/src/views/shop.ejs
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Shop' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Shop</h1>
+      <table>
+        <thead>
+          <tr><th>Name</th><th>Description</th><th>Price</th><th>Stock</th><th>Order</th></tr>
+        </thead>
+        <tbody>
+          <% products.forEach(function(p){ %>
+            <tr>
+              <td><%= p.name %></td>
+              <td><%= p.description %></td>
+              <td>$<%= p.price %></td>
+              <td><%= p.stock %></td>
+              <td>
+                <form action="/shop/order" method="post">
+                  <input type="hidden" name="productId" value="<%= p.id %>">
+                  <input type="number" name="quantity" min="1" max="<%= p.stock %>" value="1">
+                  <button type="submit">Order</button>
+                </form>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add product and order tables plus shop permission migration
- implement shop pages, admin management, and CRUD API endpoints
- expose shop access control in sidebar and admin assignments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c6a5d44b0832d96f47c3f6ba71bbb