### PR TITLE
Fix automation admin view import alias

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -82,7 +82,7 @@ from app.repositories import cart as cart_repo
 from app.repositories import scheduled_tasks as scheduled_tasks_repo
 from app.repositories import staff as staff_repo
 from app.repositories import tickets as tickets_repo
-from app.repositories import automations as automations_repo
+from app.repositories import automations as automation_repo
 from app.repositories import integration_modules as integration_modules_repo
 from app.repositories import webhook_events as webhook_events_repo
 from app.repositories import user_companies as user_company_repo
@@ -6314,7 +6314,7 @@ async def _render_automations_dashboard(
     error_message: str | None = None,
     status_code: int = status.HTTP_200_OK,
 ) -> HTMLResponse:
-    automations = await automations_repo.list_automations(
+    automations = await automation_repo.list_automations(
         status=status_filter,
         kind=kind_filter,
         limit=200,

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-20, 09:45 UTC, Fix, Corrected automation admin handler to import the automation repository consistently so creation succeeds without runtime errors
 - 2025-12-20, 09:15 UTC, Fix, Corrected automation insert column list to avoid SQL syntax errors when creating ticket automations
 - 2025-12-20, 09:00 UTC, Fix, Restored scheduler task creation responses by fetching the inserted row using the returned task ID
 - 2025-10-21, 11:50 UTC, Fix, Removed automation workspace sidebar so the orchestration view spans the full width per request


### PR DESCRIPTION
## Summary
- import the automations repository in the admin view using the same alias referenced during creation
- record the fix in the project change log

## Testing
- pytest tests/test_automations_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f77636af60832d960c7bda7e0c4b05