### PR TITLE
Restrict group creation to super admins and allow company admins to manage staff

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -362,7 +362,7 @@ async function ensureStaffAccess(
   }
   const companies = await getCompaniesForUser(req.session.userId!);
   const current = companies.find((c) => c.company_id === req.session.companyId);
-  if (current && current.can_manage_staff) {
+  if (current && (current.can_manage_staff || current.is_admin)) {
     return next();
   }
   return res.redirect('/');
@@ -536,7 +536,7 @@ app.get('/staff', ensureAuth, ensureStaffAccess, async (req, res) => {
   });
 });
 
-app.post('/staff', ensureAuth, ensureSuperAdmin, async (req, res) => {
+app.post('/staff', ensureAuth, ensureAdmin, async (req, res) => {
   const {
     firstName,
     lastName,
@@ -1391,7 +1391,7 @@ app.post('/admin/permission', ensureAuth, ensureAdmin, async (req, res) => {
   res.redirect('/admin');
 });
 
-app.post('/admin/office-groups', ensureAuth, ensureAdmin, async (req, res) => {
+app.post('/admin/office-groups', ensureAuth, ensureSuperAdmin, async (req, res) => {
   await createOfficeGroup(req.session.companyId!, req.body.name);
   res.redirect('/admin#office-groups');
 });
@@ -1412,7 +1412,7 @@ app.post(
   }
 );
 
-app.post('/admin/office-groups/:id/delete', ensureAuth, ensureAdmin, async (req, res) => {
+app.post('/admin/office-groups/:id/delete', ensureAuth, ensureSuperAdmin, async (req, res) => {
   await deleteOfficeGroup(parseInt(req.params.id, 10));
   res.redirect('/admin#office-groups');
 });

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -167,6 +167,7 @@
           </section>
         </div>
         <div id="office-groups" class="tab-content">
+          <% if (isSuperAdmin) { %>
           <section>
             <h2>Add Group</h2>
             <form action="/admin/office-groups" method="post">
@@ -174,12 +175,13 @@
               <button type="submit">Add</button>
             </form>
           </section>
+          <% } %>
           <section>
             <h2>Groups</h2>
             <% if (officeGroups.length > 0) { %>
             <table>
               <thead>
-                <tr><th>Name</th><th>Members</th><th></th></tr>
+                <tr><th>Name</th><th>Members</th><% if (isSuperAdmin) { %><th></th><% } %></tr>
               </thead>
               <tbody>
                 <% officeGroups.forEach(function(g){ %>
@@ -193,11 +195,13 @@
                         <button type="submit">Save</button>
                       </form>
                     </td>
+                    <% if (isSuperAdmin) { %>
                     <td>
                       <form action="/admin/office-groups/<%= g.id %>/delete" method="post">
                         <button type="submit">Delete</button>
                       </form>
                     </td>
+                    <% } %>
                   </tr>
                 <% }); %>
               </tbody>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -14,8 +14,11 @@
       <br>
     <% } %>
     <a href="/" class="menu-link"><i class="fas fa-briefcase"></i> Business Info</a>
-    <% if (canManageStaff) { %>
+    <% if (canManageStaff || (typeof isAdmin !== 'undefined' && isAdmin)) { %>
       <a href="/staff" class="menu-link"><i class="fas fa-users"></i> Staff</a>
+    <% } %>
+    <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
+      <a href="/admin#office-groups" class="menu-link"><i class="fas fa-layer-group"></i> Office Groups</a>
     <% } %>
     <% if (canManageLicenses) { %>
       <a href="/licenses" class="menu-link"><i class="fas fa-file-contract"></i> Licenses</a>
@@ -38,7 +41,6 @@
   <div class="sidebar-bottom">
     <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
       <a href="/admin" class="menu-link"><i class="fas fa-user-shield"></i> Admin</a>
-      <a href="/admin#office-groups" class="menu-link"><i class="fas fa-layer-group"></i> Office Groups</a>
       <% if (!isSuperAdmin) { %>
         <a href="/forms/company" class="menu-link"><i class="fas fa-wpforms"></i> Manage Forms</a>
       <% } %>

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -6,7 +6,7 @@
     <%- include('partials/sidebar') %>
     <div class="content">
       <h1>Staff</h1>
-      <% if (isSuperAdmin) { %>
+      <% if (isAdmin) { %>
       <section>
         <h2>Add Staff</h2>
         <form action="/staff" method="post">


### PR DESCRIPTION
## Summary
- Move Office Groups menu below Staff and hide it from non-admins
- Allow company admins to add staff while reserving group creation/deletion for super admins
- Permit company admins to access staff area without explicit staff permission

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d556e11b4832d9cc3de9f54e11aff