### PR TITLE
Add CSRF tokens to scheduled task forms

### DIFF
--- a/change.md
+++ b/change.md
@@ -4,3 +4,4 @@
 - 2025-09-17, 06:59 UTC, Feature, Consolidated Company Assets column toggles into a secure header view menu
 - 2025-09-17, 07:02 UTC, Fix, Added server-rendered CSRF tokens to Apps management forms to prevent invalid token errors when saving changes
 - 2025-09-17, 07:08 UTC, Fix, Repositioned asset search/view controls above the table with a default-collapsed column accordion
+- 2025-09-17, 07:18 UTC, Fix, Added CSRF protection tokens to scheduled task forms to prevent invalid token errors when managing schedules

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -243,6 +243,7 @@
             <section>
               <h2>Add Schedule</h2>
               <form action="/admin/schedules" method="post">
+                <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                 <select name="command">
                   <option value="sync_staff">Sync Staff From Syncro</option>
                   <option value="sync_o365">Sync Office 365 License Counts</option>
@@ -466,13 +467,16 @@
                       </td>
                       <td>
                         <form action="/admin/schedules/<%= t.id %>/run" method="post" style="display:inline">
+                          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                           <button type="submit">Run Now</button>
                         </form>
                         <form action="/admin/schedules/<%= t.id %>" method="post" style="display:inline">
+                          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                           <input type="text" name="cron" value="<%= t.cron %>" required>
                           <button type="submit">Save</button>
                         </form>
                         <form action="/admin/schedules/<%= t.id %>/delete" method="post" style="display:inline" data-confirm="Delete?">
+                          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                           <button type="submit">Delete</button>
                         </form>
                       </td>


### PR DESCRIPTION
## Summary
- add CSRF tokens to the scheduled task add, run, update, and delete forms so the requests pass middleware validation
- document the fix in the change log for auditing purposes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ca60640fb0832db1129c5f05a27e3e