### PR TITLE
Fix automation action variable interpolation

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -287,3 +287,4 @@ in text
 - 2025-10-21, 12:02 UTC, Fix, Removed automation workspace sidebar from automation creation forms per request
 - 2025-12-21, 11:00 UTC, Feature, Broadcast refresh notifications after knowledge base and module mutations with notifier injection and regression tests
 - 2025-12-22, 09:15 UTC, Feature, Seeded ENABLE_AUTO_REFRESH across installers and deployment scripts with documentation and regression coverage
+- 2025-12-22, 15:30 UTC, Fix, Restored automation action variable interpolation with context-aware payload rendering and regression tests


### PR DESCRIPTION
## Summary
- add context-aware interpolation helpers for automation action payloads
- ensure automation execution uses interpolated payloads before invoking modules
- cover interpolation behaviour with regression tests and changelog entry

## Testing
- pytest tests/test_automations_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f84d8cb9e4832da39c50290205fcb3