### PR TITLE
Log Syncro ticket imports in webhook monitor

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-13, 13:45 UTC, Fix, Logged Syncro ticket import jobs in the webhook monitor with success and failure outcomes so the delivery queue lists them
 - 2025-12-13, 12:15 UTC, Feature, Added Uptime Kuma alert ingestion module with secure webhook endpoint, admin configuration UI, and alert listing APIs
 - 2025-12-13, 11:00 UTC, Fix, Marked manual webhook events as in progress when logging Syncro and module API calls so the monitor now records their delivery outcomes
 - 2025-12-13, 09:30 UTC, Fix, Ensured webhook events capture their identifiers during Syncro API logging so monitor entries persist with delivery outcomes


### PR DESCRIPTION
## Summary
- record Syncro ticket import jobs as manual webhook events with success and failure outcomes so they appear in the delivery queue
- serialize import context metadata into the webhook payload and mark manual retries on error
- cover the new webhook logging workflow with regression tests for success and failure paths

## Testing
- pytest tests/test_ticket_importer.py

------
https://chatgpt.com/codex/tasks/task_b_68f70f702cec832d8a167bb2d242ed69