### PR TITLE
Fix company membership CSRF fallback

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -5,7 +5,16 @@
     return matches ? decodeURIComponent(matches[1]) : '';
   }
 
+  function getMetaContent(name) {
+    const meta = document.querySelector(`meta[name="${name}"]`);
+    return meta ? meta.getAttribute('content') || '' : '';
+  }
+
   function getCsrfToken() {
+    const metaToken = getMetaContent('csrf-token');
+    if (metaToken) {
+      return metaToken;
+    }
     return getCookie('myportal_session_csrf');
   }
 

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-15, 13:44 UTC, Fix, Allowed company membership permission toggles to send CSRF tokens from the page meta tag when the session cookie name is customised
 - 2025-10-15, 13:26 UTC, Fix, Prevented blank CSRF headers from blocking company membership saves when the session cookie name is customised
 - 2025-11-25, 11:00 UTC, Feature, Logged SMS notifications as webhook events so delivery follows monitored retry logic
 - 2025-10-15, 13:21 UTC, Fix, Restored shop admin category, product update, archive, and visibility endpoints with validation and logging


### PR DESCRIPTION
## Summary
- update the admin portal JavaScript to read the CSRF token from the page meta tag when the cookie name changes so company membership permission toggles persist
- record the fix in the change log

## Testing
- pytest tests/test_company_memberships.py

------
https://chatgpt.com/codex/tasks/task_b_68efa2be9724832d8360093d362bc360