### PR TITLE
fix: ensure order prices are numeric

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -753,7 +753,10 @@ export async function getOrdersByCompany(companyId: number): Promise<OrderItem[]
     'SELECT o.*, p.name as product_name, p.price FROM shop_orders o JOIN shop_products p ON o.product_id = p.id WHERE o.company_id = ?',
     [companyId]
   );
-  return rows as OrderItem[];
+  return (rows as RowDataPacket[]).map((row) => ({
+    ...(row as any),
+    price: Number(row.price),
+  })) as OrderItem[];
 }
 
 export async function getOrderSummariesByCompany(
@@ -774,7 +777,10 @@ export async function getOrderItems(
     'SELECT o.*, p.name as product_name, p.price FROM shop_orders o JOIN shop_products p ON o.product_id = p.id WHERE o.order_number = ? AND o.company_id = ?',
     [orderNumber, companyId]
   );
-  return rows as OrderItem[];
+  return (rows as RowDataPacket[]).map((row) => ({
+    ...(row as any),
+    price: Number(row.price),
+  })) as OrderItem[];
 }
 
 export async function getExternalApiSettings(


### PR DESCRIPTION
## Summary
- parse price fields into numbers for order queries so templates can use `toFixed`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c7a80d0ec832d9b51f09621d7b605