### PR TITLE
Hash legacy API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ DB_NAME=myportal
 # DB_ALLOW_MULTIPLE_STATEMENTS=false
 # SESSION_SECRET must be a high-entropy value (e.g. generated with `openssl rand -hex 32`)
 SESSION_SECRET=
+# Secret used to HMAC-hash API keys
+API_KEY_SECRET=
 XERO_WEBHOOK_URL=
 XERO_API_KEY=
 SYNCRO_WEBHOOK_URL=

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,6 +75,7 @@ import {
   deleteApiKey,
   getApiKeyRecord,
   recordApiKeyUsage,
+  hashExistingApiKeys,
   logAudit,
   getAuditLogs,
   getAssetsByCompany,
@@ -2867,9 +2868,8 @@ app.post('/admin/invite', ensureAuth, ensureAdmin, async (req, res) => {
 
 app.post('/admin/api-key', ensureAuth, ensureAdmin, async (req, res) => {
   const { description, expiryDate } = req.body;
-  const key = crypto.randomBytes(32).toString('hex');
-  await createApiKey(key, description, expiryDate);
-  res.redirect('/admin');
+  const key = await createApiKey(description, expiryDate);
+  res.render('api-key', { key });
 });
 
 app.post('/admin/api-key/delete', ensureAuth, ensureAdmin, async (req, res) => {
@@ -5694,6 +5694,7 @@ const host = process.env.HOST || '0.0.0.0';
 
 async function start() {
   await runMigrations();
+  await hashExistingApiKeys();
   await scheduleAllTasks();
   app.listen(port, host, () => {
     console.log(`Server running at http://${host}:${port}`);

--- a/src/views/api-key.ejs
+++ b/src/views/api-key.ejs
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'API Key Created' }) %>
+<body>
+  <h1>API Key Created</h1>
+  <p>This is your new API key. Please store it securely; it will not be shown again.</p>
+  <pre><%= key %></pre>
+  <p><a href="/admin">Back to Admin</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce `hashExistingApiKeys` to migrate plaintext API keys to HMAC digests
- run key hashing during server startup and document `API_KEY_SECRET` in env example

## Testing
- `SESSION_SECRET=secret API_KEY_SECRET=secret npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7b83e052c832d96c5109e860a7be0