### PR TITLE
Allow OpnForm embeds in CSP

### DIFF
--- a/change.md
+++ b/change.md
@@ -9,3 +9,4 @@
 - 2025-09-17, 07:38 UTC, Feature, Added automated product DBP threshold alerts with super admin email and popup notifications
 - 2025-09-17, 07:47 UTC, Fix, Normalised Syncro CPUAge import to populate asset Approx Age
 - 2025-09-17, 07:54 UTC, Feature, Added OpnForm deployment guidance, nginx proxy config, and super admin builder link
+- 2025-09-17, 09:16 UTC, Fix, Updated CSP frame policy to allow embedding OpnForm frames from form.hawkinsit.au

--- a/src/server.ts
+++ b/src/server.ts
@@ -943,6 +943,7 @@ app.use(
         ],
         imgSrc: ["'self'", 'data:', 'https:'],
         connectSrc: ["'self'"],
+        frameSrc: ["'self'", 'https://form.hawkinsit.au'],
         fontSrc: ["'self'", 'https:', 'data:'],
         objectSrc: ["'none'"],
         upgradeInsecureRequests: [],


### PR DESCRIPTION
## Summary
- allow embedding OpnForm-hosted forms by permitting form.hawkinsit.au in Helmet's CSP frame policy
- log the CSP update in the change log for operational tracking

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ca7c25f6dc832dbb0f3a6c23ce5f79