### PR TITLE
feat: add office groups management

### DIFF
--- a/migrations/025_office_groups.sql
+++ b/migrations/025_office_groups.sql
@@ -1,0 +1,14 @@
+CREATE TABLE office_groups (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  company_id INT NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  FOREIGN KEY (company_id) REFERENCES companies(id)
+);
+
+CREATE TABLE office_group_members (
+  group_id INT NOT NULL,
+  staff_id INT NOT NULL,
+  PRIMARY KEY (group_id, staff_id),
+  FOREIGN KEY (group_id) REFERENCES office_groups(id) ON DELETE CASCADE,
+  FOREIGN KEY (staff_id) REFERENCES staff(id) ON DELETE CASCADE
+);

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -10,6 +10,7 @@
         <div class="tabs">
           <button data-tab="companies" class="active">Companies</button>
           <button data-tab="assignments">Current Assignments</button>
+          <button data-tab="office-groups">Office Groups</button>
           <% if (isSuperAdmin) { %>
             <button data-tab="apps">Apps</button>
             <button data-tab="api-keys">API Keys</button>
@@ -163,6 +164,51 @@
               <% }); %>
               </tbody>
             </table>
+          </section>
+        </div>
+        <div id="office-groups" class="tab-content">
+          <% if (isSuperAdmin) { %>
+          <section>
+            <h2>Add Group</h2>
+            <form action="/admin/office-groups" method="post">
+              <input type="text" name="name" placeholder="Group Name" required>
+              <button type="submit">Add</button>
+            </form>
+          </section>
+          <% } %>
+          <section>
+            <h2>Groups</h2>
+            <% if (officeGroups.length > 0) { %>
+            <table>
+              <thead>
+                <tr><th>Name</th><th>Members</th><th></th></tr>
+              </thead>
+              <tbody>
+                <% officeGroups.forEach(function(g){ %>
+                  <tr>
+                    <td><%= g.name %></td>
+                    <td>
+                      <form action="/admin/office-groups/<%= g.id %>/members" method="post">
+                        <% staff.forEach(function(s){ %>
+                          <label><input type="checkbox" name="staffIds" value="<%= s.id %>" <%= g.members.some(m => m.id === s.id) ? 'checked' : '' %>> <%= s.first_name %> <%= s.last_name %></label><br>
+                        <% }); %>
+                        <button type="submit">Save</button>
+                      </form>
+                    </td>
+                    <td>
+                      <% if (isSuperAdmin) { %>
+                      <form action="/admin/office-groups/<%= g.id %>/delete" method="post">
+                        <button type="submit">Delete</button>
+                      </form>
+                      <% } %>
+                    </td>
+                  </tr>
+                <% }); %>
+              </tbody>
+            </table>
+            <% } else { %>
+              <p>No groups.</p>
+            <% } %>
           </section>
         </div>
         <% if (isSuperAdmin) { %>
@@ -576,7 +622,9 @@
         });
       });
 
-      let initialTab = localStorage.getItem(ACTIVE_TAB_KEY) || 'companies';
+      let initialTab = window.location.hash
+        ? window.location.hash.substring(1)
+        : localStorage.getItem(ACTIVE_TAB_KEY) || 'companies';
       <% if (isSuperAdmin && selectedFormId && selectedCompanyId) { %>
       initialTab = 'form-permissions';
       <% } %>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -17,6 +17,9 @@
     <% if (canManageStaff) { %>
       <a href="/staff" class="menu-link"><i class="fas fa-users"></i> Staff</a>
     <% } %>
+    <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
+      <a href="/admin#office-groups" class="menu-link"><i class="fas fa-layer-group"></i> Office Groups</a>
+    <% } %>
     <% if (canManageLicenses) { %>
       <a href="/licenses" class="menu-link"><i class="fas fa-file-contract"></i> Licenses</a>
     <% } %>


### PR DESCRIPTION
## Summary
- add migrations for office group tables
- support office group queries and server routes
- expose Office Groups tab and link in admin interface
- restrict group creation/deletion to super admins and place menu under Staff

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d4bf10498832d8fdd6a3ed7257658