### PR TITLE
Queue ticket automation events in background tasks

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-24, 09:00 UTC, Fix, Queued ticket automation module execution in background tasks so ntfy notifications run without blocking the UI
 - 2025-12-23, 08:45 UTC, Fix, Removed event automation fetch limits so ntfy publish alerts fire during ticket creation workflows
 - 2025-12-22, 12:00 UTC, Fix, Ensured ticket creation helper emits ticket-created automation events across UI, API, and Syncro imports so event workflows fire consistently
 - 2025-12-21, 09:30 UTC, Feature, Added configurable auto-refresh websocket client with toast notifications before page reloads


### PR DESCRIPTION
## Summary
- queue event-triggered automation executions on background tasks so ticket-created ntfy alerts run asynchronously
- add defensive task tracking and logging for automation background work
- refresh automation service regression tests and record the change in the changelog

## Testing
- pytest tests/test_automations_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f82bfbc454832d8f64b6c4600d7cd9