### PR TITLE
Fix admin API key dashboard query grouping

### DIFF
--- a/app/repositories/api_keys.py
+++ b/app/repositories/api_keys.py
@@ -85,7 +85,13 @@ async def list_api_keys_with_usage(
         FROM api_keys AS ak
         LEFT JOIN api_key_usage AS aku ON ak.id = aku.api_key_id
         {where}
-        GROUP BY ak.id
+        GROUP BY
+            ak.id,
+            ak.description,
+            ak.expiry_date,
+            ak.created_at,
+            ak.last_used_at,
+            ak.key_prefix
         ORDER BY {column} {direction}, ak.id ASC
     """
     rows = await db.fetch_all(sql, tuple(params))
@@ -120,7 +126,13 @@ async def get_api_key_with_usage(api_key_id: int) -> dict[str, Any] | None:
         FROM api_keys AS ak
         LEFT JOIN api_key_usage AS aku ON ak.id = aku.api_key_id
         WHERE ak.id = %s
-        GROUP BY ak.id
+        GROUP BY
+            ak.id,
+            ak.description,
+            ak.expiry_date,
+            ak.created_at,
+            ak.last_used_at,
+            ak.key_prefix
         """,
         (api_key_id,),
     )

--- a/changes.md
+++ b/changes.md
@@ -93,3 +93,4 @@
 - 2025-10-08, 10:32 UTC, Fix, Added resilient switch-company payload parsing fallback for raw form bodies and undocumented clients
 - 2025-10-10, 12:00 UTC, Feature, Added persistent scheduler management APIs, webhook retry monitoring UI, and admin automation controls with database migrations
 - 2025-10-10, 12:45 UTC, Fix, Corrected scheduler monitoring migration defaults and enforced UTC MySQL sessions to restore startup
+- 2025-10-09, 05:40 UTC, Fix, Restored admin API key dashboard by aligning API key usage queries with ONLY_FULL_GROUP_BY SQL mode to prevent runtime errors


### PR DESCRIPTION
## Summary
- include all selected columns in the API key usage aggregation queries so they work with MySQL ONLY_FULL_GROUP_BY enabled and restore the admin dashboard
- log the fix in changes.md

## Testing
- python -m compileall app/repositories/api_keys.py

------
https://chatgpt.com/codex/tasks/task_b_68e74a6814f0832dad6f6b81bc0f77cf