### PR TITLE
Display scheduled task last run in local time

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2464,6 +2464,7 @@ app.get('/admin', ensureAuth, async (req, res) => {
     products,
     productRestrictions,
     tasks,
+    cronTimezone: process.env.CRON_TIMEZONE || Intl.DateTimeFormat().resolvedOptions().timeZone,
     showArchived: includeArchived,
     selectedFormId: isNaN(formId) ? null : formId,
     selectedCompanyId: isNaN(companyIdParam) ? null : companyIdParam,

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -481,10 +481,12 @@
               </table>
             </section>
             <script>
+              const tz = <%= JSON.stringify(cronTimezone) %>;
               document.querySelectorAll('.local-time').forEach(function(el){
                 const date = new Date(el.dataset.time);
                 if (!isNaN(date)) {
-                  el.textContent = date.toLocaleString();
+                  const opts = tz ? { timeZone: tz } : undefined;
+                  el.textContent = date.toLocaleString(undefined, opts);
                 }
               });
             </script>


### PR DESCRIPTION
## Summary
- Show scheduled task `Last Run` values in configured timezone
- Pass cron timezone from server to admin view and apply with `toLocaleString`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7de7e5e18832d8230484f2530bdab