### PR TITLE
feat(staff): add email search option

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -513,13 +513,22 @@ export async function getStaffByCompany(
 }
 
 export async function getAllStaff(
-  accountAction?: string
+  accountAction?: string,
+  email?: string
 ): Promise<Staff[]> {
   let sql = 'SELECT * FROM staff';
   const params: any[] = [];
+  const conditions: string[] = [];
   if (accountAction) {
-    sql += ' WHERE account_action = ?';
+    conditions.push('account_action = ?');
     params.push(accountAction);
+  }
+  if (email) {
+    conditions.push('email LIKE ?');
+    params.push(`%${email}%`);
+  }
+  if (conditions.length) {
+    sql += ' WHERE ' + conditions.join(' AND ');
   }
   const [rows] = await pool.query<RowDataPacket[]>(sql, params);
   return rows as Staff[];

--- a/src/server.ts
+++ b/src/server.ts
@@ -3377,6 +3377,12 @@ api.delete('/licenses/:id', async (req, res) => {
  *           type: string
  *         required: false
  *         description: Filter by account action
+ *       - in: query
+ *         name: email
+ *         schema:
+ *           type: string
+ *         required: false
+ *         description: Filter by email address
  *     responses:
  *       200:
  *         description: Array of staff
@@ -3439,7 +3445,8 @@ api.delete('/licenses/:id', async (req, res) => {
  */
 api.get('/staff', async (req, res) => {
   const accountAction = req.query.accountAction as string | undefined;
-  const staff = await getAllStaff(accountAction);
+  const email = req.query.email as string | undefined;
+  const staff = await getAllStaff(accountAction, email);
   res.json(staff);
 });
 


### PR DESCRIPTION
## Summary
- add optional email filter to GET /api/staff
- update staff query to allow email substring search
- document new `email` query param in Swagger

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689e9f57dfac832db6efa50d96dc0567