### PR TITLE
Split scheduled tasks by scope

### DIFF
--- a/change.md
+++ b/change.md
@@ -5,3 +5,4 @@
 - 2025-09-17, 07:02 UTC, Fix, Added server-rendered CSRF tokens to Apps management forms to prevent invalid token errors when saving changes
 - 2025-09-17, 07:08 UTC, Fix, Repositioned asset search/view controls above the table with a default-collapsed column accordion
 - 2025-09-17, 07:18 UTC, Fix, Added CSRF protection tokens to scheduled task forms to prevent invalid token errors when managing schedules
+- 2025-09-17, 07:26 UTC, Feature, Split scheduled tasks into system and company tables for clearer administration and visibility

--- a/src/server.ts
+++ b/src/server.ts
@@ -3075,6 +3075,8 @@ app.get('/admin', ensureAuth, async (req, res) => {
   let products: any[] = [];
   let productRestrictions: Record<number, ProductCompanyRestriction[]> = {};
   let tasks: any[] = [];
+  let systemTasks: any[] = [];
+  let companyTasks: any[] = [];
   let emailTemplate: EmailTemplate | null = null;
   if (isSuperAdmin) {
     allCompanies = await getAllCompanies();
@@ -3109,6 +3111,8 @@ app.get('/admin', ensureAuth, async (req, res) => {
       company_name:
         allCompanies.find((c) => c.id === t.company_id)?.name || null,
     }));
+    systemTasks = tasks.filter((t) => t.company_id === null);
+    companyTasks = tasks.filter((t) => t.company_id !== null);
     emailTemplate = await getEmailTemplate('staff_invitation');
   } else {
     const companyId = req.session.companyId!;
@@ -3178,6 +3182,8 @@ app.get('/admin', ensureAuth, async (req, res) => {
     products,
     productRestrictions,
     tasks,
+    systemTasks,
+    companyTasks,
     credentials,
     showArchived: includeArchived,
     selectedFormId: isNaN(formId) ? null : formId,

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -449,41 +449,94 @@
             </section>
             <section>
               <h2>Schedules</h2>
-              <table>
-                <thead>
-                  <tr><th>ID</th><th>Company</th><th>Command</th><th>Cron</th><th>Last Run</th><th>Actions</th></tr>
-                </thead>
-                <tbody>
-                  <% tasks.forEach(function(t){ %>
-                    <tr>
-                      <td><%= t.id %></td>
-                      <td><%= t.company_name || '' %></td>
-                      <td><%= t.command %></td>
-                      <td><%= t.cron %></td>
-                      <td>
-                        <% if (t.last_run_at) { %>
-                          <span class="local-time" data-time="<%= new Date(t.last_run_at).toISOString() %>"></span>
-                        <% } %>
-                      </td>
-                      <td>
-                        <form action="/admin/schedules/<%= t.id %>/run" method="post" style="display:inline">
-                          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                          <button type="submit">Run Now</button>
-                        </form>
-                        <form action="/admin/schedules/<%= t.id %>" method="post" style="display:inline">
-                          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                          <input type="text" name="cron" value="<%= t.cron %>" required>
-                          <button type="submit">Save</button>
-                        </form>
-                        <form action="/admin/schedules/<%= t.id %>/delete" method="post" style="display:inline" data-confirm="Delete?">
-                          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                          <button type="submit">Delete</button>
-                        </form>
-                      </td>
-                    </tr>
-                  <% }); %>
-                </tbody>
-              </table>
+              <div class="schedule-table">
+                <h3>System Tasks</h3>
+                <table>
+                  <thead>
+                    <tr><th>ID</th><th>Scope</th><th>Command</th><th>Cron</th><th>Last Run</th><th>Actions</th></tr>
+                  </thead>
+                  <tbody>
+                    <% if (systemTasks.length === 0) { %>
+                      <tr>
+                        <td colspan="6" class="empty-state">No system tasks scheduled.</td>
+                      </tr>
+                    <% } else { %>
+                      <% systemTasks.forEach(function(t){ %>
+                        <tr>
+                          <td><%= t.id %></td>
+                          <td>System</td>
+                          <td><%= t.command %></td>
+                          <td><%= t.cron %></td>
+                          <td>
+                            <% if (t.last_run_at) { %>
+                              <span class="local-time" data-time="<%= new Date(t.last_run_at).toISOString() %>"></span>
+                            <% } %>
+                          </td>
+                          <td>
+                            <form action="/admin/schedules/<%= t.id %>/run" method="post" style="display:inline">
+                              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                              <button type="submit">Run Now</button>
+                            </form>
+                            <form action="/admin/schedules/<%= t.id %>" method="post" style="display:inline">
+                              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                              <input type="text" name="cron" value="<%= t.cron %>" required>
+                              <button type="submit">Save</button>
+                            </form>
+                            <form action="/admin/schedules/<%= t.id %>/delete" method="post" style="display:inline" data-confirm="Delete?">
+                              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                              <button type="submit">Delete</button>
+                            </form>
+                          </td>
+                        </tr>
+                      <% }); %>
+                    <% } %>
+                  </tbody>
+                </table>
+              </div>
+              <div class="schedule-table">
+                <h3>Company Tasks</h3>
+                <table>
+                  <thead>
+                    <tr><th>ID</th><th>Company</th><th>Command</th><th>Cron</th><th>Last Run</th><th>Actions</th></tr>
+                  </thead>
+                  <tbody>
+                    <% if (companyTasks.length === 0) { %>
+                      <tr>
+                        <td colspan="6" class="empty-state">No company tasks scheduled.</td>
+                      </tr>
+                    <% } else { %>
+                      <% companyTasks.forEach(function(t){ %>
+                        <tr>
+                          <td><%= t.id %></td>
+                          <td><%= t.company_name || '' %></td>
+                          <td><%= t.command %></td>
+                          <td><%= t.cron %></td>
+                          <td>
+                            <% if (t.last_run_at) { %>
+                              <span class="local-time" data-time="<%= new Date(t.last_run_at).toISOString() %>"></span>
+                            <% } %>
+                          </td>
+                          <td>
+                            <form action="/admin/schedules/<%= t.id %>/run" method="post" style="display:inline">
+                              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                              <button type="submit">Run Now</button>
+                            </form>
+                            <form action="/admin/schedules/<%= t.id %>" method="post" style="display:inline">
+                              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                              <input type="text" name="cron" value="<%= t.cron %>" required>
+                              <button type="submit">Save</button>
+                            </form>
+                            <form action="/admin/schedules/<%= t.id %>/delete" method="post" style="display:inline" data-confirm="Delete?">
+                              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                              <button type="submit">Delete</button>
+                            </form>
+                          </td>
+                        </tr>
+                      <% }); %>
+                    <% } %>
+                  </tbody>
+                </table>
+              </div>
             </section>
             <script>
               document.querySelectorAll('.local-time').forEach(function(el){


### PR DESCRIPTION
## Summary
- compute separate system and company scheduled task lists in the admin handler
- render system tasks above company tasks with empty-state messaging in the schedules tab
- log the change in change.md for release tracking

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ca6252f824832db43ac01952d2821d