### PR TITLE
Add company Syncro/Xero IDs and flexible order status

### DIFF
--- a/migrations/022_add_syncro_xero_ids.sql
+++ b/migrations/022_add_syncro_xero_ids.sql
@@ -1,0 +1,2 @@
+ALTER TABLE companies ADD COLUMN syncro_company_id VARCHAR(255);
+ALTER TABLE companies ADD COLUMN xero_id VARCHAR(255);

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -14,6 +14,8 @@
         <h2>Add Company</h2>
         <form action="/admin/company" method="post">
           <input type="text" name="name" placeholder="Company Name" required>
+          <input type="text" name="syncroCompanyId" placeholder="Syncro Company ID">
+          <input type="text" name="xeroId" placeholder="Xero ID">
           <label><input type="checkbox" name="isVip" value="1"> VIP</label>
           <button type="submit">Add</button>
         </form>
@@ -21,15 +23,19 @@
       <section>
         <h2>Companies</h2>
         <table>
-          <thead><tr><th>Name</th><th>VIP</th></tr></thead>
+          <thead>
+            <tr><th>Name</th><th>Syncro Company ID</th><th>Xero ID</th><th>VIP</th><th></th></tr>
+          </thead>
           <tbody>
             <% allCompanies.forEach(function(c) { %>
               <tr>
                 <td><%= c.name %></td>
+                <td><input type="text" name="syncroCompanyId" value="<%= c.syncro_company_id || '' %>" form="c<%= c.id %>"></td>
+                <td><input type="text" name="xeroId" value="<%= c.xero_id || '' %>" form="c<%= c.id %>"></td>
+                <td><input type="checkbox" name="isVip" value="1" <%= c.is_vip ? 'checked' : '' %> form="c<%= c.id %>"></td>
                 <td>
-                  <form action="/admin/company/<%= c.id %>/vip" method="post">
-                    <input type="hidden" name="isVip" value="0">
-                    <input type="checkbox" name="isVip" value="1" <%= c.is_vip ? 'checked' : '' %> onchange="this.form.submit()">
+                  <form id="c<%= c.id %>" action="/admin/company/<%= c.id %>" method="post">
+                    <button type="submit">Save</button>
                   </form>
                 </td>
               </tr>

--- a/src/views/orders.ejs
+++ b/src/views/orders.ejs
@@ -15,6 +15,7 @@
               <th>Order Number</th>
               <th>PO Number</th>
               <th>Status</th>
+              <th>Notes</th>
               <th>Date</th>
               <% if (isSuperAdmin) { %><th>Actions</th><% } %>
             </tr>
@@ -25,6 +26,7 @@
                 <td><a href="/orders/<%= o.order_number %>"><%= o.order_number %></a></td>
                 <td><%= o.po_number %></td>
                 <td><%= o.status %></td>
+                <td><%= o.notes || '' %></td>
                 <td><%= o.order_date.toISOString().slice(0,10) %></td>
                 <% if (isSuperAdmin) { %>
                   <td>


### PR DESCRIPTION
## Summary
- allow storing Syncro Company ID and Xero ID on companies and expose fields in admin UI and API
- show order notes in the orders list
- permit arbitrary order status values, including during order creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689c9b9869e4832d984058601936dfe7