### PR TITLE
Add portal commerce and forms Jinja templates

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -43,6 +43,10 @@ class Settings(BaseSettings):
     default_timezone: str = Field(default="UTC", validation_alias="CRON_TIMEZONE")
     enable_csrf: bool = Field(default=True, validation_alias="ENABLE_CSRF")
     swagger_ui_url: str = Field(default="/docs", validation_alias="SWAGGER_UI_URL")
+    opnform_base_url: AnyHttpUrl | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OPNFORM_BASE_URL", "OPNFORM_URL"),
+    )
 
     model_config = SettingsConfigDict(
         env_file=(Path(__file__).resolve().parent.parent.parent / ".env"),

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -504,6 +504,10 @@ body {
   font-size: 0.9rem;
 }
 
+.text-success {
+  color: #bbf7d0;
+}
+
 .stacked {
   display: flex;
   flex-direction: column;
@@ -557,6 +561,333 @@ body {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+.page-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.filters--compact {
+  gap: 0.75rem;
+}
+
+.filters__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 180px;
+}
+
+.filters__group--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: auto;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.checkbox input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+}
+
+.link-button:focus-visible {
+  outline: 2px solid rgba(56, 189, 248, 0.7);
+  outline-offset: 2px;
+}
+
+.product-thumb {
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.product-preview {
+  width: 120px;
+  height: auto;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.inline-form {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.form-input--sm {
+  max-width: 90px;
+}
+
+.form-input--inline {
+  width: 100%;
+  min-width: 160px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.badge--success {
+  background: rgba(134, 239, 172, 0.2);
+  color: #bbf7d0;
+}
+
+.badge--warning {
+  background: rgba(253, 224, 71, 0.18);
+  color: #fef3c7;
+}
+
+.badge--danger {
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+}
+
+.badge--muted {
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(229, 231, 235, 0.9);
+}
+
+.alert {
+  border-radius: 0.85rem;
+  padding: 1rem 1.25rem;
+  font-weight: 600;
+}
+
+.alert--error {
+  background: rgba(248, 113, 113, 0.2);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(6px);
+  padding: 2rem;
+  z-index: 1000;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal__content {
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 1rem;
+  padding: 2rem;
+  position: relative;
+  width: min(640px, 90vw);
+  max-height: 90vh;
+  overflow-y: auto;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 24px 50px -20px rgba(15, 23, 42, 0.85);
+}
+
+.modal__close {
+  position: absolute;
+  top: 0.75rem;
+  right: 1rem;
+  border: none;
+  background: none;
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.modal__title {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.modal__subtitle {
+  margin: 1rem 0 0.35rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modal__image {
+  width: 100%;
+  max-height: 320px;
+  object-fit: contain;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.modal__text {
+  margin: 0.5rem 0;
+}
+
+.forms-layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+  align-items: start;
+}
+
+@media (max-width: 960px) {
+  .forms-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.forms-layout__menu,
+.forms-layout__viewer {
+  height: 100%;
+}
+
+.forms-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.forms-menu__button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  padding: 0.9rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(148, 163, 184, 0.08);
+  border: 1px solid transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.forms-menu__button.is-active {
+  border-color: rgba(56, 189, 248, 0.6);
+  background: rgba(56, 189, 248, 0.1);
+}
+
+.forms-menu__button:hover,
+.forms-menu__button:focus {
+  border-color: rgba(148, 163, 184, 0.4);
+}
+
+.forms-menu__name {
+  font-weight: 600;
+}
+
+.forms-menu__description {
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.9rem;
+}
+
+.form-frame {
+  width: 100%;
+  min-height: 560px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 240px;
+  color: rgba(148, 163, 184, 0.85);
+  font-weight: 500;
+}
+
+.form-field--checkbox {
+  justify-content: flex-end;
+}
+
+.form-field--wide {
+  grid-column: span 2;
+}
+
+@media (max-width: 720px) {
+  .form-field--wide {
+    grid-column: span 1;
+  }
+}
+
+.admin-grid__full {
+  grid-column: 1 / -1;
+}
+
+.category-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.category-list__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.category-list__item--empty {
+  justify-content: center;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.visibility-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-bottom: 1rem;
+}
+
+.visibility-grid__item {
+  background: rgba(30, 41, 59, 0.75);
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
 }
 .card h2 {
   margin-top: 0;

--- a/app/static/js/forms.js
+++ b/app/static/js/forms.js
@@ -1,0 +1,37 @@
+(function () {
+  function parseJson(elementId) {
+    const element = document.getElementById(elementId);
+    if (!element) {
+      return [];
+    }
+    try {
+      return JSON.parse(element.textContent || '[]');
+    } catch (error) {
+      console.error('Unable to parse JSON data for', elementId, error);
+      return [];
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const data = parseJson('forms-data');
+    const iframe = document.getElementById('form-frame');
+    const buttons = Array.from(document.querySelectorAll('[data-form-switch]'));
+
+    if (buttons.length === 0 || !iframe) {
+      return;
+    }
+
+    buttons.forEach((button, index) => {
+      button.addEventListener('click', () => {
+        buttons.forEach((btn) => btn.classList.remove('is-active'));
+        button.classList.add('is-active');
+        const url = button.getAttribute('data-form-url') || '';
+        if (url) {
+          iframe.src = url;
+        } else if (data[index] && data[index].iframe_url) {
+          iframe.src = data[index].iframe_url;
+        }
+      });
+    });
+  });
+})();

--- a/app/static/js/forms_admin.js
+++ b/app/static/js/forms_admin.js
@@ -1,0 +1,12 @@
+(function () {
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('form[data-confirm]').forEach((form) => {
+      form.addEventListener('submit', (event) => {
+        const message = form.getAttribute('data-confirm') || 'Are you sure?';
+        if (!confirm(message)) {
+          event.preventDefault();
+        }
+      });
+    });
+  });
+})();

--- a/app/static/js/shop.js
+++ b/app/static/js/shop.js
@@ -1,0 +1,151 @@
+(function () {
+  function parseJson(elementId) {
+    const element = document.getElementById(elementId);
+    if (!element) {
+      return [];
+    }
+    try {
+      return JSON.parse(element.textContent || '[]');
+    } catch (error) {
+      console.error('Unable to parse JSON data for', elementId, error);
+      return [];
+    }
+  }
+
+  function submitOnChange(container) {
+    container.querySelectorAll('[data-submit-on-change]').forEach((input) => {
+      input.addEventListener('change', () => {
+        const form = input.closest('form');
+        if (form) {
+          form.submit();
+        }
+      });
+    });
+  }
+
+  function openModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.hidden = false;
+    modal.classList.add('is-visible');
+  }
+
+  function closeModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.classList.remove('is-visible');
+    modal.hidden = true;
+  }
+
+  function bindModalDismissal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal || event.target.hasAttribute('data-modal-close')) {
+        closeModal(modal);
+      }
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !modal.hidden) {
+        closeModal(modal);
+      }
+    });
+  }
+
+  function createDetailRow(label, value) {
+    const row = document.createElement('p');
+    row.className = 'modal__text';
+    row.textContent = `${label}: ${value}`;
+    return row;
+  }
+
+  function renderProductDetails(product) {
+    const container = document.getElementById('product-details-body');
+    if (!container) {
+      return;
+    }
+    container.innerHTML = '';
+    if (!product) {
+      const empty = document.createElement('p');
+      empty.className = 'text-muted';
+      empty.textContent = 'Product details are unavailable.';
+      container.appendChild(empty);
+      return;
+    }
+
+    if (product.image_url) {
+      const image = document.createElement('img');
+      image.src = product.image_url;
+      image.alt = `${product.name} image`;
+      image.className = 'modal__image';
+      container.appendChild(image);
+    }
+
+    container.appendChild(createDetailRow('Price', `$${Number(product.price || 0).toFixed(2)}`));
+
+    const stock = Number(product.stock || 0);
+    let stockText = 'Out of stock';
+    if (stock > 5) {
+      stockText = 'In stock';
+    } else if (stock > 0) {
+      stockText = 'Low stock';
+    }
+    container.appendChild(createDetailRow('Availability', stockText));
+
+    if (product.vendor_sku) {
+      container.appendChild(createDetailRow('Vendor SKU', product.vendor_sku));
+    }
+
+    if (product.description) {
+      const descriptionTitle = document.createElement('h3');
+      descriptionTitle.className = 'modal__subtitle';
+      descriptionTitle.textContent = 'Description';
+      container.appendChild(descriptionTitle);
+
+      product.description.split(/\r?\n/).forEach((line) => {
+        if (!line) {
+          return;
+        }
+        const paragraph = document.createElement('p');
+        paragraph.textContent = line;
+        container.appendChild(paragraph);
+      });
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const container = document.body;
+    submitOnChange(container);
+
+    const products = parseJson('shop-products-data');
+    const productsById = new Map(products.map((product) => [product.id, product]));
+
+    const imageModal = document.getElementById('product-image-modal');
+    const detailsModal = document.getElementById('product-details-modal');
+    const imagePreview = document.getElementById('product-image-preview');
+
+    bindModalDismissal(imageModal);
+    bindModalDismissal(detailsModal);
+
+    container.querySelectorAll('[data-image-preview]').forEach((button) => {
+      button.addEventListener('click', () => {
+        if (!imageModal || !imagePreview) {
+          return;
+        }
+        imagePreview.src = button.getAttribute('data-image-url') || '';
+        openModal(imageModal);
+      });
+    });
+
+    container.querySelectorAll('[data-product-details]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const id = Number(button.getAttribute('data-product-details'));
+        renderProductDetails(productsById.get(id));
+        openModal(detailsModal);
+      });
+    });
+  });
+})();

