### PR TITLE
Handle partial company updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && cp -r src/views dist && cp -r src/public dist",
     "start": "node dist/server.js",
     "dev": "nodemon src/server.ts",
-    "test": "tsc --noEmit"
+    "test": "tsc --noEmit && node --test --require ts-node/register/transpile-only tests/updateCompany.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2460,25 +2460,55 @@ api.get('/companies/:id', async (req, res) => {
  *       200:
  *         description: Update successful
  */
-api.put('/companies/:id', async (req, res) => {
+export async function updateCompanyHandler(
+  req: express.Request,
+  res: express.Response,
+  deps: {
+    getCompanyById: typeof getCompanyById;
+    updateCompany: typeof updateCompany;
+    updateCompanyIds: typeof updateCompanyIds;
+  } = {
+    getCompanyById,
+    updateCompany,
+    updateCompanyIds,
+  }
+): Promise<void> {
   const { name, address, syncroCompanyId, xeroId, isVip } = req.body;
+  const id = parseInt(req.params.id, 10);
   if (name !== undefined || address !== undefined) {
-    await updateCompany(parseInt(req.params.id, 10), name, address);
+    let newName = name;
+    let newAddress = address;
+    if (name === undefined || address === undefined) {
+      const current = await deps.getCompanyById(id);
+      if (!current) {
+        res.status(404).json({ error: 'Company not found' });
+        return;
+      }
+      if (newName === undefined) {
+        newName = current.name;
+      }
+      if (newAddress === undefined) {
+        newAddress = current.address || null;
+      }
+    }
+    await deps.updateCompany(id, newName, newAddress || null);
   }
   if (
     syncroCompanyId !== undefined ||
     xeroId !== undefined ||
     isVip !== undefined
   ) {
-    await updateCompanyIds(
-      parseInt(req.params.id, 10),
+    await deps.updateCompanyIds(
+      id,
       syncroCompanyId || null,
       xeroId || null,
       parseCheckbox(isVip)
     );
   }
   res.json({ success: true });
-});
+}
+
+api.put('/companies/:id', (req, res) => updateCompanyHandler(req, res));
 
 /**
  * @openapi
@@ -3730,4 +3760,8 @@ async function start() {
   });
 }
 
-start();
+if (require.main === module) {
+  start();
+}
+
+export { app, api, start };

--- a/tests/updateCompany.test.ts
+++ b/tests/updateCompany.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { updateCompanyHandler } from '../src/server';
+
+test('omitting address keeps existing address', async () => {
+  const getCompanyByIdCalls: number[] = [];
+  const updateCompanyCalls: any[] = [];
+  const deps = {
+    getCompanyById: async (id: number) => {
+      getCompanyByIdCalls.push(id);
+      return { id, name: 'Existing Name', address: 'Existing Address' };
+    },
+    updateCompany: async (id: number, name: string, address: string | null) => {
+      updateCompanyCalls.push([id, name, address]);
+    },
+    updateCompanyIds: async () => {},
+  };
+  const req: any = { params: { id: '1' }, body: { name: 'New Name' } };
+  const res: any = { json: () => {} };
+  await updateCompanyHandler(req, res, deps);
+  assert.deepEqual(getCompanyByIdCalls, [1]);
+  assert.deepEqual(updateCompanyCalls, [[1, 'New Name', 'Existing Address']]);
+});
+
+test('omitting name keeps existing name', async () => {
+  const getCompanyByIdCalls: number[] = [];
+  const updateCompanyCalls: any[] = [];
+  const deps = {
+    getCompanyById: async (id: number) => {
+      getCompanyByIdCalls.push(id);
+      return { id, name: 'Existing Name', address: 'Existing Address' };
+    },
+    updateCompany: async (id: number, name: string, address: string | null) => {
+      updateCompanyCalls.push([id, name, address]);
+    },
+    updateCompanyIds: async () => {},
+  };
+  const req: any = { params: { id: '1' }, body: { address: 'New Address' } };
+  const res: any = { json: () => {} };
+  await updateCompanyHandler(req, res, deps);
+  assert.deepEqual(getCompanyByIdCalls, [1]);
+  assert.deepEqual(updateCompanyCalls, [[1, 'Existing Name', 'New Address']]);
+});


### PR DESCRIPTION
## Summary
- Fetch existing company details for partial updates and merge omitted fields with current values
- Add tests ensuring missing name or address retains existing database values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d5265257c832d9315610ebceccb88