### PR TITLE
Fix companyName rendering in admin view

### DIFF
--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -304,7 +304,7 @@
             <h2>Site Settings</h2>
             <form action="/admin/site-settings" method="post" enctype="multipart/form-data">
               <label>Company Name:
-                <input type="text" name="companyName" value="<%= siteSettings?.company_name || '' %>">
+                <input type="text" name="companyName" value="<%= siteSettings && siteSettings.company_name ? siteSettings.company_name : '' %>">
               </label>
               <div>
                 <label>Login/Verify Logo:


### PR DESCRIPTION
## Summary
- Avoid optional chaining when rendering company name in admin view to support older runtime environments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a55cc9248c832d852120bd4d441b1e