### PR TITLE
Add Syncro ticket importer via API and admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,34 @@ There are no default login credentials; the first visit will prompt you to regis
 - Automation builder covering scheduled and event-driven workflows with Ollama, SMTP, TacticalRMM, and ntfy integrations
 - Integration module catalogue to manage external credentials, run diagnostics, and ensure webhook retries remain observable
 - ChatGPT MCP module providing secure ticket triage tools and automations to OpenAI ChatGPT via the Model Context Protocol
+- Syncro ticket importer with super admin UI controls, rate limiting, and REST API access for bulk migrations
+
+## Syncro Ticket Importer
+
+Super administrators can synchronise Syncro tickets into MyPortal directly from **Admin → Tickets**. The import console offers
+three modes:
+
+- **Single ticket** – supply a Syncro ticket ID for one-off imports or re-syncs.
+- **Range import** – provide `startId` and `endId` values to sweep a consecutive block of tickets.
+- **Import all tickets** – iterate through the entire Syncro queue using the 25-item pagination window.
+
+Each request observes the Syncro 180 requests-per-minute ceiling and reports how many tickets were created, updated, or skipped
+after upserting into MyPortal.
+
+The same workflow is exposed through the Swagger-documented endpoint `POST /api/tickets/import/syncro`. The request body accepts
+camelCase or snake_case keys:
+
+```json
+{
+  "mode": "range",
+  "startId": 1500,
+  "endId": 1525
+}
+```
+
+Use `"mode": "single"` with `ticketId` for targeted imports or `"mode": "all"` without additional fields to crawl every page.
+The response echoes the mode alongside `fetched`, `created`, `updated`, and `skipped` counters so integrations can audit the
+result.
 
 ## Port Catalogue & Pricing Workflows
 

