### PR TITLE
Handle unsupported time zone in schedule last run display

### DIFF
--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -482,11 +482,17 @@
             </section>
             <script>
               const tz = <%= JSON.stringify(cronTimezone) %>;
-              document.querySelectorAll('.local-time').forEach(function(el){
+              document.querySelectorAll('.local-time').forEach(function (el) {
                 const date = new Date(el.dataset.time);
                 if (!isNaN(date)) {
-                  const opts = tz ? { timeZone: tz } : undefined;
-                  el.textContent = date.toLocaleString(undefined, opts);
+                  try {
+                    const opts = tz ? { timeZone: tz } : undefined;
+                    el.textContent = date.toLocaleString(undefined, opts);
+                  } catch (err) {
+                    // Fall back to default locale without timezone if the provided
+                    // timezone is not supported by the browser.
+                    el.textContent = date.toLocaleString();
+                  }
                 }
               });
             </script>


### PR DESCRIPTION
## Summary
- handle unsupported time zones when rendering schedule last run times

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a7e01768c4832dbcbbbfd7d7c7d4c4