### PR TITLE
Improve dashboard summary card spacing

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -616,14 +616,14 @@ body {
 }
 
 .summary-card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-gap-tight);
+  display: grid;
+  gap: clamp(var(--space-compact), 0.9vw, var(--space-gap-base));
   min-height: 100%;
+  align-content: start;
 }
 
 .summary-card--compact {
-  gap: var(--space-compact);
+  gap: clamp(var(--space-compact), 0.75vw, var(--space-gap-tight));
 }
 
 .summary-card__label {
@@ -637,12 +637,15 @@ body {
   font-size: 1.4rem;
   font-weight: 700;
   color: #f8fafc;
-  line-height: 1.3;
+  line-height: 1.4;
+  display: block;
 }
 
 .summary-card__meta {
   font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.7);
+  color: rgba(226, 232, 240, 0.72);
+  line-height: 1.45;
+  display: block;
 }
 
 .status-card {

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-15, 23:46 UTC, Fix, Prevented dashboard summary cards from overlapping their meta text by expanding spacing and line heights
 - 2025-10-15, 13:45 UTC, Fix, Restored sidebar company features for company admins when memberships grant access
 - 2025-11-26, 09:00 UTC, Fix, Expanded dashboard padding and responsive spacing so overview cards and status lists no longer overlap on compact screens
 - 2025-10-15, 13:44 UTC, Fix, Allowed company membership permission toggles to send CSRF tokens from the page meta tag when the session cookie name is customised


### PR DESCRIPTION
## Summary
- relax the dashboard summary card layout spacing so metric values and meta labels have room to breathe
- tweak summary card typography line heights to prevent overlap at compact widths
- log the dashboard spacing fix in the running change history

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f0316c1ad8832dbb3bbeab84a2bee8