### PR TITLE
Fix shop catalogue filtering to include SKU-named products

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -39,3 +39,4 @@
 - 2025-10-08, 04:05 UTC, Feature, Introduced role-based company memberships with audit logging and admin control panels
 - 2025-10-08, 06:07 UTC, Feature, Rebuilt shop, forms, staff, and commerce admin dashboards with Jinja templates, responsive layout components, and supporting scripts
 - 2025-10-08, 06:33 UTC, Fix, Added global sidebar navigation for admin pages so new management views are accessible from the portal
+- 2025-10-08, 06:41 UTC, Fix, Restored shop catalogue display for products whose names match their SKUs so existing items appear

--- a/src/server.ts
+++ b/src/server.ts
@@ -2739,9 +2739,7 @@ app.get('/shop', ensureAuth, ensureShopAccess, async (req, res) => {
   ]);
   const current = companies.find((c) => c.company_id === req.session.companyId);
   const isVip = current?.is_vip === 1;
-  const filtered = products.filter(
-    (p) => p.name !== p.sku && (showOutOfStock || p.stock > 0)
-  );
+  const filtered = products.filter((p) => showOutOfStock || p.stock > 0);
   const adjusted = filtered.map((p) => ({
     ...p,
     price: isVip && p.vip_price !== null ? p.vip_price : p.price,


### PR DESCRIPTION
## Summary
- allow shop listings to include products even when their display name matches the SKU so existing items reappear
- document the fix in the change log

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e607546dcc832d9e3f563f72fd9b7e