### PR TITLE
Add super admin change log page

### DIFF
--- a/app/templates/admin/change_log.html
+++ b/app/templates/admin/change_log.html
@@ -1,0 +1,101 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="admin-grid">
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Change log</h2>
+        <p class="card__subtitle">
+          Review recent features and fixes synced from the repository's <code>changes</code> directory. Timestamps display in your local timezone.
+        </p>
+      </div>
+      <form method="get" class="filter-grid">
+        <div class="form-field">
+          <label class="form-label" for="filter-change-type">Change type</label>
+          <select class="form-input" id="filter-change-type" name="change_type">
+            <option value="" {% if not filters.selected_change_type %}selected{% endif %}>All changes</option>
+            {% for change_type in change_types %}
+              <option
+                value="{{ change_type }}"
+                {% if change_type.lower() == filters.selected_change_type %}selected{% endif %}
+              >
+                {{ change_type }}
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="filter-limit">Limit</label>
+          <input
+            class="form-input"
+            id="filter-limit"
+            type="number"
+            min="1"
+            max="500"
+            name="limit"
+            value="{{ filters.limit }}"
+          />
+        </div>
+        <div class="form-actions form-actions--inline">
+          <button type="submit" class="button">Apply filters</button>
+          <a class="button button--ghost" href="/admin/change-log">Reset</a>
+        </div>
+      </form>
+    </header>
+    <div class="card__controls card__controls--bordered">
+      <input
+        type="search"
+        class="form-input"
+        placeholder="Search change log"
+        aria-label="Search change log"
+        data-table-filter="change-log-table"
+      />
+    </div>
+    <div class="table-wrapper">
+      <table class="table" id="change-log-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col" data-sort="date">Occurred</th>
+            <th scope="col" data-sort="string">Type</th>
+            <th scope="col" data-sort="string">Summary</th>
+            <th scope="col" data-sort="string">Source file</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if change_entries %}
+            {% for entry in change_entries %}
+              <tr>
+                <td data-label="Occurred" data-utc="{{ entry.occurred_at_iso or '' }}" data-value="{{ entry.occurred_at_iso or '' }}">
+                  {{ entry.occurred_at_iso or '—' }}
+                </td>
+                <td data-label="Type">
+                  <span class="tag">{{ entry.change_type }}</span>
+                </td>
+                <td data-label="Summary">{{ entry.summary }}</td>
+                <td data-label="Source file">
+                  {% if entry.source_file %}
+                    <code>{{ entry.source_file }}</code>
+                  {% else %}
+                    <span class="text-muted">—</span>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          {% else %}
+            <tr>
+              <td colspan="4" class="table__empty">No change log entries match the selected filters.</td>
+            </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/admin.js" defer></script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -294,6 +294,14 @@
                 </a>
               </li>
               <li class="menu__item">
