### PR TITLE
Add company membership roles and audit tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ There are no default login credentials; the first visit will prompt you to regis
 - Optional TOTP multi-factor authentication with QR-code provisioning
 - Business information summary tab to confirm the logged-in company
 - Licenses tab showing license name, SKU, count, allocated staff, expiry date and contract term
+- Centralised company membership management with reusable roles and real-time audit logging
+- Super admin UI for reviewing membership changes and role edits with filtering and sorting controls
 - First-time visit redirects to a registration page when no users exist
 - Basic shop with product SKUs and admin management API
 - VIP pricing for companies with special product rates

--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -1,0 +1,10 @@
+from . import audit_logs, auth, companies, memberships, roles, users
+
+__all__ = [
+    "audit_logs",
+    "auth",
+    "companies",
+    "memberships",
+    "roles",
+    "users",
+]

--- a/app/api/routes/audit_logs.py
+++ b/app/api/routes/audit_logs.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app.api.dependencies.auth import require_super_admin
+from app.api.dependencies.database import require_database
+from app.repositories import audit_logs as audit_repo
+from app.schemas.audit_logs import AuditLogResponse
+
+router = APIRouter(prefix="/audit-logs", tags=["Audit Logs"])
+
+
+@router.get("", response_model=list[AuditLogResponse])
+async def list_audit_logs(
+    entity_type: str | None = Query(default=None, max_length=100),
+    entity_id: int | None = Query(default=None, ge=1),
+    user_id: int | None = Query(default=None, ge=1),
+    limit: int = Query(default=200, ge=1, le=500),
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    logs = await audit_repo.list_audit_logs(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        user_id=user_id,
+        limit=limit,
+    )
+    return logs
+
+
+@router.get("/{log_id}", response_model=AuditLogResponse)
+async def get_audit_log(
+    log_id: int,
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    log = await audit_repo.get_audit_log(log_id)
+    if not log:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audit log not found")
+    return log

--- a/app/api/routes/memberships.py
+++ b/app/api/routes/memberships.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from app.api.dependencies.auth import require_super_admin
+from app.api.dependencies.database import require_database
+from app.repositories import companies as company_repo
+from app.repositories import company_memberships as membership_repo
+from app.repositories import roles as role_repo
+from app.repositories import users as user_repo
+from app.schemas.memberships import MembershipCreate, MembershipResponse, MembershipUpdate
+from app.services import audit as audit_service
+
+router = APIRouter(prefix="/companies/{company_id}/memberships", tags=["Company Memberships"])
+
+
+async def _ensure_company(company_id: int) -> dict:
+    company = await company_repo.get_company_by_id(company_id)
+    if not company:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    return company
+
+
+@router.get("", response_model=list[MembershipResponse])
+async def list_memberships(
+    company_id: int,
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    await _ensure_company(company_id)
+    memberships = await membership_repo.list_company_memberships(company_id)
+    return memberships
+
+
+@router.post("", response_model=MembershipResponse, status_code=status.HTTP_201_CREATED)
+async def create_membership(
+    company_id: int,
+    payload: MembershipCreate,
+    request: Request,
+    _: None = Depends(require_database),
+    current_user: dict = Depends(require_super_admin),
+):
+    await _ensure_company(company_id)
+    user = await user_repo.get_user_by_id(payload.user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    role = await role_repo.get_role_by_id(payload.role_id)
+    if not role:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
+    existing = await membership_repo.get_membership_by_company_user(company_id, payload.user_id)
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Membership already exists")
+    created = await membership_repo.create_membership(
+        company_id=company_id,
+        user_id=payload.user_id,
+        role_id=payload.role_id,
+        status=payload.status,
+        invited_by=current_user["id"],
+    )
+    await audit_service.log_action(
+        action="membership.created",
+        user_id=current_user["id"],
+        entity_type="company_membership",
+        entity_id=created["id"],
+        new_value=created,
+        metadata={"company_id": company_id},
+        request=request,
+    )
+    return created
+
+
+@router.patch("/{membership_id}", response_model=MembershipResponse)
+async def update_membership(
+    company_id: int,
+    membership_id: int,
+    payload: MembershipUpdate,
+    request: Request,
+    _: None = Depends(require_database),
+    current_user: dict = Depends(require_super_admin),
+):
+    await _ensure_company(company_id)
+    membership = await membership_repo.get_membership_by_id(membership_id)
+    if not membership or membership["company_id"] != company_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Membership not found")
+    data = payload.model_dump(exclude_unset=True)
+    if "role_id" in data:
+        role = await role_repo.get_role_by_id(data["role_id"])
+        if not role:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
+    updated = await membership_repo.update_membership(membership_id, **data)
+    await audit_service.log_action(
+        action="membership.updated",
+        user_id=current_user["id"],
+        entity_type="company_membership",
+        entity_id=membership_id,
+        previous_value=membership,
+        new_value=updated,
+        metadata={"company_id": company_id},
+        request=request,
+    )
+    return updated
+
+
+@router.delete("/{membership_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_membership(
+    company_id: int,
+    membership_id: int,
+    request: Request,
+    _: None = Depends(require_database),
+    current_user: dict = Depends(require_super_admin),
+):
+    await _ensure_company(company_id)
+    membership = await membership_repo.get_membership_by_id(membership_id)
+    if not membership or membership["company_id"] != company_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Membership not found")
+    await membership_repo.delete_membership(membership_id)
+    await audit_service.log_action(
+        action="membership.deleted",
+        user_id=current_user["id"],
+        entity_type="company_membership",
+        entity_id=membership_id,
+        previous_value=membership,
+        new_value=None,
+        metadata={"company_id": company_id},
+        request=request,
+    )
+    return None

--- a/app/api/routes/roles.py
+++ b/app/api/routes/roles.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from app.api.dependencies.auth import require_super_admin
+from app.api.dependencies.database import require_database
+from app.repositories import roles as role_repo
+from app.schemas.roles import RoleCreate, RoleResponse, RoleUpdate
+from app.services import audit as audit_service
+
+router = APIRouter(prefix="/roles", tags=["Roles"])
+
+
+@router.get("", response_model=list[RoleResponse])
+async def list_roles(
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    return await role_repo.list_roles()
+
+
+@router.post("", response_model=RoleResponse, status_code=status.HTTP_201_CREATED)
+async def create_role(
+    payload: RoleCreate,
+    request: Request,
+    _: None = Depends(require_database),
+    current_user: dict = Depends(require_super_admin),
+):
+    existing = await role_repo.get_role_by_name(payload.name)
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Role name already exists")
+    created = await role_repo.create_role(
+        name=payload.name,
+        description=payload.description,
+        permissions=payload.permissions,
+        is_system=payload.is_system,
+    )
+    await audit_service.log_action(
+        action="role.created",
+        user_id=current_user["id"],
+        entity_type="role",
+        entity_id=created["id"],
+        new_value=created,
+        request=request,
+    )
+    return created
+
+
+@router.get("/{role_id}", response_model=RoleResponse)
+async def get_role(
+    role_id: int,
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    role = await role_repo.get_role_by_id(role_id)
+    if not role:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
+    return role
+
+
+@router.patch("/{role_id}", response_model=RoleResponse)
+async def update_role(
+    role_id: int,
+    payload: RoleUpdate,
+    request: Request,
+    _: None = Depends(require_database),
+    current_user: dict = Depends(require_super_admin),
+):
+    role = await role_repo.get_role_by_id(role_id)
+    if not role:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
+    if role.get("is_system") and payload.name and payload.name != role["name"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="System roles cannot be renamed",
+        )
+    data = payload.model_dump(exclude_unset=True)
+    updated = await role_repo.update_role(role_id, **data)
+    await audit_service.log_action(
+        action="role.updated",
+        user_id=current_user["id"],
+        entity_type="role",
+        entity_id=role_id,
+        previous_value=role,
+        new_value=updated,
+        request=request,
+    )
+    return updated
+
+
+@router.delete("/{role_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_role(
+    role_id: int,
+    request: Request,
+    _: None = Depends(require_database),
+    current_user: dict = Depends(require_super_admin),
+):
+    role = await role_repo.get_role_by_id(role_id)
+    if not role:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
+    if role.get("is_system"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cannot delete system role")
+    await role_repo.delete_role(role_id)
+    await audit_service.log_action(
+        action="role.deleted",
+        user_id=current_user["id"],
+        entity_type="role",
+        entity_id=role_id,
+        previous_value=role,
+        new_value=None,
+        request=request,
+    )
+    return None

--- a/app/main.py
+++ b/app/main.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from datetime import datetime
 
-from fastapi import FastAPI, Request, status
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
-from app.api.routes import auth, companies, users
+from app.api.routes import audit_logs, auth, companies, memberships, roles, users
 from app.core.config import get_settings, get_templates_config
 from app.core.database import db
 from app.core.logging import configure_logging, log_error, log_info
+from app.repositories import audit_logs as audit_repo
+from app.repositories import companies as company_repo
+from app.repositories import company_memberships as membership_repo
+from app.repositories import roles as role_repo
 from app.repositories import users as user_repo
 from app.security.csrf import CSRFMiddleware
 from app.security.rate_limiter import RateLimiterMiddleware, SimpleRateLimiter
@@ -45,6 +53,33 @@ app.mount("/static", StaticFiles(directory=str(templates_config.static_path)), n
 app.include_router(auth.router)
 app.include_router(users.router)
 app.include_router(companies.router)
+app.include_router(roles.router)
+app.include_router(memberships.router)
+app.include_router(audit_logs.router)
+
+
+async def _require_super_admin_page(request: Request) -> tuple[dict[str, Any] | None, RedirectResponse | None]:
+    session = await session_manager.load_session(request)
+    if not session:
+        return None, RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+    user = await user_repo.get_user_by_id(session.user_id)
+    if not user:
+        return None, RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+    if not user.get("is_super_admin"):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Super admin privileges required")
+    return user, None
+
+
+def _to_iso(dt: Any) -> str | None:
+    if not dt:
+        return None
+    if isinstance(dt, datetime):
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt.isoformat()
+    return str(dt)
 
 
 @app.on_event("startup")
@@ -68,6 +103,106 @@ async def index(request: Request):
         "current_year": datetime.utcnow().year,
     }
     return templates.TemplateResponse("dashboard.html", context)
+
+
+@app.get("/admin/roles", response_class=HTMLResponse)
+async def admin_roles(request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+    roles_list = await role_repo.list_roles()
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "current_year": datetime.utcnow().year,
+        "title": "Role management",
+        "roles": roles_list,
+        "current_user": current_user,
+    }
+    return templates.TemplateResponse("admin/roles.html", context)
+
+
+@app.get("/admin/memberships", response_class=HTMLResponse)
+async def admin_memberships(request: Request, company_id: int | None = None):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+    companies = await company_repo.list_companies()
+    effective_company_id = company_id
+    selected_company = None
+    memberships: list[dict[str, Any]] = []
+    if not effective_company_id and companies:
+        effective_company_id = companies[0]["id"]
+    if effective_company_id:
+        selected_company = next((c for c in companies if c["id"] == effective_company_id), None)
+        if not selected_company and companies:
+            selected_company = companies[0]
+            effective_company_id = selected_company["id"]
+        if selected_company:
+            memberships = await membership_repo.list_company_memberships(effective_company_id)
+            for record in memberships:
+                record["invited_at_iso"] = _to_iso(record.get("invited_at"))
+                record["joined_at_iso"] = _to_iso(record.get("joined_at"))
+                record["last_seen_at_iso"] = _to_iso(record.get("last_seen_at"))
+    roles_list = await role_repo.list_roles()
+    users = await user_repo.list_users()
+    status_options = [
+        {"value": "invited", "label": "Invited"},
+        {"value": "active", "label": "Active"},
+        {"value": "suspended", "label": "Suspended"},
+    ]
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "current_year": datetime.utcnow().year,
+        "title": "Company memberships",
+        "current_user": current_user,
+        "companies": companies,
+        "selected_company": selected_company,
+        "selected_company_id": effective_company_id,
+        "memberships": memberships,
+        "roles": roles_list,
+        "users": users,
+        "status_options": status_options,
+    }
+    return templates.TemplateResponse("admin/memberships.html", context)
+
+
+@app.get("/admin/audit-logs", response_class=HTMLResponse)
+async def admin_audit_logs(
+    request: Request,
+    entity_type: str | None = None,
+    entity_id: int | None = None,
+    user_id: int | None = None,
+    limit: int = 100,
+):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+    limit = max(1, min(limit, 500))
+    logs = await audit_repo.list_audit_logs(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        user_id=user_id,
+        limit=limit,
+    )
+    for log in logs:
+        log["created_at_iso"] = _to_iso(log.get("created_at"))
+    context = {
+        "request": request,
+        "app_name": settings.app_name,
+        "current_year": datetime.utcnow().year,
+        "title": "Audit trail",
+        "current_user": current_user,
+        "logs": logs,
+        "filters": {
+            "entity_type": entity_type or "",
+            "entity_id": entity_id or "",
+            "user_id": user_id or "",
+            "limit": limit,
+        },
+    }
+    return templates.TemplateResponse("admin/audit_logs.html", context)
 
 
 @app.get("/login", response_class=HTMLResponse)

--- a/app/repositories/audit_logs.py
+++ b/app/repositories/audit_logs.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+from app.core.database import db
+
+
+async def create_audit_log(
+    *,
+    user_id: int | None,
+    action: str,
+    entity_type: str | None = None,
+    entity_id: int | None = None,
+    previous_value: Any = None,
+    new_value: Any = None,
+    metadata: dict[str, Any] | None = None,
+    api_key: str | None = None,
+    ip_address: str | None = None,
+) -> None:
+    await db.execute(
+        """
+        INSERT INTO audit_logs (user_id, action, entity_type, entity_id, previous_value, new_value, metadata, api_key, ip_address, created_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            user_id,
+            action,
+            entity_type,
+            entity_id,
+            _serialise(previous_value),
+            _serialise(new_value),
+            _serialise(metadata or {}),
+            api_key,
+            ip_address,
+            datetime.utcnow(),
+        ),
+    )
+
+
+async def list_audit_logs(
+    *,
+    entity_type: str | None = None,
+    entity_id: int | None = None,
+    user_id: int | None = None,
+    limit: int = 200,
+) -> list[dict[str, Any]]:
+    clauses: list[str] = []
+    params: list[Any] = []
+    if entity_type:
+        clauses.append("al.entity_type = %s")
+        params.append(entity_type)
+    if entity_id is not None:
+        clauses.append("al.entity_id = %s")
+        params.append(entity_id)
+    if user_id is not None:
+        clauses.append("al.user_id = %s")
+        params.append(user_id)
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    params.append(limit)
+    rows = await db.fetch_all(
+        f"""
+        SELECT al.*, u.email AS user_email
+        FROM audit_logs AS al
+        LEFT JOIN users AS u ON u.id = al.user_id
+        {where}
+        ORDER BY al.created_at DESC
+        LIMIT %s
+        """,
+        tuple(params),
+    )
+    return [_normalise(row) for row in rows]
+
+
+async def get_audit_log(log_id: int) -> dict[str, Any] | None:
+    row = await db.fetch_one(
+        """
+        SELECT al.*, u.email AS user_email
+        FROM audit_logs AS al
+        LEFT JOIN users AS u ON u.id = al.user_id
+        WHERE al.id = %s
+        """,
+        (log_id,),
+    )
+    if not row:
+        return None
+    return _normalise(row)
+
+
+def _serialise(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return json.dumps(value)
+    return json.dumps(value, default=str)
+
+
+def _deserialise(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return value
+
+
+def _normalise(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **row,
+        "previous_value": _deserialise(row.get("previous_value")),
+        "new_value": _deserialise(row.get("new_value")),
+        "metadata": _deserialise(row.get("metadata")),
+        "created_at": row.get("created_at"),
+    }

--- a/app/repositories/company_memberships.py
+++ b/app/repositories/company_memberships.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Optional
+
+from app.core.database import db
+
+_VALID_STATUSES = {"invited", "active", "suspended"}
+
+
+async def list_company_memberships(company_id: int) -> list[dict[str, Any]]:
+    rows = await db.fetch_all(
+        """
+        SELECT m.*, u.email AS user_email, u.first_name, u.last_name, r.name AS role_name, r.permissions
+        FROM company_memberships AS m
+        INNER JOIN users AS u ON u.id = m.user_id
+        INNER JOIN roles AS r ON r.id = m.role_id
+        WHERE m.company_id = %s
+        ORDER BY u.email
+        """,
+        (company_id,),
+    )
+    return [_normalise_membership(row) for row in rows]
+
+
+async def get_membership_by_id(membership_id: int) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one(
+        """
+        SELECT m.*, u.email AS user_email, u.first_name, u.last_name, r.name AS role_name, r.permissions
+        FROM company_memberships AS m
+        INNER JOIN users AS u ON u.id = m.user_id
+        INNER JOIN roles AS r ON r.id = m.role_id
+        WHERE m.id = %s
+        """,
+        (membership_id,),
+    )
+    if not row:
+        return None
+    return _normalise_membership(row)
+
+
+async def get_membership_by_company_user(company_id: int, user_id: int) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one(
+        """
+        SELECT m.*, u.email AS user_email, u.first_name, u.last_name, r.name AS role_name, r.permissions
+        FROM company_memberships AS m
+        INNER JOIN users AS u ON u.id = m.user_id
+        INNER JOIN roles AS r ON r.id = m.role_id
+        WHERE m.company_id = %s AND m.user_id = %s
+        """,
+        (company_id, user_id),
+    )
+    if not row:
+        return None
+    return _normalise_membership(row)
+
+
+async def create_membership(
+    *,
+    company_id: int,
+    user_id: int,
+    role_id: int,
+    status: str = "active",
+    invited_by: int | None = None,
+) -> dict[str, Any]:
+    if status not in _VALID_STATUSES:
+        raise ValueError("Invalid membership status")
+    now = datetime.utcnow()
+    joined_at: datetime | None = None
+    if status == "active":
+        joined_at = now
+    await db.execute(
+        """
+        INSERT INTO company_memberships (company_id, user_id, role_id, status, invited_by, invited_at, joined_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            company_id,
+            user_id,
+            role_id,
+            status,
+            invited_by,
+            now,
+            joined_at,
+        ),
+    )
+    created = await get_membership_by_company_user(company_id, user_id)
+    if not created:
+        raise RuntimeError("Failed to create membership")
+    return created
+
+
+async def update_membership(membership_id: int, **updates: Any) -> dict[str, Any]:
+    if not updates:
+        membership = await get_membership_by_id(membership_id)
+        if not membership:
+            raise ValueError("Membership not found")
+        return membership
+
+    params: list[Any] = []
+    columns: list[str] = []
+    status = updates.get("status")
+    if status is not None:
+        if status not in _VALID_STATUSES:
+            raise ValueError("Invalid membership status")
+    for column, value in updates.items():
+        if column == "status" and value == "active":
+            columns.append("joined_at = IFNULL(joined_at, %s)")
+            params.append(datetime.utcnow())
+        columns.append(f"{column} = %s")
+        params.append(value)
+    params.append(membership_id)
+    sql = f"UPDATE company_memberships SET {', '.join(columns)} WHERE id = %s"
+    await db.execute(sql, tuple(params))
+    updated = await get_membership_by_id(membership_id)
+    if not updated:
+        raise ValueError("Membership not found after update")
+    return updated
+
+
+async def delete_membership(membership_id: int) -> None:
+    await db.execute("DELETE FROM company_memberships WHERE id = %s", (membership_id,))
+
+
+def _normalise_membership(row: dict[str, Any]) -> dict[str, Any]:
+    permissions_raw = row.get("permissions")
+    permissions: list[str]
+    if isinstance(permissions_raw, str):
+        try:
+            permissions = json.loads(permissions_raw)
+        except json.JSONDecodeError:
+            permissions = []
+    else:
+        permissions = permissions_raw or []
+    return {
+        **row,
+        "permissions": permissions,
+        "is_active": row.get("status") == "active",
+    }

--- a/app/repositories/roles.py
+++ b/app/repositories/roles.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Optional
+
+from app.core.database import db
+
+
+async def list_roles() -> list[dict[str, Any]]:
+    rows = await db.fetch_all("SELECT * FROM roles ORDER BY name")
+    return [_normalise(row) for row in rows]
+
+
+async def get_role_by_id(role_id: int) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one("SELECT * FROM roles WHERE id = %s", (role_id,))
+    if not row:
+        return None
+    return _normalise(row)
+
+
+async def get_role_by_name(name: str) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one("SELECT * FROM roles WHERE name = %s", (name,))
+    if not row:
+        return None
+    return _normalise(row)
+
+
+async def create_role(*, name: str, description: str | None = None, permissions: list[str] | None = None, is_system: bool = False) -> dict[str, Any]:
+    now = datetime.utcnow()
+    await db.execute(
+        """
+        INSERT INTO roles (name, description, permissions, is_system, created_at, updated_at)
+        VALUES (%s, %s, %s, %s, %s, %s)
+        """,
+        (
+            name,
+            description,
+            json.dumps(permissions or []),
+            1 if is_system else 0,
+            now,
+            now,
+        ),
+    )
+    created = await get_role_by_name(name)
+    if not created:
+        raise RuntimeError("Failed to create role")
+    return created
+
+
+async def update_role(role_id: int, **updates: Any) -> dict[str, Any]:
+    if not updates:
+        role = await get_role_by_id(role_id)
+        if not role:
+            raise ValueError("Role not found")
+        return role
+    columns = []
+    params: list[Any] = []
+    for column, value in updates.items():
+        if column == "permissions" and value is not None:
+            value = json.dumps(value)
+        columns.append(f"{column} = %s")
+        params.append(value)
+    columns.append("updated_at = %s")
+    params.append(datetime.utcnow())
+    params.append(role_id)
+    sql = f"UPDATE roles SET {', '.join(columns)} WHERE id = %s"
+    await db.execute(sql, tuple(params))
+    updated = await get_role_by_id(role_id)
+    if not updated:
+        raise ValueError("Role not found after update")
+    return updated
+
+
+async def delete_role(role_id: int) -> None:
+    await db.execute("DELETE FROM roles WHERE id = %s", (role_id,))
+
+
+def _normalise(row: dict[str, Any]) -> dict[str, Any]:
+    permissions_raw = row.get("permissions")
+    if isinstance(permissions_raw, str):
+        try:
+            permissions = json.loads(permissions_raw)
+        except json.JSONDecodeError:
+            permissions = []
+    else:
+        permissions = permissions_raw or []
+    return {
+        **row,
+        "permissions": permissions,
+        "is_system": bool(row.get("is_system", 0)),
+    }

--- a/app/schemas/audit_logs.py
+++ b/app/schemas/audit_logs.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class AuditLogResponse(BaseModel):
+    id: int
+    user_id: Optional[int] = None
+    user_email: Optional[str] = None
+    action: str
+    entity_type: Optional[str] = None
+    entity_id: Optional[int] = None
+    previous_value: Optional[Any] = None
+    new_value: Optional[Any] = None
+    metadata: Optional[Any] = None
+    api_key: Optional[str] = None
+    ip_address: Optional[str] = None
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/app/schemas/memberships.py
+++ b/app/schemas/memberships.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class MembershipBase(BaseModel):
+    role_id: int
+    status: str = Field(default="active", pattern=r"^(invited|active|suspended)$")
+
+
+class MembershipCreate(MembershipBase):
+    user_id: int
+
+
+class MembershipUpdate(BaseModel):
+    role_id: Optional[int] = None
+    status: Optional[str] = Field(default=None, pattern=r"^(invited|active|suspended)$")
+
+
+class MembershipUser(BaseModel):
+    id: int
+    email: str
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+
+
+class MembershipRole(BaseModel):
+    id: int
+    name: str
+    permissions: list[str] = Field(default_factory=list)
+
+
+class MembershipResponse(BaseModel):
+    id: int
+    company_id: int
+    user_id: int
+    role_id: int
+    status: str
+    invited_by: Optional[int] = None
+    invited_at: Optional[datetime] = None
+    joined_at: Optional[datetime] = None
+    last_seen_at: Optional[datetime] = None
+    user_email: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    role_name: Optional[str] = None
+    permissions: list[str] = Field(default_factory=list)
+
+    class Config:
+        from_attributes = True

--- a/app/schemas/roles.py
+++ b/app/schemas/roles.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class RoleBase(BaseModel):
+    name: str = Field(..., min_length=2, max_length=100)
+    description: Optional[str] = None
+    permissions: list[str] = Field(default_factory=list)
+
+
+class RoleCreate(RoleBase):
+    is_system: bool = False
+
+
+class RoleUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=2, max_length=100)
+    description: Optional[str] = None
+    permissions: Optional[list[str]] = None
+
+
+class RoleResponse(RoleBase):
+    id: int
+    is_system: bool = False
+
+    class Config:
+        from_attributes = True

--- a/app/services/audit.py
+++ b/app/services/audit.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Request
+
+from app.repositories import audit_logs as audit_repo
+
+
+async def log_action(
+    *,
+    action: str,
+    user_id: int | None,
+    entity_type: str | None = None,
+    entity_id: int | None = None,
+    previous_value: Any = None,
+    new_value: Any = None,
+    metadata: dict[str, Any] | None = None,
+    request: Request | None = None,
+    api_key: str | None = None,
+) -> None:
+    ip_address = None
+    if request is not None:
+        forwarded = request.headers.get("x-forwarded-for")
+        if forwarded:
+            ip_address = forwarded.split(",")[0].strip()
+        elif request.client:
+            ip_address = request.client.host
+    await audit_repo.create_audit_log(
+        user_id=user_id,
+        action=action,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        previous_value=previous_value,
+        new_value=new_value,
+        metadata=metadata,
+        api_key=api_key,
+        ip_address=ip_address,
+    )

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -243,6 +243,15 @@ body {
   justify-content: flex-end;
 }
 
+.form-actions--inline {
+  justify-content: flex-start;
+}
+
+.form-input--textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
 .form-actions--stacked {
   justify-content: flex-start;
 }
@@ -324,6 +333,231 @@ body {
   border: 1px solid rgba(148, 163, 184, 0.1);
 }
 
+.card--panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.card__header--stacked {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.card__title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.card__subtitle {
+  margin: 0.35rem 0 0;
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.95rem;
+}
+
+.card__controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.card__control {
+  margin: 0;
+}
+
+.admin-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.admin-grid--columns {
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  align-items: flex-start;
+}
+
+@media (max-width: 1080px) {
+  .admin-grid--columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 680px;
+}
+
+.table th,
+.table td {
+  padding: 0.9rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.table th {
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.85);
+  cursor: pointer;
+  user-select: none;
+}
+
+.table th:hover {
+  color: #38bdf8;
+}
+
+.table__actions {
+  text-align: right;
+}
+
+.table__action-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.table__empty {
+  text-align: center;
+  padding: 2rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.button--ghost {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: #e2e8f0;
+  padding: 0.75rem 1.25rem;
+}
+
+.button--ghost:hover,
+.button--ghost:focus {
+  background: rgba(148, 163, 184, 0.15);
+}
+
+.button--danger {
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+  border: 1px solid rgba(248, 113, 113, 0.6);
+  padding: 0.75rem 1.25rem;
+}
+
+.button--danger:hover,
+.button--danger:focus {
+  background: rgba(248, 113, 113, 0.35);
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.2);
+  color: #bae6fd;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.status--active {
+  background: rgba(134, 239, 172, 0.18);
+  color: #bbf7d0;
+}
+
+.status--invited {
+  background: rgba(253, 186, 116, 0.18);
+  color: #fed7aa;
+}
+
+.status--suspended {
+  background: rgba(248, 113, 113, 0.18);
+  color: #fecaca;
+}
+
+.text-muted {
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 0.9rem;
+}
+
+.stacked {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.divider {
+  border: none;
+  height: 1px;
+  background: rgba(148, 163, 184, 0.15);
+  margin: 1.5rem 0;
+}
+
+.filter-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.code-block {
+  margin-top: 0.75rem;
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  max-height: 220px;
+  overflow: auto;
+}
+
+.code-block pre {
+  margin: 0.35rem 0 0.85rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.details summary {
+  cursor: pointer;
+  color: #38bdf8;
+  font-weight: 600;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 .card h2 {
   margin-top: 0;
   color: #f8fafc;

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1,0 +1,260 @@
+(function () {
+  function getCookie(name) {
+    const pattern = `(?:^|; )${name.replace(/([.$?*|{}()\[\]\\\/\+^])/g, '\\$1')}=([^;]*)`;
+    const matches = document.cookie.match(new RegExp(pattern));
+    return matches ? decodeURIComponent(matches[1]) : '';
+  }
+
+  function getCsrfToken() {
+    return getCookie('myportal_session_csrf');
+  }
+
+  async function requestJson(url, options) {
+    const response = await fetch(url, {
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': getCsrfToken(),
+        ...(options.headers || {}),
+      },
+      ...options,
+    });
+    if (!response.ok) {
+      let detail = `${response.status} ${response.statusText}`;
+      try {
+        const data = await response.json();
+        if (data && data.detail) {
+          detail = Array.isArray(data.detail)
+            ? data.detail.map((entry) => entry.msg || entry).join(', ')
+            : data.detail;
+        }
+      } catch (error) {
+        /* ignore json parse errors */
+      }
+      throw new Error(detail);
+    }
+    return response.status !== 204 ? response.json() : null;
+  }
+
+  function parsePermissions(value) {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  }
+
+  function bindRoleForm() {
+    const form = document.getElementById('role-form');
+    if (!form) {
+      return;
+    }
+    const idField = form.querySelector('#role-id');
+    const nameField = form.querySelector('#role-name');
+    const descriptionField = form.querySelector('#role-description');
+    const permissionsField = form.querySelector('#role-permissions');
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const roleId = idField.value;
+      const payload = {
+        name: nameField.value.trim(),
+        description: descriptionField.value.trim() || null,
+        permissions: parsePermissions(permissionsField.value),
+      };
+      const method = roleId ? 'PATCH' : 'POST';
+      const url = roleId ? `/roles/${roleId}` : '/roles';
+      try {
+        await requestJson(url, { method, body: JSON.stringify(payload) });
+        window.location.reload();
+      } catch (error) {
+        alert(`Unable to save role: ${error.message}`);
+      }
+    });
+
+    const resetButton = form.querySelector('[data-role-reset]');
+    if (resetButton) {
+      resetButton.addEventListener('click', () => {
+        idField.value = '';
+        nameField.value = '';
+        descriptionField.value = '';
+        permissionsField.value = '';
+        nameField.focus();
+      });
+    }
+
+    document.querySelectorAll('[data-role-edit]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const row = button.closest('tr');
+        if (!row) {
+          return;
+        }
+        idField.value = row.dataset.roleId || '';
+        nameField.value = row.dataset.roleName || '';
+        descriptionField.value = row.dataset.roleDescription || '';
+        try {
+          const permissions = JSON.parse(row.dataset.rolePermissions || '[]');
+          permissionsField.value = Array.isArray(permissions) ? permissions.join(', ') : '';
+        } catch (error) {
+          permissionsField.value = '';
+        }
+        nameField.focus();
+      });
+    });
+
+    document.querySelectorAll('[data-role-delete]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const row = button.closest('tr');
+        if (!row) {
+          return;
+        }
+        const roleId = row.dataset.roleId;
+        if (!roleId) {
+          return;
+        }
+        if (!confirm('Delete this role? This action cannot be undone.')) {
+          return;
+        }
+        try {
+          await requestJson(`/roles/${roleId}`, { method: 'DELETE' });
+          window.location.reload();
+        } catch (error) {
+          alert(`Unable to delete role: ${error.message}`);
+        }
+      });
+    });
+  }
+
+  function bindMembershipForms() {
+    const createForm = document.getElementById('membership-create-form');
+    const updateForm = document.getElementById('membership-update-form');
+    const companyField = createForm ? createForm.querySelector('input[name="company_id"]') : null;
+    const updateCompanyField = updateForm ? updateForm.querySelector('input[name="company_id"]') : null;
+    const membershipIdField = updateForm ? updateForm.querySelector('#membership-id') : null;
+    const membershipUserDisplay = updateForm ? updateForm.querySelector('#membership-user-display') : null;
+    const membershipRoleSelect = updateForm ? updateForm.querySelector('#membership-role-update') : null;
+    const membershipStatusSelect = updateForm ? updateForm.querySelector('#membership-status-update') : null;
+    const membershipSubmit = updateForm ? updateForm.querySelector('[data-membership-submit]') : null;
+
+    if (createForm) {
+      createForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const companyId = companyField ? companyField.value : '';
+        if (!companyId) {
+          alert('Choose a company before adding memberships.');
+          return;
+        }
+        const formData = new FormData(createForm);
+        const payload = {
+          user_id: Number(formData.get('user_id')),
+          role_id: Number(formData.get('role_id')),
+          status: String(formData.get('status')),
+        };
+        try {
+          await requestJson(`/companies/${companyId}/memberships`, {
+            method: 'POST',
+            body: JSON.stringify(payload),
+          });
+          window.location.reload();
+        } catch (error) {
+          alert(`Unable to create membership: ${error.message}`);
+        }
+      });
+    }
+
+    function clearMembershipForm() {
+      if (!updateForm) {
+        return;
+      }
+      membershipIdField.value = '';
+      membershipUserDisplay.value = '';
+      if (membershipRoleSelect) {
+        membershipRoleSelect.selectedIndex = 0;
+      }
+      if (membershipStatusSelect) {
+        membershipStatusSelect.selectedIndex = 0;
+      }
+      if (membershipSubmit) {
+        membershipSubmit.disabled = true;
+      }
+    }
+
+    if (updateForm) {
+      updateForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const companyId = updateCompanyField ? updateCompanyField.value : '';
+        const membershipId = membershipIdField ? membershipIdField.value : '';
+        if (!companyId || !membershipId) {
+          return;
+        }
+        const payload = {
+          role_id: Number(membershipRoleSelect.value),
+          status: String(membershipStatusSelect.value),
+        };
+        try {
+          await requestJson(`/companies/${companyId}/memberships/${membershipId}`, {
+            method: 'PATCH',
+            body: JSON.stringify(payload),
+          });
+          window.location.reload();
+        } catch (error) {
+          alert(`Unable to update membership: ${error.message}`);
+        }
+      });
+
+      const clearButton = updateForm.querySelector('[data-membership-clear]');
+      if (clearButton) {
+        clearButton.addEventListener('click', () => {
+          clearMembershipForm();
+        });
+      }
+    }
+
+    document.querySelectorAll('[data-membership-edit]').forEach((button) => {
+      button.addEventListener('click', () => {
+        if (!updateForm) {
+          return;
+        }
+        const row = button.closest('tr');
+        if (!row) {
+          return;
+        }
+        membershipIdField.value = row.dataset.membershipId || '';
+        membershipRoleSelect.value = row.dataset.membershipRoleId || '';
+        membershipStatusSelect.value = row.dataset.membershipStatus || '';
+        const userCell = row.querySelector('[data-label="User"]');
+        membershipUserDisplay.value = userCell ? userCell.textContent.trim() : '';
+        if (membershipSubmit) {
+          membershipSubmit.disabled = false;
+        }
+      });
+    });
+
+    document.querySelectorAll('[data-membership-delete]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const row = button.closest('tr');
+        if (!row) {
+          return;
+        }
+        const companyId = updateCompanyField ? updateCompanyField.value : '';
+        const membershipId = row.dataset.membershipId;
+        if (!companyId || !membershipId) {
+          return;
+        }
+        if (!confirm('Remove this membership? The user will immediately lose access.')) {
+          return;
+        }
+        try {
+          await requestJson(`/companies/${companyId}/memberships/${membershipId}`, { method: 'DELETE' });
+          window.location.reload();
+        } catch (error) {
+          alert(`Unable to delete membership: ${error.message}`);
+        }
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    bindRoleForm();
+    bindMembershipForms();
+  });
+})();

