### PR TITLE
Allow DataTables to show fewer than ten entries

### DIFF
--- a/src/public/app.js
+++ b/src/public/app.js
@@ -93,6 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize DataTables for visible tables
     if (typeof DataTable !== 'undefined') {
       DataTable.defaults.pageLength = 5;
+      DataTable.defaults.lengthMenu = [5, 10, 25, 50, 100];
       function initDataTable(table) {
         if (table.dataset.datatableInitialized) return;
         new DataTable(table);


### PR DESCRIPTION
## Summary
- configure DataTables defaults to show 5 items and offer 5-100 options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c2783ca1d0832d84f3051c056e7844