### PR TITLE
Harden embedded form sandboxing

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2672,7 +2672,16 @@ app.get('/forms/embed/:formId', ensureAuth, async (req, res) => {
   res.setHeader('Cache-Control', 'no-store');
   res.setHeader(
     'Content-Security-Policy',
-    "default-src 'self' https: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https:; frame-src 'self' https:;"
+    [
+      'sandbox allow-forms allow-scripts',
+      "default-src 'self' https: data: blob:",
+      "script-src 'self' 'unsafe-inline' https:",
+      "style-src 'self' 'unsafe-inline' https:",
+      "img-src 'self' data: https:",
+      "font-src 'self' data: https:",
+      "connect-src 'self' https:",
+      "frame-src 'self' https:"
+    ].join('; ') + ';'
   );
   res.send(html);
 });

--- a/src/views/forms.ejs
+++ b/src/views/forms.ejs
@@ -12,7 +12,14 @@
             <button data-open-form data-embed-url="<%= f.embedPath %>" class="<%= idx === 0 ? 'active' : '' %>"><%= f.name %></button>
           <% }); %>
         </div>
-        <iframe id="form-frame" class="form-frame" src="<%= forms[0].embedPath %>" loading="lazy" title="Selected form"></iframe>
+        <iframe
+          id="form-frame"
+          class="form-frame"
+          src="<%= forms[0].embedPath %>"
+          loading="lazy"
+          title="Selected form"
+          sandbox="allow-forms allow-scripts"
+        ></iframe>
       <% } else { %>
         <p>No forms available.</p>
       <% } %>


### PR DESCRIPTION
## Summary
- add a CSP sandbox to proxied form responses so third-party scripts execute in an isolated origin
- sandbox the forms iframe so embedded content cannot escalate privileges while still supporting scripts and submissions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cb363500e8832d86dde3f73cd06b54