### PR TITLE
Add viewport-aware pagination to webhook queue

### DIFF
--- a/app/templates/admin/webhooks.html
+++ b/app/templates/admin/webhooks.html
@@ -75,6 +75,26 @@
       </tbody>
     </table>
   </div>
+  <div class="table-pagination" data-pagination="webhooks-table">
+    <div class="table-pagination__group">
+      <button
+        type="button"
+        class="button button--ghost table-pagination__button"
+        data-page-prev
+        disabled
+      >
+        Previous
+      </button>
+      <button
+        type="button"
+        class="button button--ghost table-pagination__button"
+        data-page-next
+      >
+        Next
+      </button>
+    </div>
+    <p class="table-pagination__status" data-page-info aria-live="polite"></p>
+  </div>
 </section>
 
 <div class="modal" id="webhook-attempts-modal" role="dialog" aria-modal="true" hidden>

--- a/changes.md
+++ b/changes.md
@@ -134,3 +134,4 @@
 - 2025-10-09, 11:09 UTC, Feature, Moved scheduler editing into modal workflows, added per-task run history popups, and created a dedicated webhook delivery monitoring page
 - 2025-10-09, 11:36 UTC, Fix, Removed the SKU column from the software licenses table to simplify the display per request
 - 2025-10-09, 12:53 UTC, Fix, Hardened system update cleanup to skip inaccessible user site-packages paths and avoid permission failures
+- 2025-10-09, 13:15 UTC, Feature, Added viewport-aware pagination controls to the webhook delivery queue for responsive monitoring


### PR DESCRIPTION
## Summary
- add pagination controls to the admin webhook delivery table so the existing table controller can size pages to the viewport
- record the feature addition in the project change log

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e7b518bdb8832d830650bf7dc99bcd