### PR TITLE
Enhance Syncro ticket import with replies and watchers

### DIFF
--- a/app/repositories/companies.py
+++ b/app/repositories/companies.py
@@ -30,6 +30,14 @@ async def get_company_by_syncro_id(syncro_company_id: str) -> Optional[dict[str,
     return _normalise_company(row) if row else None
 
 
+async def get_company_by_name(name: str) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one(
+        "SELECT * FROM companies WHERE LOWER(name) = LOWER(%s) LIMIT 1",
+        (name,),
+    )
+    return _normalise_company(row) if row else None
+
+
 async def list_companies() -> List[dict[str, Any]]:
     rows = await db.fetch_all("SELECT * FROM companies ORDER BY name")
     return [_normalise_company(row) for row in rows]

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-14, 09:00 UTC, Feature, Enriched Syncro ticket import to persist ticket numbers, map companies by business name, sync comment replies, and subscribe watcher emails from destination lists
 - 2025-10-21, 07:59 UTC, Feature, Persisted webhook attempt request and response payloads with an admin monitor detail viewer for troubleshooting
 - 2025-12-13, 18:00 UTC, Fix, Loaded the admin.js bundle on the Syncro ticket import page so the import forms trigger the API workflow
 - 2025-12-13, 17:15 UTC, Fix, Added detailed Syncro ticket import logging for admin requests and webhook lifecycle events to troubleshoot missing monitor processing

--- a/migrations/078_syncro_ticket_reply_enhancements.sql
+++ b/migrations/078_syncro_ticket_reply_enhancements.sql
@@ -1,0 +1,6 @@
+ALTER TABLE tickets
+    ADD COLUMN ticket_number VARCHAR(64) NULL AFTER external_reference;
+
+ALTER TABLE ticket_replies
+    ADD COLUMN external_reference VARCHAR(128) NULL AFTER body,
+    ADD UNIQUE KEY uq_ticket_replies_external (ticket_id, external_reference);


### PR DESCRIPTION
## Summary
- add a migration to persist Syncro ticket numbers and external reply identifiers so imported data can be deduplicated
- extend the Syncro ticket importer to map business names to companies, capture contact/requester links, sync comment replies, and subscribe watcher emails
- update repositories and tests to support the new ticket fields and validate the reply/watcher import logic

## Testing
- `poetry run pytest tests/test_ticket_importer.py`


------
https://chatgpt.com/codex/tasks/task_b_68f75c0379cc832d9254dae8f0c2c848