### PR TITLE
Fix Microsoft 365 license sync user query

### DIFF
--- a/src/services/m365Licenses.ts
+++ b/src/services/m365Licenses.ts
@@ -107,7 +107,8 @@ export async function syncM365Licenses(companyId: number): Promise<void> {
         }
 
         const users = await client
-          .api(`/subscribedSkus/${skuId}/users`)
+          .api('/users')
+          .filter(`assignedLicenses/any(x:x/skuId eq ${skuId})`)
           .select(['id', 'userPrincipalName', 'mail'])
           .get();
         const assignedEmails: string[] = [];


### PR DESCRIPTION
## Summary
- query Microsoft 365 users by assigned license using /users filter instead of nonexistent subscribedSkus/{skuId}/users path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c23598e4b8832dbb3dfc6b502d1424