### PR TITLE
Fix ticket detail layout without sidebar

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -12,7 +12,7 @@
     </div>
   {% endif %}
 
-  <div class="management" data-layout>
+  <div class="management management--single" data-layout>
     <section class="management__content">
       <header class="management__header">
         <div>

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-04, 09:20 UTC, Fix, Restored ticket detail layout to single-column grid when the sidebar is absent to prevent content squeezing
 - 2025-10-20, 11:13 UTC, Feature, Introduced WYSIWYG knowledge base section editor with ordered multi-section storage and sanitised HTML handling
 - 2025-12-03, 10:15 UTC, Fix, Reconnected automation repository queries before writes so creating automations no longer fails when the database pool is cold
 - 2025-12-02, 15:00 UTC, Fix, Removed the ticket controls sidebar and placed the watcher list beneath the Updated metadata on the admin ticket detail view


### PR DESCRIPTION
## Summary
- ensure the ticket detail management wrapper uses the single-column layout variant now that the sidebar has been removed
- record the layout fix in the running change log

## Testing
- pytest *(fails: missing optional dependency `bleach` required by knowledge base service)*

------
https://chatgpt.com/codex/tasks/task_b_68f61b398734832d891a0fbe3bb1d6bb