### PR TITLE
Fix login TOTP validation to accept legacy payload keys

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -32,3 +32,4 @@
 - 2025-10-08, 00:58 UTC, Feature, Delivered responsive login and super-admin registration pages with session-aware redirects and client-side MFA support
 - 2025-10-09, 13:05 UTC, Feature, Documented legacy Node.js parity gaps and outlined restoration tasks in docs/node-parity-gap.md
 - 2025-10-09, 15:42 UTC, Fix, Switched password hashing to bcrypt_sha256 to support long credentials without login failures
+- 2025-10-09, 16:18 UTC, Fix, Normalised login TOTP payload handling to accept legacy keys and enforce numeric codes server-side

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "httpx",
     "loguru",
     "cryptography",
+    "email-validator",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_auth_login_request.py
+++ b/tests/test_auth_login_request.py
@@ -1,0 +1,39 @@
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.auth import LoginRequest
+
+
+def _base_payload() -> dict[str, object]:
+    return {
+        "email": "user@example.com",
+        "password": "super-secret",
+    }
+
+
+def test_login_request_accepts_legacy_totp_alias_with_whitespace():
+    payload = _base_payload()
+    payload["totpCode"] = "123 456"
+
+    request = LoginRequest.model_validate(payload)
+
+    assert request.totp_code == "123456"
+
+
+def test_login_request_discards_blank_totp_values():
+    payload = _base_payload()
+    payload["totp_code"] = "   "
+
+    request = LoginRequest.model_validate(payload)
+
+    assert request.totp_code is None
+
+
+def test_login_request_rejects_non_numeric_totp_tokens():
+    payload = _base_payload()
+    payload["totp"] = "12ab34"
+
+    with pytest.raises(ValidationError) as exc:
+        LoginRequest.model_validate(payload)
+
+    assert "TOTP code must contain only digits" in str(exc.value)


### PR DESCRIPTION
## Summary
- normalise authentication TOTP code handling to accept legacy field names, strip whitespace, and enforce numeric values
- add the missing email-validator dependency required for EmailStr parsing and log the change
- cover the updated LoginRequest schema with dedicated unit tests

## Testing
- pytest tests/test_auth_login_request.py

------
https://chatgpt.com/codex/tasks/task_b_68e5c3c59e88832d9d7ff8f7d048f134