### PR TITLE
feat: allow super admin deletion

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -703,6 +703,11 @@ app.put('/licenses/:id', ensureAuth, ensureSuperAdmin, async (req, res) => {
   res.json({ success: true });
 });
 
+app.delete('/licenses/:id', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  await deleteLicense(parseInt(req.params.id, 10));
+  res.json({ success: true });
+});
+
 app.get('/staff', ensureAuth, ensureStaffAccess, async (req, res) => {
   const companies = await getCompaniesForUser(req.session.userId!);
   const enabledFilter = req.query.enabled as string | undefined;
@@ -825,6 +830,11 @@ app.put('/staff/:id', ensureAuth, ensureStaffAccess, async (req, res) => {
   res.json({ success: true });
 });
 
+app.delete('/staff/:id', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  await deleteStaff(parseInt(req.params.id, 10));
+  res.json({ success: true });
+});
+
 app.post('/staff/enabled', ensureAuth, ensureStaffAccess, async (req, res) => {
   const { staffId, enabled } = req.body;
   await updateStaffEnabled(parseInt(staffId, 10), !!enabled);
@@ -851,6 +861,11 @@ app.get('/assets', ensureAuth, ensureAssetsAccess, async (req, res) => {
   });
 });
 
+app.delete('/assets/:id', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  await deleteAsset(parseInt(req.params.id, 10));
+  res.json({ success: true });
+});
+
 app.get('/invoices', ensureAuth, ensureInvoicesAccess, async (req, res) => {
   const companies = await getCompaniesForUser(req.session.userId!);
   const invoices = req.session.companyId
@@ -869,6 +884,11 @@ app.get('/invoices', ensureAuth, ensureInvoicesAccess, async (req, res) => {
     canOrderLicenses: current?.can_order_licenses ?? 0,
     canAccessShop: current?.can_access_shop ?? 0,
   });
+});
+
+app.delete('/invoices/:id', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  await deleteInvoice(parseInt(req.params.id, 10));
+  res.json({ success: true });
 });
 
 app.get('/forms', ensureAuth, async (req, res) => {
@@ -1638,6 +1658,17 @@ app.post('/admin/assign', ensureAuth, ensureAdmin, async (req, res) => {
     false
   );
   res.redirect('/admin');
+});
+
+app.delete('/admin/assign/:companyId/:userId', ensureAuth, ensureSuperAdmin, async (
+  req,
+  res
+) => {
+  await unassignUserFromCompany(
+    parseInt(req.params.userId, 10),
+    parseInt(req.params.companyId, 10)
+  );
+  res.json({ success: true });
 });
 
 function parseCheckbox(value: unknown): boolean {

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -97,7 +97,7 @@
             <h2>Current Assignments</h2>
             <table>
               <thead>
-                <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Assets</th><th>Invoices</th><th>Shop</th></tr>
+                <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Assets</th><th>Invoices</th><th>Shop</th><% if (isSuperAdmin) { %><th>Remove</th><% } %></tr>
               </thead>
               <tbody>
               <% assignments.forEach(function(a) { %>
@@ -160,6 +160,9 @@
                       <input type="checkbox" name="canAccessShop" value="1" <%= a.can_access_shop ? 'checked' : '' %> onchange="this.form.submit()">
                     </form>
                   </td>
+                  <% if (isSuperAdmin) { %>
+                  <td><button class="unassign-btn" data-user-id="<%= a.user_id %>" data-company-id="<%= a.company_id %>">Remove</button></td>
+                  <% } %>
                 </tr>
               <% }); %>
               </tbody>
@@ -676,6 +679,14 @@
             body: JSON.stringify({ companyId: parseInt(companyId,10), quantity: parseInt(qty,10) })
           });
           alert('App added to company');
