### PR TITLE
Add template variable support for external app URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,34 @@ There are no default login credentials; the first visit will prompt you to regis
 - CSRF protection on authenticated state-changing requests
 - Super admin access to the OpnForm builder for creating and editing forms
 
+## Template Variables for External Apps
+
+MyPortal exposes a curated set of template variables that can be embedded in
+form URLs or other external application links. When a page is rendered these
+placeholders are substituted with details from the logged-in user and their
+currently selected company. Each variable is available in two forms:
+
+- `{{variable}}` – the raw value.
+- `{{variable}}UrlEncoded` – the same value pre-encoded with
+  `encodeURIComponent` so it can be safely appended to query strings.
+
+| Placeholder | Description |
+| --- | --- |
+| `{{user.email}}` | Email address for the logged-in user. |
+| `{{user.firstName}}` | User's first name. |
+| `{{user.lastName}}` | User's last name. |
+| `{{user.fullName}}` | Combination of first and last name with whitespace trimmed. |
+| `{{company.id}}` | Numeric identifier of the active company. |
+| `{{company.name}}` | Name of the active company. |
+| `{{company.syncroId}}` | Syncro customer ID when available for the company. |
+| `{{portal.baseUrl}}` | Base URL of the MyPortal instance. |
+| `{{portal.loginUrl}}` | Direct link to the MyPortal login page. |
+
+For example, a form URL such as
+`https://forms.example.com/start?email={{user.emailUrlEncoded}}&company={{company.nameUrlEncoded}}`
+will resolve to the current user's email and company at runtime. Missing values
+gracefully fall back to an empty string.
+
 ## Setup
 
 1. Install dependencies:

--- a/change.md
+++ b/change.md
@@ -10,3 +10,4 @@
 - 2025-09-17, 07:47 UTC, Fix, Normalised Syncro CPUAge import to populate asset Approx Age
 - 2025-09-17, 07:54 UTC, Feature, Added OpnForm deployment guidance, nginx proxy config, and super admin builder link
 - 2025-09-17, 09:16 UTC, Fix, Updated CSP frame policy to allow embedding OpnForm frames from form.hawkinsit.au
+- 2025-09-17, 09:34 UTC, Feature, Added dynamic template variables for app URLs and documented usage in README

--- a/src/services/templateVariables.ts
+++ b/src/services/templateVariables.ts
@@ -1,0 +1,112 @@
+export interface TemplateVariableDefinition {
+  key: string;
+  description: string;
+  resolve: (context: TemplateContext) => string | number | null | undefined;
+}
+
+export interface TemplateContextUser {
+  id?: number;
+  email?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+}
+
+export interface TemplateContextCompany {
+  id?: number | null;
+  name?: string | null;
+  syncroCustomerId?: string | null;
+}
+
+export interface TemplateContextPortal {
+  baseUrl?: string | null;
+  loginUrl?: string | null;
+}
+
+export interface TemplateContext {
+  user?: TemplateContextUser;
+  company?: TemplateContextCompany;
+  portal?: TemplateContextPortal;
+}
+
+export const TEMPLATE_VARIABLES: TemplateVariableDefinition[] = [
+  {
+    key: 'user.email',
+    description: 'Email address of the logged-in user.',
+    resolve: (context) => context.user?.email ?? '',
+  },
+  {
+    key: 'user.firstName',
+    description: 'First name of the logged-in user.',
+    resolve: (context) => context.user?.firstName ?? '',
+  },
+  {
+    key: 'user.lastName',
+    description: 'Last name of the logged-in user.',
+    resolve: (context) => context.user?.lastName ?? '',
+  },
+  {
+    key: 'user.fullName',
+    description: 'Full name of the logged-in user.',
+    resolve: (context) => {
+      const first = context.user?.firstName?.trim() ?? '';
+      const last = context.user?.lastName?.trim() ?? '';
+      return [first, last].filter(Boolean).join(' ').trim();
+    },
+  },
+  {
+    key: 'company.id',
+    description: 'Numeric identifier of the active company.',
+    resolve: (context) =>
+      context.company?.id !== undefined && context.company?.id !== null
+        ? String(context.company.id)
+        : '',
+  },
+  {
+    key: 'company.name',
+    description: 'Name of the active company.',
+    resolve: (context) => context.company?.name ?? '',
+  },
+  {
+    key: 'company.syncroId',
+    description: 'Syncro customer identifier for the active company, when available.',
+    resolve: (context) => context.company?.syncroCustomerId ?? '',
+  },
+  {
+    key: 'portal.baseUrl',
+    description: 'Base URL for the MyPortal instance.',
+    resolve: (context) => context.portal?.baseUrl ?? '',
+  },
+  {
+    key: 'portal.loginUrl',
+    description: 'Login URL for the MyPortal instance.',
+    resolve: (context) => context.portal?.loginUrl ?? '',
+  },
+];
+
+export interface TemplateReplacementMap {
+  [placeholder: string]: string;
+}
+
+export function buildTemplateReplacementMap(context: TemplateContext): TemplateReplacementMap {
+  const replacements: TemplateReplacementMap = {};
+  for (const variable of TEMPLATE_VARIABLES) {
+    const rawValue = variable.resolve(context);
+    const stringValue = rawValue === undefined || rawValue === null ? '' : String(rawValue);
+    const token = `{{${variable.key}}}`;
+    replacements[token] = stringValue;
+    replacements[`${token}UrlEncoded`] = encodeURIComponent(stringValue);
+  }
+  return replacements;
+}
+
+export function applyTemplateVariables(value: string, replacements: TemplateReplacementMap): string {
+  let result = value;
+  const ordered = Object.entries(replacements).sort(
+    ([tokenA], [tokenB]) => tokenB.length - tokenA.length
+  );
+  for (const [token, replacement] of ordered) {
+    if (!token) continue;
+    result = result.split(token).join(replacement);
+  }
+  return result;
+}

