### PR TITLE
Hide source file from admin change log view

### DIFF
--- a/app/templates/admin/change_log.html
+++ b/app/templates/admin/change_log.html
@@ -59,7 +59,6 @@
             <th scope="col" data-sort="date">Occurred</th>
             <th scope="col" data-sort="string">Type</th>
             <th scope="col" data-sort="string">Summary</th>
-            <th scope="col" data-sort="string">Source file</th>
           </tr>
         </thead>
         <tbody>
@@ -73,18 +72,11 @@
                   <span class="tag">{{ entry.change_type }}</span>
                 </td>
                 <td data-label="Summary">{{ entry.summary }}</td>
-                <td data-label="Source file">
-                  {% if entry.source_file %}
-                    <code>{{ entry.source_file }}</code>
-                  {% else %}
-                    <span class="text-muted">—</span>
-                  {% endif %}
-                </td>
               </tr>
             {% endfor %}
           {% else %}
             <tr>
-              <td colspan="4" class="table__empty">No change log entries match the selected filters.</td>
+              <td colspan="3" class="table__empty">No change log entries match the selected filters.</td>
             </tr>
           {% endif %}
         </tbody>

--- a/changes/77335448-cc78-4982-ae04-fe83209ef23d.json
+++ b/changes/77335448-cc78-4982-ae04-fe83209ef23d.json
@@ -1,0 +1,7 @@
+{
+  "guid": "77335448-cc78-4982-ae04-fe83209ef23d",
+  "occurred_at": "2025-10-23T02:19Z",
+  "change_type": "Fix",
+  "summary": "Removed source file column from admin change log to hide repository paths.",
+  "content_hash": "0f14bc7c2858edbf56fbfd5b914787da7943194084183cd7ba2f4335c650b05f"
+}

--- a/tests/test_admin_change_log_page.py
+++ b/tests/test_admin_change_log_page.py
@@ -97,7 +97,8 @@ def test_change_log_page_renders_entries(super_admin_context, monkeypatch):
     assert response.status_code == 200
     html = response.text
     assert "Added change log page" in html
-    assert "changes/example.json" in html
+    assert "Source file" not in html
+    assert "changes/example.json" not in html
     assert "data-utc=\"2025-01-01T12:30:00+00:00\"" in html
 
 


### PR DESCRIPTION
## Summary
- remove the source file column from the admin change log table
- update the change log page test expectations
- record the change in a new change log entry

## Testing
- pytest tests/test_admin_change_log_page.py

------
https://chatgpt.com/codex/tasks/task_b_68f98fe36d94832dbbe78f6b1f695756