### PR TITLE
Ensure upgrade automation locates python3 interpreter

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,5 @@
 # Change Log
+- 2025-10-19, 09:45 UTC, Fix, Hardened upgrade automation to locate python3 when python is absent so system updates no longer fail
 - 2025-10-19, 08:30 UTC, Fix, Ensured the system upgrade automation reuses the managed virtual environment before reinstalling dependencies
 - 2025-10-18, 11:30 UTC, Fix, Restored the Orders navigation link by initialising membership context before evaluating shop permissions in the base template
 - 2025-10-19, 07:15 UTC, Fix, Routed the system update scheduler task through scripts/upgrade.sh for consistent upgrade automation


### PR DESCRIPTION
## Summary
- detect the appropriate Python interpreter before running upgrade automation, preferring the managed virtualenv
- reuse the detected interpreter for .env credential parsing and dependency installation fallbacks
- document the system update fix in the change log

## Testing
- bash -n scripts/upgrade.sh

------
https://chatgpt.com/codex/tasks/task_b_68e7ac8830a8832d8449591935202972