### PR TITLE
Fix license editing without API key

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -511,7 +511,7 @@ export async function updateLicense(
   name: string,
   platform: string,
   count: number,
-  expiryDate: string,
+  expiryDate: string | null,
   contractTerm: string
 ): Promise<void> {
   await pool.execute(

--- a/src/server.ts
+++ b/src/server.ts
@@ -464,6 +464,23 @@ app.post('/licenses/:id/remove', ensureAuth, async (req, res) => {
   res.json({ success: true });
 });
 
+app.put('/licenses/:id', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  const { name, platform, count, expiryDate, contractTerm } = req.body;
+  if (!req.session.companyId) {
+    return res.status(400).json({ error: 'No company selected' });
+  }
+  await updateLicense(
+    parseInt(req.params.id, 10),
+    req.session.companyId!,
+    name,
+    platform,
+    count,
+    expiryDate || null,
+    contractTerm
+  );
+  res.json({ success: true });
+});
+
 app.get('/staff', ensureAuth, ensureStaffAccess, async (req, res) => {
   const companies = await getCompaniesForUser(req.session.userId!);
   const staff = req.session.companyId
@@ -2155,6 +2172,7 @@ api.get('/licenses/:id', async (req, res) => {
  *               expiryDate:
  *                 type: string
  *                 format: date
+ *                 nullable: true
  *               contractTerm:
  *                 type: string
  *     responses:
@@ -2169,7 +2187,7 @@ api.put('/licenses/:id', async (req, res) => {
     name,
     platform,
     count,
-    expiryDate,
+    expiryDate || null,
     contractTerm
   );
   res.json({ success: true });

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -36,7 +36,7 @@
                     data-name="<%= lic.name %>"
                     data-sku="<%= lic.platform %>"
                     data-count="<%= lic.count %>"
-                    data-expiry-date="<%= lic.expiry_date %>"
+                    data-expiry-date="<%= lic.expiry_date ? new Date(lic.expiry_date).toISOString().split('T')[0] : '' %>"
                     data-contract-term="<%= lic.contract_term %>"
                   >Edit</button>
                 <% } %>
@@ -170,14 +170,13 @@
     editForm.addEventListener('submit', async function (e) {
       e.preventDefault();
       const payload = {
-        companyId: currentCompanyId,
         name: document.getElementById('edit-name').value,
         platform: document.getElementById('edit-sku').value,
         count: parseInt(document.getElementById('edit-count').value, 10),
-        expiryDate: document.getElementById('edit-expiry').value,
+        expiryDate: document.getElementById('edit-expiry').value || null,
         contractTerm: document.getElementById('edit-contract').value,
       };
-      const res = await fetch(`/api/licenses/${editingId}`, {
+      const res = await fetch(`/licenses/${editingId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- Allow super admins to update licenses through a regular authenticated route
- Adjust license edit form to use new endpoint without API key
- Permit license updates without an expiry date
- Preload current expiry date into the edit modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c83f3aa34832dbc20f34e820b8e54