### PR TITLE
Restore file column in change log admin table

### DIFF
--- a/app/templates/admin/change_log.html
+++ b/app/templates/admin/change_log.html
@@ -58,6 +58,7 @@
           <tr>
             <th scope="col" data-sort="date">Occurred</th>
             <th scope="col" data-sort="string">Type</th>
+            <th scope="col" data-sort="string">File</th>
             <th scope="col" data-sort="string">Summary</th>
           </tr>
         </thead>
@@ -71,12 +72,19 @@
                 <td data-label="Type">
                   <span class="tag">{{ entry.change_type }}</span>
                 </td>
+                <td data-label="File">
+                  {% if entry.source_file %}
+                    <code>{{ entry.source_file }}</code>
+                  {% else %}
+                    —
+                  {% endif %}
+                </td>
                 <td data-label="Summary">{{ entry.summary }}</td>
               </tr>
             {% endfor %}
           {% else %}
             <tr>
-              <td colspan="3" class="table__empty">No change log entries match the selected filters.</td>
+              <td colspan="4" class="table__empty">No change log entries match the selected filters.</td>
             </tr>
           {% endif %}
         </tbody>

--- a/changes/6d3a86fa-011e-4285-9a3d-5810f990d812.json
+++ b/changes/6d3a86fa-011e-4285-9a3d-5810f990d812.json
@@ -1,0 +1,7 @@
+{
+  "guid": "6d3a86fa-011e-4285-9a3d-5810f990d812",
+  "occurred_at": "2025-10-23T03:05Z",
+  "change_type": "Fix",
+  "summary": "Reintroduced source file column to the admin change log table.",
+  "content_hash": "592e9a7075b25f5540b4170af7cfbfbce1d3dc4f919818a80ca5386d3bd4b7f4"
+}

--- a/tests/test_admin_change_log_page.py
+++ b/tests/test_admin_change_log_page.py
@@ -97,8 +97,8 @@ def test_change_log_page_renders_entries(super_admin_context, monkeypatch):
     assert response.status_code == 200
     html = response.text
     assert "Added change log page" in html
-    assert "Source file" not in html
-    assert "changes/example.json" not in html
+    assert "<th scope=\"col\" data-sort=\"string\">File</th>" in html
+    assert "<code>changes/example.json</code>" in html
     assert "data-utc=\"2025-01-01T12:30:00+00:00\"" in html
 
 


### PR DESCRIPTION
## Summary
- show the source file name alongside each entry in the admin change log table
- align the change log page test with the restored file column
- record the UI fix in the change history feed

## Testing
- pytest tests/test_admin_change_log_page.py

------
https://chatgpt.com/codex/tasks/task_b_68f99b2b293c832dafb22842c16302b1