### PR TITLE
Fix Syncro asset approximate age parsing

### DIFF
--- a/src/syncro.ts
+++ b/src/syncro.ts
@@ -228,7 +228,11 @@ export function extractAssetDetails(asset: any): ExtractedAssetDetails {
     form_factor:
       asset.form_factor ?? props.form_factor ?? kabuto.form_factor ?? general.form_factor,
     last_user: asset.last_user ?? props.last_user ?? kabuto.last_user,
-    cpu_age: asset.cpu_age ?? props.cpu_age ?? kabuto.cpu_age,
+    cpu_age:
+      (() => {
+        const cpuAge = asset.cpu_age ?? props.cpu_age ?? kabuto.cpu_age;
+        return cpuAge !== undefined ? Number(cpuAge) : undefined;
+      })(),
     performance_score: performance !== undefined ? Number(performance) : undefined,
     warranty_status: asset.warranty_status ?? props.warranty_status,
     warranty_end_date: asset.warranty_end_date ?? props.warranty_end_date,

--- a/tests/syncro.test.ts
+++ b/tests/syncro.test.ts
@@ -158,7 +158,7 @@ test('extractAssetDetails maps nested properties', () => {
         last_synced_at: '2025-07-27T06:11:41.000Z',
         motherboard: { manufacturer: 'HP' },
         last_user: 'DOMAIN\\user',
-        cpu_age: 2,
+        cpu_age: '2',
       },
       form_factor: 'Physical Desktop',
       'Performance Score': '7',


### PR DESCRIPTION
## Summary
- ensure CPU age from Syncro assets is parsed as a number for approx_age
- test Syncro asset detail extraction with string CPU age

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bad1b09648832d9b9a3320aadebc14