### PR TITLE
Fix DataTables width not updating on window resize

### DIFF
--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -23,6 +23,12 @@
         table.dataset.datatableInitialized = 'true';
       }
 
+      function adjustDataTables() {
+        DataTable.tables({ visible: true, api: true }).forEach((dt) =>
+          dt.columns.adjust()
+        );
+      }
+
       function initVisibleTables() {
         document.querySelectorAll('table').forEach((table) => {
           if (
@@ -32,10 +38,12 @@
             initDataTable(table);
           }
         });
+        adjustDataTables();
       }
 
       initVisibleTables();
       setTimeout(initVisibleTables, 0);
+      window.addEventListener('resize', adjustDataTables);
 
       document.querySelectorAll('.tabs button').forEach((btn) => {
         btn.addEventListener('click', () => {
@@ -45,6 +53,7 @@
               initDataTable(table);
             }
           });
+          adjustDataTables();
         });
       });
     });


### PR DESCRIPTION
## Summary
- adjust DataTables columns whenever the window resizes
- ensure newly shown tables and initial render have correct widths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b30d80be2c832dace69b90bbf72c38