### PR TITLE
Fix knowledge base admin JSON serialization error

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,7 @@ from fastapi import (
     UploadFile,
     status,
 )
+from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -4757,6 +4758,7 @@ async def admin_knowledge_base_page(request: Request):
         include_unpublished=True,
         include_permissions=True,
     )
+    serialised_articles = jsonable_encoder(articles)
 
     users_task = asyncio.create_task(user_repo.list_users())
     companies_task = asyncio.create_task(company_repo.list_companies())
@@ -4806,7 +4808,7 @@ async def admin_knowledge_base_page(request: Request):
 
     extra = {
         "title": "Knowledge base admin",
-        "kb_articles": articles,
+        "kb_articles": serialised_articles,
         "kb_user_options": user_options,
         "kb_company_options": company_options,
     }

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-20, 21:10 UTC, Fix, Serialised knowledge base admin context timestamps before embedding JSON so the admin console loads without datetime errors
 - 2025-12-02, 10:15 UTC, Feature, Added super-admin knowledge base composer with granular permission assignments, inline preview, and CRUD workflow integration
 - 2025-12-01, 09:15 UTC, Fix, Restored knowledge base search by including the CSRF token header in fetch submissions
 - 2025-12-02, 14:30 UTC, Feature, Added ticket detail workspace with standalone status management and threaded reply history


### PR DESCRIPTION
## Summary
- serialize knowledge base admin article metadata with `jsonable_encoder` before embedding it into the template
- record the fix in the changelog for traceability

## Testing
- pytest tests/test_knowledge_base_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f61657cb40832d9dd64523c239b47d