### PR TITLE
Add scheduled task admin and rename account link

### DIFF
--- a/migrations/046_scheduled_tasks.sql
+++ b/migrations/046_scheduled_tasks.sql
@@ -1,0 +1,11 @@
+CREATE TABLE scheduled_tasks (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  company_id INT NULL,
+  name VARCHAR(255) NOT NULL,
+  command VARCHAR(100) NOT NULL,
+  cron VARCHAR(100) NOT NULL,
+  last_run_at DATETIME NULL,
+  active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "express-session": "^1.18.2",
         "multer": "^1.4.5-lts.1",
         "mysql2": "^3.14.3",
+        "node-cron": "^3.0.3",
         "nodemailer": "^6.9.8",
         "otplib": "^12.0.1",
         "qrcode": "^1.5.3",
@@ -31,6 +32,7 @@
         "@types/express-session": "^1.18.2",
         "@types/multer": "^1.4.7",
         "@types/node": "^24.2.1",
+        "@types/node-cron": "^3.0.8",
         "@types/nodemailer": "^7.0.0",
         "@types/qrcode": "^1.5.5",
         "@types/swagger-jsdoc": "^6.0.4",
@@ -1659,6 +1661,13 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/nodemailer": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.0.tgz",
@@ -3147,6 +3156,27 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-gyp-build": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "otplib": "^12.0.1",
     "qrcode": "^1.5.3",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "node-cron": "^3.0.3"
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
@@ -40,6 +41,7 @@
     "@types/qrcode": "^1.5.5",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
+    "@types/node-cron": "^3.0.8",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -50,8 +50,9 @@
     <% } %>
     <% if (isSuperAdmin) { %>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
+      <a href="/admin/schedules" class="menu-link"><i class="fas fa-clock"></i> Schedules</a>
     <% } %>
-    <a href="/admin" class="menu-link"><i class="fas fa-user"></i> Account</a>
+    <a href="/admin" class="menu-link"><i class="fas fa-user"></i> <%= (isAdmin || isSuperAdmin) ? 'Admin' : 'Account' %></a>
     <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
   </div>
 </nav>

--- a/src/views/schedules.ejs
+++ b/src/views/schedules.ejs
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Schedules' }) %>
+  <body>
+    <div class="app-container">
+      <%- include('partials/sidebar') %>
+      <div class="content">
+        <h1>Schedules</h1>
+        <table>
+          <thead>
+            <tr>
+              <th>ID</th><th>Company</th><th>Name</th><th>Command</th><th>Cron</th><th>Last Run</th><th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% tasks.forEach(function(t){ %>
+              <tr>
+                <td><%= t.id %></td>
+                <td><%= t.company_name || '' %></td>
+                <td><%= t.name %></td>
+                <td><%= t.command %></td>
+                <td><%= t.cron %></td>
+                <td><%= t.last_run_at ? new Date(t.last_run_at).toLocaleString() : '' %></td>
+                <td>
+                  <form action="/admin/schedules/<%= t.id %>/run" method="post" style="display:inline">
+                    <button type="submit">Run Now</button>
+                  </form>
+                  <form action="/admin/schedules/<%= t.id %>" method="post" style="display:inline">
+                    <input type="text" name="name" value="<%= t.name %>" required>
+                    <input type="text" name="cron" value="<%= t.cron %>" required>
+                    <button type="submit">Save</button>
+                  </form>
+                  <form action="/admin/schedules/<%= t.id %>/delete" method="post" style="display:inline" onsubmit="return confirm('Delete?');">
+                    <button type="submit">Delete</button>
+                  </form>
+                </td>
+              </tr>
+            <% }); %>
+          </tbody>
+        </table>
+        <h2>Add Schedule</h2>
+        <form action="/admin/schedules" method="post">
+          <input type="text" name="name" placeholder="Name" required>
+          <select name="command">
+            <option value="sync_staff">Sync Staff From Syncro</option>
+            <option value="sync_o365">Sync Office 365 License Counts</option>
+            <option value="sync_xero">Sync Xero Invoices</option>
+            <option value="sync_assets">Sync Assets From Syncro</option>
+            <option value="system_update">MyPortal System Update</option>
+          </select>
+          <input type="text" name="cron" placeholder="Cron Expression" required>
+          <select name="companyId">
+            <option value="">System</option>
+            <% allCompanies.forEach(function(c){ %>
+              <option value="<%= c.id %>"><%= c.name %></option>
+            <% }); %>
+          </select>
+          <button type="submit">Add</button>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- introduce `scheduled_tasks` table and query helpers
- add cron-based scheduler with super admin interface to manage, run, and delete tasks
- rename Account link to Admin for privileged users and expose Schedules page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a564c11cb4832db7781dfacc083ea5