### PR TITLE
Sanitise Syncro ticket HTML content during import

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-16, 10:00 UTC, Fix, Sanitised Syncro ticket import text to convert HTML line breaks and remove unsupported tags
 - 2025-12-15, 09:30 UTC, Feature, Added automated webhook cleanup after 24 hours with admin delete controls to cancel pending deliveries
 - 2025-12-15, 09:30 UTC, Fix, Imported Syncro ticket Initial Issue comments as descriptions and mapped reply authors to customer or technician users
 - 2025-12-14, 09:00 UTC, Feature, Enriched Syncro ticket import to persist ticket numbers, map companies by business name, sync comment replies, and subscribe watcher emails from destination lists

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -26,6 +26,15 @@ def test_normalise_priority_mapping():
     assert ticket_importer._normalise_priority(None) == "normal"
 
 
+def test_clean_text_converts_basic_html():
+    value = "<p>Hello<br />World</p>\n<div>Next&nbsp;Line</div>"
+    assert ticket_importer._clean_text(value) == "Hello\nWorld\nNext Line"
+
+
+def test_clean_text_preserves_angle_brackets_when_not_tags():
+    assert ticket_importer._clean_text("Value is < 3 &amp; rising") == "Value is < 3 & rising"
+
+
 @pytest.mark.anyio
 async def test_import_ticket_by_id_creates_new_ticket(monkeypatch):
     async def fake_get_ticket(ticket_id, rate_limiter=None):


### PR DESCRIPTION
## Summary
- normalise Syncro ticket text imported from Syncro by converting HTML line breaks to newlines, removing unsupported tags, and unescaping entities
- add regression tests ensuring HTML is sanitised without stripping comparison operators
- record the change in the changelog

## Testing
- pytest tests/test_ticket_importer.py

------
https://chatgpt.com/codex/tasks/task_b_68f769935aa0832db3cf8640d2a4358a