### PR TITLE
Refine cron generator UI and suppress DataTables warning

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -292,3 +292,11 @@ table th {
 .verify-container .success {
   text-align: center;
 }
+
+#cron-generator-container {
+  font-size: 0.5em;
+}
+
+#cron-input {
+  width: 200%;
+}

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -244,7 +244,9 @@
                   <% }); %>
                 </select>
                 <input type="text" name="cron" id="cron-input" placeholder="Cron Expression" required>
-                <div id="cron-generator-container">
+                <details id="cron-generator">
+                  <summary>Cron Generator</summary>
+                  <div id="cron-generator-container">
                   <table class="generator">
                     <tr>
                       <td>
@@ -406,7 +408,8 @@
                       </td>
                     </tr>
                   </table>
-                </div>
+                  </div>
+                </details>
                 <button type="submit">Add</button>
               </form>
             </section>

--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -7,7 +7,7 @@
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script>
     $(function() {
-      $('table').DataTable();
+      $('table').not('#cron-generator-container table').DataTable();
     });
   </script>
 </head>


### PR DESCRIPTION
## Summary
- Collapse cron generator by default via accordion
- Reduce cron generator text size and expand output input width
- Prevent DataTables initialization on cron generator to fix column count warning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a5997a8034832d8ddc377fd3461c18