### PR TITLE
Restore direct form URL management

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ Forms admin area. See [docs/opnform.md](docs/opnform.md) for deployment and
 security guidance, including the supplied nginx configuration snippet in
 [`deploy/nginx/opnform.conf`](deploy/nginx/opnform.conf).
 
-When registering a form inside MyPortal, paste the OpnForm **Embed** snippet
-(the iframe code) into the Forms admin. The server validates that the embed
-targets the configured OpnForm host, normalises the markup, and stores the
-resolved form URL for secure proxying through MyPortal.
+When registering a form inside MyPortal, paste the published OpnForm form URL
+into the Forms admin. The server validates that the URL targets the expected
+OpnForm host (when configured) and stores it for secure proxying through
+MyPortal. Template variables remain available so query string parameters can be
+personalised for the current user and company.

--- a/changes.md
+++ b/changes.md
@@ -16,3 +16,4 @@
 - 2025-09-17, 23:06 UTC, Feature, Enabled OpnForm iframe embed snippets in Forms admin with validation and sanitised storage
 - 2025-09-18, 01:20 UTC, Fix, Served sanitised OpnForm embed snippets directly to avoid upstream fetch failures when loading forms
 - 2025-09-18, 02:45 UTC, Fix, Always proxy OpnForm content and show an in-portal unavailable message when upstream embedding is blocked
+- 2025-09-18, 04:10 UTC, Fix, Restored direct OpnForm URL management in Forms admin instead of requiring iframe embed snippets

--- a/docs/opnform.md
+++ b/docs/opnform.md
@@ -95,12 +95,11 @@ integrations always generate consistent links.
 1. Sign in as the super admin and visit **Admin → Forms**.
 2. Click **Open OpnForm**; the builder should open in a new tab.
 3. Create or update a form in OpnForm and publish it.
-4. From the OpnForm share dialog, copy the **Embed** snippet (the `<iframe>` code
-   block). MyPortal normalises this HTML and validates that it points to the
-   configured OpnForm host.
-5. Return to MyPortal and, under **Admin → Forms**, paste the embed snippet into
-   the **Embed Code** textarea alongside the form name and description. Submit
-   the form to save it.
+4. From the OpnForm share dialog, copy the public form URL. MyPortal validates
+   that the URL points to the configured OpnForm host.
+5. Return to MyPortal and, under **Admin → Forms**, paste the URL into the
+   **Form URL** field alongside the form name and description. Submit the form
+   to save it.
 6. Refresh the page—the form will now appear in the list for assignment to
    companies and users.
 

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -2301,7 +2301,7 @@ export async function isUserSubscribedToOrder(
 export async function createForm(
   name: string,
   url: string,
-  embedCode: string,
+  embedCode: string | null,
   description: string
 ): Promise<number> {
   const [result] = await pool.execute(
@@ -2316,7 +2316,7 @@ export async function updateForm(
   id: number,
   name: string,
   url: string,
-  embedCode: string,
+  embedCode: string | null,
   description: string
 ): Promise<void> {
   await pool.execute(

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -895,7 +895,7 @@
             <h2>Add Form</h2>
             <form action="/forms/admin" method="post">
               <input type="text" name="name" placeholder="Name" required>
-              <textarea name="embedCode" placeholder="Paste the OpnForm iframe embed code" rows="4" required></textarea>
+              <input type="text" name="url" placeholder="https://forms.example.com/your-form" required>
               <input type="text" name="description" placeholder="Description">
               <button type="submit">Add</button>
             </form>
@@ -904,13 +904,13 @@
             <h2>Edit Forms</h2>
             <table>
               <thead>
-                <tr><th>Name</th><th>Embed Code</th><th>Description</th><th>Actions</th></tr>
+                <tr><th>Name</th><th>URL</th><th>Description</th><th>Actions</th></tr>
               </thead>
               <tbody>
                 <% forms.forEach(function(f){ %>
                   <tr>
                     <td><input form="form-<%= f.id %>" type="text" name="name" value="<%= f.name %>" required></td>
-                    <td><textarea form="form-<%= f.id %>" name="embedCode" rows="4" required><%= f.embedCodeForDisplay %></textarea></td>
+                    <td><input form="form-<%= f.id %>" type="text" name="url" value="<%= f.url %>" required></td>
                     <td><input form="form-<%= f.id %>" type="text" name="description" value="<%= f.description %>"></td>
                     <td>
                       <form id="form-<%= f.id %>" action="/forms/admin/edit" method="post">

--- a/src/views/forms-admin.ejs
+++ b/src/views/forms-admin.ejs
@@ -28,7 +28,7 @@
         <h2>Add Form</h2>
         <form action="/forms/admin" method="post">
           <input type="text" name="name" placeholder="Name" required>
-          <textarea name="embedCode" placeholder="Paste the OpnForm iframe embed code" rows="4" required></textarea>
+          <input type="text" name="url" placeholder="https://forms.example.com/your-form" required>
           <input type="text" name="description" placeholder="Description">
           <button type="submit">Add</button>
         </form>
@@ -37,13 +37,13 @@
         <h2>Edit Forms</h2>
         <table>
           <thead>
-            <tr><th>Name</th><th>Embed Code</th><th>Description</th><th>Actions</th></tr>
+            <tr><th>Name</th><th>URL</th><th>Description</th><th>Actions</th></tr>
           </thead>
           <tbody>
             <% forms.forEach(function(f){ %>
               <tr>
                 <td><input form="form-<%= f.id %>" type="text" name="name" value="<%= f.name %>" required></td>
-                <td><textarea form="form-<%= f.id %>" name="embedCode" rows="4" required><%= (f.embedCodeForDisplay || f.embed_code || '') %></textarea></td>
+                <td><input form="form-<%= f.id %>" type="text" name="url" value="<%= f.url %>" required></td>
                 <td><input form="form-<%= f.id %>" type="text" name="description" value="<%= f.description %>"></td>
                 <td>
                   <form id="form-<%= f.id %>" action="/forms/admin/edit" method="post">


### PR DESCRIPTION
## Summary
- allow super admins to register OpnForm entries by URL again with strict host and protocol validation
- update admin interfaces and persistence layer to work with direct URLs and drop the embed snippet requirement
- refresh OpnForm documentation and change log to reflect the restored workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cbabb3abbc832d99d21f0172ec90e1