### PR TITLE
Refine Company Assets column view controls

### DIFF
--- a/change.md
+++ b/change.md
@@ -1,3 +1,4 @@
 # Change Log
 
 - 2025-09-17, 06:44 UTC, Setup change log file
+- 2025-09-17, 06:59 UTC, Consolidated Company Assets column toggles into a secure header view menu

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -195,6 +195,108 @@ table th {
   gap: 0.5rem;
 }
 
+.search-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: #f3f3f3;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-control:focus-within {
+  border-color: #4a00e0;
+  box-shadow: 0 0 0 3px rgba(74, 0, 224, 0.15);
+}
+
+.search-control input {
+  border: none;
+  background: transparent;
+  outline: none;
+  min-width: 200px;
+}
+
+.search-control i {
+  color: #4a00e0;
+}
+
+.view-menu {
+  position: relative;
+}
+
+.view-menu-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: #4a00e0;
+  color: #fff;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.view-menu-button:focus {
+  outline: 3px solid rgba(74, 0, 224, 0.4);
+  outline-offset: 2px;
+}
+
+.view-menu-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+  padding: 1rem;
+  min-width: 220px;
+  display: none;
+  z-index: 10;
+}
+
+.view-menu.open .view-menu-dropdown {
+  display: block;
+}
+
+.view-menu-title {
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.view-menu-dropdown ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.view-menu-dropdown label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.view-menu-dropdown input[type="checkbox"] {
+  accent-color: #4a00e0;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .swagger-frame {
   width: 100%;
   height: calc(100vh - 80px - 4rem);

--- a/src/views/assets.ejs
+++ b/src/views/assets.ejs
@@ -5,21 +5,49 @@
   <div class="app-container">
     <%- include('partials/sidebar') %>
     <div class="content">
-      <h1>Assets</h1>
-      <section>
-        <h2>Company Assets</h2>
-        <div class="asset-controls">
-          <label for="asset-search">Search: <input type="text" id="asset-search"></label>
-          <div id="column-toggles">
-            <% columns.forEach(function(col){ %>
-              <label>
-                <input type="checkbox" class="column-toggle" data-column="<%= col.key %>" <%= col.key === 'name' ? 'checked disabled' : 'checked' %>>
-                <%= col.label %>
-              </label>
-            <% }); %>
+      <div class="page-header">
+        <div class="page-title">
+          <h1>Assets</h1>
+          <p class="page-subtitle">Company Assets</p>
+        </div>
+        <div class="header-actions">
+          <label for="asset-search" class="search-control">
+            <span class="visually-hidden">Search assets</span>
+            <i class="fas fa-search" aria-hidden="true"></i>
+            <input type="text" id="asset-search" placeholder="Search assets" autocomplete="off" />
+          </label>
+          <div class="view-menu">
+            <button
+              type="button"
+              id="view-menu-toggle"
+              class="view-menu-button"
+              aria-haspopup="true"
+              aria-expanded="false"
+              aria-controls="view-menu-dropdown"
+            >
+              <i class="fas fa-eye" aria-hidden="true"></i>
+              <span>View</span>
+              <i class="fas fa-chevron-down" aria-hidden="true"></i>
+            </button>
+            <div class="view-menu-dropdown" id="view-menu-dropdown" role="menu" aria-hidden="true">
+              <p class="view-menu-title">Toggle columns</p>
+              <ul>
+                <% columns.forEach(function(col){ %>
+                  <li>
+                    <label>
+                      <input type="checkbox" class="column-toggle" data-column="<%= col.key %>" <%= col.key === 'name' ? 'checked disabled' : 'checked' %>>
+                      <span><%= col.label %></span>
+                    </label>
+                  </li>
+                <% }); %>
+              </ul>
+            </div>
           </div>
         </div>
-        <table id="assets-table">
+      </div>
+      <div class="page-body">
+        <section class="asset-section">
+          <table id="assets-table">
           <thead>
             <tr>
               <% columns.forEach(function(col){ %>
@@ -47,8 +75,9 @@
             </tr>
           <% }); %>
           </tbody>
-        </table>
-      </section>
+          </table>
+        </section>
+      </div>
     </div>
   </div>
   <script>
@@ -56,6 +85,40 @@
     const searchInput = document.getElementById('asset-search');
     const STORAGE_KEY = 'assetsTableColumns';
     const toggles = document.querySelectorAll('.column-toggle');
+    const viewMenu = document.querySelector('.view-menu');
+    const viewMenuToggle = document.getElementById('view-menu-toggle');
+    const viewMenuDropdown = document.getElementById('view-menu-dropdown');
+
+    function setViewMenuState(isOpen) {
+      if (!viewMenu || !viewMenuToggle || !viewMenuDropdown) return;
+      viewMenu.classList.toggle('open', isOpen);
+      viewMenuToggle.setAttribute('aria-expanded', String(isOpen));
+      viewMenuDropdown.setAttribute('aria-hidden', String(!isOpen));
+    }
+
+    if (viewMenu && viewMenuToggle && viewMenuDropdown) {
+      viewMenuToggle.addEventListener('click', (event) => {
+        event.stopPropagation();
+        const expanded = viewMenuToggle.getAttribute('aria-expanded') === 'true';
+        setViewMenuState(!expanded);
+      });
+
+      viewMenuDropdown.addEventListener('click', (event) => {
+        event.stopPropagation();
+      });
+
+      document.addEventListener('click', (event) => {
+        if (!viewMenu.contains(event.target)) {
+          setViewMenuState(false);
+        }
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          setViewMenuState(false);
+        }
+      });
+    }
 
     function toggleColumn(col, show) {
       table.querySelectorAll('[data-column="' + col + '"]').forEach((el) => {


### PR DESCRIPTION
## Summary
- reorganized the Company Assets header to host the search input and new consolidated view menu
- implemented an accessible dropdown menu that groups column visibility toggles while preserving saved preferences
- refreshed shared styling for the search bar and view selector and recorded the change in the project log

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ca5c2d5a98832d868280233bf4128f