### PR TITLE
feat: add SMS contact field for admins

### DIFF
--- a/migrations/044_add_mobile_phone_to_users.sql
+++ b/migrations/044_add_mobile_phone_to_users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN mobile_phone VARCHAR(20);

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -9,6 +9,7 @@ export interface User {
   first_name?: string | null;
   last_name?: string | null;
   force_password_change?: number;
+  mobile_phone?: string | null;
 }
 
 export interface UserTotpAuthenticator {
@@ -734,6 +735,16 @@ export async function updateUserName(
   await pool.execute('UPDATE users SET first_name = ?, last_name = ? WHERE id = ?', [
     firstName,
     lastName,
+    id,
+  ]);
+}
+
+export async function updateUserMobile(
+  id: number,
+  mobilePhone: string | null
+): Promise<void> {
+  await pool.execute('UPDATE users SET mobile_phone = ? WHERE id = ?', [
+    mobilePhone,
     id,
   ]);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,6 +46,7 @@ import {
   deleteUser,
   updateUserPassword,
   updateUserName,
+  updateUserMobile,
   setUserForcePasswordChange,
   getUserTotpAuthenticators,
   addUserTotpAuthenticator,
@@ -728,6 +729,17 @@ app.post('/change-name', ensureAuth, ensureAdmin, async (req, res) => {
   }
   await updateUserName(req.session.userId!, firstName, lastName);
   req.session.nameSuccess = 'Name updated successfully';
+  res.redirect('/admin#account');
+});
+
+app.post('/change-mobile', ensureAuth, ensureAdmin, async (req, res) => {
+  const mobilePhone = (req.body.mobilePhone || '').trim();
+  if (!mobilePhone) {
+    req.session.mobileError = 'Mobile phone is required';
+    return res.redirect('/admin#account');
+  }
+  await updateUserMobile(req.session.userId!, mobilePhone);
+  req.session.mobileSuccess = 'Mobile phone updated';
   res.redirect('/admin#account');
 });
 
@@ -1896,11 +1908,15 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
   const passwordSuccess = req.session.passwordSuccess || '';
   const nameError = req.session.nameError || '';
   const nameSuccess = req.session.nameSuccess || '';
+  const mobileError = req.session.mobileError || '';
+  const mobileSuccess = req.session.mobileSuccess || '';
   req.session.passwordError = undefined;
   req.session.passwordSuccess = undefined;
   req.session.newTotpError = undefined;
   req.session.nameError = undefined;
   req.session.nameSuccess = undefined;
+  req.session.mobileError = undefined;
+  req.session.mobileSuccess = undefined;
   res.render('admin', {
     allCompanies,
     users,
@@ -1938,8 +1954,11 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
     passwordSuccess,
     nameError,
     nameSuccess,
+    mobileError,
+    mobileSuccess,
     currentUserFirstName: currentUser?.first_name || '',
     currentUserLastName: currentUser?.last_name || '',
+    currentUserMobilePhone: currentUser?.mobile_phone || '',
     siteSettings: res.locals.siteSettings,
   });
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -27,6 +27,8 @@ declare module 'express-session' {
     passwordSuccess?: string;
     nameError?: string;
     nameSuccess?: string;
+    mobileError?: string;
+    mobileSuccess?: string;
     mustChangePassword?: boolean;
     pendingForcePassword?: boolean;
   }

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -224,6 +224,17 @@
             </form>
           </section>
           <section>
+            <h2>SMS Alerts</h2>
+            <% if (mobileError) { %><p class="error"><%= mobileError %></p><% } %>
+            <% if (mobileSuccess) { %><p class="success"><%= mobileSuccess %></p><% } %>
+            <form method="post" action="/change-mobile">
+              <label>Mobile Phone:
+                <input type="tel" name="mobilePhone" value="<%= currentUserMobilePhone %>">
+              </label>
+              <button type="submit">Update Mobile</button>
+            </form>
+          </section>
+          <section>
             <h2>Change Password</h2>
             <% if (passwordError) { %><p class="error"><%= passwordError %></p><% } %>
             <% if (passwordSuccess) { %><p class="success"><%= passwordSuccess %></p><% } %>


### PR DESCRIPTION
## Summary
- allow admins to store a mobile phone number used for SMS alerts
- persist mobile numbers in users table and expose in account settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a295a2f710832db21f680124f793cf