### PR TITLE
feat: add site settings and logos

### DIFF
--- a/migrations/037_site_settings.sql
+++ b/migrations/037_site_settings.sql
@@ -1,0 +1,8 @@
+CREATE TABLE site_settings (
+  id INT PRIMARY KEY,
+  company_name VARCHAR(255),
+  login_logo LONGTEXT,
+  sidebar_logo LONGTEXT
+);
+
+INSERT INTO site_settings (id) VALUES (1);

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -198,6 +198,12 @@ export interface AuditLog {
   company_name: string | null;
 }
 
+export interface SiteSettings {
+  company_name: string | null;
+  login_logo: string | null;
+  sidebar_logo: string | null;
+}
+
 export interface Form {
   id: number;
   name: string;
@@ -1594,5 +1600,28 @@ export async function updateOfficeGroupMembers(groupId: number, staffIds: number
   await pool.execute(
     `INSERT INTO office_group_members (group_id, staff_id) VALUES ${values}`,
     params
+  );
+}
+
+export async function getSiteSettings(): Promise<SiteSettings> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    'SELECT company_name, login_logo, sidebar_logo FROM site_settings WHERE id = 1'
+  );
+  const row = (rows as SiteSettings[])[0];
+  return {
+    company_name: row?.company_name || null,
+    login_logo: row?.login_logo || null,
+    sidebar_logo: row?.sidebar_logo || null,
+  };
+}
+
+export async function updateSiteSettings(
+  companyName: string,
+  loginLogo?: string | null,
+  sidebarLogo?: string | null
+): Promise<void> {
+  await pool.query(
+    'UPDATE site_settings SET company_name = ?, login_logo = COALESCE(?, login_logo), sidebar_logo = COALESCE(?, sidebar_logo) WHERE id = 1',
+    [companyName, loginLogo ?? null, sidebarLogo ?? null]
   );
 }

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -12,6 +12,7 @@
           <button data-tab="assignments">Current Assignments</button>
           <button data-tab="account">Account</button>
           <% if (isSuperAdmin) { %>
+            <button data-tab="site-settings">Site Settings</button>
             <button data-tab="apps">Apps</button>
             <button data-tab="api-keys">API Keys</button>
             <button data-tab="forms-admin">Forms</button>
@@ -231,6 +232,33 @@
           </section>
         </div>
         <% if (isSuperAdmin) { %>
+        <div id="site-settings" class="tab-content">
+          <section>
+            <h2>Site Settings</h2>
+            <form action="/admin/site-settings" method="post" enctype="multipart/form-data">
+              <label>Company Name:
+                <input type="text" name="companyName" value="<%= siteSettings?.company_name || '' %>">
+              </label>
+              <div>
+                <label>Login/Verify Logo:
+                  <input type="file" name="loginLogo" accept="image/*">
+                </label>
+                <% if (siteSettings && siteSettings.login_logo) { %>
+                  <img src="<%= siteSettings.login_logo %>" alt="Login Logo" style="max-width:200px;display:block;margin-top:10px;"/>
+                <% } %>
+              </div>
+              <div>
+                <label>Sidebar Logo:
+                  <input type="file" name="sidebarLogo" accept="image/*">
+                </label>
+                <% if (siteSettings && siteSettings.sidebar_logo) { %>
+                  <img src="<%= siteSettings.sidebar_logo %>" alt="Sidebar Logo" style="max-width:200px;display:block;margin-top:10px;"/>
+                <% } %>
+              </div>
+              <button type="submit">Save</button>
+            </form>
+          </section>
+        </div>
         <div id="apps" class="tab-content">
           <section>
             <h2>Add App</h2>

--- a/src/views/login.ejs
+++ b/src/views/login.ejs
@@ -3,6 +3,9 @@
   <%- include('partials/head', { title: 'Login' }) %>
 <body class="login-page">
   <div class="login-container">
+    <% if (siteSettings && siteSettings.login_logo) { %>
+      <img src="<%= siteSettings.login_logo %>" alt="Logo" style="max-width:200px;display:block;margin:0 auto 20px;">
+    <% } %>
     <h1>Login</h1>
     <% if (error) { %>
       <p class="error"><%= error %></p>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -1,5 +1,8 @@
 <nav class="sidebar">
   <div class="sidebar-top">
+    <% if (siteSettings && siteSettings.sidebar_logo) { %>
+      <img src="<%= siteSettings.sidebar_logo %>" alt="Logo" style="max-width:200px;display:block;margin:10px auto;">
+    <% } %>
     <% if (companies && companies.length > 1) { %>
       <div class="company-switcher">
         <h3>Select Company</h3>

--- a/src/views/verify.ejs
+++ b/src/views/verify.ejs
@@ -3,6 +3,9 @@
   <%- include('partials/head', { title: 'Verify Code' }) %>
   <body class="login-page">
     <div class="login-container">
+      <% if (siteSettings && siteSettings.login_logo) { %>
+        <img src="<%= siteSettings.login_logo %>" alt="Logo" style="max-width:200px;display:block;margin:0 auto 20px;">
+      <% } %>
       <h1>Verify Code</h1>
       <% if (result === 'valid') { %>
         <div class="verify-icon success">&#10004;</div>


### PR DESCRIPTION
## Summary
- allow super admins to configure site-wide company name and logos
- store logos in base64 and load them across the app
- show uploaded logos on login, verify, and sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a266f045a4832d83641b1e1498092a