### PR TITLE
fix: include jQuery for DataTables

### DIFF
--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -10,6 +10,7 @@
   />
   <link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.dataTables.min.css">
   <script src="/app.js" defer></script>
+  <script src="https://code.jquery.com/jquery-3.7.0.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.datatables.net/2.0.0/js/dataTables.min.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- include jQuery before DataTables to resolve runtime reference error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b307d79814832da2be4beab17f6561