### PR TITLE
Enable deletion of company app prices with default fallback

### DIFF
--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -700,7 +700,14 @@
                   <td><%= p.sku %></td>
                   <td><%= p.app_name %></td>
                   <td><%= p.price %></td>
-                  <td><button class="add-sku-company" data-app-id="<%= p.app_id %>" data-company-id="<%= p.company_id %>" data-company-name="<%= p.company_name %>">Add to Company</button></td>
+                  <td>
+                    <form action="/apps/price/delete" method="post" style="display:inline" data-confirm="Delete company price?">
+                      <input type="hidden" name="companyId" value="<%= p.company_id %>">
+                      <input type="hidden" name="appId" value="<%= p.app_id %>">
+                      <button type="submit">Delete</button>
+                    </form>
+                    <button class="add-sku-company" data-app-id="<%= p.app_id %>" data-company-id="<%= p.company_id %>" data-company-name="<%= p.company_name %>">Add to Company</button>
+                  </td>
                 </tr>
               <% }); %>
               </tbody>

--- a/tests/getCompanyAppPrice.test.ts
+++ b/tests/getCompanyAppPrice.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+process.env.SESSION_SECRET = 'test';
+process.env.TOTP_ENCRYPTION_KEY = 'test';
+const { getCompanyAppPriceHandler } = require('../src/server');
+
+test('falls back to default price when company price missing', async () => {
+  const req: any = { params: { companyId: '1', appId: '2' } };
+  const jsonCalls: any[] = [];
+  const res: any = {
+    json: (data: any) => { jsonCalls.push(data); },
+    status: (code: number) => { res.statusCode = code; return res; },
+  };
+  const deps = {
+    getAppPrice: async () => null,
+    getAppById: async () => ({ default_price: 10 }),
+  };
+  await getCompanyAppPriceHandler(req, res, deps);
+  assert.equal(res.statusCode, undefined);
+  assert.deepEqual(jsonCalls, [{ price: 10 }]);
+});
+
+test('returns 404 when app not found', async () => {
+  const req: any = { params: { companyId: '1', appId: '2' } };
+  const jsonCalls: any[] = [];
+  const res: any = {
+    json: (data: any) => { jsonCalls.push(data); },
+    status: (code: number) => { res.statusCode = code; return res; },
+  };
+  const deps = {
+    getAppPrice: async () => null,
+    getAppById: async () => null,
+  };
+  await getCompanyAppPriceHandler(req, res, deps);
+  assert.equal(res.statusCode, 404);
+  assert.deepEqual(jsonCalls, [{ error: 'App not found' }]);
+});


### PR DESCRIPTION
## Summary
- Allow admins to delete company-specific app prices, reverting to default app pricing
- API now returns the default app price when no company override exists
- Cover pricing fallback with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c2349f3d7c832da9a7d843f2d1a33d