### PR TITLE
Fix CDN integrity and DataTables import

### DIFF
--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -1,10 +1,16 @@
 <head>
   <title><%= title %></title>
   <link rel="stylesheet" href="/style.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnH1zqD+XzdzN7D8YGN9VOGZsv5nYeD1yfknhk+aoCA8DmF5asJ5AZt0fjOEtRjdbc/YWZL0w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
+    integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  />
   <link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.dataTables.min.css">
   <script type="module">
-    import DataTable from 'https://cdn.datatables.net/2.0.0/js/dataTables.min.js';
+    import DataTable from 'https://cdn.datatables.net/2.0.0/js/dataTables.min.mjs';
 
     document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('table').forEach((table) => {


### PR DESCRIPTION
## Summary
- correct Font Awesome CDN integrity hash so stylesheet loads without blocking
- load DataTables as an ES module using the `.mjs` build to avoid missing default export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b303df1bf4832d94db34c67564ee7a