### PR TITLE
Delay page refresh during system update

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2687,8 +2687,13 @@ app.post('/admin/schedules/:id', ensureAuth, ensureSuperAdmin, async (req, res) 
 
 app.post('/admin/schedules/:id/run', ensureAuth, ensureSuperAdmin, async (req, res) => {
   const id = parseInt(req.params.id, 10);
-  await runScheduledTask(id);
-  res.redirect('/admin#schedules');
+  const task = await getScheduledTask(id);
+  runScheduledTask(id).catch((err) => console.error('Scheduled task failed', err));
+  if (task?.command === 'system_update') {
+    res.render('update-progress');
+  } else {
+    res.redirect('/admin#schedules');
+  }
 });
 
 app.post('/admin/schedules/:id/delete', ensureAuth, ensureSuperAdmin, async (req, res) => {

--- a/src/views/update-progress.ejs
+++ b/src/views/update-progress.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'System Update' }) %>
+  <body class="login-page">
+    <div class="login-container">
+      <h1>Installing Update</h1>
+      <p>An update is being installed. This page will refresh once the process completes.</p>
+    </div>
+    <script>
+      setTimeout(function() {
+        window.location.href = '/admin#schedules';
+      }, 15000);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Render an update progress page when running the system update task to avoid reload errors
- Add dedicated view with message and delayed redirect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b2f52d23b8832da93e4d453d6a76a2