### PR TITLE
Fix ticket creation to return inserted row

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -56,6 +56,15 @@ class Database:
             async with conn.cursor() as cursor:
                 await cursor.execute(sql, params)
 
+    async def execute_returning_lastrowid(
+        self, sql: str, params: tuple | dict | None = None
+    ) -> int:
+        async with self.acquire() as conn:
+            async with conn.cursor() as cursor:
+                await cursor.execute(sql, params)
+                last_row_id = cursor.lastrowid
+        return int(last_row_id) if last_row_id is not None else 0
+
     async def fetch_one(self, sql: str, params: tuple | dict | None = None):
         async with self.acquire() as conn:
             async with conn.cursor(aiomysql.DictCursor) as cursor:

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-20, 08:20 UTC, Fix, Ensured ticket creation reuses insert connections so watcher setup no longer triggers 500 errors
 - 2025-10-20, 07:49 UTC, Feature, Moved integration module diagnostics actions into each module card with inline testing controls and refreshed layout spacing
 - 2025-11-27, 11:00 UTC, Feature, Added admin navigation entries for tickets, ticket automations, and modules while retaining the scheduler automation tools
 - 2025-10-20, 06:59 UTC, Fix, Aligned ticketing migration key types with existing INT identifiers so startup migrations succeed on MySQL

--- a/tests/test_tickets_repository.py
+++ b/tests/test_tickets_repository.py
@@ -1,0 +1,134 @@
+import pytest
+
+from app.repositories import tickets
+
+
+class _DummyTicketDB:
+    def __init__(self, fetched_row):
+        self.insert_sql: str | None = None
+        self.insert_params: tuple | None = None
+        self.fetch_sql: str | None = None
+        self.fetch_params: tuple | None = None
+        self._fetched_row = fetched_row
+
+    async def execute_returning_lastrowid(self, sql, params):
+        self.insert_sql = sql.strip()
+        self.insert_params = params
+        return 42
+
+    async def fetch_one(self, sql, params):
+        self.fetch_sql = sql.strip()
+        self.fetch_params = params
+        return self._fetched_row
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_create_ticket_returns_inserted_record(monkeypatch):
+    fetched = {
+        "id": 42,
+        "company_id": None,
+        "requester_id": 7,
+        "assigned_user_id": None,
+        "subject": "Test Ticket",
+        "description": "Body",
+        "status": "open",
+        "priority": "normal",
+        "category": None,
+        "module_slug": None,
+        "external_reference": None,
+        "created_at": None,
+        "updated_at": None,
+        "closed_at": None,
+    }
+    dummy_db = _DummyTicketDB(fetched)
+    monkeypatch.setattr(tickets, "db", dummy_db)
+
+    record = await tickets.create_ticket(
+        subject="Test Ticket",
+        description="Body",
+        requester_id=7,
+        company_id=None,
+        assigned_user_id=None,
+        priority="normal",
+        status="open",
+        category=None,
+        module_slug=None,
+        external_reference=None,
+    )
+
+    assert record["id"] == 42
+    assert dummy_db.fetch_sql == "SELECT * FROM tickets WHERE id = %s"
+    assert dummy_db.fetch_params == (42,)
+
+
+@pytest.mark.anyio
+async def test_create_ticket_falls_back_when_fetch_missing(monkeypatch):
+    dummy_db = _DummyTicketDB(fetched_row=None)
+    monkeypatch.setattr(tickets, "db", dummy_db)
+
+    record = await tickets.create_ticket(
+        subject="Fallback",
+        description=None,
+        requester_id=None,
+        company_id=5,
+        assigned_user_id=11,
+        priority="urgent",
+        status="new",
+        category="support",
+        module_slug="tickets",
+        external_reference="ABC",
+    )
+
+    assert record["id"] == 42
+    assert record["company_id"] == 5
+    assert record["assigned_user_id"] == 11
+    assert record["priority"] == "urgent"
+
+
+@pytest.mark.anyio
+async def test_create_reply_returns_inserted_record(monkeypatch):
+    fetched = {
+        "id": 42,
+        "ticket_id": 3,
+        "author_id": 4,
+        "body": "Reply",
+        "is_internal": 0,
+        "created_at": None,
+    }
+    dummy_db = _DummyTicketDB(fetched)
+    monkeypatch.setattr(tickets, "db", dummy_db)
+
+    record = await tickets.create_reply(
+        ticket_id=3,
+        author_id=4,
+        body="Reply",
+        is_internal=False,
+    )
+
+    assert record["id"] == 42
+    assert dummy_db.fetch_sql == "SELECT * FROM ticket_replies WHERE id = %s"
+    assert dummy_db.fetch_params == (42,)
+
+
+@pytest.mark.anyio
+async def test_create_reply_falls_back_when_fetch_missing(monkeypatch):
+    dummy_db = _DummyTicketDB(fetched_row=None)
+    monkeypatch.setattr(tickets, "db", dummy_db)
+
+    record = await tickets.create_reply(
+        ticket_id=9,
+        author_id=None,
+        body="Internal",
+        is_internal=True,
+    )
+
+    assert record["id"] == 42
+    assert record["ticket_id"] == 9
+    assert record["author_id"] is None
+    assert record["body"] == "Internal"
+    assert record["is_internal"] == 1


### PR DESCRIPTION
## Summary
- add a database helper to return the last inserted id from insert statements
- update ticket and reply creation to reuse the inserted id before adding watchers
- add regression tests that cover missing fetch fallbacks and log the fix in the change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f5eb69e7fc832d95b584b23661228f