### PR TITLE
Ensure company switch submits companyId

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -223,6 +223,23 @@
         if (!form) return;
         const select = form.querySelector('.company-switcher__select');
         if (!select) return;
+
+        form.addEventListener('submit', function () {
+          const selected = select.value;
+          if (!selected) {
+            return;
+          }
+          let hidden = form.querySelector('input[data-company-switcher-hidden="true"]');
+          if (!hidden) {
+            hidden = document.createElement('input');
+            hidden.type = 'hidden';
+            hidden.name = 'companyId';
+            hidden.setAttribute('data-company-switcher-hidden', 'true');
+            form.appendChild(hidden);
+          }
+          hidden.value = selected;
+        });
+
         select.addEventListener('change', function () {
           if (typeof form.requestSubmit === 'function') {
             form.requestSubmit();

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,7 @@
 - 2025-10-08, 12:22 UTC, Fix, Removed the product description textarea from the shop admin add product form and refreshed helper copy
 - 2025-10-11, 10:30 UTC, Fix, Restored legacy shop product image loading by securing nested upload path handling
 - 2025-10-08, 12:34 UTC, Fix, Added multipart fallback parsing for mislabelled switch-company submissions so company switching succeeds for FormData clients
+- 2025-10-08, 12:44 UTC, Fix, Ensured company switch submissions always post the selected companyId by injecting a hidden field before form submission
 - 2025-10-08, 12:20 UTC, Fix, Embedded CSRF tokens into Shop admin templates and base helpers to restore product management submissions
 - 2025-10-08, 12:17 UTC, Change, Updated the customer forms portal route to /myforms with navigation updates and a legacy redirect
 - 2025-10-08, 12:12 UTC, Fix, Removed product description input from the shop admin creation form per request

--- a/src/public/app.js
+++ b/src/public/app.js
@@ -170,7 +170,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const companySwitcher = document.getElementById('company-switcher');
     if (companySwitcher) {
       companySwitcher.addEventListener('change', () => {
-        companySwitcher.form?.submit();
+        const form = companySwitcher.form;
+        if (!form) return;
+        const selected = companySwitcher.value;
+        if (!selected) return;
+        let hidden = form.querySelector('input[data-company-switcher-hidden="true"]');
+        if (!hidden) {
+          hidden = document.createElement('input');
+          hidden.type = 'hidden';
+          hidden.name = 'companyId';
+          hidden.setAttribute('data-company-switcher-hidden', 'true');
+          form.appendChild(hidden);
+        }
+        hidden.value = selected;
+        form.submit();
       });
     }
   });


### PR DESCRIPTION
## Summary
- inject a hidden companyId field before submitting the sidebar switcher so the POST body always carries the selected company identifier
- mirror the hidden field logic for the Node.js frontend and document the fix in the change log

## Testing
- pytest tests/test_switch_company_payload.py

------
https://chatgpt.com/codex/tasks/task_b_68e65bace1d0832db62869c70585b43b