### PR TITLE
Fix CSRF validation for multipart uploads

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -508,6 +508,9 @@ function csrfMiddleware(
   next: express.NextFunction
 ) {
   if (req.session.userId) {
+    if (req.is('multipart/form-data')) {
+      return next();
+    }
     csrfProtection(req, res, (err) => {
       if (err) return next(err);
       res.locals.csrfToken = req.csrfToken();
@@ -583,7 +586,11 @@ const enforceFilePermissions: express.RequestHandler = async (req, _res, next) =
   next();
 };
 
-const uploadMiddleware = [upload.single('image'), enforceFilePermissions];
+const uploadMiddleware = [
+  upload.single('image'),
+  enforceFilePermissions,
+  csrfProtection,
+];
 const memoryUpload = multer();
 
 // Serve uploaded files via controlled route
@@ -2895,6 +2902,7 @@ app.post(
     { name: 'loginLogo', maxCount: 1 },
     { name: 'sidebarLogo', maxCount: 1 },
   ]),
+  csrfProtection,
   async (req, res) => {
     const { companyName } = req.body;
     const files = req.files as {
@@ -5714,4 +5722,4 @@ if (require.main === module) {
   start();
 }
 
-export { app, api, start, csrfMiddleware };
+export { app, api, start, csrfMiddleware, csrfProtection };

--- a/tests/csrf.test.ts
+++ b/tests/csrf.test.ts
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict';
 import express from 'express';
 import session from 'express-session';
 import request from 'supertest';
-import { csrfMiddleware } from '../src/server';
+import multer from 'multer';
+process.env.SESSION_SECRET = 'test';
+const { csrfMiddleware, csrfProtection } = require('../src/server');
 
 function buildApp(authenticated: boolean) {
   const app = express();
@@ -44,4 +46,35 @@ test('authenticated POST requires CSRF token', async () => {
 test('unauthenticated POST skips CSRF check', async () => {
   const app = buildApp(false);
   await request(app).post('/submit').expect(200);
+});
+
+test('multipart POST requires CSRF token', async () => {
+  const app = express();
+  app.use(express.urlencoded({ extended: true }));
+  app.use(session({ secret: 'test', resave: false, saveUninitialized: true }));
+  app.use((req, _res, next) => {
+    req.session.userId = 1;
+    next();
+  });
+  app.use(csrfMiddleware);
+  const upload = multer();
+  app.get('/token', (req, res) => {
+    res.json({ token: res.locals.csrfToken || null });
+  });
+  app.post('/upload', upload.single('file'), csrfProtection, (req, res) => {
+    res.json({ success: true });
+  });
+  const agent = request.agent(app);
+  const tokenRes = await agent.get('/token');
+  const token = tokenRes.body.token;
+  assert.ok(token, 'token should be provided');
+  await agent
+    .post('/upload')
+    .attach('file', Buffer.from('test'), 'test.txt')
+    .field('_csrf', token)
+    .expect(200);
+  await agent
+    .post('/upload')
+    .attach('file', Buffer.from('test'), 'test.txt')
+    .expect(403);
 });

--- a/tests/updateCompany.test.ts
+++ b/tests/updateCompany.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { updateCompanyHandler } from '../src/server';
+process.env.SESSION_SECRET = 'test';
+const { updateCompanyHandler } = require('../src/server');
 
 test('omitting address keeps existing address', async () => {
   const getCompanyByIdCalls: number[] = [];


### PR DESCRIPTION
## Summary
- handle CSRF for multipart/form-data by skipping early checks and validating after file parsing
- apply CSRF protection to uploads and site settings
- add tests ensuring multipart requests require valid CSRF tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7c256c31c832d82b9187440318094