### PR TITLE
Fix company switch payload handling

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -44,3 +44,4 @@
 - 2025-10-08, 06:49 UTC, Fix, Restored shop admin and catalogue views to load categories and products from the database with VIP pricing and company restrictions
 - 2025-10-09, 18:00 UTC, Feature, Added port catalogue data models, secure document uploads, pricing workflow approvals, notification APIs, and refreshed Swagger documentation
 - 2025-10-08, 07:28 UTC, Feature, Rebuilt staff data models, Syncro import client, scheduled sync runner, and management UI with API parity and permissions
+- 2025-10-08, 10:14 UTC, Fix, Allowed company switching endpoint to accept JSON and form payloads while validating memberships


### PR DESCRIPTION
## Summary
- allow the FastAPI company switch endpoint to parse both JSON and form submissions
- validate the resolved company identifier before updating the active session
- record the fix in the change log for operational tracking

## Testing
- pytest *(fails: missing python-multipart dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e6393bbef4832d9aa0c279e67527dd