### PR TITLE
Map Office 365 SKUs to product names

### DIFF
--- a/src/services/m365Licenses.ts
+++ b/src/services/m365Licenses.ts
@@ -11,6 +11,17 @@ import {
 import { decryptSecret, encryptSecret } from '../crypto';
 import { logInfo, logError } from '../logger';
 
+// Map Microsoft 365 SKU part numbers to friendly product names
+const skuNameMap: Record<string, string> = {
+  O365_BUSINESS: 'Microsoft 365 Apps for Business',
+  O365_BUSINESS_ESSENTIALS: 'Microsoft 365 Business Basic',
+  O365_BUSINESS_PREMIUM: 'Microsoft 365 Business Standard',
+  STANDARDPACK: 'Office 365 E1',
+  ENTERPRISEPACK: 'Office 365 E3',
+  ENTERPRISEPREMIUM: 'Office 365 E5',
+  ENTERPRISEPREMIUM_NOPSTNCONF: 'Office 365 E5 without Audio Conferencing',
+  DESKLESSPACK: 'Office 365 F3',
+};
 async function createCca(companyId: number): Promise<ConfidentialClientApplication> {
   const creds = await getM365Credentials(companyId);
   if (!creds) {
@@ -74,19 +85,20 @@ export async function syncM365Licenses(companyId: number): Promise<void> {
       for (const sku of skus.value) {
         const partNumber = sku.skuPartNumber as string;
         const count = sku.prepaidUnits?.enabled || 0;
+        const name = skuNameMap[partNumber as keyof typeof skuNameMap] ?? partNumber;
         const existing = await getLicenseByCompanyAndSku(companyId, partNumber);
         if (existing) {
           await updateLicense(
             existing.id,
             companyId,
-            existing.name,
+            name,
             partNumber,
             count,
             existing.expiry_date,
             existing.contract_term
           );
         } else {
-          await createLicense(companyId, partNumber, partNumber, count, null, '');
+          await createLicense(companyId, name, partNumber, count, null, '');
         }
       }
     }


### PR DESCRIPTION
## Summary
- map Microsoft 365 SKU part numbers to friendly product names
- store mapped name when syncing Microsoft 365 licenses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c221858d08832db7cf7c2243940caf