### PR TITLE
Ensure modal edit forms have labeled single-line fields

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -196,6 +196,19 @@ table th {
   width: 90%;
 }
 
+.modal-content form label {
+  display: block;
+  margin-top: 0.5rem;
+}
+
+.modal-content form input,
+.modal-content form textarea,
+.modal-content form select {
+  display: block;
+  width: 100%;
+  margin-top: 0.25rem;
+}
+
 .modal .close {
   float: right;
   cursor: pointer;

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -582,21 +582,30 @@
               <div class="modal-content" style="width:300px;">
                 <h3>Edit Product</h3>
                 <form id="editForm" method="post" enctype="multipart/form-data">
-                  <input type="text" name="name" placeholder="Name" required>
-                  <input type="text" name="sku" placeholder="SKU" required>
-                  <input type="text" name="vendor_sku" placeholder="Vendor SKU" required>
-                  <textarea name="description" placeholder="Description"></textarea>
-                  <input type="number" step="0.01" name="price" placeholder="Price" required>
-                  <input type="number" step="0.01" name="vip_price" placeholder="VIP Price">
-                  <input type="number" name="stock" placeholder="Stock" required>
-                  <select name="category_id">
+                  <label for="edit-name">Name</label>
+                  <input type="text" id="edit-name" name="name" required>
+                  <label for="edit-sku">SKU</label>
+                  <input type="text" id="edit-sku" name="sku" required>
+                  <label for="edit-vendor-sku">Vendor SKU</label>
+                  <input type="text" id="edit-vendor-sku" name="vendor_sku" required>
+                  <label for="edit-description">Description</label>
+                  <textarea id="edit-description" name="description"></textarea>
+                  <label for="edit-price">Price</label>
+                  <input type="number" step="0.01" id="edit-price" name="price" required>
+                  <label for="edit-vip-price">VIP Price</label>
+                  <input type="number" step="0.01" id="edit-vip-price" name="vip_price">
+                  <label for="edit-stock">Stock</label>
+                  <input type="number" id="edit-stock" name="stock" required>
+                  <label for="edit-category">Category</label>
+                  <select id="edit-category" name="category_id">
                     <option value="">No Category</option>
                     <% categories.forEach(function(c){ %>
                       <option value="<%= c.id %>"><%= c.name %></option>
                     <% }) %>
                   </select>
-                  <img id="editImagePreview" src="" width="100" alt="" style="display:none;"><br>
-                  <input type="file" name="image">
+                  <label for="edit-image">Image</label>
+                  <img id="editImagePreview" src="" width="100" alt="" style="display:none;">
+                  <input type="file" id="edit-image" name="image">
                   <button type="submit">Save</button>
                   <button type="button" onclick="closeEditModal()">Close</button>
                 </form>

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -67,26 +67,16 @@
       <span id="edit-close" class="close">&times;</span>
       <h2>Edit License</h2>
       <form id="edit-form">
-        <label>
-          Name
-          <input type="text" id="edit-name">
-        </label>
-        <label>
-          SKU
-          <input type="text" id="edit-sku">
-        </label>
-        <label>
-          Count
-          <input type="number" id="edit-count">
-        </label>
-        <label>
-          Expiry
-          <input type="date" id="edit-expiry">
-        </label>
-        <label>
-          Contract Term
-          <input type="text" id="edit-contract">
-        </label>
+        <label for="edit-name">Name</label>
+        <input type="text" id="edit-name">
+        <label for="edit-sku">SKU</label>
+        <input type="text" id="edit-sku">
+        <label for="edit-count">Count</label>
+        <input type="number" id="edit-count">
+        <label for="edit-expiry">Expiry</label>
+        <input type="date" id="edit-expiry">
+        <label for="edit-contract">Contract Term</label>
+        <input type="text" id="edit-contract">
         <button type="submit">Save</button>
       </form>
     </div>

--- a/src/views/shop-admin.ejs
+++ b/src/views/shop-admin.ejs
@@ -170,23 +170,32 @@
           <div class="modal-content" style="width:300px;">
             <h3>Edit Product</h3>
             <form id="editForm" method="post" enctype="multipart/form-data">
-              <input type="text" name="name" placeholder="Name" required>
-              <input type="text" name="sku" placeholder="SKU" required>
-              <input type="text" name="vendor_sku" placeholder="Vendor SKU" required>
-              <textarea name="description" placeholder="Description"></textarea>
-            <input type="number" step="0.01" name="price" placeholder="Price" required>
-            <input type="number" step="0.01" name="vip_price" placeholder="VIP Price">
-            <input type="number" name="stock" placeholder="Stock" required>
-            <select name="category_id">
-              <option value="">No Category</option>
-              <% categories.forEach(function(c){ %>
-                <option value="<%= c.id %>"><%= c.name %></option>
-              <% }) %>
-            </select>
-            <img id="editImagePreview" src="" width="100" alt="" style="display:none;"><br>
-            <input type="file" name="image">
-            <button type="submit">Save</button>
-            <button type="button" onclick="closeEditModal()">Close</button>
+              <label for="edit-name">Name</label>
+              <input type="text" id="edit-name" name="name" required>
+              <label for="edit-sku">SKU</label>
+              <input type="text" id="edit-sku" name="sku" required>
+              <label for="edit-vendor-sku">Vendor SKU</label>
+              <input type="text" id="edit-vendor-sku" name="vendor_sku" required>
+              <label for="edit-description">Description</label>
+              <textarea id="edit-description" name="description"></textarea>
+              <label for="edit-price">Price</label>
+              <input type="number" step="0.01" id="edit-price" name="price" required>
+              <label for="edit-vip-price">VIP Price</label>
+              <input type="number" step="0.01" id="edit-vip-price" name="vip_price">
+              <label for="edit-stock">Stock</label>
+              <input type="number" id="edit-stock" name="stock" required>
+              <label for="edit-category">Category</label>
+              <select id="edit-category" name="category_id">
+                <option value="">No Category</option>
+                <% categories.forEach(function(c){ %>
+                  <option value="<%= c.id %>"><%= c.name %></option>
+                <% }) %>
+              </select>
+              <label for="edit-image">Image</label>
+              <img id="editImagePreview" src="" width="100" alt="" style="display:none;">
+              <input type="file" id="edit-image" name="image">
+              <button type="submit">Save</button>
+              <button type="button" onclick="closeEditModal()">Close</button>
             </form>
           </div>
         </div>

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -84,38 +84,51 @@
       <span id="edit-close" class="close">&times;</span>
       <h2>Edit Staff</h2>
       <form id="edit-form">
-        <label>First Name<input type="text" id="edit-first-name" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-        <label>Last Name<input type="text" id="edit-last-name" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-        <label>Email<input type="email" id="edit-email" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-        <label>Date Onboarded<input type="date" id="edit-date-onboarded" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-        <label>Offboard Date<input type="datetime-local" id="edit-date-offboarded" <%= isAdmin ? '' : 'readonly' %>></label>
-        <label>Account Action
-          <select id="edit-account-action" <%= isSuperAdmin ? '' : 'disabled' %>>
-            <option value="Onboard Requested">Onboard Requested</option>
-            <option value="Onboard Approved">Onboard Approved</option>
-            <option value="Onboarding In Progress">Onboarding In Progress</option>
-            <option value="Onboarded">Onboarded</option>
-            <option value="Offboard Requested">Offboard Requested</option>
-            <option value="Offboard Approved">Offboard Approved</option>
-            <option value="Offboard Scheduled">Offboard Scheduled</option>
-            <option value="Offboarded">Offboarded</option>
-          </select>
-        </label>
+        <label for="edit-first-name">First Name</label>
+        <input type="text" id="edit-first-name" <%= isSuperAdmin ? '' : 'readonly' %>>
+        <label for="edit-last-name">Last Name</label>
+        <input type="text" id="edit-last-name" <%= isSuperAdmin ? '' : 'readonly' %>>
+        <label for="edit-email">Email</label>
+        <input type="email" id="edit-email" <%= isSuperAdmin ? '' : 'readonly' %>>
+        <label for="edit-date-onboarded">Date Onboarded</label>
+        <input type="date" id="edit-date-onboarded" <%= isSuperAdmin ? '' : 'readonly' %>>
+        <label for="edit-date-offboarded">Offboard Date</label>
+        <input type="datetime-local" id="edit-date-offboarded" <%= isAdmin ? '' : 'readonly' %>>
+        <label for="edit-account-action">Account Action</label>
+        <select id="edit-account-action" <%= isSuperAdmin ? '' : 'disabled' %>>
+          <option value="Onboard Requested">Onboard Requested</option>
+          <option value="Onboard Approved">Onboard Approved</option>
+          <option value="Onboarding In Progress">Onboarding In Progress</option>
+          <option value="Onboarded">Onboarded</option>
+          <option value="Offboard Requested">Offboard Requested</option>
+          <option value="Offboard Approved">Offboard Approved</option>
+          <option value="Offboard Scheduled">Offboard Scheduled</option>
+          <option value="Offboarded">Offboarded</option>
+        </select>
         <label><input type="checkbox" id="edit-enabled" <%= isSuperAdmin ? '' : 'disabled' %>> Enabled</label>
         <fieldset>
           <legend>Address</legend>
-          <label>Street<input type="text" id="edit-street" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-          <label>City<input type="text" id="edit-city" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-          <label>State<input type="text" id="edit-state" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-          <label>Postcode<input type="text" id="edit-postcode" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-          <label>Country<input type="text" id="edit-country" <%= isSuperAdmin ? '' : 'readonly' %>></label>
+          <label for="edit-street">Street</label>
+          <input type="text" id="edit-street" <%= isSuperAdmin ? '' : 'readonly' %>>
+          <label for="edit-city">City</label>
+          <input type="text" id="edit-city" <%= isSuperAdmin ? '' : 'readonly' %>>
+          <label for="edit-state">State</label>
+          <input type="text" id="edit-state" <%= isSuperAdmin ? '' : 'readonly' %>>
+          <label for="edit-postcode">Postcode</label>
+          <input type="text" id="edit-postcode" <%= isSuperAdmin ? '' : 'readonly' %>>
+          <label for="edit-country">Country</label>
+          <input type="text" id="edit-country" <%= isSuperAdmin ? '' : 'readonly' %>>
         </fieldset>
         <fieldset>
           <legend>Organisation</legend>
-          <label>Department<input type="text" id="edit-department" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-          <label>Job Title<input type="text" id="edit-job-title" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-          <label>Company<input type="text" id="edit-company" <%= isSuperAdmin ? '' : 'readonly' %>></label>
-          <label>Manager's Name<input type="text" id="edit-manager-name" <%= isSuperAdmin ? '' : 'readonly' %>></label>
+          <label for="edit-department">Department</label>
+          <input type="text" id="edit-department" <%= isSuperAdmin ? '' : 'readonly' %>>
+          <label for="edit-job-title">Job Title</label>
+          <input type="text" id="edit-job-title" <%= isSuperAdmin ? '' : 'readonly' %>>
+          <label for="edit-company">Company</label>
+          <input type="text" id="edit-company" <%= isSuperAdmin ? '' : 'readonly' %>>
+          <label for="edit-manager-name">Manager's Name</label>
+          <input type="text" id="edit-manager-name" <%= isSuperAdmin ? '' : 'readonly' %>>
         </fieldset>
         <button type="submit">Save</button>
       </form>


### PR DESCRIPTION
## Summary
- Add block-level label and input styling for modal forms
- Provide explicit labels and ids for product edit modals in shop admin and admin pages
- Restructure staff and license edit modals to show one labeled input per line

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_689eb3dffb34832d92c9d4029e16d30c