### PR TITLE
Refine companies admin layout

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -385,11 +385,117 @@
     });
   }
 
+  function bindAddCompanyModal() {
+    const modal = document.getElementById('add-company-modal');
+    const openButton = document.querySelector('[data-add-company-modal-open]');
+    if (!modal || !openButton) {
+      return;
+    }
+
+    const focusableSelector =
+      'a[href], button:not([disabled]), textarea, input:not([type="hidden"]):not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    let previousActiveElement = null;
+
+    function getFocusableElements() {
+      return Array.from(modal.querySelectorAll(focusableSelector)).filter((element) => {
+        if (element.hasAttribute('disabled')) {
+          return false;
+        }
+        if (element.getAttribute('aria-hidden') === 'true') {
+          return false;
+        }
+        return element.offsetParent !== null;
+      });
+    }
+
+    function focusFirstElement() {
+      const [firstFocusable] = getFocusableElements();
+      if (firstFocusable && typeof firstFocusable.focus === 'function') {
+        firstFocusable.focus();
+      }
+    }
+
+    function handleKeydown(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        closeModal();
+        return;
+      }
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusable = getFocusableElements();
+      if (!focusable.length) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeElement = document.activeElement;
+
+      if (event.shiftKey) {
+        if (activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    function openModal() {
+      previousActiveElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      modal.hidden = false;
+      modal.classList.add('is-visible');
+      modal.setAttribute('aria-hidden', 'false');
+      openButton.setAttribute('aria-expanded', 'true');
+      document.addEventListener('keydown', handleKeydown);
+      focusFirstElement();
+    }
+
+    function closeModal() {
+      modal.classList.remove('is-visible');
+      modal.hidden = true;
+      modal.setAttribute('aria-hidden', 'true');
+      openButton.setAttribute('aria-expanded', 'false');
+      document.removeEventListener('keydown', handleKeydown);
+      if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
+        previousActiveElement.focus();
+      } else {
+        openButton.focus();
+      }
+    }
+
+    openButton.setAttribute('aria-expanded', 'false');
+
+    openButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      openModal();
+    });
+
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        closeModal();
+      }
+    });
+
+    modal.querySelectorAll('[data-modal-close]').forEach((button) => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        closeModal();
+      });
+    });
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     bindRoleForm();
     bindMembershipForms();
     bindCompanyAssignmentControls();
     bindApiKeyCopyButtons();
     bindConfirmationButtons();
+    bindAddCompanyModal();
   });
 })();

--- a/app/templates/admin/companies.html
+++ b/app/templates/admin/companies.html
@@ -1,22 +1,13 @@
 {% extends "base.html" %}
 
 {% block content %}
-  {% if error_message or success_message or temporary_password %}
+  {% if error_message or success_message %}
     <div class="stacked" style="margin-bottom: 1.5rem; gap: 1rem;">
       {% if success_message %}
         <div class="alert" role="status">{{ success_message }}</div>
       {% endif %}
       {% if error_message %}
         <div class="alert alert--error" role="alert">{{ error_message }}</div>
-      {% endif %}
-      {% if temporary_password %}
-        <div class="alert" role="status">
-          <p class="stacked" style="gap: 0.5rem; margin: 0;">
-            <strong>Temporary password generated for {{ invited_email }}</strong>
-            <span>Share this secret securely with the recipient. They will be prompted to change it at first login.</span>
-            <code style="word-break: break-word;">{{ temporary_password }}</code>
-          </p>
-        </div>
       {% endif %}
     </div>
   {% endif %}
@@ -25,49 +16,28 @@
     {% if is_super_admin %}
       <section class="card card--panel">
         <header class="card__header">
