### PR TITLE
Add account action dropdown to staff editor

### DIFF
--- a/migrations/029_staff_account_action.sql
+++ b/migrations/029_staff_account_action.sql
@@ -1,0 +1,2 @@
+ALTER TABLE staff
+  ADD COLUMN account_action VARCHAR(50) NULL;

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -146,6 +146,7 @@ export interface Staff {
   job_title?: string | null;
   org_company?: string | null;
   manager_name?: string | null;
+  account_action?: string | null;
 }
 
 export interface ApiKey {
@@ -524,10 +525,11 @@ export async function addStaff(
   department?: string | null,
   jobTitle?: string | null,
   orgCompany?: string | null,
-  managerName?: string | null
+  managerName?: string | null,
+  accountAction?: string | null
 ): Promise<void> {
   await pool.execute(
-    'INSERT INTO staff (company_id, first_name, last_name, email, date_onboarded, date_offboarded, enabled, street, city, state, postcode, country, department, job_title, org_company, manager_name) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO staff (company_id, first_name, last_name, email, date_onboarded, date_offboarded, enabled, street, city, state, postcode, country, department, job_title, org_company, manager_name, account_action) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
     [
       companyId,
       firstName,
@@ -545,6 +547,7 @@ export async function addStaff(
       jobTitle || null,
       orgCompany || null,
       managerName || null,
+      accountAction || null,
     ]
   );
 }
@@ -576,10 +579,11 @@ export async function updateStaff(
   department?: string | null,
   jobTitle?: string | null,
   orgCompany?: string | null,
-  managerName?: string | null
+  managerName?: string | null,
+  accountAction?: string | null
 ): Promise<void> {
   await pool.execute(
-    'UPDATE staff SET company_id = ?, first_name = ?, last_name = ?, email = ?, date_onboarded = ?, date_offboarded = ?, enabled = ?, street = ?, city = ?, state = ?, postcode = ?, country = ?, department = ?, job_title = ?, org_company = ?, manager_name = ? WHERE id = ?',
+    'UPDATE staff SET company_id = ?, first_name = ?, last_name = ?, email = ?, date_onboarded = ?, date_offboarded = ?, enabled = ?, street = ?, city = ?, state = ?, postcode = ?, country = ?, department = ?, job_title = ?, org_company = ?, manager_name = ?, account_action = ? WHERE id = ?',
     [
       companyId,
       firstName,
@@ -597,6 +601,7 @@ export async function updateStaff(
       jobTitle || null,
       orgCompany || null,
       managerName || null,
+      accountAction || null,
       id,
     ]
   );

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -57,6 +57,7 @@
                   data-job-title="<%= s.job_title || '' %>"
                   data-company="<%= s.org_company || '' %>"
                   data-manager-name="<%= s.manager_name || '' %>"
+                  data-account-action="<%= s.account_action || '' %>"
                 >Edit</button>
               </td>
             </tr>
@@ -76,6 +77,18 @@
         <label>Email<input type="email" id="edit-email"></label>
         <label>Date Onboarded<input type="datetime-local" id="edit-date-onboarded"></label>
         <label>Offboard Date<input type="datetime-local" id="edit-date-offboarded"></label>
+        <label>Account Action
+          <select id="edit-account-action" <%= isSuperAdmin ? '' : 'disabled' %>>
+            <option value="Onboard Requested">Onboard Requested</option>
+            <option value="Onboard Approved">Onboard Approved</option>
+            <option value="Onboarding In Progress">Onboarding In Progress</option>
+            <option value="Onboarded">Onboarded</option>
+            <option value="Offboard Requested">Offboard Requested</option>
+            <option value="Offboard Approved">Offboard Approved</option>
+            <option value="Offboard Scheduled">Offboard Scheduled</option>
+            <option value="Offboarded">Offboarded</option>
+          </select>
+        </label>
         <label><input type="checkbox" id="edit-enabled"> Enabled</label>
         <fieldset>
           <legend>Address</legend>
@@ -127,6 +140,7 @@
         document.getElementById('edit-job-title').value = this.dataset.jobTitle || '';
         document.getElementById('edit-company').value = this.dataset.company || '';
         document.getElementById('edit-manager-name').value = this.dataset.managerName || '';
+        document.getElementById('edit-account-action').value = this.dataset.accountAction || '';
         editModal.style.display = 'flex';
       });
     });
@@ -153,6 +167,7 @@
         jobTitle: document.getElementById('edit-job-title').value,
         company: document.getElementById('edit-company').value,
         managerName: document.getElementById('edit-manager-name').value,
+        accountAction: document.getElementById('edit-account-action').value,
       };
       const res = await fetch(`/staff/${editingId}`, {
         method: 'PUT',


### PR DESCRIPTION
## Summary
- add account_action column and persistence
- restrict editing of account action to super admins
- expose account action dropdown in staff editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689e88895f9c832dafe4f10145032665