### PR TITLE
Add favicon upload to site settings

### DIFF
--- a/migrations/050_add_favicon_to_site_settings.sql
+++ b/migrations/050_add_favicon_to_site_settings.sql
@@ -1,0 +1,2 @@
+ALTER TABLE site_settings ADD COLUMN favicon LONGTEXT;
+

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -241,6 +241,7 @@ export interface SiteSettings {
   company_name: string | null;
   login_logo: string | null;
   sidebar_logo: string | null;
+  favicon: string | null;
 }
 
 export interface Form {
@@ -1921,24 +1922,26 @@ export async function updateOfficeGroupMembers(groupId: number, staffIds: number
 
 export async function getSiteSettings(): Promise<SiteSettings> {
   const [rows] = await pool.query<RowDataPacket[]>(
-    'SELECT company_name, login_logo, sidebar_logo FROM site_settings WHERE id = 1'
+    'SELECT company_name, login_logo, sidebar_logo, favicon FROM site_settings WHERE id = 1'
   );
   const row = (rows as SiteSettings[])[0];
   return {
     company_name: row?.company_name || null,
     login_logo: row?.login_logo || null,
     sidebar_logo: row?.sidebar_logo || null,
+    favicon: row?.favicon || null,
   };
 }
 
 export async function updateSiteSettings(
   companyName: string,
   loginLogo?: string | null,
-  sidebarLogo?: string | null
+  sidebarLogo?: string | null,
+  favicon?: string | null
 ): Promise<void> {
   await pool.query(
-    'UPDATE site_settings SET company_name = ?, login_logo = COALESCE(?, login_logo), sidebar_logo = COALESCE(?, sidebar_logo) WHERE id = 1',
-    [companyName, loginLogo ?? null, sidebarLogo ?? null]
+    'UPDATE site_settings SET company_name = ?, login_logo = COALESCE(?, login_logo), sidebar_logo = COALESCE(?, sidebar_logo), favicon = COALESCE(?, favicon) WHERE id = 1',
+    [companyName, loginLogo ?? null, sidebarLogo ?? null, favicon ?? null]
   );
 }
 

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -620,6 +620,14 @@
                   <img src="<%= siteSettings.sidebar_logo %>" alt="Sidebar Logo" style="max-width:200px;display:block;margin-top:10px;"/>
                 <% } %>
               </div>
+              <div>
+                <label>Favicon:
+                  <input type="file" name="favicon" accept="image/*">
+                </label>
+                <% if (siteSettings && siteSettings.favicon) { %>
+                  <img src="<%= siteSettings.favicon %>" alt="Favicon" style="max-width:64px;display:block;margin-top:10px;"/>
+                <% } %>
+              </div>
               <button type="submit">Save</button>
             </form>
           </section>

--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -1,6 +1,9 @@
 <head>
   <title><%= title %></title>
   <link rel="stylesheet" href="/style.css">
+  <% if (siteSettings && siteSettings.favicon) { %>
+    <link rel="icon" href="<%= siteSettings.favicon %>">
+  <% } %>
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"


### PR DESCRIPTION
## Summary
- allow image/x-icon, image/vnd.microsoft.icon and image/svg+xml uploads
- add favicon field to site settings table and backend
- expose uploaded favicon in head and admin site settings form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b4ef2d3cd4832d88ded66e1da9ee0e