### PR TITLE
Fix Syncro asset scheduler handling

### DIFF
--- a/app/repositories/assets.py
+++ b/app/repositories/assets.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+from typing import Any
+
+from app.core.database import db
+
+
+def _ensure_datetime(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, date):
+        dt = datetime.combine(value, time.min)
+    else:
+        text = str(value).strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        for fmt in (
+            "%Y-%m-%dT%H:%M:%S.%f%z",
+            "%Y-%m-%dT%H:%M:%S%z",
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d %H:%M",
+            "%Y-%m-%d",
+        ):
+            try:
+                parsed = datetime.strptime(text, fmt)
+                dt = parsed
+                break
+            except ValueError:
+                continue
+        else:
+            try:
+                dt = datetime.fromisoformat(text)
+            except ValueError:
+                return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt
+
+
+def _to_mysql_datetime(value: Any) -> str | None:
+    dt = _ensure_datetime(value)
+    if not dt:
+        return None
+    return dt.replace(tzinfo=None).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _to_mysql_date(value: Any) -> str | None:
+    dt = _ensure_datetime(value)
+    if not dt:
+        return None
+    return dt.date().isoformat()
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        digits = ""
+        for ch in text:
+            if ch.isdigit() or ch in {"-", "."}:
+                digits += ch
+            elif digits:
+                break
+        if not digits:
+            return None
+        try:
+            return float(digits)
+        except ValueError:
+            return None
+
+
+async def upsert_asset(
+    *,
+    company_id: int,
+    name: str,
+    type: str | None = None,
+    serial_number: str | None = None,
+    status: str | None = None,
+    os_name: str | None = None,
+    cpu_name: str | None = None,
+    ram_gb: Any = None,
+    hdd_size: str | None = None,
+    last_sync: Any = None,
+    motherboard_manufacturer: str | None = None,
+    form_factor: str | None = None,
+    last_user: str | None = None,
+    approx_age: Any = None,
+    performance_score: Any = None,
+    warranty_status: str | None = None,
+    warranty_end_date: Any = None,
+    syncro_asset_id: str | None = None,
+) -> None:
+    sync_id = str(syncro_asset_id) if syncro_asset_id else None
+    ram_value = _coerce_float(ram_gb)
+    approx_value = _coerce_float(approx_age)
+    performance_value = _coerce_float(performance_score)
+    last_sync_db = _to_mysql_datetime(last_sync)
+    warranty_end_db = _to_mysql_date(warranty_end_date)
+
+    row = None
+    if sync_id:
+        row = await db.fetch_one(
+            "SELECT id FROM assets WHERE company_id = %s AND syncro_asset_id = %s",
+            (company_id, sync_id),
+        )
+    if not row and serial_number:
+        row = await db.fetch_one(
+            "SELECT id FROM assets WHERE company_id = %s AND serial_number = %s",
+            (company_id, serial_number),
+        )
+
+    params = (
+        name,
+        type,
+        status,
+        os_name,
+        cpu_name,
+        ram_value,
+        hdd_size,
+        last_sync_db,
+        motherboard_manufacturer,
+        form_factor,
+        last_user,
+        approx_value,
+        performance_value,
+        warranty_status,
+        warranty_end_db,
+        sync_id,
+        serial_number,
+    )
+
+    if row:
+        await db.execute(
+            """
+            UPDATE assets
+            SET name = %s,
+                type = %s,
+                status = %s,
+                os_name = %s,
+                cpu_name = %s,
+                ram_gb = %s,
+                hdd_size = %s,
+                last_sync = %s,
+                motherboard_manufacturer = %s,
+                form_factor = %s,
+                last_user = %s,
+                approx_age = %s,
+                performance_score = %s,
+                warranty_status = %s,
+                warranty_end_date = %s,
+                syncro_asset_id = %s,
+                serial_number = %s
+            WHERE id = %s
+            """,
+            params + (row["id"],),
+        )
+    else:
+        await db.execute(
+            """
+            INSERT INTO assets (
+                company_id,
+                name,
+                type,
+                serial_number,
+                status,
+                os_name,
+                cpu_name,
+                ram_gb,
+                hdd_size,
+                last_sync,
+                motherboard_manufacturer,
+                form_factor,
+                last_user,
+                approx_age,
+                performance_score,
+                warranty_status,
+                warranty_end_date,
+                syncro_asset_id
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                company_id,
+                name,
+                type,
+                serial_number,
+                status,
+                os_name,
+                cpu_name,
+                ram_value,
+                hdd_size,
+                last_sync_db,
+                motherboard_manufacturer,
+                form_factor,
+                last_user,
+                approx_value,
+                performance_value,
+                warranty_status,
+                warranty_end_db,
+                sync_id,
+            ),
+        )

--- a/app/services/asset_importer.py
+++ b/app/services/asset_importer.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.logging import log_info
+from app.repositories import assets as assets_repo
+from app.repositories import companies as company_repo
+from app.services import syncro
+
+
+def _clean_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+async def import_assets_for_company(
+    company_id: int,
+    *,
+    syncro_company_id: str | None = None,
+) -> int:
+    company = await company_repo.get_company_by_id(company_id)
+    if not company:
+        raise ValueError(f"Company {company_id} not found")
+    syncro_id = syncro_company_id or company.get("syncro_company_id")
+    if not syncro_id:
+        raise syncro.SyncroConfigurationError("Company is missing a Syncro mapping")
+
+    log_info("Starting Syncro asset import", company_id=company_id, syncro_id=syncro_id)
+    assets = await syncro.get_assets(syncro_id)
+    processed = 0
+
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        details = syncro.extract_asset_details(asset)
+        name = _clean_string(details.get("name") or asset.get("name")) or "Asset"
+        type_value = _clean_string(details.get("type"))
+        serial = _clean_string(details.get("serial_number"))
+        status = _clean_string(details.get("status"))
+        os_name = _clean_string(details.get("os_name"))
+        cpu_name = _clean_string(details.get("cpu_name"))
+        hdd_size = _clean_string(details.get("hdd_size"))
+        last_user = _clean_string(details.get("last_user"))
+        motherboard = _clean_string(details.get("motherboard_manufacturer"))
+        form_factor = _clean_string(details.get("form_factor"))
+        warranty_status = _clean_string(details.get("warranty_status"))
+        warranty_end = details.get("warranty_end_date")
+        last_sync = details.get("last_sync")
+        ram_value = details.get("ram_gb")
+        approx_age = details.get("cpu_age")
+        performance_score = details.get("performance_score")
+
+        syncro_asset_id = asset.get("id") or details.get("id")
+        syncro_asset_id = str(syncro_asset_id) if syncro_asset_id is not None else None
+
+        await assets_repo.upsert_asset(
+            company_id=company_id,
+            name=name,
+            type=type_value,
+            serial_number=serial,
+            status=status,
+            os_name=os_name,
+            cpu_name=cpu_name,
+            ram_gb=ram_value,
+            hdd_size=hdd_size,
+            last_sync=last_sync,
+            motherboard_manufacturer=motherboard,
+            form_factor=form_factor,
+            last_user=last_user,
+            approx_age=approx_age,
+            performance_score=performance_score,
+            warranty_status=warranty_status,
+            warranty_end_date=warranty_end,
+            syncro_asset_id=syncro_asset_id,
+        )
+        processed += 1
+
+    log_info(
+        "Completed Syncro asset import",
+        company_id=company_id,
+        syncro_id=syncro_id,
+        processed=processed,
+        total=len(assets),
+    )
+    return processed

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -13,6 +13,7 @@ from apscheduler.triggers.cron import CronTrigger
 from app.core.config import get_settings
 from app.core.logging import log_error, log_info
 from app.repositories import scheduled_tasks as scheduled_tasks_repo
+from app.services import asset_importer
 from app.services import staff_importer
 from app.services import m365 as m365_service
 from app.services import products as products_service
@@ -124,6 +125,10 @@ class SchedulerService:
                 company_id = task.get("company_id")
                 if company_id:
                     await staff_importer.import_contacts_for_company(int(company_id))
+            elif command == "sync_assets":
+                company_id = task.get("company_id")
+                if company_id:
+                    await asset_importer.import_assets_for_company(int(company_id))
             elif command == "sync_o365":
                 company_id = task.get("company_id")
                 if company_id:

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-16, 09:55 UTC, Fix, Restored Syncro asset scheduled sync with importer service and repository upsert handling
 - 2025-10-16, 08:45 UTC, Fix, Added a secure system update scheduler handler that runs update.sh with locking and output auditing
 - 2025-10-09, 06:01 UTC, Fix, Seeded the MyPortal System Update scheduled task so the automation runs on its daily cron
 - 2025-10-09, 05:52 UTC, Fix, Normalised string timestamp values from the database to UTC datetimes so the admin API key dashboard loads


### PR DESCRIPTION
## Summary
- add a Syncro asset importer service and repository helper to persist asset details
- extend the Syncro client with asset pagination and normalisation utilities
- wire the scheduler sync_assets command to the importer and document the fix in the change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e752539818832d8ad8fbf9c06d91ba