### PR TITLE
feat: add global admin license editing

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -91,7 +91,7 @@ app.use(
 );
 
 app.use((req, res, next) => {
-  res.locals.isSuperAdmin = req.session.userId === 1;
+  res.locals.isGlobalAdmin = req.session.userId === 1;
   next();
 });
 
@@ -128,7 +128,7 @@ const swaggerSpec = swaggerJSDoc({
 app.use(
   '/swagger',
   ensureAuth,
-  ensureSuperAdmin,
+  ensureGlobalAdmin,
   swaggerUi.serve,
   swaggerUi.setup(swaggerSpec)
 );
@@ -156,7 +156,7 @@ async function ensureAdmin(
   return res.redirect('/');
 }
 
-function ensureSuperAdmin(
+function ensureGlobalAdmin(
   req: express.Request,
   res: express.Response,
   next: express.NextFunction
@@ -167,7 +167,7 @@ function ensureSuperAdmin(
   return res.redirect('/');
 }
 
-app.get('/api-docs', ensureAuth, ensureSuperAdmin, async (req, res) => {
+app.get('/api-docs', ensureAuth, ensureGlobalAdmin, async (req, res) => {
   const companies = await getCompaniesForUser(req.session.userId!);
   const current = companies.find((c) => c.company_id === req.session.companyId);
   res.render('api-docs', {
@@ -343,6 +343,33 @@ app.get(
   }
 );
 
+app.get('/licenses/:id', ensureAuth, ensureGlobalAdmin, async (req, res) => {
+  const license = await getLicenseById(parseInt(req.params.id, 10));
+  if (!license) {
+    return res.status(404).json({ error: 'License not found' });
+  }
+  res.json(license);
+});
+
+app.post('/licenses/:id/edit', ensureAuth, ensureGlobalAdmin, async (req, res) => {
+  const licenseId = parseInt(req.params.id, 10);
+  const license = await getLicenseById(licenseId);
+  if (!license) {
+    return res.status(404).json({ error: 'License not found' });
+  }
+  const { name, platform, count, expiryDate, contractTerm } = req.body;
+  await updateLicense(
+    licenseId,
+    license.company_id,
+    name,
+    platform,
+    parseInt(count, 10),
+    expiryDate,
+    contractTerm
+  );
+  res.json({ success: true });
+});
+
 app.post('/licenses/:id/order', ensureAuth, async (req, res) => {
   const { quantity } = req.body;
   const companies = await getCompaniesForUser(req.session.userId!);
@@ -490,7 +517,7 @@ app.post('/switch-company', ensureAuth, async (req, res) => {
   res.redirect('/');
 });
 
-app.get('/external-apis', ensureAuth, ensureSuperAdmin, async (req, res) => {
+app.get('/external-apis', ensureAuth, ensureGlobalAdmin, async (req, res) => {
   const companies = await getCompaniesForUser(req.session.userId!);
   const settings = req.session.companyId
     ? await getExternalApiSettings(req.session.companyId)
@@ -509,7 +536,7 @@ app.get('/external-apis', ensureAuth, ensureSuperAdmin, async (req, res) => {
   });
 });
 
-app.post('/external-apis', ensureAuth, ensureSuperAdmin, async (req, res) => {
+app.post('/external-apis', ensureAuth, ensureGlobalAdmin, async (req, res) => {
   const {
     xeroEndpoint,
     xeroApiKey,
@@ -532,7 +559,7 @@ app.post('/external-apis', ensureAuth, ensureSuperAdmin, async (req, res) => {
   res.redirect('/external-apis');
 });
 
-app.get('/apps', ensureAuth, ensureSuperAdmin, async (req, res) => {
+app.get('/apps', ensureAuth, ensureGlobalAdmin, async (req, res) => {
   const apps = await getAllApps();
   const companiesForUser = await getCompaniesForUser(req.session.userId!);
   const current = companiesForUser.find(
@@ -555,13 +582,13 @@ app.get('/apps', ensureAuth, ensureSuperAdmin, async (req, res) => {
   });
 });
 
-app.post('/apps', ensureAuth, ensureSuperAdmin, async (req, res) => {
+app.post('/apps', ensureAuth, ensureGlobalAdmin, async (req, res) => {
   const { sku, name, price, contractTerm } = req.body;
   await createApp(sku, name, parseFloat(price), contractTerm);
   res.redirect('/apps');
 });
 
-app.post('/apps/price', ensureAuth, ensureSuperAdmin, async (req, res) => {
+app.post('/apps/price', ensureAuth, ensureGlobalAdmin, async (req, res) => {
   const { companyId, appId, price } = req.body;
   await upsertCompanyAppPrice(
     parseInt(companyId, 10),
@@ -571,7 +598,7 @@ app.post('/apps/price', ensureAuth, ensureSuperAdmin, async (req, res) => {
   res.redirect('/apps');
 });
 
-app.post('/apps/:appId/add', ensureAuth, ensureSuperAdmin, async (req, res) => {
+app.post('/apps/:appId/add', ensureAuth, ensureGlobalAdmin, async (req, res) => {
   const appId = parseInt(req.params.appId, 10);
   const { companyId, quantity } = req.body;
   const appInfo = await getAppById(appId);
@@ -591,12 +618,12 @@ app.post('/apps/:appId/add', ensureAuth, ensureSuperAdmin, async (req, res) => {
 });
 
 app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
-  const isSuperAdmin = req.session.userId === 1;
+  const isGlobalAdmin = req.session.userId === 1;
   let allCompanies: Company[] = [];
   let users: User[] = [];
   let assignments: UserCompany[] = [];
   let apiKeys: ApiKey[] = [];
-  if (isSuperAdmin) {
+  if (isGlobalAdmin) {
     allCompanies = await getAllCompanies();
     users = await getAllUsers();
     assignments = await getUserCompanyAssignments();
@@ -616,7 +643,7 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
     assignments,
     apiKeys,
     isAdmin: true,
-    isSuperAdmin,
+    isGlobalAdmin,
     companies,
     currentCompanyId: req.session.companyId,
     canManageLicenses: current?.can_manage_licenses ?? 0,
@@ -635,9 +662,9 @@ app.post('/admin/company', ensureAuth, ensureAdmin, async (req, res) => {
 
 app.post('/admin/user', ensureAuth, ensureAdmin, async (req, res) => {
   const { email, password } = req.body;
-  const isSuperAdmin = req.session.userId === 1;
+  const isGlobalAdmin = req.session.userId === 1;
   const passwordHash = await bcrypt.hash(password, 10);
-  const companyId = isSuperAdmin
+  const companyId = isGlobalAdmin
     ? parseInt(req.body.companyId, 10)
     : req.session.companyId!;
   const userId = await createUser(email, passwordHash, companyId);

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -6,10 +6,10 @@
     <%- include('partials/sidebar') %>
     <div class="content">
       <h1>Admin</h1>
-        <% if (isSuperAdmin) { %>
+        <% if (isGlobalAdmin) { %>
         <p><a href="/api-docs">API Docs</a></p>
         <% } %>
-      <% if (isSuperAdmin) { %>
+      <% if (isGlobalAdmin) { %>
       <section>
         <h2>Add Company</h2>
         <form action="/admin/company" method="post">
@@ -23,7 +23,7 @@
         <form action="/admin/user" method="post">
           <input type="email" name="email" placeholder="Email" required>
           <input type="password" name="password" placeholder="Password" required>
-          <% if (isSuperAdmin) { %>
+          <% if (isGlobalAdmin) { %>
             <select name="companyId">
               <% allCompanies.forEach(function(c) { %>
                 <option value="<%= c.id %>"><%= c.name %></option>
@@ -35,7 +35,7 @@
           <button type="submit">Add User</button>
         </form>
       </section>
-      <% if (isSuperAdmin) { %>
+      <% if (isGlobalAdmin) { %>
       <section>
         <h2>Assign Existing User to Company</h2>
         <form action="/admin/assign" method="post">
@@ -117,7 +117,7 @@
             </tbody>
           </table>
         </section>
-      <% if (isSuperAdmin) { %>
+      <% if (isGlobalAdmin) { %>
         <section>
           <h2>API Keys</h2>
           <form action="/admin/api-key" method="post">

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -10,12 +10,12 @@
         <thead>
           <tr>
             <th>Name</th>
-            <th>Platform</th>
+            <th>SKU</th>
             <th>Count</th>
             <th>Allocated</th>
             <th>Expiry</th>
             <th>Contract Term</th>
-            <% if (canOrderLicenses) { %><th>Actions</th><% } %>
+            <% if (canOrderLicenses || isGlobalAdmin) { %><th>Actions</th><% } %>
           </tr>
         </thead>
         <tbody>
@@ -27,10 +27,15 @@
             <td><a href="#" class="allocated-link" data-license-id="<%= lic.id %>"><%= lic.allocated %></a></td>
             <td><%= lic.expiry_date %></td>
             <td><%= lic.contract_term %></td>
-            <% if (canOrderLicenses) { %>
+            <% if (canOrderLicenses || isGlobalAdmin) { %>
               <td>
-                <button class="order-btn" data-license-id="<%= lic.id %>">Order More</button>
-                <button class="remove-btn" data-license-id="<%= lic.id %>">Request Removal</button>
+                <% if (canOrderLicenses) { %>
+                  <button class="order-btn" data-license-id="<%= lic.id %>">Order More</button>
+                  <button class="remove-btn" data-license-id="<%= lic.id %>">Request Removal</button>
+                <% } %>
+                <% if (isGlobalAdmin) { %>
+                  <button class="edit-btn" data-license-id="<%= lic.id %>">Edit</button>
+                <% } %>
               </td>
             <% } %>
           </tr>
@@ -45,6 +50,21 @@
       <span id="allocated-close" class="close">&times;</span>
       <h2>Allocated Users</h2>
       <ul id="allocated-users"></ul>
+    </div>
+  </div>
+
+  <div id="edit-license-modal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <span id="edit-license-close" class="close">&times;</span>
+      <h2>Edit License</h2>
+      <form id="edit-license-form">
+        <label>Name: <input type="text" id="edit-name" required></label><br>
+        <label>SKU: <input type="text" id="edit-sku" required></label><br>
+        <label>Count: <input type="number" id="edit-count" required></label><br>
+        <label>Expiry: <input type="date" id="edit-expiry"></label><br>
+        <label>Contract Term: <input type="text" id="edit-contract-term"></label><br>
+        <button type="submit">Save</button>
+      </form>
     </div>
   </div>
 
@@ -75,6 +95,44 @@
 
     document.getElementById('allocated-close').addEventListener('click', function () {
       document.getElementById('allocated-modal').style.display = 'none';
+    });
+
+    document.querySelectorAll('.edit-btn').forEach(function (btn) {
+      btn.addEventListener('click', async function () {
+        const id = this.dataset.licenseId;
+        const res = await fetch(`/licenses/${id}`);
+        if (!res.ok) return;
+        const lic = await res.json();
+        document.getElementById('edit-name').value = lic.name;
+        document.getElementById('edit-sku').value = lic.platform;
+        document.getElementById('edit-count').value = lic.count;
+        document.getElementById('edit-expiry').value = lic.expiry_date ? lic.expiry_date.substring(0, 10) : '';
+        document.getElementById('edit-contract-term').value = lic.contract_term || '';
+        document.getElementById('edit-license-form').dataset.licenseId = id;
+        document.getElementById('edit-license-modal').style.display = 'flex';
+      });
+    });
+
+    document.getElementById('edit-license-close').addEventListener('click', function () {
+      document.getElementById('edit-license-modal').style.display = 'none';
+    });
+
+    document.getElementById('edit-license-form').addEventListener('submit', async function (e) {
+      e.preventDefault();
+      const id = this.dataset.licenseId;
+      const body = {
+        name: document.getElementById('edit-name').value,
+        platform: document.getElementById('edit-sku').value,
+        count: parseInt(document.getElementById('edit-count').value, 10),
+        expiryDate: document.getElementById('edit-expiry').value,
+        contractTerm: document.getElementById('edit-contract-term').value,
+      };
+      await fetch(`/licenses/${id}/edit`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      location.reload();
     });
 
     document.querySelectorAll('.order-btn').forEach(function (btn) {

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -28,13 +28,13 @@
     <% } %>
   </div>
   <div class="sidebar-bottom">
-    <% if (isSuperAdmin) { %>
+    <% if (isGlobalAdmin) { %>
       <a href="/apps" class="menu-link"><i class="fas fa-th-large"></i> Apps</a>
     <% } %>
     <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
       <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
     <% } %>
-    <% if (isSuperAdmin) { %>
+    <% if (isGlobalAdmin) { %>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
       <a href="/external-apis" class="menu-link"><i class="fas fa-plug"></i> External APIs</a>
     <% } %>


### PR DESCRIPTION
## Summary
- rename super admin terminology to global admin
- allow global admin to edit licenses directly
- relabel Platform column on license list to SKU

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c6b912b58832d8976470d1507b9bf