### PR TITLE
Enable editing for ticket automations

### DIFF
--- a/app/templates/admin/automations.html
+++ b/app/templates/admin/automations.html
@@ -121,23 +121,26 @@
                     <td data-label="Next run">{{ automation.next_run_at.astimezone().strftime('%Y-%m-%d %H:%M') if automation.next_run_at else '—' }}</td>
                     <td data-label="Last run">{{ automation.last_run_at.astimezone().strftime('%Y-%m-%d %H:%M') if automation.last_run_at else '—' }}</td>
                     <td class="table__actions">
-                      <form action="/admin/automations/{{ automation.id }}/status" method="post" class="inline-form">
-                        {% if csrf_token %}
-                          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-                        {% endif %}
-                        <label class="visually-hidden" for="automation-status-{{ automation.id }}">Status</label>
-                        <select id="automation-status-{{ automation.id }}" name="status" class="form-input form-input--compact">
-                          <option value="active" {% if automation.status == 'active' %}selected{% endif %}>Active</option>
-                          <option value="inactive" {% if automation.status != 'active' %}selected{% endif %}>Inactive</option>
-                        </select>
-                        <button type="submit" class="button button--ghost">Update</button>
-                      </form>
-                      <form action="/admin/automations/{{ automation.id }}/execute" method="post" class="inline-form">
-                        {% if csrf_token %}
-                          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-                        {% endif %}
-                        <button type="submit" class="button button--ghost">Run now</button>
-                      </form>
+                      <div class="table__action-buttons">
+                        <a class="button button--ghost" href="/admin/automations/{{ automation.id }}/edit">Edit</a>
+                        <form action="/admin/automations/{{ automation.id }}/status" method="post" class="inline-form">
+                          {% if csrf_token %}
+                            <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                          {% endif %}
+                          <label class="visually-hidden" for="automation-status-{{ automation.id }}">Status</label>
+                          <select id="automation-status-{{ automation.id }}" name="status" class="form-input form-input--compact">
+                            <option value="active" {% if automation.status == 'active' %}selected{% endif %}>Active</option>
+                            <option value="inactive" {% if automation.status != 'active' %}selected{% endif %}>Inactive</option>
+                          </select>
+                          <button type="submit" class="button button--ghost">Update</button>
+                        </form>
+                        <form action="/admin/automations/{{ automation.id }}/execute" method="post" class="inline-form">
+                          {% if csrf_token %}
+                            <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                          {% endif %}
+                          <button type="submit" class="button button--ghost">Run now</button>
+                        </form>
+                      </div>
                     </td>
                   </tr>
                 {% endfor %}

--- a/app/templates/admin/automations_create_event.html
+++ b/app/templates/admin/automations_create_event.html
@@ -15,14 +15,18 @@
   {% set values = form_values or {} %}
   {% set trigger_select = values.get('triggerSelectValue', '') %}
   {% set trigger_custom = values.get('triggerCustomValue', '') %}
+  {% set header_title = page_title or 'Create event automation' %}
+  {% set header_subtitle = page_subtitle or 'Link webhook payloads and application events to integration modules for immediate processing.' %}
+  {% set submit_text = submit_label or 'Save automation' %}
+  {% set action_url = form_action or '/admin/automations' %}
 
   <div class="management management--single" data-layout>
 
     <section class="management__content">
       <header class="management__header">
         <div>
-          <h1 class="management__title">Create event automation</h1>
-          <p class="management__subtitle">Link webhook payloads and application events to integration modules for immediate processing.</p>
+          <h1 class="management__title">{{ header_title }}</h1>
+          <p class="management__subtitle">{{ header_subtitle }}</p>
         </div>
         <div class="management__header-actions">
           <a class="button button--ghost" href="/admin/automations">
@@ -31,12 +35,14 @@
             </span>
             Back to automations
           </a>
-          <a class="button button--ghost" href="/admin/automations/create/scheduled">
-            <span class="button__icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2a2 2 0 0 0-2 2v3a1 1 0 0 0 1 1h1v2H5a1 1 0 0 0-1 1v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8a1 1 0 0 0-1-1h-1V8h1a1 1 0 0 0 1-1V4a2 2 0 0 0-2-2h-3a2 2 0 0 0-2 2v1h-2V4a2 2 0 0 0-2-2z"/></svg>
-            </span>
-            Switch to scheduled automation
-          </a>
+          {% if alternate_link %}
+            <a class="button button--ghost" href="{{ alternate_link.url }}">
+              <span class="button__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2a2 2 0 0 0-2 2v3a1 1 0 0 0 1 1h1v2H5a1 1 0 0 0-1 1v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8a1 1 0 0 0-1-1h-1V8h1a1 1 0 0 0 1-1V4a2 2 0 0 0-2-2h-3a2 2 0 0 0-2 2v1h-2V4a2 2 0 0 0-2-2z"/></svg>
+              </span>
+              {{ alternate_link.label }}
+            </a>
+          {% endif %}
         </div>
       </header>
 
@@ -47,7 +53,7 @@
             <p class="card__subtitle">Provide deterministic JSON filters to keep automations secure and auditable.</p>
           </header>
           <div class="card__body">
