### PR TITLE
Guard aiomysql connection shutdown for compatibility

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -79,7 +79,9 @@ class Database:
                 f"CREATE DATABASE IF NOT EXISTS `{self._settings.database_name}`"
             )
         temp_conn.close()
-        await temp_conn.wait_closed()
+        wait_closed = getattr(temp_conn, "wait_closed", None)
+        if wait_closed:
+            await wait_closed()
 
         await self.connect()
         migrations_dir = Path(__file__).resolve().parent.parent.parent / "migrations"

--- a/changes.md
+++ b/changes.md
@@ -25,3 +25,4 @@
 - 2025-10-07, 11:53 UTC, Fix, Added a virtual environment bootstrap script and README guidance to bypass externally managed pip install failures
 - 2025-10-07, 12:00 UTC, Fix, Allowed extra environment variables in Python settings loader to restore API startup
 - 2025-10-07, 12:10 UTC, Fix, Switched configuration fields to validation aliases so startup accepts secret and database env vars
+- 2025-10-07, 12:30 UTC, Fix, Guarded MySQL bootstrap connection shutdown to support aiomysql versions without wait_closed


### PR DESCRIPTION
## Summary
- guard the temporary aiomysql connection shutdown to avoid calling wait_closed when unavailable
- log the fix in the project change history

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e504297ca0832d908851cd912985ba