### PR TITLE
Gracefully handle missing clamscan during uploads

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -949,12 +949,18 @@ async function scanFileForViruses(filePath: string): Promise<void> {
   try {
     await execFileAsync('clamscan', ['--no-summary', filePath]);
   } catch (err: any) {
-    if (err && typeof err.code === 'number') {
-      if (err.code === 1) {
-        throw new Error('Virus detected in uploaded file');
+    if (err) {
+      if (typeof err.code === 'number') {
+        if (err.code === 1) {
+          throw new Error('Virus detected in uploaded file');
+        }
+        console.warn('Virus scan failed or clamscan not installed', err);
+        throw new Error('Virus scan failed');
       }
-      console.warn('Virus scan failed or clamscan not installed', err);
-      throw new Error('Virus scan failed');
+      if (err.code === 'ENOENT') {
+        console.warn('clamscan not found, skipping virus scan');
+        return;
+      }
     }
     console.warn('Failed to run virus scan', err);
     throw new Error('Virus scan failed');


### PR DESCRIPTION
## Summary
- avoid failing uploads when clamscan is not installed by skipping scan on ENOENT

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c110d72e44832d8cd290857d12a502