### PR TITLE
Protect uploaded files behind authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .env
 dist
+/uploads
+/private_uploads

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ There are no default login credentials; the first visit will prompt you to regis
    npm test
    ```
 
+## File Storage
+
+Static assets located under `src/public` are served directly and are intended
+to be publicly accessible. User-uploaded files and other sensitive assets are
+stored in the `private_uploads` directory outside of the public tree. These
+files are only available through the `/uploads/:filename` route, which now
+requires authentication. Generating a signed URL can be used to grant
+temporary access if public sharing is needed.
+
 ## CSRF Protection
 
 Authenticated POST, PUT and DELETE routes require a CSRF token. Tokens are

--- a/src/server.ts
+++ b/src/server.ts
@@ -572,13 +572,13 @@ function csrfMiddleware(
 app.use(csrfMiddleware);
 
 // Secure file upload handling
-const uploadDir = path.join(__dirname, '..', 'uploads');
-if (!fs.existsSync(uploadDir)) {
-  fs.mkdirSync(uploadDir, { recursive: true, mode: 0o700 });
+const privateUploadDir = path.join(__dirname, '..', 'private_uploads');
+if (!fs.existsSync(privateUploadDir)) {
+  fs.mkdirSync(privateUploadDir, { recursive: true, mode: 0o700 });
 }
 
 const storage = multer.diskStorage({
-  destination: (_req, _file, cb) => cb(null, uploadDir),
+  destination: (_req, _file, cb) => cb(null, privateUploadDir),
   filename: (_req, file, cb) => {
     const safeName = file.originalname
       .toLowerCase()
@@ -651,8 +651,8 @@ const memoryUpload = multer({
 });
 
 // Serve uploaded files via controlled route
-app.get('/uploads/:filename', (req, res) => {
-  const filePath = path.join(uploadDir, path.basename(req.params.filename));
+app.get('/uploads/:filename', ensureAuth, (req, res) => {
+  const filePath = path.join(privateUploadDir, path.basename(req.params.filename));
   res.sendFile(filePath);
 });
 


### PR DESCRIPTION
## Summary
- Restrict `/uploads/:filename` route with `ensureAuth`
- Store user uploads in a private directory and ignore it in git
- Document public vs private file storage locations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a95801d3d8832d9d87f0d121fb8928