### PR TITLE
Fix shop sidebar alignment offset

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -344,7 +344,12 @@ body {
 
 .layout__content {
   flex: 1;
-  padding: 2rem;
+  --layout-content-padding-top: 2rem;
+  --layout-content-padding-inline: 2rem;
+  --layout-content-padding-bottom: 2rem;
+  padding: var(--layout-content-padding-top)
+    var(--layout-content-padding-inline)
+    var(--layout-content-padding-bottom);
   overflow-y: auto;
 }
 
@@ -618,7 +623,7 @@ body {
 
 .shop-layout__sidebar {
   position: sticky;
-  top: 5.5rem;
+  top: var(--layout-content-padding-top, 2rem);
   align-self: start;
 }
 
@@ -698,6 +703,7 @@ body {
 
   .shop-layout__sidebar {
     position: static;
+    top: auto;
   }
 
   .shop-toolbar {

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-08, 13:09 UTC, Fix, Ensured the shop category sidebar remains top-aligned when product listings extend the page
 - 2025-10-08, 13:01 UTC, Feature, Redesigned shop catalogue layout with sidebar category navigation and removed vendor SKUs from the customer view
 - 2025-10-08, 12:51 UTC, Fix, Restored shop product creation with validated uploads and database persistence to resolve Not Found errors
 - 2025-10-08, 12:41 UTC, Fix, Updated API documentation links to open in a new tab with secure attributes for consistent navigation


### PR DESCRIPTION
## Summary
- expose layout content padding as reusable CSS variables
- align the shop category sidebar to the top by reusing the content padding variable for the sticky offset
- record the alignment fix in the running change log

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e661c715ec832d9a556257c4f8c69b