### PR TITLE
Add shipping status notification default event

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ There are no default login credentials; the first visit will prompt you to regis
 - VIP pricing for companies with special product rates
 - Shop admin interface to archive products and view archived items
 - Order details include product image, SKU and description
+- Customisable shipping status notifications with per-channel delivery preferences
 - Port catalogue with searchable metadata, secure document uploads, and lifecycle tracking
 - Pricing workflow approvals with notification feed and audit-friendly status changes
 - Super administrators can publish portal alerts with the `/api/notifications` API for targeted or global announcements
@@ -62,7 +63,9 @@ Each user can tailor how those events are delivered from `/notifications/setting
 or programmatically through `GET`/`PUT /api/notifications/preferences`. The
 preferences API returns the merged catalogue of known event types and delivery
 channels (in-app feed, email, SMS) while updates persist the full set of
-choices in a single request.
+choices in a single request. Default events now include shipping status updates
+(`shop.shipping_status_updated`) so customers can follow fulfilment progress
+alongside billing, port, and webhook alerts.
 
 ## Template Variables for External Apps
 

--- a/app/core/notifications.py
+++ b/app/core/notifications.py
@@ -17,6 +17,7 @@ DEFAULT_NOTIFICATION_EVENT_TYPES: list[str] = [
     "port.pricing.rejected",
     "shop.order_submitted",
     "shop.order_cancelled",
+    "shop.shipping_status_updated",
     "webhook.failed",
     "webhook.retried",
 ]

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-15, 11:59 UTC, Feature, Added shipping status notification event defaults so users can subscribe to fulfilment updates across UI and API
 - 2025-10-10, 03:54 UTC, Fix, Removed the five item page cap from the shop catalogue so pagination now follows viewport measurements
 - 2025-10-22, 09:30 UTC, Feature, Added configurable notification delivery settings with API-backed preferences, UI controls, and persistence tests
 - 2025-10-10, 03:37 UTC, Fix, Compacted portal spacing with reusable 5px+ padding variables so the UI stays dense yet readable

--- a/tests/test_notifications_api.py
+++ b/tests/test_notifications_api.py
@@ -173,6 +173,7 @@ def test_list_notification_preferences_merges_defaults(monkeypatch, active_sessi
     data = response.json()
     assert any(item["event_type"] == "general" for item in data)
     assert any(item["event_type"] == "custom.event" for item in data)
+    assert any(item["event_type"] == "shop.shipping_status_updated" for item in data)
 
 
 def test_update_notification_preferences_persists_changes(monkeypatch, active_session):


### PR DESCRIPTION
## Summary
- add the `shop.shipping_status_updated` event to the default notification catalogue so users can opt into shipping alerts immediately
- document the new shipping notification capability in the README and record the feature in the change log
- extend the notification preferences API test coverage to expect the shipping status event in the default set

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ef8bf23760832d9de4cea8d4b674cf