### PR TITLE
Add super-admin ticket deletion from detail view

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5894,6 +5894,7 @@ async def _render_ticket_detail(
         "ticket_requester_options": requester_options,
         "ticket_priority_options": priority_options,
         "ticket_return_url": request.url.path,
+        "can_delete_ticket": bool(user.get("is_super_admin")),
         "success_message": success_message,
         "error_message": error_message,
     }
@@ -6254,6 +6255,41 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
         destination = f"{return_url}{separator}success={message}"
 
     return RedirectResponse(url=destination, status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post("/admin/tickets/{ticket_id}/delete", response_class=HTMLResponse)
+async def admin_delete_ticket(ticket_id: int, request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    ticket = await tickets_repo.get_ticket(ticket_id)
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
+
+    try:
+        await tickets_repo.delete_ticket(ticket_id)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log_error("Failed to delete ticket", ticket_id=ticket_id, error=str(exc))
+        return await _render_ticket_detail(
+            request,
+            current_user,
+            ticket_id=ticket_id,
+            error_message="Unable to delete the ticket. Please try again.",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+    log_info(
+        "Ticket deleted",
+        ticket_id=ticket_id,
+        deleted_by=current_user.get("id") if current_user else None,
+    )
+
+    message = quote(f"Ticket {ticket_id} deleted.")
+    return RedirectResponse(
+        url=f"/admin/tickets?success={message}",
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
 
 
 @app.post("/admin/tickets/{ticket_id}/replies", response_class=HTMLResponse)

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -40,6 +40,19 @@
         </div>
         <div class="management__header-actions">
           <a href="/admin/tickets" class="button button--ghost">Back to tickets</a>
+          {% if can_delete_ticket %}
+            <form
+              action="/admin/tickets/{{ ticket.id }}/delete"
+              method="post"
+              class="inline-form"
+              data-confirm="Delete ticket {{ ticket.id }}? This cannot be undone."
+            >
+              {% if csrf_token %}
+                <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+              {% endif %}
+              <button type="submit" class="button button--danger">Delete ticket</button>
+            </form>
+          {% endif %}
         </div>
       </header>
 

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-20, 10:30 UTC, Feature, Added super-admin ticket deletion control on the admin ticket detail page with secure backend handling and confirmation prompts
 - 2025-12-20, 09:45 UTC, Fix, Corrected automation admin handler to import the automation repository consistently so creation succeeds without runtime errors
 - 2025-12-20, 09:15 UTC, Fix, Corrected automation insert column list to avoid SQL syntax errors when creating ticket automations
 - 2025-12-20, 09:00 UTC, Fix, Restored scheduler task creation responses by fetching the inserted row using the returned task ID


### PR DESCRIPTION
## Summary
- add a super-admin only admin endpoint to delete tickets and surface it from the ticket detail view
- show a CSRF-protected delete button with a confirmation prompt and log successful removals
- record the new capability in the change log

## Testing
- pytest tests/test_ticket_access.py::test_non_admin_ticket_listing_scoped_to_requester

------
https://chatgpt.com/codex/tasks/task_b_68f777f96864832d9d21052d3c7dc275