### PR TITLE
Silence MySQL startup warnings from migration bootstrap

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -86,9 +86,13 @@ class Database:
             init_command="SET time_zone = '+00:00'",
         )
         async with temp_conn.cursor() as cursor:
-            await cursor.execute(
-                f"CREATE DATABASE IF NOT EXISTS `{self._settings.database_name}`"
-            )
+            await cursor.execute("SET sql_notes = 0")
+            try:
+                await cursor.execute(
+                    f"CREATE DATABASE IF NOT EXISTS `{self._settings.database_name}`"
+                )
+            finally:
+                await cursor.execute("SET sql_notes = 1")
         temp_conn.close()
         wait_closed = getattr(temp_conn, "wait_closed", None)
         if wait_closed:
@@ -119,9 +123,13 @@ class Database:
                     raise RuntimeError("Could not obtain database migration lock")
 
                 async with conn.cursor() as cursor:
-                    await cursor.execute(
-                        "CREATE TABLE IF NOT EXISTS migrations (name VARCHAR(255) PRIMARY KEY)"
-                    )
+                    await cursor.execute("SET sql_notes = 0")
+                    try:
+                        await cursor.execute(
+                            "CREATE TABLE IF NOT EXISTS migrations (name VARCHAR(255) PRIMARY KEY)"
+                        )
+                    finally:
+                        await cursor.execute("SET sql_notes = 1")
 
                 async with conn.cursor(aiomysql.DictCursor) as cursor:
                     await cursor.execute("SELECT name FROM migrations")

--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,5 @@
 - 2025-12-05, 09:20 UTC, Fix, Restored ticket assignment technician list by filtering active memberships in code and including super admins when populating options
+- 2025-10-20, 21:35 UTC, Fix, Suppressed MySQL duplicate database and migrations table warnings during startup by temporarily disabling sql_notes around idempotent CREATE statements
 - 2025-10-20, 11:24 UTC, Feature, Split the knowledge base admin into a catalogue list with dedicated editor pages for creating and updating articles
 - 2025-10-20, 21:30 UTC, Fix, Guarded startup migrations with MySQL advisory locks so concurrent workers stop raising duplicate index errors
 - 2025-12-04, 09:20 UTC, Fix, Restored ticket detail layout to single-column grid when the sidebar is absent to prevent content squeezing


### PR DESCRIPTION
## Summary
- disable MySQL sql_notes before running idempotent CREATE DATABASE and CREATE TABLE statements during startup
- re-enable sql_notes afterwards so other queries retain default behaviour
- document the fix in changes.md

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'bleach')*


------
https://chatgpt.com/codex/tasks/task_b_68f61dcee81c832d9cec6e2fd7ad610f