### PR TITLE
Allow WebAuthn flows inside embedded forms

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -12,3 +12,4 @@
 - 2025-09-17, 09:16 UTC, Fix, Updated CSP frame policy to allow embedding OpnForm frames from form.hawkinsit.au
 - 2025-09-17, 09:34 UTC, Feature, Added dynamic template variables for app URLs and documented usage in README
 - 2025-09-17, 14:47 UTC, Fix, Proxied OpnForm embeds through an internal viewer to keep forms inside the portal while honouring template variables
+- 2025-09-17, 15:30 UTC, Fix, Relaxed embedded form sandbox and CSP to support FIDO2 postMessage flows while keeping CSP restrictions

--- a/src/server.ts
+++ b/src/server.ts
@@ -2670,10 +2670,13 @@ app.get('/forms/embed/:formId', ensureAuth, async (req, res) => {
 
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
   res.setHeader('Cache-Control', 'no-store');
+  // Allow the embedded OpnForm experience to use WebAuthn (FIDO2) flows which rely on
+  // postMessage communication and popups. The sandbox is kept while explicitly allowing
+  // the required capabilities and still forcing everything through a restrictive CSP.
   res.setHeader(
     'Content-Security-Policy',
     [
-      'sandbox allow-forms allow-scripts',
+      'sandbox allow-forms allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox',
       "default-src 'self' https: data: blob:",
       "script-src 'self' 'unsafe-inline' https:",
       "style-src 'self' 'unsafe-inline' https:",

--- a/src/views/forms.ejs
+++ b/src/views/forms.ejs
@@ -18,7 +18,8 @@
           src="<%= forms[0].embedPath %>"
           loading="lazy"
           title="Selected form"
-          sandbox="allow-forms allow-scripts"
+          sandbox="allow-forms allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+          allow="publickey-credentials-get *; publickey-credentials-create *"
         ></iframe>
       <% } else { %>
         <p>No forms available.</p>


### PR DESCRIPTION
## Summary
- relax the embedded forms iframe sandbox to permit same-origin messaging, popups, and WebAuthn credential APIs
- align the proxy CSP sandbox directive with the iframe allowances while documenting the rationale
- log the change in the change log for release tracking

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cb39e1ccf0832d9610397c201fc96c