### PR TITLE
Add tabs and company context to Forms Admin

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1230,11 +1230,20 @@ export interface FormPermissionEntry {
   form_name: string;
   user_id: number;
   email: string;
+  company_names: string;
 }
 
 export async function getAllFormPermissionEntries(): Promise<FormPermissionEntry[]> {
   const [rows] = await pool.query<RowDataPacket[]>(
-    'SELECT fp.form_id, f.name AS form_name, fp.user_id, u.email FROM form_permissions fp JOIN forms f ON fp.form_id = f.id JOIN users u ON fp.user_id = u.id ORDER BY u.email, f.name'
+    `SELECT fp.form_id, f.name AS form_name, fp.user_id, u.email,
+            GROUP_CONCAT(c.name ORDER BY c.name SEPARATOR ', ') AS company_names
+     FROM form_permissions fp
+     JOIN forms f ON fp.form_id = f.id
+     JOIN users u ON fp.user_id = u.id
+     JOIN user_companies uc ON fp.user_id = uc.user_id
+     JOIN companies c ON uc.company_id = c.id
+     GROUP BY fp.form_id, f.name, fp.user_id, u.email
+     ORDER BY u.email, f.name`
   );
   return rows as FormPermissionEntry[];
 }

--- a/src/views/forms-admin.ejs
+++ b/src/views/forms-admin.ejs
@@ -6,92 +6,111 @@
     <%- include('partials/sidebar') %>
     <div class="content">
       <h1>Forms Admin</h1>
