### PR TITLE
feat: restrict shop products per company

### DIFF
--- a/migrations/019_product_exclusions.sql
+++ b/migrations/019_product_exclusions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS shop_product_exclusions (
+  product_id INT NOT NULL,
+  company_id INT NOT NULL,
+  PRIMARY KEY (product_id, company_id),
+  FOREIGN KEY (product_id) REFERENCES shop_products(id) ON DELETE CASCADE,
+  FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE
+);

--- a/src/views/shop-admin.ejs
+++ b/src/views/shop-admin.ejs
@@ -68,6 +68,7 @@
                   <form action="/shop/admin/product/<%= p.id %>/delete" method="post" style="display:inline-block" onsubmit="return confirm('Are you sure you want to delete this product?');">
                     <button type="submit">Delete</button>
                   </form>
+                  <button type="button" class="manage-companies" data-product-id="<%= p.id %>">Manage Companies</button>
                 </td>
               </tr>
             <% }) %>
@@ -75,6 +76,38 @@
         </table>
         <% products.forEach(function(p){ %>
           <form id="form-<%= p.id %>" action="/shop/admin/product/<%= p.id %>" method="post" enctype="multipart/form-data"></form>
+        <% }) %>
+        <% products.forEach(function(p){ %>
+          <div id="company-modal-<%= p.id %>" class="modal" style="display:none;">
+            <div class="modal-content">
+              <span class="close">&times;</span>
+              <h3>Manage Companies for <%= p.name %></h3>
+              <p>Excluded Companies:</p>
+              <ul>
+                <% const restrictions = productRestrictions[p.id] || []; %>
+                <% if (restrictions.length === 0) { %>
+                  <li>None</li>
+                <% } %>
+                <% restrictions.forEach(function(r){ %>
+                  <li>
+                    <form action="/shop/admin/product/<%= p.id %>/add-company" method="post" style="display:inline;">
+                      <input type="hidden" name="company_id" value="<%= r.company_id %>">
+                      <button type="submit">Add <%= r.company_name %></button>
+                    </form>
+                  </li>
+                <% }) %>
+              </ul>
+              <form action="/shop/admin/product/<%= p.id %>/remove-company" method="post">
+                <input type="text" name="company_id" list="company-list-<%= p.id %>" placeholder="Company ID">
+                <datalist id="company-list-<%= p.id %>">
+                  <% allCompanies.forEach(function(c){ %>
+                    <option value="<%= c.id %>" label="<%= c.name %>"></option>
+                  <% }) %>
+                </datalist>
+                <button type="submit">Exclude</button>
+              </form>
+            </div>
+          </div>
         <% }) %>
         <script>
           const searchInput = document.getElementById('search');
@@ -104,6 +137,23 @@
               url.searchParams.delete('showArchived');
             }
             window.location.href = url.toString();
+          });
+          document.querySelectorAll('.manage-companies').forEach(btn => {
+            btn.addEventListener('click', () => {
+              document.getElementById(`company-modal-${btn.dataset.productId}`).style.display = 'flex';
+            });
+          });
+          document.querySelectorAll('.modal .close').forEach(btn => {
+            btn.addEventListener('click', () => {
+              btn.closest('.modal').style.display = 'none';
+            });
+          });
+          document.querySelectorAll('.modal').forEach(modal => {
+            modal.addEventListener('click', (e) => {
+              if (e.target === modal) {
+                modal.style.display = 'none';
+              }
+            });
           });
         </script>
       </section>


### PR DESCRIPTION
## Summary
- add table to track shop product exclusions by company
- allow shop and API routes to filter products based on company visibility
- let admins remove or restore products for specific companies
- manage company restrictions in a modal with an exclude text box

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c8cc490fc832db07385f15a8bbb8a