### PR TITLE
Filter zero-priced items from shop catalogue

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1542,6 +1542,17 @@ async def shop_page(
             if vip_price is not None:
                 product["price"] = vip_price
 
+    def _product_has_price(product: Mapping[str, Any]) -> bool:
+        raw_price = product.get("price")
+        if raw_price is None:
+            return False
+        try:
+            return Decimal(str(raw_price)) > 0
+        except (InvalidOperation, TypeError, ValueError):
+            return False
+
+    products = [product for product in products if _product_has_price(product)]
+
     extra = {
         "title": "Shop",
         "categories": categories,

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-14, 11:55 UTC, Fix, Filtered zero-priced products from the shop catalogue so customers only see priced items
 - 2025-10-11, 11:45 UTC, Feature, Recreated the invoices dashboard with FastAPI templates, filtering UI, and secured API endpoints
 - 2025-10-11, 11:45 UTC, Fix, Synced stock feed images into the portal and replaced zero pricing with RRP during product updates
 - 2025-10-08, 13:23 UTC, Feature, Restored company management console with invitations, permissions, and admin UI parity


### PR DESCRIPTION
## Summary
- filter zero-priced products out of the customer-facing shop view after applying company-specific pricing
- record the catalogue visibility fix in the project change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e668c07544832db7274dec2aedd8b1