### PR TITLE
Fix admin.js modal handler syntax error

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -254,7 +254,14 @@
           }
         } catch (error) {
           alert(`Unable to remove membership: ${error.message}`);
+        } finally {
           button.disabled = false;
+        }
+      });
+    });
+
+  }
+
   function bindApiKeyCopyButtons() {
     document.querySelectorAll('[data-copy-api-key]').forEach((button) => {
       const value = button.getAttribute('data-copy-api-key');

--- a/changes.md
+++ b/changes.md
@@ -173,3 +173,4 @@
 - 2025-10-09, 23:30 UTC, Fix, Removed leftover patch markers from dashboard template to restore valid Jinja block structure
 - 2025-10-09, 23:32 UTC, Fix, Resized all modal popups to occupy 75% of the viewport for consistent layout compliance
 - 2025-10-10, 13:45 UTC, Fix, Restored notification API actions with summary counts, event-type catalogues, repository insert reliability, and UI refresh
+- 2025-10-15, 23:36 UTC, Fix, Restored admin membership removal handler closures to resolve admin.js syntax error


### PR DESCRIPTION
## Summary
- restore the missing closure in the admin membership removal handler to eliminate the Unexpected token runtime error
- ensure the remove member action always re-enables its trigger button after requests complete
- record the fix in the project changelog

## Testing
- not run (frontend-only change)


------
https://chatgpt.com/codex/tasks/task_b_68f02fad8e30832da991ffcc4281181f