### PR TITLE
Add user forms with super-admin management

### DIFF
--- a/migrations/023_forms.sql
+++ b/migrations/023_forms.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS forms (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  url VARCHAR(1024) NOT NULL,
+  description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS form_permissions (
+  form_id INT NOT NULL,
+  user_id INT NOT NULL,
+  PRIMARY KEY (form_id, user_id),
+  FOREIGN KEY (form_id) REFERENCES forms(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -152,6 +152,24 @@ table th {
   border: none;
 }
 
+.forms-menu {
+  margin-bottom: 1rem;
+}
+
+.forms-menu button {
+  margin-right: 0.5rem;
+}
+
+.forms-menu button.active {
+  background-color: #3700b3;
+}
+
+.form-frame {
+  width: 100%;
+  height: calc(100vh - 200px);
+  border: none;
+}
+
 .modal {
   position: fixed;
   top: 0;

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -156,6 +156,13 @@ export interface ApiKey {
   expiry_date: string | null;
 }
 
+export interface Form {
+  id: number;
+  name: string;
+  url: string;
+  description: string;
+}
+
 export async function getUserByEmail(email: string): Promise<User | null> {
   const [rows] = await pool.query<RowDataPacket[]>('SELECT * FROM users WHERE email = ?', [email]);
   return (rows as User[])[0] || null;
@@ -1128,5 +1135,64 @@ export async function upsertExternalApiSettings(
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON DUPLICATE KEY UPDATE xero_endpoint = VALUES(xero_endpoint), xero_api_key = VALUES(xero_api_key), syncro_endpoint = VALUES(syncro_endpoint), syncro_api_key = VALUES(syncro_api_key), webhook_url = VALUES(webhook_url), webhook_api_key = VALUES(webhook_api_key), shop_webhook_url = VALUES(shop_webhook_url), shop_webhook_api_key = VALUES(shop_webhook_api_key)` ,
     [companyId, xeroEndpoint, xeroApiKey, syncroEndpoint, syncroApiKey, webhookUrl, webhookApiKey, shopWebhookUrl, shopWebhookApiKey]
+  );
+}
+
+export async function createForm(
+  name: string,
+  url: string,
+  description: string
+): Promise<number> {
+  const [result] = await pool.execute(
+    'INSERT INTO forms (name, url, description) VALUES (?, ?, ?)',
+    [name, url, description]
+  );
+  const insert = result as ResultSetHeader;
+  return insert.insertId;
+}
+
+export async function getAllForms(): Promise<Form[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    'SELECT * FROM forms ORDER BY name'
+  );
+  return rows as Form[];
+}
+
+export async function getFormsForUser(userId: number): Promise<Form[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    'SELECT f.* FROM forms f JOIN form_permissions fp ON f.id = fp.form_id WHERE fp.user_id = ? ORDER BY f.name',
+    [userId]
+  );
+  return rows as Form[];
+}
+
+export async function getFormPermissions(formId: number): Promise<number[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    'SELECT user_id FROM form_permissions WHERE form_id = ?',
+    [formId]
+  );
+  return (rows as RowDataPacket[]).map((r) => r.user_id as number);
+}
+
+export async function updateFormPermissions(
+  formId: number,
+  companyId: number,
+  userIds: number[]
+): Promise<void> {
+  await pool.execute(
+    'DELETE fp FROM form_permissions fp JOIN user_companies uc ON fp.user_id = uc.user_id WHERE fp.form_id = ? AND uc.company_id = ?',
+    [formId, companyId]
+  );
+  if (userIds.length === 0) {
+    return;
+  }
+  const values = userIds.map(() => '(?, ?)').join(', ');
+  const params: (number | string)[] = [];
+  userIds.forEach((id) => {
+    params.push(formId, id);
+  });
+  await pool.execute(
+    `INSERT INTO form_permissions (form_id, user_id) VALUES ${values}`,
+    params
   );
 }

--- a/src/views/forms-admin.ejs
+++ b/src/views/forms-admin.ejs
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Forms Admin' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Forms Admin</h1>
+      <section>
+        <h2>Add Form</h2>
+        <form action="/forms/admin" method="post">
+          <input type="text" name="name" placeholder="Name" required>
+          <input type="url" name="url" placeholder="URL" required>
+          <input type="text" name="description" placeholder="Description">
+          <button type="submit">Add</button>
+        </form>
+      </section>
+      <section>
+        <h2>Manage Permissions</h2>
+        <form action="/forms/admin" method="get">
+          <select name="formId" onchange="this.form.submit()">
+            <option value="">Select Form</option>
+            <% forms.forEach(function(f){ %>
+              <option value="<%= f.id %>" <%= selectedFormId === f.id ? 'selected' : '' %>><%= f.name %></option>
+            <% }); %>
+          </select>
+          <select name="companyId" onchange="this.form.submit()">
+            <option value="">Select Company</option>
+            <% allCompanies.forEach(function(c){ %>
+              <option value="<%= c.id %>" <%= selectedCompanyId === c.id ? 'selected' : '' %>><%= c.name %></option>
+            <% }); %>
+          </select>
+        </form>
+        <% if (selectedFormId && selectedCompanyId) { %>
+          <form action="/forms/admin/permissions" method="post">
+            <input type="hidden" name="formId" value="<%= selectedFormId %>">
+            <input type="hidden" name="companyId" value="<%= selectedCompanyId %>">
+            <% users.forEach(function(u){ %>
+              <label><input type="checkbox" name="userIds" value="<%= u.user_id %>" <%= permissions.includes(u.user_id) ? 'checked' : '' %>> <%= u.email %></label><br>
+            <% }); %>
+            <button type="submit">Save</button>
+          </form>
+        <% } %>
+      </section>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/forms.ejs
+++ b/src/views/forms.ejs
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Forms' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Forms</h1>
+      <% if (forms.length > 0) { %>
+        <div class="forms-menu">
+          <% forms.forEach(function(f, idx){ %>
+            <button onclick="showForm('<%= f.url %>', this)" class="<%= idx === 0 ? 'active' : '' %>"><%= f.name %></button>
+          <% }); %>
+        </div>
+        <iframe id="form-frame" class="form-frame" src="<%= forms[0].url %>"></iframe>
+      <% } else { %>
+        <p>No forms available.</p>
+      <% } %>
+    </div>
+  </div>
+  <script>
+    function showForm(url, btn) {
+      document.getElementById('form-frame').src = url;
+      document.querySelectorAll('.forms-menu button').forEach(b => b.classList.remove('active'));
+      if (btn) btn.classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -26,6 +26,7 @@
     <% if (canManageInvoices) { %>
       <a href="/invoices" class="menu-link"><i class="fas fa-file-invoice"></i> Invoices</a>
     <% } %>
+    <a href="/forms" class="menu-link"><i class="fas fa-wpforms"></i> Forms</a>
     <% if (canAccessShop) { %>
       <a href="/shop" class="menu-link"><i class="fas fa-shopping-cart"></i> Shop</a>
       <a href="/cart" class="menu-link"><i class="fas fa-shopping-basket"></i> Cart (<%= cart.reduce((sum, i) => sum + i.quantity, 0) %>)</a>
@@ -34,6 +35,7 @@
   </div>
   <div class="sidebar-bottom">
     <% if (isSuperAdmin) { %>
+      <a href="/forms/admin" class="menu-link"><i class="fas fa-wpforms"></i> Forms Admin</a>
       <a href="/apps" class="menu-link"><i class="fas fa-th-large"></i> Apps</a>
     <% } %>
     <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>


### PR DESCRIPTION
## Summary
- Add database tables for forms and per-user form permissions
- Provide super-admin Forms Admin panel to create forms and assign user access
- Introduce user Forms page with dynamic form buttons and iframe embed
- Update navigation and styles for new forms features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d1e977ae0832d903943a1227bed1e