### PR TITLE
Fix embedded forms by proxying allowed hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,10 @@ to that service so that super admins can launch the builder directly from the
 Forms admin area. See [docs/opnform.md](docs/opnform.md) for deployment and
 security guidance, including the supplied nginx configuration snippet in
 [`deploy/nginx/opnform.conf`](deploy/nginx/opnform.conf).
+
+When OpnForm is hosted on a different origin, add the host to the
+`FORM_PROXY_ALLOWED_HOSTS` environment variable (comma separated). The portal
+will securely proxy matching forms so that they continue to render inside the
+iframe while preserving the “Open form in new tab” behaviour for everything
+else. The value from `OPNFORM_BASE_URL` and `form.hawkinsit.au` are permitted by
+default.

--- a/change.md
+++ b/change.md
@@ -11,3 +11,4 @@
 - 2025-09-17, 07:54 UTC, Feature, Added OpnForm deployment guidance, nginx proxy config, and super admin builder link
 - 2025-09-17, 09:16 UTC, Fix, Updated CSP frame policy to allow embedding OpnForm frames from form.hawkinsit.au
 - 2025-09-17, 09:34 UTC, Feature, Added dynamic template variables for app URLs and documented usage in README
+- 2025-09-17, 14:09 UTC, Fix, Added secure proxying for external OpnForm embeds with in-portal fallback messaging and documentation

--- a/docs/opnform.md
+++ b/docs/opnform.md
@@ -90,6 +90,13 @@ OPNFORM_BASE_URL=https://forms.example.com/
 The middleware normalises this URL so that templates, notifications, and future
 integrations always generate consistent links.
 
+To embed forms hosted on separate domains, set the
+`FORM_PROXY_ALLOWED_HOSTS` environment variable to a comma-separated list of
+trusted hostnames (for example, `forms.example.com`). Matching forms are
+retrieved through the portal so they render inside the iframe while still
+providing an “Open form in new tab” option. The host defined in
+`OPNFORM_BASE_URL` and `form.hawkinsit.au` are always allowed.
+
 ## 4. Verify the integration
 
 1. Sign in as the super admin and visit **Admin → Forms**.

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -91,6 +91,31 @@ button:hover {
   background-color: #3700b3;
 }
 
+.button-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 4px;
+  background-color: #4a00e0;
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s ease-in-out, opacity 0.2s ease-in-out;
+}
+
+.button-link:hover,
+.button-link:focus {
+  background-color: #3700b3;
+}
+
+.button-link.is-disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
@@ -400,12 +425,41 @@ table th {
   background-color: #3700b3;
 }
 
