### PR TITLE
Remove jQuery dependency for DataTables

### DIFF
--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -2,12 +2,15 @@
   <title><%= title %></title>
   <link rel="stylesheet" href="/style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnH1zqD+XzdzN7D8YGN9VOGZsv5nYeD1yfknhk+aoCA8DmF5asJ5AZt0fjOEtRjdbc/YWZL0w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
-  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.dataTables.min.css">
+  <script src="https://cdn.datatables.net/2.0.0/js/dataTables.min.js"></script>
   <script>
-    $(function() {
-      $('table').not('#cron-generator-container table').DataTable();
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('table').forEach((table) => {
+        if (!table.closest('#cron-generator-container')) {
+          new DataTable(table);
+        }
+      });
     });
   </script>
   <% if (typeof csrfToken !== 'undefined') { %>


### PR DESCRIPTION
## Summary
- replace jQuery-based DataTables initialization with vanilla JS DataTables
- load DataTables v2 directly, eliminating `$` usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b2fe9cc280832dafb9ba5445a338e0