### PR TITLE
Fix shop product image serving in FastAPI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -126,7 +126,20 @@ app.add_middleware(
 app.add_middleware(CSRFMiddleware)
 
 templates = Jinja2Templates(directory=str(templates_config.template_path))
+
+# Ensure product and document uploads remain web-accessible with the same
+# paths used by the legacy Node.js implementation.  The uploads directory is
+# created on startup so FastAPI's static file handler can serve cached product
+# images without returning 404 responses.
+_uploads_path = templates_config.static_path / "uploads"
+_uploads_path.mkdir(parents=True, exist_ok=True)
+
 app.mount("/static", StaticFiles(directory=str(templates_config.static_path)), name="static")
+app.mount(
+    "/uploads",
+    StaticFiles(directory=str(_uploads_path), check_dir=False),
+    name="uploads",
+)
 
 app.include_router(auth.router)
 app.include_router(users.router)

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-10, 04:30 UTC, Fix, Mounted legacy uploads directory in FastAPI so shop product images load successfully
 - 2025-10-08, 11:08 UTC, Fix, Allowed switch-company requests with incorrect JSON headers to fall back to form parsing so company switching succeeds
 - 2025-10-10, 03:15 UTC, Fix, Prevented switch-company payload parsing from failing after CSRF middleware consumes the request body stream
 - 2025-10-08, 10:55 UTC, Fix, Hardened active company session migration for legacy MySQL compatibility so company switching succeeds


### PR DESCRIPTION
## Summary
- mount the legacy /uploads static directory so cached product images resolve under FastAPI
- create the uploads directory during startup to prevent missing-folder errors
- document the fix in the running change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e647d24b00832db087ec5ac1ba30c0