### PR TITLE
Ensure fetch requests send CSRF token

### DIFF
--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -14,7 +14,10 @@
     <meta name="csrf-token" content="<%= csrfToken %>">
     <script>
       document.addEventListener('DOMContentLoaded', () => {
-        const token = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+        const tokenMeta = document.querySelector('meta[name="csrf-token"]');
+        const token = tokenMeta?.getAttribute('content');
+        if (!token) return;
+
         document.querySelectorAll('form[method="post"]').forEach((form) => {
           if (!form.querySelector('input[name="_csrf"]')) {
             const input = document.createElement('input');
@@ -24,6 +27,22 @@
             form.appendChild(input);
           }
         });
+
+        const originalFetch = window.fetch.bind(window);
+        window.fetch = (input, init = {}) => {
+          init.headers = init.headers || {};
+          if (init.headers instanceof Headers) {
+            if (!init.headers.has('X-CSRF-Token')) {
+              init.headers.set('X-CSRF-Token', token);
+            }
+          } else if (!('X-CSRF-Token' in init.headers)) {
+            init.headers['X-CSRF-Token'] = token;
+          }
+          if (!init.credentials) {
+            init.credentials = 'same-origin';
+          }
+          return originalFetch(input, init);
+        };
       });
     </script>
   <% } %>


### PR DESCRIPTION
## Summary
- Attach CSRF token to all client-side `fetch` calls so super admin changes persist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b2f0916598832db1efba5fa3998d22