### PR TITLE
Log SMTP email delivery events in webhook monitor

### DIFF
--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -277,7 +277,7 @@ async def password_forgot(
         "<p>If you did not request a reset you can ignore this email.</p>"
     )
     try:
-        sent = await email_service.send_email(
+        sent, event_metadata = await email_service.send_email(
             subject=f"Reset your {settings.app_name} password",
             recipients=[user["email"]],
             text_body=text_body,
@@ -287,6 +287,7 @@ async def password_forgot(
             logger.warning(
                 "Password reset email skipped because SMTP is not configured",
                 user_id=user["id"],
+                event_id=(event_metadata or {}).get("id") if isinstance(event_metadata, dict) else None,
             )
     except email_service.EmailDispatchError as exc:  # pragma: no cover - log and continue
         logger.error(

--- a/app/main.py
+++ b/app/main.py
@@ -3856,7 +3856,7 @@ async def invite_staff_member(staff_id: int, request: Request):
         "<p>The link expires in one hour. If you were not expecting this invitation you can ignore this email.</p>"
     )
     try:
-        sent = await email_service.send_email(
+        sent, event_metadata = await email_service.send_email(
             subject=f"You're invited to {settings.app_name}",
             recipients=[staff["email"]],
             text_body=text_body,
@@ -3868,12 +3868,14 @@ async def invite_staff_member(staff_id: int, request: Request):
                 "Staff invitation email skipped due to SMTP configuration",
                 staff_id=staff_id,
                 invited_user_id=created_user["id"],
+                event_id=(event_metadata or {}).get("id") if isinstance(event_metadata, dict) else None,
             )
         else:
             log_info(
                 "Staff invitation email sent",
                 staff_id=staff_id,
                 invited_user_id=created_user["id"],
+                event_id=(event_metadata or {}).get("id") if isinstance(event_metadata, dict) else None,
             )
     except email_service.EmailDispatchError as exc:  # pragma: no cover - logged for diagnostics
         log_error(
@@ -3881,6 +3883,7 @@ async def invite_staff_member(staff_id: int, request: Request):
             staff_id=staff_id,
             invited_user_id=created_user["id"],
             error=str(exc),
+            event_id=(event_metadata or {}).get("id") if "event_metadata" in locals() and isinstance(event_metadata, dict) else None,
         )
 
     log_info(

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -571,7 +571,7 @@ async def _invoke_smtp(settings: Mapping[str, Any], payload: Mapping[str, Any]) 
         raise RuntimeError("Failed to create webhook event for SMTP request")
     attempt_number = 1
     try:
-        sent = await email_service.send_email(
+        sent, email_event_metadata = await email_service.send_email(
             subject=subject,
             recipients=recipients,
             html_body=html_body,
@@ -603,7 +603,13 @@ async def _invoke_smtp(settings: Mapping[str, Any], payload: Mapping[str, Any]) 
         )
         return _build_event_result(
             updated_event,
-            extra={"recipients": recipients, "subject": subject},
+            extra={
+                "recipients": recipients,
+                "subject": subject,
+                "email_event_id": (email_event_metadata or {}).get("id")
+                if isinstance(email_event_metadata, dict)
+                else None,
+            },
         )
 
     response_body = json.dumps({"recipients": recipients, "subject": subject})
@@ -615,7 +621,13 @@ async def _invoke_smtp(settings: Mapping[str, Any], payload: Mapping[str, Any]) 
     )
     return _build_event_result(
         updated_event,
-        extra={"recipients": recipients, "subject": subject},
+        extra={
+            "recipients": recipients,
+            "subject": subject,
+            "email_event_id": (email_event_metadata or {}).get("id")
+            if isinstance(email_event_metadata, dict)
+            else None,
+        },
     )
 
 

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -82,7 +82,7 @@ async def emit_notification(
             text_body = message
             html_body = f"<p>{escape(message)}</p>"
             try:
-                sent = await email_service.send_email(
+                sent, event_metadata = await email_service.send_email(
                     subject=subject,
                     recipients=[user["email"]],
                     text_body=text_body,
@@ -93,6 +93,7 @@ async def emit_notification(
                         "Notification email delivery skipped because SMTP is not configured",
                         user_id=user_id,
                         event_type=event_type,
+                        event_id=(event_metadata or {}).get("id") if isinstance(event_metadata, dict) else None,
                     )
             except email_service.EmailDispatchError as exc:  # pragma: no cover - log for visibility
                 logger.error(

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-12, 12:30 UTC, Feature, Logged SMTP email deliveries through the webhook monitor with outcome metadata and test updates
 - 2025-12-12, 09:00 UTC, Fix, Routed shop Discord stock notifications through the webhook monitor with persisted event metadata and tests
 - 2025-12-11, 10:00 UTC, Feature, Routed integration module webhooks through the monitor with persisted event metadata and regression tests
 - 2025-12-10, 13:30 UTC, Feature, Moved Syncro ticket import to dedicated admin page with module gating and configuration controls

--- a/tests/test_auth_password_reset.py
+++ b/tests/test_auth_password_reset.py
@@ -52,7 +52,7 @@ def test_password_forgot_sends_email(monkeypatch):
 
     async def fake_send_email(**kwargs):
         email_payload.update(kwargs)
-        return True
+        return True, {"id": 11, "status": "succeeded"}
 
     def fake_token_hex(size: int) -> str:
         return "fixedtoken"

--- a/tests/test_modules_service.py
+++ b/tests/test_modules_service.py
@@ -201,7 +201,7 @@ def test_invoke_smtp_records_success(monkeypatch):
 
     async def fake_send_email(**kwargs):
         captured_event["email_kwargs"] = kwargs
-        return True
+        return True, {"id": 70, "status": "succeeded"}
 
     monkeypatch.setattr(modules.webhook_monitor, "enqueue_event", fake_enqueue_event)
     monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
@@ -221,6 +221,7 @@ def test_invoke_smtp_records_success(monkeypatch):
     assert result["status"] == "succeeded"
     assert result["recipients"] == ["user@example.com"]
     assert captured_event["attempt_immediately"] is False
+    assert result["email_event_id"] == 70
     assert "email_kwargs" in captured_event
 
 
@@ -259,7 +260,7 @@ def test_invoke_smtp_records_failure(monkeypatch):
         return dict(fake_event_state)
 
     async def fake_send_email(**kwargs):
-        return False
+        return False, None
 
     monkeypatch.setattr(modules.webhook_monitor, "enqueue_event", fake_enqueue_event)
     monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
@@ -278,6 +279,7 @@ def test_invoke_smtp_records_failure(monkeypatch):
     assert result["event_id"] == 9
     assert result["status"] == "failed"
     assert "last_error" in result
+    assert result.get("email_event_id") is None
 
 
 def test_invoke_tacticalrmm_records_success(monkeypatch):

--- a/tests/test_notifications_service.py
+++ b/tests/test_notifications_service.py
@@ -17,7 +17,7 @@ def test_emit_notification_sends_email(monkeypatch):
 
     async def fake_send_email(**kwargs):
         captured["email"] = kwargs
-        return True
+        return True, {"id": 1, "status": "succeeded"}
 
     monkeypatch.setattr(notifications.preferences_repo, "get_preference", fake_get_preference)
     monkeypatch.setattr(notifications.notifications_repo, "create_notification", fake_create_notification)


### PR DESCRIPTION
## Summary
- enqueue webhook monitor events for SMTP emails and record success or failure outcomes
- expose helper utilities for manual webhook monitor updates from external dispatchers
- adjust email consumers and tests to capture webhook metadata alongside delivery results

## Testing
- pytest tests/test_email_service.py tests/test_notifications_service.py tests/test_auth_password_reset.py tests/test_modules_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f6eb5b5f34832d8cb47cf5d2178a09