### PR TITLE
Allow super admin to delete forms

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1163,6 +1163,10 @@ export async function updateForm(
   );
 }
 
+export async function deleteForm(id: number): Promise<void> {
+  await pool.execute('DELETE FROM forms WHERE id = ?', [id]);
+}
+
 export async function getAllForms(): Promise<Form[]> {
   const [rows] = await pool.query<RowDataPacket[]>(
     'SELECT * FROM forms ORDER BY name'

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,6 +56,7 @@ import {
     getAllForms,
     createForm,
     updateForm,
+    deleteForm,
     getFormsForUser,
     getFormPermissions,
     updateFormPermissions,
@@ -1073,6 +1074,12 @@ app.post('/forms/admin/permissions', ensureAuth, ensureSuperAdmin, async (req, r
 app.post('/forms/admin/edit', ensureAuth, ensureSuperAdmin, async (req, res) => {
   const { id, name, url, description } = req.body;
   await updateForm(parseInt(id, 10), name, url, description);
+  res.redirect('/forms/admin');
+});
+
+app.post('/forms/admin/delete', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  const { id } = req.body;
+  await deleteForm(parseInt(id, 10));
   res.redirect('/forms/admin');
 });
 

--- a/src/views/forms-admin.ejs
+++ b/src/views/forms-admin.ejs
@@ -32,6 +32,10 @@
                     <input type="hidden" name="id" value="<%= f.id %>">
                     <button type="submit">Save</button>
                   </form>
+                  <form action="/forms/admin/delete" method="post">
+                    <input type="hidden" name="id" value="<%= f.id %>">
+                    <button type="submit">Delete</button>
+                  </form>
                 </td>
               </tr>
             <% }); %>


### PR DESCRIPTION
## Summary
- Enable removing forms from Forms Admin when needed
- Restrict form deletion to Super Admins only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d262b4410832db8ab3d322b8c85a3