### PR TITLE
fix: ensure admin view compiles on older Node

### DIFF
--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -843,9 +843,12 @@
           document.getElementById('ip-modal').style.display = 'flex';
         });
       });
-      document.getElementById('ip-modal-close')?.addEventListener('click', function(){
-        document.getElementById('ip-modal').style.display = 'none';
-      });
+      var ipModalClose = document.getElementById('ip-modal-close');
+      if (ipModalClose) {
+        ipModalClose.addEventListener('click', function(){
+          document.getElementById('ip-modal').style.display = 'none';
+        });
+      }
       document.querySelectorAll('.show-key').forEach(function(link){
         link.addEventListener('click', function(e){
           e.preventDefault();
@@ -853,9 +856,12 @@
           document.getElementById('key-modal').style.display = 'flex';
         });
       });
-      document.getElementById('key-modal-close')?.addEventListener('click', function(){
-        document.getElementById('key-modal').style.display = 'none';
-      });
+      var keyModalClose = document.getElementById('key-modal-close');
+      if (keyModalClose) {
+        keyModalClose.addEventListener('click', function(){
+          document.getElementById('key-modal').style.display = 'none';
+        });
+      }
       document.querySelectorAll('td.last-used').forEach(function(td){
         const val = td.dataset.last;
         if(val){


### PR DESCRIPTION
## Summary
- avoid optional chaining in `admin.ejs` for modal close buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a55a2d3aec832d98c05bb9b23d147d