### PR TITLE
Fix DataTables iteration error causing TypeError

### DIFF
--- a/src/views/partials/head.ejs
+++ b/src/views/partials/head.ejs
@@ -27,9 +27,7 @@
       }
 
       function adjustDataTables() {
-        DataTable.tables({ visible: true, api: true }).forEach((dt) =>
-          dt.columns.adjust()
-        );
+        DataTable.tables({ visible: true, api: true }).columns.adjust();
       }
 
       function initVisibleTables() {


### PR DESCRIPTION
## Summary
- use DataTables API `columns.adjust` to adjust visible tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b9531f7df4832dac2c81afac50e752