### PR TITLE
feat: redesign license management dashboard

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-10, 05:30 UTC, Feature, Reimagined license management dashboard with status filters, CRUD modal workflows, and responsive usage insights
 - 2025-10-08, 11:08 UTC, Fix, Allowed switch-company requests with incorrect JSON headers to fall back to form parsing so company switching succeeds
 - 2025-10-10, 03:15 UTC, Fix, Prevented switch-company payload parsing from failing after CSRF middleware consumes the request body stream
 - 2025-10-08, 10:55 UTC, Fix, Hardened active company session migration for legacy MySQL compatibility so company switching succeeds

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -192,7 +192,92 @@ table th {
 
 .header-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.page-header__summary p {
+  margin: 0.25rem 0 0;
+  color: #555;
+}
+
+.page-header__summary strong {
+  color: #4a00e0;
+}
+
+.filter-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.filter-control span {
+  font-weight: 600;
+}
+
+.input-control {
+  padding: 0.45rem 0.6rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  min-width: 160px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background-color: #4a00e0;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 0.9rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover,
+.btn:focus {
+  background-color: #3700b3;
+  color: #fff;
+}
+
+.btn-secondary {
+  background-color: #eef0ff;
+  color: #4a00e0;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+  background-color: #d7dcff;
+  color: #3700b3;
+}
+
+.btn-danger {
+  background-color: #e53935;
+  color: #fff;
+}
+
+.btn-danger:hover,
+.btn-danger:focus {
+  background-color: #b71c1c;
+}
+
+.btn-small {
+  padding: 0.35rem 0.6rem;
+  font-size: 0.85rem;
+}
+
+.table-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
 }
 
 .search-control {
@@ -419,25 +504,42 @@ table th {
   justify-content: center;
 }
 
+.modal.hidden {
+  display: none;
+}
+
+.modal.open {
+  display: flex;
+}
+
 .modal-content {
   background: #fff;
   padding: 1rem;
   border-radius: 8px;
   max-width: 400px;
   width: 90%;
+  position: relative;
 }
 
-.modal-content form label {
-  display: flex;
-  align-items: center;
-  margin-top: 0.5rem;
-  gap: 0.5rem;
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  color: #555;
+  font-size: 1rem;
+  cursor: pointer;
 }
 
-.modal-content form label > input:not([type="checkbox"]):not([type="radio"]),
-.modal-content form label > textarea,
-.modal-content form label > select {
-  flex: 1;
+.modal-close:hover,
+.modal-close:focus {
+  color: #000;
+}
+
+.modal-description {
+  margin: 0.5rem 0 1rem;
+  color: #555;
 }
 
 .modal .close {
@@ -445,9 +547,65 @@ table th {
   cursor: pointer;
 }
 
+.form-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-grid label {
+  font-weight: 600;
+  color: #444;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  padding: 0.45rem 0.6rem;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+.modal-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.form-error {
+  margin-top: 0.5rem;
+  color: #c62828;
+  font-weight: 600;
+}
+
+.allocated-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.allocated-list li {
+  padding: 0.4rem 0.6rem;
+  background-color: #f6f7ff;
+  border-radius: 4px;
+}
+
+.text-muted {
+  color: #777;
+}
+
 .stats {
   display: flex;
   gap: 1rem;
+  flex-wrap: wrap;
   margin-bottom: 2rem;
 }
 
@@ -457,6 +615,112 @@ table th {
   padding: 1rem;
   border-radius: 8px;
   text-align: center;
+  min-width: 160px;
+}
+
+.stat-card__label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  color: #666;
+}
+
+.stat-card__value {
+  font-size: 2rem;
+  line-height: 1.2;
+  color: #4a00e0;
+}
+
+.stat-card__hint {
+  margin: 0.5rem 0 0;
+  color: #666;
+  font-size: 0.85rem;
+}
+
+.table-card {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: #555;
+  gap: 0.75rem;
+  padding: 3rem 1rem;
+}
+
+.empty-state i {
+  font-size: 2rem;
+  color: #4a00e0;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.status-badge--active {
+  background-color: #e0f2f1;
+  color: #00695c;
+}
+
+.status-badge--expiring {
+  background-color: #fff8e1;
+  color: #f57f17;
+}
+
+.status-badge--expired {
+  background-color: #ffebee;
+  color: #c62828;
+}
+
+.status-chip {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.status-chip--warning {
+  background-color: #fff3cd;
+  color: #856404;
+}
+
+.status-chip--danger {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: #4a00e0;
+  text-decoration: underline;
+  cursor: pointer;
+  font: inherit;
+}
+
+.link-button:hover,
+.link-button:focus {
+  color: #3700b3;
 }
 
 #image-modal .modal-content {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2169,6 +2169,30 @@ app.get(
   }
 );
 
+app.post('/licenses', ensureAuth, ensureSuperAdmin, async (req, res) => {
+  if (!req.session.companyId) {
+    return res.status(400).send('No company selected.');
+  }
+  const name = typeof req.body.name === 'string' ? req.body.name.trim() : '';
+  const platform = typeof req.body.platform === 'string' ? req.body.platform.trim() : '';
+  const contractTerm = typeof req.body.contractTerm === 'string' ? req.body.contractTerm.trim() : '';
+  const expiryDateRaw = typeof req.body.expiryDate === 'string' ? req.body.expiryDate.trim() : '';
+  const seatCount = Number.parseInt(String(req.body.count ?? ''), 10);
+  if (!name || !platform || Number.isNaN(seatCount) || seatCount < 0) {
+    return res.status(400).send('Name, SKU, and a non-negative seat count are required.');
+  }
+  const expiryDate = expiryDateRaw ? expiryDateRaw : null;
+  await createLicense(
+    req.session.companyId!,
+    name,
+    platform,
+    seatCount,
+    expiryDate,
+    contractTerm
+  );
+  return res.status(201).json({ success: true });
+});
+
 app.post('/licenses/:id/order', ensureAuth, async (req, res) => {
   const { quantity } = req.body;
   const companies = await getCompaniesForUser(req.session.userId!);
@@ -2230,17 +2254,25 @@ app.post('/licenses/:id/remove', ensureAuth, async (req, res) => {
 });
 
 app.put('/licenses/:id', ensureAuth, ensureSuperAdmin, async (req, res) => {
-  const { name, platform, count, expiryDate, contractTerm } = req.body;
   if (!req.session.companyId) {
-    return res.status(400).json({ error: 'No company selected' });
+    return res.status(400).send('No company selected.');
   }
+  const name = typeof req.body.name === 'string' ? req.body.name.trim() : '';
+  const platform = typeof req.body.platform === 'string' ? req.body.platform.trim() : '';
+  const contractTerm = typeof req.body.contractTerm === 'string' ? req.body.contractTerm.trim() : '';
+  const expiryDateRaw = typeof req.body.expiryDate === 'string' ? req.body.expiryDate.trim() : '';
+  const seatCount = Number.parseInt(String(req.body.count ?? ''), 10);
+  if (!name || !platform || Number.isNaN(seatCount) || seatCount < 0) {
+    return res.status(400).send('Name, SKU, and a non-negative seat count are required.');
+  }
+  const expiryDate = expiryDateRaw ? expiryDateRaw : null;
   await updateLicense(
     parseInt(req.params.id, 10),
     req.session.companyId!,
     name,
     platform,
-    count,
-    expiryDate || null,
+    seatCount,
+    expiryDate,
     contractTerm
   );
   res.json({ success: true });

--- a/src/views/licenses.ejs
+++ b/src/views/licenses.ejs
@@ -1,200 +1,613 @@
 <!DOCTYPE html>
 <html>
   <%- include('partials/head', { title: 'Licenses' }) %>
-<body>
-  <div class="app-container">
-    <%- include('partials/sidebar') %>
-    <div class="content">
-      <h1>Licenses</h1>
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>SKU</th>
-            <th>Count</th>
-            <th>Allocated</th>
-            <th>Expiry</th>
-            <th>Contract Term</th>
-            <% if (canOrderLicenses || isSuperAdmin) { %><th>Actions</th><% } %>
-          </tr>
-        </thead>
-        <tbody>
-        <% licenses.forEach(function(lic) { %>
-          <tr>
-            <td><%= lic.display_name %></td>
-            <td><%= lic.platform %></td>
-            <td><%= lic.count %></td>
-            <td><a href="#" class="allocated-link" data-license-id="<%= lic.id %>"><%= lic.allocated %></a></td>
-            <td><%= lic.expiry_date %></td>
-            <td><%= lic.contract_term %></td>
-            <% if (canOrderLicenses || isSuperAdmin) { %>
-              <td>
-                <% if (isSuperAdmin) { %>
-                  <button
-                    class="edit-btn"
-                    data-license-id="<%= lic.id %>"
-                    data-name="<%= lic.name %>"
-                    data-sku="<%= lic.platform %>"
-                    data-count="<%= lic.count %>"
-                    data-expiry-date="<%= lic.expiry_date ? new Date(lic.expiry_date).toISOString().split('T')[0] : '' %>"
-                    data-contract-term="<%= lic.contract_term %>"
-                  >Edit</button>
-                  <button class="delete-btn" data-license-id="<%= lic.id %>">Delete</button>
-                <% } %>
-                <% if (canOrderLicenses) { %>
-                  <button class="order-btn" data-license-id="<%= lic.id %>">Order More</button>
-                  <button class="remove-btn" data-license-id="<%= lic.id %>">Request Removal</button>
-                <% } %>
-              </td>
+  <body>
+    <div class="app-container">
+      <%- include('partials/sidebar') %>
+      <div class="content">
+        <div class="page-header">
+          <div class="page-header__summary">
+            <h1>Licenses</h1>
+            <p>
+              Review software entitlements, monitor seat usage, and action renewals for
+              <strong><%= companies.find((c) => c.company_id === currentCompanyId)?.company_name || 'this company' %></strong>.
+            </p>
+          </div>
+          <div class="header-actions">
+            <label class="filter-control" for="license-status-filter">
+              <span>Status</span>
+              <select id="license-status-filter" class="input-control">
+                <option value="all">All statuses</option>
+                <option value="active" selected>Active</option>
+                <option value="expiring">Expiring (30 days)</option>
+                <option value="expired">Expired</option>
+              </select>
+            </label>
+            <button type="button" id="refresh-licenses" class="btn btn-secondary">
+              <i class="fas fa-rotate"></i>
+              <span>Refresh</span>
+            </button>
+            <% if (canManageLicenses) { %>
+              <a href="/m365" class="btn btn-secondary" aria-label="Open Microsoft 365 sync">
+                <i class="fas fa-sync-alt"></i>
+                <span>Microsoft 365 Sync</span>
+              </a>
             <% } %>
-          </tr>
-        <% }); %>
-        </tbody>
-      </table>
-    </div>
-  </div>
+            <% if (isSuperAdmin) { %>
+              <button type="button" id="open-create-license" class="btn">
+                <i class="fas fa-plus"></i>
+                <span>Add License</span>
+              </button>
+            <% } %>
+          </div>
+        </div>
 
-  <div id="allocated-modal" class="modal" style="display:none;">
-    <div class="modal-content">
-      <span id="allocated-close" class="close">&times;</span>
-      <h2>Allocated Users</h2>
-      <ul id="allocated-users"></ul>
-    </div>
-  </div>
+        <%
+          const nowMs = Date.now();
+          const expiringThresholdMs = nowMs + 30 * 24 * 60 * 60 * 1000;
+          const totals = licenses.reduce(
+            (acc, lic) => {
+              const count = Number(lic.count) || 0;
+              const allocated = Number(lic.allocated) || 0;
+              acc.total += count;
+              acc.allocated += allocated;
+              const expiryRaw = lic.expiry_date;
+              if (expiryRaw) {
+                const expiryIso = expiryRaw.endsWith('Z') ? expiryRaw : `${expiryRaw}T00:00:00Z`;
+                const expiryMs = Date.parse(expiryIso);
+                if (!Number.isNaN(expiryMs)) {
+                  if (expiryMs < nowMs) {
+                    acc.expired += 1;
+                  } else if (expiryMs <= expiringThresholdMs) {
+                    acc.expiring += 1;
+                  }
+                }
+              }
+              return acc;
+            },
+            { total: 0, allocated: 0, expiring: 0, expired: 0 }
+          );
+          const availableTotal = Math.max(totals.total - totals.allocated, 0);
+        %>
 
-  <div id="edit-modal" class="modal" style="display:none;">
-    <div class="modal-content">
-      <span id="edit-close" class="close">&times;</span>
-      <h2>Edit License</h2>
-      <form id="edit-form">
-        <label for="edit-name">Name
-          <input type="text" id="edit-name">
-        </label>
-        <label for="edit-sku">SKU
-          <input type="text" id="edit-sku">
-        </label>
-        <label for="edit-count">Count
-          <input type="number" id="edit-count">
-        </label>
-        <label for="edit-expiry">Expiry
-          <input type="date" id="edit-expiry">
-        </label>
-        <label for="edit-contract">Contract Term
-          <input type="text" id="edit-contract">
-        </label>
-        <button type="submit">Save</button>
-      </form>
-    </div>
-  </div>
+        <div class="stats" aria-label="License usage overview">
+          <div class="stat-card">
+            <span class="stat-card__label">Total seats</span>
+            <strong class="stat-card__value"><%= totals.total %></strong>
+            <p class="stat-card__hint">Across all licensed products</p>
+          </div>
+          <div class="stat-card">
+            <span class="stat-card__label">Allocated</span>
+            <strong class="stat-card__value"><%= totals.allocated %></strong>
+            <p class="stat-card__hint">Seats currently assigned to staff</p>
+          </div>
+          <div class="stat-card">
+            <span class="stat-card__label">Available</span>
+            <strong class="stat-card__value"><%= availableTotal %></strong>
+            <p class="stat-card__hint">Seats ready to be provisioned</p>
+          </div>
+          <div class="stat-card">
+            <span class="stat-card__label">Expiring soon</span>
+            <strong class="stat-card__value"><%= totals.expiring %></strong>
+            <p class="stat-card__hint">Due within the next 30 days</p>
+          </div>
+          <div class="stat-card">
+            <span class="stat-card__label">Expired</span>
+            <strong class="stat-card__value"><%= totals.expired %></strong>
+            <p class="stat-card__hint">Licenses past their expiry date</p>
+          </div>
+        </div>
 
-  <script>
-    const currentCompanyId = <%= currentCompanyId %>;
-    document.querySelectorAll('.allocated-link').forEach(function (link) {
-      link.addEventListener('click', async function (e) {
-        e.preventDefault();
-        const id = this.dataset.licenseId;
-        const res = await fetch(`/licenses/${id}/allocated`);
-        if (!res.ok) return;
-        const users = await res.json();
-        const list = document.getElementById('allocated-users');
-        list.innerHTML = '';
-        if (users.length === 0) {
-          const li = document.createElement('li');
-          li.textContent = 'No users allocated';
-          list.appendChild(li);
-        } else {
-          users.forEach(function (u) {
-            const li = document.createElement('li');
-            li.textContent = `${u.first_name} ${u.last_name} (${u.email})`;
-            list.appendChild(li);
+        <div class="page-body">
+          <div class="table-card" aria-live="polite">
+            <% if (licenses.length === 0) { %>
+              <div class="empty-state">
+                <i class="fas fa-file-contract" aria-hidden="true"></i>
+                <p>No licenses found for this company yet.</p>
+                <% if (isSuperAdmin) { %>
+                  <p>Use the <strong>Add License</strong> action to onboard your first entitlement.</p>
+                <% } %>
+              </div>
+            <% } else { %>
+              <table id="licenses-table" class="display license-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">SKU</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Total</th>
+                    <th scope="col">Allocated</th>
+                    <th scope="col">Available</th>
+                    <th scope="col">Expiry</th>
+                    <th scope="col">Contract Term</th>
+                    <% if (canOrderLicenses || isSuperAdmin) { %><th scope="col">Actions</th><% } %>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% licenses.forEach(function(lic) { %>
+                    <%
+                      const count = Number(lic.count) || 0;
+                      const allocated = Number(lic.allocated) || 0;
+                      const available = Math.max(count - allocated, 0);
+                      const expiryRaw = lic.expiry_date;
+                      const expiryIso = expiryRaw ? (expiryRaw.endsWith('Z') ? expiryRaw : `${expiryRaw}T00:00:00Z`) : null;
+                      const expiryMs = expiryIso ? Date.parse(expiryIso) : NaN;
+                      const isExpired = expiryIso ? !Number.isNaN(expiryMs) && expiryMs < nowMs : false;
+                      const isExpiringSoon = expiryIso ? !Number.isNaN(expiryMs) && expiryMs >= nowMs && expiryMs <= expiringThresholdMs : false;
+                      const status = isExpired ? 'expired' : (isExpiringSoon ? 'expiring' : 'active');
+                      const statusLabel = status === 'expired' ? 'Expired' : (status === 'expiring' ? 'Expiring soon' : 'Active');
+                    %>
+                    <tr
+                      class="license-row"
+                      data-license-id="<%= lic.id %>"
+                      data-status="<%= status %>"
+                      <% if (expiryIso) { %>data-expiry="<%= expiryIso %>"<% } %>
+                    >
+                      <td data-title="Name"><%= lic.display_name || lic.name %></td>
+                      <td data-title="SKU"><%= lic.platform %></td>
+                      <td data-title="Status">
+                        <span class="status-badge status-badge--<%= status %>"><%= statusLabel %></span>
+                      </td>
+                      <td data-title="Total"><%= count %></td>
+                      <td data-title="Allocated">
+                        <% if (allocated > 0) { %>
+                          <button
+                            type="button"
+                            class="link-button allocated-link"
+                            data-license-id="<%= lic.id %>"
+                            aria-haspopup="dialog"
+                          >
+                            <%= allocated %>
+                          </button>
+                        <% } else { %>
+                          <span>0</span>
+                        <% } %>
+                      </td>
+                      <td data-title="Available"><%= available %></td>
+                      <td data-title="Expiry">
+                        <% if (expiryIso) { %>
+                          <time class="utc-date" datetime="<%= expiryIso %>"><%= expiryIso %></time>
+                          <% if (isExpiringSoon && !isExpired) { %>
+                            <span class="status-chip status-chip--warning">Expiring soon</span>
+                          <% } else if (isExpired) { %>
+                            <span class="status-chip status-chip--danger">Expired</span>
+                          <% } %>
+                        <% } else { %>
+                          <span class="text-muted">No expiry</span>
+                        <% } %>
+                      </td>
+                      <td data-title="Contract Term"><%= lic.contract_term || '—' %></td>
+                      <% if (canOrderLicenses || isSuperAdmin) { %>
+                        <td data-title="Actions">
+                          <div class="table-actions">
+                            <% if (canOrderLicenses) { %>
+                              <button type="button" class="btn btn-secondary btn-small order-btn" data-license-id="<%= lic.id %>">
+                                <i class="fas fa-cart-plus"></i>
+                                <span>Order</span>
+                              </button>
+                              <button type="button" class="btn btn-secondary btn-small remove-btn" data-license-id="<%= lic.id %>">
+                                <i class="fas fa-undo"></i>
+                                <span>Remove</span>
+                              </button>
+                            <% } %>
+                            <% if (isSuperAdmin) { %>
+                              <button
+                                type="button"
+                                class="btn btn-small edit-btn"
+                                data-license-id="<%= lic.id %>"
+                                data-name="<%= lic.name %>"
+                                data-sku="<%= lic.platform %>"
+                                data-count="<%= count %>"
+                                data-expiry-date="<%= expiryIso ? expiryIso.split('T')[0] : '' %>"
+                                data-contract-term="<%= lic.contract_term || '' %>"
+                              >
+                                <i class="fas fa-edit"></i>
+                                <span>Edit</span>
+                              </button>
+                              <button type="button" class="btn btn-danger btn-small delete-btn" data-license-id="<%= lic.id %>">
+                                <i class="fas fa-trash"></i>
+                                <span>Delete</span>
+                              </button>
+                            <% } %>
+                          </div>
+                        </td>
+                      <% } %>
+                    </tr>
+                  <% }); %>
+                </tbody>
+              </table>
+            <% } %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div id="allocated-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="allocated-modal-title">
+      <div class="modal-content">
+        <button type="button" class="modal-close" data-modal-close="allocated-modal" aria-label="Close allocated users modal">
+          <i class="fas fa-times"></i>
+        </button>
+        <h2 id="allocated-modal-title">Allocated users</h2>
+        <p class="modal-description">Track which staff members currently hold seats for the selected license.</p>
+        <ul id="allocated-users" class="allocated-list" aria-live="polite"></ul>
+      </div>
+    </div>
+
+    <div id="license-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="license-modal-title">
+      <div class="modal-content">
+        <button type="button" class="modal-close" data-modal-close="license-modal" aria-label="Close license form">
+          <i class="fas fa-times"></i>
+        </button>
+        <h2 id="license-modal-title">Edit license</h2>
+        <p id="license-modal-description" class="modal-description">Update licensing details to keep counts and expiry tracking accurate.</p>
+        <form id="license-form" aria-describedby="license-modal-description">
+          <div class="form-grid">
+            <label for="license-name">Name
+              <input type="text" id="license-name" name="name" autocomplete="off" required>
+            </label>
+            <label for="license-sku">SKU
+              <input type="text" id="license-sku" name="platform" autocomplete="off" required>
+            </label>
+            <label for="license-count">Total seats
+              <input type="number" id="license-count" name="count" min="0" step="1" required>
+            </label>
+            <label for="license-expiry">Expiry date
+              <input type="date" id="license-expiry" name="expiryDate">
+            </label>
+            <label for="license-contract">Contract term
+              <input type="text" id="license-contract" name="contractTerm" autocomplete="off" placeholder="e.g. Annual">
+            </label>
+          </div>
+          <p id="license-form-error" class="form-error" role="alert" hidden></p>
+          <div class="modal-actions">
+            <button type="submit" class="btn" id="license-form-submit">Save changes</button>
+            <button type="button" class="btn btn-secondary" data-modal-close="license-modal">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const statusFilter = document.getElementById('license-status-filter');
+        const refreshBtn = document.getElementById('refresh-licenses');
+        const allocatedModal = document.getElementById('allocated-modal');
+        const allocatedList = document.getElementById('allocated-users');
+        const licenseModal = document.getElementById('license-modal');
+        const licenseForm = document.getElementById('license-form');
+        const licenseFormError = document.getElementById('license-form-error');
+        const licenseModalTitle = document.getElementById('license-modal-title');
+        const licenseModalDescription = document.getElementById('license-modal-description');
+        const licenseFormSubmit = document.getElementById('license-form-submit');
+        const licenseNameInput = document.getElementById('license-name');
+        const licenseSkuInput = document.getElementById('license-sku');
+        const licenseCountInput = document.getElementById('license-count');
+        const licenseExpiryInput = document.getElementById('license-expiry');
+        const licenseContractInput = document.getElementById('license-contract');
+        const licensesTable = document.getElementById('licenses-table');
+        let editingId = null;
+
+        function openModal(modal) {
+          if (!modal) return;
+          modal.classList.remove('hidden');
+          modal.classList.add('open');
+          modal.setAttribute('aria-hidden', 'false');
+          const focusable = modal.querySelector('button, [href], input, select, textarea');
+          if (focusable) {
+            focusable.focus();
+          }
+        }
+
+        function closeModal(modal) {
+          if (!modal) return;
+          modal.classList.remove('open');
+          modal.classList.add('hidden');
+          modal.setAttribute('aria-hidden', 'true');
+        }
+
+        document.querySelectorAll('.modal').forEach((modal) => {
+          modal.addEventListener('click', (event) => {
+            if (event.target === modal) {
+              closeModal(modal);
+            }
           });
-        }
-        document.getElementById('allocated-modal').style.display = 'flex';
-      });
-    });
-
-    document.getElementById('allocated-close').addEventListener('click', function () {
-      document.getElementById('allocated-modal').style.display = 'none';
-    });
-
-    document.querySelectorAll('.order-btn').forEach(function (btn) {
-      btn.addEventListener('click', async function () {
-        const qty = prompt('How many licenses to order?');
-        if (!qty) return;
-        await fetch(`/licenses/${this.dataset.licenseId}/order`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ quantity: parseInt(qty, 10) }),
         });
-        alert('Order submitted');
-      });
-    });
 
-    document.querySelectorAll('.remove-btn').forEach(function (btn) {
-      btn.addEventListener('click', async function () {
-        const qty = prompt('How many licenses to remove?');
-        if (!qty) return;
-        await fetch(`/licenses/${this.dataset.licenseId}/remove`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ quantity: parseInt(qty, 10) }),
+        document.querySelectorAll('[data-modal-close]').forEach((btn) => {
+          btn.addEventListener('click', () => {
+            const targetId = btn.getAttribute('data-modal-close');
+            if (targetId) {
+              const modal = document.getElementById(targetId);
+              closeModal(modal);
+            }
+          });
         });
-        alert('Removal requested');
-      });
-    });
 
-    const editModal = document.getElementById('edit-modal');
-    const editForm = document.getElementById('edit-form');
-    let editingId = null;
+        window.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') {
+            closeModal(allocatedModal);
+            closeModal(licenseModal);
+          }
+        });
 
-    document.querySelectorAll('.edit-btn').forEach(function (btn) {
-      btn.addEventListener('click', function () {
-        editingId = this.dataset.licenseId;
-        document.getElementById('edit-name').value = this.dataset.name;
-        document.getElementById('edit-sku').value = this.dataset.sku;
-        document.getElementById('edit-count').value = this.dataset.count;
-        document.getElementById('edit-expiry').value = this.dataset.expiryDate;
-        document.getElementById('edit-contract').value = this.dataset.contractTerm;
-        editModal.style.display = 'flex';
-      });
-    });
+        refreshBtn?.addEventListener('click', () => {
+          window.location.reload();
+        });
 
-    document.getElementById('edit-close').addEventListener('click', function () {
-      editModal.style.display = 'none';
-    });
+        document.querySelectorAll('.utc-date').forEach((timeEl) => {
+          const iso = timeEl.getAttribute('datetime');
+          if (!iso) return;
+          const value = iso.includes('T') ? iso : `${iso}T00:00:00Z`;
+          const date = new Date(value);
+          if (!Number.isNaN(date.getTime())) {
+            timeEl.textContent = date.toLocaleDateString(undefined, {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            });
+          }
+        });
 
-    editForm.addEventListener('submit', async function (e) {
-      e.preventDefault();
-      const payload = {
-        name: document.getElementById('edit-name').value,
-        platform: document.getElementById('edit-sku').value,
-        count: parseInt(document.getElementById('edit-count').value, 10),
-        expiryDate: document.getElementById('edit-expiry').value || null,
-        contractTerm: document.getElementById('edit-contract').value,
-      };
-      const res = await fetch(`/licenses/${editingId}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      if (res.ok) {
-        location.reload();
-      } else {
-        alert('Failed to update license');
-      }
-    });
+        document.querySelectorAll('.allocated-link').forEach((link) => {
+          link.addEventListener('click', async (event) => {
+            event.preventDefault();
+            const id = link.getAttribute('data-license-id');
+            if (!id) return;
+            try {
+              const res = await fetch(`/licenses/${id}/allocated`);
+              if (!res.ok) {
+                throw new Error('Failed to load allocated users');
+              }
+              const users = await res.json();
+              allocatedList.innerHTML = '';
+              if (!users.length) {
+                const li = document.createElement('li');
+                li.textContent = 'No users allocated';
+                allocatedList.appendChild(li);
+              } else {
+                users.forEach((user) => {
+                  const li = document.createElement('li');
+                  li.textContent = `${user.first_name} ${user.last_name} (${user.email})`;
+                  allocatedList.appendChild(li);
+                });
+              }
+              openModal(allocatedModal);
+            } catch (err) {
+              console.error(err);
+              alert('Unable to load allocated users right now. Please try again shortly.');
+            }
+          });
+        });
 
-    document.querySelectorAll('.delete-btn').forEach(function(btn) {
-      btn.addEventListener('click', async function() {
-        if (!confirm('Delete license?')) return;
-        const res = await fetch(`/licenses/${this.dataset.licenseId}`, { method: 'DELETE' });
-        if (res.ok) {
-          location.reload();
-        } else {
-          alert('Failed to delete license');
+        document.querySelectorAll('.order-btn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            const id = btn.getAttribute('data-license-id');
+            if (!id) return;
+            const qty = prompt('How many licenses would you like to order?');
+            if (!qty) return;
+            const amount = Number.parseInt(qty, 10);
+            if (!Number.isFinite(amount) || amount <= 0) {
+              alert('Please provide a valid quantity.');
+              return;
+            }
+            try {
+              const res = await fetch(`/licenses/${id}/order`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ quantity: amount }),
+              });
+              if (!res.ok) {
+                throw new Error('Failed to submit order');
+              }
+              alert('Order submitted successfully.');
+            } catch (err) {
+              console.error(err);
+              alert('We could not submit your order. Please try again later.');
+            }
+          });
+        });
+
+        document.querySelectorAll('.remove-btn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            const id = btn.getAttribute('data-license-id');
+            if (!id) return;
+            const qty = prompt('How many licenses should be removed?');
+            if (!qty) return;
+            const amount = Number.parseInt(qty, 10);
+            if (!Number.isFinite(amount) || amount <= 0) {
+              alert('Please provide a valid quantity.');
+              return;
+            }
+            try {
+              const res = await fetch(`/licenses/${id}/remove`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ quantity: amount }),
+              });
+              if (!res.ok) {
+                throw new Error('Failed to submit removal request');
+              }
+              alert('Removal request submitted.');
+            } catch (err) {
+              console.error(err);
+              alert('We could not submit your removal request. Please try again later.');
+            }
+          });
+        });
+
+        function resetForm() {
+          licenseForm?.reset();
+          if (licenseFormError) {
+            licenseFormError.hidden = true;
+            licenseFormError.textContent = '';
+          }
+        }
+
+        document.getElementById('open-create-license')?.addEventListener('click', () => {
+          editingId = null;
+          resetForm();
+          if (licenseModalTitle) {
+            licenseModalTitle.textContent = 'Add license';
+          }
+          if (licenseModalDescription) {
+            licenseModalDescription.textContent = 'Capture a new entitlement for this company.';
+          }
+          if (licenseFormSubmit) {
+            licenseFormSubmit.textContent = 'Create license';
+          }
+          openModal(licenseModal);
+        });
+
+        document.querySelectorAll('.edit-btn').forEach((btn) => {
+          btn.addEventListener('click', () => {
+            editingId = btn.getAttribute('data-license-id');
+            resetForm();
+            if (licenseNameInput) {
+              licenseNameInput.value = btn.getAttribute('data-name') || '';
+            }
+            if (licenseSkuInput) {
+              licenseSkuInput.value = btn.getAttribute('data-sku') || '';
+            }
+            if (licenseCountInput) {
+              licenseCountInput.value = btn.getAttribute('data-count') || '0';
+            }
+            if (licenseExpiryInput) {
+              licenseExpiryInput.value = btn.getAttribute('data-expiry-date') || '';
+            }
+            if (licenseContractInput) {
+              licenseContractInput.value = btn.getAttribute('data-contract-term') || '';
+            }
+            if (licenseModalTitle) {
+              licenseModalTitle.textContent = 'Edit license';
+            }
+            if (licenseModalDescription) {
+              licenseModalDescription.textContent = 'Update licensing details to keep counts and expiry tracking accurate.';
+            }
+            if (licenseFormSubmit) {
+              licenseFormSubmit.textContent = 'Save changes';
+            }
+            openModal(licenseModal);
+          });
+        });
+
+        document.querySelectorAll('.delete-btn').forEach((btn) => {
+          btn.addEventListener('click', async () => {
+            const id = btn.getAttribute('data-license-id');
+            if (!id) return;
+            if (!confirm('Are you sure you want to permanently delete this license?')) {
+              return;
+            }
+            try {
+              const res = await fetch(`/licenses/${id}`, { method: 'DELETE' });
+              if (!res.ok) {
+                throw new Error('Failed to delete license');
+              }
+              window.location.reload();
+            } catch (err) {
+              console.error(err);
+              alert('Unable to delete the license right now. Please try again later.');
+            }
+          });
+        });
+
+        licenseForm?.addEventListener('submit', async (event) => {
+          event.preventDefault();
+          if (!licenseForm) return;
+          const formData = new FormData(licenseForm);
+          const payload = {
+            name: String(formData.get('name') || '').trim(),
+            platform: String(formData.get('platform') || '').trim(),
+            count: Number.parseInt(String(formData.get('count') || '0'), 10),
+            expiryDate: String(formData.get('expiryDate') || '').trim() || null,
+            contractTerm: String(formData.get('contractTerm') || '').trim(),
+          };
+
+          if (!payload.name || !payload.platform || !Number.isFinite(payload.count) || payload.count < 0) {
+            if (licenseFormError) {
+              licenseFormError.textContent = 'Name, SKU, and a non-negative seat count are required.';
+              licenseFormError.hidden = false;
+            }
+            return;
+          }
+
+          try {
+            const endpoint = editingId ? `/licenses/${editingId}` : '/licenses';
+            const method = editingId ? 'PUT' : 'POST';
+            const res = await fetch(endpoint, {
+              method,
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+            if (!res.ok) {
+              const message = await res.text();
+              throw new Error(message || 'Failed to save license');
+            }
+            window.location.reload();
+          } catch (err) {
+            console.error(err);
+            if (licenseFormError) {
+              licenseFormError.textContent = err instanceof Error ? err.message : 'Failed to save license. Please try again later.';
+              licenseFormError.hidden = false;
+            }
+          }
+        });
+
+        if (statusFilter && typeof DataTable !== 'undefined') {
+          if (!licensesTable) {
+            statusFilter.disabled = true;
+            return;
+          }
+          let tableApiRef = null;
+          const filterFn = (settings, _data, dataIndex) => {
+            if (settings.nTable.id !== 'licenses-table') {
+              return true;
+            }
+            if (!tableApiRef) {
+              return true;
+            }
+            const required = statusFilter.value;
+            if (required === 'all') {
+              return true;
+            }
+            const rowNode = tableApiRef.row(dataIndex).node();
+            if (!rowNode) {
+              return true;
+            }
+            const status = rowNode.getAttribute('data-status');
+            return status === required;
+          };
+
+          const registerFilter = () => {
+            const tablesApi = DataTable.tables({ api: true });
+            for (let i = 0; i < tablesApi.length; i += 1) {
+              const api = tablesApi[i];
+              if (api.table().node().id === 'licenses-table') {
+                tableApiRef = api;
+                break;
+              }
+            }
+            if (!tableApiRef) {
+              setTimeout(registerFilter, 100);
+              return;
+            }
+            if (!DataTable.ext.search.includes(filterFn)) {
+              DataTable.ext.search.push(filterFn);
+            }
+            statusFilter.addEventListener('change', () => {
+              tableApiRef.draw();
+            });
+            statusFilter.dispatchEvent(new Event('change'));
+            window.addEventListener('unload', () => {
+              const idx = DataTable.ext.search.indexOf(filterFn);
+              if (idx > -1) {
+                DataTable.ext.search.splice(idx, 1);
+              }
+            });
+          };
+
+          registerFilter();
         }
       });
-    });
-  </script>
-</body>
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the licenses view with a three-pane layout, usage stats, status filtering, and accessibility-friendly modals
- add a super admin license creation endpoint and tighten validation when saving licenses
- extend shared styles to support responsive cards, modals, and inline action buttons, and log the feature in the change log

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e647ea4578832dae45ec7bb25059d6