--- a/app/static/js/shop_admin.js
+++ b/app/static/js/shop_admin.js
@@ -1,0 +1,177 @@
+(function () {
+  function parseJson(elementId, fallback) {
+    const element = document.getElementById(elementId);
+    if (!element) {
+      return fallback;
+    }
+    try {
+      return JSON.parse(element.textContent || 'null') ?? fallback;
+    } catch (error) {
+      console.error('Unable to parse JSON data for', elementId, error);
+      return fallback;
+    }
+  }
+
+  function bindConfirmations() {
+    document.querySelectorAll('form[data-confirm]').forEach((form) => {
+      form.addEventListener('submit', (event) => {
+        const message = form.getAttribute('data-confirm') || 'Are you sure?';
+        if (!confirm(message)) {
+          event.preventDefault();
+        }
+      });
+    });
+  }
+
+  function submitOnChange(container) {
+    container.querySelectorAll('[data-submit-on-change]').forEach((input) => {
+      input.addEventListener('change', () => {
+        const form = input.closest('form');
+        if (form) {
+          form.submit();
+        }
+      });
+    });
+  }
+
+  function openModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.hidden = false;
+    modal.classList.add('is-visible');
+  }
+
+  function closeModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.classList.remove('is-visible');
+    modal.hidden = true;
+  }
+
+  function bindModalDismissal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal || event.target.hasAttribute('data-modal-close')) {
+        closeModal(modal);
+      }
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !modal.hidden) {
+        closeModal(modal);
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const container = document.body;
+    submitOnChange(container);
+    bindConfirmations();
+
+    const products = parseJson('admin-products-data', []);
+    const restrictions = parseJson('admin-product-restrictions', {});
+    const productsById = new Map(products.map((product) => [product.id, product]));
+
+    const stockFilter = document.getElementById('stock-filter');
+    const showArchivedCheckbox = document.getElementById('show-archived');
+    const productsTable = document.getElementById('admin-products-table');
+
+    function applyFilters() {
+      if (!productsTable) {
+        return;
+      }
+      const rows = productsTable.querySelectorAll('tbody tr');
+      const stockValue = stockFilter ? stockFilter.value : '';
+      const showArchived = showArchivedCheckbox ? showArchivedCheckbox.checked : false;
+      rows.forEach((row) => {
+        const stock = Number(row.getAttribute('data-stock') || '0');
+        const isArchived = row.getAttribute('data-archived') === 'true';
+        const matchesStock =
+          !stockValue ||
+          (stockValue === 'in' && stock > 0) ||
+          (stockValue === 'out' && stock === 0);
+        const matchesArchived = showArchived || !isArchived;
+        row.style.display = matchesStock && matchesArchived ? '' : 'none';
+      });
+    }
+
+    if (stockFilter) {
+      stockFilter.addEventListener('change', applyFilters);
+    }
+    if (showArchivedCheckbox) {
+      showArchivedCheckbox.addEventListener('change', () => {
+        const url = new URL(window.location.href);
+        if (showArchivedCheckbox.checked) {
+          url.searchParams.set('showArchived', '1');
+        } else {
+          url.searchParams.delete('showArchived');
+        }
+        window.history.replaceState({}, '', url.toString());
+        applyFilters();
+      });
+    }
+    applyFilters();
+
+    const editModal = document.getElementById('product-edit-modal');
+    const visibilityModal = document.getElementById('product-visibility-modal');
+    const editForm = document.getElementById('product-edit-form');
+    const visibilityForm = document.getElementById('product-visibility-form');
+    const previewImage = document.getElementById('edit-product-preview');
+    const editIdField = document.getElementById('edit-product-id');
+
+    bindModalDismissal(editModal);
+    bindModalDismissal(visibilityModal);
+
+    container.querySelectorAll('[data-product-edit]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const id = Number(button.getAttribute('data-product-edit'));
+        const product = productsById.get(id);
+        if (!product || !editForm || !editIdField) {
+          return;
+        }
+        editIdField.value = String(id);
+        editForm.action = `/shop/admin/product/${id}`;
+        editForm.querySelector('#edit-product-name').value = product.name || '';
+        editForm.querySelector('#edit-product-sku').value = product.sku || '';
+        editForm.querySelector('#edit-product-vendor').value = product.vendor_sku || '';
+        editForm.querySelector('#edit-product-description').value = product.description || '';
+        editForm.querySelector('#edit-product-price').value = product.price != null ? product.price : '';
+        editForm.querySelector('#edit-product-vip').value = product.vip_price != null ? product.vip_price : '';
+        editForm.querySelector('#edit-product-stock').value = product.stock != null ? product.stock : '';
+        const categorySelect = editForm.querySelector('#edit-product-category');
+        if (categorySelect) {
+          categorySelect.value = product.category_id || '';
+        }
+        if (previewImage) {
+          if (product.image_url) {
+            previewImage.src = product.image_url;
+            previewImage.hidden = false;
+          } else {
+            previewImage.hidden = true;
+          }
+        }
+        openModal(editModal);
+      });
+    });
+
+    container.querySelectorAll('[data-product-visibility]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const id = Number(button.getAttribute('data-product-visibility'));
+        const form = visibilityForm;
+        if (!form) {
+          return;
+        }
+        form.action = `/shop/admin/product/${id}/visibility`;
+        const selected = (restrictions[id] || []).map((entry) => Number(entry.company_id));
+        form.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+          const value = Number(checkbox.value);
+          checkbox.checked = selected.includes(value);
+        });
+        openModal(visibilityModal);
+      });
+    });
+  });
+})();

