### PR TITLE
feat: log API calls on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ pm2 logs myportal
 pm2 restart myportal
 ```
 
+### API Debug Logging
+
+Enable API request logging to the pm2 logs by setting `API_DEBUG=1` when starting the server:
+
+```bash
+API_DEBUG=1 pm2 start dist/server.js --name myportal
+```
+
 ## Updating from GitHub
 
 Run the included update script to fetch the latest changes and rebuild the project:

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -158,14 +158,11 @@ document.addEventListener('DOMContentLoaded', () => {
           if (!init.credentials) {
             init.credentials = 'same-origin';
           }
-          const url = typeof input === 'string' ? input : input.url;
-          const method = init.method || (typeof input !== 'string' && input.method) || 'GET';
-          if (localStorage.getItem('apiDebug') === '1') {
-            console.debug('API Call:', method, url);
-          }
-          return originalFetch(input, init);
-        };
-      }
+            const url = typeof input === 'string' ? input : input.url;
+            const method = init.method || (typeof input !== 'string' && input.method) || 'GET';
+            return originalFetch(input, init);
+          };
+        }
 
     // Company switcher form submission
     const companySwitcher = document.getElementById('company-switcher');

--- a/src/server.ts
+++ b/src/server.ts
@@ -790,6 +790,14 @@ app.set('trust proxy', 1);
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 
+// Log API calls to pm2 logs when enabled
+if (process.env.API_DEBUG === '1' || process.env.API_DEBUG === 'true') {
+  app.use('/api', (req, _res, next) => {
+    console.debug('API Call:', req.method, req.originalUrl);
+    next();
+  });
+}
+
 // Register security middleware early
 app.use(
   helmet({

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -6,11 +6,6 @@
     <%- include('partials/sidebar') %>
     <div class="content">
       <h1><%= isAdmin ? 'Admin' : 'Account' %></h1>
-      <div class="debug-toggle">
-        <label>
-          <input type="checkbox" id="enable-api-debug"> Enable API debug logging
-        </label>
-      </div>
       <div class="admin-tabs">
         <div class="tabs">
           <% if (isSuperAdmin) { %>
@@ -1100,18 +1095,6 @@
           submitPermission(el.form);
         });
       });
-
-      const debugCheckbox = document.getElementById('enable-api-debug');
-      if (debugCheckbox) {
-        debugCheckbox.checked = localStorage.getItem('apiDebug') === '1';
-        debugCheckbox.addEventListener('change', function () {
-          if (debugCheckbox.checked) {
-            localStorage.setItem('apiDebug', '1');
-          } else {
-            localStorage.removeItem('apiDebug');
-          }
-        });
-      }
 
       const tabs = document.querySelectorAll('.tabs button');
       const contents = document.querySelectorAll('.tab-content');


### PR DESCRIPTION
## Summary
- log API requests on the server when API_DEBUG=1 so pm2 captures them
- remove browser-based API debug UI and logging
- document API_DEBUG usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bac41abec0832d89d795bf78000e66