### PR TITLE
Restore shop product creation with secure image handling

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-08, 12:51 UTC, Fix, Restored shop product creation with validated uploads and database persistence to resolve Not Found errors
 - 2025-10-08, 12:41 UTC, Fix, Updated API documentation links to open in a new tab with secure attributes for consistent navigation
 - 2025-10-11, 09:30 UTC, Fix, Added server-rendered CSRF tokens across portal forms so submissions succeed even without client-side scripts
 - 2025-10-08, 12:36 UTC, Fix, Allowed the CSRF middleware to validate multipart form tokens so shop product uploads succeed

--- a/tests/test_file_storage.py
+++ b/tests/test_file_storage.py
@@ -1,8 +1,18 @@
-import pytest
-from fastapi import HTTPException
+from __future__ import annotations
 
-from app.services.file_storage import delete_stored_file, sanitize_filename
+import asyncio
+from io import BytesIO
 from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, UploadFile, status
+from starlette.datastructures import Headers
+
+from app.services.file_storage import (
+    delete_stored_file,
+    sanitize_filename,
+    store_product_image,
+)
 
 
 def test_sanitize_filename_replaces_unsafe_characters():
@@ -18,3 +28,47 @@ def test_delete_stored_file_rejects_outside_paths(tmp_path: Path):
     uploads_root.mkdir(parents=True)
     with pytest.raises(HTTPException):
         delete_stored_file("../etc/passwd", uploads_root)
+
+
+def _make_upload(data: bytes, filename: str, content_type: str) -> UploadFile:
+    headers = Headers({"content-type": content_type})
+    return UploadFile(file=BytesIO(data), filename=filename, headers=headers)
+
+
+def test_store_product_image_persists_file(tmp_path: Path):
+    uploads_root = tmp_path / "private_uploads"
+    uploads_root.mkdir(parents=True)
+    data = b"fake image data"
+    upload = _make_upload(data, "test.png", "image/png")
+
+    public_url, stored_path = asyncio.run(
+        store_product_image(
+            upload=upload,
+            uploads_root=uploads_root,
+            max_size=1024 * 1024,
+        )
+    )
+
+    assert public_url.startswith("/uploads/shop/")
+    assert stored_path.exists()
+    assert stored_path.read_bytes() == data
+
+
+def test_store_product_image_rejects_invalid_type(tmp_path: Path):
+    uploads_root = tmp_path / "private_uploads"
+    uploads_root.mkdir(parents=True)
+    upload = _make_upload(b"data", "malicious.txt", "text/plain")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(store_product_image(upload=upload, uploads_root=uploads_root))
+    assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_store_product_image_enforces_size_limit(tmp_path: Path):
+    uploads_root = tmp_path / "private_uploads"
+    uploads_root.mkdir(parents=True)
+    upload = _make_upload(b"a" * (1024 * 1024), "large.png", "image/png")
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(store_product_image(upload=upload, uploads_root=uploads_root, max_size=1024))
+    assert exc.value.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE


### PR DESCRIPTION
## Summary
- add a /shop/admin/product route that validates incoming data, stores product images securely, and returns the admin redirect
- extend the shop repository with helpers to validate categories and persist new products
- add a reusable product image storage helper with regression tests and document the fix in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e65d28a304832db4af7a218ae7e9ee