### PR TITLE
Preserve existing company permissions when assigning staff access

### DIFF
--- a/changes/c4f37ec3-5ffd-4a94-9168-9750e6204aa1.md
+++ b/changes/c4f37ec3-5ffd-4a94-9168-9750e6204aa1.md
@@ -1,0 +1,3 @@
+# Change Log Entry
+
+- 2025-10-23, 02:10 UTC, Fix, Preserved existing company assignment permissions when granting staff access via the admin companies page.


### PR DESCRIPTION
## Summary
- retain existing company permission toggles when updating staff access through the admin companies form
- cover the regression with a unit test to ensure assignments keep prior permissions
- log the fix in the change history

## Testing
- pytest tests/test_company_memberships.py

------
https://chatgpt.com/codex/tasks/task_b_68f993a66c98832da0fa56b79d0f76f2