### PR TITLE
Add admin name management and verification tracking

### DIFF
--- a/migrations/035_add_user_names.sql
+++ b/migrations/035_add_user_names.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+  ADD COLUMN first_name VARCHAR(255) NULL,
+  ADD COLUMN last_name VARCHAR(255) NULL;

--- a/migrations/036_add_admin_name_to_verification_codes.sql
+++ b/migrations/036_add_admin_name_to_verification_codes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE staff_verification_codes
+  ADD COLUMN admin_name VARCHAR(255) NULL;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -25,6 +25,8 @@ declare module 'express-session' {
     newTotpError?: string;
     passwordError?: string;
     passwordSuccess?: string;
+    nameError?: string;
+    nameSuccess?: string;
   }
 }
 

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -171,6 +171,20 @@
         </div>
         <div id="account" class="tab-content">
           <section>
+            <h2>Profile</h2>
+            <% if (nameError) { %><p class="error"><%= nameError %></p><% } %>
+            <% if (nameSuccess) { %><p class="success"><%= nameSuccess %></p><% } %>
+            <form method="post" action="/change-name">
+              <label>First Name:
+                <input type="text" name="firstName" value="<%= currentUserFirstName %>" required>
+              </label>
+              <label>Last Name:
+                <input type="text" name="lastName" value="<%= currentUserLastName %>" required>
+              </label>
+              <button type="submit">Update Name</button>
+            </form>
+          </section>
+          <section>
             <h2>Change Password</h2>
             <% if (passwordError) { %><p class="error"><%= passwordError %></p><% } %>
             <% if (passwordSuccess) { %><p class="success"><%= passwordSuccess %></p><% } %>


### PR DESCRIPTION
## Summary
- Allow admins to set their first and last name
- Track which admin generates staff verification codes and send name in verify webhook
- Database migrations for storing user names and verification code admin names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a260bf54a8832d95192ec188bba820