### PR TITLE
Serve stored OpnForm embeds when proxy fails

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -14,3 +14,4 @@
 - 2025-09-17, 14:47 UTC, Fix, Proxied OpnForm embeds through an internal viewer to keep forms inside the portal while honouring template variables
 - 2025-09-17, 15:30 UTC, Fix, Relaxed embedded form sandbox and CSP to support FIDO2 postMessage flows while keeping CSP restrictions
 - 2025-09-17, 23:06 UTC, Feature, Enabled OpnForm iframe embed snippets in Forms admin with validation and sanitised storage
+- 2025-09-18, 01:20 UTC, Fix, Served sanitised OpnForm embed snippets directly to avoid upstream fetch failures when loading forms


### PR DESCRIPTION
## Summary
- render stored OpnForm embed snippets directly when forms are loaded to avoid failing upstream proxy calls
- add helpers to rewrite the iframe source with resolved template variables and wrap the snippet in a minimal HTML shell
- log the change in the project changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cb488dd97c832d8b88fe621c460eef