### PR TITLE
Run module integrations in background tasks

### DIFF
--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -230,6 +230,7 @@ async def _execute_automation(
                     action_result = await modules_service.trigger_module(
                         module_slug,
                         module_payload,
+                        background=False,
                     )
                     results.append(
                         {"module": module_slug, "status": "succeeded", "result": action_result}
@@ -258,7 +259,9 @@ async def _execute_automation(
                 module_payload = dict(payload)
                 if context:
                     module_payload.setdefault("context", context)
-                result_payload = await modules_service.trigger_module(str(module_slug), module_payload)
+                result_payload = await modules_service.trigger_module(
+                    str(module_slug), module_payload, background=False
+                )
             else:
                 result_payload = {"status": "skipped", "reason": "No action module configured"}
     except Exception as exc:  # pragma: no cover - network/runtime guard

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-24, 11:30 UTC, Fix, Moved Ollama module generation into shared background tasks with ticket and knowledge base callbacks to remove UI delays
 - 2025-12-24, 09:00 UTC, Fix, Queued ticket automation module execution in background tasks so ntfy notifications run without blocking the UI
 - 2025-12-23, 08:45 UTC, Fix, Removed event automation fetch limits so ntfy publish alerts fire during ticket creation workflows
 - 2025-12-22, 12:00 UTC, Fix, Ensured ticket creation helper emits ticket-created automation events across UI, API, and Syncro imports so event workflows fire consistently

--- a/tests/test_refresh_events.py
+++ b/tests/test_refresh_events.py
@@ -15,7 +15,7 @@ def anyio_backend() -> str:
 async def test_create_article_broadcasts_refresh(monkeypatch):
     notifier = AsyncMock(spec=RefreshNotifier)
 
-    monkeypatch.setattr(kb_service, "_generate_article_ai_tags", AsyncMock(return_value=["tag"]))
+    monkeypatch.setattr(kb_service, "_schedule_article_ai_tags", AsyncMock())
     monkeypatch.setattr(kb_service.kb_repo, "create_article", AsyncMock(return_value={"id": 11, "slug": "intro"}))
     monkeypatch.setattr(kb_service.kb_repo, "replace_article_sections", AsyncMock())
     monkeypatch.setattr(kb_service.kb_repo, "replace_article_users", AsyncMock())
@@ -52,11 +52,7 @@ async def test_update_article_broadcasts_refresh(monkeypatch):
         "get_article_by_id",
         AsyncMock(side_effect=[current_article, refreshed_article]),
     )
-    monkeypatch.setattr(
-        kb_service,
-        "_generate_article_ai_tags",
-        AsyncMock(return_value=["updated"]),
-    )
+    monkeypatch.setattr(kb_service, "_schedule_article_ai_tags", AsyncMock())
     monkeypatch.setattr(kb_service.kb_repo, "update_article", AsyncMock(return_value=refreshed_article))
     monkeypatch.setattr(kb_service.kb_repo, "replace_article_sections", AsyncMock())
     monkeypatch.setattr(kb_service.kb_repo, "replace_article_users", AsyncMock())


### PR DESCRIPTION
## Summary
- run Ollama, SMTP, TacticalRMM, and other module handlers via reusable background tasks and expose optional completion callbacks
- update ticket AI summary/tag workflows to enqueue Ollama work, update statuses immediately, and apply results asynchronously
- queue knowledge base tag generation in the background and refresh articles when results arrive while keeping synchronous calls (automations, search) blocking for results
- adjust tests and change log to cover background behaviour and asynchronous callbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f83099d9cc832d86e12a7fcff7b866