--- a/app/static/js/staff.js
+++ b/app/static/js/staff.js
@@ -1,0 +1,308 @@
+(function () {
+  function parseJson(elementId, fallback) {
+    const element = document.getElementById(elementId);
+    if (!element) {
+      return fallback;
+    }
+    try {
+      return JSON.parse(element.textContent || 'null') ?? fallback;
+    } catch (error) {
+      console.error('Unable to parse JSON data for', elementId, error);
+      return fallback;
+    }
+  }
+
+  function getCookie(name) {
+    const pattern = `(?:^|; )${name.replace(/([.$?*|{}()\[\]\\\/\+^])/g, '\\$1')}=([^;]*)`;
+    const matches = document.cookie.match(new RegExp(pattern));
+    return matches ? decodeURIComponent(matches[1]) : '';
+  }
+
+  function getCsrfToken() {
+    return getCookie('myportal_session_csrf');
+  }
+
+  async function requestJson(url, options) {
+    const response = await fetch(url, {
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': getCsrfToken(),
+        ...(options && options.headers ? options.headers : {}),
+      },
+      ...options,
+    });
+    if (!response.ok) {
+      let detail = `${response.status} ${response.statusText}`;
+      try {
+        const data = await response.json();
+        if (data && data.detail) {
+          detail = Array.isArray(data.detail)
+            ? data.detail.map((entry) => entry.msg || entry).join(', ')
+            : data.detail;
+        }
+      } catch (error) {
+        // ignore json parsing errors
+      }
+      throw new Error(detail);
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    try {
+      return await response.json();
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function submitOnChange(container) {
+    container.querySelectorAll('[data-submit-on-change]').forEach((input) => {
+      input.addEventListener('change', () => {
+        const form = input.closest('form');
+        if (form) {
+          form.submit();
+        }
+      });
+    });
+  }
+
+  function openModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.hidden = false;
+    modal.classList.add('is-visible');
+  }
+
+  function closeModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.classList.remove('is-visible');
+    modal.hidden = true;
+  }
+
+  function bindModalDismissal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal || event.target.hasAttribute('data-modal-close')) {
+        closeModal(modal);
+      }
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !modal.hidden) {
+        closeModal(modal);
+      }
+    });
+  }
+
+  function getField(id) {
+    return document.getElementById(id);
+  }
+
+  function setValue(element, value) {
+    if (!element) {
+      return;
+    }
+    element.value = value ?? '';
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const container = document.body;
+    const staffList = parseJson('staff-data', []);
+    const flags = parseJson('staff-flags', {});
+    const staffById = new Map(staffList.map((member) => [member.id, member]));
+
+    submitOnChange(container);
+
+    const editModal = document.getElementById('staff-edit-modal');
+    const editForm = document.getElementById('staff-edit-form');
+    const editIdField = getField('edit-staff-id');
+
+    const editFields = {
+      first_name: getField('edit-first-name'),
+      last_name: getField('edit-last-name'),
+      email: getField('edit-email'),
+      mobile_phone: getField('edit-mobile'),
+      date_onboarded: getField('edit-date-onboarded'),
+      date_offboarded: getField('edit-date-offboarded'),
+      enabled: getField('edit-enabled'),
+      street: getField('edit-street'),
+      city: getField('edit-city'),
+      state: getField('edit-state'),
+      postcode: getField('edit-postcode'),
+      country: getField('edit-country'),
+      department: getField('edit-department'),
+      job_title: getField('edit-job-title'),
+      org_company: getField('edit-company'),
+      manager_name: getField('edit-manager-name'),
+      account_action: getField('edit-account-action'),
+    };
+
+    bindModalDismissal(editModal);
+
+    if (flags && flags.isAdmin && !flags.isSuperAdmin) {
+      const offboardField = editFields.date_offboarded;
+      if (offboardField) {
+        offboardField.addEventListener('change', () => {
+          if (offboardField.value) {
+            alert(
+              'The offboard will be scheduled immediately for the requested date and time. Contact IT to make changes after saving.'
+            );
+          }
+        });
+      }
+    }
+
+    container.querySelectorAll('[data-staff-edit]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const id = Number(button.getAttribute('data-staff-edit'));
+        const member = staffById.get(id);
+        if (!member || !editForm || !editIdField) {
+          return;
+        }
+        editIdField.value = String(id);
+        setValue(editFields.first_name, member.first_name);
+        setValue(editFields.last_name, member.last_name);
+        setValue(editFields.email, member.email);
+        setValue(editFields.mobile_phone, member.mobile_phone);
+        setValue(editFields.date_onboarded, member.date_onboarded ? member.date_onboarded.slice(0, 10) : '');
+        setValue(editFields.date_offboarded, member.date_offboarded ? member.date_offboarded.slice(0, 16) : '');
+        if (editFields.enabled) {
+          editFields.enabled.checked = Boolean(member.enabled);
+        }
+        setValue(editFields.street, member.street);
+        setValue(editFields.city, member.city);
+        setValue(editFields.state, member.state);
+        setValue(editFields.postcode, member.postcode);
+        setValue(editFields.country, member.country);
+        setValue(editFields.department, member.department);
+        setValue(editFields.job_title, member.job_title);
+        setValue(editFields.org_company, member.org_company);
+        setValue(editFields.manager_name, member.manager_name);
+        if (editFields.account_action) {
+          editFields.account_action.value = member.account_action || 'Onboard Requested';
+        }
+        openModal(editModal);
+      });
+    });
+
+    if (editForm) {
+      editForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const staffId = editIdField ? editIdField.value : '';
+        if (!staffId) {
+          return;
+        }
+        const payload = {
+          firstName: editFields.first_name ? editFields.first_name.value : '',
+          lastName: editFields.last_name ? editFields.last_name.value : '',
+          email: editFields.email ? editFields.email.value : '',
+          mobilePhone: editFields.mobile_phone ? editFields.mobile_phone.value : '',
+          dateOnboarded: editFields.date_onboarded ? editFields.date_onboarded.value : '',
+          dateOffboarded: editFields.date_offboarded ? editFields.date_offboarded.value : '',
+          enabled: editFields.enabled ? editFields.enabled.checked : false,
+          street: editFields.street ? editFields.street.value : '',
+          city: editFields.city ? editFields.city.value : '',
+          state: editFields.state ? editFields.state.value : '',
+          postcode: editFields.postcode ? editFields.postcode.value : '',
+          country: editFields.country ? editFields.country.value : '',
+          department: editFields.department ? editFields.department.value : '',
+          jobTitle: editFields.job_title ? editFields.job_title.value : '',
+          company: editFields.org_company ? editFields.org_company.value : '',
+          managerName: editFields.manager_name ? editFields.manager_name.value : '',
+          accountAction: editFields.account_action ? editFields.account_action.value : '',
+        };
+        try {
+          await requestJson(`/staff/${staffId}`, {
+            method: 'PUT',
+            body: JSON.stringify(payload),
+          });
+          window.location.reload();
+        } catch (error) {
+          alert(`Unable to update staff member: ${error.message}`);
+        }
+      });
+    }
+
+    container.querySelectorAll('[data-staff-verify]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const id = button.getAttribute('data-staff-verify');
+        if (!id) {
+          return;
+        }
+        try {
+          const data = await requestJson(`/staff/${id}/verify`, { method: 'POST' });
+          const row = button.closest('tr');
+          const codeCell = row ? row.querySelector('.verification-code') : null;
+          if (codeCell) {
+            codeCell.textContent = data && data.code ? data.code : '';
+            codeCell.classList.toggle('text-success', data && data.status === 202);
+          }
+          if (!data || data.status !== 202) {
+            alert('Verification code dispatched, but upstream delivery may have failed.');
+          }
+        } catch (error) {
+          alert(`Failed to send verification code: ${error.message}`);
+        }
+      });
+    });
+
+    container.querySelectorAll('[data-staff-invite]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        if (!confirm('Send an invitation to this staff member?')) {
+          return;
+        }
+        const id = button.getAttribute('data-staff-invite');
+        if (!id) {
+          return;
+        }
+        try {
+          await requestJson(`/staff/${id}/invite`, { method: 'POST' });
+          alert('Invitation sent successfully.');
+        } catch (error) {
+          alert(`Failed to send invitation: ${error.message}`);
+        }
+      });
+    });
+
+    container.querySelectorAll('[data-staff-delete]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        if (!confirm('Delete this staff record? This action cannot be undone.')) {
+          return;
+        }
+        const id = button.getAttribute('data-staff-delete');
+        if (!id) {
+          return;
+        }
+        try {
+          await requestJson(`/staff/${id}`, { method: 'DELETE' });
+          window.location.reload();
+        } catch (error) {
+          alert(`Failed to delete staff record: ${error.message}`);
+        }
+      });
+    });
+
+    const importButton = container.querySelector('[data-import-syncro]');
+    if (importButton && flags && flags.syncroCompanyId) {
+      importButton.addEventListener('click', async () => {
+        if (!confirm('Import contacts from Syncro now?')) {
+          return;
+        }
+        try {
+          await requestJson('/admin/syncro/import-contacts', {
+            method: 'POST',
+            body: JSON.stringify({ syncroCompanyId: flags.syncroCompanyId }),
+          });
+          window.location.reload();
+        } catch (error) {
+          alert(`Unable to import contacts: ${error.message}`);
+        }
+      });
+    }
+  });
+})();

