### PR TITLE
Allow CDN resources in Content Security Policy

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -495,8 +495,18 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        scriptSrc: ["'self'", "'unsafe-inline'"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
+        scriptSrc: [
+          "'self'",
+          "'unsafe-inline'",
+          'https://cdn.datatables.net',
+          'https://static.cloudflareinsights.com',
+        ],
+        styleSrc: [
+          "'self'",
+          "'unsafe-inline'",
+          'https://cdnjs.cloudflare.com',
+          'https://cdn.datatables.net',
+        ],
         imgSrc: ["'self'", 'data:', 'https:'],
         connectSrc: ["'self'"],
         fontSrc: ["'self'", 'https:', 'data:'],


### PR DESCRIPTION
## Summary
- permit DataTables, Font Awesome, and Cloudflare Insights CDNs in CSP

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b3029bcc44832dba6eda6601278ae8