### PR TITLE
Fix ntfy automation variable interpolation

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-24, 14:20 UTC, Fix, Restored uppercase automation variable interpolation for ntfy event alerts and added regression coverage
 - 2025-12-24, 13:45 UTC, Feature, Seeded default automation filter and action templates so new workflows start with example JSON payloads in the admin builder
 - 2025-10-22, 02:23 UTC, Feature, Added quick add dropdowns for automation trigger filters and module-specific action templates
 - 2025-10-22, 01:47 UTC, Feature, Enabled ticket automation editing with prefilled forms and admin entry points for updating workflows


### PR DESCRIPTION
## Summary
- add legacy uppercase token interpolation for automation payload rendering so ntfy alerts receive resolved ticket data
- cover the uppercase token rendering with a regression test and record the change in the changelog

## Testing
- pytest tests/test_automations_service.py::test_execute_automation_supports_constant_tokens -q

------
https://chatgpt.com/codex/tasks/task_b_68f8527aa208832da1121b3e59fcc160