### PR TITLE
feat: support multiple app pricing terms

### DIFF
--- a/migrations/057_app_price_options.sql
+++ b/migrations/057_app_price_options.sql
@@ -1,0 +1,20 @@
+CREATE TABLE app_price_options (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  app_id INT NOT NULL,
+  payment_term ENUM('monthly','annual') NOT NULL,
+  contract_term ENUM('monthly','annual') NOT NULL,
+  price DECIMAL(10,2) NOT NULL,
+  UNIQUE KEY uniq_app_term (app_id, payment_term, contract_term),
+  FOREIGN KEY (app_id) REFERENCES apps(id)
+);
+
+ALTER TABLE company_app_prices
+  ADD COLUMN IF NOT EXISTS payment_term ENUM('monthly','annual') NOT NULL DEFAULT 'monthly',
+  ADD COLUMN IF NOT EXISTS contract_term ENUM('monthly','annual') NOT NULL DEFAULT 'monthly';
+
+INSERT INTO app_price_options (app_id, payment_term, contract_term, price)
+SELECT id, 'monthly', contract_term, default_price FROM apps;
+
+ALTER TABLE apps
+  DROP COLUMN IF EXISTS default_price,
+  DROP COLUMN IF EXISTS contract_term;

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -639,8 +639,6 @@
                 <input type="text" name="sku" placeholder="SKU" required>
                 <input type="text" name="vendorSku" placeholder="Vendor SKU">
                 <input type="text" name="name" placeholder="Name" required>
-                <input type="number" step="0.01" name="price" placeholder="Default Price" required>
-                <input type="text" name="contractTerm" placeholder="Contract Term" required>
                 <button type="submit">Add App</button>
               </form>
             </section>
@@ -648,7 +646,7 @@
               <h2>Apps</h2>
               <table>
                 <thead>
-                  <tr><th>SKU</th><th>Vendor SKU</th><th>Name</th><th>Default Price</th><th>Contract Term</th><th>Actions</th></tr>
+                  <tr><th>SKU</th><th>Vendor SKU</th><th>Name</th><th>Actions</th></tr>
                 </thead>
                 <tbody>
                 <% apps.forEach(function(a){ %>
@@ -656,8 +654,6 @@
                     <td><input type="text" name="sku" value="<%= a.sku %>" form="app-<%= a.id %>"></td>
                     <td><input type="text" name="vendorSku" value="<%= a.vendor_sku || '' %>" form="app-<%= a.id %>"></td>
                     <td><input type="text" name="name" value="<%= a.name %>" form="app-<%= a.id %>"></td>
-                    <td><input type="number" step="0.01" name="price" value="<%= a.default_price %>" form="app-<%= a.id %>"></td>
-                    <td><input type="text" name="contractTerm" value="<%= a.contract_term %>" form="app-<%= a.id %>"></td>
                     <td>
                       <form id="app-<%= a.id %>" action="/apps/<%= a.id %>/update" method="post" style="display:inline">
                         <button type="submit">Save</button>
@@ -673,11 +669,54 @@
               </table>
             </section>
           <section>
-            <h2>Company Pricing</h2>
-            <form action="/apps/price" method="post">
+            <h2>App Price Options</h2>
+            <form action="/apps/prices" method="post">
               <select name="appId">
                 <% apps.forEach(function(a){ %>
                   <option value="<%= a.id %>"><%= a.name %></option>
+                <% }); %>
+              </select>
+              <select name="paymentTerm">
+                <option value="monthly">Monthly</option>
+                <option value="annual">Annual</option>
+              </select>
+              <select name="contractTerm">
+                <option value="monthly">Monthly</option>
+                <option value="annual">Annual</option>
+              </select>
+              <input type="number" step="0.01" name="price" placeholder="Price" required>
+              <button type="submit">Add Price</button>
+            </form>
+            <h3>Existing App Prices</h3>
+            <table>
+              <thead>
+                <tr><th>App</th><th>Payment Term</th><th>Contract Term</th><th>Price</th><th>Actions</th></tr>
+              </thead>
+              <tbody>
+              <% appPrices.forEach(function(p){ %>
+                <tr>
+                  <td><%= apps.find(a => a.id === p.app_id)?.name %></td>
+                  <td><%= p.payment_term %></td>
+                  <td><%= p.contract_term %></td>
+                  <td><%= p.price %></td>
+                  <td>
+                    <form action="/apps/prices/<%= p.id %>/delete" method="post" style="display:inline" data-confirm="Delete price option?">
+                      <button type="submit">Delete</button>
+                    </form>
+                  </td>
+                </tr>
+              <% }); %>
+              </tbody>
+            </table>
+          </section>
+          <section>
+            <h2>Company Pricing</h2>
+            <form action="/apps/price" method="post">
+              <select name="combo">
+                <% appPrices.forEach(function(p){ %>
+                  const app = apps.find(a => a.id === p.app_id);
+                %>
+                  <option value="<%= p.app_id %>|<%= p.payment_term %>|<%= p.contract_term %>"><%= app ? app.name : '' %> - <%= p.payment_term %> / <%= p.contract_term %></option>
                 <% }); %>
               </select>
               <select name="companyId">
@@ -691,7 +730,7 @@
             <h3>Existing Company Prices</h3>
             <table>
               <thead>
-                <tr><th>Company</th><th>SKU</th><th>App</th><th>Price</th><th>Actions</th></tr>
+                <tr><th>Company</th><th>SKU</th><th>App</th><th>Payment</th><th>Contract</th><th>Price</th><th>Actions</th></tr>
               </thead>
               <tbody>
               <% companyPrices.forEach(function(p){ %>
@@ -699,11 +738,15 @@
                   <td><%= p.company_name %></td>
                   <td><%= p.sku %></td>
                   <td><%= p.app_name %></td>
+                  <td><%= p.payment_term %></td>
+                  <td><%= p.contract_term %></td>
                   <td><%= p.price %></td>
                   <td>
                     <form action="/apps/price/delete" method="post" style="display:inline" data-confirm="Delete company price?">
                       <input type="hidden" name="companyId" value="<%= p.company_id %>">
                       <input type="hidden" name="appId" value="<%= p.app_id %>">
+                      <input type="hidden" name="paymentTerm" value="<%= p.payment_term %>">
+                      <input type="hidden" name="contractTerm" value="<%= p.contract_term %>">
                       <button type="submit">Delete</button>
                     </form>
                     <button class="add-sku-company" data-app-id="<%= p.app_id %>" data-company-id="<%= p.company_id %>" data-company-name="<%= p.company_name %>">Add to Company</button>
@@ -1141,10 +1184,12 @@
           if(!companyId) return;
           const qty = prompt('Number of licenses purchased?');
           if(!qty) return;
+          const term = prompt('Contract term? (monthly/annual)', 'monthly');
+          if(!term) return;
           await fetch(`/apps/${appId}/add`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ companyId: parseInt(companyId,10), quantity: parseInt(qty,10) })
+            body: JSON.stringify({ companyId: parseInt(companyId,10), quantity: parseInt(qty,10), contractTerm: term })
           });
           alert('App added to company');
         });
