### PR TITLE
feat: add admin tabs

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -218,3 +218,32 @@ table th {
   display: block;
   margin: 0 auto;
 }
+
+/* Admin tabs */
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tabs button {
+  background-color: #f3f3f3;
+  color: #333;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px 4px 0 0;
+  cursor: pointer;
+}
+
+.tabs button.active {
+  background-color: #4a00e0;
+  color: #fff;
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -6,182 +6,208 @@
     <%- include('partials/sidebar') %>
     <div class="content">
       <h1>Admin</h1>
-        <% if (isSuperAdmin) { %>
-        <p><a href="/api-docs">API Docs</a></p>
-        <% } %>
-      <% if (isSuperAdmin) { %>
-      <section>
-        <h2>Add Company</h2>
-        <form action="/admin/company" method="post">
-          <input type="text" name="name" placeholder="Company Name" required>
-          <input type="text" name="syncroCompanyId" placeholder="Syncro Company ID">
-          <input type="text" name="xeroId" placeholder="Xero ID">
-          <label><input type="checkbox" name="isVip" value="1"> VIP</label>
-          <button type="submit">Add</button>
-        </form>
-      </section>
-      <section>
-        <h2>Companies</h2>
-        <table>
-          <thead>
-            <tr><th>Name</th><th>Syncro Company ID</th><th>Xero ID</th><th>VIP</th><th></th></tr>
-          </thead>
-          <tbody>
-            <% allCompanies.forEach(function(c) { %>
-              <tr>
-                <td><%= c.name %></td>
-                <td><input type="text" name="syncroCompanyId" value="<%= c.syncro_company_id || '' %>" form="c<%= c.id %>"></td>
-                <td><input type="text" name="xeroId" value="<%= c.xero_id || '' %>" form="c<%= c.id %>"></td>
-                <td><input type="checkbox" name="isVip" value="1" <%= c.is_vip ? 'checked' : '' %> form="c<%= c.id %>"></td>
-                <td>
-                  <form id="c<%= c.id %>" action="/admin/company/<%= c.id %>" method="post">
-                    <button type="submit">Save</button>
-                  </form>
-                </td>
-              </tr>
-            <% }); %>
-          </tbody>
-        </table>
-      </section>
-      <% } %>
-      <section>
-        <h2>Add User</h2>
-        <form action="/admin/user" method="post">
-          <input type="email" name="email" placeholder="Email" required>
-          <input type="password" name="password" placeholder="Password" required>
+      <div class="admin-tabs">
+        <div class="tabs">
+          <button data-tab="companies" class="active">Companies</button>
+          <button data-tab="assignments">Current Assignments</button>
           <% if (isSuperAdmin) { %>
-            <select name="companyId">
-              <% allCompanies.forEach(function(c) { %>
-                <option value="<%= c.id %>"><%= c.name %></option>
-              <% }); %>
-            </select>
-          <% } else { %>
-            <input type="hidden" name="companyId" value="<%= currentCompanyId %>">
+            <button data-tab="api-keys">API Keys</button>
           <% } %>
-          <button type="submit">Add User</button>
-        </form>
-      </section>
-      <% if (isSuperAdmin) { %>
-      <section>
-        <h2>Assign Existing User to Company</h2>
-        <form action="/admin/assign" method="post">
-          <select name="userId">
-            <% users.forEach(function(u) { %>
-              <option value="<%= u.id %>"><%= u.email %></option>
-            <% }); %>
-          </select>
-          <select name="companyId">
-            <% allCompanies.forEach(function(c) { %>
-              <option value="<%= c.id %>"><%= c.name %></option>
-            <% }); %>
-          </select>
-          <button type="submit">Assign</button>
-        </form>
-      </section>
-      <% } %>
-        <section>
-          <h2>Current Assignments</h2>
-          <table>
-            <thead>
-              <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Assets</th><th>Invoices</th><th>Shop</th></tr>
-            </thead>
-            <tbody>
-            <% assignments.forEach(function(a) { %>
-              <tr>
-                <td><%= a.email %></td>
-                <td><%= a.company_name %></td>
-                <td>
-                  <form action="/admin/permission" method="post">
-                    <input type="hidden" name="userId" value="<%= a.user_id %>">
-                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                    <input type="hidden" name="isAdmin" value="0">
-                    <input type="checkbox" name="isAdmin" value="1" <%= a.is_admin ? 'checked' : '' %> onchange="this.form.submit()">
-                  </form>
-                </td>
-                <td>
-                  <form action="/admin/permission" method="post">
-                    <input type="hidden" name="userId" value="<%= a.user_id %>">
-                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                    <input type="hidden" name="canManageLicenses" value="0">
-                    <input type="checkbox" name="canManageLicenses" value="1" <%= a.can_manage_licenses ? 'checked' : '' %> onchange="this.form.submit()">
-                  </form>
-                </td>
-                <td>
-                  <form action="/admin/permission" method="post">
-                    <input type="hidden" name="userId" value="<%= a.user_id %>">
-                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                    <input type="hidden" name="canOrderLicenses" value="0">
-                    <input type="checkbox" name="canOrderLicenses" value="1" <%= a.can_order_licenses ? 'checked' : '' %> onchange="this.form.submit()">
-                  </form>
-                </td>
-                <td>
-                  <form action="/admin/permission" method="post">
-                    <input type="hidden" name="userId" value="<%= a.user_id %>">
-                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                    <input type="hidden" name="canManageStaff" value="0">
-                    <input type="checkbox" name="canManageStaff" value="1" <%= a.can_manage_staff ? 'checked' : '' %> onchange="this.form.submit()">
-                  </form>
-                </td>
-                <td>
-                  <form action="/admin/permission" method="post">
-                    <input type="hidden" name="userId" value="<%= a.user_id %>">
-                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                    <input type="hidden" name="canManageAssets" value="0">
-                    <input type="checkbox" name="canManageAssets" value="1" <%= a.can_manage_assets ? 'checked' : '' %> onchange="this.form.submit()">
-                  </form>
-                </td>
-                <td>
-                  <form action="/admin/permission" method="post">
-                    <input type="hidden" name="userId" value="<%= a.user_id %>">
-                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                    <input type="hidden" name="canManageInvoices" value="0">
-                    <input type="checkbox" name="canManageInvoices" value="1" <%= a.can_manage_invoices ? 'checked' : '' %> onchange="this.form.submit()">
-                  </form>
-                </td>
-                <td>
-                  <form action="/admin/permission" method="post">
-                    <input type="hidden" name="userId" value="<%= a.user_id %>">
-                    <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                    <input type="hidden" name="canAccessShop" value="0">
-                    <input type="checkbox" name="canAccessShop" value="1" <%= a.can_access_shop ? 'checked' : '' %> onchange="this.form.submit()">
-                  </form>
-                </td>
-              </tr>
-            <% }); %>
-            </tbody>
-          </table>
-        </section>
-      <% if (isSuperAdmin) { %>
-        <section>
-          <h2>API Keys</h2>
-          <form action="/admin/api-key" method="post">
-            <input type="text" name="description" placeholder="Description">
-            <input type="date" name="expiryDate">
-            <button type="submit">Add API Key</button>
-          </form>
-          <table>
-            <thead>
-              <tr><th>Key</th><th>Description</th><th>Expiry</th><th></th></tr>
-            </thead>
-            <tbody>
-            <% apiKeys.forEach(function(k) { %>
-              <tr>
-                <td><%= k.api_key %></td>
-                <td><%= k.description %></td>
-                <td><%= k.expiry_date || '' %></td>
-                <td>
-                  <form action="/admin/api-key/delete" method="post">
-                    <input type="hidden" name="id" value="<%= k.id %>">
-                    <button type="submit">Delete</button>
-                  </form>
-                </td>
-              </tr>
-            <% }); %>
-            </tbody>
-          </table>
-        </section>
-      <% } %>
+        </div>
+        <div id="companies" class="tab-content active">
+          <% if (isSuperAdmin) { %>
+          <section>
+            <h2>Add Company</h2>
+            <form action="/admin/company" method="post">
+              <input type="text" name="name" placeholder="Company Name" required>
+              <input type="text" name="syncroCompanyId" placeholder="Syncro Company ID">
+              <input type="text" name="xeroId" placeholder="Xero ID">
+              <label><input type="checkbox" name="isVip" value="1"> VIP</label>
+              <button type="submit">Add</button>
+            </form>
+          </section>
+          <section>
+            <h2>Companies</h2>
+            <table>
+              <thead>
+                <tr><th>Name</th><th>Syncro Company ID</th><th>Xero ID</th><th>VIP</th><th></th></tr>
+              </thead>
+              <tbody>
+                <% allCompanies.forEach(function(c) { %>
+                  <tr>
+                    <td><%= c.name %></td>
+                    <td><input type="text" name="syncroCompanyId" value="<%= c.syncro_company_id || '' %>" form="c<%= c.id %>"></td>
+                    <td><input type="text" name="xeroId" value="<%= c.xero_id || '' %>" form="c<%= c.id %>"></td>
+                    <td><input type="checkbox" name="isVip" value="1" <%= c.is_vip ? 'checked' : '' %> form="c<%= c.id %>"></td>
+                    <td>
+                      <form id="c<%= c.id %>" action="/admin/company/<%= c.id %>" method="post">
+                        <button type="submit">Save</button>
+                      </form>
+                    </td>
+                  </tr>
+                <% }); %>
+              </tbody>
+            </table>
+          </section>
+          <% } %>
+          <section>
+            <h2>Add User</h2>
+            <form action="/admin/user" method="post">
+              <input type="email" name="email" placeholder="Email" required>
+              <input type="password" name="password" placeholder="Password" required>
+              <% if (isSuperAdmin) { %>
+                <select name="companyId">
+                  <% allCompanies.forEach(function(c) { %>
+                    <option value="<%= c.id %>"><%= c.name %></option>
+                  <% }); %>
+                </select>
+              <% } else { %>
+                <input type="hidden" name="companyId" value="<%= currentCompanyId %>">
+              <% } %>
+              <button type="submit">Add User</button>
+            </form>
+          </section>
+          <% if (isSuperAdmin) { %>
+          <section>
+            <h2>Assign Existing User to Company</h2>
+            <form action="/admin/assign" method="post">
+              <select name="userId">
+                <% users.forEach(function(u) { %>
+                  <option value="<%= u.id %>"><%= u.email %></option>
+                <% }); %>
+              </select>
+              <select name="companyId">
+                <% allCompanies.forEach(function(c) { %>
+                  <option value="<%= c.id %>"><%= c.name %></option>
+                <% }); %>
+              </select>
+              <button type="submit">Assign</button>
+            </form>
+          </section>
+          <% } %>
+        </div>
+        <div id="assignments" class="tab-content">
+          <section>
+            <h2>Current Assignments</h2>
+            <table>
+              <thead>
+                <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Assets</th><th>Invoices</th><th>Shop</th></tr>
+              </thead>
+              <tbody>
+              <% assignments.forEach(function(a) { %>
+                <tr>
+                  <td><%= a.email %></td>
+                  <td><%= a.company_name %></td>
+                  <td>
+                    <form action="/admin/permission" method="post">
+                      <input type="hidden" name="userId" value="<%= a.user_id %>">
+                      <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                      <input type="hidden" name="isAdmin" value="0">
+                      <input type="checkbox" name="isAdmin" value="1" <%= a.is_admin ? 'checked' : '' %> onchange="this.form.submit()">
+                    </form>
+                  </td>
+                  <td>
+                    <form action="/admin/permission" method="post">
+                      <input type="hidden" name="userId" value="<%= a.user_id %>">
+                      <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                      <input type="hidden" name="canManageLicenses" value="0">
+                      <input type="checkbox" name="canManageLicenses" value="1" <%= a.can_manage_licenses ? 'checked' : '' %> onchange="this.form.submit()">
+                    </form>
+                  </td>
+                  <td>
+                    <form action="/admin/permission" method="post">
+                      <input type="hidden" name="userId" value="<%= a.user_id %>">
+                      <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                      <input type="hidden" name="canOrderLicenses" value="0">
+                      <input type="checkbox" name="canOrderLicenses" value="1" <%= a.can_order_licenses ? 'checked' : '' %> onchange="this.form.submit()">
+                    </form>
+                  </td>
+                  <td>
+                    <form action="/admin/permission" method="post">
+                      <input type="hidden" name="userId" value="<%= a.user_id %>">
+                      <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                      <input type="hidden" name="canManageStaff" value="0">
+                      <input type="checkbox" name="canManageStaff" value="1" <%= a.can_manage_staff ? 'checked' : '' %> onchange="this.form.submit()">
+                    </form>
+                  </td>
+                  <td>
+                    <form action="/admin/permission" method="post">
+                      <input type="hidden" name="userId" value="<%= a.user_id %>">
+                      <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                      <input type="hidden" name="canManageAssets" value="0">
+                      <input type="checkbox" name="canManageAssets" value="1" <%= a.can_manage_assets ? 'checked' : '' %> onchange="this.form.submit()">
+                    </form>
+                  </td>
+                  <td>
+                    <form action="/admin/permission" method="post">
+                      <input type="hidden" name="userId" value="<%= a.user_id %>">
+                      <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                      <input type="hidden" name="canManageInvoices" value="0">
+                      <input type="checkbox" name="canManageInvoices" value="1" <%= a.can_manage_invoices ? 'checked' : '' %> onchange="this.form.submit()">
+                    </form>
+                  </td>
+                  <td>
+                    <form action="/admin/permission" method="post">
+                      <input type="hidden" name="userId" value="<%= a.user_id %>">
+                      <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                      <input type="hidden" name="canAccessShop" value="0">
+                      <input type="checkbox" name="canAccessShop" value="1" <%= a.can_access_shop ? 'checked' : '' %> onchange="this.form.submit()">
+                    </form>
+                  </td>
+                </tr>
+              <% }); %>
+              </tbody>
+            </table>
+          </section>
+        </div>
+        <% if (isSuperAdmin) { %>
+        <div id="api-keys" class="tab-content">
+          <section>
+            <h2>API Keys</h2>
+            <form action="/admin/api-key" method="post">
+              <input type="text" name="description" placeholder="Description">
+              <input type="date" name="expiryDate">
+              <button type="submit">Add API Key</button>
+            </form>
+            <table>
+              <thead>
+                <tr><th>Key</th><th>Description</th><th>Expiry</th><th></th></tr>
+              </thead>
+              <tbody>
+              <% apiKeys.forEach(function(k) { %>
+                <tr>
+                  <td><%= k.api_key %></td>
+                  <td><%= k.description %></td>
+                  <td><%= k.expiry_date || '' %></td>
+                  <td>
+                    <form action="/admin/api-key/delete" method="post">
+                      <input type="hidden" name="id" value="<%= k.id %>">
+                      <button type="submit">Delete</button>
+                    </form>
+                  </td>
+                </tr>
+              <% }); %>
+              </tbody>
+            </table>
+          </section>
+        </div>
+        <% } %>
+      </div>
     </div>
   </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const tabs = document.querySelectorAll('.tabs button');
+      const contents = document.querySelectorAll('.tab-content');
+      tabs.forEach(function (tab) {
+        tab.addEventListener('click', function () {
+          tabs.forEach(function (t) { t.classList.remove('active'); });
+          contents.forEach(function (c) { c.classList.remove('active'); });
+          tab.classList.add('active');
+          document.getElementById(tab.dataset.tab).classList.add('active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reorganize admin page with tabs for companies, current assignments, and API keys
- remove API docs link from admin page
- style tab navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d2d0d04f8832dbb87b8fdfa82b7a1