### PR TITLE
Fix missing Form dependency for FastAPI startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import FastAPI, HTTPException, Query, Request, status
+from fastapi import FastAPI, Form, HTTPException, Query, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,7 @@
 # Change Log
 
 - 2025-09-17, 06:44 UTC, Feature, Setup change log file
+- 2025-10-09, 20:50 UTC, Fix, Added missing FastAPI Form import to restore API startup
 - 2025-10-09, 19:30 UTC, Fix, Restored company switching with session-backed active company tracking and sidebar selector
 - 2025-09-17, 06:59 UTC, Feature, Consolidated Company Assets column toggles into a secure header view menu
 - 2025-09-17, 07:02 UTC, Fix, Added server-rendered CSRF tokens to Apps management forms to prevent invalid token errors when saving changes


### PR DESCRIPTION
## Summary
- add the missing FastAPI Form import so startup succeeds when handling form-based requests
- record the fix in the change log for traceability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e63e3adbb8832dab8b0bc4f8b3a902