### PR TITLE
Switch order number prefix to ORD

### DIFF
--- a/migrations/016_add_order_number.sql
+++ b/migrations/016_add_order_number.sql
@@ -2,5 +2,5 @@ ALTER TABLE shop_orders
   ADD COLUMN order_number VARCHAR(20);
 
 UPDATE shop_orders
-SET order_number = CONCAT('TBC', LPAD(id, 12, '0'))
+SET order_number = CONCAT('ORD', LPAD(id, 12, '0'))
 WHERE order_number IS NULL;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1479,7 +1479,7 @@ app.post('/cart/place-order', ensureAuth, ensureShopAccess, async (req, res) => 
         console.error('Failed to call webhook', err);
       }
     }
-    let orderNumber = 'TBC';
+    let orderNumber = 'ORD';
     for (let i = 0; i < 12; i++) {
       orderNumber += Math.floor(Math.random() * 10).toString();
     }
@@ -3099,7 +3099,7 @@ api
     } = req.body;
     let num = orderNumber as string | undefined;
     if (!num) {
-      num = 'TBC';
+      num = 'ORD';
       for (let i = 0; i < 12; i++) {
         num += Math.floor(Math.random() * 10).toString();
       }


### PR DESCRIPTION
## Summary
- prefix order numbers with `ORD` instead of `TBC`
- adjust existing migration to use new prefix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a2a6743e6c832d9f1701d7a7a6ddaa