@@ -1156,10 +1201,12 @@
           const companyName = this.dataset.companyName;
           const qty = prompt(`Number of licenses for ${companyName}?`);
           if(!qty) return;
+          const term = prompt('Contract term? (monthly/annual)', 'monthly');
+          if(!term) return;
           await fetch(`/apps/${appId}/add`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ companyId: parseInt(companyId,10), quantity: parseInt(qty,10) })
+            body: JSON.stringify({ companyId: parseInt(companyId,10), quantity: parseInt(qty,10), contractTerm: term })
           });
           alert('App added to company');
         });

--- a/tests/getCompanyAppPrice.test.ts
+++ b/tests/getCompanyAppPrice.test.ts
@@ -5,7 +5,7 @@ process.env.TOTP_ENCRYPTION_KEY = 'test';
 const { getCompanyAppPriceHandler } = require('../src/server');
 
 test('falls back to default price when company price missing', async () => {
-  const req: any = { params: { companyId: '1', appId: '2' } };
+  const req: any = { params: { companyId: '1', appId: '2' }, query: { paymentTerm: 'monthly', contractTerm: 'annual' } };
   const jsonCalls: any[] = [];
   const res: any = {
     json: (data: any) => { jsonCalls.push(data); },
@@ -13,15 +13,15 @@ test('falls back to default price when company price missing', async () => {
   };
   const deps = {
     getAppPrice: async () => null,
-    getAppById: async () => ({ default_price: 10 }),
+    getAppPriceOption: async () => ({ price: 10 }),
   };
   await getCompanyAppPriceHandler(req, res, deps);
   assert.equal(res.statusCode, undefined);
   assert.deepEqual(jsonCalls, [{ price: 10 }]);
 });
 
-test('returns 404 when app not found', async () => {
-  const req: any = { params: { companyId: '1', appId: '2' } };
+test('returns 404 when price option missing', async () => {
+  const req: any = { params: { companyId: '1', appId: '2' }, query: { paymentTerm: 'monthly', contractTerm: 'annual' } };
   const jsonCalls: any[] = [];
   const res: any = {
     json: (data: any) => { jsonCalls.push(data); },
@@ -29,9 +29,9 @@ test('returns 404 when app not found', async () => {
   };
   const deps = {
     getAppPrice: async () => null,
-    getAppById: async () => null,
+    getAppPriceOption: async () => null,
   };
   await getCompanyAppPriceHandler(req, res, deps);
   assert.equal(res.statusCode, 404);
-  assert.deepEqual(jsonCalls, [{ error: 'App not found' }]);
+  assert.deepEqual(jsonCalls, [{ error: 'App price not found' }]);
 });


### PR DESCRIPTION
## Summary
- allow defining multiple price options per app with payment/contract terms
- enable company-specific pricing to include payment and contract terms
- add migration for app price options table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c236be8d78832d907bc88e6a55ba2e