### PR TITLE
Add quick add templates for automation filters and actions

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -568,6 +568,24 @@ body {
   }
 }
 
+.form-quick-add {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-gap-tight);
+  margin-bottom: var(--space-gap-tight);
+}
+
+.form-quick-add__select {
+  flex: 1 1 220px;
+  min-width: 200px;
+}
+
+.form-quick-add .button {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
 .form-help--error,
 .form-help[data-action-error]:not([hidden]) {
   color: #fecaca;

--- a/app/templates/admin/automations_create_event.html
+++ b/app/templates/admin/automations_create_event.html
@@ -97,7 +97,21 @@
               </div>
               <div class="form-field">
                 <label class="form-label" for="automation-filters">Trigger filters (JSON)</label>
-                <textarea id="automation-filters" name="triggerFilters" class="form-input" rows="3" placeholder='{"match":{"status":"open"}}'>{{ values.get('triggerFiltersRaw', '') }}</textarea>
+                <div class="form-quick-add">
+                  <label class="sr-only" for="automation-filter-quick-add">Quick add trigger filter template</label>
+                  <select id="automation-filter-quick-add" class="form-input form-quick-add__select" data-filter-quick-add>
+                    <option value="">Select a filter template</option>
+                  </select>
+                  <button type="button" class="button button--ghost" data-filter-quick-add-apply>Insert template</button>
+                </div>
+                <textarea
+                  id="automation-filters"
+                  name="triggerFilters"
+                  class="form-input"
+                  rows="3"
+                  placeholder='{"match":{"status":"open"}}'
+                >{{ values.get('triggerFiltersRaw', '') }}</textarea>
+                <p class="form-help">Use filter templates to match webhook payloads without manually writing JSON.</p>
               </div>
               <div class="form-field" data-automation-actions>
                 <label class="form-label">Trigger actions</label>

--- a/app/templates/admin/automations_create_scheduled.html
+++ b/app/templates/admin/automations_create_scheduled.html
@@ -114,7 +114,21 @@
               </div>
               <div class="form-field">
                 <label class="form-label" for="automation-filters">Trigger filters (JSON)</label>
-                <textarea id="automation-filters" name="triggerFilters" class="form-input" rows="3" placeholder='{"match":{"status":"open"}}'>{{ values.get('triggerFiltersRaw', '') }}</textarea>
+                <div class="form-quick-add">
+                  <label class="sr-only" for="automation-filter-quick-add">Quick add trigger filter template</label>
+                  <select id="automation-filter-quick-add" class="form-input form-quick-add__select" data-filter-quick-add>
+                    <option value="">Select a filter template</option>
+                  </select>
+                  <button type="button" class="button button--ghost" data-filter-quick-add-apply>Insert template</button>
+                </div>
+                <textarea
+                  id="automation-filters"
+                  name="triggerFilters"
+                  class="form-input"
+                  rows="3"
+                  placeholder='{"match":{"status":"open"}}'
+                >{{ values.get('triggerFiltersRaw', '') }}</textarea>
+                <p class="form-help">Use filter templates to match webhook payloads without manually writing JSON.</p>
               </div>
               <div class="form-field" data-automation-actions>
                 <label class="form-label">Trigger actions</label>

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-22, 02:23 UTC, Feature, Added quick add dropdowns for automation trigger filters and module-specific action templates
 - 2025-10-22, 01:47 UTC, Feature, Enabled ticket automation editing with prefilled forms and admin entry points for updating workflows
 - 2025-12-24, 11:30 UTC, Fix, Moved Ollama module generation into shared background tasks with ticket and knowledge base callbacks to remove UI delays
 - 2025-12-24, 09:00 UTC, Fix, Queued ticket automation module execution in background tasks so ntfy notifications run without blocking the UI


### PR DESCRIPTION
## Summary
- add quick-add dropdowns to automation forms so users can insert common trigger filter JSON snippets
- extend the action builder with module-specific payload templates and supporting styles for the quick-add controls
- document the feature in the change log

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_b_68f83f2b2fd8832d8050b3f04144937e