### PR TITLE
Add order status, notes, and PO number with order API

### DIFF
--- a/migrations/021_add_status_notes_po_number.sql
+++ b/migrations/021_add_status_notes_po_number.sql
@@ -1,0 +1,4 @@
+ALTER TABLE shop_orders
+  ADD COLUMN status VARCHAR(50) NOT NULL DEFAULT 'pending',
+  ADD COLUMN notes TEXT,
+  ADD COLUMN po_number VARCHAR(50);

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -89,6 +89,9 @@ export interface OrderItem {
   product_id: number;
   quantity: number;
   order_date: Date;
+  status: string;
+  notes: string | null;
+  po_number: string | null;
   product_name: string;
   sku: string;
   description: string;
@@ -99,6 +102,9 @@ export interface OrderItem {
 export interface OrderSummary {
   order_number: string;
   order_date: Date;
+  status: string;
+  notes: string | null;
+  po_number: string | null;
 }
 
 export interface Asset {
@@ -964,14 +970,15 @@ export async function createOrder(
   companyId: number,
   productId: number,
   quantity: number,
-  orderNumber: string
+  orderNumber: string,
+  poNumber: string | null
 ): Promise<void> {
   const conn = await pool.getConnection();
   try {
     await conn.beginTransaction();
     await conn.execute(
-      'INSERT INTO shop_orders (user_id, company_id, product_id, quantity, order_number) VALUES (?, ?, ?, ?, ?)',
-      [userId, companyId, productId, quantity, orderNumber]
+      'INSERT INTO shop_orders (user_id, company_id, product_id, quantity, order_number, status, notes, po_number) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      [userId, companyId, productId, quantity, orderNumber, 'pending', null, poNumber]
     );
     await conn.execute(
       'UPDATE shop_products SET stock = stock - ? WHERE id = ?',
@@ -1005,7 +1012,8 @@ export async function getOrderSummariesByCompany(
   companyId: number
 ): Promise<OrderSummary[]> {
   const [rows] = await pool.query<RowDataPacket[]>(
-    'SELECT order_number, MAX(order_date) as order_date FROM shop_orders WHERE company_id = ? GROUP BY order_number ORDER BY order_date DESC',
+    `SELECT order_number, MAX(order_date) as order_date, MAX(status) as status, MAX(notes) as notes, MAX(po_number) as po_number
+     FROM shop_orders WHERE company_id = ? GROUP BY order_number ORDER BY order_date DESC`,
     [companyId]
   );
   return rows as OrderSummary[];
@@ -1051,6 +1059,18 @@ export async function deleteOrder(
   } finally {
     conn.release();
   }
+}
+
+export async function updateOrder(
+  orderNumber: string,
+  companyId: number,
+  status: string,
+  notes: string | null
+): Promise<void> {
+  await pool.execute(
+    'UPDATE shop_orders SET status = ?, notes = ? WHERE order_number = ? AND company_id = ?',
+    [status, notes, orderNumber, companyId]
+  );
 }
 
 export async function getExternalApiSettings(

--- a/src/views/cart.ejs
+++ b/src/views/cart.ejs
@@ -43,6 +43,7 @@
         </form>
         <form action="/cart/place-order" method="post">
           <p>Total: $<%= total.toFixed(2) %></p>
+          <label>PO Number: <input type="text" name="poNumber" /></label>
           <button type="submit">Place Order</button>
         </form>
       <% } %>

--- a/src/views/order-details.ejs
+++ b/src/views/order-details.ejs
@@ -6,6 +6,9 @@
       <%- include('partials/sidebar') %>
       <div class="content">
         <h1>Order <%= orderNumber %></h1>
+        <p>PO Number: <%= poNumber %></p>
+        <p>Status: <%= status %></p>
+        <% if (notes) { %><p>Notes: <%= notes %></p><% } %>
         <% if (items.length === 0) { %>
           <p>No items found.</p>
         <% } else { %>

--- a/src/views/orders.ejs
+++ b/src/views/orders.ejs
@@ -13,6 +13,8 @@
           <thead>
             <tr>
               <th>Order Number</th>
+              <th>PO Number</th>
+              <th>Status</th>
               <th>Date</th>
               <% if (isSuperAdmin) { %><th>Actions</th><% } %>
             </tr>
@@ -21,6 +23,8 @@
             <% orders.forEach(function(o){ %>
               <tr>
                 <td><a href="/orders/<%= o.order_number %>"><%= o.order_number %></a></td>
+                <td><%= o.po_number %></td>
+                <td><%= o.status %></td>
                 <td><%= o.order_date.toISOString().slice(0,10) %></td>
                 <% if (isSuperAdmin) { %>
                   <td>


### PR DESCRIPTION
## Summary
- track order status, notes, and PO numbers in database
- capture PO number during checkout and display on order pages
- expose API endpoints to list, update, and delete orders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689c973085bc832daeb6bb7f8923b2c4