### PR TITLE
Fix Syncro ticket import admin form bindings

### DIFF
--- a/app/templates/admin/syncro_ticket_import.html
+++ b/app/templates/admin/syncro_ticket_import.html
@@ -113,3 +113,8 @@
     </section>
   </div>
 {% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/admin.js" defer></script>
+{% endblock %}

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-13, 18:00 UTC, Fix, Loaded the admin.js bundle on the Syncro ticket import page so the import forms trigger the API workflow
 - 2025-12-13, 17:15 UTC, Fix, Added detailed Syncro ticket import logging for admin requests and webhook lifecycle events to troubleshoot missing monitor processing
 - 2025-12-13, 16:30 UTC, Fix, Routed Syncro ticket import fallback logging through the webhook repository so webhook monitor entries persist when manual monitor helpers fail
 - 2025-12-13, 15:45 UTC, Fix, Normalised webhook event timestamp updates to stay database-agnostic so Syncro ticket import API calls appear in the monitor log


### PR DESCRIPTION
## Summary
- load the admin.js bundle on the Syncro ticket import admin page so the import forms invoke the async importer
- document the change in the running change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f739e68a20832da659bc05e3436f4e