### PR TITLE
Import Syncro initial issue comment and attribute replies

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-15, 09:30 UTC, Fix, Imported Syncro ticket Initial Issue comments as descriptions and mapped reply authors to customer or technician users
 - 2025-12-14, 09:00 UTC, Feature, Enriched Syncro ticket import to persist ticket numbers, map companies by business name, sync comment replies, and subscribe watcher emails from destination lists
 - 2025-10-21, 10:39 UTC, Feature, Auto-created missing companies from Syncro ticket imports using returned customer details to keep tickets linked
 - 2025-10-21, 10:39 UTC, Fix, Displayed ticket conversation history with newest replies first across admin views, APIs, and AI prompts

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -262,6 +262,7 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
             "comments": [
                 {
                     "id": 1,
+                    "subject": "Initial Issue",
                     "body": "Customer message",
                     "tech": "customer-reply",
                     "hidden": False,
@@ -275,6 +276,7 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
                     "id": 2,
                     "body": "Internal update",
                     "tech": "agent",
+                    "user_email": "tech@example.com",
                     "hidden": True,
                     "destination_emails": [
                         "tech@example.com",
@@ -351,11 +353,14 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
     assert created_call["ticket_number"] == "TCK-5001"
     assert created_call["company_id"] == 8
     assert created_call["requester_id"] == 21
+    assert created_call["description"] == "Customer message"
     assert len(reply_calls) == 2
     assert reply_calls[0]["external_reference"] == "1"
     assert reply_calls[0]["is_internal"] is False
+    assert reply_calls[0]["author_id"] == 21
     assert reply_calls[1]["external_reference"] == "2"
     assert reply_calls[1]["is_internal"] is True
+    assert reply_calls[1]["author_id"] == 31
     assert added_watchers == [(400, 31)]
 
 


### PR DESCRIPTION
## Summary
- use the Syncro comment titled "Initial Issue" as the imported ticket description when available
- attribute imported ticket replies to the customer requester or technician based on comment metadata while keeping the reply in the conversation history
- expand regression coverage to cover description sourcing and reply author assignment

## Testing
- pytest tests/test_ticket_importer.py

------
https://chatgpt.com/codex/tasks/task_b_68f765531000832db27f3186b3de1905