### PR TITLE
Move scheduler editor into modals and add webhook monitor page

### DIFF
--- a/app/static/js/webhooks.js
+++ b/app/static/js/webhooks.js
@@ -1,0 +1,253 @@
+(function () {
+  let attemptsModal = null;
+
+  function getCookie(name) {
+    const pattern = `(?:^|; )${name.replace(/([.$?*|{}()\[\]\\\/\+^])/g, '\\$1')}=([^;]*)`;
+    const matches = document.cookie.match(new RegExp(pattern));
+    return matches ? decodeURIComponent(matches[1]) : '';
+  }
+
+  function getCsrfToken() {
+    return getCookie('myportal_session_csrf');
+  }
+
+  async function requestJson(url, options) {
+    const response = await fetch(url, {
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': getCsrfToken(),
+        ...(options && options.headers ? options.headers : {}),
+      },
+      ...options,
+    });
+    if (!response.ok) {
+      let detail = `${response.status} ${response.statusText}`;
+      try {
+        const data = await response.json();
+        if (data && data.detail) {
+          detail = Array.isArray(data.detail)
+            ? data.detail.map((entry) => entry.msg || entry).join(', ')
+            : data.detail;
+        }
+      } catch (error) {
+        /* ignore */
+      }
+      throw new Error(detail);
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    try {
+      return await response.json();
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function parseEvent(row) {
+    if (!row) {
+      return null;
+    }
+    try {
+      const value = row.dataset.event || '{}';
+      return JSON.parse(value);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function query(id) {
+    return document.getElementById(id);
+  }
+
+  function openModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.hidden = false;
+    modal.classList.add('is-visible');
+    modal.__previousActive = document.activeElement;
+    const focusTarget =
+      modal.querySelector('[data-initial-focus]') ||
+      modal.querySelector(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+    if (focusTarget && typeof focusTarget.focus === 'function') {
+      focusTarget.focus();
+    }
+  }
+
+  function closeModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.classList.remove('is-visible');
+    modal.hidden = true;
+    const previous = modal.__previousActive;
+    if (previous && typeof previous.focus === 'function') {
+      previous.focus();
+    }
+  }
+
+  function bindModalDismissal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal || event.target.hasAttribute('data-modal-close')) {
+        closeModal(modal);
+      }
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !modal.hidden) {
+        closeModal(modal);
+      }
+    });
+  }
+
+  function formatIso(iso) {
+    if (!iso) {
+      return { text: '—', value: '' };
+    }
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) {
+      return { text: '—', value: '' };
+    }
+    return { text: date.toLocaleString(), value: iso };
+  }
+
+  function setAttemptsPlaceholder(message) {
+    const tbody = query('webhook-attempts-body');
+    if (!tbody) {
+      return;
+    }
+    tbody.innerHTML = '';
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 5;
+    cell.className = 'table__empty';
+    cell.textContent = message;
+    row.appendChild(cell);
+    tbody.appendChild(row);
+  }
+
+  function renderAttempts(attempts) {
+    const tbody = query('webhook-attempts-body');
+    if (!tbody) {
+      return;
+    }
+    tbody.innerHTML = '';
+    if (!attempts || attempts.length === 0) {
+      setAttemptsPlaceholder('No delivery attempts recorded for this event.');
+      return;
+    }
+    attempts.forEach((attempt) => {
+      const row = document.createElement('tr');
+
+      const attemptedCell = document.createElement('td');
+      attemptedCell.setAttribute('data-label', 'Attempted');
+      const attempted = formatIso(
+        attempt.attempted_at || attempt.attemptedAt || attempt.attemptedIso
+      );
+      attemptedCell.setAttribute('data-value', attempted.value);
+      attemptedCell.textContent = attempted.text;
+      row.appendChild(attemptedCell);
+
+      const statusCell = document.createElement('td');
+      statusCell.setAttribute('data-label', 'Status');
+      statusCell.textContent = attempt.status || 'unknown';
+      statusCell.setAttribute('data-value', attempt.status || '');
+      row.appendChild(statusCell);
+
+      const durationCell = document.createElement('td');
+      durationCell.setAttribute('data-label', 'Duration (ms)');
+      const duration = typeof attempt.duration_ms === 'number' ? attempt.duration_ms : attempt.durationMs;
+      durationCell.setAttribute('data-value', String(duration ?? 0));
+      durationCell.textContent = Number.isFinite(duration) ? String(duration) : '—';
+      row.appendChild(durationCell);
+
+      const responseCell = document.createElement('td');
+      responseCell.setAttribute('data-label', 'Response');
+      const statusCode =
+        attempt.response_status ?? attempt.responseStatus ?? attempt.statusCode ?? null;
+      responseCell.setAttribute('data-value', statusCode !== null ? String(statusCode) : '');
+      responseCell.textContent = statusCode !== null ? String(statusCode) : '—';
+      row.appendChild(responseCell);
+
+      const errorCell = document.createElement('td');
+      errorCell.setAttribute('data-label', 'Error');
+      const errorMessage = attempt.error_message || attempt.errorMessage || attempt.error;
+      errorCell.textContent = errorMessage || '—';
+      row.appendChild(errorCell);
+
+      tbody.appendChild(row);
+    });
+  }
+
+  async function showAttemptsModal(eventData) {
+    if (!attemptsModal || !eventData || !eventData.id) {
+      return;
+    }
+    const title = query('webhook-attempts-title');
+    if (title) {
+      title.textContent = `Webhook attempts — ${eventData.name || `Event #${eventData.id}`}`;
+    }
+    const description = query('webhook-attempts-description');
+    if (description) {
+      const target = eventData.target_url || eventData.targetUrl || '';
+      description.textContent = target
+        ? `Review the latest delivery attempts for ${target}.`
+        : 'Review the latest delivery attempts for the selected webhook event.';
+    }
+    setAttemptsPlaceholder('Loading attempts…');
+    openModal(attemptsModal);
+    try {
+      const attempts = await requestJson(`/scheduler/webhooks/${eventData.id}/attempts?limit=50`);
+      renderAttempts(Array.isArray(attempts) ? attempts : []);
+    } catch (error) {
+      setAttemptsPlaceholder(`Unable to load attempts: ${error.message}`);
+    }
+  }
+
+  function bindRetryButtons() {
+    document.querySelectorAll('[data-webhook-retry]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        if (button.disabled) {
+          return;
+        }
+        const row = button.closest('tr');
+        const eventData = parseEvent(row);
+        if (!eventData || !eventData.id) {
+          return;
+        }
+        try {
+          await requestJson(`/scheduler/webhooks/${eventData.id}/retry`, { method: 'POST' });
+          alert('Webhook retry has been queued. Refresh the page to see updates.');
+          window.location.reload();
+        } catch (error) {
+          alert(`Unable to retry webhook: ${error.message}`);
+        }
+      });
+    });
+  }
+
+  function bindAttemptsButtons() {
+    document.querySelectorAll('[data-webhook-attempts]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const row = button.closest('tr');
+        const eventData = parseEvent(row);
+        if (eventData) {
+          showAttemptsModal(eventData);
+        }
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    attemptsModal = query('webhook-attempts-modal');
+    bindModalDismissal(attemptsModal);
+    bindRetryButtons();
+    bindAttemptsButtons();
+  });
+})();

