### PR TITLE
Handle missing Syncro assets gracefully

### DIFF
--- a/src/syncro.ts
+++ b/src/syncro.ts
@@ -66,7 +66,13 @@ async function syncroRequest(path: string, init: RequestInit = {}): Promise<any>
   }
   const res = await fetch(url, { ...init, headers });
   if (!res.ok) {
+    if (res.status === 404) {
+      return null;
+    }
     throw new Error(`Syncro API request failed: ${res.status}`);
+  }
+  if (res.status === 204) {
+    return null;
   }
   return res.json();
 }

--- a/tests/syncro.test.ts
+++ b/tests/syncro.test.ts
@@ -69,6 +69,33 @@ test('getSyncroAssets uses /assets endpoint', async () => {
   }
 });
 
+// Ensure getSyncroAssets handles 404 responses gracefully
+test('getSyncroAssets returns empty array on 404', async () => {
+  const customerId = 999;
+
+  const mockFetch = async (_url: string, _init?: RequestInit) => {
+    return {
+      ok: false,
+      status: 404,
+    } as Response;
+  };
+
+  const originalFetch = global.fetch;
+  // @ts-expect-error assign mock
+  global.fetch = mockFetch;
+  process.env.SYNCRO_WEBHOOK_URL = 'https://example.com';
+
+  try {
+    const assets = await getSyncroAssets(customerId);
+    assert.deepEqual(assets, []);
+  } finally {
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    }
+    delete process.env.SYNCRO_WEBHOOK_URL;
+  }
+});
+
 test('upsertAsset uses syncro id when serial missing', async () => {
   const origEnv = {
     TOTP_ENCRYPTION_KEY: process.env.TOTP_ENCRYPTION_KEY,


### PR DESCRIPTION
## Summary
- avoid throwing on 404 responses from Syncro API
- test that asset import returns empty array on 404

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ba4a8c78d8832dab2216f8df9514b0