### PR TITLE
Fix Syncro ticket import fallback logging in webhook monitor

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-13, 16:30 UTC, Fix, Routed Syncro ticket import fallback logging through the webhook repository so webhook monitor entries persist when manual monitor helpers fail
 - 2025-12-13, 15:45 UTC, Fix, Normalised webhook event timestamp updates to stay database-agnostic so Syncro ticket import API calls appear in the monitor log
 - 2025-12-13, 14:30 UTC, Fix, Hardened Syncro ticket import webhook fallback with repository error handling tests and logging coverage
 - 2025-12-13, 13:45 UTC, Fix, Logged Syncro ticket import jobs in the webhook monitor with success and failure outcomes so the delivery queue lists them


### PR DESCRIPTION
## Summary
- ensure Syncro ticket import requests fall back to the webhook repository when manual monitor helpers are unavailable
- exercise repository fallback behaviour with new regression tests covering success and failure flows
- document the fix in the changelog

## Testing
- pytest tests/test_ticket_importer.py

------
https://chatgpt.com/codex/tasks/task_b_68f727303934832d9da5e90fdb1312c8