### PR TITLE
Convert cart item price to number to prevent toFixed error

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -573,7 +573,8 @@ app.post('/cart/add', ensureAuth, ensureShopAccess, async (req, res) => {
         name: product.name,
         sku: product.sku,
         description: product.description,
-        price: product.price,
+        // Ensure price is stored as a number since MySQL may return strings
+        price: Number(product.price),
         quantity: parseInt(quantity, 10),
       });
     }


### PR DESCRIPTION
## Summary
- Convert product price to a number when adding items to the session cart to avoid runtime errors in the cart view.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c73e54dc0832da24238132b16c5c2