### PR TITLE
Separate staff permissions and add department filtering

### DIFF
--- a/migrations/047_staff_office_permissions.sql
+++ b/migrations/047_staff_office_permissions.sql
@@ -1,0 +1,8 @@
+ALTER TABLE user_companies
+  ADD COLUMN IF NOT EXISTS staff_permission TINYINT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS can_manage_office_groups TINYINT(1) NOT NULL DEFAULT 0;
+
+UPDATE user_companies
+SET staff_permission = IF(can_manage_staff = 1, 3, 0),
+    can_manage_office_groups = can_manage_staff
+WHERE staff_permission = 0;

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -142,7 +142,7 @@
             <h2>Current Assignments</h2>
             <table>
               <thead>
-                <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Assets</th><th>Invoices</th><th>Shop</th><% if (isSuperAdmin) { %><th>Remove</th><% } %></tr>
+                <tr><th>User</th><th>Company</th><th>Admin</th><th>Licenses</th><th>Order</th><th>Staff</th><th>Office Groups</th><th>Assets</th><th>Invoices</th><th>Shop</th><% if (isSuperAdmin) { %><th>Remove</th><% } %></tr>
               </thead>
               <tbody>
               <% assignments.forEach(function(a) { %>
@@ -177,8 +177,20 @@
                     <form action="/admin/permission" method="post">
                       <input type="hidden" name="userId" value="<%= a.user_id %>">
                       <input type="hidden" name="companyId" value="<%= a.company_id %>">
-                      <input type="hidden" name="canManageStaff" value="0">
-                      <input type="checkbox" name="canManageStaff" value="1" <%= a.can_manage_staff ? 'checked' : '' %> onchange="this.form.submit()">
+                      <select name="staffPermission" onchange="this.form.submit()">
+                        <option value="0" <%= a.staff_permission === 0 ? 'selected' : '' %>>None</option>
+                        <option value="1" <%= a.staff_permission === 1 ? 'selected' : '' %>>Department</option>
+                        <option value="2" <%= a.staff_permission === 2 ? 'selected' : '' %>>Department + Unassigned</option>
+                        <option value="3" <%= a.staff_permission === 3 ? 'selected' : '' %>>Company</option>
+                      </select>
+                    </form>
+                  </td>
+                  <td>
+                    <form action="/admin/permission" method="post">
+                      <input type="hidden" name="userId" value="<%= a.user_id %>">
+                      <input type="hidden" name="companyId" value="<%= a.company_id %>">
+                      <input type="hidden" name="canManageOfficeGroups" value="0">
+                      <input type="checkbox" name="canManageOfficeGroups" value="1" <%= a.can_manage_office_groups ? 'checked' : '' %> onchange="this.form.submit()">
                     </form>
                   </td>
                   <td>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -20,7 +20,7 @@
     <% if (canManageStaff || isSuperAdmin) { %>
       <a href="/staff" class="menu-link"><i class="fas fa-users"></i> Staff</a>
     <% } %>
-    <% if (canManageStaff || isSuperAdmin) { %>
+    <% if (canManageOfficeGroups || isSuperAdmin) { %>
       <a href="/office-groups" class="menu-link"><i class="fas fa-layer-group"></i> Office Groups</a>
     <% } %>
     <% if (canManageLicenses) { %>

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -20,6 +20,7 @@
           <input type="text" name="lastName" placeholder="Last Name" required>
           <input type="email" name="email" placeholder="Email" required>
           <input type="tel" name="mobilePhone" placeholder="Mobile">
+          <input type="text" name="department" placeholder="Department">
           <input type="date" name="dateOnboarded">
           <label><input type="checkbox" name="enabled" value="1" checked> Enabled</label>
           <button type="submit">Add</button>
@@ -36,6 +37,16 @@
               <option value="0" <%= enabledFilter === '0' ? 'selected' : '' %>>Disabled</option>
             </select>
           </label>
+          <% if (staffPermission === 3 && departments && departments.length) { %>
+          <label>Department
+            <select name="department" onchange="document.getElementById('filter-form').submit()">
+              <option value="" <%= departmentFilter === '' ? 'selected' : '' %>>All</option>
+              <% departments.forEach(function(d) { %>
+                <option value="<%= d %>" <%= departmentFilter === d ? 'selected' : '' %>><%= d %></option>
+              <% }) %>
+            </select>
+          </label>
+          <% } %>
         </form>
         <table>
           <thead>


### PR DESCRIPTION
## Summary
- Split staff and office group permissions with new `staff_permission` levels
- Sync and display staff department with company-wide department filtering
- Update admin UI and sidebar for granular staff controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a5cee9ccec832d9ba0ee2eaac4352e