--- a/app/static/js/tables.js
+++ b/app/static/js/tables.js
@@ -1,0 +1,94 @@
+(function () {
+  function getCellValue(row, index) {
+    const cell = row.children[index];
+    return cell ? cell.getAttribute('data-value') || cell.textContent.trim() : '';
+  }
+
+  function parseValue(value, type) {
+    if (type === 'number') {
+      const parsed = parseFloat(value);
+      return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+    }
+    if (type === 'date') {
+      const timestamp = Date.parse(value);
+      return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
+    }
+    return value.toLowerCase();
+  }
+
+  function sortTable(table, columnIndex, type) {
+    const tbody = table.tBodies[0];
+    const rows = Array.from(tbody.querySelectorAll('tr'));
+    const current = table.getAttribute('data-sort-index') === String(columnIndex)
+      ? table.getAttribute('data-sort-order')
+      : null;
+    const ascending = current !== 'asc';
+
+    rows.sort((a, b) => {
+      const valueA = parseValue(getCellValue(a, columnIndex), type);
+      const valueB = parseValue(getCellValue(b, columnIndex), type);
+      if (valueA < valueB) {
+        return ascending ? -1 : 1;
+      }
+      if (valueA > valueB) {
+        return ascending ? 1 : -1;
+      }
+      return 0;
+    });
+
+    const fragment = document.createDocumentFragment();
+    rows.forEach((row) => fragment.appendChild(row));
+    tbody.appendChild(fragment);
+    table.setAttribute('data-sort-index', String(columnIndex));
+    table.setAttribute('data-sort-order', ascending ? 'asc' : 'desc');
+  }
+
+  function attachSorting(table) {
+    const headers = table.querySelectorAll('th[data-sort]');
+    headers.forEach((header, index) => {
+      header.addEventListener('click', () => {
+        sortTable(table, index, header.getAttribute('data-sort') || 'string');
+      });
+    });
+  }
+
+  function attachFilters() {
+    document.querySelectorAll('[data-table-filter]').forEach((input) => {
+      const tableId = input.getAttribute('data-table-filter');
+      const table = document.getElementById(tableId);
+      if (!table) {
+        return;
+      }
+      input.addEventListener('input', () => {
+        const term = input.value.trim().toLowerCase();
+        table.querySelectorAll('tbody tr').forEach((row) => {
+          const text = row.textContent || '';
+          row.style.display = !term || text.toLowerCase().includes(term) ? '' : 'none';
+        });
+      });
+    });
+  }
+
+  function convertUtcElements() {
+    document.querySelectorAll('[data-utc]').forEach((element) => {
+      const iso = element.getAttribute('data-utc');
+      if (!iso) {
+        return;
+      }
+      const date = new Date(iso);
+      if (Number.isNaN(date.getTime())) {
+        return;
+      }
+      const formatted = date.toLocaleString();
+      element.textContent = formatted;
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('table[data-table]').forEach((table) => {
+      attachSorting(table);
+    });
+    attachFilters();
+    convertUtcElements();
+  });
+})();

--- a/app/templates/admin/audit_logs.html
+++ b/app/templates/admin/audit_logs.html
@@ -1,0 +1,129 @@
+{% extends "base.html" %}
+
+{% block sidebar_menu %}
+  {{ super() }}
+  <li class="menu__item">
+    <a href="/admin/memberships">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5zm0 2c-3.33 0-10 1.67-10 5v1h20v-1c0-3.33-6.67-5-10-5z"/></svg>
+      </span>
+      <span class="menu__label">Memberships</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/roles">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M10.67 3.5a1 1 0 0 1 1.66 0l1.36 2.04a1 1 0 0 0 .63.43l2.35.5a1 1 0 0 1 .54 1.68l-1.67 1.8a1 1 0 0 0-.26.74l.2 2.4a1 1 0 0 1-1.4 1l-2.2-1a1 1 0 0 0-.84 0l-2.2 1a1 1 0 0 1-1.4-1l.2-2.4a1 1 0 0 0-.26-.74L6.39 8.15a1 1 0 0 1 .54-1.68l2.35-.5a1 1 0 0 0 .63-.43z"/></svg>
+      </span>
+      <span class="menu__label">Roles</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/audit-logs" aria-current="page">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M5 4h14a1 1 0 0 1 1 1v15l-8-3-8 3V5a1 1 0 0 1 1-1z"/></svg>
+      </span>
+      <span class="menu__label">Audit trail</span>
+    </a>
+  </li>
+{% endblock %}
+
+{% block content %}
+<div class="admin-grid">
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Audit trail</h2>
+        <p class="card__subtitle">Every change to memberships and roles is recorded to support compliance reviews.</p>
+      </div>
+      <form method="get" class="filter-grid">
+        <div class="form-field">
+          <label class="form-label" for="filter-entity-type">Entity type</label>
+          <input class="form-input" id="filter-entity-type" name="entity_type" value="{{ filters.entity_type }}" />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="filter-entity-id">Entity ID</label>
+          <input class="form-input" id="filter-entity-id" name="entity_id" value="{{ filters.entity_id }}" />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="filter-user-id">User ID</label>
+          <input class="form-input" id="filter-user-id" name="user_id" value="{{ filters.user_id }}" />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="filter-limit">Limit</label>
+          <input class="form-input" id="filter-limit" type="number" min="1" max="500" name="limit" value="{{ filters.limit }}" />
+        </div>
+        <div class="form-actions form-actions--inline">
+          <button type="submit" class="button">Apply filters</button>
+          <a class="button button--ghost" href="/admin/audit-logs">Reset</a>
+        </div>
+      </form>
+    </header>
+    <div class="table-wrapper">
+      <table class="table" id="audit-log-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col" data-sort="date">Timestamp</th>
+            <th scope="col" data-sort="string">Actor</th>
+            <th scope="col" data-sort="string">Action</th>
+            <th scope="col" data-sort="string">Entity</th>
+            <th scope="col" data-sort="string">Changes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if logs %}
+            {% for log in logs %}
+              <tr>
+                <td data-label="Timestamp" data-utc="{{ log.created_at_iso or '' }}" data-value="{{ log.created_at_iso or '' }}">{{ log.created_at_iso or '—' }}</td>
+                <td data-label="Actor">
+                  {% if log.user_email %}
+                    <span class="stacked"><strong>{{ log.user_email }}</strong><span class="text-muted">User #{{ log.user_id }}</span></span>
+                  {% else %}
+                    <span class="text-muted">System</span>
+                  {% endif %}
+                </td>
+                <td data-label="Action">{{ log.action }}</td>
+                <td data-label="Entity">
+                  {% if log.entity_type %}
+                    <span class="tag">{{ log.entity_type }}</span>
+                    {% if log.entity_id %}
+                      <span class="text-muted">#{{ log.entity_id }}</span>
+                    {% endif %}
+                  {% else %}
+                    <span class="text-muted">—</span>
+                  {% endif %}
+                </td>
+                <td data-label="Changes">
+                  <details class="details">
+                    <summary>View</summary>
+                    <div class="code-block">
+                      <strong>Previous:</strong>
+                      <pre>{{ log.previous_value | tojson(indent=2) }}</pre>
+                      <strong>New:</strong>
+                      <pre>{{ log.new_value | tojson(indent=2) }}</pre>
+                      {% if log.metadata %}
+                        <strong>Metadata:</strong>
+                        <pre>{{ log.metadata | tojson(indent=2) }}</pre>
+                      {% endif %}
+                    </div>
+                  </details>
+                </td>
+              </tr>
+            {% endfor %}
+          {% else %}
+            <tr>
+              <td colspan="5" class="table__empty">No audit records match the selected filters.</td>
+            </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/admin.js" defer></script>
+{% endblock %}

