### PR TITLE
feat: restrict shop products per company

### DIFF
--- a/migrations/019_product_exclusions.sql
+++ b/migrations/019_product_exclusions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS shop_product_exclusions (
+  product_id INT NOT NULL,
+  company_id INT NOT NULL,
+  PRIMARY KEY (product_id, company_id),
+  FOREIGN KEY (product_id) REFERENCES shop_products(id) ON DELETE CASCADE,
+  FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE
+);

--- a/src/views/shop-admin.ejs
+++ b/src/views/shop-admin.ejs
@@ -68,6 +68,20 @@
                   <form action="/shop/admin/product/<%= p.id %>/delete" method="post" style="display:inline-block" onsubmit="return confirm('Are you sure you want to delete this product?');">
                     <button type="submit">Delete</button>
                   </form>
+                  <form action="/shop/admin/product/<%= p.id %>/remove-company" method="post" style="display:inline-block">
+                    <select name="company_id">
+                      <% allCompanies.forEach(function(c){ %>
+                        <option value="<%= c.id %>"><%= c.name %></option>
+                      <% }) %>
+                    </select>
+                    <button type="submit">Remove for Company</button>
+                  </form>
+                  <% (productRestrictions[p.id] || []).forEach(function(r){ %>
+                    <form action="/shop/admin/product/<%= p.id %>/add-company" method="post" style="display:inline-block">
+                      <input type="hidden" name="company_id" value="<%= r.company_id %>">
+                      <button type="submit">Add <%= r.company_name %></button>
+                    </form>
+                  <% }) %>
                 </td>
               </tr>
             <% }) %>


### PR DESCRIPTION
## Summary
- add table to track shop product exclusions by company
- allow shop and API routes to filter products based on company visibility
- let admins remove or restore products for specific companies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c8cc490fc832db07385f15a8bbb8a