### PR TITLE
Open Swagger docs in new tab

### DIFF
--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -12,7 +12,7 @@
   </a>
 </li>
 <li class="menu__item">
-  <a href="/docs">
+  <a href="/docs" target="_blank" rel="noopener noreferrer">
     <span class="menu__icon" aria-hidden="true">
       <svg viewBox="0 0 24 24" focusable="false"><path d="M6 3h9l5 5v13a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm8 6V4.5L18.5 9H14z"/></svg>
     </span>
@@ -22,7 +22,14 @@
 {% endblock %}
 
 {% block header_actions %}
-<a class="button-link" href="/docs" aria-label="Open API documentation">Swagger UI</a>
+<a
+  class="button-link"
+  href="/docs"
+  target="_blank"
+  rel="noopener noreferrer"
+  aria-label="Open API documentation"
+  >Swagger UI</a
+>
 {% endblock %}
 
 {% block content %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -99,7 +99,12 @@
             </a>
           </li>
           <li class="menu__item">
-            <a href="/docs" {% if current_path.startswith('/docs') %}aria-current="page"{% endif %}>
+            <a
+              href="/docs"
+              target="_blank"
+              rel="noopener noreferrer"
+              {% if current_path.startswith('/docs') %}aria-current="page"{% endif %}
+            >
               <span class="menu__icon" aria-hidden="true">
                 <svg viewBox="0 0 24 24" focusable="false"><path d="M6 3h9l5 5v13a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm8 6V4.5L18.5 9H14z"/></svg>
               </span>

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-08, 12:41 UTC, Fix, Updated API documentation links to open in a new tab with secure attributes for consistent navigation
 - 2025-10-11, 09:30 UTC, Fix, Added server-rendered CSRF tokens across portal forms so submissions succeed even without client-side scripts
 - 2025-10-08, 12:22 UTC, Fix, Removed the product description textarea from the shop admin add product form and refreshed helper copy
 - 2025-10-11, 10:30 UTC, Fix, Restored legacy shop product image loading by securing nested upload path handling


### PR DESCRIPTION
## Summary
- update navigation and authentication templates so Swagger UI links open in a new tab with secure attributes
- record the documentation link update in the change log

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e65bdf3de8832d85e10d5a2fee65fb