### PR TITLE
Improve audit log value display and logging

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -92,6 +92,8 @@ table th {
   width: 90%;
   margin: 40px auto;
   min-height: calc(100vh - 80px);
+  max-width: 100vw;
+  overflow-x: auto;
 }
 
 .sidebar {
@@ -144,6 +146,7 @@ table th {
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   margin-left: 1rem;
+  overflow-x: auto;
 }
 
 .swagger-frame {
@@ -246,4 +249,13 @@ table th {
 
 .tab-content.active {
   display: block;
+}
+
+.audit-value span.truncate {
+  display: inline-block;
+  max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: pointer;
 }

--- a/src/views/audit-logs.ejs
+++ b/src/views/audit-logs.ejs
@@ -25,7 +25,7 @@
               <% if (isSuperAdmin) { %><th>Company</th><% } %>
               <th>User</th>
               <th>Action</th>
-              <th>New</th>
+              <th>Value</th>
               <th>API Key</th>
               <th>IP Address</th>
               <th>Date</th>
@@ -37,7 +37,13 @@
                 <% if (isSuperAdmin) { %><td><%= l.company_name || '' %></td><% } %>
                 <td><%= l.email || '' %></td>
                 <td><%= l.action %></td>
-                <td><%= l.new_value || '' %></td>
+                <td class="audit-value">
+                  <% if (l.value && l.value.length > 100) { %>
+                    <span class="truncate" data-full="<%- l.value %>"><%= l.value.slice(0, 100) %>...</span>
+                  <% } else { %>
+                    <span><%- l.value || '' %></span>
+                  <% } %>
+                </td>
                 <td><%= l.api_key || '' %></td>
                 <td><%= l.ip_address || '' %></td>
                 <td class="created-at" data-created-at="<%= l.created_at %>"></td>
@@ -53,6 +59,19 @@
         if (!isNaN(date.getTime())) {
           td.textContent = date.toLocaleString();
         }
+      });
+      document.querySelectorAll('.audit-value .truncate').forEach(function(span){
+        span.addEventListener('click', function(){
+          var modal = document.createElement('div');
+          modal.className = 'modal';
+          modal.innerHTML = '<div class="modal-content"><span class="close">&times;</span><pre>' +
+            span.dataset.full.replace(/</g, '&lt;') + '</pre></div>';
+          document.body.appendChild(modal);
+          modal.style.display = 'flex';
+          modal.querySelector('.close').addEventListener('click', function(){
+            modal.remove();
+          });
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- Prevent layout from stretching beyond viewport and truncate lengthy audit log values
- Rename audit log "New" column to "Value" and allow clicking truncated entries to view full value
- Log only changed fields in audit entries instead of full records

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689d90069018832dbb7ff117c1afd479