### PR TITLE
feat: manage product visibility via modal

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -857,6 +857,27 @@ export async function getProductCompanyRestrictions(): Promise<
   return rows as ProductCompanyRestriction[];
 }
 
+export async function setProductCompanyExclusions(
+  productId: number,
+  companyIds: number[]
+): Promise<void> {
+  await pool.execute('DELETE FROM shop_product_exclusions WHERE product_id = ?', [
+    productId,
+  ]);
+  if (companyIds.length === 0) {
+    return;
+  }
+  const values = companyIds.map(() => '(?, ?)').join(', ');
+  const params: (number | string)[] = [];
+  companyIds.forEach((id) => {
+    params.push(productId, id);
+  });
+  await pool.execute(
+    `INSERT INTO shop_product_exclusions (product_id, company_id) VALUES ${values}`,
+    params
+  );
+}
+
 export async function createOrder(
   userId: number,
   companyId: number,

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,9 +61,8 @@ import {
   archiveProduct,
   unarchiveProduct,
   deleteProduct,
-  removeProductForCompany,
-  addProductForCompany,
   getProductCompanyRestrictions,
+  setProductCompanyExclusions,
   createOrder,
   getOrdersByCompany,
   getOrderSummariesByCompany,
@@ -862,23 +861,17 @@ app.post('/shop/admin/product/:id/delete', ensureAuth, ensureSuperAdmin, async (
 });
 
 app.post(
-  '/shop/admin/product/:id/remove-company',
+  '/shop/admin/product/:id/visibility',
   ensureAuth,
   ensureSuperAdmin,
   async (req, res) => {
-    const companyId = parseInt(req.body.company_id, 10);
-    await removeProductForCompany(parseInt(req.params.id, 10), companyId);
-    res.redirect('/shop/admin');
-  }
-);
-
-app.post(
-  '/shop/admin/product/:id/add-company',
-  ensureAuth,
-  ensureSuperAdmin,
-  async (req, res) => {
-    const companyId = parseInt(req.body.company_id, 10);
-    await addProductForCompany(parseInt(req.params.id, 10), companyId);
+    const body = req.body.excluded;
+    const ids = Array.isArray(body) ? body : body ? [body] : [];
+    const companyIds = ids.map((id: string) => parseInt(id, 10)).filter((n) => !isNaN(n));
+    await setProductCompanyExclusions(
+      parseInt(req.params.id, 10),
+      companyIds
+    );
     res.redirect('/shop/admin');
   }
 );

--- a/src/views/shop-admin.ejs
+++ b/src/views/shop-admin.ejs
@@ -68,20 +68,7 @@
                   <form action="/shop/admin/product/<%= p.id %>/delete" method="post" style="display:inline-block" onsubmit="return confirm('Are you sure you want to delete this product?');">
                     <button type="submit">Delete</button>
                   </form>
-                  <form action="/shop/admin/product/<%= p.id %>/remove-company" method="post" style="display:inline-block">
-                    <select name="company_id">
-                      <% allCompanies.forEach(function(c){ %>
-                        <option value="<%= c.id %>"><%= c.name %></option>
-                      <% }) %>
-                    </select>
-                    <button type="submit">Remove for Company</button>
-                  </form>
-                  <% (productRestrictions[p.id] || []).forEach(function(r){ %>
-                    <form action="/shop/admin/product/<%= p.id %>/add-company" method="post" style="display:inline-block">
-                      <input type="hidden" name="company_id" value="<%= r.company_id %>">
-                      <button type="submit">Add <%= r.company_name %></button>
-                    </form>
-                  <% }) %>
+                  <button type="button" onclick="openVisibilityModal(<%= p.id %>)">Visibility</button>
                 </td>
               </tr>
             <% }) %>
@@ -119,7 +106,33 @@
             }
             window.location.href = url.toString();
           });
+          const productRestrictions = <%- JSON.stringify(productRestrictions) %>;
+          function openVisibilityModal(id) {
+            const modal = document.getElementById('visibilityModal');
+            const form = document.getElementById('visibilityForm');
+            form.action = `/shop/admin/product/${id}/visibility`;
+            const selected = (productRestrictions[id] || []).map(r => r.company_id);
+            form.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+              cb.checked = selected.includes(parseInt(cb.value, 10));
+            });
+            modal.style.display = 'block';
+          }
+          function closeVisibilityModal() {
+            document.getElementById('visibilityModal').style.display = 'none';
+          }
         </script>
+        <div id="visibilityModal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5);">
+          <div style="background:#fff; margin:10% auto; padding:20px; width:300px;">
+            <h3>Product Visibility</h3>
+            <form id="visibilityForm" method="post">
+              <% allCompanies.forEach(function(c){ %>
+                <label><input type="checkbox" name="excluded" value="<%= c.id %>"> <%= c.name %></label><br>
+              <% }) %>
+              <button type="submit">Save</button>
+              <button type="button" onclick="closeVisibilityModal()">Close</button>
+            </form>
+          </div>
+        </div>
       </section>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add endpoint to set excluded companies for a product
- replace per-company forms with a visibility modal in admin view
- update database queries to support bulk exclusion updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c912f2a88832da9de40c8428b6508