--- a/app/templates/admin/automation.html
+++ b/app/templates/admin/automation.html
@@ -3,18 +3,23 @@
 {% block content %}
 <div class="admin-grid">
   <section class="card card--panel">
-    <header class="card__header">
+    <header class="card__header card__header--actions">
       <div>
         <h2 class="card__title">Scheduled tasks</h2>
         <p class="card__subtitle">Create, monitor, and control background automation jobs.</p>
       </div>
-      <input
-        type="search"
-        class="form-input"
-        placeholder="Filter tasks"
-        aria-label="Filter scheduled tasks"
-        data-table-filter="tasks-table"
-      />
+      <div class="card__controls">
+        <input
+          type="search"
+          class="form-input"
+          placeholder="Filter tasks"
+          aria-label="Filter scheduled tasks"
+          data-table-filter="tasks-table"
+        />
+        <button type="button" class="button" data-task-create>
+          New task
+        </button>
+      </div>
     </header>
     <div class="table-wrapper">
       <table class="table" id="tasks-table" data-table>
@@ -57,6 +62,7 @@
                     {{ 'Disable' if task.active else 'Enable' }}
                   </button>
                   <button type="button" class="button button--ghost" data-task-run>Run now</button>
+                  <button type="button" class="button button--ghost" data-task-logs>View logs</button>
                   <button type="button" class="button button--danger" data-task-delete>Delete</button>
                 </div>
               </td>
@@ -70,205 +76,120 @@
       </table>
     </div>
   </section>