--- a/app/templates/admin/memberships.html
+++ b/app/templates/admin/memberships.html
@@ -1,0 +1,193 @@
+{% extends "base.html" %}
+
+{% block sidebar_menu %}
+  {{ super() }}
+  <li class="menu__item">
+    <a href="/admin/memberships" aria-current="page">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5zm0 2c-3.33 0-10 1.67-10 5v1h20v-1c0-3.33-6.67-5-10-5z"/></svg>
+      </span>
+      <span class="menu__label">Memberships</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/roles">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M10.67 3.5a1 1 0 0 1 1.66 0l1.36 2.04a1 1 0 0 0 .63.43l2.35.5a1 1 0 0 1 .54 1.68l-1.67 1.8a1 1 0 0 0-.26.74l.2 2.4a1 1 0 0 1-1.4 1l-2.2-1a1 1 0 0 0-.84 0l-2.2 1a1 1 0 0 1-1.4-1l.2-2.4a1 1 0 0 0-.26-.74L6.39 8.15a1 1 0 0 1 .54-1.68l2.35-.5a1 1 0 0 0 .63-.43z"/></svg>
+      </span>
+      <span class="menu__label">Roles</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/audit-logs">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M5 4h14a1 1 0 0 1 1 1v15l-8-3-8 3V5a1 1 0 0 1 1-1z"/></svg>
+      </span>
+      <span class="menu__label">Audit trail</span>
+    </a>
+  </li>
+{% endblock %}
+
+{% block content %}
+<div class="admin-grid admin-grid--columns">
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Company memberships</h2>
+        <p class="card__subtitle">Assign users to companies, manage their roles, and pause access when needed.</p>
+      </div>
+      <div class="card__controls">
+        <form method="get" class="card__control">
+          <label class="visually-hidden" for="company-select">Choose company</label>
+          <select id="company-select" class="form-input" name="company_id" onchange="this.form.submit()">
+            {% for company in companies %}
+              <option value="{{ company.id }}" {% if selected_company_id == company.id %}selected{% endif %}>{{ company.name }}</option>
+            {% endfor %}
+          </select>
+        </form>
+        <input
+          type="search"
+          class="form-input"
+          placeholder="Filter memberships"
+          aria-label="Filter memberships"
+          data-table-filter="memberships-table"
+        />
+      </div>
+    </header>
+    <div class="table-wrapper">
+      <table class="table" id="memberships-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col" data-sort="string">User</th>
+            <th scope="col" data-sort="string">Role</th>
+            <th scope="col" data-sort="string">Status</th>
+            <th scope="col" data-sort="date">Invited</th>
+            <th scope="col" data-sort="date">Joined</th>
+            <th scope="col" data-sort="date">Last seen</th>
+            <th scope="col" class="table__actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if memberships %}
+            {% for membership in memberships %}
+              <tr
+                data-membership-id="{{ membership.id }}"
+                data-membership-user-id="{{ membership.user_id }}"
+                data-membership-role-id="{{ membership.role_id }}"
+                data-membership-status="{{ membership.status }}"
+              >
+                <td data-label="User">
+                  <div class="stacked">
+                    <strong>{{ membership.user_email }}</strong>
+                    <span class="text-muted">{{ membership.first_name or '' }} {{ membership.last_name or '' }}</span>
+                  </div>
+                </td>
+                <td data-label="Role">{{ membership.role_name }}</td>
+                <td data-label="Status">
+                  <span class="status status--{{ membership.status }}">{{ membership.status | capitalize }}</span>
+                </td>
+                <td data-label="Invited" data-utc="{{ membership.invited_at_iso or '' }}" data-value="{{ membership.invited_at_iso or '' }}">{{ membership.invited_at_iso or '—' }}</td>
+                <td data-label="Joined" data-utc="{{ membership.joined_at_iso or '' }}" data-value="{{ membership.joined_at_iso or '' }}">{{ membership.joined_at_iso or '—' }}</td>
+                <td data-label="Last seen" data-utc="{{ membership.last_seen_at_iso or '' }}" data-value="{{ membership.last_seen_at_iso or '' }}">{{ membership.last_seen_at_iso or '—' }}</td>
+                <td class="table__actions">
+                  <div class="table__action-buttons">
+                    <button type="button" class="button button--ghost" data-membership-edit>Edit</button>
+                    <button type="button" class="button button--danger" data-membership-delete>Remove</button>
+                  </div>
+                </td>
+              </tr>
+            {% endfor %}
+          {% else %}
+            <tr>
+              <td colspan="7" class="table__empty">No memberships are assigned to this company.</td>
+            </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="card card--panel">
+    <header class="card__header">
+      <div>
+        <h2 class="card__title">Invite an existing user</h2>
+        <p class="card__subtitle">Select a user and assign their role to add them to the chosen company.</p>
+      </div>
+    </header>
+    <form id="membership-create-form" class="form" autocomplete="off">
+      <input type="hidden" name="company_id" value="{{ selected_company_id or '' }}" />
+      <div class="form-field">
+        <label class="form-label" for="membership-user">User</label>
+        <select id="membership-user" name="user_id" class="form-input" required>
+          <option value="">Select a user</option>
+          {% for user in users %}
+            <option value="{{ user.id }}">{{ user.email }}{% if user.first_name or user.last_name %} — {{ user.first_name or '' }} {{ user.last_name or '' }}{% endif %}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="membership-role">Role</label>
+        <select id="membership-role" name="role_id" class="form-input" required>
+          {% for role in roles %}
+            <option value="{{ role.id }}">{{ role.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="membership-status">Status</label>
+        <select id="membership-status" name="status" class="form-input" required>
+          {% for status in status_options %}
+            <option value="{{ status.value }}">{{ status.label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button">Add membership</button>
+      </div>
+    </form>
+
+    <hr class="divider" />
+
+    <header class="card__header">
+      <div>
+        <h2 class="card__title">Update or suspend membership</h2>
+        <p class="card__subtitle">Select a membership to load its details. Changes take effect immediately.</p>
+      </div>
+    </header>
+    <form id="membership-update-form" class="form" autocomplete="off">
+      <input type="hidden" name="company_id" value="{{ selected_company_id or '' }}" />
+      <input type="hidden" name="membership_id" id="membership-id" />
+      <div class="form-field">
+        <label class="form-label" for="membership-user-display">User</label>
+        <input id="membership-user-display" class="form-input" disabled placeholder="Select a membership from the table" />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="membership-role-update">Role</label>
+        <select id="membership-role-update" name="role_id" class="form-input" required>
+          {% for role in roles %}
+            <option value="{{ role.id }}">{{ role.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="membership-status-update">Status</label>
+        <select id="membership-status-update" name="status" class="form-input" required>
+          {% for status in status_options %}
+            <option value="{{ status.value }}">{{ status.label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button" disabled data-membership-submit>Save changes</button>
+        <button type="button" class="button button--ghost" data-membership-clear>Clear selection</button>
+      </div>
+    </form>
+  </section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/admin.js" defer></script>
+{% endblock %}

--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -1,0 +1,142 @@
+{% extends "base.html" %}
+
+{% block sidebar_menu %}
+  {{ super() }}
+  <li class="menu__item">
+    <a href="/admin/memberships">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5zm0 2c-3.33 0-10 1.67-10 5v1h20v-1c0-3.33-6.67-5-10-5z"/></svg>
+      </span>
+      <span class="menu__label">Memberships</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/roles" aria-current="page">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M10.67 3.5a1 1 0 0 1 1.66 0l1.36 2.04a1 1 0 0 0 .63.43l2.35.5a1 1 0 0 1 .54 1.68l-1.67 1.8a1 1 0 0 0-.26.74l.2 2.4a1 1 0 0 1-1.4 1l-2.2-1a1 1 0 0 0-.84 0l-2.2 1a1 1 0 0 1-1.4-1l.2-2.4a1 1 0 0 0-.26-.74L6.39 8.15a1 1 0 0 1 .54-1.68l2.35-.5a1 1 0 0 0 .63-.43z"/></svg>
+      </span>
+      <span class="menu__label">Roles</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/audit-logs">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M5 4h14a1 1 0 0 1 1 1v15l-8-3-8 3V5a1 1 0 0 1 1-1z"/></svg>
+      </span>
+      <span class="menu__label">Audit trail</span>
+    </a>
+  </li>
+{% endblock %}
+
+{% block content %}
+<div class="admin-grid">
+  <section class="card card--panel">
+    <header class="card__header">
+      <div>
+        <h2 class="card__title">Defined roles</h2>
+        <p class="card__subtitle">Manage reusable permission sets for company memberships.</p>
+      </div>
+      <input
+        type="search"
+        class="form-input"
+        placeholder="Filter roles"
+        aria-label="Filter roles"
+        data-table-filter="roles-table"
+      />
+    </header>
+    <div class="table-wrapper">
+      <table class="table" id="roles-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col" data-sort="string">Name</th>
+            <th scope="col" data-sort="string">Description</th>
+            <th scope="col" data-sort="string">Permissions</th>
+            <th scope="col" data-sort="string">System</th>
+            <th scope="col" class="table__actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for role in roles %}
+            <tr
+              data-role-id="{{ role.id }}"
+              data-role-name="{{ role.name }}"
+              data-role-description="{{ role.description or '' }}"
+              data-role-permissions='{{ role.permissions | tojson }}'
+              data-role-system="{{ 'true' if role.is_system else 'false' }}"
+            >
+              <td data-label="Name">{{ role.name }}</td>
+              <td data-label="Description">{{ role.description or '—' }}</td>
+              <td data-label="Permissions">
+                {% if role.permissions %}
+                  <span class="tag-list">
+                    {% for perm in role.permissions %}
+                      <span class="tag">{{ perm }}</span>
+                    {% endfor %}
+                  </span>
+                {% else %}
+                  <span class="text-muted">None</span>
+                {% endif %}
+              </td>
+              <td data-label="System">{{ 'Yes' if role.is_system else 'No' }}</td>
+              <td class="table__actions">
+                <div class="table__action-buttons">
+                  <button type="button" class="button button--ghost" data-role-edit>Edit</button>
+                  {% if not role.is_system %}
+                    <button type="button" class="button button--danger" data-role-delete>Delete</button>
+                  {% endif %}
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="5" class="table__empty">No roles have been defined yet.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="card card--panel">
+    <header class="card__header">
+      <div>
+        <h2 class="card__title">Create or update a role</h2>
+        <p class="card__subtitle">Editing a role updates permissions for every assigned member immediately.</p>
+      </div>
+    </header>
+    <form id="role-form" class="form" autocomplete="off">
+      <input type="hidden" name="role_id" id="role-id" />
+      <div class="form-field">
+        <label class="form-label" for="role-name">Role name</label>
+        <input class="form-input" id="role-name" name="name" required minlength="2" maxlength="100" />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="role-description">Description</label>
+        <textarea class="form-input form-input--textarea" id="role-description" name="description" rows="3"></textarea>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="role-permissions">Permissions</label>
+        <input
+          class="form-input"
+          id="role-permissions"
+          name="permissions"
+          placeholder="membership.manage, audit.view"
+          aria-describedby="role-permissions-help"
+        />
+        <p class="form-help" id="role-permissions-help">Provide a comma separated list of permission keys.</p>
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button">Save role</button>
+        <button type="button" class="button button--ghost" data-role-reset>Clear form</button>
+      </div>
+      <p class="form-hint">System roles cannot be deleted and their names are fixed to retain portal integrity.</p>
+    </form>
+  </section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/admin.js" defer></script>
+{% endblock %}

--- a/changes.md
+++ b/changes.md
@@ -36,3 +36,4 @@
 - 2025-10-09, 13:30 UTC, Feature, Documented systemd service setup for running MyPortal as a managed Linux service
 - 2025-10-09, 15:42 UTC, Fix, Switched password hashing to bcrypt_sha256 to support long credentials without login failures
 - 2025-10-09, 16:18 UTC, Fix, Normalised login TOTP payload handling to accept legacy keys and enforce numeric codes server-side
+- 2025-10-08, 04:05 UTC, Feature, Introduced role-based company memberships with audit logging and admin control panels

--- a/migrations/063_roles_and_memberships.sql
+++ b/migrations/063_roles_and_memberships.sql
@@ -1,0 +1,47 @@
+CREATE TABLE roles (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL UNIQUE,
+  description TEXT NULL,
+  permissions JSON NULL,
+  is_system TINYINT(1) NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NULL ON UPDATE CURRENT_TIMESTAMP
+);
+
+INSERT INTO roles (name, description, permissions, is_system)
+VALUES
+  (
+    'Owner',
+    'Full control over company configuration and billing.',
+    JSON_ARRAY('company.manage', 'membership.manage', 'billing.manage', 'audit.view'),
+    1
+  ),
+  (
+    'Administrator',
+    'Manage memberships, roles, and operational settings.',
+    JSON_ARRAY('membership.manage', 'audit.view'),
+    1
+  ),
+  (
+    'Member',
+    'Standard access for day-to-day work.',
+    JSON_ARRAY('portal.access'),
+    1
+  );
+
+CREATE TABLE company_memberships (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  company_id INT NOT NULL,
+  user_id INT NOT NULL,
+  role_id INT NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'active',
+  invited_by INT NULL,
+  invited_at DATETIME NULL,
+  joined_at DATETIME NULL,
+  last_seen_at DATETIME NULL,
+  UNIQUE KEY uq_company_memberships_company_user (company_id, user_id),
+  CONSTRAINT fk_company_memberships_company FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE CASCADE,
+  CONSTRAINT fk_company_memberships_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT fk_company_memberships_role FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE RESTRICT,
+  CONSTRAINT fk_company_memberships_invited_by FOREIGN KEY (invited_by) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/migrations/064_extend_audit_logs.sql
+++ b/migrations/064_extend_audit_logs.sql
@@ -1,0 +1,7 @@
+ALTER TABLE audit_logs
+  ADD COLUMN entity_type VARCHAR(100) NULL AFTER action,
+  ADD COLUMN entity_id INT NULL AFTER entity_type,
+  ADD COLUMN metadata JSON NULL AFTER new_value;
+
+CREATE INDEX idx_audit_logs_entity ON audit_logs(entity_type, entity_id);
+CREATE INDEX idx_audit_logs_created_at ON audit_logs(created_at);


### PR DESCRIPTION
## Summary
- add SQL migrations for reusable roles, company memberships, and richer audit log metadata
- expose role, membership, and audit log APIs that log every change and seed default roles
- build super-admin membership, role, and audit dashboards with sortable tables and management workflows

## Testing
- pytest *(fails: missing email_validator dependency in the test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e5e1052a1c832d8e6692b6f0e35cef