### PR TITLE
Fix DataTable initialization for staff table rendering

### DIFF
--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -3,8 +3,9 @@
   <link rel="stylesheet" href="/style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnH1zqD+XzdzN7D8YGN9VOGZsv5nYeD1yfknhk+aoCA8DmF5asJ5AZt0fjOEtRjdbc/YWZL0w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.dataTables.min.css">
-  <script src="https://cdn.datatables.net/2.0.0/js/dataTables.min.js"></script>
-  <script>
+  <script type="module">
+    import DataTable from 'https://cdn.datatables.net/2.0.0/js/dataTables.min.js';
+
     document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('table').forEach((table) => {
         if (!table.closest('#cron-generator-container')) {


### PR DESCRIPTION
## Summary
- load DataTables as an ES module and initialize tables via `DataTable`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b30175c4c8832d9734a644ec7df55e