### PR TITLE
Remove AI tag badge metadata from ticket detail view

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -152,15 +152,7 @@
                   <div class="definition-list__item">
                     <dt>AI Tags</dt>
                     <dd>
-                      <div>
-                        <span class="badge {{ ai_badge_map.get(tag_status_lower, 'badge--warning') }}">{{ tag_status_label }}</span>
-                        {% if ticket.ai_tags_model %}
-                          <span>{{ ticket.ai_tags_model }}</span>
-                        {% endif %}
-                        {% if ticket.ai_tags_updated_at %}
-                          <span>Updated {{ ticket.ai_tags_updated_at.astimezone().strftime('%Y-%m-%d %H:%M') }}</span>
-                        {% endif %}
-                      </div>
+                      <div>{{ tag_status_label }}</div>
                       {% if tag_status_lower == 'succeeded' and ticket.ai_tags %}
                         <div class="tag-list">
                           {% for tag in ticket.ai_tags %}

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-19, 15:30 UTC, Fix, Removed AI tag status badge, model label, and timestamp from the admin ticket detail metadata view
 - 2025-10-21, 11:06 UTC, Fix, Moved ticket AI tags into the Ticket details metadata panel above the module label for clearer context
 - 2025-12-15, 10:15 UTC, Fix, Escaped webhook event payloads in the admin delivery queue so delete actions parse identifiers correctly
 - 2025-12-16, 10:00 UTC, Fix, Sanitised Syncro ticket import text to convert HTML line breaks and remove unsupported tags


### PR DESCRIPTION
## Summary
- remove the badge styling and ancillary metadata from the AI Tags section on the admin ticket detail page
- record the interface adjustment in the running change log

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_b_68f76d003f70832da5378e71d62f4a78