### PR TITLE
Add shipping status tracking and order summaries

### DIFF
--- a/migrations/041_add_shipping_status_consignment_id.sql
+++ b/migrations/041_add_shipping_status_consignment_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE shop_orders
+  ADD COLUMN shipping_status VARCHAR(50) NOT NULL DEFAULT 'pending',
+  ADD COLUMN consignment_id VARCHAR(100);

--- a/src/views/order-details.ejs
+++ b/src/views/order-details.ejs
@@ -8,7 +8,20 @@
         <h1>Order <%= orderNumber %></h1>
         <p>PO Number: <%= poNumber %></p>
         <p>Status: <%= status %></p>
+        <p>Shipping Status: <%= shippingStatus %></p>
+        <% if (isSuperAdmin) { %><p>Consignment ID: <%= consignmentId || '' %></p><% } %>
         <% if (notes) { %><p>Notes: <%= notes %></p><% } %>
+        <% if (isSuperAdmin) { %>
+          <form action="/orders/<%= orderNumber %>/shipping" method="post">
+            <label>Shipping Status:
+              <input type="text" name="shippingStatus" value="<%= shippingStatus %>">
+            </label>
+            <label>Consignment ID:
+              <input type="text" name="consignmentId" value="<%= consignmentId || '' %>">
+            </label>
+            <button type="submit">Update Shipping</button>
+          </form>
+        <% } %>
         <% if (items.length === 0) { %>
           <p>No items found.</p>
         <% } else { %>

--- a/src/views/orders.ejs
+++ b/src/views/orders.ejs
@@ -6,6 +6,9 @@
     <%- include('partials/sidebar') %>
     <div class="content">
       <h1>Orders</h1>
+      <div class="chart-container" style="width: 400px; height: 200px;">
+        <canvas id="statusChart"></canvas>
+      </div>
       <% if (orders.length === 0) { %>
         <p>No orders have been placed.</p>
       <% } else { %>
@@ -15,8 +18,10 @@
               <th>Order Number</th>
               <th>PO Number</th>
               <th>Status</th>
+              <th>Shipping Status</th>
               <th>Notes</th>
               <th>Date</th>
+              <% if (isSuperAdmin) { %><th>Consignment ID</th><% } %>
               <% if (isSuperAdmin) { %><th>Actions</th><% } %>
             </tr>
           </thead>
@@ -26,8 +31,10 @@
                 <td><a href="/orders/<%= o.order_number %>"><%= o.order_number %></a></td>
                 <td><%= o.po_number %></td>
                 <td><%= o.status %></td>
+                <td><%= o.shipping_status %></td>
                 <td><%= o.notes || '' %></td>
                 <td><%= o.order_date.toISOString().slice(0,10) %></td>
+                <% if (isSuperAdmin) { %><td><%= o.consignment_id || '' %></td><% } %>
                 <% if (isSuperAdmin) { %>
                   <td>
                     <form action="/orders/<%= o.order_number %>/delete" method="post" onsubmit="return confirm('Delete order?');">
@@ -40,6 +47,31 @@
           </tbody>
         </table>
       <% } %>
+      <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+      <script>
+        const statusCounts = <%- JSON.stringify(statusCounts) %>;
+        const ctx = document.getElementById('statusChart').getContext('2d');
+        new Chart(ctx, {
+          type: 'bar',
+          data: {
+            labels: Object.keys(statusCounts),
+            datasets: [{
+              label: 'Orders',
+              data: Object.values(statusCounts),
+              backgroundColor: 'rgba(75, 192, 192, 0.5)',
+              borderColor: 'rgba(75, 192, 192, 1)',
+              borderWidth: 1
+            }]
+          },
+          options: {
+            scales: {
+              y: {
+                beginAtZero: true
+              }
+            }
+          }
+        });
+      </script>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add shipping_status and consignment_id columns to orders
- show order status chart and shipping/consignment columns in Orders page
- allow super admins or API to update shipping status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a28a59c10c832db48e0142c2387575