### PR TITLE
Ensure admin data tables use full width

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -93,6 +93,15 @@ table {
   border-collapse: collapse;
 }
 
+#api-keys table,
+#companies table,
+#apps table,
+#products table,
+#forms-admin table,
+#form-permissions table {
+  width: 100% !important;
+}
+
 table th,
 table td {
   padding: 0.5rem;


### PR DESCRIPTION
## Summary
- Force tables in API Keys, Companies, Apps, Products, Forms, and Form Permissions sections to span the full container width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b30bb32538832dbd45d5072df41c58