### PR TITLE
Remove super admin sidebar heading

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -72,7 +72,6 @@
           </li>
           {% if is_super_admin %}
             <li class="menu__divider" role="presentation"></li>
-            <li class="menu__heading" role="presentation">Super admin</li>
             <li class="menu__item">
               <a href="/shop" {% if current_path.startswith('/shop') and not current_path.startswith('/admin/shop') %}aria-current="page"{% endif %}>
                 <span class="menu__icon" aria-hidden="true">

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-11-24, 10:00 UTC, Fix, Removed the Super admin sidebar heading to keep navigation compact for privileged users
 - 2025-10-31, 09:15 UTC, Feature, Added super-admin controls to grant or block company admin access to shop, cart, order, and form sections
 - 2025-10-15, 12:55 UTC, Fix, Hardened system update automation to use a writable Git config home and tolerate missing service restart permissions
 - 2025-10-15, 12:53 UTC, Fix, Restored the full super admin sidebar with shop, cart, orders, forms, assets, licenses, invoices, and staff links


### PR DESCRIPTION
## Summary
- remove the redundant "Super admin" heading from the sidebar template so the menu divider immediately precedes the links
- record the navigation tweak in the change log with a Fix entry dated 2025-11-24

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ef9b885eb8832d91c7a2bc386cc4e9