### PR TITLE
Fix form proxy asset CORS handling

### DIFF
--- a/change.md
+++ b/change.md
@@ -13,3 +13,4 @@
 - 2025-09-17, 09:34 UTC, Feature, Added dynamic template variables for app URLs and documented usage in README
 - 2025-09-17, 13:27 UTC, Fix, Implemented authenticated Hawkins forms proxy with UI fallback to bypass X-Frame-Options errors
 - 2025-09-17, 13:34 UTC, Fix, Rewrote proxied form asset URLs to avoid cross-origin module preloads failing via CORS
+- 2025-09-17, 13:44 UTC, Fix, Forced proxied form assets to use the portal origin so scripts and styles load without CORS failures


### PR DESCRIPTION
## Summary
- ensure the form proxy rewrites asset URLs and redirects with the portal origin so base tags no longer force external requests
- propagate the portal base URL when building embed links and document the fix in the change log

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68caba276e10832da7195d75d86c50cc