### PR TITLE
Remove external fallback from OpnForm proxy

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -15,3 +15,4 @@
 - 2025-09-17, 15:30 UTC, Fix, Relaxed embedded form sandbox and CSP to support FIDO2 postMessage flows while keeping CSP restrictions
 - 2025-09-17, 23:06 UTC, Feature, Enabled OpnForm iframe embed snippets in Forms admin with validation and sanitised storage
 - 2025-09-18, 01:20 UTC, Fix, Served sanitised OpnForm embed snippets directly to avoid upstream fetch failures when loading forms
+- 2025-09-18, 02:45 UTC, Fix, Always proxy OpnForm content and show an in-portal unavailable message when upstream embedding is blocked


### PR DESCRIPTION
## Summary
- replace the OpnForm proxy fallback page with an in-portal unavailable message so forms stay inside the portal when upstream fetches fail
- update the change log entry to reflect the new fallback behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cb4fb6bd84832d8abe8a12f1907ac3