### PR TITLE
Ensure login requests always send TOTP codes

### DIFF
--- a/app/static/js/auth.js
+++ b/app/static/js/auth.js
@@ -120,6 +120,14 @@ class AuthForm {
       payload[key] = trimmed;
     }
 
+    const totpInput = this.form.querySelector('input[name="totp_code"]');
+    if (totpInput) {
+      const raw = totpInput.value;
+      if (typeof raw === 'string' && raw.trim()) {
+        payload.totp_code = raw.trim().replace(/\s+/g, '');
+      }
+    }
+
     return payload;
   }
 

--- a/changes.md
+++ b/changes.md
@@ -31,6 +31,7 @@
 - 2025-10-07, 12:36 UTC, Feature, Added FastAPI session management, CSRF middleware, login rate limiting, password reset, and TOTP flows with documented endpoints
 - 2025-10-08, 00:58 UTC, Feature, Delivered responsive login and super-admin registration pages with session-aware redirects and client-side MFA support
 - 2025-10-08, 02:12 UTC, Fix, Ensured login authenticator prompts expose and submit TOTP codes reliably while focusing invalid entries for quick retries
+- 2025-10-08, 02:32 UTC, Fix, Forced login submissions to include sanitised TOTP values from the authenticator input when present to satisfy MFA checks
 - 2025-10-09, 13:05 UTC, Feature, Documented legacy Node.js parity gaps and outlined restoration tasks in docs/node-parity-gap.md
 - 2025-10-09, 13:30 UTC, Feature, Documented systemd service setup for running MyPortal as a managed Linux service
 - 2025-10-09, 15:42 UTC, Fix, Switched password hashing to bcrypt_sha256 to support long credentials without login failures


### PR DESCRIPTION
## Summary
- mirror the authenticator input directly into the login payload to guarantee TOTP values are sent with fetch requests
- record the fix in the change log for traceability

## Testing
- pytest tests/test_auth_login_request.py

------
https://chatgpt.com/codex/tasks/task_b_68e5cb457814832d9b597e377440b3ad