### PR TITLE
Fix Syncro contacts endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && cp -r src/views dist && cp -r src/public dist",
     "start": "node dist/server.js",
     "dev": "nodemon src/server.ts",
-    "test": "tsc --noEmit && node --test --require ts-node/register/transpile-only tests/updateCompany.test.ts"
+    "test": "tsc --noEmit && node --test --require ts-node/register/transpile-only tests/*.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/src/syncro.ts
+++ b/src/syncro.ts
@@ -75,7 +75,7 @@ export async function getSyncroCustomer(id: string | number): Promise<SyncroCust
 export async function getSyncroContacts(
   customerId: string | number
 ): Promise<SyncroContact[]> {
-  const data = await syncroRequest(`/contact?customer_id=${customerId}`);
+  const data = await syncroRequest(`/contacts?customer_id=${customerId}`);
   if (Array.isArray(data)) {
     return data as SyncroContact[];
   }

--- a/tests/syncro.test.ts
+++ b/tests/syncro.test.ts
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getSyncroContacts } from '../src/syncro';
+
+// Ensure getSyncroContacts requests the correct contacts endpoint
+// Uses a mock fetch implementation to capture the requested URL
+
+test('getSyncroContacts uses /contacts endpoint', async () => {
+  const customerId = 123;
+  let requestedUrl: string | undefined;
+
+  const mockFetch = async (url: string, _init?: RequestInit) => {
+    requestedUrl = url;
+    return {
+      ok: true,
+      json: async () => [] as any,
+    } as Response;
+  };
+
+  const originalFetch = global.fetch;
+  // @ts-expect-error assign mock
+  global.fetch = mockFetch;
+  process.env.SYNCRO_WEBHOOK_URL = 'https://example.com';
+
+  try {
+    await getSyncroContacts(customerId);
+    assert.equal(
+      requestedUrl,
+      `https://example.com/contacts?customer_id=${customerId}`
+    );
+  } finally {
+    // restore env and fetch
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    }
+    delete process.env.SYNCRO_WEBHOOK_URL;
+  }
+});


### PR DESCRIPTION
## Summary
- correct Syncro contacts API path from `/contact` to `/contacts`
- add regression test for contact endpoint
- expand test script to run all tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a30e7c8790832db4b5564e3bc38fff