### PR TITLE
Fix knowledge base admin deletion redirect

### DIFF
--- a/app/static/js/knowledge_base_admin.js
+++ b/app/static/js/knowledge_base_admin.js
@@ -763,10 +763,10 @@
         const detail = await response.json().catch(() => ({}));
         throw new Error((detail && detail.detail) || `${response.status} ${response.statusText}`);
       }
-      setStatus('Article deleted. Reloading…', 'success');
+      setStatus('Article deleted. Returning to catalogue…', 'success');
       window.setTimeout(() => {
-        window.location.reload();
-      }, 600);
+        window.location.assign('/admin/knowledge-base');
+      }, 400);
     } catch (error) {
       console.error(error);
       setStatus(`Unable to delete article: ${error.message}`, 'error');

--- a/changes.md
+++ b/changes.md
@@ -1,4 +1,5 @@
 - 2025-12-10, 13:30 UTC, Feature, Moved Syncro ticket import to dedicated admin page with module gating and configuration controls
+- 2025-12-08, 16:45 UTC, Fix, Redirected knowledge base deletion flow back to the admin catalogue to prevent Article not found errors
 - 2025-10-20, 22:17 UTC, Fix, Corrected HTTP POST module knowledge base seed to keep migration column counts aligned
 - 2025-12-09, 16:30 UTC, Fix, Replaced PWA PNG icons with SVG sources and updated manifest caching to remove binary assets
 - 2025-12-09, 14:00 UTC, Fix, Allowed controlled service worker activation by removing forced skipWaiting and exposing Service-Worker-Allowed header


### PR DESCRIPTION
## Summary
- redirect the knowledge base admin delete confirmation to the catalogue once the API request succeeds
- record the change in the running change log

## Testing
- pytest tests/test_knowledge_base_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f6c582d76c832db35de22a2b8e4279