### PR TITLE
Fix MariaDB UTC timestamp defaults in scheduler migration

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-10, 13:45 UTC, Fix, Corrected scheduler monitoring migration defaults to remain MariaDB-compatible while storing UTC timestamps
 - 2025-10-08, 11:20 UTC, Feature, Added hashed API key management endpoints with usage telemetry, audit logging, and admin reporting
 - 2025-10-10, 04:30 UTC, Fix, Mounted legacy uploads directory in FastAPI so shop product images load successfully
 - 2025-10-08, 11:08 UTC, Fix, Allowed switch-company requests with incorrect JSON headers to fall back to form parsing so company switching succeeds

--- a/migrations/067_scheduler_monitoring.sql
+++ b/migrations/067_scheduler_monitoring.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS scheduled_task_runs (
   id INT AUTO_INCREMENT PRIMARY KEY,
   task_id INT NOT NULL,
   status VARCHAR(20) NOT NULL,
-  started_at DATETIME NOT NULL DEFAULT UTC_TIMESTAMP(),
+  started_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
   finished_at DATETIME NULL,
   duration_ms INT NULL,
   details TEXT NULL,
@@ -31,8 +31,8 @@ CREATE TABLE IF NOT EXISTS webhook_events (
   backoff_seconds INT NOT NULL DEFAULT 300,
   next_attempt_at DATETIME NULL,
   last_error TEXT NULL,
-  created_at DATETIME NOT NULL DEFAULT UTC_TIMESTAMP(),
-  updated_at DATETIME NOT NULL DEFAULT UTC_TIMESTAMP() ON UPDATE UTC_TIMESTAMP()
+  created_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  updated_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()) ON UPDATE (UTC_TIMESTAMP())
 );
 
 CREATE TABLE IF NOT EXISTS webhook_event_attempts (
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS webhook_event_attempts (
   response_status INT NULL,
   response_body TEXT NULL,
   error_message TEXT NULL,
-  attempted_at DATETIME NOT NULL DEFAULT UTC_TIMESTAMP(),
+  attempted_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
   FOREIGN KEY (event_id) REFERENCES webhook_events(id) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
## Summary
- wrap UTC timestamp defaults in parentheses for MariaDB compatibility within scheduler monitoring tables
- keep webhook auditing timestamps storing UTC values without breaking startup migrations
- log the fix in the project change log for operational tracking

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e64fb50860832daafe586d854b1d8a