+.form-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.form-toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .form-frame {
   width: 100%;
   /* Maintain a 10px buffer at the top and bottom */
   height: calc(100vh - 200px - 20px);
   border: none;
   margin: 10px 0;
+}
+
+.form-unavailable {
+  border: 1px solid #d1d5db;
+  background-color: #f8fafc;
+  border-radius: 8px;
+  padding: 1.5rem;
+  color: #1f2937;
+}
+
+.form-unavailable[hidden] {
+  display: none !important;
+}
+
+.form-unavailable-hint {
+  margin-top: 0.75rem;
+  color: #475569;
+  font-size: 0.95rem;
 }
 
 .modal {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import session from 'express-session';
 import RedisStore from 'connect-redis';
 import { createClient } from 'redis';
@@ -109,16 +109,17 @@ import {
   getM365Credentials,
   upsertM365Credentials,
   deleteM365Credentials,
-    getAllForms,
-    getFormsByCompany,
-    createForm,
-    updateForm,
-    deleteForm,
-    getFormsForUser,
-    getFormPermissions,
-    updateFormPermissions,
-    getAllFormPermissionEntries,
-    deleteFormPermission,
+  getAllForms,
+  getFormsByCompany,
+  createForm,
+  updateForm,
+  deleteForm,
+  getFormsForUser,
+  getFormPermissions,
+  updateFormPermissions,
+  getAllFormPermissionEntries,
+  deleteFormPermission,
+  Form,
   getAllCategories,
   getCategoryById,
   getCategoryByName,
@@ -227,6 +228,304 @@ const opnformBaseUrl = configuredOpnformBaseUrl
     ? configuredOpnformBaseUrl
     : `${configuredOpnformBaseUrl}/`
   : defaultOpnformBaseUrl;
+
+const formProxyAllowedHosts = new Set<string>();
+
+function addAllowedFormProxyHost(value: string): void {
+  if (!value) {
+    return;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return;
+  }
+  if (trimmed.includes('://')) {
+    try {
+      const parsed = new URL(trimmed);
+      if (parsed.hostname) {
+        formProxyAllowedHosts.add(parsed.hostname.toLowerCase());
+      }
+      if (parsed.host) {
+        formProxyAllowedHosts.add(parsed.host.toLowerCase());
+      }
+    } catch (error) {
+      logError('Invalid form proxy host provided', {
+        host: trimmed,
+        ...buildErrorMeta(error),
+      });
+    }
+    return;
+  }
+  formProxyAllowedHosts.add(trimmed.toLowerCase());
+}
+
+const rawFormProxyHosts = process.env.FORM_PROXY_ALLOWED_HOSTS;
+if (rawFormProxyHosts) {
+  for (const candidate of rawFormProxyHosts.split(',')) {
+    addAllowedFormProxyHost(candidate);
+  }
+}
+
+if (configuredOpnformBaseUrl && configuredOpnformBaseUrl.includes('://')) {
+  addAllowedFormProxyHost(configuredOpnformBaseUrl);
+}
+
+addAllowedFormProxyHost('form.hawkinsit.au');
+
+const FORM_PROXY_TIMEOUT_MS = 15000;
+const FORM_PROXY_SUCCESS_CSP =
+  "default-src 'self' https: data: blob:; " +
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; " +
+  "style-src 'self' 'unsafe-inline' https:; " +
+  "img-src 'self' data: https:; " +
+  "font-src 'self' data: https:; " +
+  "connect-src 'self' https:; " +
+  "frame-src 'self' https:; " +
+  "form-action 'self' https:;";
+
+const FORM_PROXY_ERROR_CSP =
+  "default-src 'self'; " +
+  "style-src 'self' 'unsafe-inline'; " +
+  "img-src 'self' data:; " +
+  "connect-src 'self'; " +
+  "frame-src 'self';";
+
+type FormWithEmbedUrl = Form & { embedUrl: string | null };
+
+function buildErrorMeta(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+    };
+  }
+  return { error: String(error) };
+}
+
+function renderFormProxyError(message: string): string {
+  const safeMessage = escapeHtml(message);
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Form unavailable</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 2rem;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #f8fafc;
+        color: #111827;
+      }
+      .message {
+        max-width: 520px;
+        margin: 0 auto;
+        background: #ffffff;
+        border-radius: 12px;
+        padding: 1.75rem;
+        box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.25);
+        border: 1px solid #e2e8f0;
+      }
+      h1 {
+        margin: 0 0 0.75rem 0;
+        font-size: 1.25rem;
+        color: #1f2937;
+      }
+      p {
+        margin: 0;
+        line-height: 1.55;
+      }
+    </style>
+  </head>
+  <body data-form-proxy-error="true" data-error-message="${safeMessage}">
+    <div class="message">
+      <h1>Form unavailable</h1>
+      <p>${safeMessage}</p>
+      <p style="margin-top: 0.75rem; color: #475569; font-size: 0.95rem;">
+        Return to the portal and use the “Open form in new tab” button to continue.
+      </p>
+    </div>
+  </body>
+</html>`;
+}
+
+function sendFormProxyError(res: Response, status: number, message: string): void {
+  res.status(status);
+  res.setHeader('Cache-Control', 'no-store');
+  res.setHeader('Content-Security-Policy', FORM_PROXY_ERROR_CSP);
+  res.type('html').send(renderFormProxyError(message));
+}
+
+function injectBaseTag(html: string, url: URL): string {
+  const baseHref = new URL('./', url.toString()).toString();
+  if (/<base\s/i.test(html)) {
+    return html;
+  }
+  if (/<head[^>]*>/i.test(html)) {
+    return html.replace(
+      /<head([^>]*)>/i,
+      `<head$1><base href="${escapeHtml(baseHref)}">`
+    );
+  }
+  return `<head><base href="${escapeHtml(baseHref)}"></head>${html}`;
+}
+
+function canProxyFormUrl(url: URL, portalOrigin: string): boolean {
+  if (url.origin === portalOrigin) {
+    return false;
+  }
+  if (url.protocol !== 'https:') {
+    return false;
+  }
+  const host = url.host.toLowerCase();
+  const hostname = url.hostname.toLowerCase();
+  return formProxyAllowedHosts.has(host) || formProxyAllowedHosts.has(hostname);
+}
+
+class ExternalFormFetchError extends Error {
+  public readonly statusCode: number;
+
+  public readonly userMessage: string;
+
+  constructor(message: string, statusCode: number, userMessage: string) {
+    super(message);
+    this.name = 'ExternalFormFetchError';
+    this.statusCode = statusCode;
+    this.userMessage = userMessage;
+  }
+}
+
+async function fetchExternalForm(url: URL): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FORM_PROXY_TIMEOUT_MS);
+  try {
+    const response = await fetch(url.toString(), {
+      headers: {
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new ExternalFormFetchError(
+          `Form not found at ${url.toString()}`,
+          404,
+          'The requested form could not be found.'
+        );
+      }
+      throw new ExternalFormFetchError(
+        `Unexpected status ${response.status} when fetching form ${url.toString()}`,
+        response.status,
+        'The form provider returned an unexpected response.'
+      );
+    }
+    const contentType = response.headers.get('content-type');
+    if (contentType && !contentType.includes('text/html')) {
+      throw new ExternalFormFetchError(
+        `Unsupported content type ${contentType} for form ${url.toString()}`,
+        502,
+        'The form provider returned an unsupported response.'
+      );
+    }
+    return await response.text();
+  } catch (error) {
+    if (error instanceof ExternalFormFetchError) {
+      throw error;
+    }
+    const isAbortError = error instanceof Error && error.name === 'AbortError';
+    throw new ExternalFormFetchError(
+      isAbortError
+        ? `Timed out fetching form ${url.toString()}`
+        : `Failed to fetch form ${url.toString()}: ${String(error)}`,
+      502,
+      'We could not contact the form provider.'
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function getPortalBaseUrl(req: Request): string {
+  return process.env.PORTAL_URL || `${req.protocol}://${req.get('host')}`;
+}
+
+function getEmbedUrlForForm(
+  hydratedUrl: string,
+  formId: number,
+  portalBaseUrl: string
+): string | null {
+  let resolved: URL;
+  try {
+    resolved = new URL(hydratedUrl, portalBaseUrl);
+  } catch (error) {
+    logError('Invalid form URL after template replacement', {
+      url: hydratedUrl,
+      ...buildErrorMeta(error),
+    });
+    return null;
+  }
+  const portalOrigin = new URL(portalBaseUrl).origin;
+  if (resolved.origin === portalOrigin) {
+    return resolved.toString();
+  }
+  return canProxyFormUrl(resolved, portalOrigin) ? `/forms/embed/${formId}` : null;
+}
+
+async function buildFormsContext(
+  req: Request
+): Promise<{
+  hydratedForms: FormWithEmbedUrl[];
+  companies: Awaited<ReturnType<typeof getCompaniesForUser>>;
+  currentCompanyAssignment: Awaited<ReturnType<typeof getCompaniesForUser>>[number] | undefined;
+  portalBaseUrl: string;
+}> {
+  const userId = req.session.userId!;
+  const [forms, companies, currentUser] = await Promise.all([
+    getFormsForUser(userId),
+    getCompaniesForUser(userId),
+    getUserById(userId),
+  ]);
+  const currentCompanyAssignment = companies.find(
+    (company) => company.company_id === req.session.companyId
+  );
+  const currentCompanyDetails = currentCompanyAssignment?.company_id
+    ? await getCompanyById(currentCompanyAssignment.company_id)
+    : null;
+  const portalBaseUrl = getPortalBaseUrl(req);
+  const replacements = buildTemplateReplacementMap({
+    user: currentUser
+      ? {
+          id: currentUser.id,
+          email: currentUser.email,
+          firstName: currentUser.first_name ?? '',
+          lastName: currentUser.last_name ?? '',
+        }
+      : undefined,
+    company: currentCompanyAssignment
+      ? {
+          id: currentCompanyAssignment.company_id,
+          name: currentCompanyDetails?.name ?? currentCompanyAssignment.company_name ?? '',
+          syncroCustomerId: currentCompanyDetails?.syncro_company_id ?? null,
+        }
+      : undefined,
+    portal: {
+      baseUrl: portalBaseUrl,
+      loginUrl: `${portalBaseUrl}/login`,
+    },
+  });
+  const hydratedForms: FormWithEmbedUrl[] = forms.map((form) => {
+    const hydratedUrl = applyTemplateVariables(form.url, replacements);
+    return {
+      ...form,
+      url: hydratedUrl,
+      embedUrl: getEmbedUrlForForm(hydratedUrl, form.id, portalBaseUrl),
+    };
+  });
+  return { hydratedForms, companies, currentCompanyAssignment, portalBaseUrl };
+}
 
 let appVersion = 'unknown';
 let appBuild = 'unknown';
