### PR TITLE
Limit list page size and constrain layout to viewport

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -92,6 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initialize DataTables for visible tables
     if (typeof DataTable !== 'undefined') {
+      DataTable.defaults.pageLength = 5;
       function initDataTable(table) {
         if (table.dataset.datatableInitialized) return;
         new DataTable(table);

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -3,7 +3,10 @@ body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   background: linear-gradient(135deg, #8e2de2, #4a00e0);
   color: #333;
+  width: 100vw;
   height: 100vh;
+  max-width: 100vw;
+  max-height: 100vh;
   display: flow;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- Ensure all DataTables show 5 entries per page by default
- Restrict body element to viewport dimensions to prevent overflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c276dcb2ac832d9d7f6f2317968832