### PR TITLE
Embed module diagnostics within integration cards

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2257,6 +2257,10 @@ body {
   align-items: start;
 }
 
+.management--single {
+  grid-template-columns: 1fr;
+}
+
 @media (max-width: 960px) {
   .management {
     grid-template-columns: 1fr;
@@ -2337,6 +2341,58 @@ body {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 1.25rem;
+}
+
+.card__header--module {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.card__module-info {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.card__module-icon {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.card__module-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.card__module-actions .card__badge {
+  align-self: flex-end;
+}
+
+.card__module-test {
+  margin: 0;
+}
+
+.card__module-test .button {
+  white-space: nowrap;
+}
+
+@media (max-width: 720px) {
+  .card__header--module {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .card__module-actions {
+    align-items: stretch;
+  }
+
+  .card__module-actions .card__badge {
+    align-self: flex-start;
+  }
 }
 
 .management__stats {

--- a/app/templates/admin/modules.html
+++ b/app/templates/admin/modules.html
@@ -12,32 +12,7 @@
     </div>
   {% endif %}
 
-  <div class="management" data-layout>
-    <aside class="management__sidebar">
-      <h2 class="management__heading">Diagnostics</h2>
-      <p class="management__intro">Trigger self-tests to confirm connectivity for each integration module.</p>
-      <ul class="management__list" role="list">
-        {% for module in modules %}
-          <li class="management__list-item">
-            <form action="/admin/modules/{{ module.slug }}/test" method="post" class="management__test">
-              {% if csrf_token %}
-                <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-              {% endif %}
-              <div class="management__test-info">
-                <span class="management__test-icon" aria-hidden="true">{{ module.icon or '🔌' }}</span>
-                <div>
-                  <strong>{{ module.name }}</strong>
-                  <p class="management__test-description">{{ module.description }}</p>
-                  <p class="management__test-status">Status: {{ 'Enabled' if module.enabled else 'Disabled' }}</p>
-                </div>
-              </div>
-              <button type="submit" class="button button--ghost">Run test</button>
-            </form>
-          </li>
-        {% endfor %}
-      </ul>
-    </aside>
-
+  <div class="management management--single" data-layout>
     <section class="management__content">
       <header class="management__header">
         <div>
@@ -50,12 +25,23 @@
         {% for module in modules %}
           {% set settings = module.settings or {} %}
           <article class="card card--panel">
-            <header class="card__header">
-              <div>
-                <h2 class="card__title">{{ module.name }}</h2>
-                <p class="card__subtitle">{{ module.description }}</p>
+            <header class="card__header card__header--module">
+              <div class="card__module-info">
+                <span class="card__module-icon" aria-hidden="true">{{ module.icon or '🔌' }}</span>
+                <div>
+                  <h2 class="card__title">{{ module.name }}</h2>
+                  <p class="card__subtitle">{{ module.description }}</p>
+                </div>
               </div>
-              <span class="card__badge" aria-label="Module status">{{ 'Enabled' if module.enabled else 'Disabled' }}</span>
+              <div class="card__module-actions">
+                <span class="card__badge" aria-label="Module status">{{ 'Enabled' if module.enabled else 'Disabled' }}</span>
+                <form action="/admin/modules/{{ module.slug }}/test" method="post" class="card__module-test">
+                  {% if csrf_token %}
+                    <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                  {% endif %}
+                  <button type="submit" class="button button--ghost button--small">Run test</button>
+                </form>
+              </div>
             </header>
             <form action="/admin/modules/{{ module.slug }}" method="post" class="form card__form">
               {% if csrf_token %}

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-20, 07:49 UTC, Feature, Moved integration module diagnostics actions into each module card with inline testing controls and refreshed layout spacing
 - 2025-11-27, 11:00 UTC, Feature, Added admin navigation entries for tickets, ticket automations, and modules while retaining the scheduler automation tools
 - 2025-10-20, 06:59 UTC, Fix, Aligned ticketing migration key types with existing INT identifiers so startup migrations succeed on MySQL
 - 2025-10-20, 06:29 UTC, Fix, Guarded module catalog and automation schedule refresh when the database is offline so startup and tests proceed without MySQL


### PR DESCRIPTION
## Summary
- remove the diagnostics sidebar from the integration modules admin view and reposition the run test control inside each module card
- surface module icons with the card heading and provide inline status plus testing controls for each integration
- add responsive styling to support the new layout and ensure the cards expand to the full width of the management page

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f5e8e15a44832daa206569ed5c9d5f