### PR TITLE
Ensure ticket creation triggers event automations

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6081,7 +6081,7 @@ async def admin_create_ticket(request: Request):
             status_code=status.HTTP_400_BAD_REQUEST,
         )
     try:
-        created = await tickets_repo.create_ticket(
+        created = await tickets_service.create_ticket(
             subject=subject,
             description=description,
             requester_id=current_user.get("id"),
@@ -6092,21 +6092,11 @@ async def admin_create_ticket(request: Request):
             category=str(form.get("category", "")).strip() or None,
             module_slug=module_slug,
             external_reference=str(form.get("externalReference", "")).strip() or None,
+            trigger_automations=True,
         )
         await tickets_repo.add_watcher(created["id"], current_user.get("id"))
         await tickets_service.refresh_ticket_ai_summary(created["id"])
         await tickets_service.refresh_ticket_ai_tags(created["id"])
-        try:
-            await automations_service.handle_event(
-                "tickets.created",
-                {"ticket": created},
-            )
-        except Exception as automation_exc:  # pragma: no cover - defensive logging
-            log_error(
-                "Failed to execute ticket creation automations",
-                ticket_id=created.get("id"),
-                error=str(automation_exc),
-            )
     except Exception as exc:  # pragma: no cover - defensive logging
         log_error("Failed to create ticket", error=str(exc))
         return await _render_tickets_dashboard(

--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -12,7 +12,7 @@ from app.repositories import companies as company_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import users as user_repo
 from app.repositories import webhook_events as webhook_events_repo
-from app.services import syncro, webhook_monitor
+from app.services import syncro, tickets as tickets_service, webhook_monitor
 
 _ALLOWED_PRIORITIES = {"urgent", "high", "normal", "low"}
 _ALLOWED_STATUSES = {"open", "in_progress", "pending", "resolved", "closed"}
@@ -619,7 +619,7 @@ async def _upsert_ticket(
         ticket_db_id = int(existing["id"])
         outcome = "updated"
     else:
-        created = await tickets_repo.create_ticket(
+        created = await tickets_service.create_ticket(
             subject=subject,
             description=description_value,
             requester_id=requester_id,
@@ -631,6 +631,7 @@ async def _upsert_ticket(
             module_slug=None,
             external_reference=external_reference,
             ticket_number=ticket_number,
+            trigger_automations=True,
         )
         created_id = created.get("id")
         ticket_db_id = int(created_id) if created_id is not None else None

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-22, 12:00 UTC, Fix, Ensured ticket creation helper emits ticket-created automation events across UI, API, and Syncro imports so event workflows fire consistently
 - 2025-12-21, 09:30 UTC, Feature, Added configurable auto-refresh websocket client with toast notifications before page reloads
 - 2025-10-21, 21:54 UTC, Feature, Added system refresh websocket notifier with super-admin broadcast API and audit logging
 - 2025-10-21, 12:33 UTC, Fix, Reordered company assignment route registration to stop FastAPI parsing the static path as a company ID

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -7,6 +7,7 @@ from app.services import ticket_importer
 from app.services import syncro
 from app.repositories import tickets as tickets_repo
 from app.repositories import companies as company_repo
+from app.services import tickets as tickets_service
 
 
 @pytest.fixture
@@ -80,7 +81,7 @@ async def test_import_ticket_by_id_creates_new_ticket(monkeypatch):
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
     monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
-    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
     monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
 
@@ -170,7 +171,7 @@ async def test_import_ticket_range_handles_missing(monkeypatch):
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", lambda syncro_id: None)
     monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
-    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
 
     summary = await ticket_importer.import_ticket_range(10, 11, rate_limiter=None)
@@ -244,7 +245,7 @@ async def test_import_all_tickets_uses_pagination(monkeypatch):
     monkeypatch.setattr(syncro, "list_tickets", fake_list_tickets)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
-    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
 
     summary = await ticket_importer.import_all_tickets(rate_limiter=None)
@@ -348,7 +349,7 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company_by_syncro_id)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
     monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
-    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
     monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)

--- a/tests/test_tickets_service_create.py
+++ b/tests/test_tickets_service_create.py
@@ -1,0 +1,78 @@
+import pytest
+
+from app.repositories import tickets as tickets_repo
+from app.services import automations as automations_service
+from app.services import tickets as tickets_service
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_create_ticket_triggers_automations(monkeypatch):
+    async def fake_create_ticket(**kwargs):
+        return {"id": 42, **kwargs}
+
+    recorded: dict[str, object] = {}
+
+    async def fake_handle_event(event_name, context):  # pragma: no cover - via test
+        recorded["event"] = event_name
+        recorded["context"] = context
+        return []
+
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
+
+    ticket = await tickets_service.create_ticket(
+        subject="Printer offline",
+        description="Printer in marketing has jammed",
+        requester_id=5,
+        company_id=3,
+        assigned_user_id=None,
+        priority="high",
+        status="open",
+        category="hardware",
+        module_slug=None,
+        external_reference=None,
+        ticket_number=None,
+    )
+
+    assert ticket["id"] == 42
+    assert recorded["event"] == "tickets.created"
+    assert recorded["context"] == {"ticket": ticket}
+
+
+@pytest.mark.anyio
+async def test_create_ticket_can_skip_automations(monkeypatch):
+    async def fake_create_ticket(**kwargs):
+        return {"id": 77, **kwargs}
+
+    called = False
+
+    async def fake_handle_event(event_name, context):  # pragma: no cover - via test
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
+
+    ticket = await tickets_service.create_ticket(
+        subject="Laptop setup",
+        description=None,
+        requester_id=None,
+        company_id=None,
+        assigned_user_id=10,
+        priority="normal",
+        status="open",
+        category=None,
+        module_slug="syncro",
+        external_reference="abc",
+        ticket_number="1001",
+        trigger_automations=False,
+    )
+
+    assert ticket["id"] == 77
+    assert called is False


### PR DESCRIPTION
## Summary
- add a tickets service helper that emits the `tickets.created` automation event after every successful insert
- refactor the API, admin UI, and Syncro importer to use the helper so event automations run for all ticket sources
- cover the new helper with tests, update importer tests, and log the fix in the changelog

## Testing
- pytest tests/test_tickets_service_create.py tests/test_ticket_importer.py tests/test_automations_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f82251d624832d8533b485134bffaa