### PR TITLE
docs: document company identifiers in API

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2415,6 +2415,12 @@ api.post('/companies', async (req, res) => {
  *                   type: string
  *                 address:
  *                   type: string
+ *                 syncroCompanyId:
+ *                   type: string
+ *                 xeroId:
+ *                   type: string
+ *                 isVip:
+ *                   type: boolean
  *       404:
  *         description: Company not found
  */


### PR DESCRIPTION
## Summary
- expand `/api/companies/{id}` response schema with `syncroCompanyId`, `xeroId`, and `isVip`

## Testing
- `npm test`
- `node -e "const path=require('path'); const swaggerJSDoc=require('swagger-jsdoc'); const spec=swaggerJSDoc({definition:{openapi:'3.0.0',info:{title:'MyPortal API',version:'1.0.0'},tags:[{name:'Apps'},{name:'Companies'},{name:'Users'},{name:'Licenses'},{name:'Staff'},{name:'Assets'},{name:'Invoices'},{name:'Shop'}],components:{securitySchemes:{ApiKeyAuth:{type:'apiKey',in:'header',name:'x-api-key'}}},security:[{ApiKeyAuth:[]}]},apis:[path.join(__dirname,'src/**/*.ts')],failOnErrors:false}); console.log(JSON.stringify(spec.paths['/api/companies/{id}'],null,2));" > /tmp/swagger.json"

------
https://chatgpt.com/codex/tasks/task_b_689d52649470832d80e320bdbf9f06fb