### PR TITLE
Fix automation action builder initialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -376,15 +376,15 @@ async def _is_helpdesk_technician(user: Mapping[str, Any], request: Request | No
         result = False
     else:
         try:
-            result = await membership_repo.user_has_permission(user_id_int, "helpdesk.technician")
-        except Exception as exc:  # pragma: no cover - defensive fallback for tests without DB
+            result = await membership_repo.user_has_permission(
+                user_id_int, HELPDESK_PERMISSION_KEY
+            )
+        except RuntimeError as exc:  # pragma: no cover - triggered when DB pool is unavailable in tests
             log_error("Failed to determine helpdesk technician role", error=str(exc))
             result = False
-        except RuntimeError:
+        except Exception as exc:  # pragma: no cover - defensive fallback for unexpected errors
+            log_error("Failed to determine helpdesk technician role", error=str(exc))
             result = False
-        result = await membership_repo.user_has_permission(
-            user_id_int, HELPDESK_PERMISSION_KEY
-        )
     if request is not None:
         request.state.is_helpdesk_technician = bool(result)
     return bool(result)

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -141,7 +141,9 @@
     idField.value = task.id || '';
     nameField.value = task.name || '';
     commandField.value = task.command || '';
-    companyField.value = task.company_id || '';
+    if (companyField) {
+      companyField.value = task.company_id || '';
+    }
     cronField.value = task.cron || '';
     descriptionField.value = task.description || '';
     maxRetriesField.value =

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,5 @@
+- 2025-12-02, 14:32 UTC, Fix, Prevented duplicate membership permission lookups when deriving helpdesk technician access without a database pool
+- 2025-12-02, 14:30 UTC, Fix, Guarded optional task company field lookups in automation.js so action builders initialise on page load
 - 2025-12-01, 09:05 UTC, Fix, Ensured automation inserts reuse their connection so creation succeeds without 500 errors
 - 2025-12-01, 09:00 UTC, Feature, Added knowledge base module with scoped permissions, Ollama-backed search, and portal UI integration
 - 2025-10-21, 20:45 UTC, Fix, Converted automation module context data to JSON-safe timestamps so the ticket automation admin page renders without template errors


### PR DESCRIPTION
## Summary
- prevent optional company field from breaking automation action builder initialisation in the admin UI
- guard helpdesk technician permission checks against missing database pools so dashboards render during tests
- document both fixes in the change log

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68f611ac2308832db8f6167765046678