### PR TITLE
Add Discord stock alerts configuration and notifications

### DIFF
--- a/migrations/060_shop_discord_webhook.sql
+++ b/migrations/060_shop_discord_webhook.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS shop_settings (
+  id INT PRIMARY KEY,
+  discord_webhook_url VARCHAR(500) NULL
+);
+
+INSERT INTO shop_settings (id, discord_webhook_url)
+VALUES (1, NULL)
+ON DUPLICATE KEY UPDATE discord_webhook_url = discord_webhook_url;

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -1028,6 +1028,24 @@
         <% } %>
         <div id="shop-settings" class="tab-content">
           <section>
+            <h2>Discord Webhook Alerts</h2>
+            <form action="/shop/admin/discord-webhook" method="post">
+              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+              <label>Webhook URL
+                <input
+                  type="url"
+                  name="discordWebhookUrl"
+                  value="<%= shopSettings && shopSettings.discord_webhook_url ? shopSettings.discord_webhook_url : '' %>"
+                  placeholder="https://discord.com/api/webhooks/..."
+                >
+              </label>
+              <p class="hint">
+                The webhook will receive notifications when products go out of stock or return to stock.
+              </p>
+              <button type="submit">Save</button>
+            </form>
+          </section>
+          <section>
             <h2>Categories</h2>
             <form action="/shop/admin/category" method="post">
               <input type="text" name="name" placeholder="Name" required>


### PR DESCRIPTION
## Summary
- add a Discord webhook form to the shop settings page so admins can opt in to stock alerts
- store the webhook URL in a new shop_settings table and expose queries for reading and updating it
- trigger Discord notifications whenever product stock moves between in stock and out of stock, including feed updates, admin edits, and order flows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d4c6f06c20832d93faf1c7809d6d9c