### PR TITLE
Ensure web UI system updates trigger restart helper

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-22, 09:55 UTC, Fix, Forced web UI system updates to run the restart helper even when the repository is already up to date
 - 2025-12-26, 09:10 UTC, Feature, Documented how to trigger targeted or full database migration reprocessing from the app helpers
 - 2025-10-22, 06:49 UTC, Feature, Added database migration reprocessing helper to re-run individual or all SQL files safely
 - 2025-12-24, 16:30 UTC, Feature, Expanded System Variables Reference knowledge base article with the full catalogue of application, runtime, and environment tokens

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -130,10 +130,14 @@ else
 fi
 
 POST_PULL_HEAD=$(git rev-parse HEAD)
+FORCE_RESTART="${FORCE_RESTART:-0}"
 
 if [[ "$PRE_PULL_HEAD" != "$POST_PULL_HEAD" ]]; then
   echo "Repository updated to $POST_PULL_HEAD. Run scripts/restart.sh to reinstall dependencies and restart the service."
-  ./scripts/restart.sh
+  "${SCRIPT_DIR}/restart.sh"
+elif [[ "$FORCE_RESTART" == "1" ]]; then
+  echo "No repository changes detected but FORCE_RESTART=1; running restart helper."
+  "${SCRIPT_DIR}/restart.sh"
 else
   echo "No changes detected from remote."
 fi

--- a/tests/test_scheduler_system_update.py
+++ b/tests/test_scheduler_system_update.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.scheduler import SchedulerService
+from app.repositories import scheduled_tasks as scheduled_tasks_repo
+
+
+def test_run_now_forces_restart_flag(monkeypatch):
+    scheduler = SchedulerService()
+
+    async def fake_get_task(task_id: int):
+        return {"id": task_id, "command": "system_update"}
+
+    monkeypatch.setattr(scheduled_tasks_repo, "get_task", fake_get_task)
+
+    async def fake_record_task_run(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(scheduled_tasks_repo, "record_task_run", fake_record_task_run)
+
+    recorded: dict[str, bool] = {}
+
+    async def fake_run_system_update(self, *, force_restart: bool = False):
+        recorded["force_restart"] = force_restart
+        return "ok"
+
+    monkeypatch.setattr(SchedulerService, "_run_system_update", fake_run_system_update)
+
+    asyncio.run(scheduler.run_now(7))
+
+    assert recorded["force_restart"] is True
+
+
+def test_system_update_sets_force_restart_env(monkeypatch):
+    scheduler = SchedulerService()
+    captured: dict[str, dict[str, str] | None] = {}
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured["env"] = kwargs.get("env")
+
+        async def _communicate():
+            return b"ok", b""
+
+        return SimpleNamespace(returncode=0, communicate=_communicate)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    output = asyncio.run(scheduler._run_system_update(force_restart=True))
+
+    assert captured["env"] is not None
+    assert captured["env"].get("FORCE_RESTART") == "1"
+    assert output == "ok"
+
+
+def test_system_update_default_env_has_no_force(monkeypatch):
+    scheduler = SchedulerService()
+    captured: dict[str, dict[str, str] | None] = {}
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured["env"] = kwargs.get("env")
+
+        async def _communicate():
+            return b"done", b""
+
+        return SimpleNamespace(returncode=0, communicate=_communicate)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    output = asyncio.run(scheduler._run_system_update())
+
+    assert captured["env"] is not None
+    assert "FORCE_RESTART" not in captured["env"]
+    assert output == "done"

--- a/tests/test_upgrade_script.py
+++ b/tests/test_upgrade_script.py
@@ -9,3 +9,5 @@ def test_upgrade_script_prefers_project_virtualenv():
     assert '"${VENV_DIR}/Scripts/python.exe"' in contents
     assert 'command -v python3' in contents and 'command -v python' in contents
     assert 'Run scripts/restart.sh to reinstall dependencies and restart the service.' in contents
+    assert 'FORCE_RESTART' in contents
+    assert 'running restart helper' in contents


### PR DESCRIPTION
## Summary
- force the scheduler's manual system update runs to pass a restart flag into the update script
- update scripts/upgrade.sh to honour the flag and call the restart helper even when no commits were pulled
- add regression tests plus a changelog entry for the behaviour

## Testing
- pytest tests/test_upgrade_script.py tests/test_scheduler_system_update.py

------
https://chatgpt.com/codex/tasks/task_b_68f8bcb1f2ac832daae26a8d6f760486