### PR TITLE
Implement password setup token flow

### DIFF
--- a/migrations/048_password_tokens.sql
+++ b/migrations/048_password_tokens.sql
@@ -1,0 +1,11 @@
+CREATE TABLE password_tokens (
+  token VARCHAR(64) PRIMARY KEY,
+  user_id INT NOT NULL,
+  expires_at DATETIME NOT NULL,
+  used TINYINT(1) NOT NULL DEFAULT 0,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+UPDATE email_templates
+SET body = '<p>Hello,</p><p>You have been invited to join {{companyName}}\'s portal.</p><p>To set your password, click <a href="{{setupLink}}">this link</a>.</p><p>Once set, login at <a href="{{portalUrl}}">{{portalUrl}}</a>.</p><img src="{{loginLogo}}" alt="{{companyName}} logo" />'
+WHERE name = 'staff_invitation';

--- a/src/views/password-setup.ejs
+++ b/src/views/password-setup.ejs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Set Password' }) %>
+  <body class="login-page">
+    <div class="login-container">
+      <% if (siteSettings && siteSettings.login_logo) { %>
+        <img src="<%= siteSettings.login_logo %>" alt="Logo" style="max-width:200px;display:block;margin:0 auto 20px;">
+      <% } %>
+      <h1>Set Password</h1>
+      <% if (error) { %>
+        <p class="error"><%= error %></p>
+      <% } %>
+      <form method="post" action="/password-setup">
+        <input type="hidden" name="token" value="<%= token %>">
+        <label>New Password:
+          <input type="password" name="newPassword" required>
+        </label>
+        <button type="submit">Set Password</button>
+      </form>
+    </div>
+  </body>
+</html>

--- a/tests/csrf.test.ts
+++ b/tests/csrf.test.ts
@@ -5,6 +5,7 @@ import session from 'express-session';
 import request from 'supertest';
 import multer from 'multer';
 process.env.SESSION_SECRET = 'test';
+process.env.TOTP_ENCRYPTION_KEY = 'test';
 const { csrfMiddleware, csrfProtection } = require('../src/server');
 
 function buildApp(authenticated: boolean) {

--- a/tests/updateCompany.test.ts
+++ b/tests/updateCompany.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 process.env.SESSION_SECRET = 'test';
+process.env.TOTP_ENCRYPTION_KEY = 'test';
 const { updateCompanyHandler } = require('../src/server');
 
 test('omitting address keeps existing address', async () => {


### PR DESCRIPTION
## Summary
- send invitation emails with single-use password setup links instead of temporary passwords
- add password setup routes to validate tokens and let users choose a password
- expire password tokens after use or one hour and update email template default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a7d535fd28832db0d4236eb5bdd6c8