### PR TITLE
Center quantity above Add to Cart on shop page

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -349,3 +349,14 @@ table th {
   width: 100%;
   box-sizing: border-box;
 }
+
+/* Center quantity and add-to-cart button in shop order column */
+.order-column form {
+  text-align: center;
+}
+
+.order-column form input[type="number"] {
+  display: block;
+  margin: 0 auto;
+  text-align: center;
+}

--- a/src/views/shop.ejs
+++ b/src/views/shop.ejs
@@ -31,10 +31,11 @@
               <td><%= p.sku %></td>
               <td>$<%= p.price.toFixed(2) %></td>
               <td><button type="button" class="details-btn" data-image="<%= p.image_url || '' %>" data-price="<%= p.price.toFixed(2) %>" data-stock="<%= p.stock %>" data-details="<%- p.description.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '&#10;') %>">Details</button></td>
-              <td>
+              <td class="order-column">
                 <form action="/cart/add" method="post">
                   <input type="hidden" name="productId" value="<%= p.id %>">
                   <input type="number" name="quantity" min="1" max="<%= p.stock %>" value="1">
+                  <br>
                   <button type="submit">Add to Cart</button>
                 </form>
               </td>


### PR DESCRIPTION
## Summary
- Center quantity input above Add to Cart button on shop page and ensure line break
- Style order column so quantity and button align vertically in the center

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b9503286f4832da754950fa990bb32