### PR TITLE
feat: add helmet security middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.1",
         "express-session": "^1.18.2",
+        "helmet": "^8.1.0",
         "multer": "^1.4.5-lts.1",
         "mysql2": "^3.14.3",
         "node-cron": "^3.0.3",
@@ -3141,6 +3142,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.1",
     "express-session": "^1.18.2",
+    "helmet": "^8.1.0",
     "multer": "^1.4.5-lts.1",
     "mysql2": "^3.14.3",
     "node-cron": "^3.0.3",

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import { getRandomDailyCron } from './cron';
 import { execFile } from 'child_process';
 import util from 'util';
 import rateLimit from 'express-rate-limit';
+import helmet from 'helmet';
 import {
   getSyncroCustomers,
   getSyncroCustomer,
@@ -487,6 +488,26 @@ const app = express();
 app.set('trust proxy', 1);
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
+
+// Register security middleware early
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", 'data:', 'https:'],
+        connectSrc: ["'self'"],
+        fontSrc: ["'self'", 'https:', 'data:'],
+        objectSrc: ["'none'"],
+        upgradeInsecureRequests: [],
+      },
+    },
+    referrerPolicy: { policy: 'no-referrer' },
+    crossOriginEmbedderPolicy: false,
+  })
+);
 
 // Register core middleware needed for all requests first
 app.use(cookieParser());


### PR DESCRIPTION
## Summary
- add helmet dependency for HTTP security headers
- apply helmet early in Express middleware with CSP, referrer, and COEP options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7ddcecd48832d9f0e0f77491ba498