### PR TITLE
chore: patch cookie dependency to fix npm audit warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2403,15 +2403,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/csurf/node_modules/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/csurf/node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
     "supertest": "^6.3.3",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"
+  },
+  "overrides": {
+    "cookie": "^0.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- override `cookie` to `^0.7.0` to satisfy `npm audit`

## Testing
- `npm install`
- `npm audit`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b2ed29eff0832db931638acef68d49