### PR TITLE
feat: allow company admins to manage form access

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1174,6 +1174,18 @@ export async function getAllForms(): Promise<Form[]> {
   return rows as Form[];
 }
 
+export async function getFormsByCompany(companyId: number): Promise<Form[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    `SELECT DISTINCT f.* FROM forms f
+     JOIN form_permissions fp ON f.id = fp.form_id
+     JOIN user_companies uc ON fp.user_id = uc.user_id
+     WHERE uc.company_id = ?
+     ORDER BY f.name`,
+    [companyId]
+  );
+  return rows as Form[];
+}
+
 export async function getFormsForUser(userId: number): Promise<Form[]> {
   const [rows] = await pool.query<RowDataPacket[]>(
     'SELECT f.* FROM forms f JOIN form_permissions fp ON f.id = fp.form_id WHERE fp.user_id = ? ORDER BY f.name',

--- a/src/views/forms-company.ejs
+++ b/src/views/forms-company.ejs
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Manage Forms' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <h1>Manage Form Access</h1>
+      <% if (forms.length > 0) { %>
+        <form action="/forms/company" method="get">
+          <select name="formId" onchange="this.form.submit()">
+            <option value="">Select Form</option>
+            <% forms.forEach(function(f){ %>
+              <option value="<%= f.id %>" <%= selectedFormId === f.id ? 'selected' : '' %>><%= f.name %></option>
+            <% }); %>
+          </select>
+        </form>
+        <% if (selectedFormId) { %>
+          <form action="/forms/company" method="post">
+            <input type="hidden" name="formId" value="<%= selectedFormId %>">
+            <% users.forEach(function(u){ %>
+              <label><input type="checkbox" name="userIds" value="<%= u.user_id %>" <%= permissions.includes(u.user_id) ? 'checked' : '' %>> <%= u.email %></label><br>
+            <% }); %>
+            <button type="submit">Save</button>
+          </form>
+        <% } %>
+      <% } else { %>
+        <p>No forms available.</p>
+      <% } %>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -40,6 +40,7 @@
     <% } %>
     <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
       <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
+      <a href="/forms/company" class="menu-link"><i class="fas fa-wpforms"></i> Manage Forms</a>
     <% } %>
     <% if (isSuperAdmin) { %>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>


### PR DESCRIPTION
## Summary
- let company admins manage form access for users in their own company
- add `getFormsByCompany` query and routes for `/forms/company`
- update sidebar with link to new form access page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d27a78adc832d89484a3334ec5958