-          <div>
-            <h2 class="card__title">Add a company</h2>
-            <p class="card__subtitle">Create a new customer record with optional Syncro and Xero identifiers.</p>
-          </div>
-        </header>
-        <form action="/admin/companies" method="post" class="form" autocomplete="off">
-          <div class="form-field">
-            <label class="form-label" for="company-name">Company name</label>
-            <input id="company-name" name="name" class="form-input" required maxlength="255" />
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="company-syncro">Syncro company ID</label>
-            <input id="company-syncro" name="syncroCompanyId" class="form-input" maxlength="255" />
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="company-xero">Xero ID</label>
-            <input id="company-xero" name="xeroId" class="form-input" maxlength="255" />
-          </div>
-          <div class="form-field form-field--checkbox">
-            <label class="checkbox" for="company-vip">
-              <input id="company-vip" type="checkbox" name="isVip" value="1" />
-              <span>VIP pricing</span>
-            </label>
-          </div>
-          <div class="form-actions">
-            <button type="submit" class="button">Create company</button>
-          </div>
-        </form>
-      </section>
-
-      <section class="card card--panel">
-        <header class="card__header card__header--stacked">
-          <div>
+          <div class="stacked">
             <h2 class="card__title">Companies</h2>
             <p class="card__subtitle">Update identifiers and VIP status for existing customers.</p>
           </div>
-          <input
-            type="search"
-            class="form-input"
-            placeholder="Filter companies"
-            aria-label="Filter companies"
-            data-table-filter="companies-table"
-          />
+          <div class="card__controls">
+            <input
+              type="search"
+              class="form-input card__control"
+              placeholder="Filter companies"
+              aria-label="Filter companies"
+              data-table-filter="companies-table"
+            />
+            <button
+              type="button"
+              class="button"
+              data-add-company-modal-open
+              aria-haspopup="dialog"
+              aria-controls="add-company-modal"
+            >
+              Add Company
+            </button>
+          </div>
         </header>
         <div class="table-wrapper">
           <table class="table" id="companies-table" data-table>
@@ -139,119 +109,48 @@
           </table>
         </div>
       </section>
-    {% endif %}
-
-    <section class="card card--panel">
-      <header class="card__header">
-        <div>
-          <h2 class="card__title">User provisioning</h2>
-          <p class="card__subtitle">Create or invite users with access to the selected company.</p>
-        </div>
-      </header>
-      <div class="stacked" style="gap: 2rem;">
-        <form action="/admin/companies/users/create" method="post" class="form" autocomplete="off">
-          <h3 class="form-title">Create user with chosen password</h3>
-          {% if is_super_admin %}
+      <div
+        class="modal"
+        id="add-company-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-company-title"
+        aria-hidden="true"
+        hidden
+      >
+        <div class="modal__content" role="document">
+          <button type="button" class="modal__close" data-modal-close>
+            <span class="visually-hidden">Close add company form</span>
+            &times;
+          </button>
+          <h2 class="modal__title" id="add-company-title">Add a company</h2>
+          <p class="modal__subtitle">Create a new customer record with optional Syncro and Xero identifiers.</p>
+          <form action="/admin/companies" method="post" class="form" autocomplete="off">
             <div class="form-field">
