### PR TITLE
Fix event automation form default seeding

### DIFF
--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -777,6 +777,7 @@
     const hasTemplates = select.options.length > 1;
     select.disabled = !hasTemplates;
     button.disabled = !hasTemplates;
+    select.value = '';
 
     button.addEventListener('click', () => {
       const value = select.value;
@@ -913,8 +914,6 @@
         label: String(entry.name || entry.slug || '').trim(),
       }))
       .filter((option) => option.value);
-
-    let hasSeededDefaultAction = false;
 
     const createModuleSelect = (value) => {
       const select = document.createElement('select');
@@ -1081,22 +1080,7 @@
         refreshQuickAddOptions = () => {
           populateActionQuickAdd(quickAddSelect, quickAddButton, quickAddWrapper, moduleSelect.value);
         };
-        if (!action && !hasSeededDefaultAction && moduleOptions.length) {
-          const defaultModule = moduleOptions[0].value;
-          if (defaultModule) {
-            moduleSelect.value = defaultModule;
-          }
-        }
         refreshQuickAddOptions();
-        if (!action && !hasSeededDefaultAction) {
-          const moduleKey = moduleSelect.value;
-          const templates = getActionTemplates(moduleKey);
-          if (templates.length) {
-            insertSnippet(payloadInput, templates[0].value);
-            quickAddSelect.value = '';
-            hasSeededDefaultAction = true;
-          }
-        }
         payloadWrapper.appendChild(quickAddWrapper);
         payloadWrapper.appendChild(payloadInput);
         row.appendChild(payloadWrapper);
@@ -1131,9 +1115,6 @@
         const parsed = JSON.parse(initialValue);
         if (parsed && Array.isArray(parsed.actions)) {
           parsed.actions.forEach((action) => addRow(action));
-          if (parsed.actions.length) {
-            hasSeededDefaultAction = true;
-          }
         }
       } catch (error) {
         addRow();

--- a/changes.md
+++ b/changes.md
@@ -301,3 +301,4 @@ in text
 - 2025-12-21, 11:00 UTC, Feature, Broadcast refresh notifications after knowledge base and module mutations with notifier injection and regression tests
 - 2025-12-22, 09:15 UTC, Feature, Seeded ENABLE_AUTO_REFRESH across installers and deployment scripts with documentation and regression coverage
 - 2025-12-22, 15:30 UTC, Fix, Restored automation action variable interpolation with context-aware payload rendering and regression tests
+- 2025-10-23, 03:05 UTC, Fix, Stopped event automation forms from seeding default trigger filters and action payload templates on load.

--- a/changes/58809939-fc29-4ee7-be16-5e3d148f5a74.md
+++ b/changes/58809939-fc29-4ee7-be16-5e3d148f5a74.md
@@ -1,0 +1,3 @@
+# Change Log Entry
+
+- 2025-10-23, 03:05 UTC, Fix, Stopped event automation forms from seeding default trigger filters and action payload templates on load.


### PR DESCRIPTION
## Summary
- prevent event automation forms from auto-inserting trigger filter templates on load
- remove automatic action module/template seeding so payloads start blank until configured
- record the fix in the change log entries

## Testing
- pytest tests/test_automations_service.py

------
https://chatgpt.com/codex/tasks/task_b_68f9956b9514832d807f754dd3b709e0