### PR TITLE
Stop auto-populating event automation trigger filters

### DIFF
--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -774,12 +774,6 @@
       select.appendChild(option);
     });
 
-    const defaultFilter = FILTER_SNIPPETS.find((snippet) => snippet && snippet.value);
-    if (defaultFilter && !textarea.value.trim()) {
-      insertSnippet(textarea, defaultFilter.value);
-      select.value = '';
-    }
-
     const hasTemplates = select.options.length > 1;
     select.disabled = !hasTemplates;
     button.disabled = !hasTemplates;

--- a/changes/948ca78b-ff53-4ddf-9def-ee196d772eb7.md
+++ b/changes/948ca78b-ff53-4ddf-9def-ee196d772eb7.md
@@ -1,0 +1,3 @@
+# Change Log Entry
+
+- 2025-10-23, 02:31 UTC, Fix, Prevented event automation trigger filters from auto-populating so templates are only applied on demand.


### PR DESCRIPTION
## Summary
- remove the default trigger filter template insertion so event automations start with an empty filter field
- record the fix in the change log for auditing

## Testing
- pytest *(fails: database pool not initialised in test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f9932086a4832db0e491317bd15069