### PR TITLE
Fix ntfy ticket notifications missing company name

### DIFF
--- a/app/services/system_variables.py
+++ b/app/services/system_variables.py
@@ -279,4 +279,7 @@ def get_system_variables(*, ticket: Mapping[str, Any] | None = None) -> dict[str
     variables.update(_runtime_variables())
     if ticket:
         variables.update(build_context_variables(ticket, prefix="ticket", stringify=True))
+        company_name = variables.get("TICKET_COMPANY_NAME")
+        if company_name and not variables.get("COMPANY_NAME"):
+            variables["COMPANY_NAME"] = company_name
     return variables

--- a/changes/2821c33a-cd02-4482-b1b3-c76981d27543.md
+++ b/changes/2821c33a-cd02-4482-b1b3-c76981d27543.md
@@ -1,0 +1,3 @@
+# Change Log Entry
+
+- 2025-10-23, 01:50 UTC, Fix, Added COMPANY_NAME alias to ticket system variables so ntfy automations receive company details.

--- a/tests/test_system_variables_service.py
+++ b/tests/test_system_variables_service.py
@@ -73,6 +73,7 @@ def test_system_variables_include_ticket_tokens(ticket):
     assert variables["TICKET_LABELS_1"] == "onsite"
     assert variables["TICKET_REQUESTER_EMAIL"] == "user@example.com"
     assert variables["TICKET_COMPANY_NAME"] == "Acme Corp"
+    assert variables["COMPANY_NAME"] == "Acme Corp"
     assert variables["TICKET_ASSIGNED_USER_EMAIL"] == "tech@example.com"
     assert variables["TICKET_ASSIGNED_USER_DISPLAY_NAME"] == "Taylor Nguyen"
     assert variables["TICKET_AI_SUMMARY"] == "Printer offline awaiting vendor response"


### PR DESCRIPTION
## Summary
- expose the COMPANY_NAME alias when building ticket system variables so existing ntfy templates continue to resolve
- cover the alias with a regression test and document the fix in the changelog entry archive

## Testing
- pytest tests/test_system_variables_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f989715ba0832daf58cd08387efe59