### PR TITLE
Restore notification flows and expose summary/event-type APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ choices in a single request. Default events now include shipping status updates
 (`shop.shipping_status_updated`) so customers can follow fulfilment progress
 alongside billing, port, and webhook alerts.
 
+Supporting endpoints expose aggregated counts and merged event type catalogues
+for richer clients:
+
+- `GET /api/notifications/summary` – Returns the total notifications and unread
+  counts matching the supplied filters alongside the global unread tally.
+- `GET /api/notifications/event-types` – Provides the distinct notification
+  event types available to the authenticated user by combining defaults,
+  preferences, and recorded history.
+
 ## Template Variables for External Apps
 
 MyPortal exposes a curated set of template variables that can be embedded in

--- a/app/schemas/notifications.py
+++ b/app/schemas/notifications.py
@@ -53,3 +53,17 @@ class NotificationPreferenceUpdateRequest(BaseModel):
         max_length=100,
         description="Complete set of notification preferences to persist for the current user.",
     )
+
+
+class NotificationSummaryResponse(BaseModel):
+    total_count: int = Field(0, ge=0, description="Total notifications that match the supplied filters.")
+    filtered_unread_count: int = Field(
+        0,
+        ge=0,
+        description="Unread notifications that match the supplied filters.",
+    )
+    global_unread_count: int = Field(
+        0,
+        ge=0,
+        description="All unread notifications for the authenticated user regardless of filters.",
+    )

--- a/changes.md
+++ b/changes.md
@@ -169,3 +169,4 @@
 - 2025-10-09, 13:15 UTC, Feature, Added viewport-aware pagination controls to the webhook delivery queue for responsive monitoring
 - 2025-10-09, 23:30 UTC, Fix, Removed leftover patch markers from dashboard template to restore valid Jinja block structure
 - 2025-10-09, 23:32 UTC, Fix, Resized all modal popups to occupy 75% of the viewport for consistent layout compliance
+- 2025-10-10, 13:45 UTC, Fix, Restored notification API actions with summary counts, event-type catalogues, repository insert reliability, and UI refresh


### PR DESCRIPTION
## Summary
- add /api/notifications/summary and /api/notifications/event-types to surface counts and event catalogues for the active user
- harden notification inserts, refresh the UI badge via the summary endpoint, and update documentation and change log
- expand API and repository coverage with new tests for read, acknowledge, summary, and event-type flows

## Testing
- pytest tests/test_notifications_repository.py tests/test_notifications_api.py -q
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68efa1fc76fc832d9c547ced06e3c649