### PR TITLE
Handle Syncro contacts with duplicate names

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import {
   getSyncroCustomer,
   getSyncroContacts,
 } from './syncro';
+import { findExistingStaff } from './staff-import';
 import {
   getUserByEmail,
   getCompanyById,
@@ -2221,11 +2222,11 @@ app.post(
             .join(' ');
         const email = (contact as any).email || (contact as any).email_address || null;
         const phone = (contact as any).mobile || (contact as any).phone || null;
-        let existing = existingStaff.find(
-          (s) =>
-            (email && s.email.toLowerCase() === email.toLowerCase()) ||
-            (s.first_name.toLowerCase() === firstName.toLowerCase() &&
-              s.last_name.toLowerCase() === lastName.toLowerCase())
+        const existing = findExistingStaff(
+          existingStaff,
+          firstName,
+          lastName,
+          email
         );
         if (existing) {
           await updateStaff(

--- a/src/staff-import.ts
+++ b/src/staff-import.ts
@@ -1,0 +1,23 @@
+export interface BasicStaff {
+  first_name: string;
+  last_name: string;
+  email: string | null;
+}
+
+export function findExistingStaff<T extends BasicStaff>(
+  existingStaff: T[],
+  firstName: string,
+  lastName: string,
+  email: string | null
+): T | undefined {
+  const emailLower = email?.toLowerCase();
+  return existingStaff.find((s) => {
+    if (emailLower) {
+      return s.email ? s.email.toLowerCase() === emailLower : false;
+    }
+    return (
+      s.first_name.toLowerCase() === firstName.toLowerCase() &&
+      s.last_name.toLowerCase() === lastName.toLowerCase()
+    );
+  });
+}

--- a/tests/staff-import.test.ts
+++ b/tests/staff-import.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { findExistingStaff, BasicStaff } from '../src/staff-import';
+
+test('findExistingStaff matches by email when provided', () => {
+  const existing: BasicStaff[] = [
+    { first_name: 'John', last_name: 'Doe', email: 'john@example.com' },
+  ];
+  const result = findExistingStaff(existing, 'John', 'Doe', 'john@example.com');
+  assert.equal(result, existing[0]);
+});
+
+test('findExistingStaff treats same name different email as new staff', () => {
+  const existing: BasicStaff[] = [
+    { first_name: 'John', last_name: 'Doe', email: 'john@example.com' },
+  ];
+  const result = findExistingStaff(existing, 'John', 'Doe', 'john2@example.com');
+  assert.equal(result, undefined);
+});
+
+test('findExistingStaff falls back to name when email missing', () => {
+  const existing: BasicStaff[] = [
+    { first_name: 'Jane', last_name: 'Smith', email: null },
+  ];
+  const result = findExistingStaff(existing, 'Jane', 'Smith', null);
+  assert.equal(result, existing[0]);
+});


### PR DESCRIPTION
## Summary
- prevent Syncro import from merging staff with same name but different emails
- add helper to locate existing staff by email
- add unit tests covering staff import matching logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a311f869c8832db561720d71d45f82