### PR TITLE
Add company email domain mapping and auto signup matching

### DIFF
--- a/app/repositories/companies.py
+++ b/app/repositories/companies.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from collections import defaultdict
+from typing import Any, Iterable, List, Optional, Sequence
 
 from app.core.database import db
+from app.services.company_domains import normalise_email_domains
 
 
 def _normalise_company(row: dict[str, Any]) -> dict[str, Any]:
     normalised = dict(row)
     if "is_vip" in normalised and normalised["is_vip"] is not None:
         normalised["is_vip"] = int(normalised["is_vip"])
+    if "id" in normalised and normalised["id"] is not None:
+        normalised["id"] = int(normalised["id"])
     return normalised
 
 
@@ -19,7 +23,11 @@ async def count_companies() -> int:
 
 async def get_company_by_id(company_id: int) -> Optional[dict[str, Any]]:
     row = await db.fetch_one("SELECT * FROM companies WHERE id = %s", (company_id,))
-    return _normalise_company(row) if row else None
+    if not row:
+        return None
+    company = _normalise_company(row)
+    company["email_domains"] = await get_email_domains_for_company(company["id"])
+    return company
 
 
 async def get_company_by_syncro_id(syncro_company_id: str) -> Optional[dict[str, Any]]:
@@ -27,7 +35,11 @@ async def get_company_by_syncro_id(syncro_company_id: str) -> Optional[dict[str,
         "SELECT * FROM companies WHERE syncro_company_id = %s",
         (syncro_company_id,),
     )
-    return _normalise_company(row) if row else None
+    if not row:
+        return None
+    company = _normalise_company(row)
+    company["email_domains"] = await get_email_domains_for_company(company["id"])
+    return company
 
 
 async def get_company_by_name(name: str) -> Optional[dict[str, Any]]:
@@ -35,15 +47,83 @@ async def get_company_by_name(name: str) -> Optional[dict[str, Any]]:
         "SELECT * FROM companies WHERE LOWER(name) = LOWER(%s) LIMIT 1",
         (name,),
     )
-    return _normalise_company(row) if row else None
+    if not row:
+        return None
+    company = _normalise_company(row)
+    company["email_domains"] = await get_email_domains_for_company(company["id"])
+    return company
+
+
+async def get_company_by_email_domain(domain: str) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one(
+        """
+        SELECT c.*
+        FROM company_email_domains AS d
+        INNER JOIN companies AS c ON c.id = d.company_id
+        WHERE d.domain = %s
+        LIMIT 1
+        """,
+        (domain,),
+    )
+    if not row:
+        return None
+    company = _normalise_company(row)
+    company["email_domains"] = await get_email_domains_for_company(company["id"])
+    return company
+
+
+async def get_email_domains_for_company(company_id: int) -> list[str]:
+    rows = await db.fetch_all(
+        "SELECT domain FROM company_email_domains WHERE company_id = %s ORDER BY domain",
+        (company_id,),
+    )
+    return [str(row["domain"]).strip().lower() for row in rows if row.get("domain")]
+
+
+async def _bulk_email_domains(company_ids: Sequence[int]) -> dict[int, list[str]]:
+    if not company_ids:
+        return {}
+    placeholders = ", ".join(["%s"] * len(company_ids))
+    rows = await db.fetch_all(
+        f"""
+        SELECT company_id, domain
+        FROM company_email_domains
+        WHERE company_id IN ({placeholders})
+        ORDER BY company_id, domain
+        """,
+        tuple(company_ids),
+    )
+    grouped: dict[int, list[str]] = defaultdict(list)
+    for row in rows:
+        raw_company_id = row.get("company_id")
+        domain = row.get("domain")
+        if raw_company_id is None or not domain:
+            continue
+        try:
+            company_id = int(raw_company_id)
+        except (TypeError, ValueError):
+            continue
+        grouped[company_id].append(str(domain).strip().lower())
+    return grouped
 
 
 async def list_companies() -> List[dict[str, Any]]:
     rows = await db.fetch_all("SELECT * FROM companies ORDER BY name")
-    return [_normalise_company(row) for row in rows]
+    companies = [_normalise_company(row) for row in rows]
+    company_ids = [company["id"] for company in companies if company.get("id") is not None]
+    domain_lookup = await _bulk_email_domains(company_ids)
+    for company in companies:
+        company_id = company.get("id")
+        if company_id is None:
+            company["email_domains"] = []
+        else:
+            company["email_domains"] = domain_lookup.get(int(company_id), [])
+    return companies
 
 
 async def create_company(**data: Any) -> dict[str, Any]:
