### PR TITLE
fix: include jQuery for DataTables and whitelist CDN

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -500,6 +500,7 @@ app.use(
           "'unsafe-inline'",
           'https://cdn.datatables.net',
           'https://cdn.jsdelivr.net',
+          'https://code.jquery.com',
           'https://static.cloudflareinsights.com',
         ],
         styleSrc: [


### PR DESCRIPTION
## Summary
- include jQuery before DataTables to resolve runtime reference error
- allow code.jquery.com in helmet content security policy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b3090105bc832db64685bfd7f773b8