### PR TITLE
Add Syncro contact import on Staff page

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1011,14 +1011,16 @@ app.get('/staff', ensureAuth, ensureStaffAccess, async (req, res) => {
   const enabledFilter = req.query.enabled as string | undefined;
   const enabledParam =
     enabledFilter === '1' ? true : enabledFilter === '0' ? false : undefined;
-  const staff = req.session.companyId
-    ? await getStaffByCompany(req.session.companyId, enabledParam)
+  const companyId = req.session.companyId;
+  const staff = companyId
+    ? await getStaffByCompany(companyId, enabledParam)
     : [];
-  const current = companies.find((c) => c.company_id === req.session.companyId);
+  const current = companies.find((c) => c.company_id === companyId);
+  const company = companyId ? await getCompanyById(companyId) : null;
   res.render('staff', {
     staff,
     companies,
-    currentCompanyId: req.session.companyId,
+    currentCompanyId: companyId,
     isAdmin: req.session.userId === 1 || (current?.is_admin ?? 0),
     isSuperAdmin: req.session.userId === 1,
     canManageLicenses: current?.can_manage_licenses ?? 0,
@@ -1028,6 +1030,7 @@ app.get('/staff', ensureAuth, ensureStaffAccess, async (req, res) => {
     canOrderLicenses: current?.can_order_licenses ?? 0,
     canAccessShop: current?.can_access_shop ?? 0,
     enabledFilter: enabledFilter ?? '',
+    syncroCompanyId: company?.syncro_company_id ?? null,
   });
 });
 

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -6,6 +6,12 @@
     <%- include('partials/sidebar') %>
     <div class="content">
       <h1>Staff</h1>
+      <% if (isSuperAdmin && syncroCompanyId) { %>
+      <section>
+        <h2>Import from Syncro</h2>
+        <button id="import-syncro-btn">Import Contacts</button>
+      </section>
+      <% } %>
       <% if (isAdmin) { %>
       <section>
         <h2>Add Staff</h2>
@@ -166,6 +172,7 @@
   <script>
     const isSuperAdmin = <%= isSuperAdmin ? 'true' : 'false' %>;
     const isAdmin = <%= isAdmin ? 'true' : 'false' %>;
+    const syncroCompanyId = <%= syncroCompanyId ? `'${syncroCompanyId}'` : 'null' %>;
     const editModal = document.getElementById('edit-modal');
     const editForm = document.getElementById('edit-form');
     let editingId = null;
@@ -230,6 +237,24 @@
       });
     });
     <% } %>
+
+    const importBtn = document.getElementById('import-syncro-btn');
+    if (importBtn && syncroCompanyId) {
+      importBtn.addEventListener('click', async function() {
+        if (!confirm('Import contacts from Syncro?')) return;
+        const res = await fetch('/admin/syncro/import-contacts', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ syncroCompanyId })
+        });
+        if (res.ok) {
+          location.reload();
+        } else {
+          const text = await res.text();
+          alert(text || 'Failed to import contacts');
+        }
+      });
+    }
 
     document.querySelectorAll('.invite-btn').forEach(function(btn) {
       btn.addEventListener('click', async function() {


### PR DESCRIPTION
## Summary
- allow staff page to import contacts via Syncro for current company
- add server route data for syncroCompanyId and frontend button with fetch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a3082d9e08832da775b3c0a9eabbe9