### PR TITLE
Fix license editing without API key

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -464,6 +464,23 @@ app.post('/licenses/:id/remove', ensureAuth, async (req, res) => {
   res.json({ success: true });
 });
 
+app.put('/licenses/:id', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  const { name, platform, count, expiryDate, contractTerm } = req.body;
+  if (!req.session.companyId) {
+    return res.status(400).json({ error: 'No company selected' });
+  }
+  await updateLicense(
+    parseInt(req.params.id, 10),
+    req.session.companyId!,
+    name,
+    platform,
+    count,
+    expiryDate,
+    contractTerm
+  );
+  res.json({ success: true });
+});
+
 app.get('/staff', ensureAuth, ensureStaffAccess, async (req, res) => {
   const companies = await getCompaniesForUser(req.session.userId!);
   const staff = req.session.companyId

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -170,14 +170,13 @@
     editForm.addEventListener('submit', async function (e) {
       e.preventDefault();
       const payload = {
-        companyId: currentCompanyId,
         name: document.getElementById('edit-name').value,
         platform: document.getElementById('edit-sku').value,
         count: parseInt(document.getElementById('edit-count').value, 10),
         expiryDate: document.getElementById('edit-expiry').value,
         contractTerm: document.getElementById('edit-contract').value,
       };
-      const res = await fetch(`/api/licenses/${editingId}`, {
+      const res = await fetch(`/licenses/${editingId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- Allow super admins to update licenses through a regular authenticated route
- Adjust license edit form to use new endpoint without API key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c83f3aa34832dbc20f34e820b8e54