### PR TITLE
Improve logging for Syncro ticket import processing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4397,6 +4397,15 @@ async def import_syncro_tickets(request: Request):
         import_request = SyncroTicketImportRequest.model_validate(payload)
     except ValidationError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=exc.errors()) from exc
+    log_info(
+        "Syncro ticket import admin request received",
+        user_id=current_user.get("id"),
+        mode=import_request.mode.value,
+        ticket_id=import_request.ticket_id,
+        start_id=import_request.start_id,
+        end_id=import_request.end_id,
+        request_path=str(request.url),
+    )
     try:
         summary = await ticket_importer.import_from_request(
             mode=import_request.mode.value,

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-13, 17:15 UTC, Fix, Added detailed Syncro ticket import logging for admin requests and webhook lifecycle events to troubleshoot missing monitor processing
 - 2025-12-13, 16:30 UTC, Fix, Routed Syncro ticket import fallback logging through the webhook repository so webhook monitor entries persist when manual monitor helpers fail
 - 2025-12-13, 15:45 UTC, Fix, Normalised webhook event timestamp updates to stay database-agnostic so Syncro ticket import API calls appear in the monitor log
 - 2025-12-13, 14:30 UTC, Fix, Hardened Syncro ticket import webhook fallback with repository error handling tests and logging coverage


### PR DESCRIPTION
## Summary
- add admin request logging for Syncro ticket imports so incoming payloads are traceable
- extend the Syncro ticket import workflow logs to capture webhook event creation, fallback paths, and failure handling
- record the logging improvements in the change history

## Testing
- pytest tests/test_ticket_importer.py

------
https://chatgpt.com/codex/tasks/task_b_68f734c5f080832d8e39b1083d8d42d8