+        });
+      });
+
+      document.querySelectorAll('.unassign-btn').forEach(function(btn){
+        btn.addEventListener('click', async function(){
+          if(!confirm('Remove assignment?')) return;
+          await fetch(`/admin/assign/${this.dataset.companyId}/${this.dataset.userId}`, { method: 'DELETE' });
+          location.reload();
         });
       });
       document.querySelectorAll('.show-ips').forEach(function(link){

--- a/src/views/assets.ejs
+++ b/src/views/assets.ejs
@@ -10,7 +10,7 @@
         <h2>Company Assets</h2>
         <table>
           <thead>
-            <tr><th>Name</th><th>Type</th><th>Serial Number</th><th>Status</th></tr>
+            <tr><th>Name</th><th>Type</th><th>Serial Number</th><th>Status</th><% if (isSuperAdmin) { %><th>Actions</th><% } %></tr>
           </thead>
           <tbody>
           <% assets.forEach(function(a) { %>
@@ -19,6 +19,9 @@
               <td><%= a.type %></td>
               <td><%= a.serial_number %></td>
               <td><%= a.status %></td>
+              <% if (isSuperAdmin) { %>
+              <td><button class="delete-btn" data-asset-id="<%= a.id %>">Delete</button></td>
+              <% } %>
             </tr>
           <% }); %>
           </tbody>
@@ -26,5 +29,20 @@
       </section>
     </div>
   </div>
+<% if (isSuperAdmin) { %>
+<script>
+  document.querySelectorAll('.delete-btn').forEach(function(btn) {
+    btn.addEventListener('click', async function() {
+      if (!confirm('Delete asset?')) return;
+      const res = await fetch(`/assets/${this.dataset.assetId}`, { method: 'DELETE' });
+      if (res.ok) {
+        location.reload();
+      } else {
+        alert('Failed to delete asset');
+      }
+    });
+  });
+</script>
+<% } %>
 </body>
 </html>

--- a/src/views/invoices.ejs
+++ b/src/views/invoices.ejs
@@ -10,7 +10,7 @@
         <h2>Company Invoices</h2>
         <table>
           <thead>
-            <tr><th>Number</th><th>Amount</th><th>Due Date</th><th>Status</th></tr>
+            <tr><th>Number</th><th>Amount</th><th>Due Date</th><th>Status</th><% if (isSuperAdmin) { %><th>Actions</th><% } %></tr>
           </thead>
           <tbody>
           <% invoices.forEach(function(i) { %>
@@ -19,6 +19,9 @@
               <td><%= i.amount %></td>
               <td><%= i.due_date %></td>
               <td><%= i.status %></td>
+              <% if (isSuperAdmin) { %>
+              <td><button class="delete-btn" data-invoice-id="<%= i.id %>">Delete</button></td>
+              <% } %>
             </tr>
           <% }); %>
           </tbody>
@@ -26,5 +29,20 @@
       </section>
     </div>
   </div>
+<% if (isSuperAdmin) { %>
+<script>
+  document.querySelectorAll('.delete-btn').forEach(function(btn) {
+    btn.addEventListener('click', async function() {
+      if (!confirm('Delete invoice?')) return;
+      const res = await fetch(`/invoices/${this.dataset.invoiceId}`, { method: 'DELETE' });
+      if (res.ok) {
+        location.reload();
+      } else {
+        alert('Failed to delete invoice');
+      }
+    });
+  });
+</script>
+<% } %>
 </body>
 </html>

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -39,6 +39,7 @@
                     data-expiry-date="<%= lic.expiry_date ? new Date(lic.expiry_date).toISOString().split('T')[0] : '' %>"
                     data-contract-term="<%= lic.contract_term %>"
                   >Edit</button>
+                  <button class="delete-btn" data-license-id="<%= lic.id %>">Delete</button>
                 <% } %>
                 <% if (canOrderLicenses) { %>
                   <button class="order-btn" data-license-id="<%= lic.id %>">Order More</button>
@@ -186,6 +187,18 @@
       } else {
         alert('Failed to update license');
       }
+    });
+
+    document.querySelectorAll('.delete-btn').forEach(function(btn) {
+      btn.addEventListener('click', async function() {
+        if (!confirm('Delete license?')) return;
+        const res = await fetch(`/licenses/${this.dataset.licenseId}`, { method: 'DELETE' });
+        if (res.ok) {
+          location.reload();
+        } else {
+          alert('Failed to delete license');
+        }
+      });
     });
   </script>
 </body>

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -68,6 +68,9 @@
                   data-manager-name="<%= s.manager_name || '' %>"
                   data-account-action="<%= s.account_action || '' %>"
                 >Edit</button>
+                <% if (isSuperAdmin) { %>
+                  <button class="delete-btn" data-id="<%= s.id %>">Delete</button>
+                <% } %>
               </td>
             </tr>
           <% }); %>
@@ -161,6 +164,18 @@
         document.getElementById('edit-manager-name').value = this.dataset.managerName || '';
         document.getElementById('edit-account-action').value = this.dataset.accountAction || '';
         editModal.style.display = 'flex';
+      });
+    });
+
+    document.querySelectorAll('.delete-btn').forEach(function(btn) {
+      btn.addEventListener('click', async function() {
+        if (!confirm('Delete staff member?')) return;
+        const res = await fetch(`/staff/${this.dataset.id}`, { method: 'DELETE' });
+        if (res.ok) {
+          location.reload();
+        } else {
+          alert('Failed to delete staff');
+        }
       });
     });
 


### PR DESCRIPTION
## Summary
- allow super admins to delete staff, licenses, assets, invoices, and assignments
- expose delete endpoints and UI buttons for restricted actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e94e94938832dbfaf2fb548509bd9