-
-  <section class="card card--panel">
-    <header class="card__header">
-      <div>
-        <h2 class="card__title">Task editor</h2>
-        <p class="card__subtitle">All schedules use UTC and respect rate limits configured on integrations.</p>
-      </div>
-    </header>
-    <form id="scheduled-task-form" class="form" autocomplete="off">
-      <input type="hidden" name="task_id" id="task-id" />
-      <div class="form-field">
-        <label class="form-label" for="task-name">Task name</label>
-        <input class="form-input" id="task-name" name="name" required maxlength="255" />
-      </div>
-      <div class="form-field">
-        <label class="form-label" for="task-command">Command</label>
-        <select class="form-input" id="task-command" name="command" required>
-          {% for option in command_options %}
-            <option value="{{ option.value }}">{{ option.label }}</option>
-          {% endfor %}
-        </select>
-      </div>
-      <div class="form-field">
-        <label class="form-label" for="task-company">Company ID</label>
-        <input
-          class="form-input"
-          id="task-company"
-          name="companyId"
-          type="number"
-          min="1"
-          placeholder="Leave blank for all companies"
-        />
-      </div>
-      <div class="form-field">
-        <label class="form-label" for="task-cron">Cron expression</label>
-        <input
-          class="form-input"
-          id="task-cron"
-          name="cron"
-          required
-          placeholder="0 2 * * *"
-          pattern="^[^\s]+(\s+[^\s]+){4,5}$"
-        />
-        <p class="form-help">Crontab syntax in UTC. Use five fields for minute through weekday.</p>
-      </div>
-      <div class="form-field">
-        <label class="form-label" for="task-description">Description</label>
-        <textarea class="form-input form-input--textarea" id="task-description" name="description" rows="3"></textarea>
-      </div>
-      <div class="form-field form-field--inline">
-        <label class="form-label" for="task-max-retries">Max retries</label>
-        <input class="form-input" id="task-max-retries" name="maxRetries" type="number" min="0" value="0" />
-      </div>
-      <div class="form-field form-field--inline">
-        <label class="form-label" for="task-backoff">Retry backoff (seconds)</label>
-        <input class="form-input" id="task-backoff" name="retryBackoffSeconds" type="number" min="30" value="300" />
-      </div>
-      <div class="form-field form-field--checkbox">
-        <label class="form-checkbox">
-          <input type="checkbox" id="task-active" name="active" checked />
-          <span>Task active</span>
-        </label>
-      </div>
-      <div class="form-actions">
-        <button type="submit" class="button">Save task</button>
-        <button type="button" class="button button--ghost" data-task-reset>Clear form</button>
-      </div>
-    </form>
-  </section>
 </div>
 
