### PR TITLE
Handle long passwords with SHA-256 + bcrypt

### DIFF
--- a/app/security/passwords.py
+++ b/app/security/passwords.py
@@ -1,14 +1,35 @@
 from __future__ import annotations
 
-from passlib.context import CryptContext
+from hashlib import sha256
+
+import bcrypt
 
 
-_pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+_BCRYPT_SHA256_PREFIX = "bcrypt_sha256$"
+# Prefix indicating passwords hashed via SHA-256 pre-hashing and bcrypt.
 
 
 def hash_password(password: str) -> str:
-    return _pwd_context.hash(password)
+    digest = sha256(password.encode("utf-8")).digest()
+    hashed = bcrypt.hashpw(digest, bcrypt.gensalt())
+    return f"{_BCRYPT_SHA256_PREFIX}{hashed.decode()}"
 
 
 def verify_password(password: str, hashed: str) -> bool:
-    return _pwd_context.verify(password, hashed)
+    password_bytes = password.encode("utf-8")
+
+    if hashed.startswith(_BCRYPT_SHA256_PREFIX):
+        digest = sha256(password_bytes).digest()
+        stored = hashed[len(_BCRYPT_SHA256_PREFIX) :].encode()
+        try:
+            return bcrypt.checkpw(digest, stored)
+        except ValueError:
+            return False
+
+    try:
+        return bcrypt.checkpw(password_bytes, hashed.encode())
+    except ValueError:
+        # bcrypt raises ValueError when the candidate password exceeds its 72-byte
+        # limit. Treat this as a failed verification to avoid leaking errors during
+        # authentication attempts.
+        return False

--- a/changes.md
+++ b/changes.md
@@ -31,3 +31,4 @@
 - 2025-10-07, 12:36 UTC, Feature, Added FastAPI session management, CSRF middleware, login rate limiting, password reset, and TOTP flows with documented endpoints
 - 2025-10-08, 00:58 UTC, Feature, Delivered responsive login and super-admin registration pages with session-aware redirects and client-side MFA support
 - 2025-10-09, 13:05 UTC, Feature, Documented legacy Node.js parity gaps and outlined restoration tasks in docs/node-parity-gap.md
+- 2025-10-09, 15:42 UTC, Fix, Switched password hashing to bcrypt_sha256 to support long credentials without login failures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+os.environ.setdefault("SESSION_SECRET", "test-session-secret")
+os.environ.setdefault("TOTP_ENCRYPTION_KEY", "A" * 64)
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_USER", "user")
+os.environ.setdefault("DB_PASSWORD", "password")
+os.environ.setdefault("DB_NAME", "testdb")

--- a/tests/test_passwords.py
+++ b/tests/test_passwords.py
@@ -1,0 +1,42 @@
+import importlib.util
+from pathlib import Path
+
+import bcrypt
+import pytest
+
+
+MODULE_NAME = "app.security.passwords"
+MODULE_PATH = Path(__file__).resolve().parents[1] / "app" / "security" / "passwords.py"
+
+spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+passwords = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(passwords)  # type: ignore[union-attr]
+
+hash_password = passwords.hash_password
+verify_password = passwords.verify_password
+
+
+def test_hash_allows_passwords_longer_than_bcrypt_limit():
+    password = "A" * 100
+    hashed = hash_password(password)
+
+    assert hashed.startswith("bcrypt_sha256$")
+    assert verify_password(password, hashed)
+
+
+@pytest.mark.parametrize("password", ["short", "another-password"])
+def test_verify_password_success(password):
+    hashed = hash_password(password)
+    assert verify_password(password, hashed)
+
+
+def test_verify_password_rejects_incorrect_password():
+    hashed = hash_password("correct-horse-battery-staple")
+    assert not verify_password("incorrect", hashed)
+
+
+def test_verify_password_accepts_legacy_bcrypt_hashes():
+    legacy_hash = bcrypt.hashpw(b"legacy-secret", bcrypt.gensalt()).decode()
+    assert verify_password("legacy-secret", legacy_hash)
+    assert not verify_password("legacy-secret-wrong", legacy_hash)


### PR DESCRIPTION
## Summary
- pre-hash passwords with SHA-256 before bcrypt so credentials longer than 72 bytes can be stored and authenticated
- gracefully reject oversize inputs while supporting legacy bcrypt hashes
- add targeted password hashing tests and pytest configuration plus changelog entry

## Testing
- pytest tests/test_passwords.py

------
https://chatgpt.com/codex/tasks/task_b_68e5be0e3ca0832dae39c7dcba5c91a2