--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from app.core.logging import log_error, log_info
+from app.repositories import companies as company_repo
+from app.repositories import tickets as tickets_repo
+from app.services import syncro
+
+_ALLOWED_PRIORITIES = {"urgent", "high", "normal", "low"}
+_ALLOWED_STATUSES = {"open", "in_progress", "pending", "resolved", "closed"}
+_DEFAULT_PRIORITY = "normal"
+_DEFAULT_STATUS = "open"
+
+_DEFAULT_RATE_LIMITER = syncro.AsyncRateLimiter(limit=180, interval=60.0)
+
+
+@dataclass(slots=True)
+class TicketImportSummary:
+    mode: str
+    fetched: int = 0
+    created: int = 0
+    updated: int = 0
+    skipped: int = 0
+
+    def record(self, outcome: str) -> None:
+        if outcome == "created":
+            self.created += 1
+        elif outcome == "updated":
+            self.updated += 1
+        else:
+            self.skipped += 1
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "fetched": self.fetched,
+            "created": self.created,
+            "updated": self.updated,
+            "skipped": self.skipped,
+        }
+
+
+def _clean_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _normalise_status(value: Any) -> str:
+    text = _clean_text(value)
+    if not text:
+        return _DEFAULT_STATUS
+    normalized = text.lower().replace(" ", "_")
+    if normalized in _ALLOWED_STATUSES:
+        return normalized
+    if "progress" in normalized:
+        return "in_progress"
+    if "pend" in normalized or "wait" in normalized:
+        return "pending"
+    if "resolv" in normalized or "complete" in normalized:
+        return "resolved"
+    if "clos" in normalized:
+        return "closed"
+    return _DEFAULT_STATUS
+
+
+def _normalise_priority(value: Any) -> str:
+    text = _clean_text(value)
+    if not text:
+        return _DEFAULT_PRIORITY
+    normalized = text.lower().replace(" ", "_")
+    if normalized in _ALLOWED_PRIORITIES:
+        return normalized
+    if "emer" in normalized or "crit" in normalized:
+        return "urgent"
+    if "high" in normalized:
+        return "high"
+    if "low" in normalized:
+        return "low"
+    return _DEFAULT_PRIORITY
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value in {None, "", 0}:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    for candidate in (text, text.replace(" ", "T", 1)):
+        try:
+            parsed = datetime.fromisoformat(candidate)
+        except ValueError:
+            continue
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    try:
+        parsed = datetime.strptime(text, "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def _extract_description(ticket: dict[str, Any]) -> str | None:
+    for key in ("problem", "description", "issue", "body", "notes"):
+        candidate = _clean_text(ticket.get(key))
+        if candidate:
+            return candidate
+    return None
+
+
+async def _resolve_company_id(ticket: dict[str, Any]) -> int | None:
+    syncro_ids: list[str] = []
+    for key in ("customer_id", "customerId", "customerid", "client_id"):
+        value = ticket.get(key)
+        if value is not None:
+            syncro_ids.append(str(value))
+    customer = ticket.get("customer")
+    if isinstance(customer, dict):
+        for key in ("id", "customer_id"):
+            value = customer.get(key)
+            if value is not None:
+                syncro_ids.append(str(value))
+    for syncro_id in syncro_ids:
+        try:
+            company = await company_repo.get_company_by_syncro_id(syncro_id)
+        except RuntimeError as exc:  # pragma: no cover - defensive logging
+            log_error("Failed to resolve company from Syncro ID", syncro_id=syncro_id, error=str(exc))
+            continue
+        if company and company.get("id") is not None:
+            try:
+                return int(company["id"])
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+async def _upsert_ticket(
+    ticket: dict[str, Any],
+) -> str:
+    syncro_id = ticket.get("id")
+    if syncro_id is None:
+        return "skipped"
+    external_reference = str(syncro_id)
+    subject = _clean_text(ticket.get("subject") or ticket.get("title") or ticket.get("summary"))
+    if not subject:
+        subject = f"Syncro Ticket {external_reference}"
+    description = _extract_description(ticket)
+    status = _normalise_status(ticket.get("status_name") or ticket.get("status"))
+    priority = _normalise_priority(ticket.get("priority"))
+    category = _clean_text(ticket.get("type") or ticket.get("category"))
+
+    created_at = _parse_datetime(
+        ticket.get("created_at")
+        or ticket.get("created_on")
+        or ticket.get("created")
+        or ticket.get("created_at_utc")
+    )
+    updated_at = _parse_datetime(
+        ticket.get("updated_at")
+        or ticket.get("updated_on")
+        or ticket.get("updated")
+        or ticket.get("updated_at_utc")
+    )
+    closed_at = _parse_datetime(
+        ticket.get("resolved_at")
+        or ticket.get("closed_at")
+        or ticket.get("completed_at")
+        or ticket.get("date_resolved")
+    )
+    if closed_at and status not in {"resolved", "closed"}:
+        status = "resolved"
+
+    company_id = await _resolve_company_id(ticket)
+
+    existing = await tickets_repo.get_ticket_by_external_reference(external_reference)
+    description_value: str | None = description or None
+    category_value: str | None = category or None
+
+    if existing:
+        updates: dict[str, Any] = {
+            "subject": subject,
+            "description": description_value,
+            "status": status,
+            "priority": priority,
+        }
+        if category_value is not None:
+            updates["category"] = category_value
+        if company_id is not None:
+            updates["company_id"] = company_id
+        if closed_at is not None:
+            updates["closed_at"] = closed_at
+        if created_at is not None:
+            updates["created_at"] = created_at
+        if updated_at is not None:
+            updates["updated_at"] = updated_at
+        await tickets_repo.update_ticket(int(existing["id"]), **updates)
+        return "updated"
+
+    created = await tickets_repo.create_ticket(
+        subject=subject,
+        description=description_value,
+        requester_id=None,
+        company_id=company_id,
+        assigned_user_id=None,
+        priority=priority,
+        status=status,
+        category=category_value,
+        module_slug=None,
+        external_reference=external_reference,
+    )
+    created_id = created.get("id")
+    if created_id is not None and any((created_at, updated_at, closed_at)):
+        timestamp_updates: dict[str, Any] = {}
+        if created_at is not None:
+            timestamp_updates["created_at"] = created_at
+        if updated_at is not None:
+            timestamp_updates["updated_at"] = updated_at
+        if closed_at is not None:
+            timestamp_updates["closed_at"] = closed_at
+        await tickets_repo.update_ticket(int(created_id), **timestamp_updates)
+    return "created"
+
+
+async def import_ticket_by_id(
+    ticket_id: int,
+    *,
+    rate_limiter: syncro.AsyncRateLimiter | None = None,
+) -> TicketImportSummary:
+    limiter = rate_limiter or _DEFAULT_RATE_LIMITER
+    summary = TicketImportSummary(mode="single")
+    log_info("Starting Syncro ticket import", mode="single", ticket_id=ticket_id)
+    ticket = await syncro.get_ticket(ticket_id, rate_limiter=limiter)
+    if not ticket:
+        summary.skipped += 1
+        log_info("Syncro ticket import completed", mode="single", fetched=summary.fetched, created=0, updated=0, skipped=1)
+        return summary
+    summary.fetched = 1
+    outcome = await _upsert_ticket(ticket)
+    summary.record(outcome)
+    log_info(
+        "Syncro ticket import completed",
+        mode="single",
+        fetched=summary.fetched,
+        created=summary.created,
+        updated=summary.updated,
+        skipped=summary.skipped,
+    )
+    return summary
+
+
+async def import_ticket_range(
+    start_id: int,
+    end_id: int,
+    *,
+    rate_limiter: syncro.AsyncRateLimiter | None = None,
+) -> TicketImportSummary:
+    limiter = rate_limiter or _DEFAULT_RATE_LIMITER
+    summary = TicketImportSummary(mode="range")
+    log_info("Starting Syncro ticket import", mode="range", start_id=start_id, end_id=end_id)
+    for identifier in range(start_id, end_id + 1):
+        ticket = await syncro.get_ticket(identifier, rate_limiter=limiter)
+        if not ticket:
+            summary.skipped += 1
+            continue
+        summary.fetched += 1
+        outcome = await _upsert_ticket(ticket)
+        summary.record(outcome)
+    log_info(
+        "Syncro ticket import completed",
+        mode="range",
+        fetched=summary.fetched,
+        created=summary.created,
+        updated=summary.updated,
+        skipped=summary.skipped,
+    )
+    return summary
+
+
+def _extract_total_pages(meta: dict[str, Any]) -> int | None:
+    candidates = [meta.get("total_pages"), meta.get("totalPages"), meta.get("total")]
+    for candidate in candidates:
+        try:
+            if candidate is None:
+                continue
+            value = int(candidate)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return None
+
+
+async def import_all_tickets(
+    *,
+    rate_limiter: syncro.AsyncRateLimiter | None = None,
+) -> TicketImportSummary:
+    limiter = rate_limiter or _DEFAULT_RATE_LIMITER
+    summary = TicketImportSummary(mode="all")
+    log_info("Starting Syncro ticket import", mode="all")
+    page = 1
+    total_pages: int | None = None
+    while True:
+        tickets, meta = await syncro.list_tickets(page=page, rate_limiter=limiter)
+        if not tickets:
+            break
+        summary.fetched += len(tickets)
+        for ticket in tickets:
+            try:
+                outcome = await _upsert_ticket(ticket)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                log_error("Failed to import Syncro ticket", syncro_id=ticket.get("id"), error=str(exc))
+                summary.skipped += 1
+                continue
+            summary.record(outcome)
+        if total_pages is None:
+            total_pages = _extract_total_pages(meta)
+        if total_pages is not None and page >= total_pages:
+            break
+        page += 1
+    log_info(
+        "Syncro ticket import completed",
+        mode="all",
+        fetched=summary.fetched,
+        created=summary.created,
+        updated=summary.updated,
+        skipped=summary.skipped,
+    )
+    return summary
+
+
+async def import_from_request(
+    *,
+    mode: str,
+    ticket_id: int | None = None,
+    start_id: int | None = None,
+    end_id: int | None = None,
+    rate_limiter: syncro.AsyncRateLimiter | None = None,
+) -> TicketImportSummary:
+    mode_lower = mode.lower()
+    if mode_lower == "single":
+        if ticket_id is None:
+            raise ValueError("ticket_id is required for single imports")
+        return await import_ticket_by_id(ticket_id, rate_limiter=rate_limiter)
+    if mode_lower == "range":
+        if start_id is None or end_id is None:
+            raise ValueError("start_id and end_id are required for range imports")
+        if end_id < start_id:
+            raise ValueError("end_id must be greater than or equal to start_id")
+        return await import_ticket_range(start_id, end_id, rate_limiter=rate_limiter)
+    if mode_lower == "all":
+        return await import_all_tickets(rate_limiter=rate_limiter)
+    raise ValueError("mode must be one of 'single', 'range', or 'all'")

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -139,6 +139,63 @@
           <input type="search" class="form-input" placeholder="Filter tickets" aria-label="Filter tickets" data-table-filter="tickets-table" />
         </div>
 
+        <div class="alert-stack" data-syncro-ticket-import-status hidden></div>
+
+        <article class="card card--panel">
+          <header class="card__header">
+            <div>
+              <h2 class="card__title">Syncro ticket import</h2>
+              <p class="card__subtitle">
+                Import tickets from Syncro individually, by range, or across the entire account. Requests are throttled to honour
+                the 180&nbsp;requests per minute limit and processed 25 results per page.
+              </p>
+            </div>
+          </header>
+          <div class="management__body management__body--cards">
+            <form class="card__form" data-syncro-ticket-import data-mode="single">
+              <div>
+                <h3 class="card__title">Single ticket</h3>
+                <p class="card__subtitle text-muted">Fetch a specific Syncro ticket by its numeric identifier.</p>
+              </div>
+              <div class="form-field">
+                <label class="form-label" for="syncro-ticket-id">Syncro ticket ID</label>
+                <input id="syncro-ticket-id" name="ticketId" class="form-input" type="number" min="1" step="1" required />
+              </div>
+              <div class="form-actions">
+                <button type="submit" class="button button--primary">Import ticket</button>
+              </div>
+            </form>
+            <form class="card__form" data-syncro-ticket-import data-mode="range">
+              <div>
+                <h3 class="card__title">Range import</h3>
+                <p class="card__subtitle text-muted">Pull a consecutive span of Syncro ticket IDs and upsert them into MyPortal.</p>
+              </div>
+              <div class="form-grid">
+                <div class="form-field">
+                  <label class="form-label" for="syncro-ticket-start">Start ID</label>
+                  <input id="syncro-ticket-start" name="startId" class="form-input" type="number" min="1" step="1" required />
+                </div>
+                <div class="form-field">
+                  <label class="form-label" for="syncro-ticket-end">End ID</label>
+                  <input id="syncro-ticket-end" name="endId" class="form-input" type="number" min="1" step="1" required />
+                </div>
+              </div>
+              <div class="form-actions">
+                <button type="submit" class="button">Import range</button>
+              </div>
+            </form>
+            <form class="card__form" data-syncro-ticket-import data-mode="all">
+              <div>
+                <h3 class="card__title">Import all tickets</h3>
+                <p class="card__subtitle text-muted">Walk the Syncro pagination to synchronise every available ticket.</p>
+              </div>
+              <div class="form-actions">
+                <button type="submit" class="button button--ghost">Import all tickets</button>
+              </div>
+            </form>
+          </div>
+        </article>
+
         <div class="table-wrapper">
           <table class="table" id="tickets-table" data-table>
             <thead>

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-08, 09:45 UTC, Feature, Added Syncro ticket importer with admin UI, rate-limited Syncro API client, and documentation
 - 2025-10-20, 12:25 UTC, Fix, Allowed super admins to be assigned to tickets by recognising their global permission during assignee validation
 - 2025-10-20, 12:20 UTC, Fix, Removed the knowledge base admin preview pane from the article editor per request
 - 2025-12-07, 09:15 UTC, Fix, Restricted ticket requester selection to enabled staff for the linked company and blocked assignments without a company

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -1,0 +1,194 @@
+import pytest
+
+from app.services import ticket_importer
+from app.services import syncro
+from app.repositories import tickets as tickets_repo
+from app.repositories import companies as company_repo
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_normalise_status_mapping():
+    assert ticket_importer._normalise_status("In Progress") == "in_progress"
+    assert ticket_importer._normalise_status("Waiting on customer") == "pending"
+    assert ticket_importer._normalise_status("Completed") == "resolved"
+
+
+def test_normalise_priority_mapping():
+    assert ticket_importer._normalise_priority("Critical") == "urgent"
+    assert ticket_importer._normalise_priority("LOW") == "low"
+    assert ticket_importer._normalise_priority(None) == "normal"
+
+
+@pytest.mark.anyio
+async def test_import_ticket_by_id_creates_new_ticket(monkeypatch):
+    async def fake_get_ticket(ticket_id, rate_limiter=None):
+        assert ticket_id == 101
+        return {
+            "id": 101,
+            "subject": "Printer offline",
+            "priority": "High",
+            "status": "In Progress",
+            "problem": "Printer in marketing is jammed",
+            "customer_id": "200",
+            "created_at": "2025-01-01T08:30:00Z",
+            "updated_at": "2025-01-02T10:45:00Z",
+        }
+
+    async def fake_get_company(syncro_id):
+        assert syncro_id == "200"
+        return {"id": 7}
+
+    async def fake_get_existing(external_reference):
+        assert external_reference == "101"
+        return None
+
+    created_calls = {}
+
+    async def fake_create_ticket(**kwargs):
+        created_calls.update(kwargs)
+        return {"id": 55, **kwargs}
+
+    update_calls = []
+
+    async def fake_update_ticket(ticket_id, **fields):
+        update_calls.append((ticket_id, fields))
+        return {"id": ticket_id, **fields}
+
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
+    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
+
+    summary = await ticket_importer.import_ticket_by_id(101, rate_limiter=None)
+
+    assert summary.mode == "single"
+    assert summary.fetched == 1
+    assert summary.created == 1
+    assert summary.updated == 0
+    assert summary.skipped == 0
+    assert created_calls["company_id"] == 7
+    assert created_calls["priority"] == "high"
+    assert created_calls["status"] == "in_progress"
+    assert update_calls[0][0] == 55
+    assert "created_at" in update_calls[0][1]
+
+
+@pytest.mark.anyio
+async def test_import_ticket_by_id_updates_existing(monkeypatch):
+    async def fake_get_ticket(ticket_id, rate_limiter=None):
+        return {
+            "id": ticket_id,
+            "subject": "Network outage",
+            "priority": "Critical",
+            "status": "Resolved",
+            "problem": "Restored connectivity",
+            "customer_id": "200",
+            "resolved_at": "2025-01-03T12:00:00Z",
+        }
+
+    async def fake_get_existing(external_reference):
+        return {"id": 99, "external_reference": external_reference}
+
+    update_calls = []
+
+    async def fake_update_ticket(ticket_id, **fields):
+        update_calls.append((ticket_id, fields))
+        return {"id": ticket_id, **fields}
+
+    async def fake_get_company(syncro_id):
+        assert syncro_id == "200"
+        return {"id": 3}
+
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
+    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
+
+    summary = await ticket_importer.import_ticket_by_id(500, rate_limiter=None)
+
+    assert summary.updated == 1
+    assert summary.created == 0
+    assert update_calls[0][0] == 99
+    assert update_calls[0][1]["status"] == "resolved"
+
+
+@pytest.mark.anyio
+async def test_import_ticket_range_handles_missing(monkeypatch):
+    async def fake_get_ticket(ticket_id, rate_limiter=None):
+        if ticket_id == 10:
+            return {"id": 10, "subject": "Login error", "status": "Open", "priority": "Normal"}
+        return None
+
+    async def fake_get_existing(external_reference):
+        if external_reference == "10":
+            return None
+        return None
+
+    async def fake_create_ticket(**kwargs):
+        return {"id": 10, **kwargs}
+
+    async def fake_update_ticket(ticket_id, **fields):
+        return {"id": ticket_id, **fields}
+
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(company_repo, "get_company_by_syncro_id", lambda syncro_id: None)
+    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
+
+    summary = await ticket_importer.import_ticket_range(10, 11, rate_limiter=None)
+
+    assert summary.mode == "range"
+    assert summary.fetched == 1
+    assert summary.created == 1
+    assert summary.skipped == 1
+
+
+@pytest.mark.anyio
+async def test_import_all_tickets_uses_pagination(monkeypatch):
+    pages = {
+        1: ([{"id": 201, "subject": "Laptop setup", "status": "Open", "priority": "Normal", "customer_id": "300"}], {"total_pages": 2}),
+        2: ([{"id": 202, "subject": "VPN issue", "status": "Resolved", "priority": "High", "customer_id": "300"}], {"total_pages": 2}),
+    }
+
+    async def fake_list_tickets(page, per_page=25, rate_limiter=None):
+        return pages.get(page, ([], {}))
+
+    async def fake_get_existing(external_reference):
+        if external_reference == "202":
+            return {"id": 88, "external_reference": external_reference}
+        return None
+
+    created = []
+    updated = []
+
+    async def fake_create_ticket(**kwargs):
+        created.append(kwargs)
+        return {"id": 77, **kwargs}
+
+    async def fake_update_ticket(ticket_id, **fields):
+        updated.append((ticket_id, fields))
+        return {"id": ticket_id, **fields}
+
+    async def fake_get_company(syncro_id):
+        return {"id": 12}
+
+    monkeypatch.setattr(syncro, "list_tickets", fake_list_tickets)
+    monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
+    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
+
+    summary = await ticket_importer.import_all_tickets(rate_limiter=None)
+
+    assert summary.mode == "all"
+    assert summary.fetched == 2
+    assert summary.created == 1
+    assert summary.updated == 1
+    assert created[0]["external_reference"] == "201"
+    assert updated[0][0] == 88


### PR DESCRIPTION
## Summary
- add a Syncro ticket importer service with rate limited API access and support for single, range, and full synchronisations
- expose the importer through a secured `/api/tickets/import/syncro` endpoint and an admin console workflow with status messaging
- document the workflow, record the change log entry, and add regression tests for importer scenarios and repository helpers

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68f62b382410832d9598130fca30591e