-<section class="card card--panel">
-  <header class="card__header">
-    <div>
-      <h2 class="card__title">Recent task executions</h2>
-      <p class="card__subtitle">Track the latest automation runs with UTC timestamps converted to local time in your browser.</p>
+<div class="modal" id="task-editor-modal" role="dialog" aria-modal="true" hidden>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close>
+      <span class="visually-hidden">Close task editor</span>
+    </button>
+    <h2 class="modal__title">Scheduled task</h2>
+    <div class="modal__body">
+      <form id="scheduled-task-form" class="form" autocomplete="off">
+        <input type="hidden" name="task_id" id="task-id" />
+        <div class="form-field">
+          <label class="form-label" for="task-name">Task name</label>
+          <input class="form-input" id="task-name" name="name" required maxlength="255" data-initial-focus />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="task-command">Command</label>
+          <select class="form-input" id="task-command" name="command" required>
+            {% for option in command_options %}
+              <option value="{{ option.value }}">{{ option.label }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="task-company">Company ID</label>
+          <input
+            class="form-input"
+            id="task-company"
+            name="companyId"
+            type="number"
+            min="1"
+            placeholder="Leave blank for all companies"
+          />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="task-cron">Cron expression</label>
+          <input
+            class="form-input"
+            id="task-cron"
+            name="cron"
+            required
+            placeholder="0 2 * * *"
+            pattern="^[^\s]+(\s+[^\s]+){4,5}$"
+          />
+          <p class="form-help">Crontab syntax in UTC. Use five fields for minute through weekday.</p>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="task-description">Description</label>
+          <textarea class="form-input form-input--textarea" id="task-description" name="description" rows="3"></textarea>
+        </div>
+        <div class="form-field form-field--inline">
+          <label class="form-label" for="task-max-retries">Max retries</label>
+          <input class="form-input" id="task-max-retries" name="maxRetries" type="number" min="0" value="0" />
+        </div>
+        <div class="form-field form-field--inline">
+          <label class="form-label" for="task-backoff">Retry backoff (seconds)</label>
+          <input class="form-input" id="task-backoff" name="retryBackoffSeconds" type="number" min="30" value="300" />
+        </div>
+        <div class="form-field form-field--checkbox">
+          <label class="form-checkbox">
+            <input type="checkbox" id="task-active" name="active" checked />
+            <span>Task active</span>
+          </label>
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="button">Save task</button>
+          <button type="button" class="button button--ghost" data-task-reset>Clear form</button>
+        </div>
+      </form>
     </div>
-    <input
-      type="search"
-      class="form-input"
-      placeholder="Filter executions"
-      aria-label="Filter scheduled task runs"
-      data-table-filter="runs-table"
-    />
-  </header>
-  <div class="table-wrapper">
-    <table class="table" id="runs-table" data-table>
-      <thead>
-        <tr>
-          <th scope="col" data-sort="string">Task</th>
-          <th scope="col" data-sort="string">Status</th>
-          <th scope="col" data-sort="date">Started</th>
-          <th scope="col" data-sort="date">Finished</th>
-          <th scope="col" data-sort="number">Duration (ms)</th>
-          <th scope="col" data-sort="string">Details</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for run in runs %}
-          <tr>
-            <td data-label="Task">{{ run.task_name }}</td>
-            <td data-label="Status">{{ run.status }}</td>
-            <td data-label="Started" data-value="{{ run.started_iso or '' }}">
-              {% if run.started_iso %}
-                <span data-utc="{{ run.started_iso }}"></span>
-              {% else %}
-                <span class="text-muted">Unknown</span>
-              {% endif %}
-            </td>
-            <td data-label="Finished" data-value="{{ run.finished_iso or '' }}">
-              {% if run.finished_iso %}
-                <span data-utc="{{ run.finished_iso }}"></span>
-              {% else %}
-                <span class="text-muted">Pending</span>
-              {% endif %}
-            </td>
-            <td data-label="Duration" data-value="{{ run.duration_ms or 0 }}">{{ run.duration_ms or '—' }}</td>
-            <td data-label="Details">{{ run.details or '—' }}</td>
-          </tr>
-        {% else %}
-          <tr>
-            <td colspan="6" class="table__empty">No automation runs recorded yet.</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
   </div>
-</section>
+</div>
 
-<section class="card card--panel">
-  <header class="card__header">
-    <div>
-      <h2 class="card__title">Webhook delivery queue</h2>
-      <p class="card__subtitle">Monitor outbound webhook calls, retry failures, and review delivery history.</p>
+<div class="modal" id="task-logs-modal" role="dialog" aria-modal="true" hidden>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close>
+      <span class="visually-hidden">Close task logs</span>
+    </button>
+    <h2 class="modal__title" id="task-logs-title">Task run history</h2>
+    <div class="modal__body">
+      <p id="task-logs-description" class="modal__subtitle text-muted">
+        View the most recent executions for this scheduled task. All timestamps are displayed in your local timezone.
+      </p>
+      <div class="modal__controls">
+        <input
+          type="search"
+          class="form-input"
+          placeholder="Filter runs"
+          aria-label="Filter task runs"
+          data-table-filter="task-logs-table"
+        />
+      </div>
+      <div class="table-wrapper">
+        <table class="table" id="task-logs-table" data-table>
+          <thead>
+            <tr>
+              <th scope="col" data-sort="string">Status</th>
+              <th scope="col" data-sort="date">Started</th>
+              <th scope="col" data-sort="date">Finished</th>
+              <th scope="col" data-sort="number">Duration (ms)</th>
+              <th scope="col" data-sort="string">Details</th>
+            </tr>
+          </thead>
+          <tbody id="task-logs-body">
+            <tr>
+              <td colspan="5" class="table__empty" id="task-logs-empty">Select a task to view its recent runs.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
-    <input
-      type="search"
-      class="form-input"
-      placeholder="Filter webhook events"
-      aria-label="Filter webhook events"
-      data-table-filter="webhooks-table"
-    />
-  </header>
-  <div class="table-wrapper">
-    <table class="table" id="webhooks-table" data-table>
-      <thead>
-        <tr>
-          <th scope="col" data-sort="string">Name</th>
-          <th scope="col" data-sort="string">Target</th>
-          <th scope="col" data-sort="string">Status</th>
-          <th scope="col" data-sort="number">Attempts</th>
-          <th scope="col" data-sort="date">Next attempt</th>
-          <th scope="col" data-sort="string">Last error</th>
-          <th scope="col" data-sort="date">Updated</th>
-          <th scope="col" class="table__actions">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for event in events %}
-          <tr data-event-id="{{ event.id }}">
-            <td data-label="Name">{{ event.name }}</td>
-            <td data-label="Target">{{ event.target_url }}</td>
-            <td data-label="Status">{{ event.status }}</td>
-            <td data-label="Attempts" data-value="{{ event.attempt_count }}">
-              {{ event.attempt_count }}/{{ event.max_attempts }}
-            </td>
-            <td data-label="Next attempt" data-value="{{ event.next_attempt_iso or '' }}">
-              {% if event.next_attempt_iso %}
-                <span data-utc="{{ event.next_attempt_iso }}"></span>
-              {% else %}
-                <span class="text-muted">—</span>
-              {% endif %}
-            </td>
-            <td data-label="Last error">{{ event.last_error or '—' }}</td>
-            <td data-label="Updated" data-value="{{ event.updated_iso or '' }}">
-              {% if event.updated_iso %}
-                <span data-utc="{{ event.updated_iso }}"></span>
-              {% endif %}
-            </td>
-            <td class="table__actions">
-              <div class="table__action-buttons">
-                <button
-                  type="button"
-                  class="button button--ghost"
-                  data-webhook-retry
-                  {% if event.status == 'succeeded' %}disabled{% endif %}
-                >Retry</button>
-              </div>
-            </td>
-          </tr>
-        {% else %}
-          <tr>
-            <td colspan="8" class="table__empty">No webhook activity recorded.</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
   </div>
