### PR TITLE
Add virtualenv bootstrapper for editable installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,18 +48,28 @@ gracefully fall back to an empty string.
 ## Setup
 
 1. Ensure Python 3.10+ is available.
-2. Install dependencies:
+2. Create a project-local virtual environment so `pip install -e .` does not conflict with externally managed Python installations:
    ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows use: .\.venv\\Scripts\\activate
+   ```
+   The helper script below automates the process and installs dependencies in one step. Pass `--recreate` to rebuild the environment from scratch.
+   ```bash
+   python scripts/bootstrap_venv.py
+   ```
+3. If you did not run the bootstrap script, upgrade pip inside the virtual environment and install dependencies:
+   ```bash
+   python -m pip install --upgrade pip
    pip install -e .
    ```
-3. Copy `.env.example` to `.env` and update the MySQL credentials. Define strong values for `SESSION_SECRET` and `TOTP_ENCRYPTION_KEY`. Optional settings such as Redis, SMTP, and Azure Graph credentials mirror the legacy environment variables.
-4. Start the development server:
+4. Copy `.env.example` to `.env` and update the MySQL credentials. Define strong values for `SESSION_SECRET` and `TOTP_ENCRYPTION_KEY`. Optional settings such as Redis, SMTP, and Azure Graph credentials mirror the legacy environment variables.
+5. Start the development server:
    ```bash
    uvicorn app.main:app --reload
    ```
    On startup the application automatically applies any pending SQL migrations and ensures the database exists.
-5. Access `http://localhost:8000` for the responsive portal UI or `http://localhost:8000/docs` for the interactive Swagger UI covering every API endpoint.
-6. The first visit will redirect the login flow to the registration page if no users exist, ensuring the first account becomes the super administrator.
+6. Access `http://localhost:8000` for the responsive portal UI or `http://localhost:8000/docs` for the interactive Swagger UI covering every API endpoint.
+7. The first visit will redirect the login flow to the registration page if no users exist, ensuring the first account becomes the super administrator.
 
 ## Office 365 Sync
 

--- a/changes.md
+++ b/changes.md
@@ -22,3 +22,4 @@
 - 2025-09-18, 07:28 UTC, Change, Migrated forms routes from /forms to /myforms with documentation, nginx, and template updates plus legacy redirects
 - 2025-09-18, 08:30 UTC, Feature, Rebuilt the MyPortal backend and UI in Python with FastAPI, async MySQL access, and responsive 3-panel theming
 - 2025-09-18, 09:05 UTC, Fix, Replaced binary image assets with SVG icons to unblock PR creation and retain themeable layout
+- 2025-10-07, 11:53 UTC, Fix, Added a virtual environment bootstrap script and README guidance to bypass externally managed pip install failures

--- a/scripts/bootstrap_venv.py
+++ b/scripts/bootstrap_venv.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Create a local virtual environment and install MyPortal in editable mode."""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import venv
+from pathlib import Path
+
+
+def _venv_python(venv_path: Path) -> Path:
+    if os.name == "nt":
+        return venv_path / "Scripts" / "python.exe"
+    return venv_path / "bin" / "python"
+
+
+def ensure_virtualenv(venv_path: Path, recreate: bool = False) -> Path:
+    if recreate and venv_path.exists():
+        shutil.rmtree(venv_path)
+
+    if not venv_path.exists():
+        builder = venv.EnvBuilder(with_pip=True)
+        builder.create(venv_path)
+
+    python_executable = _venv_python(venv_path)
+    if not python_executable.exists():
+        raise RuntimeError("Virtual environment python executable was not created correctly.")
+
+    return python_executable
+
+
+def install_editable(project_root: Path, python_executable: Path) -> None:
+    env = os.environ.copy()
+    env.setdefault("PIP_DISABLE_PIP_VERSION_CHECK", "1")
+
+    subprocess.check_call(
+        [str(python_executable), "-m", "pip", "install", "--upgrade", "pip"],
+        cwd=str(project_root),
+        env=env,
+    )
+    subprocess.check_call(
+        [str(python_executable), "-m", "pip", "install", "-e", str(project_root)],
+        cwd=str(project_root),
+        env=env,
+    )
+
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bootstrap a dedicated virtual environment so that `pip install -e .` "
+            "works even on systems with externally managed Python installations."
+        )
+    )
+    parser.add_argument(
+        "--recreate",
+        action="store_true",
+        help="Recreate the .venv directory instead of reusing the existing environment.",
+    )
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parents[1]
+    venv_path = project_root / ".venv"
+
+    python_executable = ensure_virtualenv(venv_path, recreate=args.recreate)
+    install_editable(project_root, python_executable)
+
+    if os.name == "nt":
+        activation_command = r".\\.venv\\Scripts\\activate"
+    else:
+        activation_command = "source .venv/bin/activate"
+
+    print(
+        "MyPortal has been installed in editable mode inside .venv.\n"
+        f"Run `{activation_command}` to activate the environment before development sessions."
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(exc.returncode) from exc


### PR DESCRIPTION
## Summary
- add a Python bootstrap script that provisions a local virtual environment and performs the editable install
- update the setup documentation to direct developers to the new flow and document the change in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e4feda4508832dbbaa47d84324446b