+                <a href="/admin/change-log" {% if current_path.startswith('/admin/change-log') %}aria-current="page"{% endif %}>
+                  <span class="menu__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false"><path d="M5 4a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v14.5a.5.5 0 0 1-.76.43L12 16l-6.24 2.93A.5.5 0 0 1 5 18.5zM7 6v9.62l5-2.35 5 2.35V6z"/></svg>
+                  </span>
+                  <span class="menu__label">Change log</span>
+                </a>
+              </li>
+              <li class="menu__item">
                 <a href="/admin/audit-logs" {% if current_path.startswith('/admin/audit-logs') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" focusable="false"><path d="M5 4h14a1 1 0 0 1 1 1v15l-8-3-8 3V5a1 1 0 0 1 1-1z"/></svg>

--- a/changes/f8450a85-5211-4d8d-824e-f32fb3ed5e5b.json
+++ b/changes/f8450a85-5211-4d8d-824e-f32fb3ed5e5b.json
@@ -1,0 +1,7 @@
+{
+  "guid": "f8450a85-5211-4d8d-824e-f32fb3ed5e5b",
+  "occurred_at": "2025-10-23T01:57Z",
+  "change_type": "Feature",
+  "summary": "Surfaced super-admin change log dashboard with filtering and local time display.",
+  "content_hash": "290174b324c7cc823f37640b06c5afa9379cd434ba4849989e1811084fb6c26c"
+}

--- a/tests/test_admin_change_log_page.py
+++ b/tests/test_admin_change_log_page.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import app.main as main_module
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.database import db
+from app.main import app, scheduler_service
+
+
+@pytest.fixture(autouse=True)
+def mock_startup(monkeypatch):
+    async def fake_connect():
+        return None
+
+    async def fake_disconnect():
+        return None
+
+    async def fake_run_migrations():
+        return None
+
+    async def fake_start():
+        return None
+
+    async def fake_stop():
+        return None
+
+    async def fake_sync_change_log_sources():
+        return None
+
+    async def fake_ensure_modules():
+        return None
+
+    async def fake_refresh_schedules():
+        return None
+
+    async def fake_load_session(request, *, allow_inactive: bool = False):
+        return None
+
+    async def fake_list_companies_for_user(user_id):
+        return []
+
+    async def fake_get_user_company(user_id, company_id):
+        return {}
+
+    async def fake_list_modules():
+        return []
+
+    monkeypatch.setattr(db, "connect", fake_connect)
+    monkeypatch.setattr(db, "disconnect", fake_disconnect)
+    monkeypatch.setattr(db, "run_migrations", fake_run_migrations)
+    monkeypatch.setattr(scheduler_service, "start", fake_start)
+    monkeypatch.setattr(scheduler_service, "stop", fake_stop)
+    monkeypatch.setattr(main_module.change_log_service, "sync_change_log_sources", fake_sync_change_log_sources)
+    monkeypatch.setattr(main_module.modules_service, "ensure_default_modules", fake_ensure_modules)
+    monkeypatch.setattr(main_module.automations_service, "refresh_all_schedules", fake_refresh_schedules)
+    monkeypatch.setattr(main_module.session_manager, "load_session", fake_load_session)
+    monkeypatch.setattr(main_module.user_company_repo, "list_companies_for_user", fake_list_companies_for_user)
+    monkeypatch.setattr(main_module.user_company_repo, "get_user_company", fake_get_user_company)
+    monkeypatch.setattr(main_module.modules_service, "list_modules", fake_list_modules)
+
+
+@pytest.fixture
+def super_admin_context(monkeypatch):
+    async def fake_require_super_admin_page(request):
+        return {"id": 1, "email": "admin@example.com", "is_super_admin": True}, None
+
+    monkeypatch.setattr(main_module, "_require_super_admin_page", fake_require_super_admin_page)
+    yield
+
+
+def test_change_log_page_renders_entries(super_admin_context, monkeypatch):
+    async def fake_list_change_types():
+        return ["Feature", "Fix"]
+
+    async def fake_list_entries(*, change_type=None, limit):
+        assert change_type is None
+        assert limit == 100
+        return [
+            {
+                "guid": "1",
+                "occurred_at_utc": datetime(2025, 1, 1, 12, 30, tzinfo=timezone.utc),
+                "change_type": "Feature",
+                "summary": "Added change log page",
+                "source_file": "changes/example.json",
+            }
+        ]
+
+    monkeypatch.setattr(main_module.change_log_repo, "list_change_types", fake_list_change_types)
+    monkeypatch.setattr(main_module.change_log_repo, "list_change_log_entries", fake_list_entries)
+
+    with TestClient(app) as client:
+        response = client.get("/admin/change-log")
+
+    assert response.status_code == 200
+    html = response.text
+    assert "Added change log page" in html
+    assert "changes/example.json" in html
+    assert "data-utc=\"2025-01-01T12:30:00+00:00\"" in html
+
+
+def test_change_log_page_filters_type(super_admin_context, monkeypatch):
+    async def fake_list_change_types():
+        return ["Feature", "Fix"]
+
+    recorded_args: dict[str, tuple[str | None, int]] = {}
+
+    async def fake_list_entries(*, change_type=None, limit):
+        recorded_args["call"] = (change_type, limit)
+        return []
+
+    monkeypatch.setattr(main_module.change_log_repo, "list_change_types", fake_list_change_types)
+    monkeypatch.setattr(main_module.change_log_repo, "list_change_log_entries", fake_list_entries)
+
+    with TestClient(app) as client:
+        response = client.get("/admin/change-log", params={"change_type": "fix", "limit": 25})
+
+    assert response.status_code == 200
+    assert recorded_args["call"] == ("Fix", 25)
+    assert "value=\"Fix\"\n                selected" in response.text


### PR DESCRIPTION
## Summary
- add repository helpers to list change log entries and change types for the new dashboard
- expose a super-admin change log page with filtering, search, and localised timestamps, and link it from the admin menu
- cover the new view with unit tests and record the feature in the change log source files

## Testing
- pytest tests/test_admin_change_log_page.py

------
https://chatgpt.com/codex/tasks/task_b_68f989fd6ea0832da72c937999c8dd96