### PR TITLE
Show cart item details and defer order creation to checkout

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -571,6 +571,9 @@ app.post('/cart/add', ensureAuth, ensureShopAccess, async (req, res) => {
       req.session.cart.push({
         productId: product.id,
         name: product.name,
+        sku: product.sku,
+        description: product.description,
+        price: product.price,
         quantity: parseInt(quantity, 10),
       });
     }
@@ -583,8 +586,14 @@ app.get('/cart', ensureAuth, ensureShopAccess, async (req, res) => {
   const current = companies.find((c) => c.company_id === req.session.companyId);
   const message = req.session.orderMessage;
   req.session.orderMessage = undefined;
+  const cart = req.session.cart || [];
+  const total = cart.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0
+  );
   res.render('cart', {
-    cart: req.session.cart || [],
+    cart,
+    total,
     orderMessage: message,
     companies,
     currentCompanyId: req.session.companyId,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -4,7 +4,14 @@ declare module 'express-session' {
   interface SessionData {
     userId?: number;
     companyId?: number;
-    cart?: { productId: number; name: string; quantity: number }[];
+    cart?: {
+      productId: number;
+      name: string;
+      sku: string;
+      description: string;
+      price: number;
+      quantity: number;
+    }[];
     orderMessage?: string;
   }
 }

--- a/src/views/cart.ejs
+++ b/src/views/cart.ejs
@@ -14,18 +14,28 @@
       <% } else { %>
         <table>
           <thead>
-            <tr><th>Product</th><th>Quantity</th></tr>
+            <tr>
+              <th>Name</th>
+              <th>SKU</th>
+              <th>Description</th>
+              <th>Price</th>
+              <th>Quantity</th>
+            </tr>
           </thead>
           <tbody>
             <% cart.forEach(function(item){ %>
               <tr>
                 <td><%= item.name %></td>
+                <td><%= item.sku %></td>
+                <td><%= item.description %></td>
+                <td>$<%= item.price.toFixed(2) %></td>
                 <td><%= item.quantity %></td>
               </tr>
             <% }) %>
           </tbody>
         </table>
         <form action="/cart/place-order" method="post">
+          <p>Total: $<%= total.toFixed(2) %></p>
           <button type="submit">Place Order</button>
         </form>
       <% } %>


### PR DESCRIPTION
## Summary
- Preserve cart items in session without creating orders
- Include SKU, description and price in cart and compute total
- Display detailed cart table with order total before checkout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c72c849e0832db935caa1eb6fd3e1