### PR TITLE
Fix switch-company payload parsing after middleware reads body

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-10, 03:15 UTC, Fix, Prevented switch-company payload parsing from failing after CSRF middleware consumes the request body stream
 - 2025-10-08, 10:55 UTC, Fix, Hardened active company session migration for legacy MySQL compatibility so company switching succeeds
 # Change Log
 


### PR DESCRIPTION
## Summary
- ensure switch-company payload extraction reuses cached form data and avoids re-reading consumed request streams
- fall back to cached body bytes when middleware has already handled the request to prevent runtime errors
- log the fix in the project change history

## Testing
- pytest tests/test_switch_company_payload.py

------
https://chatgpt.com/codex/tasks/task_b_68e644129768832dbedb111411f3e22b