### PR TITLE
Normalize assignment permissions to ensure changes persist

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -553,6 +553,14 @@ export async function getUserCompanyAssignments(companyId?: number): Promise<Use
   const [rows] = await pool.query<RowDataPacket[]>(sql, params);
   return (rows as RowDataPacket[]).map((row) => ({
     ...(row as any),
+    can_manage_licenses: Number(row.can_manage_licenses),
+    staff_permission: Number(row.staff_permission),
+    can_manage_office_groups: Number(row.can_manage_office_groups),
+    can_manage_assets: Number(row.can_manage_assets),
+    can_manage_invoices: Number(row.can_manage_invoices),
+    can_order_licenses: Number(row.can_order_licenses),
+    can_access_shop: Number(row.can_access_shop),
+    is_admin: Number(row.is_admin),
     is_vip: Number(row.is_vip),
   })) as UserCompany[];
 }

--- a/tests/getUserCompanyAssignments.test.ts
+++ b/tests/getUserCompanyAssignments.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.DB_HOST = 'localhost';
+process.env.DB_USER = 'root';
+process.env.DB_PASSWORD = '';
+process.env.DB_NAME = 'test';
+process.env.TOTP_ENCRYPTION_KEY = 'test';
+
+const { getUserCompanyAssignments } = require('../src/queries');
+const { pool } = require('../src/db');
+
+test('getUserCompanyAssignments normalizes boolean fields', async () => {
+  const originalQuery = pool.query;
+  (pool.query as any) = async () => [[{
+    user_id: 1,
+    company_id: 2,
+    can_manage_licenses: '0',
+    staff_permission: '3',
+    can_manage_office_groups: '1',
+    can_manage_assets: '0',
+    can_manage_invoices: '1',
+    can_order_licenses: '0',
+    can_access_shop: '1',
+    is_admin: '0',
+    company_name: 'Acme',
+    is_vip: '1',
+    email: 'user@example.com',
+  }]] as any;
+
+  try {
+    const result = await getUserCompanyAssignments();
+    assert.deepEqual(result, [{
+      user_id: 1,
+      company_id: 2,
+      can_manage_licenses: 0,
+      staff_permission: 3,
+      can_manage_office_groups: 1,
+      can_manage_assets: 0,
+      can_manage_invoices: 1,
+      can_order_licenses: 0,
+      can_access_shop: 1,
+      is_admin: 0,
+      company_name: 'Acme',
+      is_vip: 1,
+      email: 'user@example.com',
+    }]);
+  } finally {
+    (pool.query as any) = originalQuery;
+  }
+});
+


### PR DESCRIPTION
## Summary
- Normalize all permission flags returned by `getUserCompanyAssignments` to numbers so toggled values persist
- Add regression test verifying assignment fields are numeric

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b2f25d8c28832db8597e6034c8ef92