### PR TITLE
Fix TOTP login form behaviour when MFA is required

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -30,6 +30,7 @@
 - 2025-10-07, 12:30 UTC, Fix, Guarded MySQL bootstrap connection shutdown to support aiomysql versions without wait_closed
 - 2025-10-07, 12:36 UTC, Feature, Added FastAPI session management, CSRF middleware, login rate limiting, password reset, and TOTP flows with documented endpoints
 - 2025-10-08, 00:58 UTC, Feature, Delivered responsive login and super-admin registration pages with session-aware redirects and client-side MFA support
+- 2025-10-08, 02:12 UTC, Fix, Ensured login authenticator prompts expose and submit TOTP codes reliably while focusing invalid entries for quick retries
 - 2025-10-09, 13:05 UTC, Feature, Documented legacy Node.js parity gaps and outlined restoration tasks in docs/node-parity-gap.md
 - 2025-10-09, 15:42 UTC, Fix, Switched password hashing to bcrypt_sha256 to support long credentials without login failures
 - 2025-10-09, 16:18 UTC, Fix, Normalised login TOTP payload handling to accept legacy keys and enforce numeric codes server-side


### PR DESCRIPTION
## Summary
- ensure the login form reliably submits authenticator codes and automatically exposes the TOTP field on MFA errors
- update the change log to record the client-side TOTP handling fix

## Testing
- pytest tests/test_auth_login_request.py

------
https://chatgpt.com/codex/tasks/task_b_68e5c7030530832da33a19f5f4028c94