### PR TITLE
Cascade user deletions across related tables

### DIFF
--- a/migrations/002_user_companies.sql
+++ b/migrations/002_user_companies.sql
@@ -4,7 +4,7 @@ CREATE TABLE user_companies (
   can_manage_licenses TINYINT(1) DEFAULT 0,
   can_manage_staff TINYINT(1) DEFAULT 0,
   PRIMARY KEY (user_id, company_id),
-  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
   FOREIGN KEY (company_id) REFERENCES companies(id)
 );
 

--- a/migrations/043_create_order_sms_subscriptions.sql
+++ b/migrations/043_create_order_sms_subscriptions.sql
@@ -2,5 +2,5 @@ CREATE TABLE order_sms_subscriptions (
   order_number VARCHAR(20) NOT NULL,
   user_id INT NOT NULL,
   PRIMARY KEY (order_number, user_id),
-  FOREIGN KEY (user_id) REFERENCES users(id)
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );

--- a/migrations/049_cascade_user_delete.sql
+++ b/migrations/049_cascade_user_delete.sql
@@ -1,0 +1,7 @@
+ALTER TABLE user_companies
+  DROP FOREIGN KEY user_companies_ibfk_1,
+  ADD CONSTRAINT fk_user_companies_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE order_sms_subscriptions
+  DROP FOREIGN KEY order_sms_subscriptions_ibfk_1,
+  ADD CONSTRAINT fk_order_sms_subscriptions_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- cascade deletes for user foreign keys in user_companies and order_sms_subscriptions
- add migration to update existing databases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b307215904832dabe993a4bb5db4e1