### PR TITLE
fix: avoid inline handler for company switch

### DIFF
--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -46,4 +46,14 @@
       });
     </script>
   <% } %>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const companySwitcher = document.getElementById('company-switcher');
+      if (companySwitcher) {
+        companySwitcher.addEventListener('change', () => {
+          companySwitcher.form?.submit();
+        });
+      }
+    });
+  </script>
 </head>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -7,7 +7,7 @@
       <div class="company-switcher">
         <h3>Select Company</h3>
         <form action="/switch-company" method="post">
-          <select name="companyId" onchange="this.form.submit()">
+          <select name="companyId" id="company-switcher">
             <% companies.forEach(function(c) { %>
               <option value="<%= c.company_id %>" <%= c.company_id === currentCompanyId ? 'selected' : '' %>><%= c.company_name %></option>
             <% }); %>


### PR DESCRIPTION
## Summary
- submit company switch form via script instead of inline handler
- attach event listener to company selector on DOMContentLoaded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b2fcecc55c832da206ca6cf186ec69