### PR TITLE
Seed default automation templates

### DIFF
--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -750,6 +750,12 @@
       select.appendChild(option);
     });
 
+    const defaultFilter = FILTER_SNIPPETS.find((snippet) => snippet && snippet.value);
+    if (defaultFilter && !textarea.value.trim()) {
+      insertSnippet(textarea, defaultFilter.value);
+      select.value = '';
+    }
+
     const hasTemplates = select.options.length > 1;
     select.disabled = !hasTemplates;
     button.disabled = !hasTemplates;
@@ -889,6 +895,8 @@
         label: String(entry.name || entry.slug || '').trim(),
       }))
       .filter((option) => option.value);
+
+    let hasSeededDefaultAction = false;
 
     const createModuleSelect = (value) => {
       const select = document.createElement('select');
@@ -1055,7 +1063,22 @@
         refreshQuickAddOptions = () => {
           populateActionQuickAdd(quickAddSelect, quickAddButton, quickAddWrapper, moduleSelect.value);
         };
+        if (!action && !hasSeededDefaultAction && moduleOptions.length) {
+          const defaultModule = moduleOptions[0].value;
+          if (defaultModule) {
+            moduleSelect.value = defaultModule;
+          }
+        }
         refreshQuickAddOptions();
+        if (!action && !hasSeededDefaultAction) {
+          const moduleKey = moduleSelect.value;
+          const templates = getActionTemplates(moduleKey);
+          if (templates.length) {
+            insertSnippet(payloadInput, templates[0].value);
+            quickAddSelect.value = '';
+            hasSeededDefaultAction = true;
+          }
+        }
         payloadWrapper.appendChild(quickAddWrapper);
         payloadWrapper.appendChild(payloadInput);
         row.appendChild(payloadWrapper);
@@ -1090,6 +1113,9 @@
         const parsed = JSON.parse(initialValue);
         if (parsed && Array.isArray(parsed.actions)) {
           parsed.actions.forEach((action) => addRow(action));
+          if (parsed.actions.length) {
+            hasSeededDefaultAction = true;
+          }
         }
       } catch (error) {
         addRow();

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-24, 13:45 UTC, Feature, Seeded default automation filter and action templates so new workflows start with example JSON payloads in the admin builder
 - 2025-10-22, 02:23 UTC, Feature, Added quick add dropdowns for automation trigger filters and module-specific action templates
 - 2025-10-22, 01:47 UTC, Feature, Enabled ticket automation editing with prefilled forms and admin entry points for updating workflows
 - 2025-12-24, 11:30 UTC, Fix, Moved Ollama module generation into shared background tasks with ticket and knowledge base callbacks to remove UI delays


### PR DESCRIPTION
## Summary
- seed the automation filter textarea with an example template on new forms
- preselect the first module and payload snippet for the initial trigger action row
- document the UI defaults in changes.md

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f84a71eb6c832dbd9739ae24ba5846