### PR TITLE
Support OpnForm embed snippets for forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,8 @@ to that service so that super admins can launch the builder directly from the
 Forms admin area. See [docs/opnform.md](docs/opnform.md) for deployment and
 security guidance, including the supplied nginx configuration snippet in
 [`deploy/nginx/opnform.conf`](deploy/nginx/opnform.conf).
+
+When registering a form inside MyPortal, paste the OpnForm **Embed** snippet
+(the iframe code) into the Forms admin. The server validates that the embed
+targets the configured OpnForm host, normalises the markup, and stores the
+resolved form URL for secure proxying through MyPortal.

--- a/changes.md
+++ b/changes.md
@@ -13,3 +13,4 @@
 - 2025-09-17, 09:34 UTC, Feature, Added dynamic template variables for app URLs and documented usage in README
 - 2025-09-17, 14:47 UTC, Fix, Proxied OpnForm embeds through an internal viewer to keep forms inside the portal while honouring template variables
 - 2025-09-17, 15:30 UTC, Fix, Relaxed embedded form sandbox and CSP to support FIDO2 postMessage flows while keeping CSP restrictions
+- 2025-09-17, 23:06 UTC, Feature, Enabled OpnForm iframe embed snippets in Forms admin with validation and sanitised storage

--- a/docs/opnform.md
+++ b/docs/opnform.md
@@ -95,8 +95,14 @@ integrations always generate consistent links.
 1. Sign in as the super admin and visit **Admin → Forms**.
 2. Click **Open OpnForm**; the builder should open in a new tab.
 3. Create or update a form in OpnForm and publish it.
-4. Return to MyPortal and refresh the page—the form should appear in the list
-   for assignment to companies and users.
+4. From the OpnForm share dialog, copy the **Embed** snippet (the `<iframe>` code
+   block). MyPortal normalises this HTML and validates that it points to the
+   configured OpnForm host.
+5. Return to MyPortal and, under **Admin → Forms**, paste the embed snippet into
+   the **Embed Code** textarea alongside the form name and description. Submit
+   the form to save it.
+6. Refresh the page—the form will now appear in the list for assignment to
+   companies and users.
 
 Troubleshooting tips:
 

--- a/migrations/060_forms_embed_code.sql
+++ b/migrations/060_forms_embed_code.sql
@@ -1,0 +1,2 @@
+ALTER TABLE forms
+  ADD COLUMN embed_code TEXT NULL AFTER url;