-              <label class="form-label" for="create-company">Company</label>
-              <select id="create-company" name="companyId" class="form-input" required>
-                <option value="">Select company</option>
-                {% for company in managed_companies %}
-                  <option value="{{ company.id }}" {% if company.id == selected_company_id %}selected{% endif %}>
-                    {{ company.name }}
-                  </option>
-                {% endfor %}
-              </select>
-            </div>
-          {% else %}
-            <input type="hidden" name="companyId" value="{{ selected_company_id or '' }}" />
-          {% endif %}
-          <div class="form-field">
-            <label class="form-label" for="create-email">Email address</label>
-            <input id="create-email" name="email" type="email" class="form-input" required maxlength="255" />
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="create-password">Temporary password</label>
-            <input id="create-password" name="password" type="password" class="form-input" required minlength="8" maxlength="255" />
-            <p class="form-help">Users are required to change this password on first login.</p>
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="create-first-name">First name</label>
-            <input id="create-first-name" name="firstName" class="form-input" maxlength="255" />
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="create-last-name">Last name</label>
-            <input id="create-last-name" name="lastName" class="form-input" maxlength="255" />
-          </div>
-          <div class="form-actions">
-            <button type="submit" class="button">Create user</button>
-          </div>
-        </form>
-
-        <form action="/admin/companies/users/invite" method="post" class="form" autocomplete="off">
-          <h3 class="form-title">Invite user with generated password</h3>
-          {% if is_super_admin %}
-            <div class="form-field">
-              <label class="form-label" for="invite-company">Company</label>
-              <select id="invite-company" name="companyId" class="form-input" required>
-                <option value="">Select company</option>
-                {% for company in managed_companies %}
-                  <option value="{{ company.id }}" {% if company.id == selected_company_id %}selected{% endif %}>
-                    {{ company.name }}
-                  </option>
-                {% endfor %}
-              </select>
-            </div>
-          {% else %}
-            <input type="hidden" name="companyId" value="{{ selected_company_id or '' }}" />
-          {% endif %}
-          <div class="form-field">
-            <label class="form-label" for="invite-email">Email address</label>
-            <input id="invite-email" name="email" type="email" class="form-input" required maxlength="255" />
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="invite-first-name">First name</label>
-            <input id="invite-first-name" name="firstName" class="form-input" maxlength="255" />
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="invite-last-name">Last name</label>
-            <input id="invite-last-name" name="lastName" class="form-input" maxlength="255" />
-          </div>
-          <div class="form-actions">
-            <button type="submit" class="button">Generate invitation</button>
-          </div>
-        </form>
-
-        {% if is_super_admin %}
-          <form action="/admin/companies/assign" method="post" class="form" autocomplete="off">
-            <h3 class="form-title">Assign existing user</h3>
-            <div class="form-field">
-              <label class="form-label" for="assign-user">User</label>
-              <select id="assign-user" name="userId" class="form-input" required>
-                <option value="">Select user</option>
-                {% for user_option in user_options %}
-                  <option value="{{ user_option.id }}">{{ user_option.email }}</option>
-                {% endfor %}
-              </select>
+              <label class="form-label" for="company-name">Company name</label>
+              <input id="company-name" name="name" class="form-input" required maxlength="255" />
             </div>
             <div class="form-field">
-              <label class="form-label" for="assign-company">Company</label>
-              <select id="assign-company" name="companyId" class="form-input" required>
-                <option value="">Select company</option>
-                {% for company in managed_companies %}
-                  <option value="{{ company.id }}" {% if company.id == selected_company_id %}selected{% endif %}>
-                    {{ company.name }}
-                  </option>
-                {% endfor %}
-              </select>
+              <label class="form-label" for="company-syncro">Syncro company ID</label>
+              <input id="company-syncro" name="syncroCompanyId" class="form-input" maxlength="255" />
+            </div>
+            <div class="form-field">
+              <label class="form-label" for="company-xero">Xero ID</label>
+              <input id="company-xero" name="xeroId" class="form-input" maxlength="255" />
+            </div>
+            <div class="form-field form-field--checkbox">
+              <label class="checkbox" for="company-vip">
+                <input id="company-vip" type="checkbox" name="isVip" value="1" />
+                <span>VIP pricing</span>
+              </label>
             </div>
             <div class="form-actions">
-              <button type="submit" class="button">Assign user</button>
+              <button type="submit" class="button">Create company</button>
             </div>
           </form>
-        {% endif %}
+        </div>
       </div>
-    </section>
+    {% endif %}
 
     <section class="card card--panel admin-grid__full">
       <header class="card__header card__header--stacked">

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-09, 11:16 UTC, Change, Moved company creation into a modal trigger on the Companies dashboard and removed legacy user provisioning forms
 - 2025-10-16, 09:55 UTC, Fix, Restored Syncro asset scheduled sync with importer service and repository upsert handling
 - 2025-10-16, 08:45 UTC, Fix, Added a secure system update scheduler handler that runs update.sh with locking and output auditing
 - 2025-10-09, 06:01 UTC, Fix, Seeded the MyPortal System Update scheduled task so the automation runs on its daily cron


### PR DESCRIPTION
## Summary
- move the company creation form into a modal launched from the Companies table header
- remove the user provisioning flows from the companies administration template
- add modal wiring in the admin script and log the dashboard change in the changelog

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e798b52b24832da4a339cb42094627