### PR TITLE
Rebuild staff management and Syncro integration

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -1,4 +1,14 @@
-from . import audit_logs, auth, companies, memberships, notifications, ports, roles, users
+from . import (
+    audit_logs,
+    auth,
+    companies,
+    memberships,
+    notifications,
+    ports,
+    roles,
+    staff,
+    users,
+)
 
 __all__ = [
     "audit_logs",
@@ -8,5 +18,6 @@ __all__ = [
     "ports",
     "memberships",
     "roles",
+    "staff",
     "users",
 ]

--- a/app/api/routes/staff.py
+++ b/app/api/routes/staff.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.api.dependencies.auth import get_current_user, require_super_admin
+from app.api.dependencies.database import require_database
+from app.repositories import staff as staff_repo
+from app.schemas.staff import StaffCreate, StaffResponse, StaffUpdate
+
+
+router = APIRouter(prefix="/staff", tags=["Staff"])
+
+
+@router.get("", response_model=list[StaffResponse])
+async def list_staff(
+    account_action: str | None = Query(default=None, alias="accountAction"),
+    email: str | None = None,
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    records = await staff_repo.list_all_staff(
+        account_action=account_action,
+        email=email,
+    )
+    return [StaffResponse.model_validate(record) for record in records]
+
+
+@router.post("", response_model=StaffResponse, status_code=status.HTTP_201_CREATED)
+async def create_staff(
+    payload: StaffCreate,
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    created = await staff_repo.create_staff(**payload.model_dump(by_alias=False))
+    return StaffResponse.model_validate(created)
+
+
+@router.get("/{staff_id}", response_model=StaffResponse)
+async def get_staff(
+    staff_id: int,
+    _: None = Depends(require_database),
+    __: dict = Depends(get_current_user),
+):
+    staff = await staff_repo.get_staff_by_id(staff_id)
+    if not staff:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Staff not found")
+    return StaffResponse.model_validate(staff)
+
+
+@router.put("/{staff_id}", response_model=StaffResponse)
+async def update_staff(
+    staff_id: int,
+    payload: StaffUpdate,
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    existing = await staff_repo.get_staff_by_id(staff_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Staff not found")
+    data = existing | payload.model_dump(exclude_unset=True, by_alias=False)
+    updated = await staff_repo.update_staff(
+        staff_id,
+        company_id=data["company_id"],
+        first_name=data["first_name"],
+        last_name=data["last_name"],
+        email=data["email"],
+        mobile_phone=data.get("mobile_phone"),
+        date_onboarded=data.get("date_onboarded"),
+        date_offboarded=data.get("date_offboarded"),
+        enabled=bool(data.get("enabled", True)),
+        street=data.get("street"),
+        city=data.get("city"),
+        state=data.get("state"),
+        postcode=data.get("postcode"),
+        country=data.get("country"),
+        department=data.get("department"),
+        job_title=data.get("job_title"),
+        org_company=data.get("org_company"),
+        manager_name=data.get("manager_name"),
+        account_action=data.get("account_action"),
+        syncro_contact_id=data.get("syncro_contact_id"),
+    )
+    return StaffResponse.model_validate(updated)
+
+
+@router.delete("/{staff_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_staff(
+    staff_id: int,
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    existing = await staff_repo.get_staff_by_id(staff_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Staff not found")
+    await staff_repo.delete_staff(staff_id)
+    return None

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -37,6 +37,15 @@ class Settings(BaseSettings):
     smtp_user: str | None = Field(default=None, validation_alias="SMTP_USER")
     smtp_password: str | None = Field(default=None, validation_alias="SMTP_PASS")
     smtp_use_tls: bool = Field(default=True, validation_alias="SMTP_SECURE")
+    syncro_webhook_url: AnyHttpUrl | None = Field(
+        default=None, validation_alias="SYNCRO_WEBHOOK_URL"
+    )
+    syncro_api_key: str | None = Field(default=None, validation_alias="SYNCRO_API_KEY")
+    verify_webhook_url: AnyHttpUrl | None = Field(
+        default=None, validation_alias="VERIFY_WEBHOOK_URL"
+    )
+    verify_api_key: str | None = Field(default=None, validation_alias="VERIFY_API_KEY")
+    portal_url: AnyHttpUrl | None = Field(default=None, validation_alias="PORTAL_URL")
     azure_client_id: str | None = Field(default=None, validation_alias="AZURE_CLIENT_ID")
     azure_client_secret: str | None = Field(default=None, validation_alias="AZURE_CLIENT_SECRET")
     azure_tenant_id: str | None = Field(default=None, validation_alias="AZURE_TENANT_ID")

--- a/app/main.py
+++ b/app/main.py
@@ -1,29 +1,46 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+import secrets
+from datetime import datetime, time, timedelta, timezone
 
 from typing import Any
 
+import httpx
 from fastapi import FastAPI, HTTPException, Query, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
-from app.api.routes import audit_logs, auth, companies, memberships, notifications, ports, roles, users
+from app.api.routes import (
+    audit_logs,
+    auth,
+    companies,
+    memberships,
+    notifications,
+    ports,
+    roles,
+    staff as staff_api,
+    users,
+)
 from app.core.config import get_settings, get_templates_config
 from app.core.database import db
 from app.core.logging import configure_logging, log_error, log_info
 from app.repositories import audit_logs as audit_repo
+from app.repositories import auth as auth_repo
 from app.repositories import companies as company_repo
 from app.repositories import company_memberships as membership_repo
 from app.repositories import roles as role_repo
 from app.repositories import shop as shop_repo
+from app.repositories import staff as staff_repo
+from app.repositories import user_companies as user_company_repo
 from app.repositories import users as user_repo
 from app.security.csrf import CSRFMiddleware
 from app.security.rate_limiter import RateLimiterMiddleware, SimpleRateLimiter
 from app.security.session import session_manager
+from app.services.scheduler import scheduler_service
+from app.services import staff_importer
 
 configure_logging()
 settings = get_settings()
@@ -34,6 +51,10 @@ tags_metadata = [
     {"name": "Companies", "description": "Company catalogue and membership management."},
     {"name": "Roles", "description": "Role definitions and access controls."},
     {"name": "Memberships", "description": "Company membership workflows with approval tracking."},
+    {
+        "name": "Staff",
+        "description": "Staff directory management, Syncro contact synchronisation, and verification workflows.",
+    },
     {"name": "Audit Logs", "description": "Structured audit trail of privileged actions."},
     {"name": "Ports", "description": "Port catalogue, document storage, and pricing workflow APIs."},
     {"name": "Notifications", "description": "System-wide and user-specific notification feeds."},
@@ -75,6 +96,7 @@ app.include_router(roles.router)
 app.include_router(memberships.router)
 app.include_router(ports.router)
 app.include_router(notifications.router)
+app.include_router(staff_api.router)
 app.include_router(audit_logs.router)
 
 
@@ -109,15 +131,82 @@ def _to_iso(dt: Any) -> str | None:
     return str(dt)
 
 
+def _parse_input_datetime(value: str | None, *, assume_midnight: bool = False) -> datetime | None:
+    if value is None:
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        formats = ["%Y-%m-%dT%H:%M", "%Y-%m-%d %H:%M", "%Y-%m-%d"]
+        for fmt in formats:
+            try:
+                parsed = datetime.strptime(text, fmt)
+                break
+            except ValueError:
+                continue
+        else:
+            return None
+    if assume_midnight and "T" not in text and " " not in text:
+        parsed = datetime.combine(parsed.date(), time.min)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
+
+
+async def _load_staff_context(
+    request: Request,
+    *,
+    require_admin: bool = False,
+    require_super_admin: bool = False,
+):
+    user, redirect = await _require_authenticated_user(request)
+    if redirect:
+        return user, None, None, 0, None, redirect
+    is_super_admin = bool(user.get("is_super_admin"))
+    if require_super_admin and not is_super_admin:
+        return user, None, None, 0, None, RedirectResponse(
+            url="/", status_code=status.HTTP_303_SEE_OTHER
+        )
+    company_id_raw = user.get("company_id")
+    if company_id_raw is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No company associated with the current user",
+        )
+    try:
+        company_id = int(company_id_raw)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid company identifier")
+    membership = await user_company_repo.get_user_company(user["id"], company_id)
+    staff_permission = int(membership.get("staff_permission", 0)) if membership else 0
+    if not is_super_admin and staff_permission <= 0:
+        return user, membership, None, staff_permission, company_id, RedirectResponse(
+            url="/", status_code=status.HTTP_303_SEE_OTHER
+        )
+    if require_admin and not (is_super_admin or (membership and membership.get("is_admin"))):
+        return user, membership, None, staff_permission, company_id, RedirectResponse(
+            url="/", status_code=status.HTTP_303_SEE_OTHER
+        )
+    company = await company_repo.get_company_by_id(company_id)
+    return user, membership, company, staff_permission, company_id, None
+
+
 @app.on_event("startup")
 async def on_startup() -> None:
     await db.connect()
     await db.run_migrations()
+    await scheduler_service.start()
     log_info("Application started", environment=settings.environment)
 
 
 @app.on_event("shutdown")
 async def on_shutdown() -> None:
+    await scheduler_service.stop()
     await db.disconnect()
     log_info("Application shutdown")
 
@@ -226,25 +315,441 @@ async def staff_page(
     enabled: str = "",
     department: str = "",
 ):
-    user, redirect = await _require_authenticated_user(request)
+    (
+        user,
+        membership,
+        company,
+        staff_permission,
+        company_id,
+        redirect,
+    ) = await _load_staff_context(request)
     if redirect:
         return redirect
+
+    is_super_admin = bool(user.get("is_super_admin"))
+    is_admin = is_super_admin or bool(membership and membership.get("is_admin"))
+
+    enabled_value = enabled.strip()
+    enabled_filter: bool | None
+    if enabled_value == "1":
+        enabled_filter = True
+    elif enabled_value == "0":
+        enabled_filter = False
+    else:
+        enabled_filter = None
+
+    department_filter = department.strip()
+
+    staff_members: list[dict[str, Any]] = []
+    departments: list[str] = []
+    if company_id is not None:
+        staff_members = await staff_repo.list_staff(company_id, enabled=enabled_filter)
+        if not is_super_admin and staff_permission in (1, 2):
+            user_email = (user.get("email") or "").lower()
+            current_staff = next(
+                (
+                    member
+                    for member in staff_members
+                    if (member.get("email") or "").lower() == user_email
+                ),
+                None,
+            )
+            user_department = (current_staff or {}).get("department")
+            if staff_permission == 1:
+                if user_department:
+                    staff_members = [
+                        member
+                        for member in staff_members
+                        if member.get("department")
+                        and member["department"].lower() == user_department.lower()
+                    ]
+                else:
+                    staff_members = []
+            else:  # staff_permission == 2
+                if user_department:
+                    staff_members = [
+                        member
+                        for member in staff_members
+                        if (
+                            member.get("department")
+                            and member["department"].lower() == user_department.lower()
+                        )
+                        or not member.get("department")
+                    ]
+                else:
+                    staff_members = [
+                        member for member in staff_members if not member.get("department")
+                    ]
+        else:
+            if department_filter:
+                staff_members = [
+                    member
+                    for member in staff_members
+                    if (member.get("department") or "") == department_filter
+                ]
+            departments = sorted(
+                {
+                    str(member.get("department"))
+                    for member in staff_members
+                    if member.get("department")
+                }
+            )
+
     context = {
         "request": request,
         "app_name": settings.app_name,
         "current_year": datetime.utcnow().year,
         "title": "Staff",
         "current_user": user,
-        "is_super_admin": bool(user.get("is_super_admin")),
-        "is_admin": bool(user.get("is_admin")),
-        "syncro_company_id": user.get("syncro_company_id"),
-        "staff_permission": user.get("staff_permission", 0),
-        "departments": [],
-        "staff_members": [],
-        "enabled_filter": enabled,
-        "department_filter": department,
+        "is_super_admin": is_super_admin,
+        "is_admin": is_admin,
+        "syncro_company_id": company.get("syncro_company_id") if company else None,
+        "staff_permission": staff_permission,
+        "departments": departments,
+        "staff_members": staff_members,
+        "enabled_filter": enabled_value,
+        "department_filter": department_filter,
     }
     return templates.TemplateResponse("staff/index.html", context)
+
+
+@app.post("/staff", response_class=HTMLResponse)
+async def create_staff_member(request: Request):
+    (
+        user,
+        membership,
+        company,
+        staff_permission,
+        company_id,
+        redirect,
+    ) = await _load_staff_context(request, require_admin=True)
+    if redirect:
+        return redirect
+    if company_id is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No active company")
+
+    form = await request.form()
+    first_name = (form.get("firstName") or form.get("first_name") or "").strip()
+    last_name = (form.get("lastName") or form.get("last_name") or "").strip()
+    email = (form.get("email") or "").strip()
+    if not first_name or not last_name or not email:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="First name, last name, and email are required")
+
+    mobile_phone = (form.get("mobilePhone") or form.get("mobile_phone") or "").strip() or None
+    date_onboarded = _parse_input_datetime(form.get("dateOnboarded"), assume_midnight=True)
+    date_offboarded = _parse_input_datetime(form.get("dateOffboarded"))
+    enabled = str(form.get("enabled", "1")).lower() in {"1", "true", "on"}
+    street = (form.get("street") or "").strip() or None
+    city = (form.get("city") or "").strip() or None
+    state_val = (form.get("state") or "").strip() or None
+    postcode = (form.get("postcode") or "").strip() or None
+    country = (form.get("country") or "").strip() or None
+    department = (form.get("department") or "").strip() or None
+    job_title = (form.get("jobTitle") or form.get("job_title") or "").strip() or None
+    org_company = (form.get("company") or "").strip() or None
+    manager_name = (form.get("managerName") or form.get("manager_name") or "").strip() or None
+
+    await staff_repo.create_staff(
+        company_id=company_id,
+        first_name=first_name,
+        last_name=last_name,
+        email=email,
+        mobile_phone=mobile_phone,
+        date_onboarded=date_onboarded,
+        date_offboarded=date_offboarded,
+        enabled=enabled,
+        street=street,
+        city=city,
+        state=state_val,
+        postcode=postcode,
+        country=country,
+        department=department,
+        job_title=job_title,
+        org_company=org_company,
+        manager_name=manager_name,
+        account_action=None,
+        syncro_contact_id=None,
+    )
+
+    return RedirectResponse(url="/staff", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.put("/staff/{staff_id}")
+async def update_staff_member(staff_id: int, request: Request):
+    (
+        user,
+        membership,
+        company,
+        staff_permission,
+        company_id,
+        redirect,
+    ) = await _load_staff_context(request)
+    if redirect:
+        return redirect
+
+    existing = await staff_repo.get_staff_by_id(staff_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Staff not found")
+
+    is_super_admin = bool(user.get("is_super_admin"))
+    if not is_super_admin and existing.get("company_id") != company_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    payload = await request.json()
+
+    def get_value(*keys: str) -> Any:
+        for key in keys:
+            if key in payload:
+                return payload[key]
+        return None
+
+    if is_super_admin:
+        first_name = (get_value("firstName", "first_name") or existing.get("first_name") or "").strip()
+        last_name = (get_value("lastName", "last_name") or existing.get("last_name") or "").strip()
+        email = (get_value("email") or existing.get("email") or "").strip()
+        mobile_phone = (get_value("mobilePhone", "mobile_phone") or existing.get("mobile_phone") or "").strip() or None
+        date_onboarded = _parse_input_datetime(get_value("dateOnboarded", "date_onboarded"), assume_midnight=True) or _parse_input_datetime(existing.get("date_onboarded"))
+        if existing.get("date_onboarded") and not get_value("dateOnboarded", "date_onboarded"):
+            date_onboarded = _parse_input_datetime(existing.get("date_onboarded"))
+        enabled = bool(get_value("enabled") if get_value("enabled") is not None else existing.get("enabled", True))
+        street = get_value("street") or existing.get("street")
+        city = get_value("city") or existing.get("city")
+        state_val = get_value("state") or existing.get("state")
+        postcode = get_value("postcode") or existing.get("postcode")
+        country = get_value("country") or existing.get("country")
+        department = get_value("department") or existing.get("department")
+        job_title = get_value("jobTitle", "job_title") or existing.get("job_title")
+        org_company = get_value("company", "org_company") or existing.get("org_company")
+        manager_name = get_value("managerName", "manager_name") or existing.get("manager_name")
+        account_action = get_value("accountAction", "account_action") or existing.get("account_action")
+    else:
+        first_name = existing.get("first_name") or ""
+        last_name = existing.get("last_name") or ""
+        email = existing.get("email") or ""
+        mobile_phone = existing.get("mobile_phone")
+        date_onboarded = _parse_input_datetime(existing.get("date_onboarded"))
+        enabled = bool(existing.get("enabled", True))
+        street = existing.get("street")
+        city = existing.get("city")
+        state_val = existing.get("state")
+        postcode = existing.get("postcode")
+        country = existing.get("country")
+        department = existing.get("department")
+        job_title = existing.get("job_title")
+        org_company = existing.get("org_company")
+        manager_name = existing.get("manager_name")
+        account_action = existing.get("account_action")
+
+    date_offboarded = _parse_input_datetime(get_value("dateOffboarded", "date_offboarded"))
+    if date_offboarded is None and existing.get("date_offboarded"):
+        date_offboarded = _parse_input_datetime(existing.get("date_offboarded"))
+
+    updated = await staff_repo.update_staff(
+        staff_id,
+        company_id=existing.get("company_id") or company_id,
+        first_name=first_name,
+        last_name=last_name,
+        email=email,
+        mobile_phone=mobile_phone,
+        date_onboarded=date_onboarded,
+        date_offboarded=date_offboarded,
+        enabled=enabled,
+        street=street,
+        city=city,
+        state=state_val,
+        postcode=postcode,
+        country=country,
+        department=department,
+        job_title=job_title,
+        org_company=org_company,
+        manager_name=manager_name,
+        account_action=account_action,
+        syncro_contact_id=existing.get("syncro_contact_id"),
+    )
+    return JSONResponse({"success": True, "staff": updated})
+
+
+@app.delete("/staff/{staff_id}")
+async def delete_staff_member(staff_id: int, request: Request):
+    (
+        user,
+        membership,
+        company,
+        staff_permission,
+        company_id,
+        redirect,
+    ) = await _load_staff_context(request, require_super_admin=True)
+    if redirect:
+        return redirect
+    existing = await staff_repo.get_staff_by_id(staff_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Staff not found")
+    await staff_repo.delete_staff(staff_id)
+    return JSONResponse({"success": True})
+
+
+@app.post("/staff/enabled", response_class=HTMLResponse)
+async def set_staff_enabled(request: Request):
+    (
+        user,
+        membership,
+        company,
+        staff_permission,
+        company_id,
+        redirect,
+    ) = await _load_staff_context(request)
+    if redirect:
+        return redirect
+    form = await request.form()
+    staff_id_raw = form.get("staffId")
+    enabled_raw = form.get("enabled", "0")
+    try:
+        staff_id = int(staff_id_raw)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid staff identifier")
+    enabled = str(enabled_raw).lower() in {"1", "true", "on"}
+    existing = await staff_repo.get_staff_by_id(staff_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Staff not found")
+    is_super_admin = bool(user.get("is_super_admin"))
+    if not is_super_admin and existing.get("company_id") != company_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+    await staff_repo.set_enabled(staff_id, enabled)
+    return RedirectResponse(url="/staff", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post("/staff/{staff_id}/verify")
+async def verify_staff_member(staff_id: int, request: Request):
+    (
+        user,
+        membership,
+        company,
+        staff_permission,
+        company_id,
+        redirect,
+    ) = await _load_staff_context(request, require_super_admin=True)
+    if redirect:
+        return redirect
+    staff = await staff_repo.get_staff_by_id(staff_id)
+    if not staff:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Staff not found")
+    if not staff.get("mobile_phone"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No mobile phone for staff member")
+
+    await staff_repo.purge_expired_verification_codes()
+    code = f"{secrets.randbelow(900000) + 100000:06d}"
+    admin_name = " ".join(filter(None, [user.get("first_name"), user.get("last_name")])).strip()
+    await staff_repo.upsert_verification_code(
+        staff_id,
+        code=code,
+        admin_name=admin_name or None,
+    )
+
+    status_code = None
+    settings = get_settings()
+    staff_company = await company_repo.get_company_by_id(staff.get("company_id"))
+    if settings.verify_webhook_url:
+        headers = {"Content-Type": "application/json"}
+        if settings.verify_api_key:
+            headers["Authorization"] = f"Bearer {settings.verify_api_key}"
+        payload = {
+            "mobilePhone": staff.get("mobile_phone"),
+            "code": code,
+            "adminName": admin_name,
+            "companyName": staff_company.get("name") if staff_company else "",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                response = await client.post(str(settings.verify_webhook_url), json=payload, headers=headers)
+            status_code = response.status_code
+        except httpx.HTTPError as exc:
+            log_error("Verify webhook failed", staff_id=staff_id, error=str(exc))
+
+    return JSONResponse({
+        "success": status_code == status.HTTP_202_ACCEPTED if status_code else True,
+        "status": status_code,
+        "code": code,
+    })
+
+
+@app.post("/staff/{staff_id}/invite")
+async def invite_staff_member(staff_id: int, request: Request):
+    (
+        user,
+        membership,
+        company,
+        staff_permission,
+        company_id,
+        redirect,
+    ) = await _load_staff_context(request, require_admin=True)
+    if redirect:
+        return redirect
+    staff = await staff_repo.get_staff_by_id(staff_id)
+    if not staff:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Staff not found")
+    if not staff.get("email"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No email for staff member")
+    if not bool(user.get("is_super_admin")) and staff.get("company_id") != company_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+
+    existing_user = await user_repo.get_user_by_email(staff["email"])
+    if existing_user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User already exists")
+
+    temp_password = secrets.token_urlsafe(12)
+    created_user = await user_repo.create_user(
+        email=staff["email"],
+        password=temp_password,
+        first_name=staff.get("first_name"),
+        last_name=staff.get("last_name"),
+        mobile_phone=staff.get("mobile_phone"),
+        company_id=staff.get("company_id"),
+    )
+    await user_repo.update_user(created_user["id"], force_password_change=1)
+    await user_company_repo.upsert_user_company(
+        user_id=created_user["id"],
+        company_id=staff.get("company_id"),
+        can_manage_staff=False,
+        staff_permission=0,
+        is_admin=False,
+    )
+    token = secrets.token_urlsafe(32)
+    expires_at = datetime.utcnow() + timedelta(hours=1)
+    await auth_repo.create_password_reset_token(
+        user_id=created_user["id"],
+        token=token,
+        expires_at=expires_at,
+    )
+    log_info(
+        "Staff invitation generated",
+        staff_id=staff_id,
+        invited_user_id=created_user["id"],
+    )
+    return JSONResponse({"success": True})
+
+@app.post("/admin/syncro/import-contacts")
+async def import_syncro_contacts(request: Request):
+    (
+        user,
+        membership,
+        company,
+        staff_permission,
+        company_id,
+        redirect,
+    ) = await _load_staff_context(request, require_super_admin=True)
+    if redirect:
+        return redirect
+    payload = await request.json()
+    syncro_company_id = payload.get("syncroCompanyId") or payload.get("syncro_company_id")
+    if not syncro_company_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="syncroCompanyId required")
+    summary = await staff_importer.import_contacts_for_syncro_id(str(syncro_company_id))
+    return JSONResponse({
+        "success": True,
+        "created": summary.created,
+        "updated": summary.updated,
+        "skipped": summary.skipped,
+    })
 
 
 @app.get("/admin/roles", response_class=HTMLResponse)

--- a/app/repositories/scheduled_tasks.py
+++ b/app/repositories/scheduled_tasks.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from app.core.database import db
+
+
+def _normalise_task(row: dict[str, Any]) -> dict[str, Any]:
+    task = dict(row)
+    task["active"] = bool(int(task.get("active", 0)))
+    if "company_id" in task and task["company_id"] is not None:
+        task["company_id"] = int(task["company_id"])
+    if "id" in task and task["id"] is not None:
+        task["id"] = int(task["id"])
+    return task
+
+
+async def list_active_tasks() -> List[dict[str, Any]]:
+    rows = await db.fetch_all(
+        "SELECT * FROM scheduled_tasks WHERE active = 1",
+    )
+    return [_normalise_task(row) for row in rows]
+
+
+async def get_task(task_id: int) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one(
+        "SELECT * FROM scheduled_tasks WHERE id = %s",
+        (task_id,),
+    )
+    return _normalise_task(row) if row else None
+
+
+async def mark_task_run(task_id: int) -> None:
+    await db.execute(
+        "UPDATE scheduled_tasks SET last_run_at = UTC_TIMESTAMP() WHERE id = %s",
+        (task_id,),
+    )

--- a/app/repositories/staff.py
+++ b/app/repositories/staff.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+from typing import Any, Iterable, Sequence
+
+from app.core.database import db
+
+
+def _ensure_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return _ensure_utc(value).replace(tzinfo=None)
+    if isinstance(value, date):
+        dt = datetime.combine(value, time.min, tzinfo=timezone.utc)
+        return dt.replace(tzinfo=None)
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        for fmt in ("%Y-%m-%d", "%Y-%m-%d %H:%M", "%Y-%m-%d %H:%M:%S"):
+            try:
+                parsed = datetime.strptime(text, fmt)
+                break
+            except ValueError:
+                continue
+        else:
+            return None
+    return _ensure_utc(parsed).replace(tzinfo=None)
+
+
+def _serialize_datetime(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        dt = _ensure_utc(value)
+    else:
+        dt = _coerce_datetime(value)
+        if dt is None:
+            return None
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()
+
+
+def _map_staff_row(row: dict[str, Any]) -> dict[str, Any]:
+    mapped = dict(row)
+    mapped["enabled"] = bool(int(mapped.get("enabled", 0)))
+    if "company_id" in mapped and mapped["company_id"] is not None:
+        mapped["company_id"] = int(mapped["company_id"])
+    if "verification_code" in mapped and mapped["verification_code"] is None:
+        mapped["verification_code"] = None
+    mapped["date_onboarded"] = _serialize_datetime(mapped.get("date_onboarded"))
+    mapped["date_offboarded"] = _serialize_datetime(mapped.get("date_offboarded"))
+    return mapped
+
+
+async def list_staff(
+    company_id: int, *, enabled: bool | None = None
+) -> list[dict[str, Any]]:
+    conditions = ["s.company_id = %s"]
+    params: list[Any] = [company_id]
+    if enabled is not None:
+        conditions.append("s.enabled = %s")
+        params.append(1 if enabled else 0)
+    where_clause = " AND ".join(conditions)
+    rows = await db.fetch_all(
+        """
+        SELECT s.*, svc.code AS verification_code, svc.admin_name AS verification_admin_name
+        FROM staff AS s
+        LEFT JOIN staff_verification_codes AS svc ON svc.staff_id = s.id
+        WHERE {where}
+        ORDER BY s.last_name, s.first_name
+        """.format(where=where_clause),
+        tuple(params),
+    )
+    return [_map_staff_row(row) for row in rows]
+
+
+async def list_all_staff(
+    *, account_action: str | None = None, email: str | None = None
+) -> list[dict[str, Any]]:
+    conditions: list[str] = []
+    params: list[Any] = []
+    if account_action:
+        conditions.append("s.account_action = %s")
+        params.append(account_action)
+    if email:
+        conditions.append("LOWER(s.email) LIKE %s")
+        params.append(f"%{email.lower()}%")
+    where_clause = " AND ".join(conditions)
+    sql = """
+        SELECT s.*, svc.code AS verification_code, svc.admin_name AS verification_admin_name
+        FROM staff AS s
+        LEFT JOIN staff_verification_codes AS svc ON svc.staff_id = s.id
+    """
+    if where_clause:
+        sql += f" WHERE {where_clause}"
+    sql += " ORDER BY s.company_id, s.last_name, s.first_name"
+    rows = await db.fetch_all(sql, tuple(params))
+    return [_map_staff_row(row) for row in rows]
+
+
+async def list_departments(company_id: int) -> list[str]:
+    rows = await db.fetch_all(
+        """
+        SELECT DISTINCT department FROM staff
+        WHERE company_id = %s AND department IS NOT NULL AND department <> ''
+        ORDER BY department
+        """,
+        (company_id,),
+    )
+    departments = [row["department"] for row in rows if row.get("department")]
+    return [str(dept) for dept in departments]
+
+
+async def get_staff_by_id(staff_id: int) -> dict[str, Any] | None:
+    row = await db.fetch_one(
+        """
+        SELECT s.*, svc.code AS verification_code, svc.admin_name AS verification_admin_name
+        FROM staff AS s
+        LEFT JOIN staff_verification_codes AS svc ON svc.staff_id = s.id
+        WHERE s.id = %s
+        """,
+        (staff_id,),
+    )
+    return _map_staff_row(row) if row else None
+
+
+async def get_staff_by_company_and_email(
+    company_id: int, email: str
+) -> dict[str, Any] | None:
+    row = await db.fetch_one(
+        """
+        SELECT s.*, svc.code AS verification_code, svc.admin_name AS verification_admin_name
+        FROM staff AS s
+        LEFT JOIN staff_verification_codes AS svc ON svc.staff_id = s.id
+        WHERE s.company_id = %s AND LOWER(s.email) = LOWER(%s)
+        """,
+        (company_id, email),
+    )
+    return _map_staff_row(row) if row else None
+
+
+async def create_staff(
+    *,
+    company_id: int,
+    first_name: str,
+    last_name: str,
+    email: str,
+    mobile_phone: str | None = None,
+    date_onboarded: datetime | None = None,
+    date_offboarded: datetime | None = None,
+    enabled: bool = True,
+    street: str | None = None,
+    city: str | None = None,
+    state: str | None = None,
+    postcode: str | None = None,
+    country: str | None = None,
+    department: str | None = None,
+    job_title: str | None = None,
+    org_company: str | None = None,
+    manager_name: str | None = None,
+    account_action: str | None = None,
+    syncro_contact_id: str | None = None,
+) -> dict[str, Any]:
+    await db.execute(
+        """
+        INSERT INTO staff (
+            company_id,
+            first_name,
+            last_name,
+            email,
+            mobile_phone,
+            date_onboarded,
+            date_offboarded,
+            enabled,
+            street,
+            city,
+            state,
+            postcode,
+            country,
+            department,
+            job_title,
+            org_company,
+            manager_name,
+            account_action,
+            syncro_contact_id
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            company_id,
+            first_name,
+            last_name,
+            email,
+            mobile_phone,
+            _coerce_datetime(date_onboarded),
+            _coerce_datetime(date_offboarded),
+            1 if enabled else 0,
+            street,
+            city,
+            state,
+            postcode,
+            country,
+            department,
+            job_title,
+            org_company,
+            manager_name,
+            account_action,
+            syncro_contact_id,
+        ),
+    )
+    created = await db.fetch_one("SELECT * FROM staff WHERE id = LAST_INSERT_ID()")
+    if not created:
+        raise RuntimeError("Failed to create staff record")
+    return _map_staff_row(created)
+
+
+async def update_staff(
+    staff_id: int,
+    *,
+    company_id: int,
+    first_name: str,
+    last_name: str,
+    email: str,
+    mobile_phone: str | None,
+    date_onboarded: datetime | None,
+    date_offboarded: datetime | None,
+    enabled: bool,
+    street: str | None,
+    city: str | None,
+    state: str | None,
+    postcode: str | None,
+    country: str | None,
+    department: str | None,
+    job_title: str | None,
+    org_company: str | None,
+    manager_name: str | None,
+    account_action: str | None,
+    syncro_contact_id: str | None,
+) -> dict[str, Any]:
+    await db.execute(
+        """
+        UPDATE staff
+        SET
+            company_id = %s,
+            first_name = %s,
+            last_name = %s,
+            email = %s,
+            mobile_phone = %s,
+            date_onboarded = %s,
+            date_offboarded = %s,
+            enabled = %s,
+            street = %s,
+            city = %s,
+            state = %s,
+            postcode = %s,
+            country = %s,
+            department = %s,
+            job_title = %s,
+            org_company = %s,
+            manager_name = %s,
+            account_action = %s,
+            syncro_contact_id = %s
+        WHERE id = %s
+        """,
+        (
+            company_id,
+            first_name,
+            last_name,
+            email,
+            mobile_phone,
+            _coerce_datetime(date_onboarded),
+            _coerce_datetime(date_offboarded),
+            1 if enabled else 0,
+            street,
+            city,
+            state,
+            postcode,
+            country,
+            department,
+            job_title,
+            org_company,
+            manager_name,
+            account_action,
+            syncro_contact_id,
+            staff_id,
+        ),
+    )
+    updated = await get_staff_by_id(staff_id)
+    if not updated:
+        raise ValueError("Staff record not found after update")
+    return updated
+
+
+async def delete_staff(staff_id: int) -> None:
+    await db.execute("DELETE FROM staff WHERE id = %s", (staff_id,))
+
+
+async def set_enabled(staff_id: int, enabled: bool) -> None:
+    await db.execute(
+        "UPDATE staff SET enabled = %s WHERE id = %s",
+        (1 if enabled else 0, staff_id),
+    )
+
+
+async def upsert_verification_code(
+    staff_id: int, *, code: str, admin_name: str | None
+) -> None:
+    await db.execute(
+        """
+        INSERT INTO staff_verification_codes (staff_id, code, admin_name, created_at)
+        VALUES (%s, %s, %s, UTC_TIMESTAMP())
+        ON DUPLICATE KEY UPDATE
+            code = VALUES(code),
+            admin_name = VALUES(admin_name),
+            created_at = VALUES(created_at)
+        """,
+        (staff_id, code, admin_name),
+    )
+
+
+async def purge_expired_verification_codes(ttl_minutes: int = 5) -> None:
+    await db.execute(
+        "DELETE FROM staff_verification_codes WHERE created_at < (UTC_TIMESTAMP() - INTERVAL %s MINUTE)",
+        (ttl_minutes,),
+    )
+
+
+async def get_verification_by_code(code: str) -> dict[str, Any] | None:
+    row = await db.fetch_one(
+        "SELECT * FROM staff_verification_codes WHERE code = %s",
+        (code,),
+    )
+    return dict(row) if row else None

--- a/app/repositories/user_companies.py
+++ b/app/repositories/user_companies.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from app.core.database import db
+
+_BOOLEAN_FIELDS = {
+    "can_manage_licenses",
+    "can_manage_staff",
+    "can_manage_assets",
+    "can_manage_invoices",
+    "can_manage_office_groups",
+    "can_order_licenses",
+    "can_access_shop",
+    "is_admin",
+}
+
+
+def _normalise(row: dict[str, Any]) -> dict[str, Any]:
+    normalised = dict(row)
+    for key in _BOOLEAN_FIELDS:
+        if key in normalised:
+            normalised[key] = bool(int(normalised.get(key, 0)))
+    if "staff_permission" in normalised and normalised["staff_permission"] is not None:
+        normalised["staff_permission"] = int(normalised["staff_permission"])
+    if "company_id" in normalised and normalised["company_id"] is not None:
+        normalised["company_id"] = int(normalised["company_id"])
+    if "user_id" in normalised and normalised["user_id"] is not None:
+        normalised["user_id"] = int(normalised["user_id"])
+    return normalised
+
+
+async def get_user_company(user_id: int, company_id: int) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one(
+        "SELECT * FROM user_companies WHERE user_id = %s AND company_id = %s",
+        (user_id, company_id),
+    )
+    return _normalise(row) if row else None
+
+
+async def upsert_user_company(
+    *,
+    user_id: int,
+    company_id: int,
+    can_manage_staff: bool = False,
+    staff_permission: int = 0,
+    is_admin: bool = False,
+) -> None:
+    await db.execute(
+        """
+        INSERT INTO user_companies (user_id, company_id, can_manage_staff, staff_permission, is_admin)
+        VALUES (%s, %s, %s, %s, %s)
+        ON DUPLICATE KEY UPDATE
+            can_manage_staff = VALUES(can_manage_staff),
+            staff_permission = VALUES(staff_permission),
+            is_admin = VALUES(is_admin)
+        """,
+        (
+            user_id,
+            company_id,
+            1 if can_manage_staff else 0,
+            staff_permission,
+            1 if is_admin else 0,
+        ),
+    )

--- a/app/schemas/staff.py
+++ b/app/schemas/staff.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class StaffBase(BaseModel):
+    first_name: str = Field(validation_alias="firstName")
+    last_name: str = Field(validation_alias="lastName")
+    email: EmailStr
+    mobile_phone: Optional[str] = Field(default=None, validation_alias="mobilePhone")
+    date_onboarded: Optional[datetime] = Field(default=None, validation_alias="dateOnboarded")
+    date_offboarded: Optional[datetime] = Field(default=None, validation_alias="dateOffboarded")
+    enabled: bool = True
+    street: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    postcode: Optional[str] = None
+    country: Optional[str] = None
+    department: Optional[str] = None
+    job_title: Optional[str] = Field(default=None, validation_alias="jobTitle")
+    org_company: Optional[str] = Field(default=None, validation_alias="company")
+    manager_name: Optional[str] = Field(default=None, validation_alias="managerName")
+    account_action: Optional[str] = Field(default=None, validation_alias="accountAction")
+    syncro_contact_id: Optional[str] = Field(
+        default=None, validation_alias="syncroContactId"
+    )
+
+
+class StaffCreate(StaffBase):
+    company_id: int = Field(validation_alias="companyId")
+
+
+class StaffUpdate(BaseModel):
+    first_name: Optional[str] = Field(default=None, validation_alias="firstName")
+    last_name: Optional[str] = Field(default=None, validation_alias="lastName")
+    email: Optional[EmailStr] = None
+    mobile_phone: Optional[str] = Field(default=None, validation_alias="mobilePhone")
+    date_onboarded: Optional[datetime] = Field(default=None, validation_alias="dateOnboarded")
+    date_offboarded: Optional[datetime] = Field(default=None, validation_alias="dateOffboarded")
+    enabled: Optional[bool] = None
+    street: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    postcode: Optional[str] = None
+    country: Optional[str] = None
+    department: Optional[str] = None
+    job_title: Optional[str] = Field(default=None, validation_alias="jobTitle")
+    org_company: Optional[str] = Field(default=None, validation_alias="company")
+    manager_name: Optional[str] = Field(default=None, validation_alias="managerName")
+    account_action: Optional[str] = Field(default=None, validation_alias="accountAction")
+    syncro_contact_id: Optional[str] = Field(
+        default=None, validation_alias="syncroContactId"
+    )
+
+
+class StaffResponse(BaseModel):
+    id: int
+    company_id: int
+    first_name: str
+    last_name: str
+    email: str
+    mobile_phone: Optional[str] = None
+    date_onboarded: Optional[datetime] = None
+    date_offboarded: Optional[datetime] = None
+    enabled: bool
+    street: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    postcode: Optional[str] = None
+    country: Optional[str] = None
+    department: Optional[str] = None
+    job_title: Optional[str] = None
+    org_company: Optional[str] = None
+    manager_name: Optional[str] = None
+    account_action: Optional[str] = None
+    verification_code: Optional[str] = None
+    verification_admin_name: Optional[str] = None
+    syncro_contact_id: Optional[str] = None
+
+    model_config = {
+        "from_attributes": True,
+        "populate_by_name": True,
+    }

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Any
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from app.core.config import get_settings
+from app.core.logging import log_error, log_info
+from app.repositories import scheduled_tasks as scheduled_tasks_repo
+from app.services import staff_importer
+
+
+class SchedulerService:
+    def __init__(self) -> None:
+        settings = get_settings()
+        self._scheduler = AsyncIOScheduler(timezone=settings.default_timezone)
+        self._started = False
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        self._scheduler.start()
+        self._started = True
+        await self.refresh()
+        log_info("Scheduler started")
+
+    async def stop(self) -> None:
+        if not self._started:
+            return
+        self._scheduler.shutdown(wait=False)
+        self._started = False
+        log_info("Scheduler stopped")
+
+    async def refresh(self) -> None:
+        if not self._started:
+            return
+        for job in list(self._scheduler.get_jobs()):
+            job.remove()
+        tasks = await scheduled_tasks_repo.list_active_tasks()
+        for task in tasks:
+            trigger = self._build_trigger(task)
+            if not trigger:
+                continue
+            self._scheduler.add_job(
+                self._run_task,
+                trigger=trigger,
+                args=[task],
+                id=f"scheduled-task-{task['id']}",
+                replace_existing=True,
+                coalesce=True,
+                max_instances=1,
+            )
+        log_info("Scheduler tasks loaded", count=len(tasks))
+
+    def _build_trigger(self, task: dict[str, Any]) -> CronTrigger | None:
+        try:
+            return CronTrigger.from_crontab(task["cron"], timezone=self._scheduler.timezone)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            log_error(
+                "Failed to parse cron expression",
+                task_id=task.get("id"),
+                cron=task.get("cron"),
+                error=str(exc),
+            )
+            return None
+
+    async def _run_task(self, task: dict[str, Any]) -> None:
+        task_id = task.get("id")
+        command = task.get("command")
+        log_info("Running scheduled task", task_id=task_id, command=command)
+        try:
+            if command == "sync_staff":
+                company_id = task.get("company_id")
+                if company_id:
+                    await staff_importer.import_contacts_for_company(int(company_id))
+            else:
+                log_info(
+                    "Scheduled task has no handler",
+                    task_id=task_id,
+                    command=command,
+                )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            log_error(
+                "Scheduled task failed",
+                task_id=task_id,
+                command=command,
+                error=str(exc),
+            )
+        finally:
+            await scheduled_tasks_repo.mark_task_run(int(task_id))
+
+
+scheduler_service = SchedulerService()

--- a/app/services/staff_importer.py
+++ b/app/services/staff_importer.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.logging import log_info
+from app.repositories import companies as company_repo
+from app.repositories import staff as staff_repo
+from app.services import syncro
+
+
+@dataclass(slots=True)
+class ImportSummary:
+    company_id: int
+    created: int
+    updated: int
+    skipped: int
+
+    @property
+    def total(self) -> int:
+        return self.created + self.updated + self.skipped
+
+
+def _normalise(value: str | None) -> str:
+    return value.strip() if value else ""
+
+
+def _find_existing_staff(
+    existing_staff: list[dict[str, Any]],
+    *,
+    first_name: str,
+    last_name: str,
+    email: str | None,
+) -> dict[str, Any] | None:
+    email_lower = email.lower() if email else None
+    for member in existing_staff:
+        member_email = member.get("email")
+        if email_lower and member_email and member_email.lower() == email_lower:
+            return member
+        member_first = member.get("first_name", "").lower()
+        member_last = member.get("last_name", "").lower()
+        if (
+            not email_lower
+            and member_first == first_name.lower()
+            and member_last == last_name.lower()
+        ):
+            return member
+    return None
+
+
+async def import_contacts_for_company(
+    company_id: int,
+    *,
+    syncro_company_id: str | None = None,
+) -> ImportSummary:
+    company = await company_repo.get_company_by_id(company_id)
+    if not company:
+        raise ValueError(f"Company {company_id} not found")
+    syncro_id = syncro_company_id or company.get("syncro_company_id")
+    if not syncro_id:
+        raise syncro.SyncroConfigurationError("Company is missing a Syncro mapping")
+
+    log_info("Starting Syncro contact import", company_id=company_id, syncro_id=syncro_id)
+    contacts = await syncro.get_contacts(syncro_id)
+    existing_staff = await staff_repo.list_staff(company_id)
+
+    created = 0
+    updated = 0
+    skipped = 0
+
+    for contact in contacts:
+        full_name = " ".join(
+            part
+            for part in (
+                _normalise(contact.get("first_name")),
+                _normalise(contact.get("last_name")),
+            )
+            if part
+        ).strip()
+        if not full_name and contact.get("name"):
+            full_name = _normalise(contact.get("name"))
+        if not full_name:
+            skipped += 1
+            continue
+        if "ex staff" in full_name.lower():
+            skipped += 1
+            continue
+
+        parts = full_name.split()
+        first_name = _normalise(contact.get("first_name") or (parts[0] if parts else ""))
+        last_name = _normalise(
+            contact.get("last_name")
+            or (" ".join(parts[1:]) if len(parts) > 1 else "")
+        )
+        email = _normalise(contact.get("email") or contact.get("email_address") or None)
+        email = email or None
+        phone = _normalise(contact.get("mobile") or contact.get("phone") or None) or None
+
+        existing = _find_existing_staff(
+            existing_staff,
+            first_name=first_name or "Unknown",
+            last_name=last_name or "",
+            email=email,
+        )
+
+        address = _normalise(contact.get("address1") or contact.get("address") or None)
+        city = _normalise(contact.get("city") or None) or None
+        state = _normalise(contact.get("state") or None) or None
+        postcode = _normalise(contact.get("zip") or None) or None
+        country = _normalise(contact.get("country") or None) or None
+        department = _normalise(contact.get("department") or None) or None
+        job_title = _normalise(contact.get("title") or None) or None
+
+        if existing:
+            await staff_repo.update_staff(
+                existing["id"],
+                company_id=company_id,
+                first_name=first_name or existing.get("first_name", ""),
+                last_name=last_name or existing.get("last_name", ""),
+                email=email or existing.get("email", ""),
+                mobile_phone=phone or existing.get("mobile_phone"),
+                date_onboarded=existing.get("date_onboarded"),
+                date_offboarded=existing.get("date_offboarded"),
+                enabled=bool(existing.get("enabled", True)),
+                street=address or existing.get("street"),
+                city=city or existing.get("city"),
+                state=state or existing.get("state"),
+                postcode=postcode or existing.get("postcode"),
+                country=country or existing.get("country"),
+                department=department or existing.get("department"),
+                job_title=job_title or existing.get("job_title"),
+                org_company=existing.get("org_company"),
+                manager_name=existing.get("manager_name"),
+                account_action=existing.get("account_action"),
+                syncro_contact_id=str(contact.get("id")) if contact.get("id") else existing.get("syncro_contact_id"),
+            )
+            updated += 1
+        else:
+            created_staff = await staff_repo.create_staff(
+                company_id=company_id,
+                first_name=first_name or "Unknown",
+                last_name=last_name or last_name or "",
+                email=email or "",
+                mobile_phone=phone,
+                date_onboarded=None,
+                date_offboarded=None,
+                enabled=True,
+                street=address or None,
+                city=city,
+                state=state,
+                postcode=postcode,
+                country=country,
+                department=department,
+                job_title=job_title,
+                org_company=None,
+                manager_name=None,
+                account_action=None,
+                syncro_contact_id=str(contact.get("id")) if contact.get("id") else None,
+            )
+            existing_staff.append(created_staff)
+            created += 1
+
+    log_info(
+        "Completed Syncro contact import",
+        company_id=company_id,
+        created=created,
+        updated=updated,
+        skipped=skipped,
+    )
+    return ImportSummary(company_id=company_id, created=created, updated=updated, skipped=skipped)
+
+
+async def import_contacts_for_syncro_id(syncro_company_id: str) -> ImportSummary:
+    company = await company_repo.get_company_by_syncro_id(syncro_company_id)
+    if not company:
+        raise ValueError("Company not found for supplied Syncro identifier")
+    return await import_contacts_for_company(company["id"], syncro_company_id=syncro_company_id)

--- a/app/services/syncro.py
+++ b/app/services/syncro.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.core.config import get_settings
+from app.core.logging import log_error, log_info
+
+
+class SyncroConfigurationError(RuntimeError):
+    """Raised when Syncro integration settings are incomplete."""
+
+
+class SyncroAPIError(RuntimeError):
+    """Raised when Syncro responds with an error status."""
+
+
+def _get_base_url() -> str:
+    settings = get_settings()
+    base = settings.syncro_webhook_url
+    if not base:
+        raise SyncroConfigurationError("SYNCRO_WEBHOOK_URL is not configured")
+    url = str(base).rstrip("/")
+    if not url.endswith("/api/v1"):
+        url = f"{url}/api/v1"
+    return url
+
+
+async def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json: Any | None = None,
+    timeout: float = 15.0,
+) -> Any:
+    base_url = _get_base_url()
+    url = f"{base_url}{path if path.startswith('/') else f'/{path}'}"
+    headers: dict[str, str] = {}
+    settings = get_settings()
+    if settings.syncro_api_key:
+        headers["Authorization"] = f"Bearer {settings.syncro_api_key}"
+    log_info("Calling Syncro API", url=url, method=method)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        try:
+            response = await client.request(
+                method,
+                url,
+                headers=headers,
+                params=params,
+                json=json,
+            )
+        except httpx.HTTPError as exc:
+            log_error("Syncro API request failed", url=url, error=str(exc))
+            raise SyncroAPIError(str(exc)) from exc
+    if response.status_code == httpx.codes.NOT_FOUND:
+        return None
+    if response.status_code >= 400:
+        log_error(
+            "Syncro API responded with error",
+            url=url,
+            status=response.status_code,
+            body=response.text,
+        )
+        raise SyncroAPIError(f"Syncro API responded with {response.status_code}")
+    if response.status_code == httpx.codes.NO_CONTENT:
+        return None
+    try:
+        data = response.json()
+    except ValueError:
+        data = response.text
+    return data
+
+
+def _extract_collection(data: Any, *keys: str) -> list[dict[str, Any]]:
+    if isinstance(data, list):
+        return [dict(item) if isinstance(item, dict) else item for item in data]
+    for key in keys:
+        nested = data.get(key) if isinstance(data, dict) else None
+        if isinstance(nested, list):
+            return [dict(item) if isinstance(item, dict) else item for item in nested]
+    return []
+
+
+async def get_contacts(customer_id: str | int) -> list[dict[str, Any]]:
+    payload = await _request("GET", "/contacts", params={"customer_id": customer_id})
+    return _extract_collection(payload, "contacts", "data")
+
+
+async def get_customer(customer_id: str | int) -> dict[str, Any] | None:
+    payload = await _request("GET", f"/customers/{customer_id}")
+    if not payload:
+        return None
+    if isinstance(payload, dict) and "customer" in payload:
+        customer = payload.get("customer")
+        if isinstance(customer, dict):
+            return customer
+    return payload if isinstance(payload, dict) else None

--- a/changes.md
+++ b/changes.md
@@ -42,3 +42,4 @@
 - 2025-10-08, 06:41 UTC, Fix, Restored shop catalogue display for products whose names match their SKUs so existing items appear
 - 2025-10-08, 06:49 UTC, Fix, Restored shop admin and catalogue views to load categories and products from the database with VIP pricing and company restrictions
 - 2025-10-09, 18:00 UTC, Feature, Added port catalogue data models, secure document uploads, pricing workflow approvals, notification APIs, and refreshed Swagger documentation
+- 2025-10-08, 07:28 UTC, Feature, Rebuilt staff data models, Syncro import client, scheduled sync runner, and management UI with API parity and permissions

--- a/tests/test_staff_importer.py
+++ b/tests/test_staff_importer.py
@@ -1,0 +1,40 @@
+from app.services import staff_importer
+
+
+def test_find_existing_staff_matches_email():
+    existing = [
+        {"first_name": "John", "last_name": "Doe", "email": "john@example.com"},
+    ]
+    result = staff_importer._find_existing_staff(  # type: ignore[attr-defined]
+        existing,
+        first_name="John",
+        last_name="Doe",
+        email="john@example.com",
+    )
+    assert result == existing[0]
+
+
+def test_find_existing_staff_treats_different_email_as_new():
+    existing = [
+        {"first_name": "John", "last_name": "Doe", "email": "john@example.com"},
+    ]
+    result = staff_importer._find_existing_staff(  # type: ignore[attr-defined]
+        existing,
+        first_name="John",
+        last_name="Doe",
+        email="john2@example.com",
+    )
+    assert result is None
+
+
+def test_find_existing_staff_matches_by_name_when_email_missing():
+    existing = [
+        {"first_name": "Jane", "last_name": "Smith", "email": None},
+    ]
+    result = staff_importer._find_existing_staff(  # type: ignore[attr-defined]
+        existing,
+        first_name="Jane",
+        last_name="Smith",
+        email=None,
+    )
+    assert result == existing[0]


### PR DESCRIPTION
## Summary
- add a dedicated staff repository, Syncro API client, and asynchronous importer to synchronise contacts into the portal
- wire scheduled task execution, staff-facing UI endpoints, and new FastAPI staff routes to support verification, invitations, and filtering
- extend configuration, schemas, and documentation to surface new integration settings and note the change in the project log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e60f16b59c832da4e3659aaa2e1231