### PR TITLE
Fix automation admin task JSON serialization

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-08, 12:08 UTC, Fix, Sanitised automation scheduler task payloads before JSON encoding to restore the admin dashboard
 - 2025-10-10, 14:20 UTC, Fix, Replaced MariaDB-incompatible UTC timestamp defaults in scheduler migration to restore service startup
 - 2025-10-08, 11:49 UTC, Fix, Restored the licenses admin HTML view by namespacing the API under /api to prevent JSON responses from hijacking the UI route
 - 2025-10-10, 04:45 UTC, Fix, Routed staff API under /api to restore the staff management UI rendering on the Python portal


### PR DESCRIPTION
## Summary
- convert scheduler task, run, and webhook records into JSON-safe structures before rendering the automation admin template
- ensure datetime fields are exposed as UTC ISO strings for client-side scripting and display
- log the fix in the project change history

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68e653f5972c832dbcee1e893a271a45