### PR TITLE
feat: syncro contact import

### DIFF
--- a/migrations/045_add_syncro_contact_id_to_staff.sql
+++ b/migrations/045_add_syncro_contact_id_to_staff.sql
@@ -1,0 +1,1 @@
+ALTER TABLE staff ADD COLUMN syncro_contact_id VARCHAR(255);

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -172,6 +172,7 @@ export interface Staff {
   org_company?: string | null;
   manager_name?: string | null;
   account_action?: string | null;
+  syncro_contact_id?: string | null;
   verification_code?: string | null;
   verification_admin_name?: string | null;
 }
@@ -644,10 +645,11 @@ export async function addStaff(
   jobTitle?: string | null,
   orgCompany?: string | null,
   managerName?: string | null,
-  accountAction?: string | null
+  accountAction?: string | null,
+  syncroContactId?: string | null
 ): Promise<void> {
   await pool.execute(
-    'INSERT INTO staff (company_id, first_name, last_name, email, mobile_phone, date_onboarded, date_offboarded, enabled, street, city, state, postcode, country, department, job_title, org_company, manager_name, account_action) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    'INSERT INTO staff (company_id, first_name, last_name, email, mobile_phone, date_onboarded, date_offboarded, enabled, street, city, state, postcode, country, department, job_title, org_company, manager_name, account_action, syncro_contact_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
     [
       companyId,
       firstName,
@@ -667,6 +669,7 @@ export async function addStaff(
       orgCompany || null,
       managerName || null,
       accountAction || null,
+      syncroContactId || null,
     ]
   );
 }
@@ -700,10 +703,11 @@ export async function updateStaff(
   jobTitle?: string | null,
   orgCompany?: string | null,
   managerName?: string | null,
-  accountAction?: string | null
+  accountAction?: string | null,
+  syncroContactId?: string | null
 ): Promise<void> {
   await pool.execute(
-    'UPDATE staff SET company_id = ?, first_name = ?, last_name = ?, email = ?, mobile_phone = ?, date_onboarded = ?, date_offboarded = ?, enabled = ?, street = ?, city = ?, state = ?, postcode = ?, country = ?, department = ?, job_title = ?, org_company = ?, manager_name = ?, account_action = ? WHERE id = ?',
+    'UPDATE staff SET company_id = ?, first_name = ?, last_name = ?, email = ?, mobile_phone = ?, date_onboarded = ?, date_offboarded = ?, enabled = ?, street = ?, city = ?, state = ?, postcode = ?, country = ?, department = ?, job_title = ?, org_company = ?, manager_name = ?, account_action = ?, syncro_contact_id = ? WHERE id = ?',
     [
       companyId,
       firstName,
@@ -723,6 +727,7 @@ export async function updateStaff(
       orgCompany || null,
       managerName || null,
       accountAction || null,
+      syncroContactId || null,
       id,
     ]
   );

--- a/src/syncro.ts
+++ b/src/syncro.ts
@@ -15,6 +15,22 @@ export interface SyncroCustomer {
   [key: string]: any;
 }
 
+export interface SyncroContact {
+  id: number;
+  first_name?: string;
+  last_name?: string;
+  name?: string;
+  email?: string;
+  phone?: string;
+  mobile?: string;
+  address1?: string;
+  address2?: string;
+  city?: string;
+  state?: string;
+  zip?: string;
+  [key: string]: any;
+}
+
 async function syncroRequest(path: string, init: RequestInit = {}): Promise<any> {
   const base = process.env.SYNCRO_WEBHOOK_URL;
   if (!base) {
@@ -54,6 +70,22 @@ export async function getSyncroCustomer(id: string | number): Promise<SyncroCust
     return data.customer as SyncroCustomer;
   }
   return (data ?? null) as SyncroCustomer | null;
+}
+
+export async function getSyncroContacts(
+  customerId: string | number
+): Promise<SyncroContact[]> {
+  const data = await syncroRequest(`/contact?customer_id=${customerId}`);
+  if (Array.isArray(data)) {
+    return data as SyncroContact[];
+  }
+  if (Array.isArray((data as any)?.contacts)) {
+    return (data as any).contacts as SyncroContact[];
+  }
+  if (Array.isArray((data as any)?.data)) {
+    return (data as any).data as SyncroContact[];
+  }
+  return [];
 }
 
 export { syncroRequest };


### PR DESCRIPTION
## Summary
- add `syncro_contact_id` column to staff
- support Syncro contact id in staff queries
- import Syncro contacts for a company, skipping ex staff and updating existing records

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a2fea0c184832d8193bc83594251db