### PR TITLE
Encrypt TOTP secrets at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ DB_NAME=myportal
 # DB_ALLOW_MULTIPLE_STATEMENTS=false
 # SESSION_SECRET must be a high-entropy value (e.g. generated with `openssl rand -hex 32`)
 SESSION_SECRET=
+# 32-byte key used to encrypt TOTP secrets
+TOTP_ENCRYPTION_KEY=
 # Secret used to HMAC-hash API keys
 API_KEY_SECRET=
 XERO_WEBHOOK_URL=

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ There are no default login credentials; the first visit will prompt you to regis
    ```bash
    npm install
    ```
-2. Copy `.env.example` to `.env` and update the MySQL credentials. Set a high-entropy
-   `SESSION_SECRET` (e.g. via `openssl rand -hex 32`). Optionally set `CRON_TIMEZONE`
-   to control the timezone for scheduled tasks (defaults to UTC).
-3. On first run, the application will automatically apply the database schema.
+2. Copy `.env.example` to `.env` and update the MySQL credentials. Set high-entropy
+   values for `SESSION_SECRET` and `TOTP_ENCRYPTION_KEY` (e.g. via `openssl rand -hex 32`).
+   Optionally set `CRON_TIMEZONE` to control the timezone for scheduled tasks (defaults to UTC).
+3. On first run, the application will automatically apply the database schema and encrypt any existing TOTP secrets.
 4. On first run, visiting `/login` will redirect to a registration page to create the initial user and company.
 5. Run in development mode:
    ```bash

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,0 +1,33 @@
+import crypto from 'crypto';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const rawKey = process.env.TOTP_ENCRYPTION_KEY;
+if (!rawKey) {
+  throw new Error('TOTP_ENCRYPTION_KEY is not set');
+}
+const key = crypto.createHash('sha256').update(rawKey).digest();
+
+export function encryptSecret(secret: string): string {
+  const iv = crypto.randomBytes(12); // GCM standard IV length
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(secret, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString('base64')}:${tag.toString('base64')}:${encrypted.toString('base64')}`;
+}
+
+export function decryptSecret(payload: string): string {
+  if (!payload.includes(':')) {
+    // Assume plaintext from older entries
+    return payload;
+  }
+  const [ivB64, tagB64, dataB64] = payload.split(':');
+  const iv = Buffer.from(ivB64, 'base64');
+  const tag = Buffer.from(tagB64, 'base64');
+  const data = Buffer.from(dataB64, 'base64');
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+  return decrypted.toString('utf8');
+}


### PR DESCRIPTION
## Summary
- Encrypt TOTP secrets using AES-256-GCM with a server-held key
- Automatically migrate existing TOTP secrets to encrypted storage at startup
- Document new `TOTP_ENCRYPTION_KEY` environment variable and automatic migration

## Testing
- `TOTP_ENCRYPTION_KEY=testkey API_KEY_SECRET=test SESSION_SECRET=test npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7c6b3d380832db2de66aa2f3c5724