### PR TITLE
Fix company switching payload parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ All authentication routes are documented in the interactive Swagger UI and summa
 - `POST /auth/totp/verify` – Confirms the authenticator code and persists it for future logins.
 - `DELETE /auth/totp/{id}` – Removes an existing authenticator.
 
+## Company Context Switching
+
+- `POST /switch-company` – Updates the active company for the authenticated session. The endpoint accepts either
+  form-encoded or JSON payloads with a `companyId` field and honours an optional `returnUrl` parameter. Clients may
+  also supply these parameters via the query string when making server-side redirects. A valid CSRF token is required
+  for authenticated browsers; send it as the `_csrf` form field or `X-CSRF-Token` header.
+
 ## Office 365 Sync
 
 To enable Microsoft 365 license synchronization, register an application in

--- a/changes.md
+++ b/changes.md
@@ -45,3 +45,4 @@
 - 2025-10-09, 18:00 UTC, Feature, Added port catalogue data models, secure document uploads, pricing workflow approvals, notification APIs, and refreshed Swagger documentation
 - 2025-10-08, 07:28 UTC, Feature, Rebuilt staff data models, Syncro import client, scheduled sync runner, and management UI with API parity and permissions
 - 2025-10-08, 10:14 UTC, Fix, Allowed company switching endpoint to accept JSON and form payloads while validating memberships
+- 2025-10-08, 10:19 UTC, Fix, Hardened company switching payload parsing to support form, JSON, and query parameters with updated documentation

--- a/tests/test_switch_company_payload.py
+++ b/tests/test_switch_company_payload.py
@@ -1,0 +1,95 @@
+import json
+from collections.abc import Mapping
+
+import pytest
+from starlette.requests import Request
+
+from app.main import _extract_switch_company_payload, _first_non_blank
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _build_request(
+    *,
+    body: bytes = b"",
+    method: str = "POST",
+    headers: Mapping[str, str] | None = None,
+    query_string: str = "",
+) -> Request:
+    raw_headers = [
+        (key.lower().encode("latin-1"), value.encode("latin-1"))
+        for key, value in (headers or {}).items()
+    ]
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.1"},
+        "method": method,
+        "path": "/switch-company",
+        "raw_path": b"/switch-company",
+        "query_string": query_string.encode("latin-1"),
+        "headers": raw_headers,
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "scheme": "http",
+    }
+
+    body_sent = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal body_sent
+        if body_sent:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        body_sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_extracts_json_payload_without_modification() -> None:
+    request = _build_request(
+        body=json.dumps({"companyId": 42, "returnUrl": "/staff"}).encode("utf-8"),
+        headers={"content-type": "application/json"},
+    )
+
+    data = await _extract_switch_company_payload(request)
+
+    assert data == {"companyId": 42, "returnUrl": "/staff"}
+
+
+@pytest.mark.anyio("asyncio")
+async def test_extracts_form_payload_even_after_prior_reads() -> None:
+    body = "companyId=7&returnUrl=%2Fshop&_csrf=test-token".encode("utf-8")
+    request = _build_request(
+        body=body,
+        headers={"content-type": "application/x-www-form-urlencoded; charset=utf-8"},
+    )
+
+    # Simulate middleware already reading the form
+    await request.form()
+
+    data = await _extract_switch_company_payload(request)
+
+    assert data["companyId"] == "7"
+    assert data["returnUrl"] == "/shop"
+    assert data["_csrf"] == "test-token"
+
+
+def test_first_non_blank_prioritises_non_empty_values() -> None:
+    body_data = {"companyId": "  ", "company_id": None}
+    query_params = {"company_id": "99", "returnUrl": "/dashboard"}
+
+    company_id = _first_non_blank(("companyId", "company_id"), body_data, query_params)
+    return_url = _first_non_blank(("returnUrl", "return_url"), body_data, query_params)
+
+    assert company_id == "99"
+    assert return_url == "/dashboard"
+
+
+def test_first_non_blank_accepts_non_string_values() -> None:
+    source = {"companyId": 123}
+
+    assert _first_non_blank(("companyId",), source) == 123


### PR DESCRIPTION
## Summary
- harden `/switch-company` to read JSON, form, and query payloads consistently before updating the session
- document the accepted payload shapes for the company switch endpoint in the README and extend the change log
- add regression tests that cover JSON and form submissions plus helper selection logic

## Testing
- pytest tests/test_switch_company_payload.py

------
https://chatgpt.com/codex/tasks/task_b_68e63a422658832dbb41821158a37593