### PR TITLE
Handle legacy contract terms during migration

### DIFF
--- a/migrations/057_app_price_options.sql
+++ b/migrations/057_app_price_options.sql
@@ -13,7 +13,16 @@ ALTER TABLE company_app_prices
   ADD COLUMN IF NOT EXISTS contract_term ENUM('monthly','annual') NOT NULL DEFAULT 'monthly';
 
 INSERT INTO app_price_options (app_id, payment_term, contract_term, price)
-SELECT id, 'monthly', contract_term, default_price FROM apps;
+SELECT
+  id,
+  'monthly',
+  CASE
+    WHEN LOWER(contract_term) IN ('monthly', 'month') THEN 'monthly'
+    WHEN LOWER(contract_term) IN ('annual', 'year', 'yearly') THEN 'annual'
+    ELSE 'annual'
+  END,
+  default_price
+FROM apps;
 
 ALTER TABLE apps
   DROP COLUMN IF EXISTS default_price,


### PR DESCRIPTION
## Summary
- map legacy contract term strings to supported enum values during app_price_options migration

## Testing
- `node --test --require ts-node/register/transpile-only tests/*.test.ts` *(fails: process hangs; partial output shows subtests passing)*

------
https://chatgpt.com/codex/tasks/task_b_68c238c0e37c832d84f15f24a65c5751