### PR TITLE
Display product details in modal

### DIFF
--- a/src/views/shop.ejs
+++ b/src/views/shop.ejs
@@ -21,7 +21,7 @@
       </form>
       <table>
         <thead>
-          <tr><th>Image</th><th>Name</th><th>SKU</th><th>Description</th><th>Price</th><th>Order</th></tr>
+          <tr><th>Image</th><th>Name</th><th>SKU</th><th>Price</th><th>Details</th><th>Order</th></tr>
         </thead>
         <tbody>
           <% products.forEach(function(p){ %>
@@ -29,8 +29,8 @@
               <td><% if (p.image_url) { %><img src="<%= p.image_url %>" width="50" alt="" class="product-img"><% } %></td>
               <td><%= p.name %></td>
               <td><%= p.sku %></td>
-              <td><%- p.description.replace(/\n/g, '<br>') %></td>
               <td>$<%= p.price.toFixed(2) %></td>
+              <td><button type="button" class="details-btn" data-details="<%- p.description.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '&#10;') %>">Details</button></td>
               <td>
                 <form action="/cart/add" method="post">
                   <input type="hidden" name="productId" value="<%= p.id %>">
@@ -48,6 +48,12 @@
           <img id="modal-image" src="" alt="">
         </div>
       </div>
+      <div id="details-modal" class="modal" style="display:none;">
+        <div class="modal-content">
+          <span id="details-close" class="close">&times;</span>
+          <div id="details-content"></div>
+        </div>
+      </div>
     </div>
   </div>
   <script>
@@ -63,6 +69,23 @@
     });
 
     document.getElementById('image-modal').addEventListener('click', function (e) {
+      if (e.target === this) {
+        this.style.display = 'none';
+      }
+    });
+
+    document.querySelectorAll('.details-btn').forEach(function(btn) {
+      btn.addEventListener('click', function () {
+        document.getElementById('details-content').innerHTML = this.dataset.details.replace(/\n/g, '<br>');
+        document.getElementById('details-modal').style.display = 'flex';
+      });
+    });
+
+    document.getElementById('details-close').addEventListener('click', function () {
+      document.getElementById('details-modal').style.display = 'none';
+    });
+
+    document.getElementById('details-modal').addEventListener('click', function (e) {
       if (e.target === this) {
         this.style.display = 'none';
       }


### PR DESCRIPTION
## Summary
- Replace description column with details button in shop table
- Show product descriptions in a modal triggered by the details button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b94d1bba54832d882b8abb73f31324