### PR TITLE
Fix Syncro import button script variables

### DIFF
--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -170,9 +170,9 @@
   </div>
 
   <script>
-    const isSuperAdmin = <%= isSuperAdmin ? 'true' : 'false' %>;
-    const isAdmin = <%= isAdmin ? 'true' : 'false' %>;
-    const syncroCompanyId = <%= syncroCompanyId ? `'${syncroCompanyId}'` : 'null' %>;
+    const isSuperAdmin = <%- JSON.stringify(isSuperAdmin) %>;
+    const isAdmin = <%- JSON.stringify(isAdmin) %>;
+    const syncroCompanyId = <%- JSON.stringify(syncroCompanyId) %>;
     const editModal = document.getElementById('edit-modal');
     const editForm = document.getElementById('edit-form');
     let editingId = null;


### PR DESCRIPTION
## Summary
- Render staff template variables with `JSON.stringify` to avoid HTML-escaped quotes that broke the Syncro import button.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a30b5892d4832da3bf6c5836d055b2