### PR TITLE
Add consistent top and bottom padding for forms

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -195,8 +195,10 @@ table th {
 
 .form-frame {
   width: 100%;
-  height: calc(100vh - 200px);
+  /* Maintain a 10px buffer at the top and bottom */
+  height: calc(100vh - 200px - 20px);
   border: none;
+  margin: 10px 0;
 }
 
 .modal {


### PR DESCRIPTION
## Summary
- Ensure embedded forms have a constant 10px margin on top and bottom
- Adjust form iframe height so margins are maintained without overflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b42586dbd0832d90f252a4e42f5695