### PR TITLE
Add product categories with CRUD API and shop filtering

### DIFF
--- a/migrations/020_shop_categories.sql
+++ b/migrations/020_shop_categories.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS shop_categories (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL UNIQUE
+);
+
+ALTER TABLE shop_products ADD COLUMN IF NOT EXISTS category_id INT NULL;
+ALTER TABLE shop_products ADD CONSTRAINT fk_shop_products_category FOREIGN KEY (category_id) REFERENCES shop_categories(id) ON DELETE SET NULL;

--- a/src/views/shop-admin.ejs
+++ b/src/views/shop-admin.ejs
@@ -7,6 +7,23 @@
     <div class="content">
       <h1>Shop Admin</h1>
       <section>
+        <h2>Categories</h2>
+        <form action="/shop/admin/category" method="post">
+          <input type="text" name="name" placeholder="Name" required>
+          <button type="submit">Add</button>
+        </form>
+        <ul>
+          <% categories.forEach(function(c){ %>
+            <li>
+              <%= c.name %>
+              <form action="/shop/admin/category/<%= c.id %>/delete" method="post" style="display:inline" onsubmit="return confirm('Delete category?');">
+                <button type="submit">Delete</button>
+              </form>
+            </li>
+          <% }) %>
+        </ul>
+      </section>
+      <section>
         <h2>Add Product</h2>
         <form action="/shop/admin/product" method="post" enctype="multipart/form-data">
           <input type="text" name="name" placeholder="Name" required>
@@ -16,6 +33,12 @@
           <input type="number" step="0.01" name="price" placeholder="Price" required>
           <input type="number" step="0.01" name="vip_price" placeholder="VIP Price">
           <input type="number" name="stock" placeholder="Stock" required>
+          <select name="category_id">
+            <option value="">No Category</option>
+            <% categories.forEach(function(c){ %>
+              <option value="<%= c.id %>"><%= c.name %></option>
+            <% }) %>
+          </select>
           <input type="file" name="image">
           <button type="submit">Add</button>
         </form>
@@ -38,6 +61,7 @@
               <th>Vendor SKU</th>
               <th>Price</th>
               <th>VIP Price</th>
+              <th>Category</th>
               <th>Stock</th>
               <th>Actions</th>
             </tr>
@@ -56,6 +80,7 @@
                 <td><%= p.vendor_sku %></td>
                 <td><%= p.price %></td>
                 <td><%= p.vip_price !== null ? p.vip_price : '' %></td>
+                <td><%= p.category_name || '' %></td>
                 <td><%= p.stock %></td>
                 <td>
                   <button type="button" onclick="openEditModal(<%= p.id %>)">Edit</button>
@@ -114,6 +139,7 @@
             form.price.value = product.price;
             form.vip_price.value = product.vip_price !== null ? product.vip_price : '';
             form.stock.value = product.stock;
+            form.category_id.value = product.category_id || '';
             const img = document.getElementById('editImagePreview');
             if (product.image_url) {
               img.src = product.image_url;
@@ -148,13 +174,19 @@
               <input type="text" name="sku" placeholder="SKU" required>
               <input type="text" name="vendor_sku" placeholder="Vendor SKU" required>
               <textarea name="description" placeholder="Description"></textarea>
-              <input type="number" step="0.01" name="price" placeholder="Price" required>
-              <input type="number" step="0.01" name="vip_price" placeholder="VIP Price">
-              <input type="number" name="stock" placeholder="Stock" required>
-              <img id="editImagePreview" src="" width="100" alt="" style="display:none;"><br>
-              <input type="file" name="image">
-              <button type="submit">Save</button>
-              <button type="button" onclick="closeEditModal()">Close</button>
+            <input type="number" step="0.01" name="price" placeholder="Price" required>
+            <input type="number" step="0.01" name="vip_price" placeholder="VIP Price">
+            <input type="number" name="stock" placeholder="Stock" required>
+            <select name="category_id">
+              <option value="">No Category</option>
+              <% categories.forEach(function(c){ %>
+                <option value="<%= c.id %>"><%= c.name %></option>
+              <% }) %>
+            </select>
+            <img id="editImagePreview" src="" width="100" alt="" style="display:none;"><br>
+            <input type="file" name="image">
+            <button type="submit">Save</button>
+            <button type="button" onclick="closeEditModal()">Close</button>
             </form>
           </div>
         </div>

--- a/src/views/shop.ejs
+++ b/src/views/shop.ejs
@@ -9,6 +9,16 @@
       <% if (cartError) { %>
         <p><%= cartError %></p>
       <% } %>
+      <form method="get">
+        <label>Category:
+          <select name="category" onchange="this.form.submit()">
+            <option value="" <%= typeof currentCategory === 'undefined' ? 'selected' : '' %>>All</option>
+            <% categories.forEach(function(c){ %>
+              <option value="<%= c.id %>" <%= currentCategory === c.id ? 'selected' : '' %>><%= c.name %></option>
+            <% }) %>
+          </select>
+        </label>
+      </form>
       <table>
         <thead>
           <tr><th>Image</th><th>Name</th><th>SKU</th><th>Description</th><th>Price</th><th>Stock</th><th>Order</th></tr>


### PR DESCRIPTION
## Summary
- introduce `shop_categories` table and link products to a single category
- extend queries and APIs to manage categories and filter products by category
- add admin UI and shop page dropdown to create, assign, and browse categories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c94351b14832d866ba372508971c2