### PR TITLE
Auto refresh new placeholder products from stock feed

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2795,7 +2795,7 @@ app.post(
     const { name, sku, vendor_sku, description, price, vip_price, stock, category_id } =
       req.body;
     const imageUrl = req.file ? `/uploads/${req.file.filename}` : null;
-    await createProduct(
+    const createdProductId = await createProduct(
       name,
       sku,
       vendor_sku,
@@ -2806,6 +2806,23 @@ app.post(
       parseInt(stock, 10),
       category_id ? parseInt(category_id, 10) : null
     );
+    const trimmedName = typeof name === 'string' ? name.trim() : '';
+    const trimmedVendorSku =
+      typeof vendor_sku === 'string' ? vendor_sku.trim() : '';
+    const normalizedName = trimmedName ? trimmedName.toLowerCase() : '';
+    const normalizedVendorSku = trimmedVendorSku
+      ? trimmedVendorSku.toLowerCase()
+      : '';
+    if (normalizedName && normalizedName === normalizedVendorSku) {
+      try {
+        await importProductByVendorSku(trimmedVendorSku);
+      } catch (err) {
+        console.error(
+          `Automatic stock feed update failed for product ${createdProductId}`,
+          err
+        );
+      }
+    }
     res.redirect('/admin');
   }
 );


### PR DESCRIPTION
## Summary
- trigger a stock feed import when creating a product whose name matches its vendor SKU
- log and ignore stock feed import failures so product creation can still succeed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ca2e22c2b0832d9b10f40551f81378