### PR TITLE
Ensure system update automation is scheduled

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-09, 06:01 UTC, Fix, Seeded the MyPortal System Update scheduled task so the automation runs on its daily cron
 - 2025-10-09, 05:52 UTC, Fix, Normalised string timestamp values from the database to UTC datetimes so the admin API key dashboard loads
 - 2025-10-08, 13:39 UTC, Fix, Normalised Decimal audit metadata before JSON serialisation so the admin API key dashboard renders without errors
 - 2025-10-08, 13:42 UTC, Fix, Restored /admin/companies administration dashboard with user provisioning and permission controls

--- a/src/server.ts
+++ b/src/server.ts
@@ -1029,6 +1029,14 @@ async function createDefaultSystemSchedules() {
   if (!tasks.some((t) => t.command === 'update_products')) {
     await createScheduledTask(null, 'Update Products', 'update_products', getRandomDailyCron());
   }
+  if (!tasks.some((t) => t.command === 'system_update')) {
+    await createScheduledTask(
+      null,
+      'MyPortal System Update',
+      'system_update',
+      getRandomDailyCron()
+    );
+  }
 }
 
 setInterval(() => {


### PR DESCRIPTION
## Summary
- add the system update task to the default scheduler seeding so it is created automatically
- document the fix in the change log entry for operational visibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e74f8f47f4832d99b41a10df0258a9