### PR TITLE
Hide cart controls without permission

### DIFF
--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
 
 {% block header_actions %}
-  <a class="button button--ghost" href="/cart">
-    View cart{% if cart_summary.total_quantity %} ({{ cart_summary.total_quantity }}){% endif %}
-  </a>
+  {% if can_access_cart %}
+    <a class="button button--ghost" href="/cart">
+      View cart{% if cart_summary.total_quantity %} ({{ cart_summary.total_quantity }}){% endif %}
+    </a>
+  {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -107,21 +109,25 @@
                 <div class="table__action-buttons">
                   <button type="button" class="button button--ghost" data-product-details="{{ product.id }}">Details</button>
                   {% if product.stock > 0 %}
-                  <form action="/cart/add" method="post" class="inline-form">
-                      {% include "partials/csrf.html" %}
-                      <input type="hidden" name="productId" value="{{ product.id }}" />
-                      <label class="visually-hidden" for="quantity-{{ product.id }}">Quantity for {{ product.name }}</label>
-                      <input
-                        class="form-input form-input--sm"
-                        id="quantity-{{ product.id }}"
-                        type="number"
-                        name="quantity"
-                        min="1"
-                        max="{{ product.stock }}"
-                        value="1"
-                      />
-                      <button type="submit" class="button">Add to cart</button>
-                    </form>
+                    {% if can_access_cart %}
+                      <form action="/cart/add" method="post" class="inline-form">
+                        {% include "partials/csrf.html" %}
+                        <input type="hidden" name="productId" value="{{ product.id }}" />
+                        <label class="visually-hidden" for="quantity-{{ product.id }}">Quantity for {{ product.name }}</label>
+                        <input
+                          class="form-input form-input--sm"
+                          id="quantity-{{ product.id }}"
+                          type="number"
+                          name="quantity"
+                          min="1"
+                          max="{{ product.stock }}"
+                          value="1"
+                        />
+                        <button type="submit" class="button">Add to cart</button>
+                      </form>
+                    {% else %}
+                      <span class="badge badge--muted">Cart access required</span>
+                    {% endif %}
                   {% else %}
                     <span class="badge badge--muted">Out of stock</span>
                   {% endif %}

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-16, 00:08 UTC, Fix, Hid cart quantity and submission controls on the shop page when membership lacks cart permissions
 - 2025-10-15, 23:46 UTC, Fix, Prevented dashboard summary cards from overlapping their meta text by expanding spacing and line heights
 - 2025-10-15, 13:45 UTC, Fix, Restored sidebar company features for company admins when memberships grant access
 - 2025-11-26, 09:00 UTC, Fix, Expanded dashboard padding and responsive spacing so overview cards and status lists no longer overlap on compact screens


### PR DESCRIPTION
## Summary
- hide the shop page cart link and inline add-to-cart form when the user lacks cart permissions
- record the permission-gated cart UI change in the change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f0374668d0832db746c79c2004a41b