### PR TITLE
Handle permission errors during system update cleanup

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -127,3 +127,4 @@
 - 2025-10-09, 05:40 UTC, Fix, Restored admin API key dashboard by aligning API key usage queries with ONLY_FULL_GROUP_BY SQL mode to prevent runtime errors
 - 2025-10-09, 11:09 UTC, Feature, Moved scheduler editing into modal workflows, added per-task run history popups, and created a dedicated webhook delivery monitoring page
 - 2025-10-09, 11:36 UTC, Fix, Removed the SKU column from the software licenses table to simplify the display per request
+- 2025-10-09, 12:53 UTC, Fix, Hardened system update cleanup to skip inaccessible user site-packages paths and avoid permission failures


### PR DESCRIPTION
## Summary
- skip inaccessible site-packages directories when cleaning stale myportal distributions to prevent permission failures
- log the hardening work in the project change log

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e7b02c84cc832db8f4c891f8d9c065