### PR TITLE
Fix form proxy resource rewriting for CORS

### DIFF
--- a/change.md
+++ b/change.md
@@ -12,3 +12,4 @@
 - 2025-09-17, 09:16 UTC, Fix, Updated CSP frame policy to allow embedding OpnForm frames from form.hawkinsit.au
 - 2025-09-17, 09:34 UTC, Feature, Added dynamic template variables for app URLs and documented usage in README
 - 2025-09-17, 13:27 UTC, Fix, Implemented authenticated Hawkins forms proxy with UI fallback to bypass X-Frame-Options errors
+- 2025-09-17, 13:34 UTC, Fix, Rewrote proxied form asset URLs to avoid cross-origin module preloads failing via CORS

--- a/src/server.ts
+++ b/src/server.ts
@@ -998,6 +998,74 @@ function injectFormProxyHelpers(html: string, target: URL): string {
     }
   }
 
+  const proxyBasePrefix = `${FORM_PROXY_ROUTE}?target=`;
+
+  const toProxyIfSameOrigin = (value: string): string => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return value;
+    }
+    if (trimmed.startsWith(proxyBasePrefix)) {
+      return value;
+    }
+    try {
+      const absolute = new URL(trimmed, target.toString());
+      if (absolute.origin !== target.origin) {
+        return value;
+      }
+      return `${proxyBasePrefix}${encodeURIComponent(absolute.toString())}`;
+    } catch (err) {
+      return value;
+    }
+  };
+
+  const rewriteTagAttribute = (
+    inputHtml: string,
+    tagName: string,
+    attribute: string,
+    shouldRewrite: (tagHtml: string) => boolean
+  ): string => {
+    const tagRegex = new RegExp(`<${tagName}\\b[^>]*>`, 'gi');
+    return inputHtml.replace(tagRegex, (tagHtml) => {
+      if (!shouldRewrite(tagHtml)) {
+        return tagHtml;
+      }
+      const attrRegex = new RegExp(
+        `(${attribute}\\s*=\\s*)("([^"]*)"|'([^']*)')`,
+        'i'
+      );
+      const match = tagHtml.match(attrRegex);
+      if (!match) {
+        return tagHtml;
+      }
+      const fullMatch = match[0];
+      const prefix = match[1];
+      const quotedValue = match[2];
+      const value = match[3] ?? match[4] ?? '';
+      const proxied = toProxyIfSameOrigin(value);
+      if (proxied === value) {
+        return tagHtml;
+      }
+      const quote = quotedValue.startsWith('"') ? '"' : "'";
+      return tagHtml.replace(fullMatch, `${prefix}${quote}${proxied}${quote}`);
+    });
+  };
+
+  html = rewriteTagAttribute(html, 'script', 'src', () => true);
+
+  html = rewriteTagAttribute(html, 'link', 'href', (tagHtml) => {
+    const relMatch = tagHtml.match(/\brel\s*=\s*("([^"]*)"|'([^']*)')/i);
+    if (!relMatch) {
+      return false;
+    }
+    const relValue = (relMatch[2] ?? relMatch[3] ?? '').toLowerCase();
+    return /(^|\s)(modulepreload|prefetch|preload|stylesheet)(\s|$)/.test(
+      relValue
+    );
+  });
+
+  html = rewriteTagAttribute(html, 'img', 'src', () => true);
+
   const proxyBase = `${FORM_PROXY_ROUTE}?target=`;
   const scriptContent = [
     '(function(){',


### PR DESCRIPTION
## Summary
- rewrite proxied form HTML to send script, link, and image assets through the authenticated proxy when they target Hawkins forms
- ensure Nuxt modulepreload, preload, and stylesheet links resolve via the proxy so module bundles load without cross-origin CORS failures
- log the change in the changelog for traceability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cab86a77f8832daa63cd37753759b9