### PR TITLE
Fix scheduler migration UTC defaults for MariaDB compatibility

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-10, 14:20 UTC, Fix, Replaced MariaDB-incompatible UTC timestamp defaults in scheduler migration to restore service startup
 - 2025-10-08, 11:49 UTC, Fix, Restored the licenses admin HTML view by namespacing the API under /api to prevent JSON responses from hijacking the UI route
 - 2025-10-10, 04:45 UTC, Fix, Routed staff API under /api to restore the staff management UI rendering on the Python portal
 - 2025-10-10, 13:45 UTC, Fix, Corrected scheduler monitoring migration defaults to remain MariaDB-compatible while storing UTC timestamps

--- a/migrations/067_scheduler_monitoring.sql
+++ b/migrations/067_scheduler_monitoring.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS scheduled_task_runs (
   id INT AUTO_INCREMENT PRIMARY KEY,
   task_id INT NOT NULL,
   status VARCHAR(20) NOT NULL,
-  started_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  started_at DATETIME NOT NULL DEFAULT UTC_TIMESTAMP(),
   finished_at DATETIME NULL,
   duration_ms INT NULL,
   details TEXT NULL,
@@ -31,8 +31,8 @@ CREATE TABLE IF NOT EXISTS webhook_events (
   backoff_seconds INT NOT NULL DEFAULT 300,
   next_attempt_at DATETIME NULL,
   last_error TEXT NULL,
-  created_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
-  updated_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()) ON UPDATE (UTC_TIMESTAMP())
+  created_at DATETIME NOT NULL DEFAULT UTC_TIMESTAMP(),
+  updated_at DATETIME NOT NULL DEFAULT UTC_TIMESTAMP() ON UPDATE UTC_TIMESTAMP()
 );
 
 CREATE TABLE IF NOT EXISTS webhook_event_attempts (
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS webhook_event_attempts (
   response_status INT NULL,
   response_body TEXT NULL,
   error_message TEXT NULL,
-  attempted_at DATETIME NOT NULL DEFAULT (UTC_TIMESTAMP()),
+  attempted_at DATETIME NOT NULL DEFAULT UTC_TIMESTAMP(),
   FOREIGN KEY (event_id) REFERENCES webhook_events(id) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
## Summary
- replace the scheduler monitoring migration's UTC timestamp defaults with MariaDB-compatible syntax
- log the database fix in the change log for operational traceability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e650dcbdfc832d8f419c35bce4e71a