### PR TITLE
Ensure manual webhook events are recorded

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -77,7 +77,7 @@ async def send_email(
     event_record: dict[str, Any] | None = None
     event_id: int | None = None
     try:
-        event_record = await webhook_monitor.enqueue_event(
+        event_record = await webhook_monitor.create_manual_event(
             name="email.smtp.send",
             target_url=endpoint,
             payload={
@@ -88,7 +88,6 @@ async def send_email(
             headers={"X-Service": "email"},
             max_attempts=1,
             backoff_seconds=60,
-            attempt_immediately=False,
         )
         if event_record.get("id") is not None:
             event_id = int(event_record["id"])

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -484,14 +484,13 @@ async def _invoke_ollama(settings: Mapping[str, Any], payload: Mapping[str, Any]
         raise ValueError("Ollama prompt cannot be empty")
     endpoint = urljoin(f"{base_url}/", "api/generate")
     body = {"model": model, "prompt": prompt, "stream": False}
-    event = await webhook_monitor.enqueue_event(
+    event = await webhook_monitor.create_manual_event(
         name="module.ollama.generate",
         target_url=endpoint,
         payload={"request_body": body},
         headers={"Content-Type": "application/json"},
         max_attempts=1,
         backoff_seconds=60,
-        attempt_immediately=False,
     )
     event_id = int(event.get("id")) if event.get("id") is not None else None
     if event_id is None:
@@ -551,7 +550,7 @@ async def _invoke_smtp(settings: Mapping[str, Any], payload: Mapping[str, Any]) 
     html_body = str(payload.get("html") or payload.get("body") or "<p>Automation triggered.</p>")
     text_body = payload.get("text")
     sender = str(settings.get("from_address") or "") or None
-    event = await webhook_monitor.enqueue_event(
+    event = await webhook_monitor.create_manual_event(
         name="module.smtp.send",
         target_url="smtp://send",
         payload={
@@ -564,7 +563,6 @@ async def _invoke_smtp(settings: Mapping[str, Any], payload: Mapping[str, Any]) 
         headers={"X-Module": "smtp"},
         max_attempts=1,
         backoff_seconds=60,
-        attempt_immediately=False,
     )
     event_id = int(event.get("id")) if event.get("id") is not None else None
     if event_id is None:
@@ -649,7 +647,7 @@ async def _invoke_tacticalrmm(settings: Mapping[str, Any], payload: Mapping[str,
             headers[str(key)] = str(value)
     request_body = payload.get("body")
     url = urljoin(f"{base_url}/", endpoint_path)
-    event = await webhook_monitor.enqueue_event(
+    event = await webhook_monitor.create_manual_event(
         name="module.tacticalrmm.invoke",
         target_url=url,
         payload={
@@ -660,7 +658,6 @@ async def _invoke_tacticalrmm(settings: Mapping[str, Any], payload: Mapping[str,
         headers=headers,
         max_attempts=1,
         backoff_seconds=60,
-        attempt_immediately=False,
     )
     event_id = int(event.get("id")) if event.get("id") is not None else None
     if event_id is None:
@@ -733,7 +730,7 @@ async def _invoke_ntfy(settings: Mapping[str, Any], payload: Mapping[str, Any]) 
     if token:
         headers["Authorization"] = f"Bearer {token}"
     headers["Priority"] = priority
-    event = await webhook_monitor.enqueue_event(
+    event = await webhook_monitor.create_manual_event(
         name="module.ntfy.publish",
         target_url=url,
         payload={
@@ -743,7 +740,6 @@ async def _invoke_ntfy(settings: Mapping[str, Any], payload: Mapping[str, Any]) 
         headers=headers,
         max_attempts=1,
         backoff_seconds=60,
-        attempt_immediately=False,
     )
     event_id = int(event.get("id")) if event.get("id") is not None else None
     if event_id is None:

--- a/app/services/syncro.py
+++ b/app/services/syncro.py
@@ -171,14 +171,13 @@ async def _request(
     if json is not None:
         webhook_payload["body"] = json
     try:
-        webhook_event = await webhook_monitor.enqueue_event(
+        webhook_event = await webhook_monitor.create_manual_event(
             name="syncro.api.request",
             target_url=url,
             payload=webhook_payload,
             headers=None,
             max_attempts=1,
             backoff_seconds=0,
-            attempt_immediately=False,
         )
     except Exception as exc:  # pragma: no cover - webhook monitor safety
         log_error("Failed to record Syncro request in webhook monitor", url=url, error=str(exc))

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-13, 11:00 UTC, Fix, Marked manual webhook events as in progress when logging Syncro and module API calls so the monitor now records their delivery outcomes
 - 2025-12-13, 09:30 UTC, Fix, Ensured webhook events capture their identifiers during Syncro API logging so monitor entries persist with delivery outcomes
 - 2025-12-13, 08:45 UTC, Fix, Recorded Syncro API requests for ticket imports in the webhook monitor with manual success and failure logging
 - 2025-12-12, 12:30 UTC, Feature, Logged SMTP email deliveries through the webhook monitor with outcome metadata and test updates

--- a/tests/test_modules_service.py
+++ b/tests/test_modules_service.py
@@ -89,7 +89,7 @@ def test_invoke_ollama_records_event_success(monkeypatch):
 
     client_factory = _AsyncClientFactory(FakeResponse())
 
-    monkeypatch.setattr(modules.webhook_monitor, "enqueue_event", fake_enqueue_event)
+    monkeypatch.setattr(modules.webhook_monitor, "create_manual_event", fake_enqueue_event)
     monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_completed", fake_mark_event_completed)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_failed", _noop)
@@ -103,7 +103,8 @@ def test_invoke_ollama_records_event_success(monkeypatch):
     assert result["event_id"] == 1
     assert result["status"] == "succeeded"
     assert result["response"] == {"result": "ok"}
-    assert captured_event["attempt_immediately"] is False
+    assert captured_event.get("max_attempts") == 1
+    assert "attempt_immediately" not in captured_event
     assert attempts and attempts[0]["status"] == "succeeded"
 
 
@@ -150,7 +151,7 @@ def test_invoke_ollama_records_event_failure(monkeypatch):
 
     client_factory = _AsyncClientFactory(FakeResponse())
 
-    monkeypatch.setattr(modules.webhook_monitor, "enqueue_event", fake_enqueue_event)
+    monkeypatch.setattr(modules.webhook_monitor, "create_manual_event", fake_enqueue_event)
     monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_completed", _noop)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_failed", fake_mark_event_failed)
@@ -203,7 +204,7 @@ def test_invoke_smtp_records_success(monkeypatch):
         captured_event["email_kwargs"] = kwargs
         return True, {"id": 70, "status": "succeeded"}
 
-    monkeypatch.setattr(modules.webhook_monitor, "enqueue_event", fake_enqueue_event)
+    monkeypatch.setattr(modules.webhook_monitor, "create_manual_event", fake_enqueue_event)
     monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_completed", fake_mark_event_completed)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_failed", _noop)
@@ -220,7 +221,8 @@ def test_invoke_smtp_records_success(monkeypatch):
     assert result["event_id"] == 7
     assert result["status"] == "succeeded"
     assert result["recipients"] == ["user@example.com"]
-    assert captured_event["attempt_immediately"] is False
+    assert captured_event.get("max_attempts") == 1
+    assert "attempt_immediately" not in captured_event
     assert result["email_event_id"] == 70
     assert "email_kwargs" in captured_event
 
@@ -262,7 +264,7 @@ def test_invoke_smtp_records_failure(monkeypatch):
     async def fake_send_email(**kwargs):
         return False, None
 
-    monkeypatch.setattr(modules.webhook_monitor, "enqueue_event", fake_enqueue_event)
+    monkeypatch.setattr(modules.webhook_monitor, "create_manual_event", fake_enqueue_event)
     monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_completed", _noop)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_failed", fake_mark_event_failed)
@@ -335,7 +337,7 @@ def test_invoke_tacticalrmm_records_success(monkeypatch):
 
     client_factory = _AsyncClientFactory(FakeResponse())
 
-    monkeypatch.setattr(modules.webhook_monitor, "enqueue_event", fake_enqueue_event)
+    monkeypatch.setattr(modules.webhook_monitor, "create_manual_event", fake_enqueue_event)
     monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_completed", fake_mark_event_completed)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_failed", _noop)
@@ -352,7 +354,8 @@ def test_invoke_tacticalrmm_records_success(monkeypatch):
     assert result["event_id"] == 11
     assert result["status"] == "succeeded"
     assert result["status_code"] == 201
-    assert captured_event["attempt_immediately"] is False
+    assert captured_event.get("max_attempts") == 1
+    assert "attempt_immediately" not in captured_event
 
 
 def test_invoke_ntfy_records_success(monkeypatch):
@@ -401,7 +404,7 @@ def test_invoke_ntfy_records_success(monkeypatch):
 
     client_factory = _AsyncClientFactory(FakeResponse())
 
-    monkeypatch.setattr(modules.webhook_monitor, "enqueue_event", fake_enqueue_event)
+    monkeypatch.setattr(modules.webhook_monitor, "create_manual_event", fake_enqueue_event)
     monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_completed", fake_mark_event_completed)
     monkeypatch.setattr(modules.webhook_repo, "mark_event_failed", _noop)
@@ -418,4 +421,5 @@ def test_invoke_ntfy_records_success(monkeypatch):
     assert result["event_id"] == 15
     assert result["status"] == "succeeded"
     assert result["topic"] == "alerts"
-    assert captured_event["attempt_immediately"] is False
+    assert captured_event.get("max_attempts") == 1
+    assert "attempt_immediately" not in captured_event

--- a/tests/test_syncro_service.py
+++ b/tests/test_syncro_service.py
@@ -33,7 +33,7 @@ async def test_syncro_request_records_webhook_success(reset_syncro_caches):
             },
         }
 
-    async def fake_enqueue_event(**kwargs):
+    async def fake_manual_event(**kwargs):
         recorded["enqueue"] = kwargs
         return {"id": 321}
 
@@ -95,7 +95,7 @@ async def test_syncro_request_records_webhook_success(reset_syncro_caches):
             return DummyResponse()
 
     reset_syncro_caches.setattr(syncro.module_repo, "get_module", fake_get_module)
-    reset_syncro_caches.setattr(syncro.webhook_monitor, "enqueue_event", fake_enqueue_event)
+    reset_syncro_caches.setattr(syncro.webhook_monitor, "create_manual_event", fake_manual_event)
     reset_syncro_caches.setattr(syncro.webhook_monitor, "record_manual_success", fake_record_success)
     reset_syncro_caches.setattr(syncro.webhook_monitor, "record_manual_failure", fake_record_failure)
     reset_syncro_caches.setattr(syncro.httpx, "AsyncClient", DummyClient)
@@ -125,7 +125,7 @@ async def test_syncro_request_records_webhook_failure(reset_syncro_caches):
             },
         }
 
-    async def fake_enqueue_event(**kwargs):
+    async def fake_manual_event(**kwargs):
         recorded["enqueue"] = kwargs
         return {"id": 654}
 
@@ -159,7 +159,7 @@ async def test_syncro_request_records_webhook_failure(reset_syncro_caches):
             raise httpx.HTTPError("boom")
 
     reset_syncro_caches.setattr(syncro.module_repo, "get_module", fake_get_module)
-    reset_syncro_caches.setattr(syncro.webhook_monitor, "enqueue_event", fake_enqueue_event)
+    reset_syncro_caches.setattr(syncro.webhook_monitor, "create_manual_event", fake_manual_event)
     reset_syncro_caches.setattr(syncro.webhook_monitor, "record_manual_failure", fake_record_failure)
     reset_syncro_caches.setattr(syncro.webhook_monitor, "record_manual_success", fake_record_success)
     reset_syncro_caches.setattr(syncro.httpx, "AsyncClient", FailingClient)


### PR DESCRIPTION
## Summary
- add a webhook_monitor.create_manual_event helper that marks manual events in progress before recording outcomes
- route Syncro, SMTP email, and integration module requests through the manual helper so they appear in the webhook monitor
- update related unit tests and changelog entries to reflect the manual event workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f70998e32c832da967fd00ae991ff4