### PR TITLE
Add Office 365 credentials admin page and update sync setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ There are no default login credentials; the first visit will prompt you to regis
    npm test
    ```
 
+## Office 365 Sync
+
+To enable Microsoft 365 license synchronization, register an application in
+Azure Active Directory and grant it the required Graph permissions.
+
+1. Sign in to the Azure portal and open **Azure Active Directory** →
+   **App registrations** → **New registration**.
+2. Choose a name for the application and select the supported account types
+   for your tenant.
+3. Under **Redirect URI**, select **Web** and enter
+   `https://<your-domain>/m365/callback`.
+4. After creation, note the **Application (client) ID** and **Directory (tenant)
+   ID**.
+5. Create a client secret in **Certificates & secrets** and record the value; it
+   is shown only once.
+6. In **API permissions**, add Microsoft Graph **Application permissions**
+   `Directory.Read.All` and `User.Read.All`, then grant admin consent.
+7. Open the Office 365 admin page in MyPortal and enter the tenant ID, client
+   ID and client secret. The credentials can be edited or removed at any time.
+8. From the Office 365 page for a company, click **Authorize** to grant the
+   application access. The portal requests the `offline_access` scope so that a
+   refresh token is stored for background sync jobs.
+
 ## File Storage
 
 Static assets located under `src/public` are served directly and are intended

--- a/src/views/m365-admin.ejs
+++ b/src/views/m365-admin.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+  <%- include('partials/head', { title: 'Office 365 Admin' }) %>
+<body>
+  <div class="app-container">
+    <%- include('partials/sidebar') %>
+    <div class="content">
+      <div class="page-header">
+        <h1>Office 365 Credentials</h1>
+      </div>
+      <div class="page-body">
+        <% allCompanies.forEach(function(c){ const cred = credentials[c.id] || {}; %>
+          <form method="post" action="/m365/admin/<%= c.id %>" class="credential-form">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <h2><%= c.name %></h2>
+            <label>Tenant ID
+              <input type="text" name="tenantId" value="<%= cred.tenant_id || '' %>" required>
+            </label>
+            <label>Client ID
+              <input type="text" name="clientId" value="<%= cred.client_id || '' %>" required>
+            </label>
+            <label>Client Secret
+              <input type="password" name="clientSecret" required>
+            </label>
+            <button type="submit">Save</button>
+            <% if (cred.tenant_id) { %>
+              <button type="submit" formaction="/m365/admin/<%= c.id %>/delete" formmethod="post" onclick="return confirm('Delete credentials for <%= c.name %>?');">Delete</button>
+            <% } %>
+          </form>
+        <% }); %>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/views/m365.ejs
+++ b/src/views/m365.ejs
@@ -10,28 +10,15 @@
         <% if (credential) { %>
           <div class="header-actions">
             <a href="/m365/connect" class="authorize-link">Authorize</a>
-            <form method="post" action="/m365/credentials/delete" style="display:inline;">
-              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-              <button type="submit">Disconnect</button>
-            </form>
           </div>
         <% } %>
       </div>
       <div class="page-body">
         <% if (!credential) { %>
-          <form method="post" action="/m365/credentials">
-            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-            <label>Tenant ID
-              <input type="text" name="tenantId" required>
-            </label>
-            <label>Client ID
-              <input type="text" name="clientId" required>
-            </label>
-            <label>Client Secret
-              <input type="password" name="clientSecret" required>
-            </label>
-            <button type="submit">Save</button>
-          </form>
+          <p>No Office 365 credentials configured.</p>
+          <% if (typeof isSuperAdmin !== 'undefined' && isSuperAdmin) { %>
+            <p><a href="/m365/admin">Manage credentials in the Office 365 admin page.</a></p>
+          <% } %>
         <% } else { %>
           <p><strong>Tenant ID:</strong> <%= credential.tenant_id %></p>
           <p><strong>Client ID:</strong> <%= credential.client_id %></p>

--- a/src/views/partials/sidebar.ejs
+++ b/src/views/partials/sidebar.ejs
@@ -51,6 +51,7 @@
     <% } %>
     <% if (isSuperAdmin) { %>
       <a href="/api-docs" class="menu-link"><i class="fas fa-book"></i> API Docs</a>
+      <a href="/m365/admin" class="menu-link"><i class="fas fa-cloud"></i> Office 365 Admin</a>
     <% } %>
     <a href="/admin" class="menu-link"><i class="fas fa-user"></i> <%= (isAdmin || isSuperAdmin) ? 'Admin' : 'Account' %></a>
     <a href="/logout" class="menu-link logout"><i class="fas fa-sign-out-alt"></i> Logout</a>


### PR DESCRIPTION
## Summary
- document Office 365 sync setup and required Graph permissions
- move credential management to new Office 365 admin page
- link admin page in sidebar and update user-facing Office 365 page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c1584655dc832d900894a29ef661b5