### PR TITLE
feat: add business overview stats

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -175,3 +175,17 @@ table th {
   float: right;
   cursor: pointer;
 }
+
+.stats {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.stat-card {
+  flex: 1;
+  background-color: #f3f3f3;
+  padding: 1rem;
+  border-radius: 8px;
+  text-align: center;
+}

--- a/src/views/business.ejs
+++ b/src/views/business.ejs
@@ -11,6 +11,36 @@
         <% if (company.address) { %>
           <p>Address: <%= company.address %></p>
         <% } %>
+        <div class="stats">
+          <div class="stat-card">
+            <h3>Active Users</h3>
+            <p><%= activeUsers %></p>
+          </div>
+          <div class="stat-card">
+            <h3>Assets</h3>
+            <p><%= assetCount %></p>
+          </div>
+          <div class="stat-card">
+            <h3>Invoices</h3>
+            <p>Paid: <%= paidInvoices %> | Unpaid: <%= unpaidInvoices %></p>
+          </div>
+        </div>
+        <h2>Licenses</h2>
+        <table>
+          <thead>
+            <tr><th>SKU</th><th>Purchased</th><th>Used</th><th>Unused</th></tr>
+          </thead>
+          <tbody>
+          <% licenseStats.forEach(function(l) { %>
+            <tr>
+              <td><%= l.name %></td>
+              <td><%= l.count %></td>
+              <td><%= l.used %></td>
+              <td><%= l.unused %></td>
+            </tr>
+          <% }); %>
+          </tbody>
+        </table>
       <% } %>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show business dashboard stats including active users, license usage, assets, and invoice counts
- style stats section on business info page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c7006a8dc832d825cf83d30bb8d11