### PR TITLE
Handle blank optional webhook URLs

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import List, Optional
 
-from pydantic import AnyHttpUrl, AliasChoices, BaseModel, Field
+from pydantic import AnyHttpUrl, AliasChoices, BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -68,6 +68,22 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("OPNFORM_BASE_URL", "OPNFORM_URL"),
     )
+
+    @field_validator(
+        "syncro_webhook_url",
+        "verify_webhook_url",
+        "portal_url",
+        "licenses_webhook_url",
+        "opnform_base_url",
+        mode="before",
+    )
+    @classmethod
+    def _empty_string_to_none(cls, value: AnyHttpUrl | None) -> AnyHttpUrl | None:  # type: ignore[override]
+        """Coerce blank environment variables to ``None`` so optional URLs stay optional."""
+
+        if isinstance(value, str) and value.strip() == "":
+            return None
+        return value
 
     model_config = SettingsConfigDict(
         env_file=(Path(__file__).resolve().parent.parent.parent / ".env"),

--- a/changes.md
+++ b/changes.md
@@ -46,6 +46,7 @@
 - 2025-10-09, 18:00 UTC, Feature, Added port catalogue data models, secure document uploads, pricing workflow approvals, notification APIs, and refreshed Swagger documentation
 - 2025-10-08, 07:28 UTC, Feature, Rebuilt staff data models, Syncro import client, scheduled sync runner, and management UI with API parity and permissions
 - 2025-10-09, 21:15 UTC, Feature, Restored license management UI, Microsoft 365 sync services, OAuth callbacks, and admin credential workflows for parity with the legacy portal
+- 2025-10-08, 10:40 UTC, Fix, Treated blank optional webhook URLs as unset so configuration validation no longer blocks startup
 - 2025-10-08, 10:14 UTC, Fix, Allowed company switching endpoint to accept JSON and form payloads while validating memberships
 - 2025-10-08, 10:19 UTC, Fix, Hardened company switching payload parsing to support form, JSON, and query parameters with updated documentation
 - 2025-10-08, 10:32 UTC, Fix, Added resilient switch-company payload parsing fallback for raw form bodies and undocumented clients


### PR DESCRIPTION
## Summary
- coerce empty optional webhook URL environment variables to `None` during settings validation
- record the startup fix in the project change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e63f6a74d4832d85c2111049505564