-</section>
+</div>
+
 {% endblock %}
 
 {% block scripts %}

--- a/app/templates/admin/webhooks.html
+++ b/app/templates/admin/webhooks.html
@@ -1,0 +1,126 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="card card--panel">
+  <header class="card__header card__header--actions">
+    <div>
+      <h2 class="card__title">Webhook delivery queue</h2>
+      <p class="card__subtitle">
+        Monitor outbound webhook calls, retry failures, and inspect delivery attempts per integration.
+      </p>
+    </div>
+    <div class="card__controls">
+      <input
+        type="search"
+        class="form-input"
+        placeholder="Filter webhook events"
+        aria-label="Filter webhook events"
+        data-table-filter="webhooks-table"
+      />
+    </div>
+  </header>
+  <div class="table-wrapper">
+    <table class="table" id="webhooks-table" data-table>
+      <thead>
+        <tr>
+          <th scope="col" data-sort="string">Name</th>
+          <th scope="col" data-sort="string">Target</th>
+          <th scope="col" data-sort="string">Status</th>
+          <th scope="col" data-sort="number">Attempts</th>
+          <th scope="col" data-sort="date">Next attempt</th>
+          <th scope="col" data-sort="string">Last error</th>
+          <th scope="col" data-sort="date">Updated</th>
+          <th scope="col" class="table__actions">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for event in events %}
+          <tr data-event='{{ event | tojson }}'>
+            <td data-label="Name">{{ event.name }}</td>
+            <td data-label="Target">{{ event.target_url }}</td>
+            <td data-label="Status">{{ event.status }}</td>
+            <td data-label="Attempts" data-value="{{ event.attempt_count }}">
+              {{ event.attempt_count }}/{{ event.max_attempts }}
+            </td>
+            <td data-label="Next attempt" data-value="{{ event.next_attempt_iso or '' }}">
+              {% if event.next_attempt_iso %}
+                <span data-utc="{{ event.next_attempt_iso }}"></span>
+              {% else %}
+                <span class="text-muted">—</span>
+              {% endif %}
+            </td>
+            <td data-label="Last error">{{ event.last_error or '—' }}</td>
+            <td data-label="Updated" data-value="{{ event.updated_iso or '' }}">
+              {% if event.updated_iso %}
+                <span data-utc="{{ event.updated_iso }}"></span>
+              {% endif %}
+            </td>
+            <td class="table__actions">
+              <div class="table__action-buttons">
+                <button type="button" class="button button--ghost" data-webhook-attempts>View attempts</button>
+                <button
+                  type="button"
+                  class="button button--ghost"
+                  data-webhook-retry
+                  {% if event.status == 'succeeded' %}disabled{% endif %}
+                >Retry</button>
+              </div>
+            </td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="8" class="table__empty">No webhook activity recorded.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<div class="modal" id="webhook-attempts-modal" role="dialog" aria-modal="true" hidden>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close>
+      <span class="visually-hidden">Close webhook attempts</span>
+    </button>
+    <h2 class="modal__title" id="webhook-attempts-title">Webhook attempts</h2>
+    <div class="modal__body">
+      <p id="webhook-attempts-description" class="modal__subtitle text-muted">
+        Review the latest delivery attempts for the selected webhook event.
+      </p>
+      <div class="modal__controls">
+        <input
+          type="search"
+          class="form-input"
+          placeholder="Filter attempts"
+          aria-label="Filter webhook attempts"
+          data-table-filter="webhook-attempts-table"
+        />
+      </div>
+      <div class="table-wrapper">
+        <table class="table" id="webhook-attempts-table" data-table>
+          <thead>
+            <tr>
+              <th scope="col" data-sort="date">Attempted</th>
+              <th scope="col" data-sort="number">Status</th>
+              <th scope="col" data-sort="number">Duration (ms)</th>
+              <th scope="col" data-sort="string">Response</th>
+              <th scope="col" data-sort="string">Error</th>
+            </tr>
+          </thead>
+          <tbody id="webhook-attempts-body">
+            <tr>
+              <td colspan="5" class="table__empty" id="webhook-attempts-empty">Select a webhook event to inspect its attempts.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/webhooks.js" defer></script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -188,6 +188,14 @@ H8zm0 4v2h8v-2H8z"/></svg>
               </a>
             </li>
             <li class="menu__item">
