### PR TITLE
Handle system update scheduled task

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-16, 08:45 UTC, Fix, Added a secure system update scheduler handler that runs update.sh with locking and output auditing
 - 2025-10-09, 06:01 UTC, Fix, Seeded the MyPortal System Update scheduled task so the automation runs on its daily cron
 - 2025-10-09, 05:52 UTC, Fix, Normalised string timestamp values from the database to UTC datetimes so the admin API key dashboard loads
 - 2025-10-08, 13:39 UTC, Fix, Normalised Decimal audit metadata before JSON serialisation so the admin API key dashboard renders without errors


### PR DESCRIPTION
## Summary
- add a scheduler handler for the system_update command that executes update.sh with locking and output auditing
- record the fix in the change log for release tracking

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e750f7daec832d97e1ea8b52459785