### PR TITLE
Allow extra env vars in settings

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -38,7 +38,11 @@ class Settings(BaseSettings):
     enable_csrf: bool = Field(default=True, alias="ENABLE_CSRF")
     swagger_ui_url: str = Field(default="/docs", alias="SWAGGER_UI_URL")
 
-    model_config = SettingsConfigDict(env_file=(Path(__file__).resolve().parent.parent.parent / ".env"), env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_file=(Path(__file__).resolve().parent.parent.parent / ".env"),
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
 
 
 class TemplatesConfig(BaseModel):

--- a/changes.md
+++ b/changes.md
@@ -23,3 +23,4 @@
 - 2025-09-18, 08:30 UTC, Feature, Rebuilt the MyPortal backend and UI in Python with FastAPI, async MySQL access, and responsive 3-panel theming
 - 2025-09-18, 09:05 UTC, Fix, Replaced binary image assets with SVG icons to unblock PR creation and retain themeable layout
 - 2025-10-07, 11:53 UTC, Fix, Added a virtual environment bootstrap script and README guidance to bypass externally managed pip install failures
+- 2025-10-07, 12:00 UTC, Fix, Allowed extra environment variables in Python settings loader to restore API startup


### PR DESCRIPTION
## Summary
- allow the Settings loader to ignore extra environment variables while still reading the project .env file
- document the configuration fix in the change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e500c8affc832d98aa0f5a0346aacf