### PR TITLE
feat: enhance forms admin management

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1151,6 +1151,18 @@ export async function createForm(
   return insert.insertId;
 }
 
+export async function updateForm(
+  id: number,
+  name: string,
+  url: string,
+  description: string
+): Promise<void> {
+  await pool.execute(
+    'UPDATE forms SET name = ?, url = ?, description = ? WHERE id = ?',
+    [name, url, description, id]
+  );
+}
+
 export async function getAllForms(): Promise<Form[]> {
   const [rows] = await pool.query<RowDataPacket[]>(
     'SELECT * FROM forms ORDER BY name'
@@ -1194,5 +1206,29 @@ export async function updateFormPermissions(
   await pool.execute(
     `INSERT INTO form_permissions (form_id, user_id) VALUES ${values}`,
     params
+  );
+}
+
+export interface FormPermissionEntry {
+  form_id: number;
+  form_name: string;
+  user_id: number;
+  email: string;
+}
+
+export async function getAllFormPermissionEntries(): Promise<FormPermissionEntry[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    'SELECT fp.form_id, f.name AS form_name, fp.user_id, u.email FROM form_permissions fp JOIN forms f ON fp.form_id = f.id JOIN users u ON fp.user_id = u.id ORDER BY u.email, f.name'
+  );
+  return rows as FormPermissionEntry[];
+}
+
+export async function deleteFormPermission(
+  formId: number,
+  userId: number
+): Promise<void> {
+  await pool.execute(
+    'DELETE FROM form_permissions WHERE form_id = ? AND user_id = ?',
+    [formId, userId]
   );
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,11 +53,14 @@ import {
   getInvoiceById,
   updateInvoice,
   deleteInvoice,
-  getAllForms,
-  createForm,
-  getFormsForUser,
-  getFormPermissions,
-  updateFormPermissions,
+    getAllForms,
+    createForm,
+    updateForm,
+    getFormsForUser,
+    getFormPermissions,
+    updateFormPermissions,
+    getAllFormPermissionEntries,
+    deleteFormPermission,
   getAllCategories,
   getCategoryById,
   createCategory,
@@ -1024,11 +1027,13 @@ app.get('/forms/admin', ensureAuth, ensureSuperAdmin, async (req, res) => {
     users = await getUserCompanyAssignments(companyId);
     permissions = await getFormPermissions(formId);
   }
+  const formAccess = await getAllFormPermissionEntries();
   res.render('forms-admin', {
     forms,
     allCompanies,
     companies: companiesForUser,
     users,
+    formAccess,
     selectedFormId: isNaN(formId) ? null : formId,
     selectedCompanyId: isNaN(companyId) ? null : companyId,
     permissions,
@@ -1064,6 +1069,23 @@ app.post('/forms/admin/permissions', ensureAuth, ensureSuperAdmin, async (req, r
   );
   res.redirect(`/forms/admin?formId=${formId}&companyId=${companyId}`);
 });
+
+app.post('/forms/admin/edit', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  const { id, name, url, description } = req.body;
+  await updateForm(parseInt(id, 10), name, url, description);
+  res.redirect('/forms/admin');
+});
+
+app.post(
+  '/forms/admin/permissions/delete',
+  ensureAuth,
+  ensureSuperAdmin,
+  async (req, res) => {
+    const { formId, userId } = req.body;
+    await deleteFormPermission(parseInt(formId, 10), parseInt(userId, 10));
+    res.redirect('/forms/admin');
+  }
+);
 
 app.get('/apps', ensureAuth, ensureSuperAdmin, async (req, res) => {
   const apps = await getAllApps();

--- a/src/views/forms-admin.ejs
+++ b/src/views/forms-admin.ejs
@@ -16,6 +16,29 @@
         </form>
       </section>
       <section>
+        <h2>Edit Forms</h2>
+        <table>
+          <thead>
+            <tr><th>Name</th><th>URL</th><th>Description</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            <% forms.forEach(function(f){ %>
+              <tr>
+                <td><input form="form-<%= f.id %>" type="text" name="name" value="<%= f.name %>" required></td>
+                <td><input form="form-<%= f.id %>" type="url" name="url" value="<%= f.url %>" required></td>
+                <td><input form="form-<%= f.id %>" type="text" name="description" value="<%= f.description %>"></td>
+                <td>
+                  <form id="form-<%= f.id %>" action="/forms/admin/edit" method="post">
+                    <input type="hidden" name="id" value="<%= f.id %>">
+                    <button type="submit">Save</button>
+                  </form>
+                </td>
+              </tr>
+            <% }); %>
+          </tbody>
+        </table>
+      </section>
+      <section>
         <h2>Manage Permissions</h2>
         <form action="/forms/admin" method="get">
           <select name="formId" onchange="this.form.submit()">
@@ -41,6 +64,29 @@
             <button type="submit">Save</button>
           </form>
         <% } %>
+      </section>
+      <section>
+        <h2>User Form Access</h2>
+        <table>
+          <thead>
+            <tr><th>User</th><th>Form</th><th>Actions</th></tr>
+          </thead>
+          <tbody>
+            <% formAccess.forEach(function(p){ %>
+              <tr>
+                <td><%= p.email %></td>
+                <td><%= p.form_name %></td>
+                <td>
+                  <form action="/forms/admin/permissions/delete" method="post">
+                    <input type="hidden" name="formId" value="<%= p.form_id %>">
+                    <input type="hidden" name="userId" value="<%= p.user_id %>">
+                    <button type="submit">Remove</button>
+                  </form>
+                </td>
+              </tr>
+            <% }); %>
+          </tbody>
+        </table>
       </section>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- allow editing form settings directly from admin page
- display user-form access with removal controls
- add backend helpers for updating forms and managing permissions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d247f6e40832db16b818de95e6839