### PR TITLE
Disable multi-statement SQL queries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ DB_HOST=localhost
 DB_USER=root
 DB_PASSWORD=password
 DB_NAME=myportal
+# Allow multiple SQL statements in a single query (disabled by default)
+# DB_ALLOW_MULTIPLE_STATEMENTS=false
 # SESSION_SECRET must be a high-entropy value (e.g. generated with `openssl rand -hex 32`)
 SESSION_SECRET=
 XERO_WEBHOOK_URL=


### PR DESCRIPTION
## Summary
- Gate MySQL `multipleStatements` behind `DB_ALLOW_MULTIPLE_STATEMENTS` env flag
- Execute migration scripts statement-by-statement without relying on stacked queries
- Document optional multi-statement flag in `.env.example`

## Testing
- `SESSION_SECRET=test npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a69ea3f368832d8ccb0b2f76b4d812