### PR TITLE
Consolidate ticket AI tags with summary

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -185,6 +185,9 @@
           {% set ai_badge_map = {'succeeded': 'badge--success', 'error': 'badge--danger', 'skipped': 'badge--muted', 'unknown': 'badge--muted'} %}
           {% set resolution_label_map = {'likely_resolved': 'Likely Resolved', 'likely_in_progress': 'Likely In Progress'} %}
           {% set resolution_badge_map = {'likely_resolved': 'badge--success', 'likely_in_progress': 'badge--warning'} %}
+          {% set tag_status_value = ticket.ai_tags_status if ticket.ai_tags_status is not none else 'skipped' %}
+          {% set tag_status_lower = tag_status_value | lower %}
+          {% set tag_status_label = tag_status_lower.replace('_', ' ') | title %}
           {% if ticket.ai_summary or ticket.ai_summary_status %}
             <article class="card card--panel">
               <header class="card__header">
@@ -225,42 +228,34 @@
                 {% else %}
                   <p class="card__empty">AI summary is not currently available.</p>
                 {% endif %}
-              </div>
-            </article>
-          {% endif %}
 
-          {% set tag_status_value = ticket.ai_tags_status if ticket.ai_tags_status is not none else 'skipped' %}
-          {% set tag_status_lower = tag_status_value | lower %}
-          {% set tag_status_label = tag_status_lower.replace('_', ' ') | title %}
-          {% if ticket.ai_tags_status or (ticket.ai_tags is not none and ticket.ai_tags|length > 0) %}
-            <article class="card card--panel">
-              <header class="card__header">
-                <h2 class="card__title">AI Tags</h2>
-                <p class="card__subtitle">
-                  <span class="badge {{ ai_badge_map.get(tag_status_lower, 'badge--warning') }}">{{ tag_status_label }}</span>
-                  {% if ticket.ai_tags_model %}
-                    <span>{{ ticket.ai_tags_model }}</span>
+                {% if ticket.ai_tags_status or (ticket.ai_tags is not none and ticket.ai_tags|length > 0) %}
+                  <section class="divider"></section>
+                  <h3 class="card__subtitle">AI Tags</h3>
+                  <p class="card__subtitle">
+                    <span class="badge {{ ai_badge_map.get(tag_status_lower, 'badge--warning') }}">{{ tag_status_label }}</span>
+                    {% if ticket.ai_tags_model %}
+                      <span>{{ ticket.ai_tags_model }}</span>
+                    {% endif %}
+                    {% if ticket.ai_tags_updated_at %}
+                      <span>Updated {{ ticket.ai_tags_updated_at.astimezone().strftime('%Y-%m-%d %H:%M') }}</span>
+                    {% endif %}
+                  </p>
+                  {% if tag_status_lower == 'succeeded' and ticket.ai_tags %}
+                    <div class="tag-list">
+                      {% for tag in ticket.ai_tags %}
+                        <span class="tag">{{ tag.replace('-', ' ') }}</span>
+                      {% endfor %}
+                    </div>
+                  {% elif tag_status_lower == 'succeeded' %}
+                    <p class="card__empty">Ollama did not return tags for this ticket.</p>
+                  {% elif tag_status_lower == 'skipped' %}
+                    <p class="card__empty">Enable the Ollama integration module to generate tags.</p>
+                  {% elif tag_status_lower == 'error' %}
+                    <p class="card__empty">AI tag generation failed. Check the Ollama module logs.</p>
+                  {% else %}
+                    <p class="card__empty">AI tags are not currently available.</p>
                   {% endif %}
-                  {% if ticket.ai_tags_updated_at %}
-                    <span>Updated {{ ticket.ai_tags_updated_at.astimezone().strftime('%Y-%m-%d %H:%M') }}</span>
-                  {% endif %}
-                </p>
-              </header>
-              <div class="card__body">
-                {% if tag_status_lower == 'succeeded' and ticket.ai_tags %}
-                  <div class="tag-list">
-                    {% for tag in ticket.ai_tags %}
-                      <span class="tag">{{ tag.replace('-', ' ') }}</span>
-                    {% endfor %}
-                  </div>
-                {% elif tag_status_lower == 'succeeded' %}
-                  <p class="card__empty">Ollama did not return tags for this ticket.</p>
-                {% elif tag_status_lower == 'skipped' %}
-                  <p class="card__empty">Enable the Ollama integration module to generate tags.</p>
-                {% elif tag_status_lower == 'error' %}
-                  <p class="card__empty">AI tag generation failed. Check the Ollama module logs.</p>
-                {% else %}
-                  <p class="card__empty">AI tags are not currently available.</p>
                 {% endif %}
               </div>
             </article>

--- a/changes.md
+++ b/changes.md
@@ -221,3 +221,4 @@ in text
 - 2025-10-10, 13:45 UTC, Fix, Restored notification API actions with summary counts, event-type catalogues, repository insert reliability, and UI refresh
 - 2025-10-15, 23:36 UTC, Fix, Restored admin membership removal handler closures to resolve admin.js syntax error
 - 2025-12-07, 09:00 UTC, Fix, Removed knowledge base search results and Ollama insight panels from the portal view to simplify the article list
+- 2025-12-07, 12:45 UTC, Fix, Combined ticket AI tags into the AI summary panel so related insights stay in one place on the admin ticket detail view


### PR DESCRIPTION
## Summary
- embed the AI tags status and list directly inside the AI summary card on the admin ticket detail view
- record the UI consolidation in the change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f627fcf278832db6ba8986ea830b1f