### PR TITLE
Fix switch-company migration for MySQL compatibility

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-08, 10:55 UTC, Fix, Hardened active company session migration for legacy MySQL compatibility so company switching succeeds
 # Change Log
 
 - 2025-09-17, 06:44 UTC, Feature, Setup change log file

--- a/migrations/066_add_active_company_to_sessions.sql
+++ b/migrations/066_add_active_company_to_sessions.sql
@@ -1,12 +1,57 @@
-ALTER TABLE user_sessions
-  ADD COLUMN IF NOT EXISTS active_company_id INT NULL AFTER user_id;
+-- Ensure the user_sessions table can persist the active company selection even on
+-- MySQL variants that do not support IF NOT EXISTS clauses for ALTER/CREATE operations.
+SET @db_name = DATABASE();
 
-ALTER TABLE user_sessions
-  ADD CONSTRAINT fk_user_sessions_active_company
-    FOREIGN KEY (active_company_id) REFERENCES companies(id);
+SET @column_stmt = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = @db_name
+        AND TABLE_NAME = 'user_sessions'
+        AND COLUMN_NAME = 'active_company_id'
+    ),
+    'SELECT 1',
+    'ALTER TABLE user_sessions ADD COLUMN active_company_id INT NULL AFTER user_id'
+  )
+);
+PREPARE stmt FROM @column_stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
-CREATE INDEX IF NOT EXISTS idx_user_sessions_active_company
-  ON user_sessions (active_company_id);
+SET @index_stmt = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.STATISTICS
+      WHERE TABLE_SCHEMA = @db_name
+        AND TABLE_NAME = 'user_sessions'
+        AND INDEX_NAME = 'idx_user_sessions_active_company'
+    ),
+    'SELECT 1',
+    'CREATE INDEX idx_user_sessions_active_company ON user_sessions (active_company_id)'
+  )
+);
+PREPARE stmt FROM @index_stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @fk_stmt = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+      WHERE TABLE_SCHEMA = @db_name
+        AND TABLE_NAME = 'user_sessions'
+        AND CONSTRAINT_NAME = 'fk_user_sessions_active_company'
+    ),
+    'SELECT 1',
+    'ALTER TABLE user_sessions ADD CONSTRAINT fk_user_sessions_active_company FOREIGN KEY (active_company_id) REFERENCES companies(id)'
+  )
+);
+PREPARE stmt FROM @fk_stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
 UPDATE user_sessions AS s
 INNER JOIN users AS u ON u.id = s.user_id


### PR DESCRIPTION
## Summary
- rewrite the active company session migration to use conditional prepared statements compatible with legacy MySQL servers
- document the fix in the change log so the restoration of company switching is recorded

## Testing
- pytest tests/test_switch_company_payload.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e640a0c54c832dbd335e05b59d3f40