### PR TITLE
fix: load jQuery from allowed CDN

### DIFF
--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -10,7 +10,10 @@
   />
   <link rel="stylesheet" href="https://cdn.datatables.net/2.0.0/css/dataTables.dataTables.min.css">
   <script src="/app.js" defer></script>
-  <script src="https://code.jquery.com/jquery-3.7.0.min.js" crossorigin="anonymous"></script>
+  <script
+    src="https://cdn.jsdelivr.net/npm/jquery@3.7.0/dist/jquery.min.js"
+    crossorigin="anonymous"
+  ></script>
   <script src="https://cdn.datatables.net/2.0.0/js/dataTables.min.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- load jQuery via cdn.jsdelivr to comply with CSP

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b3096e48c8832d960199c7761f65d5