### PR TITLE
Require SESSION_SECRET and secure session cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@ DB_HOST=localhost
 DB_USER=root
 DB_PASSWORD=password
 DB_NAME=myportal
-SESSION_SECRET=changeme
+# SESSION_SECRET must be a high-entropy value (e.g. generated with `openssl rand -hex 32`)
+SESSION_SECRET=
 XERO_WEBHOOK_URL=
 XERO_API_KEY=
 SYNCRO_WEBHOOK_URL=

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ There are no default login credentials; the first visit will prompt you to regis
    ```bash
    npm install
    ```
-2. Copy `.env.example` to `.env` and update the MySQL credentials and session secret.
-   Optionally set `CRON_TIMEZONE` to control the timezone for scheduled tasks (defaults to UTC).
+2. Copy `.env.example` to `.env` and update the MySQL credentials. Set a high-entropy
+   `SESSION_SECRET` (e.g. via `openssl rand -hex 32`). Optionally set `CRON_TIMEZONE`
+   to control the timezone for scheduled tasks (defaults to UTC).
 3. On first run, the application will automatically apply the database schema.
 4. On first run, visiting `/login` will redirect to a registration page to create the initial user and company.
 5. Run in development mode:


### PR DESCRIPTION
## Summary
- enforce presence of `SESSION_SECRET` and use it for secure session cookies
- use the same secret when generating and verifying trusted-device tokens
- document the need for a strong `SESSION_SECRET`

## Testing
- `SESSION_SECRET=test npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a693de1fc4832dbc3eedfcf378bebb