### PR TITLE
Restrict staff menu and business summary to authorized admins

### DIFF
--- a/src/views/business.ejs
+++ b/src/views/business.ejs
@@ -12,19 +12,26 @@
           <p>Address: <%= company.address %></p>
         <% } %>
         <div class="stats">
+          <% if (canManageStaff || isSuperAdmin) { %>
           <div class="stat-card">
             <h3>Active Users</h3>
             <p><%= activeUsers %></p>
           </div>
+          <% } %>
+          <% if (canManageAssets || isSuperAdmin) { %>
           <div class="stat-card">
             <h3>Assets</h3>
             <p><%= assetCount %></p>
           </div>
+          <% } %>
+          <% if (canManageInvoices || isSuperAdmin) { %>
           <div class="stat-card">
             <h3>Invoices</h3>
             <p>Paid: <%= paidInvoices %> | Unpaid: <%= unpaidInvoices %></p>
           </div>
+          <% } %>
         </div>
+        <% if (canManageLicenses || isSuperAdmin) { %>
         <h2>Licenses</h2>
         <table>
           <thead>
@@ -41,6 +48,7 @@
           <% }); %>
           </tbody>
         </table>
+        <% } %>
       <% } %>
     </div>
   </div>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -14,10 +14,10 @@
       <br>
     <% } %>
     <a href="/" class="menu-link"><i class="fas fa-briefcase"></i> Business Info</a>
-    <% if (canManageStaff || (typeof isAdmin !== 'undefined' && isAdmin)) { %>
+    <% if (canManageStaff || isSuperAdmin) { %>
       <a href="/staff" class="menu-link"><i class="fas fa-users"></i> Staff</a>
     <% } %>
-    <% if (typeof isAdmin !== 'undefined' && isAdmin) { %>
+    <% if (canManageStaff || isSuperAdmin) { %>
       <a href="/office-groups" class="menu-link"><i class="fas fa-layer-group"></i> Office Groups</a>
     <% } %>
     <% if (canManageLicenses) { %>


### PR DESCRIPTION
## Summary
- Only fetch and display business summary metrics if the user has permission for each section
- Require staff permission for Staff and Office Groups navigation links and routes
- Tighten staff access middleware to ignore admin flag unless superadmin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e99b8de04832dbd1e1a783c626aaa