### PR TITLE
Remove automation workspace sidebar from automation creation views

### DIFF
--- a/app/templates/admin/automations_create_event.html
+++ b/app/templates/admin/automations_create_event.html
@@ -16,62 +16,7 @@
   {% set trigger_select = values.get('triggerSelectValue', '') %}
   {% set trigger_custom = values.get('triggerCustomValue', '') %}
 
-  <div class="management" data-layout>
-    <aside class="management__sidebar">
-      <h2 class="management__heading">Automation workspace</h2>
-      <p class="management__intro">React to platform signals or third-party webhooks while maintaining local audit history.</p>
-      <div class="management__quick-actions">
-        <a class="button button--ghost" href="/admin/automations">
-          <span class="button__icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false"><path d="M12.7 4.7a1 1 0 0 0-1.4 0l-6 6a1 1 0 0 0 0 1.4l6 6a1 1 0 0 0 1.4-1.4L8.41 13H19a1 1 0 0 0 0-2H8.41l4.3-4.3a1 1 0 0 0-.01-1.4z"/></svg>
-          </span>
-          Back to automation list
-        </a>
-        <a class="button button--primary" href="/admin/automations/create/scheduled">
-          <span class="button__icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2a2 2 0 0 0-2 2v3a1 1 0 0 0 1 1h1v2H5a1 1 0 0 0-1 1v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8a1 1 0 0 0-1-1h-1V8h1a1 1 0 0 0 1-1V4a2 2 0 0 0-2-2h-3a2 2 0 0 0-2 2v1h-2V4a2 2 0 0 0-2-2z"/></svg>
-          </span>
-          Switch to scheduled automation
-        </a>
-      </div>
-      <nav class="management__nav" aria-label="Automation navigation">
-        <ul class="management__list">
-          <li class="management__list-item">
-            <a class="management__nav-link" href="/admin/automations">
-              <span class="management__nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" focusable="false"><path d="M5 5a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v1h2V5a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2h-1v2h1a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2h-3a2 2 0 0 1-2-2v-1h-2v1a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h1V10H7a2 2 0 0 1-2-2zm2 0v3h3V5zm7 0v3h3V5zm-7 11v3h3v-3zm7 0v3h3v-3z"/></svg>
-              </span>
-              <span class="management__nav-text">
-                <span class="management__nav-title">Automation overview</span>
-                <span class="management__nav-subtitle">List of configured workflows</span>
-              </span>
-            </a>
-          </li>
-          <li class="management__list-item">
-            <a class="management__nav-link" href="/admin/automations/create/scheduled">
-              <span class="management__nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2a2 2 0 0 0-2 2v3a1 1 0 0 0 1 1h1v2H5a1 1 0 0 0-1 1v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8a1 1 0 0 0-1-1h-1V8h1a1 1 0 0 0 1-1V4a2 2 0 0 0-2-2h-3a2 2 0 0 0-2 2v1h-2V4a2 2 0 0 0-2-2z"/></svg>
-              </span>
-              <span class="management__nav-text">
-                <span class="management__nav-title">Scheduled workflows</span>
-                <span class="management__nav-subtitle">Create cadence-driven tasks</span>
-              </span>
-            </a>
-          </li>
-          <li class="management__list-item management__list-item--current">
-            <a class="management__nav-link" href="/admin/automations/create/event" aria-current="page">
-              <span class="management__nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a3 3 0 0 1 3 3v.18a3 3 0 0 1 2.12 2.12H17a3 3 0 0 1 3 3v.18a3 3 0 0 1 0 5.03V16a3 3 0 0 1-3 3h-.18a3 3 0 0 1-2.12 2.12V21a3 3 0 0 1-6 0v-.88A3 3 0 0 1 7.12 19H7a3 3 0 0 1-3-3v-.67a3 3 0 0 1 0-4.66V9a3 3 0 0 1 3-3h.18A3 3 0 0 1 9.3 3.18V3a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v1.5a1 1 0 0 1-.76.97 3 3 0 0 0-2.29 2.29 1 1 0 0 1-.97.76H7a1 1 0 0 0-1 1v1.5a1 1 0 0 1 .76.97 3 3 0 0 0 2.29 2.29 1 1 0 0 1 .97.76V17a1 1 0 0 0 1 1h1.5a1 1 0 0 1 .97.76 3 3 0 0 0 2.29 2.29 1 1 0 0 1 .76.97V23a1 1 0 0 0 2 0v-1.5a1 1 0 0 1 .76-.97 3 3 0 0 0 2.29-2.29 1 1 0 0 1 .97-.76H19a1 1 0 0 0 1-1v-1.5a1 1 0 0 1-.76-.97 3 3 0 0 0-2.29-2.29 1 1 0 0 1-.97-.76V9a1 1 0 0 0-1-1h-1.5a1 1 0 0 1-.97-.76 3 3 0 0 0-2.29-2.29 1 1 0 0 1-.76-.97V3a1 1 0 0 0-1-1z"/></svg>
-              </span>
-              <span class="management__nav-text">
-                <span class="management__nav-title">Event-driven flows</span>
-                <span class="management__nav-subtitle">Respond to inbound signals</span>
-              </span>
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </aside>
+  <div class="management management--single" data-layout>
 
     <section class="management__content">
       <header class="management__header">

