### PR TITLE
Restrict staff verification to super admins

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1018,7 +1018,7 @@ app.post('/staff/enabled', ensureAuth, ensureStaffAccess, async (req, res) => {
   res.redirect('/staff');
 });
 
-app.post('/staff/:id/verify', ensureAuth, ensureStaffAccess, async (req, res) => {
+app.post('/staff/:id/verify', ensureAuth, ensureSuperAdmin, async (req, res) => {
   const id = parseInt(req.params.id, 10);
   const staff = await getStaffById(id);
   if (!staff || !staff.mobile_phone) {

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -51,7 +51,9 @@
                 </form>
               </td>
               <td>
+                <% if (isSuperAdmin) { %>
                 <button class="verify-btn" data-id="<%= s.id %>" <%= s.mobile_phone ? '' : 'disabled' %>>Verify</button>
+                <% } %>
                 <button
                   class="edit-btn"
                   data-id="<%= s.id %>"
@@ -204,6 +206,7 @@
       });
     });
 
+    <% if (isSuperAdmin) { %>
     document.querySelectorAll('.verify-btn').forEach(function(btn) {
       btn.addEventListener('click', async function() {
         const res = await fetch(`/staff/${this.dataset.id}/verify`, { method: 'POST' });
@@ -223,6 +226,7 @@
         }
       });
     });
+    <% } %>
 
     document.querySelectorAll('.delete-btn').forEach(function(btn) {
       btn.addEventListener('click', async function() {


### PR DESCRIPTION
## Summary
- Hide staff verification button from non-super admins and only bind JS for super admins
- Require super admin privileges for the `/staff/:id/verify` endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a27ccab510832db74fb32789758257