### PR TITLE
Add super admin product pricing alerts

### DIFF
--- a/change.md
+++ b/change.md
@@ -6,3 +6,4 @@
 - 2025-09-17, 07:08 UTC, Fix, Repositioned asset search/view controls above the table with a default-collapsed column accordion
 - 2025-09-17, 07:18 UTC, Fix, Added CSRF protection tokens to scheduled task forms to prevent invalid token errors when managing schedules
 - 2025-09-17, 07:26 UTC, Feature, Split scheduled tasks into system and company tables for clearer administration and visibility
+- 2025-09-17, 07:38 UTC, Feature, Added automated product DBP threshold alerts with super admin email and popup notifications

--- a/migrations/059_product_price_alerts.sql
+++ b/migrations/059_product_price_alerts.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS product_price_alerts (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  product_id INT NOT NULL,
+  price DECIMAL(10,2) NOT NULL,
+  vip_price DECIMAL(10,2) NULL,
+  buy_price DECIMAL(10,2) NOT NULL,
+  threshold_price DECIMAL(10,2) NOT NULL,
+  triggered_at DATETIME NOT NULL,
+  emailed_at DATETIME NULL,
+  resolved_at DATETIME NULL,
+  CONSTRAINT fk_product_price_alerts_product FOREIGN KEY (product_id)
+    REFERENCES shop_products(id) ON DELETE CASCADE
+);
+
+ALTER TABLE product_price_alerts
+  ADD INDEX idx_product_price_alerts_product_resolved (product_id, resolved_at);

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -1368,5 +1368,31 @@
       });
     });
   </script>
+  <% if (isSuperAdmin && priceAlerts && priceAlerts.length) { %>
+    <script>
+      window.addEventListener('load', function () {
+        const alerts = <%- JSON.stringify(priceAlerts.map(function(alert) {
+          return {
+            name: alert.product_name,
+            sku: alert.product_sku,
+            price: Number(alert.price),
+            vipPrice: alert.vip_price !== null ? Number(alert.vip_price) : null,
+            threshold: Number(alert.threshold_price)
+          };
+        })).replace(/</g, '\\u003c') %>;
+        if (!Array.isArray(alerts) || !alerts.length) {
+          return;
+        }
+        const lines = alerts.map(function (alert) {
+          let message = alert.name + ' (' + alert.sku + ') has DBP +10% of $' + alert.threshold.toFixed(2) + ' while the current price is $' + alert.price.toFixed(2);
+          if (alert.vipPrice !== null) {
+            message += ' and the VIP price is $' + alert.vipPrice.toFixed(2);
+          }
+          return message;
+        });
+        alert('Product pricing alert:\n\n' + lines.join('\n\n'));
+      });
+    </script>
+  <% } %>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a migration and query helpers for storing product DBP pricing alerts
- trigger DBP +10% validations on product imports and updates, emailing the super admin when margins are at risk
- surface unresolved product pricing alerts on the admin page with an on-load popup notification

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ca63944e28832d9c1fd6f8ec7ceba0