### PR TITLE
Prevent company admins from removing their own admin permission

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1700,6 +1700,7 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
     isSuperAdmin,
     companies,
     currentCompanyId: req.session.companyId,
+    currentUserId: req.session.userId,
     canManageLicenses: current?.can_manage_licenses ?? 0,
     canManageStaff: current?.can_manage_staff ?? 0,
     canManageAssets: current?.can_manage_assets ?? 0,
@@ -2061,12 +2062,15 @@ app.post('/admin/permission', ensureAuth, ensureAdmin, async (req, res) => {
     );
   }
   if (typeof isAdminField !== 'undefined') {
-    await updateUserCompanyPermission(
-      uid,
-      cid,
-      'is_admin',
-      parseCheckbox(isAdminField)
-    );
+    const isAdminValue = parseCheckbox(isAdminField);
+    if (uid !== req.session.userId || req.session.userId === 1 || isAdminValue) {
+      await updateUserCompanyPermission(
+        uid,
+        cid,
+        'is_admin',
+        isAdminValue
+      );
+    }
   }
   res.redirect('/admin');
 });

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -118,7 +118,7 @@
                       <input type="hidden" name="userId" value="<%= a.user_id %>">
                       <input type="hidden" name="companyId" value="<%= a.company_id %>">
                       <input type="hidden" name="isAdmin" value="0">
-                      <input type="checkbox" name="isAdmin" value="1" <%= a.is_admin ? 'checked' : '' %> onchange="this.form.submit()">
+                      <input type="checkbox" name="isAdmin" value="1" <%= a.is_admin ? 'checked' : '' %> <%= (!isSuperAdmin && a.user_id === currentUserId) ? 'disabled' : '' %> onchange="this.form.submit()">
                     </form>
                   </td>
                   <td>


### PR DESCRIPTION
## Summary
- Disable the Admin checkbox for the currently logged-in company admin in the assignments table.
- Pass the current user ID to the admin view and ignore self-targeted requests that would remove admin rights.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a27fd45f40832db9876ef396fe5200