--- a/app/templates/admin/automations_create_scheduled.html
+++ b/app/templates/admin/automations_create_scheduled.html
@@ -16,62 +16,7 @@
   {% set trigger_select = values.get('triggerSelectValue', '') %}
   {% set trigger_custom = values.get('triggerCustomValue', '') %}
 
-  <div class="management" data-layout>
-    <aside class="management__sidebar">
-      <h2 class="management__heading">Automation workspace</h2>
-      <p class="management__intro">Design cadence-driven workflows that complement event-based orchestration.</p>
-      <div class="management__quick-actions">
-        <a class="button button--ghost" href="/admin/automations">
-          <span class="button__icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false"><path d="M12.7 4.7a1 1 0 0 0-1.4 0l-6 6a1 1 0 0 0 0 1.4l6 6a1 1 0 0 0 1.4-1.4L8.41 13H19a1 1 0 1 0 0-2H8.41l4.3-4.3a1 1 0 0 0-.01-1.4z"/></svg>
-          </span>
-          Back to automation list
-        </a>
-        <a class="button button--primary" href="/admin/automations/create/event">
-          <span class="button__icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a3 3 0 0 1 2.83 2H18a2 2 0 0 1 2 2v3.17a2.99 2.99 0 0 1 0 5.66V18a2 2 0 0 1-2 2h-3.17A3 3 0 0 1 9 20H6a2 2 0 0 1-2-2v-3.17a3 3 0 0 1 0-5.66V6a2 2 0 0 1 2-2h3.17A3 3 0 0 1 12 2z"/></svg>
-          </span>
-          Switch to event automation
-        </a>
-      </div>
-      <nav class="management__nav" aria-label="Automation navigation">
-        <ul class="management__list">
-          <li class="management__list-item">
-            <a class="management__nav-link" href="/admin/automations">
-              <span class="management__nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" focusable="false"><path d="M5 5a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v1h2V5a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2h-1v2h1a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2h-3a2 2 0 0 1-2-2v-1h-2v1a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h1V10H7a2 2 0 0 1-2-2zm2 0v3h3V5zm7 0v3h3V5zm-7 11v3h3v-3zm7 0v3h3v-3z"/></svg>
-              </span>
-              <span class="management__nav-text">
-                <span class="management__nav-title">Automation overview</span>
-                <span class="management__nav-subtitle">List of configured workflows</span>
-              </span>
-            </a>
-          </li>
-          <li class="management__list-item management__list-item--current">
-            <a class="management__nav-link" href="/admin/automations/create/scheduled" aria-current="page">
-              <span class="management__nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2a2 2 0 0 0-2 2v3a1 1 0 0 0 1 1h1v2H5a1 1 0 0 0-1 1v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8a1 1 0 0 0-1-1h-1V8h1a1 1 0 0 0 1-1V4a2 2 0 0 0-2-2h-3a2 2 0 0 0-2 2v1h-2V4a2 2 0 0 0-2-2zm0 6h12v7H6zm0 9v1h12v-1zm9-13h2v2h-2zm-9 0h2v2H6zm5 5a1 1 0 0 1 1 1v2h2a1 1 0 1 1 0 2h-2v2a1 1 0 1 1-2 0v-2H9a1 1 0 1 1 0-2h2V9a1 1 0 0 1 1-1z"/></svg>
-              </span>
-              <span class="management__nav-text">
-                <span class="management__nav-title">Scheduled workflows</span>
-                <span class="management__nav-subtitle">Create cadence-driven tasks</span>
-              </span>
-            </a>
-          </li>
-          <li class="management__list-item">
-            <a class="management__nav-link" href="/admin/automations/create/event">
-              <span class="management__nav-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a3 3 0 0 1 3 3v.18a3 3 0 0 1 2.12 2.12H17a3 3 0 0 1 3 3v.18a3 3 0 0 1 0 5.03V16a3 3 0 0 1-3 3h-.18a3 3 0 0 1-2.12 2.12V21a3 3 0 0 1-6 0v-.88A3 3 0 0 1 7.12 19H7a3 3 0 0 1-3-3v-.67a3 3 0 0 1 0-4.66V9a3 3 0 0 1 3-3h.18A3 3 0 0 1 9.3 3.18V3a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v1.5a1 1 0 0 1-.76.97 3 3 0 0 0-2.29 2.29 1 1 0 0 1-.97.76H7a1 1 0 0 0-1 1v1.5a1 1 0 0 1 .76.97 3 3 0 0 0 2.29 2.29 1 1 0 0 1 .97.76V17a1 1 0 0 0 1 1h1.5a1 1 0 0 1 .97.76 3 3 0 0 0 2.29 2.29 1 1 0 0 1 .76.97V23a1 1 0 0 0 2 0v-1.5a1 1 0 0 1 .76-.97 3 3 0 0 0 2.29-2.29 1 1 0 0 1 .97-.76H19a1 1 0 0 0 1-1v-1.5a1 1 0 0 1-.76-.97 3 3 0 0 0-2.29-2.29 1 1 0 0 1-.97-.76V9a1 1 0 0 0-1-1h-1.5a1 1 0 0 1-.97-.76 3 3 0 0 0-2.29-2.29 1 1 0 0 1-.76-.97V3a1 1 0 0 0-1-1z"/></svg>
-              </span>
-              <span class="management__nav-text">
-                <span class="management__nav-title">Event-driven flows</span>
-                <span class="management__nav-subtitle">Respond to inbound signals</span>
-              </span>
-            </a>
-          </li>
-        </ul>
-      </nav>
-    </aside>
+  <div class="management management--single" data-layout>
 
     <section class="management__content">
       <header class="management__header">

--- a/changes.md
+++ b/changes.md
@@ -269,3 +269,5 @@ in text
 - 2025-12-08, 10:30 UTC, Fix, Hardened SQL migration runner to respect quoted semicolons so HTML seed data applies without syntax errors
 - 2025-12-19, 14:05 UTC, Fix, Filtered unhelpful AI-generated tags for tickets and knowledge base content using shared validation helpers
 - 2025-10-21, 11:43 UTC, Feature, Automated Automation & monitoring task creation with company name selection, generated task names, random daily cron defaults, and 12 retry baseline
+
+- 2025-10-21, 12:02 UTC, Fix, Removed automation workspace sidebar from automation creation forms per request


### PR DESCRIPTION
## Summary
- remove the automation workspace sidebar and navigation from the scheduled and event automation creation templates
- collapse the automation creation layout into a single-column management view while keeping existing header actions available
- log the interface adjustment in the project changelog

## Testing
- pytest tests/test_automations_repository.py

------
https://chatgpt.com/codex/tasks/task_b_68f775df47c8832d9fab22e038d793d7