### PR TITLE
feat: add office365 auto authorization

### DIFF
--- a/src/views/m365-admin.ejs
+++ b/src/views/m365-admin.ejs
@@ -23,6 +23,7 @@
               <input type="password" name="clientSecret" required>
             </label>
             <button type="submit">Save</button>
+            <button type="button" onclick="window.location.href='/m365/admin/<%= c.id %>/authorize'">Sign in to Office 365</button>
             <% if (cred.tenant_id) { %>
               <button type="submit" formaction="/m365/admin/<%= c.id %>/delete" formmethod="post" onclick="return confirm('Delete credentials for <%= c.name %>?');">Delete</button>
             <% } %>


### PR DESCRIPTION
## Summary
- add Microsoft sign-in button to Office 365 credentials admin page
- allow super admins to authorize with Microsoft Graph and automatically store tenant and app credentials

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c20673e950832db1651b35b93e45ee