### PR TITLE
Add webhook attempt payload logging and detail viewer

### DIFF
--- a/app/schemas/scheduler.py
+++ b/app/schemas/scheduler.py
@@ -104,6 +104,9 @@ class WebhookEventAttemptResponse(BaseModel):
     response_status: int | None = Field(default=None, serialization_alias="responseStatus")
     response_body: str | None = Field(default=None, serialization_alias="responseBody")
     error_message: str | None = Field(default=None, serialization_alias="errorMessage")
+    request_headers: dict[str, Any] | None = Field(default=None, serialization_alias="requestHeaders")
+    request_body: Any = Field(default=None, serialization_alias="requestBody")
+    response_headers: dict[str, Any] | None = Field(default=None, serialization_alias="responseHeaders")
     attempted_at: datetime | None = Field(default=None, serialization_alias="attemptedAt")
 
     model_config = {

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -3263,6 +3263,78 @@ body {
   color: rgba(148, 163, 184, 0.85);
 }
 
+.table__row--active {
+  background: rgba(59, 130, 246, 0.18);
+}
+
+.attempt-details {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.attempt-details__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.attempt-details__grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 900px) {
+  .attempt-details__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.attempt-details__section {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.attempt-details__list {
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.attempt-details__list dt {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.75);
+  font-weight: 600;
+}
+
+.attempt-details__list dd {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(248, 250, 252, 0.95);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.attempt-details__code {
+  margin: 0;
+  padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.65rem;
+  max-height: 260px;
+  overflow: auto;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', ui-monospace, monospace;
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .header-search,
   .knowledge-base,

--- a/app/templates/admin/webhooks.html
+++ b/app/templates/admin/webhooks.html
@@ -125,14 +125,45 @@
               <th scope="col" data-sort="number">Duration (ms)</th>
               <th scope="col" data-sort="string">Response</th>
               <th scope="col" data-sort="string">Error</th>
+              <th scope="col" class="table__actions">Details</th>
             </tr>
           </thead>
           <tbody id="webhook-attempts-body">
             <tr>
-              <td colspan="5" class="table__empty" id="webhook-attempts-empty">Select a webhook event to inspect its attempts.</td>
+              <td colspan="6" class="table__empty" id="webhook-attempts-empty">Select a webhook event to inspect its attempts.</td>
             </tr>
           </tbody>
         </table>
+      </div>
+      <div class="attempt-details" id="webhook-attempt-details">
+        <h3 class="attempt-details__title">Attempt details</h3>
+        <p class="text-muted" data-attempt-placeholder>
+          Choose a delivery attempt to review the recorded request and response payloads.
+        </p>
+        <div class="attempt-details__grid" data-attempt-details hidden>
+          <section class="attempt-details__section" aria-labelledby="attempt-request-heading">
+            <h4 id="attempt-request-heading">Request</h4>
+            <dl class="attempt-details__list">
+              <dt>Headers</dt>
+              <dd><pre data-attempt-request-headers class="attempt-details__code">—</pre></dd>
+              <dt>Body</dt>
+              <dd><pre data-attempt-request-body class="attempt-details__code">—</pre></dd>
+            </dl>
+          </section>
+          <section class="attempt-details__section" aria-labelledby="attempt-response-heading">
+            <h4 id="attempt-response-heading">Response</h4>
+            <dl class="attempt-details__list">
+              <dt>Status</dt>
+              <dd data-attempt-response-status>—</dd>
+              <dt>Headers</dt>
+              <dd><pre data-attempt-response-headers class="attempt-details__code">—</pre></dd>
+              <dt>Body</dt>
+              <dd><pre data-attempt-response-body class="attempt-details__code">—</pre></dd>
+              <dt>Error</dt>
+              <dd data-attempt-response-error>—</dd>
+            </dl>
+          </section>
+        </div>
       </div>
     </div>
   </div>

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-21, 07:59 UTC, Feature, Persisted webhook attempt request and response payloads with an admin monitor detail viewer for troubleshooting
 - 2025-12-13, 18:00 UTC, Fix, Loaded the admin.js bundle on the Syncro ticket import page so the import forms trigger the API workflow
 - 2025-12-13, 17:15 UTC, Fix, Added detailed Syncro ticket import logging for admin requests and webhook lifecycle events to troubleshoot missing monitor processing
 - 2025-12-13, 16:30 UTC, Fix, Routed Syncro ticket import fallback logging through the webhook repository so webhook monitor entries persist when manual monitor helpers fail

--- a/migrations/077_webhook_request_logging.sql
+++ b/migrations/077_webhook_request_logging.sql
@@ -1,0 +1,8 @@
+ALTER TABLE webhook_event_attempts
+  ADD COLUMN IF NOT EXISTS request_headers TEXT NULL;
+
+ALTER TABLE webhook_event_attempts
+  ADD COLUMN IF NOT EXISTS request_body TEXT NULL;
+
+ALTER TABLE webhook_event_attempts
+  ADD COLUMN IF NOT EXISTS response_headers TEXT NULL;

--- a/tests/test_email_service.py
+++ b/tests/test_email_service.py
@@ -55,7 +55,14 @@ def test_send_email_success(monkeypatch):
         event_store[event["id"]] = event
         return event
 
-    async def fake_record_manual_success(event_id: int, *, attempt_number: int, response_status: int | None, response_body: str | None):
+    async def fake_record_manual_success(
+        event_id: int,
+        *,
+        attempt_number: int,
+        response_status: int | None,
+        response_body: str | None,
+        **_kwargs,
+    ):
         event = dict(event_store.get(event_id, {}))
         event.update(
             {
@@ -153,7 +160,16 @@ def test_send_email_raises_on_failure(monkeypatch):
         event_state.update({"payload": kwargs.get("payload"), "target_url": kwargs.get("target_url")})
         return dict(event_state)
 
-    async def fake_record_manual_failure(event_id: int, *, attempt_number: int, status: str, error_message: str | None, response_status: int | None, response_body: str | None):
+    async def fake_record_manual_failure(
+        event_id: int,
+        *,
+        attempt_number: int,
+        status: str,
+        error_message: str | None,
+        response_status: int | None,
+        response_body: str | None,
+        **_kwargs,
+    ):
         event_state.update(
             {
                 "id": event_id,

--- a/tests/test_syncro_service.py
+++ b/tests/test_syncro_service.py
@@ -37,7 +37,14 @@ async def test_syncro_request_records_webhook_success(reset_syncro_caches):
         recorded["enqueue"] = kwargs
         return {"id": 321}
 
-    async def fake_record_success(event_id: int, *, attempt_number: int, response_status: int | None, response_body: str | None):
+    async def fake_record_success(
+        event_id: int,
+        *,
+        attempt_number: int,
+        response_status: int | None,
+        response_body: str | None,
+        **_kwargs,
+    ):
         recorded.setdefault("success", []).append(
             {
                 "event_id": event_id,
@@ -48,7 +55,16 @@ async def test_syncro_request_records_webhook_success(reset_syncro_caches):
         )
         return {"id": event_id, "status": "succeeded"}
 
-    async def fake_record_failure(event_id: int, *, attempt_number: int, status: str, error_message: str | None, response_status: int | None, response_body: str | None):
+    async def fake_record_failure(
+        event_id: int,
+        *,
+        attempt_number: int,
+        status: str,
+        error_message: str | None,
+        response_status: int | None,
+        response_body: str | None,
+        **_kwargs,
+    ):
         recorded.setdefault("failure", []).append(
             {
                 "event_id": event_id,
@@ -129,7 +145,16 @@ async def test_syncro_request_records_webhook_failure(reset_syncro_caches):
         recorded["enqueue"] = kwargs
         return {"id": 654}
 
-    async def fake_record_failure(event_id: int, *, attempt_number: int, status: str, error_message: str | None, response_status: int | None, response_body: str | None):
+    async def fake_record_failure(
+        event_id: int,
+        *,
+        attempt_number: int,
+        status: str,
+        error_message: str | None,
+        response_status: int | None,
+        response_body: str | None,
+        **_kwargs,
+    ):
         recorded.setdefault("failure", []).append(
             {
                 "event_id": event_id,

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -210,7 +210,14 @@ async def test_import_from_request_records_webhook_success(monkeypatch):
         recorded["create"] = kwargs
         return {"id": 77}
 
-    async def fake_record_success(event_id, *, attempt_number, response_status, response_body):
+    async def fake_record_success(
+        event_id,
+        *,
+        attempt_number,
+        response_status,
+        response_body,
+        **_kwargs,
+    ):
         recorded["success"] = {
             "event_id": event_id,
             "attempt_number": attempt_number,
@@ -265,7 +272,16 @@ async def test_import_from_request_falls_back_to_repo(monkeypatch):
     async def fake_record_success(*_args, **_kwargs):  # pragma: no cover - should not be called
         raise AssertionError("webhook_monitor.record_manual_success should not be used on fallback")
 
-    async def fake_record_attempt(*, event_id, attempt_number, status, response_status, response_body, error_message):
+    async def fake_record_attempt(
+        *,
+        event_id,
+        attempt_number,
+        status,
+        response_status,
+        response_body,
+        error_message,
+        **_extra,
+    ):
         attempts.append(
             {
                 "event_id": event_id,
@@ -437,7 +453,16 @@ async def test_import_from_request_fallback_failure_records_repo(monkeypatch):
     attempts: list[dict[str, object]] = []
     failures: list[dict[str, object]] = []
 
-    async def fake_record_attempt(*, event_id, attempt_number, status, response_status, response_body, error_message):
+    async def fake_record_attempt(
+        *,
+        event_id,
+        attempt_number,
+        status,
+        response_status,
+        response_body,
+        error_message,
+        **_extra,
+    ):
         attempts.append(
             {
                 "event_id": event_id,


### PR DESCRIPTION
## Summary
- add storage for webhook attempt request and response metadata and sanitize persisted headers
- expose the new metadata through the scheduler API and webhook monitor UI with a detail inspector
- update Syncro manual logging, migrations, and tests to account for request/response capture

## Testing
- pytest tests/test_syncro_service.py
- pytest tests/test_email_service.py tests/test_ticket_importer.py tests/test_modules_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f73d0beb58832daa775251d4fcb774