### PR TITLE
Remove knowledge base search and Ollama panels

### DIFF
--- a/app/templates/knowledge_base/index.html
+++ b/app/templates/knowledge_base/index.html
@@ -89,30 +89,6 @@
     {% endif %}
   </section>
 
-  <section class="card card--panel knowledge-base__results" data-knowledge-base-results hidden>
-    <header class="card__header">
-      <div>
-        <h3 class="card__title">Search results</h3>
-        <p class="card__subtitle">Articles matched locally before Ollama refinement.</p>
-      </div>
-    </header>
-    <div class="card__body" data-knowledge-base-results-body>
-      <p class="knowledge-base__empty">No matching articles were found.</p>
-    </div>
-  </section>
-
-  <section class="card card--panel knowledge-base__ollama" data-knowledge-base-ollama hidden>
-    <header class="card__header">
-      <div>
-        <h3 class="card__title">Ollama insight</h3>
-        <p class="card__subtitle">Summaries generated from the enabled Ollama integration.</p>
-      </div>
-      <div class="knowledge-base__ollama-status" data-knowledge-base-ollama-status></div>
-    </header>
-    <div class="card__body" data-knowledge-base-ollama-body>
-      <p class="knowledge-base__empty">No Ollama summary available.</p>
-    </div>
-  </section>
 </div>
 {% endblock %}
 

--- a/changes.md
+++ b/changes.md
@@ -218,3 +218,4 @@ in text
 - 2025-10-09, 23:32 UTC, Fix, Resized all modal popups to occupy 75% of the viewport for consistent layout compliance
 - 2025-10-10, 13:45 UTC, Fix, Restored notification API actions with summary counts, event-type catalogues, repository insert reliability, and UI refresh
 - 2025-10-15, 23:36 UTC, Fix, Restored admin membership removal handler closures to resolve admin.js syntax error
+- 2025-12-07, 09:00 UTC, Fix, Removed knowledge base search results and Ollama insight panels from the portal view to simplify the article list


### PR DESCRIPTION
## Summary
- remove the knowledge base search results and Ollama insight cards from the portal page
- record the UI adjustment in the project change log

## Testing
- pytest *(fails: RuntimeError: Database pool not initialised in ticket access tests)*

------
https://chatgpt.com/codex/tasks/task_b_68f625e81438832d9155e8ecfa13e333