### PR TITLE
Handle mislabelled switch-company payloads

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -402,16 +402,18 @@ async def _extract_switch_company_payload(request: Request) -> dict[str, Any]:
     raw_content_type = request.headers.get("content-type", "")
     content_type = raw_content_type.split(";", 1)[0].strip().lower()
 
+    data: dict[str, Any] = {}
+
     if content_type == "application/json":
         try:
             payload = await request.json()
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, RuntimeError, UnicodeDecodeError):
             payload = None
         if isinstance(payload, dict):
             return payload
-        return {}
-
-    data: dict[str, Any] = {}
+        # Fall back to parsing the raw body below so mislabelled JSON requests
+        # (for example, form submissions with an incorrect content type) are
+        # still handled gracefully.
 
     should_attempt_form = content_type in {
         "application/x-www-form-urlencoded",

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-08, 11:08 UTC, Fix, Allowed switch-company requests with incorrect JSON headers to fall back to form parsing so company switching succeeds
 - 2025-10-10, 03:15 UTC, Fix, Prevented switch-company payload parsing from failing after CSRF middleware consumes the request body stream
 - 2025-10-08, 10:55 UTC, Fix, Hardened active company session migration for legacy MySQL compatibility so company switching succeeds
 # Change Log

--- a/tests/test_switch_company_payload.py
+++ b/tests/test_switch_company_payload.py
@@ -109,6 +109,20 @@ async def test_extracts_json_payload_when_header_missing() -> None:
     assert data["returnUrl"] == "/dashboard"
 
 
+@pytest.mark.anyio("asyncio")
+async def test_falls_back_when_json_header_contains_form_body() -> None:
+    body = "companyId=13&returnUrl=%2Fstaff".encode("utf-8")
+    request = _build_request(
+        body=body,
+        headers={"content-type": "application/json"},
+    )
+
+    data = await _extract_switch_company_payload(request)
+
+    assert data["companyId"] == "13"
+    assert data["returnUrl"] == "/staff"
+
+
 def test_first_non_blank_prioritises_non_empty_values() -> None:
     body_data = {"companyId": "  ", "company_id": None}
     query_params = {"company_id": "99", "returnUrl": "/dashboard"}


### PR DESCRIPTION
## Summary
- allow switch-company requests marked as JSON to fall back to form decoding when the payload is actually form data
- extend the switch-company payload tests to cover the mislabelled JSON scenario
- record the fix in the project change log

## Testing
- pytest tests/test_switch_company_payload.py -q

------
https://chatgpt.com/codex/tasks/task_b_68e64567ee80832db1004e57171a159b