### PR TITLE
Ensure system upgrade uses virtualenv

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-19, 08:30 UTC, Fix, Ensured the system upgrade automation reuses the managed virtual environment before reinstalling dependencies
 - 2025-10-18, 11:30 UTC, Fix, Restored the Orders navigation link by initialising membership context before evaluating shop permissions in the base template
 - 2025-10-19, 07:15 UTC, Fix, Routed the system update scheduler task through scripts/upgrade.sh for consistent upgrade automation
 - 2025-10-09, 12:17 UTC, Feature, Introduced a notifications dashboard with filtering, sorting, and read-state tracking across the UI and API

--- a/tests/test_upgrade_script.py
+++ b/tests/test_upgrade_script.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_upgrade_script_prefers_project_virtualenv():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "upgrade.sh"
+    contents = script_path.read_text()
+    assert 'VENV_DIR="${PROJECT_ROOT}/.venv"' in contents
+    assert '"${VENV_DIR}/bin/python"' in contents
+    assert '"${VENV_DIR}/Scripts/python.exe"' in contents
+    assert '"$PYTHON_BIN" -m pip install -e "$PROJECT_ROOT"' in contents
+    assert 'command -v python3' in contents and 'command -v python' in contents


### PR DESCRIPTION
## Summary
- ensure scripts/upgrade.sh installs dependencies with the project's managed virtual environment when available
- add a regression test that asserts the upgrade script favors the virtualenv and keeps system fallbacks guarded
- document the fix in changes.md for release tracking

## Testing
- pytest tests/test_upgrade_script.py

------
https://chatgpt.com/codex/tasks/task_b_68e7aa7ba27c832db553abb0636c604f