### PR TITLE
Fix shop uploads route for private product images

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -7,6 +7,7 @@
 - 2025-10-10, 04:45 UTC, Fix, Routed staff API under /api to restore the staff management UI rendering on the Python portal
 - 2025-10-10, 13:45 UTC, Fix, Corrected scheduler monitoring migration defaults to remain MariaDB-compatible while storing UTC timestamps
 - 2025-10-08, 11:20 UTC, Feature, Added hashed API key management endpoints with usage telemetry, audit logging, and admin reporting
+- 2025-10-11, 09:00 UTC, Fix, Restored authenticated legacy uploads route in FastAPI to eliminate shop image 404 errors
 - 2025-10-10, 04:30 UTC, Fix, Mounted legacy uploads directory in FastAPI so shop product images load successfully
 - 2025-10-08, 11:08 UTC, Fix, Allowed switch-company requests with incorrect JSON headers to fall back to form parsing so company switching succeeds
 - 2025-10-10, 03:15 UTC, Fix, Prevented switch-company payload parsing from failing after CSRF middleware consumes the request body stream

--- a/tests/test_upload_route.py
+++ b/tests/test_upload_route.py
@@ -1,0 +1,35 @@
+import pytest
+from fastapi import HTTPException
+
+from app import main
+
+
+@pytest.fixture(autouse=True)
+def _reset_private_uploads(tmp_path, monkeypatch):
+    monkeypatch.setattr(main, "_private_uploads_path", tmp_path)
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    try:
+        tmp_path.chmod(0o700)
+    except OSError:
+        pass
+    yield
+
+
+def test_resolve_private_upload_returns_file(tmp_path):
+    target = tmp_path / "example.png"
+    target.write_bytes(b"data")
+    resolved = main._resolve_private_upload("../example.png")
+    assert resolved == target
+
+
+def test_resolve_private_upload_missing_file(tmp_path):
+    with pytest.raises(HTTPException) as exc:
+        main._resolve_private_upload("missing.png")
+    assert exc.value.status_code == 404
+
+
+def test_resolve_private_upload_rejects_directory_escape(tmp_path):
+    outside = tmp_path.parent / "secret.png"
+    outside.write_bytes(b"data")
+    with pytest.raises(HTTPException):
+        main._resolve_private_upload("../secret.png")


### PR DESCRIPTION
## Summary
- restore the authenticated `/uploads` handler so product images are served from the legacy private directory
- harden filename resolution and directory permissions to stop traversal and unauthorised access
- add regression tests for the upload resolver and record the fix in the change log

## Testing
- pytest tests/test_upload_route.py


------
https://chatgpt.com/codex/tasks/task_b_68e656d67940832db4cb062560cace81