### PR TITLE
feat: add product deletion

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -772,6 +772,10 @@ export async function unarchiveProduct(id: number): Promise<void> {
   await pool.execute('UPDATE shop_products SET archived = 0 WHERE id = ?', [id]);
 }
 
+export async function deleteProduct(id: number): Promise<void> {
+  await pool.execute('DELETE FROM shop_products WHERE id = ?', [id]);
+}
+
 export async function createOrder(
   userId: number,
   companyId: number,

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,7 @@ import {
   updateProduct,
   archiveProduct,
   unarchiveProduct,
+  deleteProduct,
   createOrder,
   getOrdersByCompany,
   getOrderSummariesByCompany,
@@ -834,6 +835,11 @@ app.post('/shop/admin/product/:id/unarchive', ensureAuth, ensureSuperAdmin, asyn
   res.redirect('/shop/admin?showArchived=1');
 });
 
+app.post('/shop/admin/product/:id/delete', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  await deleteProduct(parseInt(req.params.id, 10));
+  res.redirect('/shop/admin');
+});
+
 app.post('/switch-company', ensureAuth, async (req, res) => {
   const { companyId } = req.body;
   const companies = await getCompaniesForUser(req.session.userId!);
@@ -1467,7 +1473,7 @@ api.route('/shop/products/:id')
     res.json({ success: true });
   })
   .delete(async (req, res) => {
-    await archiveProduct(parseInt(req.params.id, 10));
+    await deleteProduct(parseInt(req.params.id, 10));
     res.json({ success: true });
   });
 

--- a/src/views/shop-admin.ejs
+++ b/src/views/shop-admin.ejs
@@ -65,6 +65,9 @@
                   <form action="/shop/admin/product/<%= p.id %>/<%= p.archived ? 'unarchive' : 'archive' %>" method="post" style="display:inline-block">
                     <button type="submit"><%= p.archived ? 'Unarchive' : 'Archive' %></button>
                   </form>
+                  <form action="/shop/admin/product/<%= p.id %>/delete" method="post" style="display:inline-block" onsubmit="return confirm('Are you sure you want to delete this product?');">
+                    <button type="submit">Delete</button>
+                  </form>
                 </td>
               </tr>
               <form id="form-<%= p.id %>" action="/shop/admin/product/<%= p.id %>" method="post" enctype="multipart/form-data"></form>


### PR DESCRIPTION
## Summary
- allow administrators to delete products from database
- expose product deletion via API and admin interface

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c8a65dd80832d991a49c2db7d41ac