### PR TITLE
Fix OpnForm template variable URL encoding

### DIFF
--- a/src/services/templateVariables.ts
+++ b/src/services/templateVariables.ts
@@ -93,8 +93,11 @@ export function buildTemplateReplacementMap(context: TemplateContext): TemplateR
     const rawValue = variable.resolve(context);
     const stringValue = rawValue === undefined || rawValue === null ? '' : String(rawValue);
     const token = `{{${variable.key}}}`;
+    const encodedValue = encodeURIComponent(stringValue);
+
     replacements[token] = stringValue;
-    replacements[`${token}UrlEncoded`] = encodeURIComponent(stringValue);
+    replacements[`${token}UrlEncoded`] = encodedValue;
+    replacements[`{{${variable.key}UrlEncoded}}`] = encodedValue;
   }
   return replacements;
 }

--- a/tests/templateVariables.test.ts
+++ b/tests/templateVariables.test.ts
@@ -27,6 +27,7 @@ test('buildTemplateReplacementMap returns raw and encoded values', () => {
   });
 
   assert.equal(replacements['{{user.email}}'], 'user@example.com');
+  assert.equal(replacements['{{user.emailUrlEncoded}}'], 'user%40example.com');
   assert.equal(replacements['{{user.email}}UrlEncoded'], 'user%40example.com');
   assert.equal(replacements['{{user.fullName}}'], 'Ada Lovelace');
   assert.equal(replacements['{{company.id}}'], '42');
@@ -37,10 +38,14 @@ test('applyTemplateVariables replaces tokens in a string', () => {
   const replacements = {
     '{{user.email}}': 'user@example.com',
     '{{user.email}}UrlEncoded': 'user%40example.com',
+    '{{user.emailUrlEncoded}}': 'user%40example.com',
   };
-  const url = 'mailto:{{user.email}}?to={{user.email}}UrlEncoded';
+  const url = 'mailto:{{user.email}}?legacy={{user.email}}UrlEncoded&preferred={{user.emailUrlEncoded}}';
   const rendered = applyTemplateVariables(url, replacements);
-  assert.equal(rendered, 'mailto:user@example.com?to=user%40example.com');
+  assert.equal(
+    rendered,
+    'mailto:user@example.com?legacy=user%40example.com&preferred=user%40example.com'
+  );
 });
 
 test('missing values result in empty strings without undefined leakage', () => {
@@ -48,6 +53,7 @@ test('missing values result in empty strings without undefined leakage', () => {
   for (const variable of TEMPLATE_VARIABLES) {
     const token = `{{${variable.key}}}`;
     assert.equal(replacements[token], '');
+    assert.equal(replacements[`{{${variable.key}UrlEncoded}}`], '');
     assert.equal(replacements[`${token}UrlEncoded`], '');
   }
 });


### PR DESCRIPTION
## Summary
- update template variable replacement map to support the documented {{variableUrlEncoded}} syntax when hydrating OpnForm URLs
- expand template variable unit tests to cover the additional placeholder format and missing-value handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68ca8240d4fc832da194f160e176dd71