### PR TITLE
Expand companies admin card to full width

### DIFF
--- a/app/templates/admin/companies.html
+++ b/app/templates/admin/companies.html
@@ -14,7 +14,7 @@
 
   <div class="admin-grid admin-grid--columns">
     {% if is_super_admin %}
-      <section class="card card--panel">
+      <section class="card card--panel admin-grid__full">
         <header class="card__header">
           <div class="stacked">
             <h2 class="card__title">Companies</h2>

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-09, 11:34 UTC, Fix, Expanded the Companies administration card to occupy the full grid width for consistent layout
 - 2025-10-09, 11:28 UTC, Fix, Expanded the Companies dashboard card to span the full grid width for clearer management access
 - 2025-10-09, 11:21 UTC, Fix, Restored scheduled task modals by eagerly binding UI handlers and reading CSRF tokens from meta fallback
 - 2025-10-09, 11:25 UTC, Fix, Expanded the API credentials administration card to full width for improved visibility


### PR DESCRIPTION
## Summary
- expand the Companies management card on the admin companies page to span the full grid width for consistent layout spacing
- record the layout adjustment in the change log

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000 *(fails: missing required environment configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68e79da0271c832da5c96723e75b7fb8