### PR TITLE
Improve system update restart reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,8 @@ ENABLE_CSRF=true
 SWAGGER_UI_URL=/docs
 OPNFORM_BASE_URL=
 FAIL2BAN_LOG_PATH=
+SYSTEMD_SERVICE_NAME=myportal
+APP_RESTART_COMMAND=
 
 # Integration modules (defaults can be overridden via admin UI)
 OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/changes.md
+++ b/changes.md
@@ -160,6 +160,7 @@
 - 2025-09-18, 08:30 UTC, Feature, Rebuilt the MyPortal backend and UI in Python with FastAPI, async MySQL access, and responsive 3-panel theming
 - 2025-09-18, 09:05 UTC, Fix, Replaced binary image assets with SVG icons to unblock PR creation and retain themeable layout
 - 2025-10-07, 11:53 UTC, Fix, Added a virtual environment bootstrap script and README guidance to bypass externally managed pip install failures
+- 2025-10-16, 09:45 UTC, Fix, Hardened the restart automation to respect environment overrides and fail fast when system updates cannot restart the service
 - 2025-10-07, 12:00 UTC, Fix, Allowed extra environment variables in Python settings loader to restore API startup
 - 2025-10-07, 12:10 UTC, Fix, Switched configuration fields to validation aliases so startup accepts secret and database env vars
 - 2025-10-07, 12:19 UTC, Feature, Added secure upgrade automation script for pulling updates and restarting services

--- a/docs/systemd-service.md
+++ b/docs/systemd-service.md
@@ -119,6 +119,19 @@ systemctl status myportal.service
 journalctl -u myportal.service -f
 ```
 
+If you run updates via `scripts/upgrade.sh` or the scheduler's `system_update`
+task, the restart helper honours two environment variables defined in
+`.env`:
+
+- `SYSTEMD_SERVICE_NAME` overrides the default `myportal` unit name.
+- `APP_RESTART_COMMAND` executes a custom restart command (for example,
+  `sudo systemctl restart myportal.service`) before falling back to the
+  standard `systemctl` invocations.
+
+When none of the restart strategies succeed, the helper now exits with a
+non-zero status so scheduled updates surface actionable errors instead of
+silently continuing without restarting the application.
+
 When deploying updates, pull the latest code, reinstall dependencies if
 needed, and reload the service:
 

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -5,6 +5,53 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
 VENV_DIR="${PROJECT_ROOT}/.venv"
 
+read_env_var() {
+  local key="$1"
+  local default_value="${2:-}"
+
+  if [[ -n "${!key:-}" ]]; then
+    printf '%s' "${!key}"
+    return
+  fi
+
+  if [[ -z "$PYTHON_BIN" || ! -f "${PROJECT_ROOT}/.env" ]]; then
+    printf '%s' "$default_value"
+    return
+  fi
+
+  local value
+  value=$(ENV_LOOKUP_KEY="$key" ENV_LOOKUP_DEFAULT="$default_value" PROJECT_ROOT="$PROJECT_ROOT" "$PYTHON_BIN" - <<'PY'
+import os
+from pathlib import Path
+
+key = os.environ["ENV_LOOKUP_KEY"]
+default = os.environ.get("ENV_LOOKUP_DEFAULT", "")
+env_path = Path(Path(os.environ["PROJECT_ROOT"]) / ".env")
+
+if not env_path.exists():
+    print(default)
+    raise SystemExit
+
+for raw_line in env_path.read_text().splitlines():
+    line = raw_line.strip()
+    if not line or line.startswith("#") or "=" not in line:
+        continue
+    name, value = line.split("=", 1)
+    if name.strip() != key:
+        continue
+    value = value.strip()
+    if value and len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        value = value[1:-1]
+    print(value)
+    break
+else:
+    print(default)
+PY
+  )
+
+  printf '%s' "$value"
+}
+
 cleanup_invalid_distribution() {
   local interpreter="$1"
   if [[ -z "$interpreter" ]]; then
@@ -104,38 +151,65 @@ cleanup_invalid_distribution "$PYTHON_BIN"
 "$PYTHON_BIN" -m pip install -e "$PROJECT_ROOT"
 
 restart_service() {
+  local custom_command
+  custom_command=$(read_env_var "APP_RESTART_COMMAND")
+
+  local service_name
+  service_name=$(read_env_var "SYSTEMD_SERVICE_NAME" "myportal")
   if ! command -v systemctl >/dev/null 2>&1; then
     echo "systemctl not available on this host; skipping service restart." >&2
-    return
+    return 0
   fi
 
-  local service_name="myportal.service"
+  if [[ -n "$service_name" && "${service_name}" != *.service ]]; then
+    service_name+=".service"
+  fi
+
   local attempts=()
+  local succeeded=0
 
-  if systemctl restart "$service_name" >/dev/null 2>&1; then
-    echo "Restarted ${service_name} via systemctl." >&2
-    return
-  else
-    local exit_code=$?
-    attempts+=("systemctl restart ${service_name} (exit ${exit_code})")
+  if [[ -n "$custom_command" ]]; then
+    if bash -lc "$custom_command" >/dev/null 2>&1; then
+      echo "Restarted service via custom command." >&2
+      succeeded=1
+    else
+      local exit_code=$?
+      attempts+=("custom command '${custom_command}' (exit ${exit_code})")
+    fi
   fi
 
-  if [[ "${EUID:-$(id -u)}" != "0" ]] && command -v sudo >/dev/null 2>&1; then
+  if (( ! succeeded )); then
+    if systemctl restart "$service_name" >/dev/null 2>&1; then
+      echo "Restarted ${service_name} via systemctl." >&2
+      succeeded=1
+    else
+      local exit_code=$?
+      attempts+=("systemctl restart ${service_name} (exit ${exit_code})")
+    fi
+  fi
+
+  if (( ! succeeded )) && [[ "${EUID:-$(id -u)}" != "0" ]] && command -v sudo >/dev/null 2>&1; then
     if sudo -n systemctl restart "$service_name" >/dev/null 2>&1; then
       echo "Restarted ${service_name} via sudo systemctl." >&2
-      return
+      succeeded=1
     else
       local exit_code=$?
       attempts+=("sudo -n systemctl restart ${service_name} (exit ${exit_code})")
     fi
   fi
 
-  if systemctl --user restart "$service_name" >/dev/null 2>&1; then
-    echo "Restarted ${service_name} via systemctl --user." >&2
-    return
-  else
-    local exit_code=$?
-    attempts+=("systemctl --user restart ${service_name} (exit ${exit_code})")
+  if (( ! succeeded )); then
+    if systemctl --user restart "$service_name" >/dev/null 2>&1; then
+      echo "Restarted ${service_name} via systemctl --user." >&2
+      succeeded=1
+    else
+      local exit_code=$?
+      attempts+=("systemctl --user restart ${service_name} (exit ${exit_code})")
+    fi
+  fi
+
+  if (( succeeded )); then
+    return 0
   fi
 
   echo "Warning: Unable to restart ${service_name} automatically." >&2
@@ -143,6 +217,7 @@ restart_service() {
     printf '  Tried: %s\n' "${attempts[@]}" >&2
   fi
   echo "Run 'sudo systemctl restart ${service_name}' or review service permissions and logs." >&2
+  return 1
 }
 
 restart_service


### PR DESCRIPTION
## Summary
- make the restart helper respect optional APP_RESTART_COMMAND and SYSTEMD_SERVICE_NAME overrides while failing fast when restarts do not succeed
- document the new restart options in the systemd deployment guide and expose them in the environment example file
- log the fix in the changelog for operational traceability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f612e8d25c832da9eea03c9fa4da85