### PR TITLE
Remove stock column from Shop page

### DIFF
--- a/src/views/shop.ejs
+++ b/src/views/shop.ejs
@@ -21,7 +21,7 @@
       </form>
       <table>
         <thead>
-          <tr><th>Image</th><th>Name</th><th>SKU</th><th>Description</th><th>Price</th><th>Stock</th><th>Order</th></tr>
+          <tr><th>Image</th><th>Name</th><th>SKU</th><th>Description</th><th>Price</th><th>Order</th></tr>
         </thead>
         <tbody>
           <% products.forEach(function(p){ %>
@@ -31,7 +31,6 @@
               <td><%= p.sku %></td>
               <td><%- p.description.replace(/\n/g, '<br>') %></td>
               <td>$<%= p.price.toFixed(2) %></td>
-              <td><%= p.stock %></td>
               <td>
                 <form action="/cart/add" method="post">
                   <input type="hidden" name="productId" value="<%= p.id %>">


### PR DESCRIPTION
## Summary
- Remove stock column from user-facing Shop table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a286df4824832da47d55c456b04b65