-            <form action="/admin/automations" method="post" class="form management__form">
+            <form action="{{ action_url }}" method="post" class="form management__form">
               {% if csrf_token %}
                 <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
               {% endif %}
@@ -108,7 +114,7 @@
                 <input type="hidden" id="automation-actions-data" name="actionPayload" value="{{ values.get('actionPayloadRaw', '') }}" />
               </div>
               <div class="form-actions">
-                <button type="submit" class="button button--primary">Save automation</button>
+                <button type="submit" class="button button--primary">{{ submit_text }}</button>
               </div>
             </form>
           </div>

--- a/app/templates/admin/automations_create_scheduled.html
+++ b/app/templates/admin/automations_create_scheduled.html
@@ -15,14 +15,18 @@
   {% set values = form_values or {} %}
   {% set trigger_select = values.get('triggerSelectValue', '') %}
   {% set trigger_custom = values.get('triggerCustomValue', '') %}
+  {% set header_title = page_title or 'Create scheduled automation' %}
+  {% set header_subtitle = page_subtitle or 'Configure cadence, triggers, and action payloads to run on a predictable rhythm.' %}
+  {% set submit_text = submit_label or 'Save automation' %}
+  {% set action_url = form_action or '/admin/automations' %}
 
   <div class="management management--single" data-layout>
 
     <section class="management__content">
       <header class="management__header">
         <div>
-          <h1 class="management__title">Create scheduled automation</h1>
-          <p class="management__subtitle">Configure cadence, triggers, and action payloads to run on a predictable rhythm.</p>
+          <h1 class="management__title">{{ header_title }}</h1>
+          <p class="management__subtitle">{{ header_subtitle }}</p>
         </div>
         <div class="management__header-actions">
           <a class="button button--ghost" href="/admin/automations">
@@ -31,12 +35,14 @@
             </span>
             Back to automations
           </a>
-          <a class="button button--ghost" href="/admin/automations/create/event">
-            <span class="button__icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a3 3 0 0 1 3 3v.18a3 3 0 0 1 2.12 2.12H17a3 3 0 0 1 3 3v.18a3 3 0 0 1 0 5.03V16a3 3 0 0 1-3 3h-.18a3 3 0 0 1-2.12 2.12V21a3 3 0 0 1-6 0v-.88A3 3 0 0 1 7.12 19H7a3 3 0 0 1-3-3v-.67a3 3 0 0 1 0-4.66V9a3 3 0 0 1 3-3h.18A3 3 0 0 1 9.3 3.18V3a3 3 0 0 1 3-3z"/></svg>
-            </span>
-            Switch to event automation
-          </a>
+          {% if alternate_link %}
+            <a class="button button--ghost" href="{{ alternate_link.url }}">
+              <span class="button__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a3 3 0 0 1 3 3v.18a3 3 0 0 1 2.12 2.12H17a3 3 0 0 1 3 3v.18a3 3 0 0 1 0 5.03V16a3 3 0 0 1-3 3h-.18a3 3 0 0 1-2.12 2.12V21a3 3 0 0 1-6 0v-.88A3 3 0 0 1 7.12 19H7a3 3 0 0 1-3-3v-.67a3 3 0 0 1 0-4.66V9a3 3 0 0 1 3-3h.18A3 3 0 0 1 9.3 3.18V3a3 3 0 0 1 3-3z"/></svg>
+              </span>
+              {{ alternate_link.label }}
+            </a>
+          {% endif %}
         </div>
       </header>
 
@@ -47,7 +53,7 @@
             <p class="card__subtitle">All fields support JSON validation and UTC storage to keep automations deterministic.</p>
           </header>
           <div class="card__body">
-            <form action="/admin/automations" method="post" class="form management__form">
+            <form action="{{ action_url }}" method="post" class="form management__form">
               {% if csrf_token %}
                 <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
               {% endif %}
@@ -125,7 +131,7 @@
                 <input type="hidden" id="automation-actions-data" name="actionPayload" value="{{ values.get('actionPayloadRaw', '') }}" />
               </div>
               <div class="form-actions">
-                <button type="submit" class="button button--primary">Save automation</button>
+                <button type="submit" class="button button--primary">{{ submit_text }}</button>
               </div>
             </form>
           </div>

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-22, 01:47 UTC, Feature, Enabled ticket automation editing with prefilled forms and admin entry points for updating workflows
 - 2025-12-24, 11:30 UTC, Fix, Moved Ollama module generation into shared background tasks with ticket and knowledge base callbacks to remove UI delays
 - 2025-12-24, 09:00 UTC, Fix, Queued ticket automation module execution in background tasks so ntfy notifications run without blocking the UI
 - 2025-12-23, 08:45 UTC, Fix, Removed event automation fetch limits so ntfy publish alerts fire during ticket creation workflows


### PR DESCRIPTION
## Summary
- add shared helpers so the admin automation form can populate existing data and validate submissions for updates
- expose an edit route and UI entry point so ticket automations can be modified in place
- refresh automation create/edit templates to reuse headers, form actions, and submit labels while updating the change log

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68f83650123c832da854dcdba1bb61a5