### PR TITLE
Address feedback: prevent focus on collapsed mobile sidebar

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -445,8 +445,14 @@
           }
           if (mobileMedia.matches) {
             sidebar.setAttribute('aria-hidden', String(!isOpen));
+            if (!isOpen) {
+              sidebar.setAttribute('inert', '');
+            } else {
+              sidebar.removeAttribute('inert');
+            }
           } else {
             sidebar.removeAttribute('aria-hidden');
+            sidebar.removeAttribute('inert');
           }
           if (scrim) {
             scrim.setAttribute('aria-hidden', String(!isOpen));


### PR DESCRIPTION
## Summary
- add an accessible mobile hamburger toggle that controls the sidebar navigation with focus management and scrim
- clamp the layout to the viewport and style the header for responsive behaviour
- document the responsive navigation feature in the change log
- prevent focus on the collapsed mobile sidebar by toggling its inert state during the mobile experience

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f6b3871b7c832d9a79133a8bf2b6d5