### PR TITLE
Route Discord stock alerts through webhook monitor

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-12, 09:00 UTC, Fix, Routed shop Discord stock notifications through the webhook monitor with persisted event metadata and tests
 - 2025-12-11, 10:00 UTC, Feature, Routed integration module webhooks through the monitor with persisted event metadata and regression tests
 - 2025-12-10, 13:30 UTC, Feature, Moved Syncro ticket import to dedicated admin page with module gating and configuration controls
 - 2025-12-08, 16:45 UTC, Fix, Redirected knowledge base deletion flow back to the admin catalogue to prevent Article not found errors

--- a/tests/test_shop_service.py
+++ b/tests/test_shop_service.py
@@ -1,0 +1,64 @@
+import asyncio
+
+from app.services import shop as shop_service
+
+
+async def _fake_settings_with_webhook():
+    return {"discord_webhook_url": "https://discord.example.com/webhook"}
+
+
+def test_send_discord_stock_notification_enqueues_event(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_enqueue_event(**kwargs):
+        captured["event_args"] = kwargs
+        return {"id": 99, "status": "pending", "attempt_count": 0}
+
+    monkeypatch.setattr(
+        shop_service.shop_settings_repo,
+        "get_settings",
+        _fake_settings_with_webhook,
+    )
+    monkeypatch.setattr(shop_service.webhook_monitor, "enqueue_event", fake_enqueue_event)
+
+    product = {"id": 10, "name": "Widget+", "sku": "SKU-1"}
+
+    event = asyncio.run(
+        shop_service.send_discord_stock_notification(product, previous_stock=5, new_stock=0)
+    )
+
+    assert event == {"id": 99, "status": "pending", "attempt_count": 0}
+    event_args = captured["event_args"]
+    assert event_args["name"] == "shop.discord.stock_notification"
+    assert event_args["target_url"] == "https://discord.example.com/webhook"
+    assert (
+        event_args["payload"]["content"]
+        == "⚠️ **Widget+** (SKU-1) is now **Out Of Stock** (was 5)."
+    )
+
+
+def test_maybe_send_discord_stock_notification_returns_event(monkeypatch):
+    async def fake_get_product_by_id(*_, **__):
+        return {"id": 22, "name": "Laptop", "sku": "LP-5"}
+
+    async def fake_enqueue_event(**kwargs):
+        return {"id": 101, "status": "pending", "payload": kwargs.get("payload")}
+
+    monkeypatch.setattr(
+        shop_service.shop_settings_repo,
+        "get_settings",
+        _fake_settings_with_webhook,
+    )
+    monkeypatch.setattr(shop_service.webhook_monitor, "enqueue_event", fake_enqueue_event)
+    monkeypatch.setattr(shop_service.shop_repo, "get_product_by_id", fake_get_product_by_id)
+
+    event = asyncio.run(
+        shop_service.maybe_send_discord_stock_notification_by_id(
+            product_id=22,
+            previous_stock=0,
+            new_stock=3,
+        )
+    )
+
+    assert event["id"] == 101
+    assert event["payload"]["content"].startswith("✅ **Laptop** (LP-5)")


### PR DESCRIPTION
## Summary
- enqueue shop Discord stock notifications through the webhook monitor so payloads are retried and logged
- expose event metadata from the stock notification helpers for downstream retry/diagnostic usage and log queueing
- add unit coverage confirming webhook events are created and update the changelog entry

## Testing
- pytest tests/test_shop_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f6e46427b0832d828d7b0df24db4b7