### PR TITLE
Exclude high-capacity licenses from dashboard totals

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-10, 00:10 UTC, Fix, Excluded high-capacity licenses (>=10000) from dashboard metrics so totals reflect countable seats
 - 2025-10-09, 23:26 UTC, Fix, Added stock_feed.xml to .gitignore so generated stock feeds stay out of version control
 - 2025-10-09, 13:18 UTC, Fix, Allowed Run Now scheduled tasks to execute in the background without redirecting to the update progress message
 - 2025-10-09, 13:14 UTC, Feature, Added viewport-aware pagination to the software licenses table so row counts follow the available space


### PR DESCRIPTION
## Summary
- ignore licenses with seat counts of 10000 or more when computing dashboard license totals
- surface a note when high-capacity licenses are excluded so admins know why totals changed
- record the update in the changelog

## Testing
- pytest tests/test_company_memberships.py

------
https://chatgpt.com/codex/tasks/task_b_68e84e5378d0832d9a1d2a836da46c40