### PR TITLE
feat: add office groups management

### DIFF
--- a/migrations/025_office_groups.sql
+++ b/migrations/025_office_groups.sql
@@ -1,0 +1,14 @@
+CREATE TABLE office_groups (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  company_id INT NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  FOREIGN KEY (company_id) REFERENCES companies(id)
+);
+
+CREATE TABLE office_group_members (
+  group_id INT NOT NULL,
+  staff_id INT NOT NULL,
+  PRIMARY KEY (group_id, staff_id),
+  FOREIGN KEY (group_id) REFERENCES office_groups(id) ON DELETE CASCADE,
+  FOREIGN KEY (staff_id) REFERENCES staff(id) ON DELETE CASCADE
+);

--- a/src/server.ts
+++ b/src/server.ts
@@ -78,6 +78,10 @@ import {
   deleteProduct,
   getProductCompanyRestrictions,
   setProductCompanyExclusions,
+  getOfficeGroupsByCompany,
+  createOfficeGroup,
+  updateOfficeGroupMembers,
+  deleteOfficeGroup,
   createOrder,
   getOrdersByCompany,
   getOrderSummariesByCompany,
@@ -103,6 +107,8 @@ import {
   App,
   ProductCompanyRestriction,
   Category,
+  Staff,
+  OfficeGroupWithMembers,
 } from './queries';
 import { runMigrations } from './db';
 
@@ -1096,6 +1102,8 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
   let categories: Category[] = [];
   let products: any[] = [];
   let productRestrictions: Record<number, ProductCompanyRestriction[]> = {};
+  let officeGroups: OfficeGroupWithMembers[] = [];
+  let staff: Staff[] = [];
   if (isSuperAdmin) {
     allCompanies = await getAllCompanies();
     users = await getAllUsers();
@@ -1135,6 +1143,8 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
       permissions = await getFormPermissions(formId, companyIdParam);
     }
   }
+  staff = await getStaffByCompany(req.session.companyId!);
+  officeGroups = await getOfficeGroupsByCompany(req.session.companyId!);
   const companies = await getCompaniesForUser(req.session.userId!);
   const current = companies.find((c) => c.company_id === req.session.companyId);
   res.render('admin', {
@@ -1164,6 +1174,8 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
     canManageInvoices: current?.can_manage_invoices ?? 0,
     canOrderLicenses: current?.can_order_licenses ?? 0,
     canAccessShop: current?.can_access_shop ?? 0,
+    officeGroups,
+    staff,
   });
 });
 
@@ -1312,6 +1324,32 @@ app.post('/admin/permission', ensureAuth, ensureAdmin, async (req, res) => {
     );
   }
   res.redirect('/admin');
+});
+
+app.post('/admin/office-groups', ensureAuth, ensureAdmin, async (req, res) => {
+  await createOfficeGroup(req.session.companyId!, req.body.name);
+  res.redirect('/admin#office-groups');
+});
+
+app.post(
+  '/admin/office-groups/:id/members',
+  ensureAuth,
+  ensureAdmin,
+  async (req, res) => {
+    const raw = req.body.staffIds;
+    const ids = Array.isArray(raw)
+      ? raw.map((s: string) => parseInt(s, 10))
+      : raw
+      ? [parseInt(raw, 10)]
+      : [];
+    await updateOfficeGroupMembers(parseInt(req.params.id, 10), ids);
+    res.redirect('/admin#office-groups');
+  }
+);
+
+app.post('/admin/office-groups/:id/delete', ensureAuth, ensureAdmin, async (req, res) => {
+  await deleteOfficeGroup(parseInt(req.params.id, 10));
+  res.redirect('/admin#office-groups');
 });
 
 const api = express.Router();

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -10,6 +10,7 @@
         <div class="tabs">
           <button data-tab="companies" class="active">Companies</button>
           <button data-tab="assignments">Current Assignments</button>
+          <button data-tab="office-groups">Office Groups</button>
           <% if (isSuperAdmin) { %>
             <button data-tab="apps">Apps</button>
             <button data-tab="api-keys">API Keys</button>
@@ -163,6 +164,47 @@
               <% }); %>
               </tbody>
             </table>
+          </section>
+        </div>
+        <div id="office-groups" class="tab-content">
+          <section>
+            <h2>Add Group</h2>
+            <form action="/admin/office-groups" method="post">
+              <input type="text" name="name" placeholder="Group Name" required>
+              <button type="submit">Add</button>
+            </form>
+          </section>
+          <section>
+            <h2>Groups</h2>
+            <% if (officeGroups.length > 0) { %>
+            <table>
+              <thead>
+                <tr><th>Name</th><th>Members</th><th></th></tr>
+              </thead>
+              <tbody>
+                <% officeGroups.forEach(function(g){ %>
+                  <tr>
+                    <td><%= g.name %></td>
+                    <td>
+                      <form action="/admin/office-groups/<%= g.id %>/members" method="post">
+                        <% staff.forEach(function(s){ %>
+                          <label><input type="checkbox" name="staffIds" value="<%= s.id %>" <%= g.members.some(m => m.id === s.id) ? 'checked' : '' %>> <%= s.first_name %> <%= s.last_name %></label><br>
+                        <% }); %>
+                        <button type="submit">Save</button>
+                      </form>
+                    </td>
+                    <td>
+                      <form action="/admin/office-groups/<%= g.id %>/delete" method="post">
+                        <button type="submit">Delete</button>
+                      </form>
+                    </td>
+                  </tr>
+                <% }); %>
+              </tbody>
+            </table>
+            <% } else { %>
+              <p>No groups.</p>
+            <% } %>
           </section>
         </div>
         <% if (isSuperAdmin) { %>
@@ -576,7 +618,9 @@
         });
       });
 
-      let initialTab = localStorage.getItem(ACTIVE_TAB_KEY) || 'companies';
+      let initialTab = window.location.hash
+        ? window.location.hash.substring(1)
+        : localStorage.getItem(ACTIVE_TAB_KEY) || 'companies';
       <% if (isSuperAdmin && selectedFormId && selectedCompanyId) { %>
       initialTab = 'form-permissions';
       <% } %>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -38,6 +38,7 @@
   <div class="sidebar-bottom">
     <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
       <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
+      <a href="/admin#office-groups" class="menu-link"><i class="fas fa-layer-group"></i> Office Groups</a>
       <% if (!isSuperAdmin) { %>
         <a href="/forms/company" class="menu-link"><i class="fas fa-wpforms"></i> Manage Forms</a>
       <% } %>


### PR DESCRIPTION
## Summary
- add migrations for office group tables
- support office group queries and server routes
- expose Office Groups tab and link in admin interface

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d4bf10498832d8fdd6a3ed7257658