### PR TITLE
Style modal forms with inline labels

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -197,16 +197,16 @@ table th {
 }
 
 .modal-content form label {
-  display: block;
+  display: flex;
+  align-items: center;
   margin-top: 0.5rem;
+  gap: 0.5rem;
 }
 
-.modal-content form input,
-.modal-content form textarea,
-.modal-content form select {
-  display: block;
-  width: 100%;
-  margin-top: 0.25rem;
+.modal-content form label > input:not([type="checkbox"]):not([type="radio"]),
+.modal-content form label > textarea,
+.modal-content form label > select {
+  flex: 1;
 }
 
 .modal .close {

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -588,30 +588,39 @@
               <div class="modal-content" style="width:300px;">
                 <h3>Edit Product</h3>
                 <form id="editForm" method="post" enctype="multipart/form-data">
-                  <label for="edit-name">Name</label>
-                  <input type="text" id="edit-name" name="name" required>
-                  <label for="edit-sku">SKU</label>
-                  <input type="text" id="edit-sku" name="sku" required>
-                  <label for="edit-vendor-sku">Vendor SKU</label>
-                  <input type="text" id="edit-vendor-sku" name="vendor_sku" required>
-                  <label for="edit-description">Description</label>
-                  <textarea id="edit-description" name="description"></textarea>
-                  <label for="edit-price">Price</label>
-                  <input type="number" step="0.01" id="edit-price" name="price" required>
-                  <label for="edit-vip-price">VIP Price</label>
-                  <input type="number" step="0.01" id="edit-vip-price" name="vip_price">
-                  <label for="edit-stock">Stock</label>
-                  <input type="number" id="edit-stock" name="stock" required>
-                  <label for="edit-category">Category</label>
-                  <select id="edit-category" name="category_id">
-                    <option value="">No Category</option>
-                    <% categories.forEach(function(c){ %>
-                      <option value="<%= c.id %>"><%= c.name %></option>
-                    <% }) %>
-                  </select>
-                  <label for="edit-image">Image</label>
+                  <label for="edit-name">Name
+                    <input type="text" id="edit-name" name="name" required>
+                  </label>
+                  <label for="edit-sku">SKU
+                    <input type="text" id="edit-sku" name="sku" required>
+                  </label>
+                  <label for="edit-vendor-sku">Vendor SKU
+                    <input type="text" id="edit-vendor-sku" name="vendor_sku" required>
+                  </label>
+                  <label for="edit-description">Description
+                    <textarea id="edit-description" name="description"></textarea>
+                  </label>
+                  <label for="edit-price">Price
+                    <input type="number" step="0.01" id="edit-price" name="price" required>
+                  </label>
+                  <label for="edit-vip-price">VIP Price
+                    <input type="number" step="0.01" id="edit-vip-price" name="vip_price">
+                  </label>
+                  <label for="edit-stock">Stock
+                    <input type="number" id="edit-stock" name="stock" required>
+                  </label>
+                  <label for="edit-category">Category
+                    <select id="edit-category" name="category_id">
+                      <option value="">No Category</option>
+                      <% categories.forEach(function(c){ %>
+                        <option value="<%= c.id %>"><%= c.name %></option>
+                      <% }) %>
+                    </select>
+                  </label>
+                  <label for="edit-image">Image
+                    <input type="file" id="edit-image" name="image">
+                  </label>
                   <img id="editImagePreview" src="" width="100" alt="" style="display:none;">
-                  <input type="file" id="edit-image" name="image">
                   <button type="submit">Save</button>
                   <button type="button" onclick="closeEditModal()">Close</button>
                 </form>

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -67,16 +67,21 @@
       <span id="edit-close" class="close">&times;</span>
       <h2>Edit License</h2>
       <form id="edit-form">
-        <label for="edit-name">Name</label>
-        <input type="text" id="edit-name">
-        <label for="edit-sku">SKU</label>
-        <input type="text" id="edit-sku">
-        <label for="edit-count">Count</label>
-        <input type="number" id="edit-count">
-        <label for="edit-expiry">Expiry</label>
-        <input type="date" id="edit-expiry">
-        <label for="edit-contract">Contract Term</label>
-        <input type="text" id="edit-contract">
+        <label for="edit-name">Name
+          <input type="text" id="edit-name">
+        </label>
+        <label for="edit-sku">SKU
+          <input type="text" id="edit-sku">
+        </label>
+        <label for="edit-count">Count
+          <input type="number" id="edit-count">
+        </label>
+        <label for="edit-expiry">Expiry
+          <input type="date" id="edit-expiry">
+        </label>
+        <label for="edit-contract">Contract Term
+          <input type="text" id="edit-contract">
+        </label>
         <button type="submit">Save</button>
       </form>
     </div>

--- a/src/views/shop-admin.ejs
+++ b/src/views/shop-admin.ejs
@@ -170,30 +170,39 @@
           <div class="modal-content" style="width:300px;">
             <h3>Edit Product</h3>
             <form id="editForm" method="post" enctype="multipart/form-data">
-              <label for="edit-name">Name</label>
-              <input type="text" id="edit-name" name="name" required>
-              <label for="edit-sku">SKU</label>
-              <input type="text" id="edit-sku" name="sku" required>
-              <label for="edit-vendor-sku">Vendor SKU</label>
-              <input type="text" id="edit-vendor-sku" name="vendor_sku" required>
-              <label for="edit-description">Description</label>
-              <textarea id="edit-description" name="description"></textarea>
-              <label for="edit-price">Price</label>
-              <input type="number" step="0.01" id="edit-price" name="price" required>
-              <label for="edit-vip-price">VIP Price</label>
-              <input type="number" step="0.01" id="edit-vip-price" name="vip_price">
-              <label for="edit-stock">Stock</label>
-              <input type="number" id="edit-stock" name="stock" required>
-              <label for="edit-category">Category</label>
-              <select id="edit-category" name="category_id">
-                <option value="">No Category</option>
-                <% categories.forEach(function(c){ %>
-                  <option value="<%= c.id %>"><%= c.name %></option>
-                <% }) %>
-              </select>
-              <label for="edit-image">Image</label>
+              <label for="edit-name">Name
+                <input type="text" id="edit-name" name="name" required>
+              </label>
+              <label for="edit-sku">SKU
+                <input type="text" id="edit-sku" name="sku" required>
+              </label>
+              <label for="edit-vendor-sku">Vendor SKU
+                <input type="text" id="edit-vendor-sku" name="vendor_sku" required>
+              </label>
+              <label for="edit-description">Description
+                <textarea id="edit-description" name="description"></textarea>
+              </label>
+              <label for="edit-price">Price
+                <input type="number" step="0.01" id="edit-price" name="price" required>
+              </label>
+              <label for="edit-vip-price">VIP Price
+                <input type="number" step="0.01" id="edit-vip-price" name="vip_price">
+              </label>
+              <label for="edit-stock">Stock
+                <input type="number" id="edit-stock" name="stock" required>
+              </label>
+              <label for="edit-category">Category
+                <select id="edit-category" name="category_id">
+                  <option value="">No Category</option>
+                  <% categories.forEach(function(c){ %>
+                    <option value="<%= c.id %>"><%= c.name %></option>
+                  <% }) %>
+                </select>
+              </label>
+              <label for="edit-image">Image
+                <input type="file" id="edit-image" name="image">
+              </label>
               <img id="editImagePreview" src="" width="100" alt="" style="display:none;">
-              <input type="file" id="edit-image" name="image">
               <button type="submit">Save</button>
               <button type="button" onclick="closeEditModal()">Close</button>
             </form>

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -84,51 +84,66 @@
       <span id="edit-close" class="close">&times;</span>
       <h2>Edit Staff</h2>
       <form id="edit-form">
-        <label for="edit-first-name">First Name</label>
-        <input type="text" id="edit-first-name" <%= isSuperAdmin ? '' : 'readonly' %>>
-        <label for="edit-last-name">Last Name</label>
-        <input type="text" id="edit-last-name" <%= isSuperAdmin ? '' : 'readonly' %>>
-        <label for="edit-email">Email</label>
-        <input type="email" id="edit-email" <%= isSuperAdmin ? '' : 'readonly' %>>
-        <label for="edit-date-onboarded">Date Onboarded</label>
-        <input type="date" id="edit-date-onboarded" <%= isSuperAdmin ? '' : 'readonly' %>>
-        <label for="edit-date-offboarded">Offboard Date</label>
-        <input type="datetime-local" id="edit-date-offboarded" <%= isAdmin ? '' : 'readonly' %>>
-        <label for="edit-account-action">Account Action</label>
-        <select id="edit-account-action" <%= isSuperAdmin ? '' : 'disabled' %>>
-          <option value="Onboard Requested">Onboard Requested</option>
-          <option value="Onboard Approved">Onboard Approved</option>
-          <option value="Onboarding In Progress">Onboarding In Progress</option>
-          <option value="Onboarded">Onboarded</option>
-          <option value="Offboard Requested">Offboard Requested</option>
-          <option value="Offboard Approved">Offboard Approved</option>
-          <option value="Offboard Scheduled">Offboard Scheduled</option>
-          <option value="Offboarded">Offboarded</option>
-        </select>
+        <label for="edit-first-name">First Name
+          <input type="text" id="edit-first-name" <%= isSuperAdmin ? '' : 'readonly' %>>
+        </label>
+        <label for="edit-last-name">Last Name
+          <input type="text" id="edit-last-name" <%= isSuperAdmin ? '' : 'readonly' %>>
+        </label>
+        <label for="edit-email">Email
+          <input type="email" id="edit-email" <%= isSuperAdmin ? '' : 'readonly' %>>
+        </label>
+        <label for="edit-date-onboarded">Date Onboarded
+          <input type="date" id="edit-date-onboarded" <%= isSuperAdmin ? '' : 'readonly' %>>
+        </label>
+        <label for="edit-date-offboarded">Offboard Date
+          <input type="datetime-local" id="edit-date-offboarded" <%= isAdmin ? '' : 'readonly' %>>
+        </label>
+        <label for="edit-account-action">Account Action
+          <select id="edit-account-action" <%= isSuperAdmin ? '' : 'disabled' %>>
+            <option value="Onboard Requested">Onboard Requested</option>
+            <option value="Onboard Approved">Onboard Approved</option>
+            <option value="Onboarding In Progress">Onboarding In Progress</option>
+            <option value="Onboarded">Onboarded</option>
+            <option value="Offboard Requested">Offboard Requested</option>
+            <option value="Offboard Approved">Offboard Approved</option>
+            <option value="Offboard Scheduled">Offboard Scheduled</option>
+            <option value="Offboarded">Offboarded</option>
+          </select>
+        </label>
         <label><input type="checkbox" id="edit-enabled" <%= isSuperAdmin ? '' : 'disabled' %>> Enabled</label>
         <fieldset>
           <legend>Address</legend>
-          <label for="edit-street">Street</label>
-          <input type="text" id="edit-street" <%= isSuperAdmin ? '' : 'readonly' %>>
-          <label for="edit-city">City</label>
-          <input type="text" id="edit-city" <%= isSuperAdmin ? '' : 'readonly' %>>
-          <label for="edit-state">State</label>
-          <input type="text" id="edit-state" <%= isSuperAdmin ? '' : 'readonly' %>>
-          <label for="edit-postcode">Postcode</label>
-          <input type="text" id="edit-postcode" <%= isSuperAdmin ? '' : 'readonly' %>>
-          <label for="edit-country">Country</label>
-          <input type="text" id="edit-country" <%= isSuperAdmin ? '' : 'readonly' %>>
+          <label for="edit-street">Street
+            <input type="text" id="edit-street" <%= isSuperAdmin ? '' : 'readonly' %>>
+          </label>
+          <label for="edit-city">City
+            <input type="text" id="edit-city" <%= isSuperAdmin ? '' : 'readonly' %>>
+          </label>
+          <label for="edit-state">State
+            <input type="text" id="edit-state" <%= isSuperAdmin ? '' : 'readonly' %>>
+          </label>
+          <label for="edit-postcode">Postcode
+            <input type="text" id="edit-postcode" <%= isSuperAdmin ? '' : 'readonly' %>>
+          </label>
+          <label for="edit-country">Country
+            <input type="text" id="edit-country" <%= isSuperAdmin ? '' : 'readonly' %>>
+          </label>
         </fieldset>
         <fieldset>
           <legend>Organisation</legend>
-          <label for="edit-department">Department</label>
-          <input type="text" id="edit-department" <%= isSuperAdmin ? '' : 'readonly' %>>
-          <label for="edit-job-title">Job Title</label>
-          <input type="text" id="edit-job-title" <%= isSuperAdmin ? '' : 'readonly' %>>
-          <label for="edit-company">Company</label>
-          <input type="text" id="edit-company" <%= isSuperAdmin ? '' : 'readonly' %>>
-          <label for="edit-manager-name">Manager's Name</label>
-          <input type="text" id="edit-manager-name" <%= isSuperAdmin ? '' : 'readonly' %>>
+          <label for="edit-department">Department
+            <input type="text" id="edit-department" <%= isSuperAdmin ? '' : 'readonly' %>>
+          </label>
+          <label for="edit-job-title">Job Title
+            <input type="text" id="edit-job-title" <%= isSuperAdmin ? '' : 'readonly' %>>
+          </label>
+          <label for="edit-company">Company
+            <input type="text" id="edit-company" <%= isSuperAdmin ? '' : 'readonly' %>>
+          </label>
+          <label for="edit-manager-name">Manager's Name
+            <input type="text" id="edit-manager-name" <%= isSuperAdmin ? '' : 'readonly' %>>
+          </label>
         </fieldset>
         <button type="submit">Save</button>
       </form>


### PR DESCRIPTION
## Summary
- display modal form labels and inputs inline for cleaner presentation
- apply new label-input structure to staff, license, and product edit modals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689ee039dbb8832da2ce152db1d17ee0