### PR TITLE
Display user form access per company

### DIFF
--- a/migrations/024_form_permissions_company_id.sql
+++ b/migrations/024_form_permissions_company_id.sql
@@ -1,0 +1,4 @@
+ALTER TABLE form_permissions ADD COLUMN company_id INT NOT NULL DEFAULT 0 AFTER user_id;
+ALTER TABLE form_permissions DROP PRIMARY KEY,
+  ADD PRIMARY KEY (form_id, user_id, company_id);
+ALTER TABLE form_permissions ADD CONSTRAINT fk_form_permissions_company FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE;

--- a/src/server.ts
+++ b/src/server.ts
@@ -615,7 +615,9 @@ app.get('/forms/company', ensureAuth, ensureAdmin, async (req, res) => {
     getUserCompanyAssignments(req.session.companyId!),
   ]);
   const current = companies.find((c) => c.company_id === req.session.companyId);
-  const permissions = !isNaN(formId) ? await getFormPermissions(formId) : [];
+  const permissions = !isNaN(formId)
+    ? await getFormPermissions(formId, req.session.companyId!)
+    : [];
   res.render('forms-company', {
     forms,
     users,
@@ -1026,8 +1028,12 @@ app.post(
   ensureAuth,
   ensureSuperAdmin,
   async (req, res) => {
-    const { formId, userId } = req.body;
-    await deleteFormPermission(parseInt(formId, 10), parseInt(userId, 10));
+    const { formId, userId, companyId } = req.body;
+    await deleteFormPermission(
+      parseInt(formId, 10),
+      parseInt(userId, 10),
+      parseInt(companyId, 10)
+    );
     res.redirect('/admin');
   }
 );
@@ -1096,7 +1102,7 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
     formAccess = await getAllFormPermissionEntries();
     if (!isNaN(formId) && !isNaN(companyIdParam)) {
       formUsers = await getUserCompanyAssignments(companyIdParam);
-      permissions = await getFormPermissions(formId);
+      permissions = await getFormPermissions(formId, companyIdParam);
     }
     const [prodList, restrictionsList, catList] = await Promise.all([
       getAllProducts(includeArchived),
@@ -1121,7 +1127,7 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
     formAccess = await getAllFormPermissionEntries();
     if (!isNaN(formId) && !isNaN(companyIdParam)) {
       formUsers = await getUserCompanyAssignments(companyIdParam);
-      permissions = await getFormPermissions(formId);
+      permissions = await getFormPermissions(formId, companyIdParam);
     }
   }
   const companies = await getCompaniesForUser(req.session.userId!);

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -348,12 +348,13 @@
                   <% formAccess.forEach(function(p){ %>
                     <tr>
                       <td><%= p.email %></td>
-                      <td><%= p.company_names %></td>
+                      <td><%= p.company_name %></td>
                       <td><%= p.form_name %></td>
                       <td>
                         <form action="/forms/admin/permissions/delete" method="post">
                           <input type="hidden" name="formId" value="<%= p.form_id %>">
                           <input type="hidden" name="userId" value="<%= p.user_id %>">
+                          <input type="hidden" name="companyId" value="<%= p.company_id %>">
                           <button type="submit">Remove</button>
                         </form>
                       </td>

--- a/src/views/forms-admin.ejs
+++ b/src/views/forms-admin.ejs
@@ -93,12 +93,13 @@
               <% formAccess.forEach(function(p){ %>
                 <tr>
                   <td><%= p.email %></td>
-                  <td><%= p.company_names %></td>
+                  <td><%= p.company_name %></td>
                   <td><%= p.form_name %></td>
                   <td>
                     <form action="/forms/admin/permissions/delete" method="post">
                       <input type="hidden" name="formId" value="<%= p.form_id %>">
                       <input type="hidden" name="userId" value="<%= p.user_id %>">
+                      <input type="hidden" name="companyId" value="<%= p.company_id %>">
                       <button type="submit">Remove</button>
                     </form>
                   </td>


### PR DESCRIPTION
## Summary
- add company_id to form_permissions and adjust queries to manage form access per company
- list user-form access rows per company in admin views
- allow removing form access for a specific company

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d33ecfc00832d9b996020fd155104