### PR TITLE
Show API key snippet with modal and CF IP logging

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -274,6 +274,7 @@ function auditLogger(
       }
     }
 
+    const ip = (req.headers['cf-connecting-ip'] as string) || req.ip;
     logAudit({
       userId: req.session.userId || null,
       companyId,
@@ -281,7 +282,7 @@ function auditLogger(
       previousValue: null,
       newValue: JSON.stringify(sanitizedBody),
       apiKey: req.apiKey,
-      ipAddress: req.ip,
+      ipAddress: ip,
     }).catch(() => {});
   });
   next();
@@ -1867,7 +1868,8 @@ api.use(async (req, res, next) => {
     return res.status(403).json({ error: 'Invalid API key' });
   }
   req.apiKey = key;
-  await recordApiKeyUsage(record.id, req.ip || '');
+  const ip = (req.headers['cf-connecting-ip'] as string) || req.ip || '';
+  await recordApiKeyUsage(record.id, ip);
   next();
 });
 

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -299,11 +299,11 @@
               <tbody>
               <% apiKeys.forEach(function(k) { %>
                 <tr>
-                  <td><%= k.api_key %></td>
+                  <td><a href="#" class="show-key" data-full="<%= k.api_key %>"><%= k.api_key.slice(0,3) %>...<%= k.api_key.slice(-3) %></a></td>
                   <td><%= k.description %></td>
                   <td><%= k.expiry_date || '' %></td>
                   <td><%= k.usage_count %></td>
-                  <td><%= k.last_used_at || '' %></td>
+                  <td class="last-used" data-last="<%= k.last_used_at ? (k.last_used_at.toISOString ? k.last_used_at.toISOString() : k.last_used_at) : '' %>"></td>
                   <td><a href="#" class="show-ips" data-ips='<%- JSON.stringify(k.ips) %>'>View</a></td>
                   <td>
                     <form action="/admin/api-key/delete" method="post">
@@ -319,6 +319,12 @@
               <div class="modal-content">
                 <button id="ip-modal-close">Close</button>
                 <ul id="ip-list"></ul>
+              </div>
+            </div>
+            <div id="key-modal" class="modal" style="display:none;">
+              <div class="modal-content">
+                <button id="key-modal-close">Close</button>
+                <pre id="full-key"></pre>
               </div>
             </div>
           </section>
@@ -714,6 +720,23 @@
       });
       document.getElementById('ip-modal-close')?.addEventListener('click', function(){
         document.getElementById('ip-modal').style.display = 'none';
+      });
+      document.querySelectorAll('.show-key').forEach(function(link){
+        link.addEventListener('click', function(e){
+          e.preventDefault();
+          document.getElementById('full-key').textContent = this.dataset.full || '';
+          document.getElementById('key-modal').style.display = 'flex';
+        });
+      });
+      document.getElementById('key-modal-close')?.addEventListener('click', function(){
+        document.getElementById('key-modal').style.display = 'none';
+      });
+      document.querySelectorAll('td.last-used').forEach(function(td){
+        const val = td.dataset.last;
+        if(val){
+          const d = new Date(val);
+          td.textContent = d.toLocaleString();
+        }
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- Display API keys as snippets with click-to-view modal and convert last-used timestamps to the browser's local time
- Record IP addresses using `Cf-Connecting-Ip` header when available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689ece888dc8832db2be5598e50789cb