### PR TITLE
Add option to hide Syncro customers

### DIFF
--- a/migrations/040_hidden_syncro_customers.sql
+++ b/migrations/040_hidden_syncro_customers.sql
@@ -1,0 +1,4 @@
+CREATE TABLE hidden_syncro_customers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  syncro_customer_id VARCHAR(255) UNIQUE NOT NULL
+);

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -241,6 +241,27 @@ export async function getCompanyBySyncroId(
   return row ? ({ ...(row as any), is_vip: Number(row.is_vip) } as Company) : null;
 }
 
+export async function getHiddenSyncroCustomerIds(): Promise<string[]> {
+  const [rows] = await pool.query<RowDataPacket[]>(
+    'SELECT syncro_customer_id FROM hidden_syncro_customers'
+  );
+  return (rows as RowDataPacket[]).map((r) => String(r.syncro_customer_id));
+}
+
+export async function hideSyncroCustomer(id: string): Promise<void> {
+  await pool.query(
+    'INSERT IGNORE INTO hidden_syncro_customers (syncro_customer_id) VALUES (?)',
+    [id]
+  );
+}
+
+export async function unhideSyncroCustomer(id: string): Promise<void> {
+  await pool.query(
+    'DELETE FROM hidden_syncro_customers WHERE syncro_customer_id = ?',
+    [id]
+  );
+}
+
 export async function getLicensesByCompany(companyId: number): Promise<License[]> {
   const [rows] = await pool.query<RowDataPacket[]>(
     `SELECT l.*, COUNT(sl.staff_id) AS allocated

--- a/src/views/syncro-customers.ejs
+++ b/src/views/syncro-customers.ejs
@@ -6,23 +6,43 @@
       <%- include('partials/sidebar') %>
       <div class="content">
         <h1>Syncro Customers</h1>
+        <p>
+          <a href="/admin/syncro/customers<%= showHidden ? '' : '?showHidden=1' %>">
+            <%= showHidden ? 'Hide Hidden Customers' : 'Show Hidden Customers' %>
+          </a>
+        </p>
         <table>
           <thead>
-            <tr><th>Name</th><th>Status</th><th></th></tr>
+            <tr><th>Name</th><th>Status</th><th>Actions</th></tr>
           </thead>
           <tbody>
             <% customers.forEach(function(c){
                  var imported = importedIds.includes(String(c.id));
+                 var hidden = hiddenIds.includes(String(c.id));
                  var name = c.business_name || [c.first_name, c.last_name].filter(Boolean).join(' ');
             %>
             <tr>
               <td><%= name || ('Customer ' + c.id) %></td>
-              <td><%= imported ? 'Imported' : 'Not Imported' %></td>
+              <td><%= hidden ? 'Hidden' : (imported ? 'Imported' : 'Not Imported') %></td>
               <td>
-                <form method="post" action="/admin/syncro/import">
+                <form method="post" action="/admin/syncro/import" style="display:inline">
                   <input type="hidden" name="customerId" value="<%= c.id %>">
+                  <input type="hidden" name="showHidden" value="<%= showHidden ? 1 : 0 %>">
                   <button type="submit"><%= imported ? 'Update' : 'Import' %></button>
                 </form>
+                <% if (hidden) { %>
+                <form method="post" action="/admin/syncro/unhide" style="display:inline">
+                  <input type="hidden" name="customerId" value="<%= c.id %>">
+                  <input type="hidden" name="showHidden" value="<%= showHidden ? 1 : 0 %>">
+                  <button type="submit">Unhide</button>
+                </form>
+                <% } else { %>
+                <form method="post" action="/admin/syncro/hide" style="display:inline">
+                  <input type="hidden" name="customerId" value="<%= c.id %>">
+                  <input type="hidden" name="showHidden" value="<%= showHidden ? 1 : 0 %>">
+                  <button type="submit">Hide</button>
+                </form>
+                <% } %>
               </td>
             </tr>
             <% }); %>


### PR DESCRIPTION
## Summary
- allow admins to hide Syncro customers from the import list
- toggle hidden customers from the Syncro customers page
- store hidden Syncro customer IDs in a new table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a283adfb60832dbd69fb9a5f569ae7