### PR TITLE
Expand API credentials card to full width

### DIFF
--- a/app/templates/admin/api_keys.html
+++ b/app/templates/admin/api_keys.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="admin-grid admin-grid--columns">
-  <section class="card card--panel">
+  <section class="card card--panel admin-grid__full">
     <header class="card__header card__header--stacked">
       <div>
         <h2 class="card__title">API credentials</h2>

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-09, 11:25 UTC, Fix, Expanded the API credentials administration card to full width for improved visibility
 - 2025-10-17, 08:15 UTC, Fix, Positioned the cross-service audit correlations card below API credentials for consistent admin layout
 - 2025-10-09, 11:16 UTC, Change, Moved company creation into a modal trigger on the Companies dashboard and removed legacy user provisioning forms
 - 2025-10-16, 09:55 UTC, Fix, Restored Syncro asset scheduled sync with importer service and repository upsert handling


### PR DESCRIPTION
## Summary
- expand the API credentials administration panel to span the full admin grid width for consistent layout
- record the layout update in the change log

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e79b6b6d1c832d970a4afd481c26e5