### PR TITLE
Add user management table to admin

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2332,6 +2332,11 @@ app.post('/admin/user', ensureAuth, ensureAdmin, async (req, res) => {
   res.redirect('/admin');
 });
 
+app.delete('/admin/user/:id', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  await deleteUser(parseInt(req.params.id, 10));
+  res.json({ success: true });
+});
+
 app.post('/admin/invite', ensureAuth, ensureAdmin, async (req, res) => {
   const { email, firstName, lastName } = req.body;
   const isSuperAdmin = req.session.userId === 1;

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -117,6 +117,19 @@
               </select>
               <button type="submit">Assign</button>
             </form>
+            <table>
+              <thead>
+                <tr><th>User</th><th>Delete</th></tr>
+              </thead>
+              <tbody>
+                <% users.forEach(function(u){ %>
+                  <tr>
+                    <td><%= u.email %></td>
+                    <td><button class="delete-user-btn" data-user-id="<%= u.id %>">Delete</button></td>
+                  </tr>
+                <% }); %>
+              </tbody>
+            </table>
           </section>
           <% } %>
         </div>
@@ -801,6 +814,13 @@
         btn.addEventListener('click', async function(){
           if(!confirm('Remove assignment?')) return;
           await fetch(`/admin/assign/${this.dataset.companyId}/${this.dataset.userId}`, { method: 'DELETE' });
+          location.reload();
+        });
+      });
+      document.querySelectorAll('.delete-user-btn').forEach(function(btn){
+        btn.addEventListener('click', async function(){
+          if(!confirm('Delete user?')) return;
+          await fetch(`/admin/user/${this.dataset.userId}`, { method: 'DELETE' });
           location.reload();
         });
       });


### PR DESCRIPTION
## Summary
- show all users on the admin company assignment page with delete buttons
- allow super admins to delete users via new endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a53a164190832db2aa1f457769bf01