### PR TITLE
Improve automation task defaults and company selection

### DIFF
--- a/app/repositories/scheduled_tasks.py
+++ b/app/repositories/scheduled_tasks.py
@@ -70,7 +70,7 @@ async def create_task(
     company_id: int | None = None,
     description: str | None = None,
     active: bool = True,
-    max_retries: int = 0,
+    max_retries: int = 12,
     retry_backoff_seconds: int = 300,
 ) -> dict[str, Any]:
     await db.execute(

--- a/app/schemas/scheduler.py
+++ b/app/schemas/scheduler.py
@@ -13,7 +13,7 @@ class ScheduledTaskBase(BaseModel):
     company_id: int | None = Field(default=None, validation_alias="companyId")
     description: str | None = None
     active: bool = True
-    max_retries: int = Field(default=0, validation_alias="maxRetries")
+    max_retries: int = Field(default=12, validation_alias="maxRetries")
     retry_backoff_seconds: int = Field(default=300, validation_alias="retryBackoffSeconds")
 
     model_config = {

--- a/app/templates/admin/automation.html
+++ b/app/templates/admin/automation.html
@@ -27,7 +27,7 @@
           <tr>
             <th scope="col" data-sort="string">Name</th>
             <th scope="col" data-sort="string">Command</th>
-            <th scope="col" data-sort="number">Company</th>
+            <th scope="col" data-sort="string">Company</th>
             <th scope="col" data-sort="string">Cron</th>
             <th scope="col" data-sort="string">Active</th>
             <th scope="col" data-sort="date">Last run</th>
@@ -40,8 +40,8 @@
             <tr data-task='{{ task | tojson }}'>
               <td data-label="Name">{{ task.name }}</td>
               <td data-label="Command">{{ task.command }}</td>
-              <td data-label="Company" data-value="{{ task.company_id or 0 }}">
-                {{ task.company_id if task.company_id else 'All companies' }}
+              <td data-label="Company" data-value="{{ task.company_name }}">
+                {{ task.company_name }}
               </td>
               <td data-label="Cron">{{ task.cron }}</td>
               <td data-label="Active">
@@ -108,8 +108,19 @@
       <form id="scheduled-task-form" class="form" autocomplete="off">
         <input type="hidden" name="task_id" id="task-id" />
         <div class="form-field">
-          <label class="form-label" for="task-name">Task name</label>
-          <input class="form-input" id="task-name" name="name" required maxlength="255" data-initial-focus />
+          <label class="form-label" for="task-name-display">Task name</label>
+          <input
+            class="form-input"
+            id="task-name-display"
+            type="text"
+            value=""
+            readonly
+            aria-readonly="true"
+            tabindex="-1"
+            data-initial-focus
+          />
+          <p class="form-help">Generated automatically from the selected company and command.</p>
+          <input type="hidden" id="task-name" name="name" />
         </div>
         <div class="form-field">
           <label class="form-label" for="task-command">Command</label>
@@ -120,15 +131,13 @@
           </select>
         </div>
         <div class="form-field">
-          <label class="form-label" for="task-company">Company ID</label>
-          <input
-            class="form-input"
-            id="task-company"
-            name="companyId"
-            type="number"
-            min="1"
-            placeholder="Leave blank for all companies"
-          />
+          <label class="form-label" for="task-company">Company</label>
+          <select class="form-input" id="task-company" name="companyId">
+            {% for option in company_options %}
+              <option value="{{ option.value }}">{{ option.label }}</option>
+            {% endfor %}
+          </select>
+          <p class="form-help">Choose a company or leave All companies selected to run globally.</p>
         </div>
         <div class="form-field">
           <label class="form-label" for="task-cron">Cron expression</label>
@@ -148,7 +157,7 @@
         </div>
         <div class="form-field form-field--inline">
           <label class="form-label" for="task-max-retries">Max retries</label>
-          <input class="form-input" id="task-max-retries" name="maxRetries" type="number" min="0" value="0" />
+          <input class="form-input" id="task-max-retries" name="maxRetries" type="number" min="0" value="12" />
         </div>
         <div class="form-field form-field--inline">
           <label class="form-label" for="task-backoff">Retry backoff (seconds)</label>

--- a/changes.md
+++ b/changes.md
@@ -261,3 +261,4 @@ in text
 - 2025-12-07, 12:45 UTC, Fix, Combined ticket AI tags into the AI summary panel so related insights stay in one place on the admin ticket detail view
 - 2025-12-08, 10:30 UTC, Fix, Hardened SQL migration runner to respect quoted semicolons so HTML seed data applies without syntax errors
 - 2025-12-19, 14:05 UTC, Fix, Filtered unhelpful AI-generated tags for tickets and knowledge base content using shared validation helpers
+- 2025-10-21, 11:43 UTC, Feature, Automated Automation & monitoring task creation with company name selection, generated task names, random daily cron defaults, and 12 retry baseline


### PR DESCRIPTION
## Summary
- show company names and generated task names when creating automation scheduler entries
- default new tasks to a random daily cron window with a 12 retry baseline across API, UI, and repository layers
- surface company options in the admin automation page and record the update in the change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f76ff28e3c832d94b19b34e951fa7d