### PR TITLE
Fix schedule last run timezone

### DIFF
--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -460,7 +460,7 @@
                       <td><%= t.cron %></td>
                       <td>
                         <% if (t.last_run_at) { %>
-                          <span class="local-time" data-time="<%= t.last_run_at %>"></span>
+                          <span class="local-time" data-time="<%= new Date(t.last_run_at).toISOString() %>"></span>
                         <% } %>
                       </td>
                       <td>


### PR DESCRIPTION
## Summary
- show Last Run times based on user's locale by emitting ISO timestamps in schedule table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a5dfd76b44832d9843006105436715