### PR TITLE
Fix DataTables initialization by adding jQuery dependency

### DIFF
--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -10,6 +10,7 @@
   />
   <link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.dataTables.min.css">
   <script src="/app.js" defer></script>
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.datatables.net/2.0.0/js/dataTables.min.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- load jQuery before DataTables to fix missing global

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b30835eba8832d9554cd74bc131cdb