### PR TITLE
Fix verify webhook requiring API key

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -976,14 +976,17 @@ app.post('/staff/:id/verify', ensureAuth, ensureStaffAccess, async (req, res) =>
   await setStaffVerificationCode(id, code);
   const url = process.env.VERIFY_WEBHOOK_URL;
   const apiKey = process.env.VERIFY_API_KEY;
-  if (url && apiKey) {
+  if (url) {
     try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (apiKey) {
+        headers.Authorization = apiKey;
+      }
       await fetch(url, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: apiKey,
-        },
+        headers,
         body: JSON.stringify({ mobilePhone: staff.mobile_phone, code }),
       });
     } catch (err) {


### PR DESCRIPTION
## Summary
- Allow verification webhook to be called without VERIFY_API_KEY
- Send optional Authorization header only when API key is provided

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a25cfa30e0832dbfde03c74efb04fd