### PR TITLE
Fix ticket-created automations not firing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6003,6 +6003,17 @@ async def admin_create_ticket(request: Request):
         await tickets_repo.add_watcher(created["id"], current_user.get("id"))
         await tickets_service.refresh_ticket_ai_summary(created["id"])
         await tickets_service.refresh_ticket_ai_tags(created["id"])
+        try:
+            await automations_service.handle_event(
+                "tickets.created",
+                {"ticket": created},
+            )
+        except Exception as automation_exc:  # pragma: no cover - defensive logging
+            log_error(
+                "Failed to execute ticket creation automations",
+                ticket_id=created.get("id"),
+                error=str(automation_exc),
+            )
     except Exception as exc:  # pragma: no cover - defensive logging
         log_error("Failed to create ticket", error=str(exc))
         return await _render_tickets_dashboard(

--- a/app/repositories/automations.py
+++ b/app/repositories/automations.py
@@ -330,3 +330,26 @@ async def set_last_error(automation_id: int, message: str | None) -> None:
         """,
         (message, automation_id),
     )
+
+
+async def list_event_automations(
+    trigger_event: str,
+    *,
+    limit: int = 50,
+) -> list[AutomationRecord]:
+    """Return active event-driven automations matching the provided trigger."""
+
+    await _ensure_connection()
+    rows = await db.fetch_all(
+        """
+        SELECT *
+        FROM automations
+        WHERE status = 'active'
+          AND kind = 'event'
+          AND trigger_event = %s
+        ORDER BY id ASC
+        LIMIT %s
+        """,
+        (trigger_event, limit),
+    )
+    return [_normalise_automation(row) for row in rows]

--- a/changes.md
+++ b/changes.md
@@ -1,6 +1,7 @@
 - 2025-12-20, 09:45 UTC, Fix, Corrected automation admin handler to import the automation repository consistently so creation succeeds without runtime errors
 - 2025-12-20, 09:15 UTC, Fix, Corrected automation insert column list to avoid SQL syntax errors when creating ticket automations
 - 2025-12-20, 09:00 UTC, Fix, Restored scheduler task creation responses by fetching the inserted row using the returned task ID
+- 2025-10-21, 12:17 UTC, Fix, Triggered ticket-created automations with event filter support and event repository helpers so workflows fire on new tickets
 - 2025-10-21, 11:50 UTC, Fix, Removed automation workspace sidebar so the orchestration view spans the full width per request
 - 2025-12-19, 16:10 UTC, Fix, Removed the AI tag status label entirely from the admin ticket detail view for a leaner tags section
 - 2025-10-21, 11:44 UTC, Fix, Removed succeeded/skipped AI tag status labels from the admin ticket detail view to declutter the tags section

--- a/tests/test_automations_service.py
+++ b/tests/test_automations_service.py
@@ -1,6 +1,14 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
+from app.services import automations as automations_service
 from app.services.automations import calculate_next_run
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
 
 
 def test_calculate_next_run_hourly_cadence():
@@ -21,3 +29,70 @@ def test_calculate_next_run_for_event_automation():
     reference = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
     automation = {"kind": "event"}
     assert calculate_next_run(automation, reference=reference) is None
+
+
+@pytest.mark.anyio
+async def test_handle_event_executes_matching_automations(monkeypatch):
+    contexts: list[tuple[int, dict[str, object] | None]] = []
+
+    async def fake_list_event_automations(trigger_event: str, *, limit: int = 50):
+        assert trigger_event == "tickets.created"
+        assert limit == 50
+        return [
+            {"id": 1, "trigger_filters": {"match": {"ticket.status": "open"}}},
+            {"id": 2, "trigger_filters": {"match": {"ticket.status": "closed"}}},
+        ]
+
+    async def fake_execute(automation, *, context=None):
+        contexts.append((int(automation["id"]), context))
+        now = datetime.now(timezone.utc)
+        return {
+            "status": "succeeded",
+            "result": None,
+            "error": None,
+            "started_at": now,
+            "finished_at": now,
+            "next_run_at": None,
+        }
+
+    monkeypatch.setattr(
+        automations_service.automation_repo,
+        "list_event_automations",
+        fake_list_event_automations,
+    )
+    monkeypatch.setattr(
+        automations_service,
+        "_execute_automation",
+        fake_execute,
+    )
+
+    results = await automations_service.handle_event(
+        "tickets.created",
+        {"ticket": {"status": "open"}},
+    )
+
+    assert contexts == [(1, {"ticket": {"status": "open"}})]
+    assert len(results) == 1
+    assert results[0]["automation_id"] == 1
+    assert results[0]["status"] == "succeeded"
+
+
+@pytest.mark.anyio
+async def test_handle_event_returns_empty_for_blank_event(monkeypatch):
+    called = False
+
+    async def fake_list_event_automations(*args, **kwargs):  # pragma: no cover - defensive
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(
+        automations_service.automation_repo,
+        "list_event_automations",
+        fake_list_event_automations,
+    )
+
+    results = await automations_service.handle_event("", {"ticket": {}})
+
+    assert results == []
+    assert called is False


### PR DESCRIPTION
## Summary
- add repository helper to list active event-driven automations by trigger
- ensure ticket creation paths dispatch the tickets.created automation event with context and filtering support
- extend automation service with trigger filter evaluation, event handling, and tests covering new behaviour

## Testing
- `pytest tests/test_automations_service.py`

------
https://chatgpt.com/codex/tasks/task_b_68f777a772d0832d98acc5b3c48f5c1b