### PR TITLE
Update Microsoft 365 OAuth scopes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1943,7 +1943,7 @@ app.get('/m365/callback', async (req, res) => {
   try {
     const token: any = await appCca.acquireTokenByCode({
       code,
-      scopes: ['openid', 'profile', 'offline_access', 'User.Read'],
+      scopes: ['openid', 'profile', 'offline_access', 'User.Read', 'https://graph.microsoft.com/.default'],
       redirectUri: `${req.protocol}://${req.get('host')}/m365/callback`,
     });
     await upsertM365Credentials(


### PR DESCRIPTION
## Summary
- request delegated permissions by including `openid`, `profile`, `offline_access` and `User.Read` scopes during Microsoft 365 OAuth flow
- restore Graph `.default` scope so downstream license sync can refresh tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c21f9d2274832dbae7f4732bc89e27