### PR TITLE
Fix AI summary rendering when models return code blocks

### DIFF
--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping as MappingABC
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
@@ -132,6 +133,98 @@ def _render_prompt(
     return "\n".join(lines)
 
 
+def _strip_wrapped_block(text: str) -> str:
+    """Remove common Markdown or triple-quoted wrappers from a response."""
+
+    stripped = text.strip()
+    if not stripped:
+        return stripped
+
+    def _strip_language_preamble(body: str) -> str:
+        body = body.lstrip("\n")
+        if "\n" not in body:
+            return body.strip()
+        first_line, rest = body.split("\n", 1)
+        candidate = first_line.strip()
+        if candidate and not candidate.startswith("{") and not candidate.startswith("["):
+            if all(ch.isalnum() or ch in {"-", "_", "."} for ch in candidate):
+                return rest.strip()
+        return body.strip()
+
+    wrappers: tuple[tuple[str, bool], ...] = (
+        ("```", True),
+        ("~~~", True),
+        ('"""', True),
+        ("'''", True),
+    )
+
+    for fence, remove_language in wrappers:
+        if stripped.startswith(fence) and stripped.endswith(fence) and len(stripped) >= len(fence) * 2:
+            inner = stripped[len(fence) : -len(fence)]
+            inner = inner.strip()
+            if remove_language:
+                inner = _strip_language_preamble(inner)
+            return inner.strip()
+
+    for fence, remove_language in wrappers:
+        start = stripped.find(fence)
+        end = stripped.rfind(fence)
+        if start != -1 and end != -1 and end > start + len(fence):
+            candidate = stripped[start : end + len(fence)]
+            cleaned = _strip_wrapped_block(candidate)
+            if cleaned != candidate.strip():
+                return cleaned
+
+    return stripped
+
+
+def _parse_json_candidate(candidate: str) -> tuple[str | None, str | None] | None:
+    if not candidate:
+        return None
+
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+
+    if isinstance(parsed, MappingABC):
+        summary_candidate = (
+            parsed.get("summary")
+            or parsed.get("analysis")
+            or parsed.get("text")
+        )
+        if isinstance(summary_candidate, str):
+            summary_text = summary_candidate.strip()
+        elif summary_candidate is None:
+            summary_text = None
+        else:
+            summary_text = str(summary_candidate)
+        if isinstance(summary_text, str) and not summary_text:
+            summary_text = None
+        resolution_candidate = (
+            parsed.get("resolution")
+            or parsed.get("resolution_label")
+            or parsed.get("status")
+            or parsed.get("state")
+        )
+        resolution_label = resolution_candidate.strip() if isinstance(resolution_candidate, str) else None
+        if not summary_text:
+            other_items = {
+                key: value
+                for key, value in parsed.items()
+                if key not in {"resolution", "resolution_label", "status", "state"}
+            }
+            if other_items:
+                summary_text = json.dumps(other_items, ensure_ascii=False)
+        return summary_text, resolution_label
+
+    if isinstance(parsed, str):
+        cleaned = parsed.strip()
+        return (cleaned or None, None)
+
+    return candidate, None
+
+
 def _extract_summary_fields(payload: Any) -> tuple[str | None, str | None]:
     if isinstance(payload, Mapping):
         direct_summary = payload.get("summary")
@@ -156,28 +249,15 @@ def _extract_summary_fields(payload: Any) -> tuple[str | None, str | None]:
     if not text:
         return None, None
 
-    try:
-        parsed = json.loads(text)
-    except json.JSONDecodeError:
-        return text, None
+    cleaned = _strip_wrapped_block(text)
 
-    if isinstance(parsed, Mapping):
-        summary_candidate = parsed.get("summary") or parsed.get("analysis") or parsed.get("text")
-        summary_text = (
-            summary_candidate.strip() if isinstance(summary_candidate, str) else str(summary_candidate) if summary_candidate else None
-        )
-        if summary_text:
-            summary_text = summary_text.strip()
-        resolution_candidate = parsed.get("resolution") or parsed.get("resolution_label") or parsed.get("status") or parsed.get("state")
-        resolution_label = resolution_candidate.strip() if isinstance(resolution_candidate, str) else None
-        if not summary_text:
-            other_items = {k: v for k, v in parsed.items() if k not in {"resolution", "resolution_label", "status", "state"}}
-            if other_items:
-                summary_text = json.dumps(other_items, ensure_ascii=False)
-        return summary_text, resolution_label
+    for candidate in (cleaned, text) if cleaned != text else (text,):
+        result = _parse_json_candidate(candidate)
+        if result is not None:
+            return result
 
-    if isinstance(parsed, str):
-        return parsed.strip() or None, None
+    if cleaned != text:
+        return cleaned, None
 
     return text, None
 

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,5 @@
+- 2025-12-06, 12:25 UTC, Fix, Normalised AI summary parsing to strip Markdown-style code blocks so ticket summaries render as pla
+in text
 - 2025-12-06, 10:00 UTC, Feature, Added Ollama-powered ticket AI summaries with resolution insights and admin workspace display
 - 2025-12-06, 08:30 UTC, Fix, Expanded the upgrade cleanup to purge truncated ~myportal metadata directories so pip stops warning about invalid distributions during installs
 - 2025-10-20, 11:41 UTC, Fix, Split knowledge base article sections into a dedicated panel separate from article metadata in the admin editor

--- a/tests/test_ticket_ai_summary_service.py
+++ b/tests/test_ticket_ai_summary_service.py
@@ -128,3 +128,21 @@ async def test_refresh_ticket_ai_summary_handles_errors(monkeypatch):
     assert captured["ai_summary_status"] == "error"
     assert captured["ai_summary"] is None
     assert captured["ai_resolution_state"] is None
+
+
+def test_extract_summary_fields_from_markdown_block():
+    payload = "```json\n{\"summary\": \"Issue resolved\", \"resolution\": \"Likely Resolved\"}\n```"
+
+    summary, resolution = tickets_service._extract_summary_fields(payload)
+
+    assert summary == "Issue resolved"
+    assert resolution == "Likely Resolved"
+
+
+def test_extract_summary_fields_from_triple_quoted_block():
+    payload = '"""json\n{"summary": "Still working", "resolution": "Likely In Progress"}\n"""'
+
+    summary, resolution = tickets_service._extract_summary_fields(payload)
+
+    assert summary == "Still working"
+    assert resolution == "Likely In Progress"


### PR DESCRIPTION
## Summary
- strip Markdown and triple-quoted wrappers from AI responses before attempting to parse JSON payloads
- add regression coverage ensuring fenced code block responses decode correctly
- record the fix in the project change log

## Testing
- pytest tests/test_ticket_ai_summary_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f62233e6a4832d97eccbd9b5e1e54e