### PR TITLE
Add cart with order processing via external webhook

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -69,6 +69,7 @@ export interface Order {
   product_id: number;
   quantity: number;
   order_date: Date;
+  product_name: string;
 }
 
 export interface Asset {
@@ -735,7 +736,7 @@ export async function createOrder(
 
 export async function getOrdersByCompany(companyId: number): Promise<Order[]> {
   const [rows] = await pool.query<RowDataPacket[]>(
-    'SELECT * FROM shop_orders WHERE company_id = ?',
+    'SELECT o.*, p.name as product_name FROM shop_orders o JOIN shop_products p ON o.product_id = p.id WHERE o.company_id = ?',
     [companyId]
   );
   return rows as Order[];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,5 +4,7 @@ declare module 'express-session' {
   interface SessionData {
     userId?: number;
     companyId?: number;
+    cart?: { productId: number; name: string; quantity: number }[];
+    orderMessage?: string;
   }
 }

--- a/src/views/cart.ejs
+++ b/src/views/cart.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Cart' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Cart</h1>
+      <% if (orderMessage) { %>
+        <p><%= orderMessage %></p>
+      <% } %>
+      <% if (cart.length === 0) { %>
+        <p>Your cart is empty.</p>
+      <% } else { %>
+        <table>
+          <thead>
+            <tr><th>Product</th><th>Quantity</th></tr>
+          </thead>
+          <tbody>
+            <% cart.forEach(function(item){ %>
+              <tr>
+                <td><%= item.name %></td>
+                <td><%= item.quantity %></td>
+              </tr>
+            <% }) %>
+          </tbody>
+        </table>
+        <form action="/cart/place-order" method="post">
+          <button type="submit">Place Order</button>
+        </form>
+      <% } %>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/orders.ejs
+++ b/src/views/orders.ejs
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Orders' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Orders</h1>
+      <% if (orders.length === 0) { %>
+        <p>No orders have been placed.</p>
+      <% } else { %>
+        <table>
+          <thead>
+            <tr><th>Product</th><th>Quantity</th><th>Date</th></tr>
+          </thead>
+          <tbody>
+            <% orders.forEach(function(o){ %>
+              <tr>
+                <td><%= o.product_name %></td>
+                <td><%= o.quantity %></td>
+                <td><%= o.order_date.toISOString().slice(0,10) %></td>
+              </tr>
+            <% }) %>
+          </tbody>
+        </table>
+      <% } %>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -28,6 +28,15 @@
     <% } %>
     <% if (canAccessShop) { %>
       <a href="/shop" class="menu-link"><i class="fas fa-shopping-cart"></i> Shop</a>
+      <a href="/cart" class="menu-link"><i class="fas fa-shopping-basket"></i> Cart</a>
+      <% if (cart && cart.length > 0) { %>
+        <ul class="cart-items">
+          <% cart.forEach(function(item){ %>
+            <li><%= item.name %> x<%= item.quantity %></li>
+          <% }) %>
+        </ul>
+      <% } %>
+      <a href="/orders" class="menu-link"><i class="fas fa-list"></i> Orders</a>
     <% } %>
   </div>
   <div class="sidebar-bottom">

--- a/src/views/shop.ejs
+++ b/src/views/shop.ejs
@@ -19,10 +19,10 @@
               <td>$<%= p.price %></td>
               <td><%= p.stock %></td>
               <td>
-                <form action="/shop/order" method="post">
+                <form action="/cart/add" method="post">
                   <input type="hidden" name="productId" value="<%= p.id %>">
                   <input type="number" name="quantity" min="1" max="<%= p.stock %>" value="1">
-                  <button type="submit">Order</button>
+                  <button type="submit">Add to Cart</button>
                 </form>
               </td>
             </tr>


### PR DESCRIPTION
## Summary
- Rename shop order button to "Add to Cart" and introduce cart page with order placement
- Show cart items and orders in sidebar, storing cart in session
- Call external API webhook when placing orders, persist orders and clear cart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c7109cd28832da0a5dec2c09f0d50