@@ -2495,43 +2794,11 @@ app.delete('/invoices/:id', ensureAuth, ensureSuperAdmin, async (req, res) => {
 });
 
 app.get('/forms', ensureAuth, async (req, res) => {
-  const userId = req.session.userId!;
-  const [forms, companies, currentUser] = await Promise.all([
-    getFormsForUser(userId),
-    getCompaniesForUser(userId),
-    getUserById(userId),
-  ]);
-  req.session.hasForms = forms.length > 0;
-  const current = companies.find((c) => c.company_id === req.session.companyId);
-  const currentCompanyDetails = current?.company_id
-    ? await getCompanyById(current.company_id)
-    : null;
-  const baseUrl = process.env.PORTAL_URL || `${req.protocol}://${req.get('host')}`;
-  const replacements = buildTemplateReplacementMap({
-    user: currentUser
-      ? {
-          id: currentUser.id,
-          email: currentUser.email,
-          firstName: currentUser.first_name ?? '',
-          lastName: currentUser.last_name ?? '',
-        }
-      : undefined,
-    company: current
-      ? {
-          id: current.company_id,
-          name: currentCompanyDetails?.name ?? current.company_name ?? '',
-          syncroCustomerId: currentCompanyDetails?.syncro_company_id ?? null,
-        }
-      : undefined,
-    portal: {
-      baseUrl,
-      loginUrl: `${baseUrl}/login`,
-    },
-  });
-  const hydratedForms = forms.map((form) => ({
-    ...form,
-    url: applyTemplateVariables(form.url, replacements),
-  }));
+  const { hydratedForms, companies, currentCompanyAssignment } = await buildFormsContext(
+    req
+  );
+  req.session.hasForms = hydratedForms.length > 0;
+  const current = currentCompanyAssignment;
   res.render('forms', {
     forms: hydratedForms,
     companies,
@@ -2546,6 +2813,67 @@ app.get('/forms', ensureAuth, async (req, res) => {
     canOrderLicenses: current?.can_order_licenses ?? 0,
     canAccessShop: current?.can_access_shop ?? 0,
   });
+});
+
+app.get('/forms/embed/:id', ensureAuth, async (req, res) => {
+  const formId = Number.parseInt(req.params.id, 10);
+  if (!Number.isFinite(formId)) {
+    return sendFormProxyError(res, 400, 'The requested form identifier is invalid.');
+  }
+  const { hydratedForms, portalBaseUrl } = await buildFormsContext(req);
+  const target = hydratedForms.find((form) => form.id === formId);
+  if (!target) {
+    return sendFormProxyError(res, 404, 'The requested form is no longer assigned to your account.');
+  }
+  let resolvedUrl: URL;
+  try {
+    resolvedUrl = new URL(target.url, portalBaseUrl);
+  } catch (error) {
+    logError('Failed to resolve hydrated form URL', {
+      formId,
+      url: target.url,
+      ...buildErrorMeta(error),
+    });
+    return sendFormProxyError(res, 400, 'The form URL could not be resolved.');
+  }
+  const portalOrigin = new URL(portalBaseUrl).origin;
+  if (resolvedUrl.origin === portalOrigin) {
+    return res.redirect(resolvedUrl.toString());
+  }
+  if (!canProxyFormUrl(resolvedUrl, portalOrigin)) {
+    return sendFormProxyError(
+      res,
+      403,
+      'This form cannot be embedded securely. Use the “Open form in new tab” button to continue.'
+    );
+  }
+  try {
+    const html = await fetchExternalForm(resolvedUrl);
+    const responseHtml = injectBaseTag(html, resolvedUrl);
+    res.setHeader('Cache-Control', 'no-store');
+    res.setHeader('Content-Security-Policy', FORM_PROXY_SUCCESS_CSP);
+    res.type('html').send(responseHtml);
+  } catch (error) {
+    if (error instanceof ExternalFormFetchError) {
+      logError('External form fetch error', {
+        formId,
+        url: resolvedUrl.toString(),
+        statusCode: error.statusCode,
+        ...buildErrorMeta(error),
+      });
+      return sendFormProxyError(res, error.statusCode, error.userMessage);
+    }
+    logError('Unexpected error while embedding form', {
+      formId,
+      url: resolvedUrl.toString(),
+      ...buildErrorMeta(error),
+    });
+    return sendFormProxyError(
+      res,
+      502,
+      'We could not load this form. Use the “Open form in new tab” button to continue.'
+    );
+  }
 });
 
 app.get('/forms/company', ensureAuth, ensureAdmin, async (req, res) => {

--- a/src/views/forms.ejs
+++ b/src/views/forms.ejs
@@ -7,23 +7,142 @@
     <div class="content">
       <h1>Forms</h1>
       <% if (forms.length > 0) { %>
+        <% const initialForm = forms[0]; %>
         <div class="forms-menu">
           <% forms.forEach(function(f, idx){ %>
-            <button data-open-form data-url="<%= f.url %>" class="<%= idx === 0 ? 'active' : '' %>"><%= f.name %></button>
+            <button
+              data-open-form
+              data-direct-url="<%= f.url %>"
+              data-embed-url="<%= f.embedUrl ? f.embedUrl : '' %>"
+              class="<%= idx === 0 ? 'active' : '' %>"
+            >
+              <%= f.name %>
+            </button>
           <% }); %>
         </div>
-        <iframe id="form-frame" class="form-frame" src="<%= forms[0].url %>"></iframe>
+        <div class="form-viewer">
+          <div class="form-toolbar">
+            <a
+              id="form-open-link"
+              class="button-link"
+              href="<%= initialForm.url %>"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Open form in new tab
+            </a>
+          </div>
+          <iframe
+            id="form-frame"
+            class="form-frame"
+            src="<%= initialForm.embedUrl || 'about:blank' %>"
+            <%= initialForm.embedUrl ? '' : 'hidden' %>
+          ></iframe>
+          <div
+            id="form-unavailable"
+            class="form-unavailable"
+            <%= initialForm.embedUrl ? 'hidden' : '' %>
+          >
+            <p id="form-unavailable-message">
+              <%= initialForm.embedUrl
+                ? 'Loading form…'
+                : 'This form must be opened in a new tab.' %>
+            </p>
+            <p class="form-unavailable-hint">
+              Use the button above to open the form in a separate tab.
+            </p>
+          </div>
+        </div>
       <% } else { %>
         <p>No forms available.</p>
       <% } %>
     </div>
   </div>
   <script>
-    function showForm(url, btn) {
-      document.getElementById('form-frame').src = url;
-      document.querySelectorAll('.forms-menu button').forEach(b => b.classList.remove('active'));
-      if (btn) btn.classList.add('active');
-    }
+    (function () {
+      const buttons = Array.from(document.querySelectorAll('[data-open-form]'));
+      if (!buttons.length) {
+        return;
+      }
+      const iframe = document.getElementById('form-frame');
+      const openLink = document.getElementById('form-open-link');
+      const fallback = document.getElementById('form-unavailable');
+      const fallbackMessage = document.getElementById('form-unavailable-message');
+
+      function setActiveButton(activeButton) {
+        buttons.forEach((button) => {
+          button.classList.toggle('active', button === activeButton);
+        });
+      }
+
+      function updateOpenLink(url) {
+        if (!openLink) return;
+        openLink.href = url || '#';
+        const hasUrl = !!url;
+        openLink.classList.toggle('is-disabled', !hasUrl);
+        openLink.setAttribute('aria-disabled', hasUrl ? 'false' : 'true');
+      }
+
+      function showFallback(message) {
+        if (!iframe || !fallback || !fallbackMessage) return;
+        iframe.src = 'about:blank';
+        iframe.hidden = true;
+        fallback.hidden = false;
+        fallbackMessage.textContent = message;
+      }
+
+      function showIframe(embedUrl) {
+        if (!iframe || !fallback) return;
+        if (embedUrl) {
+          iframe.hidden = false;
+          iframe.src = embedUrl;
+          fallback.hidden = true;
+        } else {
+          showFallback('This form must be opened in a new tab.');
+        }
+      }
+
+      function handleSelection(button) {
+        const embedUrl = button.getAttribute('data-embed-url') || '';
+        const directUrl = button.getAttribute('data-direct-url') || '';
+        updateOpenLink(directUrl);
+        setActiveButton(button);
+        if (embedUrl) {
+          showIframe(embedUrl);
+        } else {
+          showFallback('This form must be opened in a new tab.');
+        }
+      }
+
+      buttons.forEach((button) => {
+        button.addEventListener('click', () => handleSelection(button));
+      });
+
+      if (iframe) {
+        iframe.addEventListener('load', () => {
+          if (iframe.hidden) {
+            return;
+          }
+          try {
+            const doc = iframe.contentDocument;
+            if (doc && doc.body?.dataset.formProxyError === 'true') {
+              const message =
+                doc.body.dataset.errorMessage ||
+                'This form could not be embedded securely. Use the button above to open it in a new tab.';
+              showFallback(message);
+            }
+          } catch (err) {
+            // Ignore cross-origin access issues.
+          }
+        });
+      }
+
+      const initialButton =
+        buttons.find((button) => button.classList.contains('active')) || buttons[0];
+      if (initialButton) {
+        handleSelection(initialButton);
+      }
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a secure proxy + iframe route so OpnForm URLs on approved hosts render inside the portal while logging friendly errors
- refresh the Forms page UI with open-in-new-tab controls, fallback messaging, and supporting styles
- document the new FORM_PROXY_ALLOWED_HOSTS setting and record the change in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cabd35f15c832d86dd6897da669e28