+    email_domains = data.pop("email_domains", None) or []
+    email_domains = normalise_email_domains(email_domains)
     columns = ", ".join(data.keys())
     placeholders = ", ".join(["%s"] * len(data))
     await db.execute(
@@ -55,14 +135,25 @@ async def create_company(**data: Any) -> dict[str, Any]:
     )
     if not row:
         raise RuntimeError("Failed to create company")
-    return _normalise_company(row)
+    company = _normalise_company(row)
+    if email_domains:
+        await replace_company_email_domains(company["id"], email_domains)
+        company["email_domains"] = email_domains
+    else:
+        company["email_domains"] = []
+    return company
 
 
 async def update_company(company_id: int, **updates: Any) -> dict[str, Any]:
+    email_domains: Iterable[str] | None = updates.pop("email_domains", None)
     if not updates:
         company = await get_company_by_id(company_id)
         if not company:
             raise ValueError("Company not found")
+        if email_domains is not None:
+            normalised = normalise_email_domains(email_domains)
+            await replace_company_email_domains(company_id, normalised)
+            company["email_domains"] = normalised
         return company
 
     columns = ", ".join(f"{column} = %s" for column in updates.keys())
@@ -71,8 +162,30 @@ async def update_company(company_id: int, **updates: Any) -> dict[str, Any]:
     updated = await get_company_by_id(company_id)
     if not updated:
         raise ValueError("Company not found after update")
+    if email_domains is not None:
+        normalised = normalise_email_domains(email_domains)
+        await replace_company_email_domains(company_id, normalised)
+        updated["email_domains"] = normalised
     return updated
 
 
 async def delete_company(company_id: int) -> None:
     await db.execute("DELETE FROM companies WHERE id = %s", (company_id,))
+
+
+async def replace_company_email_domains(company_id: int, domains: Iterable[str]) -> None:
+    normalised = normalise_email_domains(domains)
+    await db.execute(
+        "DELETE FROM company_email_domains WHERE company_id = %s",
+        (company_id,),
+    )
+    if not normalised:
+        return
+    values = ", ".join(["(%s, %s)"] * len(normalised))
+    params: list[Any] = []
+    for domain in normalised:
+        params.extend([company_id, domain])
+    await db.execute(
+        f"INSERT INTO company_email_domains (company_id, domain) VALUES {values}",
+        tuple(params),
+    )

--- a/app/schemas/companies.py
+++ b/app/schemas/companies.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
+
+from app.services.company_domains import EmailDomainError, normalise_email_domains
 
 
 class CompanyBase(BaseModel):
@@ -11,6 +13,15 @@ class CompanyBase(BaseModel):
     is_vip: Optional[int] = None
     syncro_company_id: Optional[str] = None
     xero_id: Optional[str] = None
+    email_domains: list[str] = Field(default_factory=list)
+
+    @field_validator("email_domains", mode="after")
+    @classmethod
+    def _validate_email_domains(cls, value: list[str]) -> list[str]:
+        try:
+            return normalise_email_domains(value)
+        except EmailDomainError as exc:
+            raise ValueError(str(exc)) from exc
 
 
 class CompanyCreate(CompanyBase):
@@ -23,6 +34,7 @@ class CompanyUpdate(BaseModel):
     is_vip: Optional[int] = None
     syncro_company_id: Optional[str] = None
     xero_id: Optional[str] = None
+    email_domains: Optional[list[str]] = None
 
 
 class CompanyResponse(CompanyBase):

