### PR TITLE
fix: correctly render warranty end date on Assets page

### DIFF
--- a/src/views/assets.ejs
+++ b/src/views/assets.ejs
@@ -113,12 +113,12 @@
       const type = td.dataset.date;
       const value = td.textContent;
       if (!value) return;
-      const date =
-        type === 'date'
-          ? new Date(value + 'T00:00:00Z')
-          : new Date(value + 'Z');
+      const date = new Date(value);
+      if (isNaN(date)) return;
       td.textContent =
-        type === 'date' ? date.toLocaleDateString() : date.toLocaleString();
+        type === 'date'
+          ? new Intl.DateTimeFormat('en-CA').format(date)
+          : date.toLocaleString();
     });
 
     applyPreferences();


### PR DESCRIPTION
## Summary
- parse warranty end dates without appending extra timezone markers
- show warranty end dates as YYYY-MM-DD in the user's locale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bad2e51868832da150e92422524810