### PR TITLE
Center verify text and reorder admin tabs

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -282,3 +282,7 @@ table th {
   text-align: center;
   margin: 1rem 0;
 }
+
+.verify-container p {
+  text-align: center;
+}

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -8,20 +8,24 @@
       <h1>Admin</h1>
       <div class="admin-tabs">
         <div class="tabs">
-          <button data-tab="companies" class="active">Companies</button>
-          <button data-tab="assignments">Current Assignments</button>
-          <button data-tab="account">Account</button>
           <% if (isSuperAdmin) { %>
-            <button data-tab="site-settings">Site Settings</button>
-            <button data-tab="apps">Apps</button>
+            <button data-tab="site-settings" class="active">Site Settings</button>
+            <button data-tab="account">Account</button>
             <button data-tab="api-keys">API Keys</button>
-            <button data-tab="forms-admin">Forms</button>
-            <button data-tab="form-permissions">Form Permissions</button>
+            <button data-tab="companies">Companies</button>
+            <button data-tab="assignments">Current Assignments</button>
+            <button data-tab="apps">Apps</button>
             <button data-tab="shop-settings">Shop Settings</button>
             <button data-tab="products">Products</button>
+            <button data-tab="forms-admin">Forms</button>
+            <button data-tab="form-permissions">Form Permissions</button>
+          <% } else { %>
+            <button data-tab="account" class="active">Account</button>
+            <button data-tab="companies">Companies</button>
+            <button data-tab="assignments">Current Assignments</button>
           <% } %>
         </div>
-        <div id="companies" class="tab-content active">
+        <div id="companies" class="tab-content">
           <% if (isSuperAdmin) { %>
           <section>
             <h2>Add Company</h2>
@@ -170,7 +174,7 @@
             </table>
           </section>
         </div>
-        <div id="account" class="tab-content">
+        <div id="account" class="tab-content<% if (!isSuperAdmin) { %> active<% } %>">
           <section>
             <h2>Profile</h2>
             <% if (nameError) { %><p class="error"><%= nameError %></p><% } %>
@@ -232,7 +236,7 @@
           </section>
         </div>
         <% if (isSuperAdmin) { %>
-        <div id="site-settings" class="tab-content">
+        <div id="site-settings" class="tab-content active">
           <section>
             <h2>Site Settings</h2>
             <form action="/admin/site-settings" method="post" enctype="multipart/form-data">
@@ -706,7 +710,7 @@
 
       let initialTab = window.location.hash
         ? window.location.hash.substring(1)
-        : localStorage.getItem(ACTIVE_TAB_KEY) || 'companies';
+        : localStorage.getItem(ACTIVE_TAB_KEY) || '<%= isSuperAdmin ? "site-settings" : "account" %>';
       <% if (isSuperAdmin && selectedFormId && selectedCompanyId) { %>
       initialTab = 'form-permissions';
       <% } %>

--- a/src/views/verify.ejs
+++ b/src/views/verify.ejs
@@ -2,7 +2,7 @@
 <html>
   <%- include('partials/head', { title: 'Verify Code' }) %>
   <body class="login-page">
-    <div class="login-container">
+    <div class="login-container verify-container">
       <% if (siteSettings && siteSettings.login_logo) { %>
         <img src="<%= siteSettings.login_logo %>" alt="Logo" style="max-width:200px;display:block;margin:0 auto 20px;">
       <% } %>


### PR DESCRIPTION
## Summary
- center verification messages by adding `.verify-container` styling
- reorganize Admin tabs to prioritize Site Settings and set Account as default for regular admins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a26b49b6d8832d89aa3376de9a5a9b