--- a/src/opnform-embed.ts
+++ b/src/opnform-embed.ts
@@ -1,0 +1,149 @@
+import { URL } from 'url';
+
+export interface NormalizedOpnformEmbed {
+  sanitizedEmbedCode: string;
+  formUrl: string;
+}
+
+export interface NormalizeOpnformEmbedOptions {
+  allowedHost?: string | null;
+}
+
+const IFRAME_TAG_REGEX = /<iframe\b[^>]*>/i;
+const SCRIPT_TAG_REGEX = /<script\b[^>]*>[\s\S]*?<\/script>/i;
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&amp;/gi, '&');
+}
+
+function extractAttribute(tag: string, attribute: string): string | null {
+  const attrRegex = new RegExp(
+    `${attribute}\\s*=\\s*(\"([^\"]*)\"|'([^']*)'|([^\\s\"'>]+))`,
+    'i'
+  );
+  const match = tag.match(attrRegex);
+  if (!match) {
+    return null;
+  }
+  return match[2] ?? match[3] ?? match[4] ?? null;
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/'/g, '&#39;');
+}
+
+function sanitizeStyle(value: string): string {
+  const cleaned = value
+    .replace(/\/\*.*?\*\//gs, '')
+    .replace(/[^a-z0-9:;,%#\.\s\-()]/gi, '')
+    .trim();
+  return cleaned;
+}
+
+function normalizeIframeId(id: string | null): string | null {
+  if (!id) {
+    return null;
+  }
+  const trimmed = id.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return /^[A-Za-z][A-Za-z0-9_:\-.]*$/.test(trimmed) ? trimmed : null;
+}
+
+export function normalizeOpnformEmbedCode(
+  rawEmbedCode: string,
+  options: NormalizeOpnformEmbedOptions = {}
+): NormalizedOpnformEmbed {
+  const trimmed = rawEmbedCode.trim();
+  if (!trimmed) {
+    throw new Error('OpnForm embed code is required');
+  }
+
+  const iframeTagMatch = trimmed.match(IFRAME_TAG_REGEX);
+  if (!iframeTagMatch) {
+    throw new Error('OpnForm embed code must include an iframe tag');
+  }
+  const iframeTag = iframeTagMatch[0];
+  const rawSrc = extractAttribute(iframeTag, 'src');
+  if (!rawSrc) {
+    throw new Error('OpnForm iframe is missing a src attribute');
+  }
+
+  const decodedSrc = decodeHtmlEntities(rawSrc).trim();
+  let formUrl: URL;
+  try {
+    formUrl = new URL(decodedSrc);
+  } catch (err) {
+    throw new Error('OpnForm iframe src must be an absolute URL');
+  }
+
+  if (!['http:', 'https:'].includes(formUrl.protocol)) {
+    throw new Error('OpnForm iframe src must use HTTP or HTTPS');
+  }
+
+  const expectedHost = options.allowedHost ?? formUrl.host;
+  if (options.allowedHost && formUrl.host !== expectedHost) {
+    throw new Error('OpnForm iframe host is not allowed');
+  }
+
+  const iframeId = normalizeIframeId(extractAttribute(iframeTag, 'id'));
+  let iframeStyle = extractAttribute(iframeTag, 'style');
+  iframeStyle = iframeStyle ? sanitizeStyle(decodeHtmlEntities(iframeStyle)) : '';
+  if (!iframeStyle) {
+    iframeStyle = 'border:0;width:100%;min-height:480px;';
+  }
+
+  const attrs = [
+    `src="${escapeHtmlAttribute(formUrl.toString())}"`,
+    `style="${escapeHtmlAttribute(iframeStyle)}"`,
+    'loading="lazy"',
+    'allow="publickey-credentials-get *; publickey-credentials-create *"',
+    'title="OpnForm form"',
+  ];
+  if (iframeId) {
+    attrs.push(`id="${escapeHtmlAttribute(iframeId)}"`);
+  }
+
+  let scriptSnippet = '';
+  const scriptTagMatch = trimmed.match(SCRIPT_TAG_REGEX);
+  if (scriptTagMatch) {
+    const scriptTag = scriptTagMatch[0];
+    const rawScriptSrc = extractAttribute(scriptTag, 'src');
+    if (!rawScriptSrc) {
+      throw new Error('OpnForm script embed must include a src attribute');
+    }
+    let scriptUrl: URL;
+    try {
+      scriptUrl = new URL(decodeHtmlEntities(rawScriptSrc).trim(), formUrl);
+    } catch (err) {
+      throw new Error('OpnForm script src must resolve to an absolute URL');
+    }
+    if (!['http:', 'https:'].includes(scriptUrl.protocol)) {
+      throw new Error('OpnForm script src must use HTTP or HTTPS');
+    }
+    if (scriptUrl.host !== expectedHost) {
+      throw new Error('OpnForm script host must match the iframe host');
+    }
+    scriptSnippet = `\n<script src="${escapeHtmlAttribute(
+      scriptUrl.toString()
+    )}" async data-opnform-embed="support"></script>`;
+  }
+
+  const sanitizedEmbedCode = `<iframe ${attrs.join(' ')}></iframe>${scriptSnippet}`;
+
+  return {
+    sanitizedEmbedCode,
+    formUrl: formUrl.toString(),
+  };
+}

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -324,6 +324,7 @@ export interface Form {
   name: string;
   url: string;
   description: string;
+  embed_code: string | null;
 }
 
 export async function getUserByEmail(email: string): Promise<User | null> {
@@ -2300,11 +2301,12 @@ export async function isUserSubscribedToOrder(
 export async function createForm(
   name: string,
   url: string,
+  embedCode: string,
   description: string
 ): Promise<number> {
   const [result] = await pool.execute(
-    'INSERT INTO forms (name, url, description) VALUES (?, ?, ?)',
-    [name, url, description]
+    'INSERT INTO forms (name, url, embed_code, description) VALUES (?, ?, ?, ?)',
+    [name, url, embedCode, description]
   );
   const insert = result as ResultSetHeader;
   return insert.insertId;
@@ -2314,11 +2316,12 @@ export async function updateForm(
   id: number,
   name: string,
   url: string,
+  embedCode: string,
   description: string
 ): Promise<void> {
   await pool.execute(
-    'UPDATE forms SET name = ?, url = ?, description = ? WHERE id = ?',
-    [name, url, description, id]
+    'UPDATE forms SET name = ?, url = ?, embed_code = ?, description = ? WHERE id = ?',
+    [name, url, embedCode, description, id]
   );
 }
 

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -895,7 +895,7 @@
             <h2>Add Form</h2>
             <form action="/forms/admin" method="post">
               <input type="text" name="name" placeholder="Name" required>
-              <input type="url" name="url" placeholder="URL" required>
+              <textarea name="embedCode" placeholder="Paste the OpnForm iframe embed code" rows="4" required></textarea>
               <input type="text" name="description" placeholder="Description">
               <button type="submit">Add</button>
             </form>
@@ -904,13 +904,13 @@
             <h2>Edit Forms</h2>
             <table>
               <thead>
-                <tr><th>Name</th><th>URL</th><th>Description</th><th>Actions</th></tr>
+                <tr><th>Name</th><th>Embed Code</th><th>Description</th><th>Actions</th></tr>
               </thead>
               <tbody>
                 <% forms.forEach(function(f){ %>
                   <tr>
                     <td><input form="form-<%= f.id %>" type="text" name="name" value="<%= f.name %>" required></td>
-                    <td><input form="form-<%= f.id %>" type="url" name="url" value="<%= f.url %>" required></td>
+                    <td><textarea form="form-<%= f.id %>" name="embedCode" rows="4" required><%= f.embedCodeForDisplay %></textarea></td>
                     <td><input form="form-<%= f.id %>" type="text" name="description" value="<%= f.description %>"></td>
                     <td>
                       <form id="form-<%= f.id %>" action="/forms/admin/edit" method="post">

--- a/src/views/forms-admin.ejs
+++ b/src/views/forms-admin.ejs
@@ -28,7 +28,7 @@
         <h2>Add Form</h2>
         <form action="/forms/admin" method="post">
           <input type="text" name="name" placeholder="Name" required>
-          <input type="url" name="url" placeholder="URL" required>
+          <textarea name="embedCode" placeholder="Paste the OpnForm iframe embed code" rows="4" required></textarea>
           <input type="text" name="description" placeholder="Description">
           <button type="submit">Add</button>
         </form>
@@ -37,13 +37,13 @@
         <h2>Edit Forms</h2>
         <table>
           <thead>
-            <tr><th>Name</th><th>URL</th><th>Description</th><th>Actions</th></tr>
+            <tr><th>Name</th><th>Embed Code</th><th>Description</th><th>Actions</th></tr>
           </thead>
           <tbody>
             <% forms.forEach(function(f){ %>
               <tr>
                 <td><input form="form-<%= f.id %>" type="text" name="name" value="<%= f.name %>" required></td>
-                <td><input form="form-<%= f.id %>" type="url" name="url" value="<%= f.url %>" required></td>
+                <td><textarea form="form-<%= f.id %>" name="embedCode" rows="4" required><%= (f.embedCodeForDisplay || f.embed_code || '') %></textarea></td>
                 <td><input form="form-<%= f.id %>" type="text" name="description" value="<%= f.description %>"></td>
                 <td>
                   <form id="form-<%= f.id %>" action="/forms/admin/edit" method="post">


### PR DESCRIPTION
## Summary
- add a migration and helper to normalise OpnForm iframe embed snippets and validate they target the configured host
- update forms administration endpoints to accept embed code, persist the sanitised snippet, and hydrate admin views with safe defaults
- refresh the forms admin UI and documentation to describe pasting OpnForm embed code instead of raw URLs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cb3e3813e0832daf0b298b8aab3a64