### PR TITLE
Document roles administration menu guidance

### DIFF
--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -104,6 +104,64 @@
       <p class="form-hint">System roles cannot be deleted and their names are fixed to retain portal integrity.</p>
     </form>
   </section>
+
+  <section class="card card--panel">
+    <header class="card__header">
+      <div>
+        <h2 class="card__title">Roles administration menu</h2>
+        <p class="card__subtitle">Understand how the administration menu supports secure, least-privilege access control.</p>
+      </div>
+    </header>
+    <div class="card__body card__body--stacked">
+      <p>
+        The Roles administration menu is the central hub for defining reusable permission sets that can be applied to any
+        company membership. Super administrators can review every existing role in the table above, inspect its granted
+        permissions, and revoke obsolete definitions while retaining system-protected defaults that safeguard mandatory
+        access policies.
+      </p>
+      <p>
+        When you open the menu from the navigation sidebar, two panels are always available: the catalogue of existing
+        roles and the management form for updates. Use the search filter to quickly locate a role, select <strong>Edit</strong>
+        to populate the form, and provide a comma-separated list of permission keys when creating or refining roles. All
+        changes take effect immediately across the portal to keep member privileges aligned with the latest security
+        requirements.
+      </p>
+      <p>
+        System roles are identified in the table and are intentionally immutable to preserve baseline security for
+        critical workflows. Custom roles, however, can be updated or deleted as your governance model evolves. Regularly
+        review the menu to confirm roles still match business needs, and document significant adjustments in your
+        compliance records.
+      </p>
+      <h3>Assignable permissions</h3>
+      <p>
+        Roles can draw from the following permission catalogue. Combine only the capabilities required for each persona to
+        maintain least-privilege access.
+      </p>
+      <dl class="definition-list">
+        <div class="definition-list__item">
+          <dt><code>company.manage</code></dt>
+          <dd>Grant authority to configure company profiles, contact details, and operational settings.</dd>
+        </div>
+        <div class="definition-list__item">
+          <dt><code>membership.manage</code></dt>
+          <dd>Allow administrators to invite, approve, suspend, or reassign company members.</dd>
+        </div>
+        <div class="definition-list__item">
+          <dt><code>billing.manage</code></dt>
+          <dd>Enable access to subscription, invoicing, and payment method management workflows.</dd>
+        </div>
+        <div class="definition-list__item">
+          <dt><code>audit.view</code></dt>
+          <dd>Provide read-only visibility into security and activity audit trails.</dd>
+        </div>
+        <div class="definition-list__item">
+          <dt><code>portal.access</code></dt>
+          <dd>Permit authenticated users to sign in and use the general portal experience.</dd>
+        </div>
+      </dl>
+      <p class="text-muted">New permissions will be documented here as they become available.</p>
+    </div>
+  </section>
 </div>
 {% endblock %}
 

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,5 @@
+- 2025-11-24, 10:45 UTC, Feature, Expanded role documentation with detailed permission descriptions on the Roles administration page
+- 2025-10-15, 13:09 UTC, Feature, Documented the Roles administration menu with guidance on secure privilege management
 - 2025-11-24, 10:00 UTC, Fix, Removed the Super admin sidebar heading to keep navigation compact for privileged users
 - 2025-10-31, 09:15 UTC, Feature, Added super-admin controls to grant or block company admin access to shop, cart, order, and form sections
 - 2025-10-15, 12:55 UTC, Fix, Hardened system update automation to use a writable Git config home and tolerate missing service restart permissions


### PR DESCRIPTION
## Summary
- extend the role management page with a guidance card that explains how to use the Roles administration menu securely, now including detailed descriptions for every assignable permission
- emphasise how super administrators manage reusable permission sets and immutable system roles
- record the update in the project change log

## Testing
- not run (UI-only content update)

------
https://chatgpt.com/codex/tasks/task_b_68ef9cbd162c832da0bca633516940e5