### PR TITLE
Refine knowledge base article sections layout

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2672,6 +2672,36 @@ body {
   gap: 1.5rem;
 }
 
+.kb-admin__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.kb-admin__fieldset {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  margin: 0;
+  background-color: var(--surface-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.kb-admin__fieldset-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.kb-admin__fieldset-body {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
 .kb-admin__panel {
   display: flex;
   flex-direction: column;
@@ -2721,12 +2751,45 @@ body {
   min-height: 12rem;
 }
 
+.kb-admin__sections-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  background-color: var(--surface-card);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
 .kb-admin__sections-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 1rem;
-  margin-bottom: 0.75rem;
+}
+
+.kb-admin__sections-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.kb-admin__sections-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.kb-admin__sections-help {
+  margin: 0;
+}
+
+.kb-admin__sections-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .kb-admin__sections {

--- a/app/templates/admin/knowledge_base_editor.html
+++ b/app/templates/admin/knowledge_base_editor.html
@@ -46,58 +46,72 @@
           </label>
         </div>
       </header>
-      <form id="kb-article-form" class="form-grid form-grid--vertical" autocomplete="off" data-kb-mode="{{ kb_form_mode }}">
+      <form id="kb-article-form" class="kb-admin__form" autocomplete="off" data-kb-mode="{{ kb_form_mode }}">
         <input type="hidden" id="kb-article-id" />
-        <div class="form-field">
-          <label class="form-label" for="kb-article-slug">Slug</label>
-          <input class="form-input" id="kb-article-slug" name="slug" required minlength="1" maxlength="191" />
-          <p class="form-help">Use a unique, URL-friendly slug. Existing links update automatically after saving changes.</p>
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="kb-article-title">Title</label>
-          <input class="form-input" id="kb-article-title" name="title" required maxlength="255" />
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="kb-article-summary">Summary</label>
-          <textarea class="form-input form-input--textarea" id="kb-article-summary" name="summary" rows="3" maxlength="2000"></textarea>
-          <p class="form-help">Summaries appear beside article titles and improve search relevance.</p>
-        </div>
-        <div class="form-field form-field--wide">
-          <div class="kb-admin__sections-header">
-            <label class="form-label" for="kb-article-sections">Sections</label>
-            <button type="button" class="button button--ghost" data-kb-add-section>
+        <fieldset class="kb-admin__fieldset">
+          <legend class="kb-admin__fieldset-title">Article details</legend>
+          <div class="kb-admin__fieldset-body">
+            <div class="form-field">
+              <label class="form-label" for="kb-article-slug">Slug</label>
+              <input class="form-input" id="kb-article-slug" name="slug" required minlength="1" maxlength="191" />
+              <p class="form-help">Use a unique, URL-friendly slug. Existing links update automatically after saving changes.</p>
+            </div>
+            <div class="form-field">
+              <label class="form-label" for="kb-article-title">Title</label>
+              <input class="form-input" id="kb-article-title" name="title" required maxlength="255" />
+            </div>
+            <div class="form-field form-field--wide">
+              <label class="form-label" for="kb-article-summary">Summary</label>
+              <textarea class="form-input form-input--textarea" id="kb-article-summary" name="summary" rows="3" maxlength="2000"></textarea>
+              <p class="form-help">Summaries appear beside article titles and improve search relevance.</p>
+            </div>
+          </div>
+        </fieldset>
+        <fieldset class="kb-admin__fieldset">
+          <legend class="kb-admin__fieldset-title">Visibility &amp; permissions</legend>
+          <div class="kb-admin__fieldset-body">
+            <div class="form-field">
+              <label class="form-label" for="kb-article-scope">Permission scope</label>
+              <select class="form-input" id="kb-article-scope" name="permission_scope">
+                <option value="anonymous">Public</option>
+                <option value="user">Specific users</option>
+                <option value="company">Company members</option>
+                <option value="company_admin">Company admins</option>
+                <option value="super_admin">Super admins</option>
+              </select>
+              <p class="form-help kb-admin__scope-help" data-kb-scope-help>Public articles are visible to anyone with the URL.</p>
+            </div>
+            <div class="form-field" data-kb-user-select hidden>
+              <label class="form-label" for="kb-article-users">Allow specific users</label>
+              <select class="form-input" id="kb-article-users" name="allowed_user_ids" multiple size="6"></select>
+              <p class="form-help">Hold Ctrl (Windows) or Command (macOS) to select multiple users. Leave empty to revoke access.</p>
+            </div>
+            <div class="form-field" data-kb-company-select hidden>
+              <label class="form-label" for="kb-article-companies">Allow specific companies</label>
+              <select class="form-input" id="kb-article-companies" name="allowed_company_ids" multiple size="6"></select>
+              <p class="form-help" data-kb-company-help>Leave empty to grant access to every company membership within the selected scope.</p>
+            </div>
+          </div>
+        </fieldset>
+        <section class="kb-admin__sections-card" aria-labelledby="kb-article-sections-heading">
+          <header class="kb-admin__sections-header">
+            <div class="kb-admin__sections-title-group">
+              <h3 class="kb-admin__sections-title" id="kb-article-sections-heading">Sections</h3>
+              <p class="form-help kb-admin__sections-help" id="kb-article-sections-help">Compose rich content in ordered sections. Drag the toolbar buttons to format text, add lists, or insert links. Reorder or delete sections without losing content.</p>
+            </div>
+            <button type="button" class="button button--ghost" data-kb-add-section aria-describedby="kb-article-sections-help">
               <span class="button__icon" aria-hidden="true">
                 <svg viewBox="0 0 24 24" focusable="false"><path d="M11 5a1 1 0 0 1 2 0v6h6a1 1 0 0 1 0 2h-6v6a1 1 0 0 1-2 0v-6H5a1 1 0 0 1 0-2h6z"/></svg>
               </span>
               <span class="button__label">Add section</span>
             </button>
+          </header>
+          <div class="kb-admin__sections-body" aria-describedby="kb-article-sections-help">
+            <div class="kb-admin__sections" id="kb-article-sections" data-kb-sections>
+              <p class="kb-admin__sections-empty" data-kb-sections-empty>No sections added yet. Start by creating the introduction.</p>
+            </div>
           </div>
-          <p class="form-help">Compose rich content in ordered sections. Drag the toolbar buttons to format text, add lists, or insert links. Reorder or delete sections without losing content.</p>
-          <div class="kb-admin__sections" id="kb-article-sections" data-kb-sections>
-            <p class="kb-admin__sections-empty" data-kb-sections-empty>No sections added yet. Start by creating the introduction.</p>
-          </div>
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="kb-article-scope">Permission scope</label>
-          <select class="form-input" id="kb-article-scope" name="permission_scope">
-            <option value="anonymous">Public</option>
-            <option value="user">Specific users</option>
-            <option value="company">Company members</option>
-            <option value="company_admin">Company admins</option>
-            <option value="super_admin">Super admins</option>
-          </select>
-          <p class="form-help kb-admin__scope-help" data-kb-scope-help>Public articles are visible to anyone with the URL.</p>
-        </div>
-        <div class="form-field" data-kb-user-select hidden>
-          <label class="form-label" for="kb-article-users">Allow specific users</label>
-          <select class="form-input" id="kb-article-users" name="allowed_user_ids" multiple size="6"></select>
-          <p class="form-help">Hold Ctrl (Windows) or Command (macOS) to select multiple users. Leave empty to revoke access.</p>
-        </div>
-        <div class="form-field" data-kb-company-select hidden>
-          <label class="form-label" for="kb-article-companies">Allow specific companies</label>
-          <select class="form-input" id="kb-article-companies" name="allowed_company_ids" multiple size="6"></select>
-          <p class="form-help" data-kb-company-help>Leave empty to grant access to every company membership within the selected scope.</p>
-        </div>
+        </section>
         <div class="form-actions">
           <button type="submit" class="button" data-kb-save>Save article</button>
           <button type="button" class="button button--ghost" data-kb-reset>Reset</button>

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-20, 11:41 UTC, Fix, Split knowledge base article sections into a dedicated panel separate from article metadata in the admin editor
 - 2025-12-03, 14:45 UTC, Fix, Restructured the knowledge base admin editor layout so the composer spans the full width with the preview stacked below for improved readability
 - 2025-12-05, 09:20 UTC, Fix, Restored ticket assignment technician list by filtering active memberships in code and including super admins when populating options
 - 2025-10-20, 21:35 UTC, Fix, Suppressed MySQL duplicate database and migrations table warnings during startup by temporarily disabling sql_notes around idempotent CREATE statements


### PR DESCRIPTION
## Summary
- reorganized the knowledge base article editor into fieldsets for article details and visibility controls
- moved the section composer into its own panel with dedicated heading, description, and styling
- updated shared styles and the change log to reflect the new layout separation

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'bleach')*


------
https://chatgpt.com/codex/tasks/task_b_68f61f242f20832da5ade97449809c4a