### PR TITLE
Fix admin redirect after adding apps

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1321,7 +1321,7 @@ app.post(
 app.post('/apps', ensureAuth, ensureSuperAdmin, async (req, res) => {
   const { sku, name, price, contractTerm } = req.body;
   await createApp(sku, name, parseFloat(price), contractTerm);
-  res.redirect('/apps');
+  res.redirect('/admin#apps');
 });
 
 app.post('/apps/price', ensureAuth, ensureSuperAdmin, async (req, res) => {
@@ -1331,7 +1331,7 @@ app.post('/apps/price', ensureAuth, ensureSuperAdmin, async (req, res) => {
     parseInt(appId, 10),
     parseFloat(price)
   );
-  res.redirect('/apps');
+  res.redirect('/admin#apps');
 });
 
 app.post('/apps/:appId/add', ensureAuth, ensureSuperAdmin, async (req, res) => {


### PR DESCRIPTION
## Summary
- Redirect app creation and pricing routes back to the admin page instead of non-existent /apps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689e90c479ac832dbc2a9c6db7b20a11