+              <a href="/admin/webhooks" {% if current_path.startswith('/admin/webhooks') %}aria-current="page"{% endif %}>
+                <span class="menu__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false"><path d="M4 4a2 2 0 0 1 2-2h3a2 2 0 0 1 1.73 1H13a2 2 0 0 1 1.73 1H18a2 2 0 0 1 2 2v3a2 2 0 0 1-1 1.73V13a2 2 0 0 1-1 1.73V18a2 2 0 0 1-2 2h-3a2 2 0 0 1-1.73-1H11a2 2 0 0 1-1.73 1H6a2 2 0 0 1-2-2v-3a2 2 0 0 1 1-1.73V11a2 2 0 0 1 1-1.73V6a2 2 0 0 1-2-2zm2 0v3.5a1.5 1.5 0 0 0 0 3V14a1.5 1.5 0 0 0 0 3V18h3.5a1.5 1.5 0 0 0 3 0H16a1.5 1.5 0 0 0 3 0v-3.5a1.5 1.5 0 0 0 0-3V6a1.5 1.5 0 0 0-3 0h-3.5a1.5 1.5 0 0 0-3 0z"/></svg>
+                </span>
+                <span class="menu__label">Webhook monitor</span>
+              </a>
+            </li>
+            <li class="menu__item">
               <a href="/admin/shop" {% if current_path.startswith('/admin/shop') %}aria-current="page"{% endif %}>
                 <span class="menu__icon" aria-hidden="true">
                   <svg viewBox="0 0 24 24" focusable="false"><path d="M4 7h16l-1.5 12.5A2 2 0 0 1 16.52 21H7.48a2 2 0 0 1-1.98-1.5zM6 3h12a1 1 0 0 1 1 1v2H5V4a1 1 0 0 1 1-1z"/></svg>

--- a/changes.md
+++ b/changes.md
@@ -98,3 +98,4 @@
 - 2025-10-10, 12:00 UTC, Feature, Added persistent scheduler management APIs, webhook retry monitoring UI, and admin automation controls with database migrations
 - 2025-10-10, 12:45 UTC, Fix, Corrected scheduler monitoring migration defaults and enforced UTC MySQL sessions to restore startup
 - 2025-10-09, 05:40 UTC, Fix, Restored admin API key dashboard by aligning API key usage queries with ONLY_FULL_GROUP_BY SQL mode to prevent runtime errors
+- 2025-10-09, 11:09 UTC, Feature, Moved scheduler editing into modal workflows, added per-task run history popups, and created a dedicated webhook delivery monitoring page


### PR DESCRIPTION
## Summary
- move the scheduled task editor into a modal workflow with per-task log popups
- add client-side logic to drive task modals and fetch recent runs on demand
- create a dedicated webhook delivery queue admin page with attempt history modal and navigation link
- document the feature in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e79638491c832dbcfa7c3cce7ec1db