### PR TITLE
Remove SKU column from software licenses table

### DIFF
--- a/app/templates/licenses/index.html
+++ b/app/templates/licenses/index.html
@@ -30,7 +30,6 @@
         <thead>
           <tr>
             <th scope="col" data-sort-key="display_name">Name</th>
-            <th scope="col" data-sort-key="platform">SKU</th>
             <th scope="col" data-sort-key="count">Total</th>
             <th scope="col" data-sort-key="allocated">Allocated</th>
             <th scope="col" data-sort-key="expiry_display">Expiry</th>
@@ -42,7 +41,6 @@
           {% for license in licenses %}
           <tr>
             <td data-column="display_name" data-value="{{ license.display_name or license.name }}">{{ license.display_name or license.name }}</td>
-            <td data-column="platform" data-value="{{ license.platform }}">{{ license.platform }}</td>
             <td data-column="count" data-value="{{ license.count }}">{{ license.count }}</td>
             <td data-column="allocated" data-value="{{ license.allocated }}">
               <button type="button" class="link" data-license-allocated="{{ license.id }}">{{ license.allocated }}</button>
@@ -60,7 +58,7 @@
           </tr>
           {% else %}
           <tr>
-            <td colspan="{% if can_order_licenses %}7{% else %}6{% endif %}" class="text-center">No licenses recorded for this company yet.</td>
+            <td colspan="{% if can_order_licenses %}6{% else %}5{% endif %}" class="text-center">No licenses recorded for this company yet.</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/changes.md
+++ b/changes.md
@@ -104,3 +104,4 @@
 - 2025-10-10, 12:45 UTC, Fix, Corrected scheduler monitoring migration defaults and enforced UTC MySQL sessions to restore startup
 - 2025-10-09, 05:40 UTC, Fix, Restored admin API key dashboard by aligning API key usage queries with ONLY_FULL_GROUP_BY SQL mode to prevent runtime errors
 - 2025-10-09, 11:09 UTC, Feature, Moved scheduler editing into modal workflows, added per-task run history popups, and created a dedicated webhook delivery monitoring page
+- 2025-10-09, 11:36 UTC, Fix, Removed the SKU column from the software licenses table to simplify the display per request


### PR DESCRIPTION
## Summary
- remove the SKU column from the software licenses table and adjust the empty state colspan
- log the change in the running change log

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_b_68e79e2c6870832da034fdc1988ab3e5