### PR TITLE
Add super admin staff creation form

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -351,6 +351,9 @@ async function ensureStaffAccess(
   res: express.Response,
   next: express.NextFunction
 ) {
+  if (req.session.userId === 1) {
+    return next();
+  }
   const companies = await getCompaniesForUser(req.session.userId!);
   const current = companies.find((c) => c.company_id === req.session.companyId);
   if (current && current.can_manage_staff) {
@@ -527,7 +530,7 @@ app.get('/staff', ensureAuth, ensureStaffAccess, async (req, res) => {
   });
 });
 
-app.post('/staff', ensureAuth, ensureStaffAccess, async (req, res) => {
+app.post('/staff', ensureAuth, ensureSuperAdmin, async (req, res) => {
   const { firstName, lastName, email, dateOnboarded, enabled } = req.body;
   if (req.session.companyId) {
     await addStaff(

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -6,6 +6,19 @@
     <%- include('partials/sidebar') %>
     <div class="content">
       <h1>Staff</h1>
+      <% if (isSuperAdmin) { %>
+      <section>
+        <h2>Add Staff</h2>
+        <form action="/staff" method="post">
+          <input type="text" name="firstName" placeholder="First Name" required>
+          <input type="text" name="lastName" placeholder="Last Name" required>
+          <input type="email" name="email" placeholder="Email" required>
+          <input type="date" name="dateOnboarded">
+          <label><input type="checkbox" name="enabled" value="1" checked> Enabled</label>
+          <button type="submit">Add</button>
+        </form>
+      </section>
+      <% } %>
       <section>
         <h2>Current Staff</h2>
         <table>


### PR DESCRIPTION
## Summary
- allow super admin to bypass staff access check
- restrict staff creation endpoint to super admin
- add super admin-only staff creation form on staff page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d424a30dc832d93766ffcde83b5b8