### PR TITLE
Add user forms with admin management

### DIFF
--- a/migrations/023_forms.sql
+++ b/migrations/023_forms.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS forms (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  url VARCHAR(1024) NOT NULL,
+  description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS form_permissions (
+  form_id INT NOT NULL,
+  user_id INT NOT NULL,
+  PRIMARY KEY (form_id, user_id),
+  FOREIGN KEY (form_id) REFERENCES forms(id) ON DELETE CASCADE,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -152,6 +152,24 @@ table th {
   border: none;
 }
 
+.forms-menu {
+  margin-bottom: 1rem;
+}
+
+.forms-menu button {
+  margin-right: 0.5rem;
+}
+
+.forms-menu button.active {
+  background-color: #3700b3;
+}
+
+.form-frame {
+  width: 100%;
+  height: calc(100vh - 200px);
+  border: none;
+}
+
 .modal {
   position: fixed;
   top: 0;

--- a/src/views/forms-admin.ejs
+++ b/src/views/forms-admin.ejs
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Forms Admin' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Forms Admin</h1>
+      <% if (isSuperAdmin) { %>
+      <section>
+        <h2>Add Form</h2>
+        <form action="/forms/admin" method="post">
+          <input type="text" name="name" placeholder="Name" required>
+          <input type="url" name="url" placeholder="URL" required>
+          <input type="text" name="description" placeholder="Description">
+          <button type="submit">Add</button>
+        </form>
+      </section>
+      <% } %>
+
+      <section>
+        <h2>Existing Forms</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>URL</th>
+              <th>Description</th>
+              <% if (isSuperAdmin) { %><th>Actions</th><% } %>
+            </tr>
+          </thead>
+          <tbody>
+            <% forms.forEach(function(f){ %>
+            <tr>
+              <td><input form="edit-form-<%= f.id %>" type="text" name="name" value="<%= f.name %>" <%= isSuperAdmin ? '' : 'disabled' %> required></td>
+              <td><input form="edit-form-<%= f.id %>" type="url" name="url" value="<%= f.url %>" <%= isSuperAdmin ? '' : 'disabled' %> required></td>
+              <td><input form="edit-form-<%= f.id %>" type="text" name="description" value="<%= f.description %>" <%= isSuperAdmin ? '' : 'disabled' %>></td>
+              <% if (isSuperAdmin) { %>
+              <td>
+                <form id="edit-form-<%= f.id %>" action="/forms/admin/form/<%= f.id %>" method="post">
+                  <button type="submit">Save</button>
+                </form>
+              </td>
+              <% } %>
+            </tr>
+            <% }); %>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Manage Permissions</h2>
+        <form action="/forms/admin" method="get">
+          <select name="formId" onchange="this.form.submit()">
+            <option value="">Select Form</option>
+            <% forms.forEach(function(f){ %>
+              <option value="<%= f.id %>" <%= selectedFormId === f.id ? 'selected' : '' %>><%= f.name %></option>
+            <% }); %>
+          </select>
+          <% if (isSuperAdmin) { %>
+          <select name="companyId" onchange="this.form.submit()">
+            <option value="">Select Company</option>
+            <% allCompanies.forEach(function(c){ %>
+              <option value="<%= c.id %>" <%= selectedCompanyId === c.id ? 'selected' : '' %>><%= c.name %></option>
+            <% }); %>
+          </select>
+          <% } else { %>
+          <input type="hidden" name="companyId" value="<%= currentCompanyId %>">
+          <% } %>
+        </form>
+        <% if (selectedFormId && selectedCompanyId) { %>
+          <form action="/forms/admin/permissions" method="post">
+            <input type="hidden" name="formId" value="<%= selectedFormId %>">
+            <input type="hidden" name="companyId" value="<%= selectedCompanyId %>">
+            <% users.forEach(function(u){ %>
+              <label><input type="checkbox" name="userIds" value="<%= u.user_id %>" <%= permissions.includes(u.user_id) ? 'checked' : '' %>> <%= u.email %></label><br>
+            <% }); %>
+            <button type="submit">Save</button>
+          </form>
+        <% } %>
+      </section>
+
+      <section>
+        <h2>Current Permissions</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Form</th>
+              <th>Company</th>
+              <th>User</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% permissionDetails.forEach(function(p){ %>
+            <tr>
+              <td><%= p.form_name %></td>
+              <td><%= p.company_name %></td>
+              <td><%= p.user_name %></td>
+              <td>
+                <% if (isSuperAdmin || p.company_id === currentCompanyId) { %>
+                <form action="/forms/admin/permissions/remove" method="post" style="display:inline;">
+                  <input type="hidden" name="formId" value="<%= p.form_id %>">
+                  <input type="hidden" name="userId" value="<%= p.user_id %>">
+                  <button type="submit">Remove</button>
+                </form>
+                <% } %>
+              </td>
+            </tr>
+            <% }); %>
+          </tbody>
+        </table>
+      </section>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/forms.ejs
+++ b/src/views/forms.ejs
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Forms' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Forms</h1>
+      <% if (forms.length > 0) { %>
+        <div class="forms-menu">
+          <% forms.forEach(function(f, idx){ %>
+            <button onclick="showForm('<%= f.url %>', this)" class="<%= idx === 0 ? 'active' : '' %>"><%= f.name %></button>
+          <% }); %>
+        </div>
+        <iframe id="form-frame" class="form-frame" src="<%= forms[0].url %>"></iframe>
+      <% } else { %>
+        <p>No forms available.</p>
+      <% } %>
+    </div>
+  </div>
+  <script>
+    function showForm(url, btn) {
+      document.getElementById('form-frame').src = url;
+      document.querySelectorAll('.forms-menu button').forEach(b => b.classList.remove('active'));
+      if (btn) btn.classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -26,6 +26,7 @@
     <% if (canManageInvoices) { %>
       <a href="/invoices" class="menu-link"><i class="fas fa-file-invoice"></i> Invoices</a>
     <% } %>
+    <a href="/forms" class="menu-link"><i class="fas fa-wpforms"></i> Forms</a>
     <% if (canAccessShop) { %>
       <a href="/shop" class="menu-link"><i class="fas fa-shopping-cart"></i> Shop</a>
       <a href="/cart" class="menu-link"><i class="fas fa-shopping-basket"></i> Cart (<%= cart.reduce((sum, i) => sum + i.quantity, 0) %>)</a>
@@ -33,6 +34,9 @@
     <% } %>
   </div>
   <div class="sidebar-bottom">
+    <% if (isSuperAdmin || (typeof isAdmin !== 'undefined' && isAdmin)) { %>
+      <a href="/forms/admin" class="menu-link"><i class="fas fa-wpforms"></i> Forms Admin</a>
+    <% } %>
     <% if (isSuperAdmin) { %>
       <a href="/apps" class="menu-link"><i class="fas fa-th-large"></i> Apps</a>
     <% } %>


### PR DESCRIPTION
## Summary
- Allow company admins to access Forms Admin
- Let super admins edit existing forms and everyone view form-to-user assignments
- Enable removing form permissions directly from the admin page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d1e977ae0832d903943a1227bed1e