### PR TITLE
Remove Syncro import from staff page and widen add form

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-18, 09:00 UTC, Fix, Removed Syncro import controls from the Staff page and expanded the Add Staff form to full width for better usability
 - 2025-10-17, 12:30 UTC, Fix, Added a global form confirmation handler and removed the missing forms_admin.js reference to resolve admin script 404s
 - 2025-10-09, 11:31 UTC, Change, Retired the /admin/memberships page and synced company assignments with active company membership records
 - 2025-10-09, 11:34 UTC, Fix, Expanded the Companies administration card to occupy the full grid width for consistent layout

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -179,6 +179,29 @@ table th {
   overflow-x: auto;
 }
 
+#add-staff-section {
+  width: 100%;
+}
+
+#add-staff-section form {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+#add-staff-section form input,
+#add-staff-section form select,
+#add-staff-section form button {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+#add-staff-section form label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .page-header {
   display: flex;
   justify-content: space-between;

--- a/src/views/staff.ejs
+++ b/src/views/staff.ejs
@@ -6,14 +6,8 @@
     <%- include('partials/sidebar') %>
     <div class="content">
       <h1>Staff</h1>
-      <% if (isSuperAdmin && syncroCompanyId) { %>
-      <section>
-        <h2>Import from Syncro</h2>
-        <button id="import-syncro-btn">Import Contacts</button>
-      </section>
-      <% } %>
       <% if (isAdmin) { %>
-      <section>
+      <section id="add-staff-section">
         <h2>Add Staff</h2>
         <form action="/staff" method="post">
           <%- include('partials/csrf-field') %>
@@ -185,7 +179,6 @@
   <script>
     const isSuperAdmin = <%- JSON.stringify(isSuperAdmin) %>;
     const isAdmin = <%- JSON.stringify(isAdmin) %>;
-    const syncroCompanyId = <%- JSON.stringify(syncroCompanyId) %>;
     const editModal = document.getElementById('edit-modal');
     const editForm = document.getElementById('edit-form');
     let editingId = null;
@@ -250,24 +243,6 @@
       });
     });
     <% } %>
-
-    const importBtn = document.getElementById('import-syncro-btn');
-    if (importBtn && syncroCompanyId) {
-      importBtn.addEventListener('click', async function() {
-        if (!confirm('Import contacts from Syncro?')) return;
-        const res = await fetch('/admin/syncro/import-contacts', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ syncroCompanyId })
-        });
-        if (res.ok) {
-          location.reload();
-        } else {
-          const text = await res.text();
-          alert(text || 'Failed to import contacts');
-        }
-      });
-    }
 
     document.querySelectorAll('.invite-btn').forEach(function(btn) {
       btn.addEventListener('click', async function() {


### PR DESCRIPTION
## Summary
- remove the Syncro import section from the staff management view
- stretch the Add Staff form to the full content width with new layout styling
- log the layout adjustment in the change history

## Testing
- npm run dev *(fails: existing TypeScript session typings errors in src/server.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68e7a017ec68832d898053d6ba169c9a