### PR TITLE
Add session-aware login and registration views

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -62,13 +62,211 @@ body {
   text-decoration: none;
   padding: 0.75rem 1rem;
   border-radius: 0.75rem;
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
   background: rgba(148, 163, 184, 0.08);
   transition: background 0.2s ease;
 }
 
-.menu__item a:hover {
+.menu__item a:hover,
+.menu__item a:focus {
   background: rgba(148, 163, 184, 0.25);
+}
+
+.menu__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.menu__icon svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: currentColor;
+  opacity: 0.85;
+}
+
+.menu__label {
+  font-weight: 500;
+}
+
+.button,
+.button-link {
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+}
+
+.button {
+  padding: 0.9rem 1.5rem;
+  color: #0f172a;
+  background: #38bdf8;
+  border: none;
+  box-shadow: 0 18px 30px -18px rgba(56, 189, 248, 0.8);
+}
+
+.button:focus,
+.button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 36px -16px rgba(56, 189, 248, 0.9);
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(148, 163, 184, 0.35);
+  outline-offset: 2px;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.button-link {
+  background: none;
+  border: none;
+  color: #38bdf8;
+  padding: 0;
+  text-decoration: none;
+}
+
+.button-link:hover,
+.button-link:focus {
+  color: #7dd3fc;
+  text-decoration: underline;
+}
+
+.button-link:focus-visible {
+  outline: 2px solid rgba(148, 163, 184, 0.6);
+  outline-offset: 2px;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 560px;
+  margin: 0 auto;
+  background: rgba(30, 41, 59, 0.9);
+  border-radius: 1.25rem;
+  padding: 2.25rem;
+  box-shadow: 0 30px 60px -30px rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.auth-card__header {
+  margin-bottom: 2rem;
+}
+
+.auth-card__title {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.auth-card__subtitle {
+  margin: 0.75rem 0 0;
+  color: rgba(226, 232, 240, 0.85);
+  line-height: 1.5;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.auth-form.is-loading {
+  opacity: 0.85;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.form-label {
+  font-weight: 600;
+  color: #e2e8f0;
+}
+
+.form-input-wrapper {
+  position: relative;
+}
+
+.form-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.75);
+  color: #f8fafc;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.form-help {
+  margin: -0.5rem 0 0;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.form-error {
+  border-radius: 0.85rem;
+  padding: 0.9rem 1rem;
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+  font-weight: 600;
+}
+
+.form-error[hidden] {
+  display: none;
+}
+
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: flex-end;
+}
+
+.form-actions--stacked {
+  justify-content: flex-start;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+@media (max-width: 640px) {
+  .auth-card {
+    padding: 1.75rem;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .layout__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
 }
 
 .layout__main {

--- a/app/static/js/auth.js
+++ b/app/static/js/auth.js
@@ -1,0 +1,211 @@
+const initAuthForms = () => {
+  const forms = document.querySelectorAll('[data-auth-form]');
+  forms.forEach((form) => new AuthForm(form));
+};
+
+class AuthForm {
+  constructor(form) {
+    this.form = form;
+    this.endpoint = form.dataset.endpoint;
+    this.successRedirect = form.dataset.successRedirect || '/';
+    this.loadingText = form.dataset.loadingText || 'Submitting…';
+    this.submitButton = form.querySelector('[data-auth-submit]');
+    this.errorContainer = form.querySelector('[data-auth-error]');
+    this.totpField = form.querySelector('[data-totp-field]');
+    this.totpToggle = form.querySelector('[data-auth-toggle-totp]');
+    this.defaultButtonLabel = this.submitButton ? this.submitButton.textContent : '';
+
+    form.addEventListener('submit', (event) => this.handleSubmit(event));
+
+    if (this.totpToggle && this.totpField) {
+      this.totpToggle.setAttribute('aria-expanded', this.totpField.hasAttribute('hidden') ? 'false' : 'true');
+      this.totpToggle.addEventListener('click', (event) => this.toggleTotp(event));
+    }
+  }
+
+  toggleTotp(event) {
+    event.preventDefault();
+    if (!this.totpField || !this.totpToggle) {
+      return;
+    }
+
+    const isHidden = this.totpField.hasAttribute('hidden');
+    if (isHidden) {
+      this.totpField.removeAttribute('hidden');
+      this.totpField.setAttribute('aria-hidden', 'false');
+      this.totpToggle.textContent = 'Hide authenticator code';
+      this.totpToggle.setAttribute('aria-expanded', 'true');
+      const input = this.totpField.querySelector('input');
+      if (input) {
+        window.requestAnimationFrame(() => input.focus());
+      }
+    } else {
+      this.totpField.setAttribute('hidden', '');
+      this.totpField.setAttribute('aria-hidden', 'true');
+      this.totpToggle.textContent = 'Use authenticator code';
+      this.totpToggle.setAttribute('aria-expanded', 'false');
+      const input = this.totpField.querySelector('input');
+      if (input) {
+        input.value = '';
+      }
+    }
+  }
+
+  async handleSubmit(event) {
+    event.preventDefault();
+    if (!this.endpoint) {
+      this.showError('Authentication endpoint is not configured.');
+      return;
+    }
+
+    this.showError('');
+
+    const payload = this.buildPayload();
+    if (!payload) {
+      return;
+    }
+
+    this.setLoading(true);
+
+    try {
+      const response = await fetch(this.endpoint, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const result = await this.parseJson(response);
+
+      if (!response.ok) {
+        const detail = this.extractDetail(result) || 'Unable to complete the request. Check your credentials and try again.';
+        this.showError(detail);
+        return;
+      }
+
+      window.location.assign(this.successRedirect);
+    } catch (error) {
+      console.error('Authentication request failed', error);
+      this.showError('A network error occurred while contacting the server. Please try again.');
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
+  buildPayload() {
+    const formData = new FormData(this.form);
+    const payload = {};
+
+    for (const [key, value] of formData.entries()) {
+      if (typeof value !== 'string') {
+        continue;
+      }
+
+      if (!value && key !== 'password') {
+        continue;
+      }
+
+      if (key === 'password') {
+        payload[key] = value;
+        continue;
+      }
+
+      const trimmed = value.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      if (key === 'totp_code') {
+        if (this.totpField && this.totpField.hasAttribute('hidden')) {
+          continue;
+        }
+        payload[key] = trimmed.replace(/\s+/g, '');
+        continue;
+      }
+
+      if (key === 'company_id') {
+        const numeric = Number(trimmed);
+        if (!Number.isNaN(numeric)) {
+          payload[key] = numeric;
+        }
+        continue;
+      }
+
+      payload[key] = trimmed;
+    }
+
+    return payload;
+  }
+
+  async parseJson(response) {
+    try {
+      return await response.json();
+    } catch (error) {
+      console.warn('Failed to parse JSON response', error);
+      return null;
+    }
+  }
+
+  extractDetail(result) {
+    if (!result) {
+      return '';
+    }
+
+    if (typeof result.detail === 'string') {
+      return result.detail;
+    }
+
+    if (Array.isArray(result.detail) && result.detail.length > 0) {
+      const first = result.detail[0];
+      if (typeof first === 'string') {
+        return first;
+      }
+      if (first && typeof first.msg === 'string') {
+        return first.msg;
+      }
+    }
+
+    if (result.message && typeof result.message === 'string') {
+      return result.message;
+    }
+
+    return '';
+  }
+
+  showError(message) {
+    if (!this.errorContainer) {
+      return;
+    }
+
+    if (!message) {
+      this.errorContainer.setAttribute('hidden', '');
+      this.errorContainer.textContent = '';
+      return;
+    }
+
+    this.errorContainer.removeAttribute('hidden');
+    this.errorContainer.textContent = message;
+  }
+
+  setLoading(isLoading) {
+    if (this.submitButton) {
+      this.submitButton.disabled = isLoading;
+      this.submitButton.textContent = isLoading ? this.loadingText : this.defaultButtonLabel;
+    }
+
+    if (isLoading) {
+      this.form.classList.add('is-loading');
+    } else {
+      this.form.classList.remove('is-loading');
+    }
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initAuthForms);
+} else {
+  initAuthForms();
+}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -1,0 +1,108 @@
+{% extends "base.html" %}
+
+{% set title = "Sign in" %}
+
+{% block sidebar_menu %}
+<li class="menu__item">
+  <a href="/login" aria-current="page">
+    <span class="menu__icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M10 4h10a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H10a1 1 0 0 1-1-1v-3h2v2h8V6h-8v2H9V5a1 1 0 0 1 1-1zm-1.707 7.293 2.586-2.586L12.293 10.12 10.414 12l1.879 1.879-1.414 1.414-2.586-2.586a1 1 0 0 1 0-1.414z"/></svg>
+    </span>
+    <span class="menu__label">Sign in</span>
+  </a>
+</li>
+<li class="menu__item">
+  <a href="/docs">
+    <span class="menu__icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M6 3h9l5 5v13a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm8 6V4.5L18.5 9H14z"/></svg>
+    </span>
+    <span class="menu__label">API Docs</span>
+  </a>
+</li>
+{% endblock %}
+
+{% block header_actions %}
+<a class="button-link" href="/docs" aria-label="Open API documentation">Swagger UI</a>
+{% endblock %}
+
+{% block content %}
+<div class="auth-card">
+  <header class="auth-card__header">
+    <h1 class="auth-card__title">Welcome back</h1>
+    <p class="auth-card__subtitle">Use your portal credentials to access the dashboard.</p>
+  </header>
+  <form
+    class="auth-form"
+    method="post"
+    data-auth-form
+    data-endpoint="/auth/login"
+    data-loading-text="Signing in&hellip;"
+    data-success-redirect="/"
+    novalidate
+  >
+    <div class="form-field">
+      <label class="form-label" for="login-email">Email address</label>
+      <div class="form-input-wrapper">
+        <input
+          id="login-email"
+          class="form-input"
+          type="email"
+          name="email"
+          autocomplete="username"
+          required
+          placeholder="you@example.com"
+        />
+      </div>
+    </div>
+    <div class="form-field">
+      <label class="form-label" for="login-password">Password</label>
+      <div class="form-input-wrapper">
+        <input
+          id="login-password"
+          class="form-input"
+          type="password"
+          name="password"
+          autocomplete="current-password"
+          required
+          minlength="8"
+          placeholder="••••••••"
+        />
+      </div>
+    </div>
+    <div class="form-field" id="login-totp-field" data-totp-field hidden aria-hidden="true">
+      <label class="form-label" for="login-totp">Authenticator code</label>
+      <div class="form-input-wrapper">
+        <input
+          id="login-totp"
+          class="form-input"
+          type="text"
+          name="totp_code"
+          inputmode="numeric"
+          pattern="[0-9]{6}"
+          autocomplete="one-time-code"
+          placeholder="123456"
+        />
+      </div>
+    </div>
+    <div class="form-actions form-actions--stacked">
+      <button
+        type="button"
+        class="button-link"
+        data-auth-toggle-totp
+        aria-controls="login-totp-field"
+      >
+        Use authenticator code
+      </button>
+    </div>
+    <p class="form-help">Forgotten your password? Contact a super administrator to trigger a reset email.</p>
+    <div class="form-error" role="alert" data-auth-error hidden></div>
+    <div class="form-actions">
+      <button type="submit" class="button" data-auth-submit>Sign in</button>
+    </div>
+  </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script type="module" src="/static/js/auth.js"></script>
+{% endblock %}

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -1,0 +1,145 @@
+{% extends "base.html" %}
+
+{% set title = "Create super administrator" %}
+
+{% block sidebar_menu %}
+<li class="menu__item">
+  <a href="/register" aria-current="page">
+    <span class="menu__icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5zm0 2c-4.35 0-8 2.24-8 5v1h16v-1c0-2.76-3.65-5-8-5zm9-11h-3V2h3a1 1 0 0 1 1 1v3h-2zM5 6H3V3a1 1 0 0 1 1-1h3v2H5zm16 13h-2v2h-3v-2h3v-3h2zm-16 0H3v-3H1v-2h3v3h3v2H5z"/></svg>
+    </span>
+    <span class="menu__label">Register</span>
+  </a>
+</li>
+<li class="menu__item">
+  <a href="/login">
+    <span class="menu__icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M14 4H4a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1v-3h-2v2H5V6h8v2h2V5a1 1 0 0 0-1-1zm1.707 7.293-2.586-2.586L11.707 10.12 13.586 12l-1.879 1.879 1.414 1.414 2.586-2.586a1 1 0 0 0 0-1.414z"/></svg>
+    </span>
+    <span class="menu__label">Sign in</span>
+  </a>
+</li>
+{% endblock %}
+
+{% block header_actions %}
+<a class="button-link" href="/login">Already registered?</a>
+{% endblock %}
+
+{% block content %}
+<div class="auth-card">
+  <header class="auth-card__header">
+    <h1 class="auth-card__title">Create the first account</h1>
+    <p class="auth-card__subtitle">
+      Set up the super administrator who will manage users, companies, and security settings for {{ app_name }}.
+    </p>
+  </header>
+  <form
+    class="auth-form"
+    method="post"
+    data-auth-form
+    data-endpoint="/auth/register"
+    data-loading-text="Creating account&hellip;"
+    data-success-redirect="/"
+    novalidate
+  >
+    <div class="form-grid">
+      <div class="form-field">
+        <label class="form-label" for="register-first-name">First name</label>
+        <div class="form-input-wrapper">
+          <input
+            id="register-first-name"
+            class="form-input"
+            type="text"
+            name="first_name"
+            autocomplete="given-name"
+            placeholder="Alex"
+            required
+          />
+        </div>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="register-last-name">Last name</label>
+        <div class="form-input-wrapper">
+          <input
+            id="register-last-name"
+            class="form-input"
+            type="text"
+            name="last_name"
+            autocomplete="family-name"
+            placeholder="Rivera"
+            required
+          />
+        </div>
+      </div>
+    </div>
+    <div class="form-field">
+      <label class="form-label" for="register-email">Work email</label>
+      <div class="form-input-wrapper">
+        <input
+          id="register-email"
+          class="form-input"
+          type="email"
+          name="email"
+          autocomplete="email"
+          required
+          placeholder="admin@example.com"
+        />
+      </div>
+    </div>
+    <div class="form-field">
+      <label class="form-label" for="register-password">Password</label>
+      <div class="form-input-wrapper">
+        <input
+          id="register-password"
+          class="form-input"
+          type="password"
+          name="password"
+          autocomplete="new-password"
+          minlength="12"
+          required
+          placeholder="Use a strong password"
+        />
+      </div>
+      <p class="form-help">Passwords must be at least 12 characters and will be stored using bcrypt hashing.</p>
+    </div>
+    <div class="form-grid">
+      <div class="form-field">
+        <label class="form-label" for="register-phone">Mobile phone (optional)</label>
+        <div class="form-input-wrapper">
+          <input
+            id="register-phone"
+            class="form-input"
+            type="tel"
+            name="mobile_phone"
+            autocomplete="tel"
+            placeholder="+61 400 000 000"
+          />
+        </div>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="register-company">Company ID (optional)</label>
+        <div class="form-input-wrapper">
+          <input
+            id="register-company"
+            class="form-input"
+            type="number"
+            min="1"
+            step="1"
+            name="company_id"
+            placeholder="1234"
+          />
+        </div>
+      </div>
+    </div>
+    <p class="form-help">You can associate the super administrator with a company now or later from the admin area.</p>
+    <div class="form-error" role="alert" data-auth-error hidden></div>
+    <div class="form-actions">
+      <button type="submit" class="button" data-auth-submit>Create account</button>
+    </div>
+  </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script type="module" src="/static/js/auth.js"></script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -6,6 +6,7 @@
     <title>{{ app_name }} - {{ title | default('Dashboard') }}</title>
     <link rel="stylesheet" href="/static/css/app.css" />
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg" />
+    {% block extra_head %}{% endblock %}
   </head>
   <body class="theme-default">
     <div class="layout">
@@ -15,8 +16,24 @@
           <span class="brand__name">{{ app_name }}</span>
         </div>
         <ul class="menu">
-          <li class="menu__item"><a href="/">Dashboard</a></li>
-          <li class="menu__item"><a href="/docs">API Docs</a></li>
+          {% block sidebar_menu %}
+          <li class="menu__item">
+            <a href="/">
+              <span class="menu__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false"><path d="M3 10.5 12 3l9 7.5V21a1 1 0 0 1-1 1h-5v-6h-6v6H4a1 1 0 0 1-1-1z"/></svg>
+              </span>
+              <span class="menu__label">Dashboard</span>
+            </a>
+          </li>
+          <li class="menu__item">
+            <a href="/docs">
+              <span class="menu__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false"><path d="M6 3h9l5 5v13a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm8 6V4.5L18.5 9H14z"/></svg>
+              </span>
+              <span class="menu__label">API Docs</span>
+            </a>
+          </li>
+          {% endblock %}
         </ul>
       </nav>
       <main class="layout__main">
@@ -29,5 +46,6 @@
         </section>
       </main>
     </div>
+    {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/changes.md
+++ b/changes.md
@@ -29,4 +29,5 @@
 
 - 2025-10-07, 12:30 UTC, Fix, Guarded MySQL bootstrap connection shutdown to support aiomysql versions without wait_closed
 - 2025-10-07, 12:36 UTC, Feature, Added FastAPI session management, CSRF middleware, login rate limiting, password reset, and TOTP flows with documented endpoints
+- 2025-10-08, 00:58 UTC, Feature, Delivered responsive login and super-admin registration pages with session-aware redirects and client-side MFA support
 - 2025-10-09, 13:05 UTC, Feature, Documented legacy Node.js parity gaps and outlined restoration tasks in docs/node-parity-gap.md


### PR DESCRIPTION
## Summary
- add session-aware `/login` and `/register` routes that gate access based on existing users and active sessions
- create responsive authentication templates with client-side MFA handling and shared fetch logic
- refresh the base layout and styles with iconised navigation, reusable button styles, and auth form components

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e5b622cf2c832d845b6c2dc15262c9