--- a/app/templates/admin/forms.html
+++ b/app/templates/admin/forms.html
@@ -1,0 +1,155 @@
+{% extends "base.html" %}
+
+{% block sidebar_menu %}
+  {{ super() }}
+  <li class="menu__item">
+    <a href="/admin/memberships">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5zm0 2c-3.33 0-10 1.67-10 5v1h20v-1c0-3.33-6.67-5-10-5z"/></svg>
+      </span>
+      <span class="menu__label">Memberships</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/roles">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M10.67 3.5a1 1 0 0 1 1.66 0l1.36 2.04a1 1 0 0 0 .63.43l2.35.5a1 1 0 0 1 .54 1.68l-1.67 1.8a1 1 0 0 0-.26.74l.2 2.4a1 1 0 0 1-1.4 1l-2.2-1a1 1 0 0 0-.84 0l-2.2 1a1 1 0 0 1-1.4-1l.2-2.4a1 1 0 0 0-.26-.74L6.39 8.15a1 1 0 0 1 .54-1.68l2.35-.5a1 1 0 0 0 .63-.43z"/></svg>
+      </span>
+      <span class="menu__label">Roles</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/audit-logs">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M5 4h14a1 1 0 0 1 1 1v15l-8-3-8 3V5a1 1 0 0 1 1-1z"/></svg>
+      </span>
+      <span class="menu__label">Audit trail</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/forms" aria-current="page">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2h9l5 5v15H6a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zm8 7h4.5L14 4.5V9z"/></svg>
+      </span>
+      <span class="menu__label">Forms admin</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/shop">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M4 7h16l-1.5 12.5A2 2 0 0 1 16.52 21H7.48a2 2 0 0 1-1.98-1.5zM6 3h12a1 1 0 0 1 1 1v2H5V4a1 1 0 0 1 1-1z"/></svg>
+      </span>
+      <span class="menu__label">Shop admin</span>
+    </a>
+  </li>
+{% endblock %}
+
+{% block content %}
+<div class="admin-grid">
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Build with OpnForm</h2>
+        <p class="card__subtitle">Design forms in OpnForm and surface them instantly within the customer portal.</p>
+      </div>
+      {% if opnform_base_url %}
+        <a class="button" href="{{ opnform_base_url }}" target="_blank" rel="noopener">Open OpnForm</a>
+      {% endif %}
+    </header>
+    <p class="text-muted">Published forms appear automatically and can be assigned to users or companies from here.</p>
+  </section>
+
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Add a form</h2>
+        <p class="card__subtitle">Store the OpnForm share URL with a friendly label and optional description.</p>
+      </div>
+    </header>
+    <form action="/myforms/admin" method="post" class="form-grid">
+      <div class="form-field">
+        <label class="form-label" for="new-form-name">Name</label>
+        <input class="form-input" id="new-form-name" name="name" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="new-form-url">Form URL</label>
+        <input class="form-input" id="new-form-url" name="url" type="url" placeholder="https://forms.example.com/" required />
+      </div>
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="new-form-description">Description</label>
+        <input class="form-input" id="new-form-description" name="description" />
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button">Save form</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Manage existing forms</h2>
+        <p class="card__subtitle">Update URLs or descriptions inline and archive forms you no longer need.</p>
+      </div>
+      <div class="card__controls">
+        <input
+          type="search"
+          class="form-input"
+          placeholder="Filter forms"
+          aria-label="Filter forms"
+          data-table-filter="forms-admin-table"
+        />
+      </div>
+    </header>
+    <div class="table-wrapper">
+      <table class="table" id="forms-admin-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col" data-sort="string">Name</th>
+            <th scope="col" data-sort="string">URL</th>
+            <th scope="col" data-sort="string">Description</th>
+            <th scope="col" class="table__actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for form in forms %}
+            <tr>
+              <td data-label="Name">
+                <input form="form-{{ form.id }}" class="form-input form-input--inline" type="text" name="name" value="{{ form.name }}" required />
+              </td>
+              <td data-label="URL">
+                <input form="form-{{ form.id }}" class="form-input form-input--inline" type="url" name="url" value="{{ form.url }}" required />
+              </td>
+              <td data-label="Description">
+                <input form="form-{{ form.id }}" class="form-input form-input--inline" type="text" name="description" value="{{ form.description or '' }}" />
+              </td>
+              <td class="table__actions">
+                <div class="table__action-buttons">
+                  <form id="form-{{ form.id }}" action="/myforms/admin/edit" method="post" class="inline-form">
+                    <input type="hidden" name="id" value="{{ form.id }}" />
+                    <button type="submit" class="button button--ghost">Save</button>
+                  </form>
+                  <form action="/myforms/admin/delete" method="post" class="inline-form" data-confirm="Delete this form?">
+                    <input type="hidden" name="id" value="{{ form.id }}" />
+                    <button type="submit" class="button button--danger">Delete</button>
+                  </form>
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="4" class="table__empty">No forms have been added yet.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/forms_admin.js" defer></script>
+{% endblock %}

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -1,0 +1,332 @@
+{% extends "base.html" %}
+
+{% block sidebar_menu %}
+  {{ super() }}
+  <li class="menu__item">
+    <a href="/admin/memberships">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5zm0 2c-3.33 0-10 1.67-10 5v1h20v-1c0-3.33-6.67-5-10-5z"/></svg>
+      </span>
+      <span class="menu__label">Memberships</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/roles">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M10.67 3.5a1 1 0 0 1 1.66 0l1.36 2.04a1 1 0 0 0 .63.43l2.35.5a1 1 0 0 1 .54 1.68l-1.67 1.8a1 1 0 0 0-.26.74l.2 2.4a1 1 0 0 1-1.4 1l-2.2-1a1 1 0 0 0-.84 0l-2.2 1a1 1 0 0 1-1.4-1l.2-2.4a1 1 0 0 0-.26-.74L6.39 8.15a1 1 0 0 1 .54-1.68l2.35-.5a1 1 0 0 0 .63-.43z"/></svg>
+      </span>
+      <span class="menu__label">Roles</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/audit-logs">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M5 4h14a1 1 0 0 1 1 1v15l-8-3-8 3V5a1 1 0 0 1 1-1z"/></svg>
+      </span>
+      <span class="menu__label">Audit trail</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/forms">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2h9l5 5v15H6a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zm8 7h4.5L14 4.5V9z"/></svg>
+      </span>
+      <span class="menu__label">Forms admin</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/admin/shop" aria-current="page">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M4 7h16l-1.5 12.5A2 2 0 0 1 16.52 21H7.48a2 2 0 0 1-1.98-1.5zM6 3h12a1 1 0 0 1 1 1v2H5V4a1 1 0 0 1 1-1z"/></svg>
+      </span>
+      <span class="menu__label">Shop admin</span>
+    </a>
+  </li>
+{% endblock %}
+
+{% block content %}
+<div class="admin-grid admin-grid--columns">
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Product categories</h2>
+        <p class="card__subtitle">Group products for faster browsing and targeted visibility rules.</p>
+      </div>
+    </header>
+    <form action="/shop/admin/category" method="post" class="form-grid">
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="category-name">Category name</label>
+        <input class="form-input" id="category-name" name="name" required />
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button">Add category</button>
+      </div>
+    </form>
+    <ul class="category-list">
+      {% for category in categories %}
+        <li class="category-list__item">
+          <span>{{ category.name }}</span>
+          <form action="/shop/admin/category/{{ category.id }}/delete" method="post" class="inline-form" data-confirm="Delete this category?">
+            <button type="submit" class="button button--danger">Delete</button>
+          </form>
+        </li>
+      {% else %}
+        <li class="category-list__item category-list__item--empty">No categories defined.</li>
+      {% endfor %}
+    </ul>
+  </section>
+
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Import product</h2>
+        <p class="card__subtitle">Pull catalogue data from upstream vendors via their SKU.</p>
+      </div>
+    </header>
+    <form action="/shop/admin/product/import" method="post" class="form-grid">
+      <div class="form-field">
+        <label class="form-label" for="import-vendor-sku">Vendor SKU</label>
+        <input class="form-input" id="import-vendor-sku" name="vendor_sku" required />
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button">Import</button>
+      </div>
+    </form>
+  </section>
+</div>
+
+<div class="admin-grid">
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Add product</h2>
+        <p class="card__subtitle">Create catalogue items with rich descriptions, pricing, and stock levels.</p>
+      </div>
+    </header>
+    <form action="/shop/admin/product" method="post" enctype="multipart/form-data" class="form-grid">
+      <div class="form-field">
+        <label class="form-label" for="product-name">Name</label>
+        <input class="form-input" id="product-name" name="name" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="product-sku">SKU</label>
+        <input class="form-input" id="product-sku" name="sku" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="product-vendor-sku">Vendor SKU</label>
+        <input class="form-input" id="product-vendor-sku" name="vendor_sku" required />
+      </div>
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="product-description">Description</label>
+        <textarea class="form-input form-input--textarea" id="product-description" name="description"></textarea>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="product-price">Price</label>
+        <input class="form-input" id="product-price" name="price" type="number" step="0.01" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="product-vip-price">VIP price</label>
+        <input class="form-input" id="product-vip-price" name="vip_price" type="number" step="0.01" />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="product-stock">Stock</label>
+        <input class="form-input" id="product-stock" name="stock" type="number" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="product-category">Category</label>
+        <select class="form-input" id="product-category" name="category_id">
+          <option value="">No category</option>
+          {% for category in categories %}
+            <option value="{{ category.id }}">{{ category.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="product-image">Image</label>
+        <input class="form-input" id="product-image" name="image" type="file" accept="image/*" />
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button">Add product</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Product catalogue</h2>
+        <p class="card__subtitle">Filter, sort, and manage catalogue items with real-time previews.</p>
+      </div>
+      <div class="card__controls">
+        <input
+          type="search"
+          class="form-input card__control"
+          placeholder="Search products"
+          aria-label="Search products"
+          data-table-filter="admin-products-table"
+        />
+        <select class="form-input card__control" id="stock-filter">
+          <option value="">All stock</option>
+          <option value="in">In stock</option>
+          <option value="out">Out of stock</option>
+        </select>
+        <label class="checkbox card__control">
+          <input type="checkbox" id="show-archived" {% if show_archived %}checked{% endif %} />
+          <span>Show archived</span>
+        </label>
+      </div>
+    </header>
+    <div class="table-wrapper">
+      <table class="table" id="admin-products-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col">Image</th>
+            <th scope="col" data-sort="string">Name</th>
+            <th scope="col" data-sort="string">SKU</th>
+            <th scope="col" data-sort="string">Vendor SKU</th>
+            <th scope="col" data-sort="number">Price</th>
+            <th scope="col" data-sort="number">VIP</th>
+            <th scope="col" data-sort="string">Category</th>
+            <th scope="col" data-sort="number">Stock</th>
+            <th scope="col" class="table__actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for product in products %}
+            <tr data-product-id="{{ product.id }}" data-stock="{{ product.stock }}" data-archived="{{ 'true' if product.archived else 'false' }}">
+              <td data-label="Image">
+                {% if product.image_url %}
+                  <img src="{{ product.image_url }}" alt="" class="product-thumb" loading="lazy" />
+                {% else %}
+                  <span class="text-muted">—</span>
+                {% endif %}
+              </td>
+              <td data-label="Name">{{ product.name }}</td>
+              <td data-label="SKU">{{ product.sku }}</td>
+              <td data-label="Vendor SKU">{{ product.vendor_sku }}</td>
+              <td data-label="Price" data-value="{{ product.price }}">${{ '%.2f'|format(product.price) }}</td>
+              <td data-label="VIP" data-value="{{ product.vip_price if product.vip_price is not none else '' }}">
+                {% if product.vip_price is not none %}
+                  ${{ '%.2f'|format(product.vip_price) }}
+                {% else %}
+                  <span class="text-muted">—</span>
+                {% endif %}
+              </td>
+              <td data-label="Category">{{ product.category_name or '—' }}</td>
+              <td data-label="Stock" data-value="{{ product.stock }}">{{ product.stock }}</td>
+              <td class="table__actions">
+                <div class="table__action-buttons">
+                  <button type="button" class="button button--ghost" data-product-edit="{{ product.id }}">Edit</button>
+                  <form action="/shop/admin/product/{{ product.id }}/{{ 'unarchive' if product.archived else 'archive' }}" method="post" class="inline-form">
+                    <button type="submit" class="button button--ghost">{{ 'Unarchive' if product.archived else 'Archive' }}</button>
+                  </form>
+                  <form action="/shop/admin/product/{{ product.id }}/delete" method="post" class="inline-form" data-confirm="Delete this product?">
+                    <button type="submit" class="button button--danger">Delete</button>
+                  </form>
+                  <button type="button" class="button button--ghost" data-product-visibility="{{ product.id }}">Visibility</button>
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="9" class="table__empty">No products found.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+
+<div class="modal" id="product-edit-modal" role="dialog" aria-modal="true" hidden>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close>
+      <span class="visually-hidden">Close product editor</span>
+      &times;
+    </button>
+    <h2 class="modal__title">Edit product</h2>
+    <form id="product-edit-form" method="post" enctype="multipart/form-data" class="form-grid">
+      <input type="hidden" id="edit-product-id" />
+      <div class="form-field">
+        <label class="form-label" for="edit-product-name">Name</label>
+        <input class="form-input" id="edit-product-name" name="name" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-product-sku">SKU</label>
+        <input class="form-input" id="edit-product-sku" name="sku" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-product-vendor">Vendor SKU</label>
+        <input class="form-input" id="edit-product-vendor" name="vendor_sku" required />
+      </div>
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="edit-product-description">Description</label>
+        <textarea class="form-input form-input--textarea" id="edit-product-description" name="description"></textarea>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-product-price">Price</label>
+        <input class="form-input" id="edit-product-price" name="price" type="number" step="0.01" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-product-vip">VIP price</label>
+        <input class="form-input" id="edit-product-vip" name="vip_price" type="number" step="0.01" />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-product-stock">Stock</label>
+        <input class="form-input" id="edit-product-stock" name="stock" type="number" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-product-category">Category</label>
+        <select class="form-input" id="edit-product-category" name="category_id">
+          <option value="">No category</option>
+          {% for category in categories %}
+            <option value="{{ category.id }}">{{ category.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-product-image">Image</label>
+        <input class="form-input" id="edit-product-image" name="image" type="file" accept="image/*" />
+        <img id="edit-product-preview" alt="Current product image" class="product-preview" hidden />
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button">Save product</button>
+        <button type="button" class="button button--ghost" data-modal-close>Cancel</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div class="modal" id="product-visibility-modal" role="dialog" aria-modal="true" hidden>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close>
+      <span class="visually-hidden">Close visibility modal</span>
+      &times;
+    </button>
+    <h2 class="modal__title">Product visibility</h2>
+    <form id="product-visibility-form" method="post" class="form-grid">
+      <div class="visibility-grid">
+        {% for company in all_companies %}
+          <label class="checkbox visibility-grid__item">
+            <input type="checkbox" name="excluded" value="{{ company.id }}" />
+            <span>{{ company.name }}</span>
+          </label>
+        {% endfor %}
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button">Save visibility</button>
+        <button type="button" class="button button--ghost" data-modal-close>Cancel</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script type="application/json" id="admin-products-data">{{ products | tojson }}</script>
+<script type="application/json" id="admin-product-restrictions">{{ product_restrictions | tojson }}</script>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/shop_admin.js" defer></script>
+{% endblock %}

--- a/app/templates/forms/index.html
+++ b/app/templates/forms/index.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+
+{% block sidebar_menu %}
+  {{ super() }}
+  <li class="menu__item">
+    <a href="/shop">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M4 7h16l-1.5 12.5A2 2 0 0 1 16.52 21H7.48a2 2 0 0 1-1.98-1.5zM6 3h12a1 1 0 0 1 1 1v2H5V4a1 1 0 0 1 1-1z"/></svg>
+      </span>
+      <span class="menu__label">Shop</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/forms" aria-current="page">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2h9l5 5v15H6a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zm8 7h4.5L14 4.5V9z"/></svg>
+      </span>
+      <span class="menu__label">Forms</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/staff">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4zm0 2c-3.31 0-8 1.66-8 5v1h16v-1c0-3.34-4.69-5-8-5z"/></svg>
+      </span>
+      <span class="menu__label">Staff</span>
+    </a>
+  </li>
+{% endblock %}
+
+{% block content %}
+<div class="forms-layout">
+  <section class="card card--panel forms-layout__menu">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Available forms</h2>
+        <p class="card__subtitle">Launch OpnForm experiences without leaving the portal.</p>
+      </div>
+    </header>
+    {% if forms %}
+      <nav class="forms-menu" aria-label="Form selection">
+        {% for form in forms %}
+          <button
+            type="button"
+            class="forms-menu__button{% if loop.first %} is-active{% endif %}"
+            data-form-switch
+            data-form-url="{{ form.iframe_url }}"
+          >
+            <span class="forms-menu__name">{{ form.name }}</span>
+            {% if form.description %}
+              <span class="forms-menu__description">{{ form.description }}</span>
+            {% endif %}
+          </button>
+        {% endfor %}
+      </nav>
+    {% else %}
+      <p class="text-muted">No forms have been published yet.</p>
+    {% endif %}
+  </section>
+
+  <section class="card card--panel forms-layout__viewer">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Form viewer</h2>
+        <p class="card__subtitle">Selected forms open securely inside the portal with sandboxed permissions.</p>
+      </div>
+      {% if opnform_base_url %}
+        <a class="button button--ghost" href="{{ opnform_base_url }}" target="_blank" rel="noopener">Open OpnForm</a>
+      {% endif %}
+    </header>
+    {% if forms %}
+      <iframe
+        id="form-frame"
+        class="form-frame"
+        src="{{ forms[0].iframe_url }}"
+        loading="lazy"
+        title="Selected form"
+        allow="publickey-credentials-get *; publickey-credentials-create *"
+        referrerpolicy="strict-origin-when-cross-origin"
+      ></iframe>
+    {% else %}
+      <div class="empty-state">
+        <p>Select or create a form to begin.</p>
+      </div>
+    {% endif %}
+  </section>
+</div>
+
+<script type="application/json" id="forms-data">{{ forms | tojson }}</script>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/forms.js" defer></script>
+{% endblock %}

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -1,0 +1,191 @@
+{% extends "base.html" %}
+
+{% block sidebar_menu %}
+  {{ super() }}
+  <li class="menu__item">
+    <a href="/shop" aria-current="page">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M4 7h16l-1.5 12.5A2 2 0 0 1 16.52 21H7.48a2 2 0 0 1-1.98-1.5zM6 3h12a1 1 0 0 1 1 1v2H5V4a1 1 0 0 1 1-1z"/></svg>
+      </span>
+      <span class="menu__label">Shop</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/forms">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2h9l5 5v15H6a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zm8 7h4.5L14 4.5V9z"/></svg>
+      </span>
+      <span class="menu__label">Forms</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/staff">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4zm0 2c-3.31 0-8 1.66-8 5v1h16v-1c0-3.34-4.69-5-8-5z"/></svg>
+      </span>
+      <span class="menu__label">Staff</span>
+    </a>
+  </li>
+{% endblock %}
+
+{% block header_actions %}
+  <a class="button button--ghost" href="/cart">View cart</a>
+{% endblock %}
+
+{% block content %}
+<div class="page-grid">
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Catalogue filters</h2>
+        <p class="card__subtitle">Narrow the product list by category, availability, or keyword.</p>
+      </div>
+    </header>
+    {% if cart_error %}
+      <div class="alert alert--error" role="alert">{{ cart_error }}</div>
+    {% endif %}
+    <form class="filters" method="get" data-auto-submit>
+      <div class="filters__group">
+        <label class="form-label" for="shop-category">Category</label>
+        <select class="form-input" id="shop-category" name="category" data-submit-on-change>
+          <option value="">All categories</option>
+          {% for category in categories %}
+            <option value="{{ category.id }}" {% if current_category and current_category == category.id %}selected{% endif %}>
+              {{ category.name }}
+            </option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="filters__group">
+        <label class="form-label" for="shop-search">Search products</label>
+        <input
+          class="form-input"
+          id="shop-search"
+          name="q"
+          type="search"
+          value="{{ search_term | default('') }}"
+          placeholder="Search by name, SKU, or vendor"
+        />
+      </div>
+      <div class="filters__group filters__group--checkbox">
+        <label class="checkbox">
+          <input type="checkbox" name="showOutOfStock" value="1" {% if show_out_of_stock %}checked{% endif %} data-submit-on-change />
+          <span>Show out of stock items</span>
+        </label>
+      </div>
+    </form>
+  </section>
+
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Available products</h2>
+        <p class="card__subtitle">Add items directly to your cart or review detailed specifications.</p>
+      </div>
+      <div class="card__controls">
+        <input
+          type="search"
+          class="form-input card__control"
+          placeholder="Quick filter products"
+          aria-label="Filter products"
+          data-table-filter="shop-table"
+        />
+      </div>
+    </header>
+    <div class="table-wrapper">
+      <table class="table" id="shop-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col">Image</th>
+            <th scope="col" data-sort="string">Name</th>
+            <th scope="col" data-sort="string">SKU</th>
+            <th scope="col" data-sort="string">Vendor SKU</th>
+            <th scope="col" data-sort="number">Price</th>
+            <th scope="col" data-sort="number">Stock</th>
+            <th scope="col" class="table__actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for product in products %}
+            <tr data-product-id="{{ product.id }}" data-stock="{{ product.stock }}">
+              <td data-label="Image">
+                {% if product.image_url %}
+                  <button type="button" class="link-button" data-image-preview data-image-url="{{ product.image_url }}">
+                    <img src="{{ product.image_url }}" alt="" class="product-thumb" loading="lazy" />
+                  </button>
+                {% else %}
+                  <span class="text-muted">—</span>
+                {% endif %}
+              </td>
+              <td data-label="Name">{{ product.name }}</td>
+              <td data-label="SKU">{{ product.sku }}</td>
+              <td data-label="Vendor SKU">{{ product.vendor_sku or '—' }}</td>
+              <td data-label="Price" data-value="{{ product.price }}">${{ '%.2f'|format(product.price) }}</td>
+              <td data-label="Stock" data-value="{{ product.stock }}">
+                <span class="badge {% if product.stock == 0 %}badge--danger{% elif product.stock < 5 %}badge--warning{% else %}badge--success{% endif %}">
+                  {{ product.stock }}
+                </span>
+              </td>
+              <td class="table__actions">
+                <div class="table__action-buttons">
+                  <button type="button" class="button button--ghost" data-product-details="{{ product.id }}">Details</button>
+                  {% if product.stock > 0 %}
+                  <form action="/cart/add" method="post" class="inline-form">
+                      <input type="hidden" name="productId" value="{{ product.id }}" />
+                      <label class="visually-hidden" for="quantity-{{ product.id }}">Quantity for {{ product.name }}</label>
+                      <input
+                        class="form-input form-input--sm"
+                        id="quantity-{{ product.id }}"
+                        type="number"
+                        name="quantity"
+                        min="1"
+                        max="{{ product.stock }}"
+                        value="1"
+                      />
+                      <button type="submit" class="button">Add to cart</button>
+                    </form>
+                  {% else %}
+                    <span class="badge badge--muted">Out of stock</span>
+                  {% endif %}
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="7" class="table__empty">No products are currently available.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+
+<div class="modal" id="product-image-modal" role="dialog" aria-modal="true" hidden>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close>
+      <span class="visually-hidden">Close image preview</span>
+      &times;
+    </button>
+    <img src="" alt="Selected product image" id="product-image-preview" />
+  </div>
+</div>
+
+<div class="modal" id="product-details-modal" role="dialog" aria-modal="true" hidden>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close>
+      <span class="visually-hidden">Close product details</span>
+      &times;
+    </button>
+    <div id="product-details-body" class="modal__body"></div>
+  </div>
+</div>
+
+<script type="application/json" id="shop-products-data">{{ products | tojson }}</script>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/shop.js" defer></script>
+{% endblock %}

--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -1,0 +1,313 @@
+{% extends "base.html" %}
+
+{% block sidebar_menu %}
+  {{ super() }}
+  <li class="menu__item">
+    <a href="/shop">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M4 7h16l-1.5 12.5A2 2 0 0 1 16.52 21H7.48a2 2 0 0 1-1.98-1.5zM6 3h12a1 1 0 0 1 1 1v2H5V4a1 1 0 0 1 1-1z"/></svg>
+      </span>
+      <span class="menu__label">Shop</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/forms">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2h9l5 5v15H6a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zm8 7h4.5L14 4.5V9z"/></svg>
+      </span>
+      <span class="menu__label">Forms</span>
+    </a>
+  </li>
+  <li class="menu__item">
+    <a href="/staff" aria-current="page">
+      <span class="menu__icon" aria-hidden="true">
+        <svg viewBox="0 0 24 24" focusable="false"><path d="M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4zm0 2c-3.31 0-8 1.66-8 5v1h16v-1c0-3.34-4.69-5-8-5z"/></svg>
+      </span>
+      <span class="menu__label">Staff</span>
+    </a>
+  </li>
+{% endblock %}
+
+{% block content %}
+<div class="admin-grid admin-grid--columns">
+  {% if is_super_admin and syncro_company_id %}
+    <section class="card card--panel">
+      <header class="card__header card__header--stacked">
+        <div>
+          <h2 class="card__title">Syncro integration</h2>
+          <p class="card__subtitle">Import contacts from Syncro to seed staff records and verification details.</p>
+        </div>
+        <button type="button" class="button" data-import-syncro>Import contacts</button>
+      </header>
+      <p class="text-muted">The importer retries automatically if Syncro returns a transient error.</p>
+    </section>
+  {% endif %}
+
+  {% if is_admin %}
+    <section class="card card--panel">
+      <header class="card__header card__header--stacked">
+        <div>
+          <h2 class="card__title">Add staff member</h2>
+          <p class="card__subtitle">Capture onboarding details to provision accounts and workflows.</p>
+        </div>
+      </header>
+      <form action="/staff" method="post" class="form-grid">
+        <div class="form-field">
+          <label class="form-label" for="staff-first-name">First name</label>
+          <input class="form-input" id="staff-first-name" name="firstName" required />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="staff-last-name">Last name</label>
+          <input class="form-input" id="staff-last-name" name="lastName" required />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="staff-email">Email</label>
+          <input class="form-input" id="staff-email" name="email" type="email" required />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="staff-mobile">Mobile phone</label>
+          <input class="form-input" id="staff-mobile" name="mobilePhone" type="tel" />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="staff-department">Department</label>
+          <input class="form-input" id="staff-department" name="department" />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="staff-date-onboarded">Onboard date</label>
+          <input class="form-input" id="staff-date-onboarded" name="dateOnboarded" type="date" />
+        </div>
+        <div class="form-field form-field--checkbox">
+          <label class="checkbox">
+            <input type="checkbox" name="enabled" value="1" checked />
+            <span>Enabled</span>
+          </label>
+        </div>
+        <div class="form-actions form-actions--inline">
+          <button type="submit" class="button">Add staff</button>
+        </div>
+      </form>
+    </section>
+  {% endif %}
+
+  <section class="card card--panel admin-grid__full">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Current staff</h2>
+        <p class="card__subtitle">Invite, verify, or update records with live filtering and sorting.</p>
+      </div>
+      <div class="card__controls">
+        <form id="staff-filter-form" method="get" action="/staff" class="filters filters--compact">
+          <div class="filters__group">
+            <label class="form-label" for="staff-enabled">Status</label>
+            <select class="form-input" id="staff-enabled" name="enabled" data-submit-on-change>
+              <option value="" {% if enabled_filter == '' %}selected{% endif %}>All</option>
+              <option value="1" {% if enabled_filter == '1' %}selected{% endif %}>Enabled</option>
+              <option value="0" {% if enabled_filter == '0' %}selected{% endif %}>Disabled</option>
+            </select>
+          </div>
+          {% if staff_permission == 3 and departments %}
+            <div class="filters__group">
+              <label class="form-label" for="staff-department-filter">Department</label>
+              <select class="form-input" id="staff-department-filter" name="department" data-submit-on-change>
+                <option value="" {% if department_filter == '' %}selected{% endif %}>All departments</option>
+                {% for department in departments %}
+                  <option value="{{ department }}" {% if department_filter == department %}selected{% endif %}>{{ department }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          {% endif %}
+          <div class="filters__group">
+            <label class="form-label" for="staff-search">Search</label>
+            <input class="form-input" id="staff-search" type="search" data-table-filter="staff-table" placeholder="Search staff" />
+          </div>
+        </form>
+      </div>
+    </header>
+    <div class="table-wrapper">
+      <table class="table" id="staff-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col" data-sort="string">First name</th>
+            <th scope="col" data-sort="string">Last name</th>
+            <th scope="col" data-sort="string">Email</th>
+            <th scope="col" data-sort="string">Mobile</th>
+            <th scope="col" data-sort="string">Code</th>
+            <th scope="col" data-sort="date">Onboarded</th>
+            <th scope="col" data-sort="string">Enabled</th>
+            <th scope="col" class="table__actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for member in staff_members %}
+            <tr data-staff-id="{{ member.id }}">
+              <td data-label="First name">{{ member.first_name }}</td>
+              <td data-label="Last name">{{ member.last_name }}</td>
+              <td data-label="Email">{{ member.email }}</td>
+              <td data-label="Mobile">{{ member.mobile_phone or '—' }}</td>
+              <td data-label="Verification code" class="verification-code">{{ member.verification_code or '—' }}</td>
+              <td data-label="Onboarded" data-value="{{ member.date_onboarded or '' }}" data-utc="{{ member.date_onboarded or '' }}">
+                {% if member.date_onboarded %}
+                  {{ member.date_onboarded }}
+                {% else %}
+                  <span class="text-muted">—</span>
+                {% endif %}
+              </td>
+              <td data-label="Enabled">
+                <form action="/staff/enabled" method="post" class="inline-form">
+                  <input type="hidden" name="staffId" value="{{ member.id }}" />
+                  <label class="visually-hidden" for="staff-enabled-{{ member.id }}">Toggle enabled state for {{ member.first_name }} {{ member.last_name }}</label>
+                  <input
+                    id="staff-enabled-{{ member.id }}"
+                    type="checkbox"
+                    name="enabled"
+                    value="1"
+                    {% if member.enabled %}checked{% endif %}
+                    data-submit-on-change
+                  />
+                </form>
+              </td>
+              <td class="table__actions">
+                <div class="table__action-buttons">
+                  {% if is_super_admin %}
+                    <button type="button" class="button button--ghost" data-staff-verify="{{ member.id }}" {% if not member.mobile_phone %}disabled{% endif %}>Send code</button>
+                  {% endif %}
+                  {% if is_admin or is_super_admin %}
+                    <button type="button" class="button button--ghost" data-staff-invite="{{ member.id }}">Invite</button>
+                  {% endif %}
+                  <button type="button" class="button button--ghost" data-staff-edit="{{ member.id }}">Edit</button>
+                  {% if is_super_admin %}
+                    <button type="button" class="button button--danger" data-staff-delete="{{ member.id }}">Delete</button>
+                  {% endif %}
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="8" class="table__empty">No staff records found.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+
+<div class="modal" id="staff-edit-modal" role="dialog" aria-modal="true" hidden>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close>
+      <span class="visually-hidden">Close edit staff modal</span>
+      &times;
+    </button>
+    <h2 class="modal__title">Edit staff member</h2>
+    <form id="staff-edit-form" class="form-grid">
+      <input type="hidden" id="edit-staff-id" />
+      <div class="form-field">
+        <label class="form-label" for="edit-first-name">First name</label>
+        <input class="form-input" id="edit-first-name" {% if not is_super_admin %}readonly{% endif %} />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-last-name">Last name</label>
+        <input class="form-input" id="edit-last-name" {% if not is_super_admin %}readonly{% endif %} />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-email">Email</label>
+        <input class="form-input" id="edit-email" type="email" {% if not is_super_admin %}readonly{% endif %} />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-mobile">Mobile phone</label>
+        <input class="form-input" id="edit-mobile" type="tel" {% if not is_super_admin %}readonly{% endif %} />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-date-onboarded">Onboard date</label>
+        <input class="form-input" id="edit-date-onboarded" type="date" {% if not is_super_admin %}readonly{% endif %} />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-date-offboarded">Offboard schedule</label>
+        <input class="form-input" id="edit-date-offboarded" type="datetime-local" {% if not is_admin %}readonly{% endif %} />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-account-action">Account action</label>
+        <select class="form-input" id="edit-account-action" {% if not is_super_admin %}disabled{% endif %}>
+          <option value="Onboard Requested">Onboard Requested</option>
+          <option value="Onboard Approved">Onboard Approved</option>
+          <option value="Onboarding In Progress">Onboarding In Progress</option>
+          <option value="Onboarded">Onboarded</option>
+          <option value="Offboard Requested">Offboard Requested</option>
+          <option value="Offboard Approved">Offboard Approved</option>
+          <option value="Offboard Scheduled">Offboard Scheduled</option>
+          <option value="Offboarded">Offboarded</option>
+        </select>
+      </div>
+      <div class="form-field form-field--checkbox">
+        <label class="checkbox">
+          <input type="checkbox" id="edit-enabled" {% if not is_super_admin %}disabled{% endif %} />
+          <span>Enabled</span>
+        </label>
+      </div>
+      <fieldset class="fieldset">
+        <legend>Address</legend>
+        <div class="form-grid">
+          <div class="form-field">
+            <label class="form-label" for="edit-street">Street</label>
+            <input class="form-input" id="edit-street" {% if not is_super_admin %}readonly{% endif %} />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-city">City</label>
+            <input class="form-input" id="edit-city" {% if not is_super_admin %}readonly{% endif %} />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-state">State</label>
+            <input class="form-input" id="edit-state" {% if not is_super_admin %}readonly{% endif %} />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-postcode">Postcode</label>
+            <input class="form-input" id="edit-postcode" {% if not is_super_admin %}readonly{% endif %} />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-country">Country</label>
+            <input class="form-input" id="edit-country" {% if not is_super_admin %}readonly{% endif %} />
+          </div>
+        </div>
+      </fieldset>
+      <fieldset class="fieldset">
+        <legend>Organisation</legend>
+        <div class="form-grid">
+          <div class="form-field">
+            <label class="form-label" for="edit-department">Department</label>
+            <input class="form-input" id="edit-department" {% if not is_super_admin %}readonly{% endif %} />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-job-title">Job title</label>
+            <input class="form-input" id="edit-job-title" {% if not is_super_admin %}readonly{% endif %} />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-company">Company</label>
+            <input class="form-input" id="edit-company" {% if not is_super_admin %}readonly{% endif %} />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-manager-name">Manager</label>
+            <input class="form-input" id="edit-manager-name" {% if not is_super_admin %}readonly{% endif %} />
+          </div>
+        </div>
+      </fieldset>
+      <div class="form-actions">
+        <button type="submit" class="button">Save changes</button>
+        <button type="button" class="button button--ghost" data-modal-close>Cancel</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script type="application/json" id="staff-data">{{ staff_members | tojson }}</script>
+<script type="application/json" id="staff-flags">{{ {
+  'isSuperAdmin': is_super_admin,
+  'isAdmin': is_admin,
+  'syncroCompanyId': syncro_company_id
+} | tojson }}</script>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/staff.js" defer></script>
+{% endblock %}

--- a/changes.md
+++ b/changes.md
@@ -37,3 +37,4 @@
 - 2025-10-09, 15:42 UTC, Fix, Switched password hashing to bcrypt_sha256 to support long credentials without login failures
 - 2025-10-09, 16:18 UTC, Fix, Normalised login TOTP payload handling to accept legacy keys and enforce numeric codes server-side
 - 2025-10-08, 04:05 UTC, Feature, Introduced role-based company memberships with audit logging and admin control panels
+- 2025-10-08, 06:07 UTC, Feature, Rebuilt shop, forms, staff, and commerce admin dashboards with Jinja templates, responsive layout components, and supporting scripts


### PR DESCRIPTION
## Summary
- recreate the customer shop, forms, and staff experiences as Jinja templates aligned with the three-panel layout
- rebuild the commerce and forms administration dashboards with responsive tables, modals, and inline editing controls
- add supporting scripts, styles, configuration, and change-log entry plus placeholder FastAPI routes for the new views

## Testing
- pytest *(fails: missing email-validator dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68e5fcf5d3f8832d809dffbf1ec878da