### PR TITLE
Enrich ticket automation variables

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-10-23, 01:25 UTC, Feature, Added enriched ticket automation variables including company and assignment metadata with AI and status fields for template tokens
 - 2025-12-26, 16:20 UTC, Fix, Allowed ntfy automation payloads to override notification headers and metadata with JSON-defined values and added regression coverage
 - 2025-10-22, 23:59 UTC, Fix, Guarded migration CREATE statements with IF NOT EXISTS to allow safe reimports when objects already exist
 - 2025-12-26, 14:50 UTC, Fix, Rebuilt system variables knowledge base section seeds with CONCAT_WS strings to restore valid SQL syntax during article re-imports

--- a/tests/test_system_variables_service.py
+++ b/tests/test_system_variables_service.py
@@ -44,6 +44,21 @@ def test_system_variables_filter_sensitive_env(monkeypatch):
             "labels": ["urgent", "onsite"],
             "priority": "high",
             "requester": {"email": "user@example.com"},
+            "status": "open",
+            "category": "hardware",
+            "external_reference": "RMM-42",
+            "ai_summary": "Printer offline awaiting vendor response",
+            "ai_tags": ["printer", "hardware"],
+            "company": {"id": 7, "name": "Acme Corp"},
+            "company_name": "Acme Corp",
+            "assigned_user": {
+                "id": 9,
+                "email": "tech@example.com",
+                "first_name": "Taylor",
+                "last_name": "Nguyen",
+            },
+            "assigned_user_email": "tech@example.com",
+            "assigned_user_display_name": "Taylor Nguyen",
         }
     ],
 )
@@ -57,3 +72,12 @@ def test_system_variables_include_ticket_tokens(ticket):
     assert variables["TICKET_LABELS_0"] == "urgent"
     assert variables["TICKET_LABELS_1"] == "onsite"
     assert variables["TICKET_REQUESTER_EMAIL"] == "user@example.com"
+    assert variables["TICKET_COMPANY_NAME"] == "Acme Corp"
+    assert variables["TICKET_ASSIGNED_USER_EMAIL"] == "tech@example.com"
+    assert variables["TICKET_ASSIGNED_USER_DISPLAY_NAME"] == "Taylor Nguyen"
+    assert variables["TICKET_AI_SUMMARY"] == "Printer offline awaiting vendor response"
+    assert variables["TICKET_AI_TAGS_0"] == "printer"
+    assert variables["TICKET_STATUS"] == "open"
+    assert variables["TICKET_CATEGORY"] == "hardware"
+    assert variables["TICKET_PRIORITY"] == "high"
+    assert variables["TICKET_EXTERNAL_REFERENCE"] == "RMM-42"


### PR DESCRIPTION
## Summary
- enrich ticket automation contexts with company and assignment metadata for downstream variable expansion
- expose company, assignee, and AI ticket details in system variable tests
- expand ticket creation tests to cover new enrichment helpers

## Testing
- pytest tests/test_system_variables_service.py tests/test_tickets_service_create.py

------
https://chatgpt.com/codex/tasks/task_b_68f9824bf47c832dbb20419cacfee883