### PR TITLE
Require 2FA for all users and expose account management

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -876,8 +876,11 @@ export async function addUserTotpAuthenticator(
   );
 }
 
-export async function deleteUserTotpAuthenticator(id: number): Promise<void> {
-  await pool.execute('DELETE FROM user_totp_authenticators WHERE id = ?', [id]);
+export async function deleteUserTotpAuthenticator(
+  userId: number,
+  id: number
+): Promise<void> {
+  await pool.execute('DELETE FROM user_totp_authenticators WHERE id = ? AND user_id = ?', [id, userId]);
 }
 
 export async function deleteUser(id: number): Promise<void> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -556,29 +556,8 @@ app.post('/login', async (req, res) => {
   const { email, password } = req.body;
   const user = await getUserByEmail(email);
   if (user && (await bcrypt.compare(password, user.password_hash))) {
-    const companies = await getCompaniesForUser(user.id);
-    const isAdmin = user.id === 1 || companies.some((c) => c.is_admin);
-    if (isAdmin) {
-      const trusted = req.cookies[`trusted_${user.id}`];
-      if (trusted && verifyTrustedDeviceToken(trusted, user.id)) {
-        await completeLogin(req, user.id);
-        if (user.force_password_change) {
-          req.session.mustChangePassword = true;
-          return res.redirect('/force-password-change');
-        }
-        return res.redirect('/');
-      }
-      req.session.tempUserId = user.id;
-      req.session.pendingForcePassword = !!user.force_password_change;
-      const totpAuths = await getUserTotpAuthenticators(user.id);
-      if (totpAuths.length === 0) {
-        req.session.pendingTotpSecret = authenticator.generateSecret();
-        req.session.requireTotpSetup = true;
-      } else {
-        req.session.requireTotpSetup = false;
-      }
-      return res.redirect('/totp');
-    } else {
+    const trusted = req.cookies[`trusted_${user.id}`];
+    if (trusted && verifyTrustedDeviceToken(trusted, user.id)) {
       await completeLogin(req, user.id);
       if (user.force_password_change) {
         req.session.mustChangePassword = true;
@@ -586,6 +565,16 @@ app.post('/login', async (req, res) => {
       }
       return res.redirect('/');
     }
+    req.session.tempUserId = user.id;
+    req.session.pendingForcePassword = !!user.force_password_change;
+    const totpAuths = await getUserTotpAuthenticators(user.id);
+    if (totpAuths.length === 0) {
+      req.session.pendingTotpSecret = authenticator.generateSecret();
+      req.session.requireTotpSetup = true;
+    } else {
+      req.session.requireTotpSetup = false;
+    }
+    return res.redirect('/totp');
   }
   res.render('login', { error: 'Invalid credentials' });
 });
@@ -737,7 +726,7 @@ app.post('/force-password-change', ensureAuth, async (req, res) => {
   res.redirect('/');
 });
 
-app.post('/change-password', ensureAuth, ensureAdmin, async (req, res) => {
+app.post('/change-password', ensureAuth, async (req, res) => {
   const { currentPassword, newPassword } = req.body;
   const user = await getUserById(req.session.userId!);
   if (!user || !(await bcrypt.compare(currentPassword, user.password_hash))) {
@@ -750,7 +739,7 @@ app.post('/change-password', ensureAuth, ensureAdmin, async (req, res) => {
   res.redirect('/admin#account');
 });
 
-app.post('/change-name', ensureAuth, ensureAdmin, async (req, res) => {
+app.post('/change-name', ensureAuth, async (req, res) => {
   const { firstName, lastName } = req.body;
   if (!firstName || !lastName) {
     req.session.nameError = 'First name and last name are required';
@@ -761,7 +750,7 @@ app.post('/change-name', ensureAuth, ensureAdmin, async (req, res) => {
   res.redirect('/admin#account');
 });
 
-app.post('/change-mobile', ensureAuth, ensureAdmin, async (req, res) => {
+app.post('/change-mobile', ensureAuth, async (req, res) => {
   const mobilePhone = (req.body.mobilePhone || '').trim();
   if (!mobilePhone) {
     req.session.mobileError = 'Mobile phone is required';
@@ -1862,8 +1851,11 @@ app.post('/apps/:appId/add', ensureAuth, ensureSuperAdmin, async (req, res) => {
   res.status(204).end();
 });
 
-app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
+app.get('/admin', ensureAuth, async (req, res) => {
+  const companies = await getCompaniesForUser(req.session.userId!);
+  const current = companies.find((c) => c.company_id === req.session.companyId);
   const isSuperAdmin = req.session.userId === 1;
+  const isAdmin = isSuperAdmin || (current?.is_admin ?? 0);
   const formId = req.query.formId ? parseInt(req.query.formId as string, 10) : NaN;
   const companyIdParam = req.query.companyId ? parseInt(req.query.companyId as string, 10) : NaN;
   const includeArchived = req.query.showArchived === '1';
@@ -1906,7 +1898,7 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
       }
       productRestrictions[r.product_id].push(r);
     });
-  } else {
+  } else if (isAdmin) {
     const companyId = req.session.companyId!;
     const company = await getCompanyById(companyId);
     allCompanies = company ? [company] : [];
@@ -1918,9 +1910,9 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
       formUsers = await getUserCompanyAssignments(companyIdParam);
       permissions = await getFormPermissions(formId, companyIdParam);
     }
+  } else {
+    allCompanies = [];
   }
-  const companies = await getCompaniesForUser(req.session.userId!);
-  const current = companies.find((c) => c.company_id === req.session.companyId);
   const currentUser = await getUserById(req.session.userId!);
   const totpAuthenticators = await getUserTotpAuthenticators(req.session.userId!);
   let newTotpQr: string | null = null;
@@ -1965,7 +1957,7 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
     showArchived: includeArchived,
     selectedFormId: isNaN(formId) ? null : formId,
     selectedCompanyId: isNaN(companyIdParam) ? null : companyIdParam,
-    isAdmin: true,
+    isAdmin,
     isSuperAdmin,
     companies,
     currentCompanyId: req.session.companyId,
@@ -1994,14 +1986,14 @@ app.get('/admin', ensureAuth, ensureAdmin, async (req, res) => {
   });
 });
 
-app.post('/admin/totp/start', ensureAuth, ensureAdmin, (req, res) => {
+app.post('/admin/totp/start', ensureAuth, (req, res) => {
   const { name } = req.body;
   req.session.newTotpName = name;
   req.session.newTotpSecret = authenticator.generateSecret();
   res.redirect('/admin#account');
 });
 
-app.post('/admin/totp/verify', ensureAuth, ensureAdmin, async (req, res) => {
+app.post('/admin/totp/verify', ensureAuth, async (req, res) => {
   if (!req.session.newTotpSecret || !req.session.newTotpName) {
     return res.redirect('/admin#account');
   }
@@ -2023,16 +2015,16 @@ app.post('/admin/totp/verify', ensureAuth, ensureAdmin, async (req, res) => {
   res.redirect('/admin#account');
 });
 
-app.post('/admin/totp/cancel', ensureAuth, ensureAdmin, (req, res) => {
+app.post('/admin/totp/cancel', ensureAuth, (req, res) => {
   req.session.newTotpSecret = undefined;
   req.session.newTotpName = undefined;
   req.session.newTotpError = undefined;
   res.redirect('/admin#account');
 });
 
-app.post('/admin/totp/:id/delete', ensureAuth, ensureAdmin, async (req, res) => {
+app.post('/admin/totp/:id/delete', ensureAuth, async (req, res) => {
   const id = parseInt(req.params.id, 10);
-  await deleteUserTotpAuthenticator(id);
+  await deleteUserTotpAuthenticator(req.session.userId!, id);
   res.redirect('/admin#account');
 });
 

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -20,12 +20,15 @@
             <button data-tab="forms-admin">Forms</button>
             <button data-tab="form-permissions">Form Permissions</button>
             <button type="button" onclick="window.location.href='/admin/email-templates'">Email Templates</button>
-          <% } else { %>
+          <% } else if (isAdmin) { %>
             <button data-tab="account" class="active">Account</button>
             <button data-tab="companies">Companies</button>
             <button data-tab="assignments">Current Assignments</button>
+          <% } else { %>
+            <button data-tab="account" class="active">Account</button>
           <% } %>
         </div>
+        <% if (isAdmin) { %>
         <div id="companies" class="tab-content">
           <% if (isSuperAdmin) { %>
           <section>
@@ -133,6 +136,7 @@
           </section>
           <% } %>
         </div>
+        <% if (isAdmin) { %>
         <div id="assignments" class="tab-content">
           <section>
             <h2>Current Assignments</h2>
@@ -221,6 +225,7 @@
             <p><em>Note: Not all functionality is currently available and will be added in future MyPortal releases.</em></p>
           </section>
         </div>
+        <% } %>
         <div id="account" class="tab-content<% if (!isSuperAdmin) { %> active<% } %>">
           <section>
             <h2>Profile</h2>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -49,6 +49,9 @@
       <% } %>
       <a href="/audit-logs" class="menu-link"><i class="fas fa-clipboard-list"></i> Audit Logs</a>
     <% } %>
+    <% if (typeof isAdmin !== 'undefined' && !isAdmin) { %>
+      <a href="/admin#account" class="menu-link"><i class="fas fa-user"></i> Account</a>
+    <% } %>
     <% if (isSuperAdmin) { %>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
     <% } %>


### PR DESCRIPTION
## Summary
- Require TOTP verification for all logins
- Allow non-admin users to access the account page and manage their profiles
- Restrict TOTP authenticator deletion to the current user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a557572248832d944f35e5334dd631