### PR TITLE
feat: manage multiple TOTP authenticators in admin

### DIFF
--- a/migrations/031_totp_authenticators.sql
+++ b/migrations/031_totp_authenticators.sql
@@ -1,0 +1,12 @@
+CREATE TABLE user_totp_authenticators (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  secret VARCHAR(255) NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+INSERT INTO user_totp_authenticators (user_id, name, secret)
+SELECT id, 'Authenticator', totp_secret FROM users WHERE totp_secret IS NOT NULL;
+
+ALTER TABLE users DROP COLUMN totp_secret;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -20,6 +20,11 @@ declare module 'express-session' {
     tempUserId?: number;
     pendingTotpSecret?: string;
     requireTotpSetup?: boolean;
+    newTotpSecret?: string;
+    newTotpName?: string;
+    newTotpError?: string;
+    passwordError?: string;
+    passwordSuccess?: string;
   }
 }
 

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -10,6 +10,7 @@
         <div class="tabs">
           <button data-tab="companies" class="active">Companies</button>
           <button data-tab="assignments">Current Assignments</button>
+          <button data-tab="account">Account</button>
           <% if (isSuperAdmin) { %>
             <button data-tab="apps">Apps</button>
             <button data-tab="api-keys">API Keys</button>
@@ -163,6 +164,53 @@
               <% }); %>
               </tbody>
             </table>
+          </section>
+        </div>
+        <div id="account" class="tab-content">
+          <section>
+            <h2>Change Password</h2>
+            <% if (passwordError) { %><p class="error"><%= passwordError %></p><% } %>
+            <% if (passwordSuccess) { %><p class="success"><%= passwordSuccess %></p><% } %>
+            <form method="post" action="/change-password">
+              <label>Current Password:
+                <input type="password" name="currentPassword" required>
+              </label>
+              <label>New Password:
+                <input type="password" name="newPassword" required>
+              </label>
+              <button type="submit">Update Password</button>
+            </form>
+          </section>
+          <section>
+            <h2>TOTP Authenticators</h2>
+            <ul>
+              <% totpAuthenticators.forEach(function(t){ %>
+                <li>
+                  <%= t.name %>
+                  <form method="post" action="/admin/totp/<%= t.id %>/delete" style="display:inline">
+                    <button type="submit">Remove</button>
+                  </form>
+                </li>
+              <% }); %>
+            </ul>
+            <% if (newTotpQr) { %>
+              <p>Scan this QR code or enter the code manually.</p>
+              <img src="<%= newTotpQr %>" alt="QR Code">
+              <p>Manual code: <code><%= newTotpSecret %></code></p>
+              <% if (totpError) { %><p class="error"><%= totpError %></p><% } %>
+              <form method="post" action="/admin/totp/verify">
+                <label>Authentication Code:
+                  <input type="text" name="token" required>
+                </label>
+                <button type="submit">Verify</button>
+              </form>
+              <form method="post" action="/admin/totp/cancel"><button type="submit">Cancel</button></form>
+            <% } else { %>
+              <form method="post" action="/admin/totp/start">
+                <input type="text" name="name" placeholder="Authenticator Name" required>
+                <button type="submit">Add Authenticator</button>
+              </form>
+            <% } %>
           </section>
         </div>
         <% if (isSuperAdmin) { %>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -45,7 +45,6 @@
         <a href="/forms/company" class="menu-link"><i class="fas fa-wpforms"></i> Manage Forms</a>
       <% } %>
       <a href="/audit-logs" class="menu-link"><i class="fas fa-clipboard-list"></i> Audit Logs</a>
-      <a href="/change-password" class="menu-link"><i class="fas fa-key"></i> Change Password</a>
     <% } %>
     <% if (isSuperAdmin) { %>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>

--- a/src/views/totp.ejs
+++ b/src/views/totp.ejs
@@ -6,10 +6,16 @@
       <h1>Two-Factor Authentication</h1>
       <% if (error) { %><p class="error"><%= error %></p><% } %>
       <% if (qrCode) { %>
-        <p>Scan this QR code with your authenticator app and enter the code below.</p>
+        <p>Scan this QR code with your authenticator app or enter the code manually.</p>
         <img src="<%= qrCode %>" alt="QR Code">
+        <p>Manual code: <code><%= secret %></code></p>
       <% } %>
       <form method="post" action="/totp">
+        <% if (requireSetup) { %>
+        <label>Device Name:
+          <input type="text" name="deviceName" required>
+        </label>
+        <% } %>
         <label>Authentication Code:
           <input type="text" name="token" required>
         </label>


### PR DESCRIPTION
## Summary
- allow admins to manage multiple TOTP authenticators with names
- move Change Password into new Account tab in admin area
- display manual codes for authenticator setup and support removal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e8e2e4f5c832da9f3e731b397bab2