### PR TITLE
Add helpdesk technician permission for ticket administration

### DIFF
--- a/app/api/dependencies/auth.py
+++ b/app/api/dependencies/auth.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi import Depends, HTTPException, Request, status
 
+from app.repositories import company_memberships as membership_repo
 from app.repositories import users as user_repo
 from app.security.session import SessionData, session_manager
 
@@ -25,4 +26,24 @@ async def get_current_user(
 async def require_super_admin(current_user: dict = Depends(get_current_user)):
     if not current_user.get("is_super_admin"):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Super admin privileges required")
+    return current_user
+
+
+async def require_helpdesk_technician(current_user: dict = Depends(get_current_user)):
+    if current_user.get("is_super_admin"):
+        return current_user
+    user_id = current_user.get("id")
+    try:
+        user_id_int = int(user_id)
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Helpdesk technician privileges required",
+        ) from None
+    has_permission = await membership_repo.user_has_permission(user_id_int, "helpdesk.technician")
+    if not has_permission:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Helpdesk technician privileges required",
+        )
     return current_user

--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -158,6 +158,10 @@
           <dt><code>portal.access</code></dt>
           <dd>Permit authenticated users to sign in and use the general portal experience.</dd>
         </div>
+        <div class="definition-list__item">
+          <dt><code>helpdesk.technician</code></dt>
+          <dd>Grant designated staff access to the global ticketing workspace so they can triage, assign, and update tickets without broader administrative privileges.</dd>
+        </div>
       </dl>
       <p class="text-muted">New permissions will be documented here as they become available.</p>
     </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -207,6 +207,8 @@
                   <span class="menu__label">API keys</span>
                 </a>
               </li>
+            {% endif %}
+            {% if is_super_admin or is_helpdesk_technician %}
               <li class="menu__item">
                 <a href="/admin/tickets" {% if current_path.startswith('/admin/tickets') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">
@@ -215,6 +217,8 @@
                   <span class="menu__label">Tickets</span>
                 </a>
               </li>
+            {% endif %}
+            {% if is_super_admin %}
               <li class="menu__item">
                 <a href="/admin/automations" {% if current_path.startswith('/admin/automations') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-11-28, 09:30 UTC, Feature, Added helpdesk.technician role permission with constrained ticket workspace access for non-super-admin technicians
 - 2025-10-20, 08:07 UTC, Feature, Enabled public self-service registration with requester-scoped ticket access and public-only replies for non-admin users
 - 2025-10-20, 07:53 UTC, Feature, Replaced the integration module enable checkbox with a themed toggle switch for clearer status control
 - 2025-10-20, 08:20 UTC, Fix, Ensured ticket creation reuses insert connections so watcher setup no longer triggers 500 errors


### PR DESCRIPTION
## Summary
- add a helpdesk.technician permission lookup and API dependency so non-super-admin technicians can work tickets without elevated access
- update ticket admin routes and navigation to recognise helpdesk technicians while keeping other admin pages super-admin only
- expand ticket access regression tests and documentation to cover the new helpdesk role

## Testing
- pytest tests/test_ticket_access.py

------
https://chatgpt.com/codex/tasks/task_b_68f5f6e21e50832db5dfbee138b31292