### PR TITLE
Prioritize syncro id when upserting assets

### DIFF
--- a/src/queries.ts
+++ b/src/queries.ts
@@ -1257,16 +1257,16 @@ export async function upsertAsset(
   const lastSyncDb = toMysqlDatetime(lastSync);
   const warrantyEndDb = toMysqlDate(warrantyEndDate);
   let rows: RowDataPacket[] = [];
-  if (serialNumber) {
-    [rows] = await pool.query<RowDataPacket[]>(
-      'SELECT id FROM assets WHERE company_id = ? AND serial_number = ?',
-      [companyId, serialNumber]
-    );
-  }
-  if (!rows.length && syncId) {
+  if (syncId) {
     [rows] = await pool.query<RowDataPacket[]>(
       'SELECT id FROM assets WHERE company_id = ? AND syncro_asset_id = ?',
       [companyId, syncId]
+    );
+  }
+  if (!rows.length && serialNumber) {
+    [rows] = await pool.query<RowDataPacket[]>(
+      'SELECT id FROM assets WHERE company_id = ? AND serial_number = ?',
+      [companyId, serialNumber]
     );
   }
   if (rows.length) {


### PR DESCRIPTION
## Summary
- Avoid duplicate asset errors by looking up existing assets by Syncro asset ID before serial number
- Update Syncro asset tests for new lookup order and add coverage for Syncro-ID priority

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bace52a0ec832d97f32bc5b7ff6739