### PR TITLE
Fix orders page script loading issues

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -499,6 +499,7 @@ app.use(
           "'self'",
           "'unsafe-inline'",
           'https://cdn.datatables.net',
+          'https://cdn.jsdelivr.net',
           'https://static.cloudflareinsights.com',
         ],
         styleSrc: [

--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -10,9 +10,8 @@
   />
   <link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.dataTables.min.css">
   <script src="/app.js" defer></script>
-  <script type="module">
-    import DataTable from 'https://cdn.datatables.net/2.0.0/js/dataTables.min.mjs';
-
+  <script src="https://cdn.datatables.net/2.0.0/js/dataTables.min.js"></script>
+  <script>
     document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('table').forEach((table) => {
         if (!table.closest('#cron-generator-container')) {


### PR DESCRIPTION
## Summary
- allow jsDelivr in CSP so Chart.js can load on orders page
- switch DataTables to non-module build to avoid jquery import errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b3062a246c832dba0723166bfc9a6c