### PR TITLE
Update Microsoft 365 OAuth scopes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1920,7 +1920,7 @@ app.get('/m365/connect', ensureAuth, ensureLicenseAccess, async (req, res) => {
     },
   });
   const authUrl = await appCca.getAuthCodeUrl({
-    scopes: ['offline_access', 'https://graph.microsoft.com/.default'],
+    scopes: ['openid', 'profile', 'offline_access', 'User.Read'],
     redirectUri: `${req.protocol}://${req.get('host')}/m365/callback`,
     state: String(companyId),
   });
@@ -1943,7 +1943,7 @@ app.get('/m365/callback', async (req, res) => {
   try {
     const token: any = await appCca.acquireTokenByCode({
       code,
-      scopes: ['offline_access', 'https://graph.microsoft.com/.default'],
+      scopes: ['openid', 'profile', 'offline_access', 'User.Read'],
       redirectUri: `${req.protocol}://${req.get('host')}/m365/callback`,
     });
     await upsertM365Credentials(


### PR DESCRIPTION
## Summary
- request delegated permissions by including `openid`, `profile`, `offline_access` and `User.Read` scopes during Microsoft 365 OAuth flow

## Testing
- `npm test`
- `apt-get install -y azure-cli` *(fails: Unable to locate package azure-cli)*

------
https://chatgpt.com/codex/tasks/task_b_68c2166a8cc0832d97c227dd64df7e9e