### PR TITLE
Add audit logging and API key usage tracking

### DIFF
--- a/migrations/026_audit_logs.sql
+++ b/migrations/026_audit_logs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE audit_logs (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NULL,
+  action VARCHAR(255) NOT NULL,
+  previous_value TEXT NULL,
+  new_value TEXT NULL,
+  api_key VARCHAR(64) NULL,
+  ip_address VARCHAR(45) NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/migrations/027_api_key_usage.sql
+++ b/migrations/027_api_key_usage.sql
@@ -1,0 +1,8 @@
+CREATE TABLE api_key_usage (
+  api_key_id INT NOT NULL,
+  ip_address VARCHAR(45) NOT NULL,
+  usage_count INT NOT NULL DEFAULT 1,
+  last_used_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (api_key_id, ip_address),
+  FOREIGN KEY (api_key_id) REFERENCES api_keys(id) ON DELETE CASCADE
+);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -19,3 +19,11 @@ declare module 'express-session' {
     hasForms?: boolean;
   }
 }
+
+declare global {
+  namespace Express {
+    interface Request {
+      apiKey?: string;
+    }
+  }
+}

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -241,7 +241,9 @@
             </form>
             <table>
               <thead>
-                <tr><th>Key</th><th>Description</th><th>Expiry</th><th></th></tr>
+                <tr>
+                  <th>Key</th><th>Description</th><th>Expiry</th><th>Usage</th><th>Last Used</th><th>IPs</th><th></th>
+                </tr>
               </thead>
               <tbody>
               <% apiKeys.forEach(function(k) { %>
@@ -249,6 +251,9 @@
                   <td><%= k.api_key %></td>
                   <td><%= k.description %></td>
                   <td><%= k.expiry_date || '' %></td>
+                  <td><%= k.usage_count %></td>
+                  <td><%= k.last_used_at || '' %></td>
+                  <td><a href="#" class="show-ips" data-ips='<%- JSON.stringify(k.ips) %>'>View</a></td>
                   <td>
                     <form action="/admin/api-key/delete" method="post">
                       <input type="hidden" name="id" value="<%= k.id %>">
@@ -259,6 +264,12 @@
               <% }); %>
               </tbody>
             </table>
+            <div id="ip-modal" style="display:none;">
+              <div>
+                <button id="ip-modal-close">Close</button>
+                <ul id="ip-list"></ul>
+              </div>
+            </div>
           </section>
         </div>
         <div id="forms-admin" class="tab-content">
@@ -620,6 +631,23 @@
           });
           alert('App added to company');
         });
+      });
+      document.querySelectorAll('.show-ips').forEach(function(link){
+        link.addEventListener('click', function(e){
+          e.preventDefault();
+          const ips = JSON.parse(this.dataset.ips || '[]');
+          const list = document.getElementById('ip-list');
+          list.innerHTML = '';
+          ips.forEach(function(ip){
+            const li = document.createElement('li');
+            li.textContent = ip.ip_address + ' (' + ip.usage_count + ')';
+            list.appendChild(li);
+          });
+          document.getElementById('ip-modal').style.display = 'block';
+        });
+      });
+      document.getElementById('ip-modal-close')?.addEventListener('click', function(){
+        document.getElementById('ip-modal').style.display = 'none';
       });
     });
   </script>

--- a/src/views/audit-logs.ejs
+++ b/src/views/audit-logs.ejs
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Audit Logs' }) %>
+  <body>
+    <div class="app-container">
+      <%- include('partials/sidebar') %>
+      <div class="content">
+        <h1>Audit Logs</h1>
+        <% if (isSuperAdmin) { %>
+          <form method="get">
+            <label>Company:
+              <select name="companyId">
+                <option value="">All</option>
+                <% filterCompanies.forEach(function(c){ %>
+                  <option value="<%= c.id %>" <%= selectedCompanyId == c.id ? 'selected' : '' %>><%= c.name %></option>
+                <% }); %>
+              </select>
+            </label>
+            <button type="submit">Filter</button>
+          </form>
+        <% } %>
+        <table>
+          <thead>
+            <tr>
+              <% if (isSuperAdmin) { %><th>Company</th><% } %>
+              <th>User</th>
+              <th>Action</th>
+              <th>Previous</th>
+              <th>New</th>
+              <th>API Key</th>
+              <th>IP Address</th>
+              <th>Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% logs.forEach(function(l){ %>
+              <tr>
+                <% if (isSuperAdmin) { %><td><%= l.company_name || '' %></td><% } %>
+                <td><%= l.email || '' %></td>
+                <td><%= l.action %></td>
+                <td><%= l.previous_value || '' %></td>
+                <td><%= l.new_value || '' %></td>
+                <td><%= l.api_key || '' %></td>
+                <td><%= l.ip_address || '' %></td>
+                <td><%= l.created_at %></td>
+              </tr>
+            <% }); %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -44,6 +44,7 @@
       <% if (!isSuperAdmin) { %>
         <a href="/forms/company" class="menu-link"><i class="fas fa-wpforms"></i> Manage Forms</a>
       <% } %>
+      <a href="/audit-logs" class="menu-link"><i class="fas fa-clipboard-list"></i> Audit Logs</a>
     <% } %>
     <% if (isSuperAdmin) { %>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>


### PR DESCRIPTION
## Summary
- log all requests and persist audit details including user, action, API key snippet, and IP
- track API key usage per IP and expose usage counts in admin view
- show API key usage stats in admin with modal listing IP addresses
- allow admins to view audit logs for their company and let super admins filter across companies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689d86e92118832dbd45d94bd428c16d