### PR TITLE
Center version info on login screen

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -30,9 +30,11 @@ body.login-page {
 .version-number {
   position: absolute;
   bottom: 10px;
-  right: 10px;
-  font-size: 0.8rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.4rem;
   color: #666;
+  text-align: center;
 }
 
 .login-container form {

--- a/src/views/login.ejs
+++ b/src/views/login.ejs
@@ -18,8 +18,9 @@
         <input type="password" name="password" required>
       </label>
       <label><input type="checkbox" id="remember-username"> Remember Username</label>
-      <button type="submit">Login</button>
-    </form>
+        <button type="submit">Login</button>
+        <br>
+      </form>
     <div class="version-number">Version <%= version %> Build <%= build %></div>
   </div>
   <script>


### PR DESCRIPTION
## Summary
- Center version and build info at bottom of login page and shrink font size
- Insert line break after login button for extra spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a683cc44f8832d9b396c1914d13bb1