### PR TITLE
Randomize daily cron defaults

### DIFF
--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,0 +1,5 @@
+export function getRandomDailyCron(): string {
+  const minute = Math.floor(Math.random() * 60);
+  const hour = Math.floor(Math.random() * 24);
+  return `${minute} ${hour} * * *`;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import swaggerJSDoc from 'swagger-jsdoc';
 import multer from 'multer';
 import nodemailer from 'nodemailer';
 import cron from 'node-cron';
+import { getRandomDailyCron } from './cron';
 import { execFile } from 'child_process';
 import util from 'util';
 import {
@@ -382,8 +383,7 @@ async function scheduleAllTasks() {
 }
 
 async function createDefaultSchedulesForCompany(companyId: number) {
-  const hour = Math.floor(Math.random() * 24);
-  const cronExpr = `0 ${hour} * * *`;
+  const cronExpr = getRandomDailyCron();
   await createScheduledTask(
     companyId,
     'Sync Staff From Syncro',

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -495,6 +495,14 @@
                   const w = getField('weekdays','weekdays-select');
                   document.getElementById('cron-input').value = `${m} ${h} ${d} ${mo} ${w}`;
                 }
+                const randomMinute = Math.floor(Math.random() * 60);
+                const randomHour = Math.floor(Math.random() * 24);
+                const minuteSelect = document.getElementById('minutes-select');
+                const hourSelect = document.getElementById('hours-select');
+                minuteSelect.value = String(randomMinute);
+                hourSelect.value = String(randomHour);
+                document.getElementById('minutes-custom').checked = true;
+                document.getElementById('hours-custom').checked = true;
                 document.querySelectorAll('#cron-generator-container input, #cron-generator-container select').forEach(function(el){
                   el.addEventListener('change', updateCron);
                 });

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getRandomDailyCron } from '../src/cron';
+
+test('getRandomDailyCron produces daily cron with valid hour and minute', () => {
+  const expr = getRandomDailyCron();
+  const parts = expr.split(' ');
+  assert.equal(parts.length, 5);
+  const minute = parseInt(parts[0], 10);
+  const hour = parseInt(parts[1], 10);
+  assert.ok(minute >= 0 && minute < 60);
+  assert.ok(hour >= 0 && hour < 24);
+  assert.equal(parts[2], '*');
+  assert.equal(parts[3], '*');
+  assert.equal(parts[4], '*');
+});


### PR DESCRIPTION
## Summary
- generate daily cron expressions with random hour and minute
- schedule default company tasks using random daily cron
- default cron generator UI to a random daily time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a5d96f0108832db37115cd2d8ef31e