### PR TITLE
Show company statistics on business info tab

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -175,3 +175,37 @@ table th {
   float: right;
   cursor: pointer;
 }
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.stats-card {
+  background-color: #f9f9f9;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.stats-card h3 {
+  margin-top: 0;
+}
+
+.stats-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.stats-table th,
+.stats-table td {
+  padding: 0.25rem;
+  border-bottom: 1px solid #ddd;
+  text-align: center;
+}
+
+.stats-table th {
+  background-color: #f3f3f3;
+}

--- a/src/views/business.ejs
+++ b/src/views/business.ejs
@@ -11,6 +11,47 @@
         <% if (company.address) { %>
           <p>Address: <%= company.address %></p>
         <% } %>
+        <div class="stats-grid">
+          <div class="stats-card">
+            <h3>Active Users</h3>
+            <p><%= activeUsers %></p>
+          </div>
+          <div class="stats-card">
+            <h3>License Usage</h3>
+            <% if (licenses && licenses.length > 0) { %>
+              <table class="stats-table">
+                <thead>
+                  <tr>
+                    <th>SKU</th>
+                    <th>Purchased</th>
+                    <th>Used</th>
+                    <th>Unused</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% licenses.forEach(function(l) { %>
+                    <tr>
+                      <td><%= l.name %></td>
+                      <td><%= l.count %></td>
+                      <td><%= l.allocated %></td>
+                      <td><%= l.count - l.allocated %></td>
+                    </tr>
+                  <% }); %>
+                </tbody>
+              </table>
+            <% } else { %>
+              <p>No licenses found.</p>
+            <% } %>
+          </div>
+          <div class="stats-card">
+            <h3>Total Assets</h3>
+            <p><%= assetCount %></p>
+          </div>
+          <div class="stats-card">
+            <h3>Invoices</h3>
+            <p>Paid: <%= invoiceCounts.paid %><br>Unpaid: <%= invoiceCounts.unpaid %></p>
+          </div>
+        </div>
       <% } %>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Display active users, license usage, asset totals, and invoice status on business info page.
- Add queries and route logic to compute company statistics.
- Style new statistics with responsive cards and tables.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c6c7c2844832db576c440f25d797e