### PR TITLE
Fix admin menu visibility on Office Groups page

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2078,8 +2078,9 @@ app.get('/office-groups', ensureAuth, ensureStaffAccess, async (req, res) => {
   ]);
   const companies = await getCompaniesForUser(req.session.userId!);
   const current = companies.find((c) => c.company_id === req.session.companyId);
+  const isAdmin = req.session.userId === 1 || (current?.is_admin ?? 0);
   res.render('office-groups', {
-    isAdmin: true,
+    isAdmin,
     isSuperAdmin,
     companies,
     currentCompanyId: req.session.companyId,


### PR DESCRIPTION
## Summary
- compute `isAdmin` correctly for Office Groups view so non-admin users do not see admin menus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a55653407c832da91afa0fa5571cb0