### PR TITLE
chore: remove lingering node references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MyPortal
 
-MyPortal is now a Python-first customer portal built with FastAPI, async MySQL access, and Jinja-powered views. The application retains parity with the prior TypeScript experience while embracing a modern Python architecture that is easier to extend, test, and deploy.
+MyPortal is now a Python-first customer portal built with FastAPI, async MySQL access, and Jinja-powered views. The application retains parity with the previous portal experience while embracing a modern Python architecture that is easier to extend, test, and deploy.
 
 There are no default login credentials; the first visit will prompt you to register the initial super administrator. If no user records exist the login flow transparently redirects to the registration screen.
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -11,8 +11,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Application configuration loaded from environment variables.
 
-    This configuration mirrors the semantics of the legacy Node.js implementation
-    while providing strongly-typed access for the new Python stack.
+    The settings preserve the existing environment variable semantics from prior
+    deployments while providing strongly-typed access for the Python stack.
     """
 
     app_name: str = "MyPortal"

--- a/app/main.py
+++ b/app/main.py
@@ -172,8 +172,8 @@ app.add_middleware(CSRFMiddleware)
 
 templates = Jinja2Templates(directory=str(templates_config.template_path))
 
-# Ensure document uploads remain web-accessible with the same paths used by the
-# legacy Node.js implementation.  Product images continue to live in the
+# Ensure document uploads remain web-accessible using the same paths as the
+# previous portal stack.  Product images continue to live in the
 # private ``/uploads`` directory which requires authentication before access.
 _uploads_path = templates_config.static_path / "uploads"
 _uploads_path.mkdir(parents=True, exist_ok=True)

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-10, 02:50 UTC, Fix, Removed remaining Node.js references from documentation and configuration comments to reflect the Python-only stack
 - 2025-10-10, 02:28 UTC, Change, Retired the legacy Node.js/TypeScript codebase and tooling so only the FastAPI stack remains
 - 2025-10-10, 00:10 UTC, Fix, Excluded high-capacity licenses (>=10000) from dashboard metrics so totals reflect countable seats
 - 2025-10-09, 23:26 UTC, Fix, Added stock_feed.xml to .gitignore so generated stock feeds stay out of version control

--- a/docs/node-parity-gap.md
+++ b/docs/node-parity-gap.md
@@ -14,5 +14,6 @@ MyPortal is now a Python-first portal that ships exclusively with the FastAPI im
 
 - Development now relies on the Python toolchain outlined in the README and the virtual environment bootstrap script; Node tooling such as `npm install` and `tsc` are no longer part of the workflow.【F:README.md†L91-L112】【F:scripts/bootstrap_venv.py†L1-L120】
 - Database migrations continue to run automatically at startup, and API documentation remains available through the integrated Swagger UI that documents every CRUD endpoint.【F:README.md†L107-L114】【F:app/main.py†L35-L151】
+- Remaining references to the Node.js stack within code comments and configuration docstrings have been retired so the repository messaging reflects the Python-only deployment.【F:app/core/config.py†L12-L19】【F:app/main.py†L175-L182】
 
 The removal of the Node.js codebase eliminates duplication while retaining feature parity inside the Python application, reducing maintenance overhead and simplifying deployment.


### PR DESCRIPTION
## Summary
- reword the settings docstring and uploads comment to drop references to the retired Node.js stack
- adjust the README introduction and Node retirement notes so messaging reflects the Python-only deployment
- log the cleanup in changes.md for visibility

## Testing
- not run (documentation-only updates)


------
https://chatgpt.com/codex/tasks/task_b_68e873a48718832da141f003786d4bf4