### PR TITLE
Adjust modal popups to 75% viewport size

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1834,8 +1834,10 @@ body {
   border-radius: 1rem;
   padding: 2rem;
   position: relative;
-  width: min(640px, 90vw);
-  max-height: 90vh;
+  width: 75vw;
+  max-width: 75vw;
+  height: 75vh;
+  max-height: 75vh;
   overflow-y: auto;
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 24px 50px -20px rgba(15, 23, 42, 0.85);

--- a/changes.md
+++ b/changes.md
@@ -145,3 +145,4 @@
 - 2025-10-09, 11:36 UTC, Fix, Removed the SKU column from the software licenses table to simplify the display per request
 - 2025-10-09, 12:53 UTC, Fix, Hardened system update cleanup to skip inaccessible user site-packages paths and avoid permission failures
 - 2025-10-09, 13:15 UTC, Feature, Added viewport-aware pagination controls to the webhook delivery queue for responsive monitoring
+- 2025-10-09, 23:32 UTC, Fix, Resized all modal popups to occupy 75% of the viewport for consistent layout compliance

--- a/src/public/style.css
+++ b/src/public/style.css
@@ -689,6 +689,7 @@ table th {
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.5);
+  display: flex;
   align-items: center;
   justify-content: center;
 }
@@ -697,8 +698,11 @@ table th {
   background: #fff;
   padding: 1rem;
   border-radius: 8px;
-  max-width: 400px;
-  width: 90%;
+  width: 75vw;
+  max-width: 75vw;
+  height: 75vh;
+  max-height: 75vh;
+  overflow-y: auto;
 }
 
 .modal-content form label {
@@ -734,7 +738,10 @@ table th {
 }
 
 #image-modal .modal-content {
-  max-width: 80%;
+  width: 75vw;
+  max-width: 75vw;
+  height: 75vh;
+  max-height: 75vh;
 }
 
 #image-modal img {
@@ -745,9 +752,10 @@ table th {
 }
 
 #details-modal .modal-content {
-  width: 60vw;
-  max-width: 60vw;
-  max-height: 95vh;
+  width: 75vw;
+  max-width: 75vw;
+  height: 75vh;
+  max-height: 75vh;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/views/admin.ejs
+++ b/src/views/admin.ejs
@@ -1217,7 +1217,7 @@
               }
             </script>
             <div id="editModal" class="modal" style="display:none;">
-              <div class="modal-content" style="width:300px;">
+              <div class="modal-content">
                 <h3>Edit Product</h3>
                 <form id="editForm" method="post" enctype="multipart/form-data">
                   <label for="edit-name">Name
@@ -1259,7 +1259,7 @@
               </div>
             </div>
             <div id="visibilityModal" class="modal" style="display:none;">
-              <div class="modal-content" style="width:300px;">
+              <div class="modal-content">
                 <h3>Product Visibility</h3>
                 <form id="visibilityForm" method="post">
                   <% allCompanies.forEach(function(c){ %>

--- a/src/views/shop-admin.ejs
+++ b/src/views/shop-admin.ejs
@@ -253,7 +253,7 @@
           }
         </script>
         <div id="editModal" class="modal" style="display:none;">
-          <div class="modal-content" style="width:300px;">
+          <div class="modal-content">
             <h3>Edit Product</h3>
             <form id="editForm" method="post" enctype="multipart/form-data">
               <%- include('partials/csrf-field') %>
@@ -296,7 +296,7 @@
           </div>
         </div>
         <div id="visibilityModal" class="modal" style="display:none;">
-          <div class="modal-content" style="width:300px;">
+          <div class="modal-content">
             <h3>Product Visibility</h3>
             <form id="visibilityForm" method="post">
               <%- include('partials/csrf-field') %>


### PR DESCRIPTION
## Summary
- size modern modal components to 75% of the viewport for consistent popup dimensions
- update legacy modal styles and remove inline widths so all popups follow the shared sizing rule
- document the UI adjustment in the changelog

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_b_68e845bb025c832d8c99118debcd0b4b