### PR TITLE
Display product details in order view

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -73,6 +73,9 @@ export interface OrderItem {
   quantity: number;
   order_date: Date;
   product_name: string;
+  sku: string;
+  description: string;
+  image_url: string | null;
   price: number;
 }
 
@@ -750,7 +753,7 @@ export async function createOrder(
 
 export async function getOrdersByCompany(companyId: number): Promise<OrderItem[]> {
   const [rows] = await pool.query<RowDataPacket[]>(
-    'SELECT o.*, p.name as product_name, p.price FROM shop_orders o JOIN shop_products p ON o.product_id = p.id WHERE o.company_id = ?',
+    'SELECT o.*, p.name as product_name, p.price, p.sku, p.description, p.image_url FROM shop_orders o JOIN shop_products p ON o.product_id = p.id WHERE o.company_id = ?',
     [companyId]
   );
   return (rows as RowDataPacket[]).map((row) => ({
@@ -774,7 +777,7 @@ export async function getOrderItems(
   companyId: number
 ): Promise<OrderItem[]> {
   const [rows] = await pool.query<RowDataPacket[]>(
-    'SELECT o.*, p.name as product_name, p.price FROM shop_orders o JOIN shop_products p ON o.product_id = p.id WHERE o.order_number = ? AND o.company_id = ?',
+    'SELECT o.*, p.name as product_name, p.price, p.sku, p.description, p.image_url FROM shop_orders o JOIN shop_products p ON o.product_id = p.id WHERE o.order_number = ? AND o.company_id = ?',
     [orderNumber, companyId]
   );
   return (rows as RowDataPacket[]).map((row) => ({

--- a/src/views/order-details.ejs
+++ b/src/views/order-details.ejs
@@ -11,12 +11,22 @@
         <% } else { %>
           <table>
             <thead>
-              <tr><th>Product</th><th>Quantity</th><th>Price</th></tr>
+              <tr>
+                <th>Image</th>
+                <th>Product</th>
+                <th>SKU</th>
+                <th>Description</th>
+                <th>Quantity</th>
+                <th>Price</th>
+              </tr>
             </thead>
             <tbody>
               <% items.forEach(function(item){ %>
                 <tr>
+                  <td><% if (item.image_url) { %><img src="<%= item.image_url %>" width="50" alt=""><% } %></td>
                   <td><%= item.product_name %></td>
+                  <td><%= item.sku %></td>
+                  <td><%- item.description.replace(/\n/g, '<br>') %></td>
                   <td><%= item.quantity %></td>
                   <td>$<%= item.price.toFixed(2) %></td>
                 </tr>


### PR DESCRIPTION
## Summary
- include product SKU, description, and image URL in order item queries
- show product image, SKU, and description on order details page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c7bcdfea4832d88346ea32ad50a23