### PR TITLE
Fix login by trusting proxy for secure sessions

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -476,6 +476,7 @@ function mapStaff(s: Staff) {
 }
 
 const app = express();
+app.set('trust proxy', 1);
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 


### PR DESCRIPTION
## Summary
- trust first proxy so secure session cookies are set when behind reverse proxies

## Testing
- `SESSION_SECRET=test npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a69fac8a00832d87ee2abed170adc8