### PR TITLE
Fix Microsoft 365 authorization check

### DIFF
--- a/src/views/m365.ejs
+++ b/src/views/m365.ejs
@@ -25,7 +25,7 @@
         <% } else { %>
           <p><strong>Tenant ID:</strong> <%= credential.tenant_id %></p>
           <p><strong>Client ID:</strong> <%= credential.client_id %></p>
-          <% if (credential.refresh_token) { %>
+          <% if (credential.refresh_token || credential.access_token) { %>
             <p>Connected. Token expires at <%= credential.token_expires_at ? new Date(credential.token_expires_at).toLocaleString() : 'unknown' %></p>
           <% } else { %>
             <p>Not authorized with Microsoft 365.</p>


### PR DESCRIPTION
## Summary
- Detect Microsoft 365 connection using access or refresh tokens to avoid false 'Not authorized' messages

## Testing
- `npm test` *(fails: tests hang without required environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c2208a791c832dae1db60dae03f766