### PR TITLE
Add offboarding dates and localize onboarding timestamps

### DIFF
--- a/migrations/028_staff_offboard_date.sql
+++ b/migrations/028_staff_offboard_date.sql
@@ -1,0 +1,3 @@
+ALTER TABLE staff
+  MODIFY date_onboarded DATETIME NULL,
+  ADD COLUMN date_offboarded DATETIME NULL;

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -134,7 +134,8 @@ export interface Staff {
   first_name: string;
   last_name: string;
   email: string;
-  date_onboarded: string;
+  date_onboarded: string | null;
+  date_offboarded?: string | null;
   enabled: number;
   street?: string | null;
   city?: string | null;
@@ -512,7 +513,8 @@ export async function addStaff(
   firstName: string,
   lastName: string,
   email: string,
-  dateOnboarded: string,
+  dateOnboarded: string | null,
+  dateOffboarded: string | null,
   enabled: boolean,
   street?: string | null,
   city?: string | null,
@@ -525,13 +527,14 @@ export async function addStaff(
   managerName?: string | null
 ): Promise<void> {
   await pool.execute(
-    'INSERT INTO staff (company_id, first_name, last_name, email, date_onboarded, enabled, street, city, state, postcode, country, department, job_title, org_company, manager_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO staff (company_id, first_name, last_name, email, date_onboarded, date_offboarded, enabled, street, city, state, postcode, country, department, job_title, org_company, manager_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
     [
       companyId,
       firstName,
       lastName,
       email,
       dateOnboarded,
+      dateOffboarded,
       enabled ? 1 : 0,
       street || null,
       city || null,
@@ -562,7 +565,8 @@ export async function updateStaff(
   firstName: string,
   lastName: string,
   email: string,
-  dateOnboarded: string,
+  dateOnboarded: string | null,
+  dateOffboarded: string | null,
   enabled: boolean,
   street?: string | null,
   city?: string | null,
@@ -575,13 +579,14 @@ export async function updateStaff(
   managerName?: string | null
 ): Promise<void> {
   await pool.execute(
-    'UPDATE staff SET company_id = ?, first_name = ?, last_name = ?, email = ?, date_onboarded = ?, enabled = ?, street = ?, city = ?, state = ?, postcode = ?, country = ?, department = ?, job_title = ?, org_company = ?, manager_name = ? WHERE id = ?',
+    'UPDATE staff SET company_id = ?, first_name = ?, last_name = ?, email = ?, date_onboarded = ?, date_offboarded = ?, enabled = ?, street = ?, city = ?, state = ?, postcode = ?, country = ?, department = ?, job_title = ?, org_company = ?, manager_name = ? WHERE id = ?',
     [
       companyId,
       firstName,
       lastName,
       email,
       dateOnboarded,
+      dateOffboarded,
       enabled ? 1 : 0,
       street || null,
       city || null,

--- a/src/server.ts
+++ b/src/server.ts
@@ -119,6 +119,10 @@ import { runMigrations } from './db';
 
 dotenv.config();
 
+function toDateTime(value?: string): string | null {
+  return value ? value.replace('T', ' ') : null;
+}
+
 const app = express();
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
@@ -586,6 +590,7 @@ app.post('/staff', ensureAuth, ensureAdmin, async (req, res) => {
     lastName,
     email,
     dateOnboarded,
+    dateOffboarded,
     enabled,
     street,
     city,
@@ -603,7 +608,8 @@ app.post('/staff', ensureAuth, ensureAdmin, async (req, res) => {
       firstName,
       lastName,
       email,
-      dateOnboarded,
+      toDateTime(dateOnboarded),
+      toDateTime(dateOffboarded),
       !!enabled,
       street,
       city,
@@ -625,6 +631,7 @@ app.put('/staff/:id', ensureAuth, ensureStaffAccess, async (req, res) => {
     lastName,
     email,
     dateOnboarded,
+    dateOffboarded,
     enabled,
     street,
     city,
@@ -645,7 +652,8 @@ app.put('/staff/:id', ensureAuth, ensureStaffAccess, async (req, res) => {
     firstName,
     lastName,
     email,
-    dateOnboarded,
+    toDateTime(dateOnboarded),
+    toDateTime(dateOffboarded),
     !!enabled,
     street,
     city,
@@ -3052,7 +3060,11 @@ api.delete('/licenses/:id', async (req, res) => {
  *                     type: string
  *                   date_onboarded:
  *                     type: string
- *                     format: date
+ *                     format: date-time
+ *                   date_offboarded:
+ *                     type: string
+ *                     format: date-time
+ *                     nullable: true
  *                   enabled:
  *                     type: integer
  *                   street:
@@ -3117,7 +3129,10 @@ api.get('/staff', async (_req, res) => {
  *                 type: string
  *               dateOnboarded:
  *                 type: string
- *                 format: date
+ *                 format: date-time
+ *               dateOffboarded:
+ *                 type: string
+ *                 format: date-time
  *               enabled:
  *                 type: boolean
  *               street:
@@ -3156,6 +3171,7 @@ api.post('/staff', async (req, res) => {
     lastName,
     email,
     dateOnboarded,
+    dateOffboarded,
     enabled,
     street,
     city,
@@ -3172,7 +3188,8 @@ api.post('/staff', async (req, res) => {
     firstName,
     lastName,
     email,
-    dateOnboarded,
+    toDateTime(dateOnboarded),
+    toDateTime(dateOffboarded),
     !!enabled,
     street,
     city,
@@ -3220,7 +3237,11 @@ api.post('/staff', async (req, res) => {
  *                   type: string
  *                 date_onboarded:
  *                   type: string
- *                   format: date
+ *                   format: date-time
+ *                 date_offboarded:
+ *                   type: string
+ *                   format: date-time
+ *                   nullable: true
  *                 enabled:
  *                   type: integer
  *                 street:
@@ -3291,7 +3312,10 @@ api.get('/staff/:id', async (req, res) => {
  *                 type: string
  *               dateOnboarded:
  *                 type: string
- *                 format: date
+ *                 format: date-time
+ *               dateOffboarded:
+ *                 type: string
+ *                 format: date-time
  *               enabled:
  *                 type: boolean
  *               street:
@@ -3323,6 +3347,7 @@ api.put('/staff/:id', async (req, res) => {
     lastName,
     email,
     dateOnboarded,
+    dateOffboarded,
     enabled,
     street,
     city,
@@ -3340,7 +3365,8 @@ api.put('/staff/:id', async (req, res) => {
     firstName,
     lastName,
     email,
-    dateOnboarded,
+    toDateTime(dateOnboarded),
+    toDateTime(dateOffboarded),
     !!enabled,
     street,
     city,

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -13,7 +13,7 @@
           <input type="text" name="firstName" placeholder="First Name" required>
           <input type="text" name="lastName" placeholder="Last Name" required>
           <input type="email" name="email" placeholder="Email" required>
-          <input type="date" name="dateOnboarded">
+          <input type="datetime-local" name="dateOnboarded">
           <label><input type="checkbox" name="enabled" value="1" checked> Enabled</label>
           <button type="submit">Add</button>
         </form>
@@ -31,7 +31,7 @@
               <td><%= s.first_name %></td>
               <td><%= s.last_name %></td>
               <td><%= s.email %></td>
-              <td><%= s.date_onboarded %></td>
+              <td class="date-onboarded" data-date="<%= s.date_onboarded %>"><%= s.date_onboarded %></td>
               <td>
                 <form action="/staff/enabled" method="post">
                   <input type="hidden" name="staffId" value="<%= s.id %>">
@@ -45,7 +45,8 @@
                   data-first-name="<%= s.first_name %>"
                   data-last-name="<%= s.last_name %>"
                   data-email="<%= s.email %>"
-                  data-date-onboarded="<%= s.date_onboarded ? new Date(s.date_onboarded).toISOString().split('T')[0] : '' %>"
+                  data-date-onboarded="<%= s.date_onboarded ? new Date(s.date_onboarded).toISOString().slice(0,16) : '' %>"
+                  data-date-offboarded="<%= s.date_offboarded ? new Date(s.date_offboarded).toISOString().slice(0,16) : '' %>"
                   data-enabled="<%= s.enabled %>"
                   data-street="<%= s.street || '' %>"
                   data-city="<%= s.city || '' %>"
@@ -73,7 +74,8 @@
         <label>First Name<input type="text" id="edit-first-name"></label>
         <label>Last Name<input type="text" id="edit-last-name"></label>
         <label>Email<input type="email" id="edit-email"></label>
-        <label>Date Onboarded<input type="date" id="edit-date-onboarded"></label>
+        <label>Date Onboarded<input type="datetime-local" id="edit-date-onboarded"></label>
+        <label>Offboard Date<input type="datetime-local" id="edit-date-offboarded"></label>
         <label><input type="checkbox" id="edit-enabled"> Enabled</label>
         <fieldset>
           <legend>Address</legend>
@@ -100,6 +102,13 @@
     const editForm = document.getElementById('edit-form');
     let editingId = null;
 
+    document.querySelectorAll('.date-onboarded').forEach(function(cell) {
+      const value = cell.dataset.date;
+      if (value) {
+        cell.textContent = new Date(value).toLocaleString();
+      }
+    });
+
     document.querySelectorAll('.edit-btn').forEach(function(btn) {
       btn.addEventListener('click', function() {
         editingId = this.dataset.id;
@@ -107,6 +116,7 @@
         document.getElementById('edit-last-name').value = this.dataset.lastName;
         document.getElementById('edit-email').value = this.dataset.email;
         document.getElementById('edit-date-onboarded').value = this.dataset.dateOnboarded;
+        document.getElementById('edit-date-offboarded').value = this.dataset.dateOffboarded || '';
         document.getElementById('edit-enabled').checked = this.dataset.enabled === '1';
         document.getElementById('edit-street').value = this.dataset.street || '';
         document.getElementById('edit-city').value = this.dataset.city || '';
@@ -132,6 +142,7 @@
         lastName: document.getElementById('edit-last-name').value,
         email: document.getElementById('edit-email').value,
         dateOnboarded: document.getElementById('edit-date-onboarded').value,
+        dateOffboarded: document.getElementById('edit-date-offboarded').value,
         enabled: document.getElementById('edit-enabled').checked,
         street: document.getElementById('edit-street').value,
         city: document.getElementById('edit-city').value,


### PR DESCRIPTION
## Summary
- display staff onboarding times in the browser's locale
- support editing offboarding dates via new datetime field and API updates
- add migration to store onboard and offboard datetimes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e8567b84c832d8e410ad6ebe8706f