### PR TITLE
Fix event automation fetch limit for ntfy notifications

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-23, 08:45 UTC, Fix, Removed event automation fetch limits so ntfy publish alerts fire during ticket creation workflows
 - 2025-12-22, 12:00 UTC, Fix, Ensured ticket creation helper emits ticket-created automation events across UI, API, and Syncro imports so event workflows fire consistently
 - 2025-12-21, 09:30 UTC, Feature, Added configurable auto-refresh websocket client with toast notifications before page reloads
 - 2025-10-21, 21:54 UTC, Feature, Added system refresh websocket notifier with super-admin broadcast API and audit logging

--- a/tests/test_automations_service.py
+++ b/tests/test_automations_service.py
@@ -35,9 +35,9 @@ def test_calculate_next_run_for_event_automation():
 async def test_handle_event_executes_matching_automations(monkeypatch):
     contexts: list[tuple[int, dict[str, object] | None]] = []
 
-    async def fake_list_event_automations(trigger_event: str, *, limit: int = 50):
+    async def fake_list_event_automations(trigger_event: str, *, limit: int | None = None):
         assert trigger_event == "tickets.created"
-        assert limit == 50
+        assert limit is None
         return [
             {"id": 1, "trigger_filters": {"match": {"ticket.status": "open"}}},
             {"id": 2, "trigger_filters": {"match": {"ticket.status": "closed"}}},


### PR DESCRIPTION
## Summary
- allow event automation lookups to fetch every matching workflow so ntfy alerts trigger on ticket creation
- cover the repository and service behaviours with regression tests
- record the fix in the project change log

## Testing
- pytest tests/test_automations_service.py tests/test_automations_repository.py

------
https://chatgpt.com/codex/tasks/task_b_68f827cb4e18832da46409d8382580a9