--- a/tests/templateVariables.test.ts
+++ b/tests/templateVariables.test.ts
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  TEMPLATE_VARIABLES,
+  applyTemplateVariables,
+  buildTemplateReplacementMap,
+} from '../src/services/templateVariables';
+
+test('buildTemplateReplacementMap returns raw and encoded values', () => {
+  const replacements = buildTemplateReplacementMap({
+    user: {
+      id: 5,
+      email: 'user@example.com',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+    },
+    company: {
+      id: 42,
+      name: 'Example Co',
+      syncroCustomerId: 'SYNC-123',
+    },
+    portal: {
+      baseUrl: 'https://portal.example.com',
+      loginUrl: 'https://portal.example.com/login',
+    },
+  });
+
+  assert.equal(replacements['{{user.email}}'], 'user@example.com');
+  assert.equal(replacements['{{user.email}}UrlEncoded'], 'user%40example.com');
+  assert.equal(replacements['{{user.fullName}}'], 'Ada Lovelace');
+  assert.equal(replacements['{{company.id}}'], '42');
+  assert.equal(replacements['{{company.syncroId}}'], 'SYNC-123');
+});
+
+test('applyTemplateVariables replaces tokens in a string', () => {
+  const replacements = {
+    '{{user.email}}': 'user@example.com',
+    '{{user.email}}UrlEncoded': 'user%40example.com',
+  };
+  const url = 'mailto:{{user.email}}?to={{user.email}}UrlEncoded';
+  const rendered = applyTemplateVariables(url, replacements);
+  assert.equal(rendered, 'mailto:user@example.com?to=user%40example.com');
+});
+
+test('missing values result in empty strings without undefined leakage', () => {
+  const replacements = buildTemplateReplacementMap({});
+  for (const variable of TEMPLATE_VARIABLES) {
+    const token = `{{${variable.key}}}`;
+    assert.equal(replacements[token], '');
+    assert.equal(replacements[`${token}UrlEncoded`], '');
+  }
+});


### PR DESCRIPTION
## Summary
- add a shared template variable catalogue and helpers for resolving runtime values
- render form URLs with the logged-in user and company data so external links can consume placeholders
- document the available placeholders in the README and record the feature in the change log

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ca7f7077b8832dbc4ab07cd1b6e7cf