-      <section>
-        <h2>Add Form</h2>
-        <form action="/forms/admin" method="post">
-          <input type="text" name="name" placeholder="Name" required>
-          <input type="url" name="url" placeholder="URL" required>
-          <input type="text" name="description" placeholder="Description">
-          <button type="submit">Add</button>
-        </form>
-      </section>
-      <section>
-        <h2>Edit Forms</h2>
-        <table>
-          <thead>
-            <tr><th>Name</th><th>URL</th><th>Description</th><th>Actions</th></tr>
-          </thead>
-          <tbody>
-            <% forms.forEach(function(f){ %>
-              <tr>
-                <td><input form="form-<%= f.id %>" type="text" name="name" value="<%= f.name %>" required></td>
-                <td><input form="form-<%= f.id %>" type="url" name="url" value="<%= f.url %>" required></td>
-                <td><input form="form-<%= f.id %>" type="text" name="description" value="<%= f.description %>"></td>
-                <td>
-                  <form id="form-<%= f.id %>" action="/forms/admin/edit" method="post">
-                    <input type="hidden" name="id" value="<%= f.id %>">
-                    <button type="submit">Save</button>
-                  </form>
-                  <form action="/forms/admin/delete" method="post">
-                    <input type="hidden" name="id" value="<%= f.id %>">
-                    <button type="submit">Delete</button>
-                  </form>
-                </td>
-              </tr>
-            <% }); %>
-          </tbody>
-        </table>
-      </section>
-      <section>
-        <h2>Manage Permissions</h2>
-        <form action="/forms/admin" method="get">
-          <select name="formId" onchange="this.form.submit()">
-            <option value="">Select Form</option>
-            <% forms.forEach(function(f){ %>
-              <option value="<%= f.id %>" <%= selectedFormId === f.id ? 'selected' : '' %>><%= f.name %></option>
-            <% }); %>
-          </select>
-          <select name="companyId" onchange="this.form.submit()">
-            <option value="">Select Company</option>
-            <% allCompanies.forEach(function(c){ %>
-              <option value="<%= c.id %>" <%= selectedCompanyId === c.id ? 'selected' : '' %>><%= c.name %></option>
-            <% }); %>
-          </select>
-        </form>
-        <% if (selectedFormId && selectedCompanyId) { %>
-          <form action="/forms/admin/permissions" method="post">
-            <input type="hidden" name="formId" value="<%= selectedFormId %>">
-            <input type="hidden" name="companyId" value="<%= selectedCompanyId %>">
-            <% users.forEach(function(u){ %>
-              <label><input type="checkbox" name="userIds" value="<%= u.user_id %>" <%= permissions.includes(u.user_id) ? 'checked' : '' %>> <%= u.email %></label><br>
-            <% }); %>
-            <button type="submit">Save</button>
+      <style>
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+        .tab-buttons { margin-bottom: 1rem; }
+        .tab-buttons button { margin-right: 0.5rem; }
+        .tab-buttons button.active { font-weight: bold; }
+      </style>
+      <div class="tab-buttons">
+        <button type="button" data-tab="forms-tab" class="active">Manage Forms</button>
+        <button type="button" data-tab="permissions-tab">Manage Permissions</button>
+      </div>
+      <div id="forms-tab" class="tab-content active">
+        <section>
+          <h2>Add Form</h2>
+          <form action="/forms/admin" method="post">
+            <input type="text" name="name" placeholder="Name" required>
+            <input type="url" name="url" placeholder="URL" required>
+            <input type="text" name="description" placeholder="Description">
+            <button type="submit">Add</button>
           </form>
-        <% } %>
-      </section>
-      <section>
-        <h2>User Form Access</h2>
-        <table>
-          <thead>
-            <tr><th>User</th><th>Form</th><th>Actions</th></tr>
-          </thead>
-          <tbody>
-            <% formAccess.forEach(function(p){ %>
-              <tr>
-                <td><%= p.email %></td>
-                <td><%= p.form_name %></td>
-                <td>
-                  <form action="/forms/admin/permissions/delete" method="post">
-                    <input type="hidden" name="formId" value="<%= p.form_id %>">
-                    <input type="hidden" name="userId" value="<%= p.user_id %>">
-                    <button type="submit">Remove</button>
-                  </form>
-                </td>
-              </tr>
-            <% }); %>
-          </tbody>
-        </table>
-      </section>
+        </section>
+        <section>
+          <h2>Edit Forms</h2>
+          <table>
+            <thead>
+              <tr><th>Name</th><th>URL</th><th>Description</th><th>Actions</th></tr>
+            </thead>
+            <tbody>
+              <% forms.forEach(function(f){ %>
+                <tr>
+                  <td><input form="form-<%= f.id %>" type="text" name="name" value="<%= f.name %>" required></td>
+                  <td><input form="form-<%= f.id %>" type="url" name="url" value="<%= f.url %>" required></td>
+                  <td><input form="form-<%= f.id %>" type="text" name="description" value="<%= f.description %>"></td>
+                  <td>
+                    <form id="form-<%= f.id %>" action="/forms/admin/edit" method="post">
+                      <input type="hidden" name="id" value="<%= f.id %>">
+                      <button type="submit">Save</button>
+                    </form>
+                    <form action="/forms/admin/delete" method="post">
+                      <input type="hidden" name="id" value="<%= f.id %>">
+                      <button type="submit">Delete</button>
+                    </form>
+                  </td>
+                </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        </section>
+      </div>
+      <div id="permissions-tab" class="tab-content">
+        <section>
+          <h2>Manage Permissions</h2>
+          <form action="/forms/admin" method="get">
+            <select name="formId" onchange="this.form.submit()">
+              <option value="">Select Form</option>
+              <% forms.forEach(function(f){ %>
+                <option value="<%= f.id %>" <%= selectedFormId === f.id ? 'selected' : '' %>><%= f.name %></option>
+              <% }); %>
+            </select>
+            <select name="companyId" onchange="this.form.submit()">
+              <option value="">Select Company</option>
+              <% allCompanies.forEach(function(c){ %>
+                <option value="<%= c.id %>" <%= selectedCompanyId === c.id ? 'selected' : '' %>><%= c.name %></option>
+              <% }); %>
+            </select>
+          </form>
+          <% if (selectedFormId && selectedCompanyId) { %>
+            <form action="/forms/admin/permissions" method="post">
+              <input type="hidden" name="formId" value="<%= selectedFormId %>">
+              <input type="hidden" name="companyId" value="<%= selectedCompanyId %>">
+              <% users.forEach(function(u){ %>
+                <label><input type="checkbox" name="userIds" value="<%= u.user_id %>" <%= permissions.includes(u.user_id) ? 'checked' : '' %>> <%= u.email %></label><br>
+              <% }); %>
+              <button type="submit">Save</button>
+            </form>
+          <% } %>
+        </section>
+        <section>
+          <h2>User Form Access</h2>
+          <table>
+            <thead>
+              <tr><th>User</th><th>Company</th><th>Form</th><th>Actions</th></tr>
+            </thead>
+            <tbody>
+              <% formAccess.forEach(function(p){ %>
+                <tr>
+                  <td><%= p.email %></td>
+                  <td><%= p.company_names %></td>
+                  <td><%= p.form_name %></td>
+                  <td>
+                    <form action="/forms/admin/permissions/delete" method="post">
+                      <input type="hidden" name="formId" value="<%= p.form_id %>">
+                      <input type="hidden" name="userId" value="<%= p.user_id %>">
+                      <button type="submit">Remove</button>
+                    </form>
+                  </td>
+                </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        </section>
+      </div>
+      <script>
+        document.querySelectorAll('.tab-buttons button').forEach(function(btn) { btn.addEventListener('click', function() { var tab = btn.getAttribute('data-tab'); document.querySelectorAll('.tab-content').forEach(function(c) { c.classList.remove('active'); }); document.querySelectorAll('.tab-buttons button').forEach(function(b) { b.classList.remove('active'); }); document.getElementById(tab).classList.add('active'); btn.classList.add('active'); }); });
+      </script>
     </div>
   </div>
 </body>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -42,7 +42,9 @@
     <% } %>
     <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
       <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
-      <a href="/forms/company" class="menu-link"><i class="fas fa-wpforms"></i> Manage Forms</a>
+      <% if (!isSuperAdmin) { %>
+        <a href="/forms/company" class="menu-link"><i class="fas fa-wpforms"></i> Manage Forms</a>
+      <% } %>
     <% } %>
     <% if (isSuperAdmin) { %>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>


### PR DESCRIPTION
## Summary
- Show companies for each user in Forms Admin access list
- Hide Manage Forms sidebar link for super admins
- Split Forms Admin into Manage Forms and Manage Permissions tabs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d2b7dccb8832db6689f8498721edf