### PR TITLE
Disable MySQL multi-statement queries

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -11,8 +11,7 @@ export const pool = mysql.createPool({
   user: process.env.DB_USER,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,
-  multipleStatements:
-    process.env.DB_ALLOW_MULTIPLE_STATEMENTS === 'true',
+  multipleStatements: false,
 });
 
 export async function runMigrations(): Promise<void> {


### PR DESCRIPTION
## Summary
- hard-disable multiple statement support for MySQL connections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a955fb16c0832d81eb052b93709ef7