### PR TITLE
Reduce gap between quantity input and add-to-cart button

### DIFF
--- a/src/public/style.css
+++ b/src/public/style.css
@@ -381,3 +381,8 @@ table th {
   margin: 0 auto;
   text-align: center;
 }
+
+.order-column form button {
+  display: block;
+  margin: 3px auto 0;
+}

--- a/src/views/shop.ejs
+++ b/src/views/shop.ejs
@@ -35,7 +35,6 @@
                 <form action="/cart/add" method="post">
                   <input type="hidden" name="productId" value="<%= p.id %>">
                   <input type="number" name="quantity" min="1" max="<%= p.stock %>" value="1">
-                  <br>
                   <button type="submit">Add to Cart</button>
                 </form>
               </td>


### PR DESCRIPTION
## Summary
- Tighten shop order column spacing by removing extra line break
- Add button styling to keep 3px gap below quantity input

## Testing
- `npm test` *(hangs: process does not exit)*
- `node --test --require ts-node/register/transpile-only tests/cron.test.ts`
- `node --test --require ts-node/register/transpile-only tests/getUserCompanyAssignments.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_68b9539cfaa4832dad949f8a149dad12