### PR TITLE
Guard upgrade service restart behind upstream changes

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -40,6 +40,7 @@
 - 2025-10-09, 16:18 UTC, Fix, Normalised login TOTP payload handling to accept legacy keys and enforce numeric codes server-side
 - 2025-10-08, 04:05 UTC, Feature, Introduced role-based company memberships with audit logging and admin control panels
 - 2025-10-08, 06:07 UTC, Feature, Rebuilt shop, forms, staff, and commerce admin dashboards with Jinja templates, responsive layout components, and supporting scripts
+- 2025-10-08, 10:48 UTC, Fix, Updated upgrade automation to skip dependency reinstalls and service restarts when no upstream changes are pulled
 - 2025-10-08, 06:33 UTC, Fix, Added global sidebar navigation for admin pages so new management views are accessible from the portal
 - 2025-10-08, 06:41 UTC, Fix, Restored shop catalogue display for products whose names match their SKUs so existing items appear
 - 2025-10-08, 06:49 UTC, Fix, Restored shop admin and catalogue views to load categories and products from the database with VIP pricing and company restrictions


### PR DESCRIPTION
## Summary
- capture repository state before and after pulling updates and skip dependency reinstalls when no new commits arrive
- only restart the MyPortal systemd service when upstream changes are detected
- document the automation change in the project change log

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e6416561d4832d999c0ebaf17d4398