### PR TITLE
feat: support per-company office 365 connections

### DIFF
--- a/migrations/055_company_m365_credentials.sql
+++ b/migrations/055_company_m365_credentials.sql
@@ -1,0 +1,13 @@
+CREATE TABLE company_m365_credentials (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  company_id INT NOT NULL UNIQUE,
+  tenant_id VARCHAR(255) NOT NULL,
+  client_id VARCHAR(255) NOT NULL,
+  client_secret TEXT NOT NULL,
+  refresh_token TEXT NULL,
+  access_token TEXT NULL,
+  token_expires_at DATETIME NULL,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE
+);

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -175,6 +175,22 @@ table th {
   overflow-x: auto;
 }
 
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.page-body {
+  overflow-x: auto;
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .swagger-frame {
   width: 100%;
   height: calc(100vh - 80px - 4rem);

--- a/src/views/m365.ejs
+++ b/src/views/m365.ejs
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Office 365 Connection' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <div class="page-header">
+        <h1>Office 365 Connection</h1>
+        <% if (credential) { %>
+          <div class="header-actions">
+            <a href="/m365/connect" class="authorize-link">Authorize</a>
+            <form method="post" action="/m365/credentials/delete" style="display:inline;">
+              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+              <button type="submit">Disconnect</button>
+            </form>
+          </div>
+        <% } %>
+      </div>
+      <div class="page-body">
+        <% if (!credential) { %>
+          <form method="post" action="/m365/credentials">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <label>Tenant ID
+              <input type="text" name="tenantId" required>
+            </label>
+            <label>Client ID
+              <input type="text" name="clientId" required>
+            </label>
+            <label>Client Secret
+              <input type="password" name="clientSecret" required>
+            </label>
+            <button type="submit">Save</button>
+          </form>
+        <% } else { %>
+          <p><strong>Tenant ID:</strong> <%= credential.tenant_id %></p>
+          <p><strong>Client ID:</strong> <%= credential.client_id %></p>
+          <% if (credential.refresh_token) { %>
+            <p>Connected. Token expires at <%= credential.token_expires_at ? new Date(credential.token_expires_at).toLocaleString() : 'unknown' %></p>
+          <% } else { %>
+            <p>Not authorized with Microsoft 365.</p>
+          <% } %>
+        <% } %>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -25,6 +25,7 @@
     <% } %>
     <% if (canManageLicenses) { %>
       <a href="/licenses" class="menu-link"><i class="fas fa-file-contract"></i> Licenses</a>
+      <a href="/m365" class="menu-link"><i class="fas fa-cloud"></i> Office 365</a>
     <% } %>
     <% if (canManageAssets) { %>
       <a href="/assets" class="menu-link"><i class="fas fa-desktop"></i> Assets</a>


### PR DESCRIPTION
## Summary
- store Microsoft 365 tenant credentials per company and encrypt secrets
- add UI and API endpoints to authorize and manage Office 365 connections
- style header/body layout and navigation link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c154d41240832dbb47fb9113b8cc4b