### PR TITLE
Fix SMS subscription persistence

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1688,7 +1688,7 @@ export async function getSmsSubscriptionsForUser(
     'SELECT order_number FROM order_sms_subscriptions WHERE user_id = ?',
     [userId]
   );
-  return rows.map((r) => r.order_number as string);
+  return rows.map((r) => String(r.order_number));
 }
 
 export async function setSmsSubscription(

--- a/src/views/orders.ejs
+++ b/src/views/orders.ejs
@@ -42,7 +42,7 @@
                 <td><%= o.eta ? o.eta.toISOString().slice(0,10) : '' %></td>
                 <td><%= o.notes || '' %></td>
                 <td><%= o.order_date.toISOString().slice(0,10) %></td>
-                <td><input type="checkbox" class="sms-subscribe" data-order="<%= o.order_number %>" <%= smsSubscriptions.includes(o.order_number) ? 'checked' : '' %>></td>
+                <td><input type="checkbox" class="sms-subscribe" data-order="<%= o.order_number %>" <%= smsSubscriptions.includes(String(o.order_number)) ? 'checked' : '' %>></td>
                 <% if (isSuperAdmin) { %><td><%= o.consignment_id || '' %></td><% } %>
                 <% if (isSuperAdmin) { %>
                   <td>


### PR DESCRIPTION
## Summary
- ensure order numbers are compared as strings when rendering SMS subscription status
- convert retrieved SMS subscription order numbers to strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b303576948832da49334d9e0986b6e