### PR TITLE
Cast product ID to number in admin edit modal

### DIFF
--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -984,7 +984,8 @@
               const productRestrictions = <%- JSON.stringify(productRestrictions) %>;
               const productsData = <%- JSON.stringify(products) %>;
               function openEditModal(id) {
-                const product = productsData.find(p => p.id === id);
+                const product = productsData.find(p => p.id === Number(id));
+                if (!product) return;
                 const modal = document.getElementById('editModal');
                 const form = document.getElementById('editForm');
                 form.action = `/shop/admin/product/${id}`;


### PR DESCRIPTION
## Summary
- cast `id` to a number before searching products
- skip editing when product is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b94a1eeeec832d838d4f207fcd7329