### PR TITLE
Allow long stock feed descriptions

### DIFF
--- a/migrations/053_expand_stock_feed_description.sql
+++ b/migrations/053_expand_stock_feed_description.sql
@@ -1,0 +1,2 @@
+ALTER TABLE stock_feed
+  MODIFY COLUMN product_name2 TEXT NULL;


### PR DESCRIPTION
## Summary
- allow unlimited-length stock feed descriptions by altering `product_name2` column to TEXT

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b94521ab80832dafedfabe6d71d714