### PR TITLE
Fix duplicate column error in form permissions migration

### DIFF
--- a/migrations/024_form_permissions_company_id.sql
+++ b/migrations/024_form_permissions_company_id.sql
@@ -1,5 +1,6 @@
 -- Allow NULL initially so existing rows can be backfilled
-ALTER TABLE form_permissions ADD COLUMN company_id INT AFTER user_id;
+ALTER TABLE form_permissions
+  ADD COLUMN IF NOT EXISTS company_id INT AFTER user_id;
 
 -- Populate the new column using each user's primary company
 UPDATE form_permissions fp
@@ -9,9 +10,13 @@ WHERE fp.company_id IS NULL;
 
 -- Enforce the new constraints and key structure
 ALTER TABLE form_permissions
-  MODIFY company_id INT NOT NULL,
+  MODIFY COLUMN company_id INT NOT NULL,
   DROP PRIMARY KEY,
   ADD PRIMARY KEY (form_id, user_id, company_id);
+
+-- Ensure the foreign key constraint exists without causing errors on re-runs
+ALTER TABLE form_permissions
+  DROP FOREIGN KEY IF EXISTS fk_form_permissions_company;
 
 ALTER TABLE form_permissions
   ADD CONSTRAINT fk_form_permissions_company


### PR DESCRIPTION
## Summary
- make `form_permissions` migration idempotent to avoid duplicate column errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d3829f070832d94814689792a2a29