--- a/app/services/company_domains.py
+++ b/app/services/company_domains.py
@@ -1,0 +1,53 @@
+"""Utilities for normalising and validating company email domains."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List
+
+EMAIL_DOMAIN_PATTERN = re.compile(
+    r"^(?=.{1,255}$)(?!-)[A-Za-z0-9-]{1,63}(?<!-)"
+    r"(?:\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))+$"
+)
+
+
+class EmailDomainError(ValueError):
+    """Raised when an email domain fails validation."""
+
+
+def normalise_email_domains(domains: Iterable[str]) -> list[str]:
+    """Validate and normalise a collection of email domains.
+
+    Domains are stripped of surrounding whitespace, converted to lowercase and
+    deduplicated while preserving the original order. Invalid entries raise an
+    :class:`EmailDomainError`.
+    """
+
+    normalised: list[str] = []
+    seen: set[str] = set()
+
+    for raw in domains:
+        candidate = str(raw or "").strip().lower()
+        if not candidate:
+            continue
+        if len(candidate) > 255:
+            raise EmailDomainError("Email domain must be 255 characters or fewer")
+        if not EMAIL_DOMAIN_PATTERN.fullmatch(candidate):
+            raise EmailDomainError(f"Invalid email domain: {candidate}")
+        if candidate not in seen:
+            seen.add(candidate)
+            normalised.append(candidate)
+    return normalised
+
+
+def parse_email_domain_text(value: str | None) -> list[str]:
+    """Parse comma and newline separated text into validated domains."""
+
+    if value is None:
+        return []
+
+    parts: List[str] = []
+    for chunk in re.split(r"[\n,]", value):
+        parts.append(chunk)
+    return normalise_email_domains(parts)
+

--- a/app/templates/admin/companies.html
+++ b/app/templates/admin/companies.html
@@ -46,6 +46,7 @@
                 <th scope="col" data-sort="string">Name</th>
                 <th scope="col" data-sort="string">Syncro ID</th>
                 <th scope="col" data-sort="string">Xero ID</th>
+                <th scope="col" data-sort="string">Email domains</th>
                 <th scope="col" data-sort="string">VIP</th>
                 <th scope="col" class="table__actions">Actions</th>
               </tr>
@@ -75,6 +76,15 @@
                         form="company-{{ company.id }}-form"
                       />
                     </td>
+                    <td data-label="Email domains">
+                      <textarea
+                        name="emailDomains"
+                        class="form-input form-input--textarea"
+                        rows="2"
+                        placeholder="example.com, example.org"
+                        form="company-{{ company.id }}-form"
+                      >{{ company.email_domains | join(', ') }}</textarea>
+                    </td>
                     <td data-label="VIP">
                       <label class="checkbox">
                         <input
@@ -102,7 +112,7 @@
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="5" class="table__empty">No companies have been registered.</td>
+                  <td colspan="6" class="table__empty">No companies have been registered.</td>
                 </tr>
               {% endif %}
             </tbody>
@@ -137,6 +147,17 @@
             <div class="form-field">
               <label class="form-label" for="company-xero">Xero ID</label>
               <input id="company-xero" name="xeroId" class="form-input" maxlength="255" />
+            </div>
+            <div class="form-field">
+              <label class="form-label" for="company-email-domains">Email domains</label>
+              <textarea
+                id="company-email-domains"
+                name="emailDomains"
+                class="form-input form-input--textarea"
+                rows="2"
+                placeholder="example.com, example.org"
+              ></textarea>
+              <p class="form-help">Use commas or new lines to list domains for automatic company matching.</p>
             </div>
             <div class="form-field form-field--checkbox">
               <label class="checkbox" for="company-vip">

--- a/changes/c160c8cf-0190-4e8e-ae2d-f3c6ace52cab.md
+++ b/changes/c160c8cf-0190-4e8e-ae2d-f3c6ace52cab.md
@@ -1,0 +1,3 @@
+# Change Log Entry
+
+- 2025-10-23, 02:40 UTC, Feature, Added company email domain mapping to support automatic signup assignment.

--- a/migrations/080_company_email_domains.sql
+++ b/migrations/080_company_email_domains.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS company_email_domains (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    company_id INT NOT NULL,
+    domain VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_company_email_domains_company FOREIGN KEY (company_id)
+        REFERENCES companies(id) ON DELETE CASCADE,
+    CONSTRAINT uq_company_email_domains_domain UNIQUE KEY (domain),
+    INDEX idx_company_email_domains_company (company_id)
+);


### PR DESCRIPTION
## Summary
- add service helpers and repository logic for managing company email domains with a dedicated migration
- update registration flow and admin company management UI to use email domains for automatic signup matching
- extend automated tests and change log entries to cover the new domain matching behaviour

## Testing
- pytest tests/test_ticket_access.py

------
https://chatgpt.com/codex/tasks/task_b_68f993e1d580832db03bac3d430f8b10