### PR TITLE
feat: add admin debug logging option

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -145,22 +145,27 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       });
 
-      const originalFetch = window.fetch.bind(window);
-      window.fetch = (input, init = {}) => {
-        init.headers = init.headers || {};
-        if (init.headers instanceof Headers) {
-          if (!init.headers.has('X-CSRF-Token')) {
-            init.headers.set('X-CSRF-Token', token);
+        const originalFetch = window.fetch.bind(window);
+        window.fetch = (input, init = {}) => {
+          init.headers = init.headers || {};
+          if (init.headers instanceof Headers) {
+            if (!init.headers.has('X-CSRF-Token')) {
+              init.headers.set('X-CSRF-Token', token);
+            }
+          } else if (!('X-CSRF-Token' in init.headers)) {
+            init.headers['X-CSRF-Token'] = token;
           }
-        } else if (!('X-CSRF-Token' in init.headers)) {
-          init.headers['X-CSRF-Token'] = token;
-        }
-        if (!init.credentials) {
-          init.credentials = 'same-origin';
-        }
-        return originalFetch(input, init);
-      };
-    }
+          if (!init.credentials) {
+            init.credentials = 'same-origin';
+          }
+          const url = typeof input === 'string' ? input : input.url;
+          const method = init.method || (typeof input !== 'string' && input.method) || 'GET';
+          if (localStorage.getItem('apiDebug') === '1') {
+            console.debug('API Call:', method, url);
+          }
+          return originalFetch(input, init);
+        };
+      }
 
     // Company switcher form submission
     const companySwitcher = document.getElementById('company-switcher');

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -6,6 +6,11 @@
     <%- include('partials/sidebar') %>
     <div class="content">
       <h1><%= isAdmin ? 'Admin' : 'Account' %></h1>
+      <div class="debug-toggle">
+        <label>
+          <input type="checkbox" id="enable-api-debug"> Enable API debug logging
+        </label>
+      </div>
       <div class="admin-tabs">
         <div class="tabs">
           <% if (isSuperAdmin) { %>
@@ -1095,6 +1100,18 @@
           submitPermission(el.form);
         });
       });
+
+      const debugCheckbox = document.getElementById('enable-api-debug');
+      if (debugCheckbox) {
+        debugCheckbox.checked = localStorage.getItem('apiDebug') === '1';
+        debugCheckbox.addEventListener('change', function () {
+          if (debugCheckbox.checked) {
+            localStorage.setItem('apiDebug', '1');
+          } else {
+            localStorage.removeItem('apiDebug');
+          }
+        });
+      }
 
       const tabs = document.querySelectorAll('.tabs button');
       const contents = document.querySelectorAll('.tab-content');


### PR DESCRIPTION
## Summary
- add admin UI toggle for enabling API debug logging
- log fetch requests to console when debug is enabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68babf544464832d9981cd35089b2af4