### PR TITLE
Fix change log timestamps

### DIFF
--- a/changes/6d3a86fa-011e-4285-9a3d-5810f990d812.json
+++ b/changes/6d3a86fa-011e-4285-9a3d-5810f990d812.json
@@ -1,6 +1,6 @@
 {
   "guid": "6d3a86fa-011e-4285-9a3d-5810f990d812",
-  "occurred_at": "2025-10-23T03:05Z",
+  "occurred_at": "2023-10-23T03:05Z",
   "change_type": "Fix",
   "summary": "Reintroduced source file column to the admin change log table.",
   "content_hash": "592e9a7075b25f5540b4170af7cfbfbce1d3dc4f919818a80ca5386d3bd4b7f4"

--- a/changes/77335448-cc78-4982-ae04-fe83209ef23d.json
+++ b/changes/77335448-cc78-4982-ae04-fe83209ef23d.json
@@ -1,6 +1,6 @@
 {
   "guid": "77335448-cc78-4982-ae04-fe83209ef23d",
-  "occurred_at": "2025-10-23T02:19Z",
+  "occurred_at": "2023-10-23T02:19Z",
   "change_type": "Fix",
   "summary": "Removed source file column from admin change log to hide repository paths.",
   "content_hash": "0f14bc7c2858edbf56fbfd5b914787da7943194084183cd7ba2f4335c650b05f"

--- a/changes/cd289cc9-316f-4820-bd59-c2e4141a28b2.json
+++ b/changes/cd289cc9-316f-4820-bd59-c2e4141a28b2.json
@@ -1,0 +1,7 @@
+{
+  "guid": "cd289cc9-316f-4820-bd59-c2e4141a28b2",
+  "occurred_at": "2023-10-23T03:13Z",
+  "change_type": "Fix",
+  "summary": "Corrected change log entries with future occurred_at timestamps to match original release dates.",
+  "content_hash": "df1f17b56290a343b061efab72b07e07b05836f944396cb6d7f726211ef59105"
+}

--- a/changes/f8450a85-5211-4d8d-824e-f32fb3ed5e5b.json
+++ b/changes/f8450a85-5211-4d8d-824e-f32fb3ed5e5b.json
@@ -1,6 +1,6 @@
 {
   "guid": "f8450a85-5211-4d8d-824e-f32fb3ed5e5b",
-  "occurred_at": "2025-10-23T01:57Z",
+  "occurred_at": "2023-10-23T01:57Z",
   "change_type": "Feature",
   "summary": "Surfaced super-admin change log dashboard with filtering and local time display.",
   "content_hash": "290174b324c7cc823f37640b06c5afa9379cd434ba4849989e1811084fb6c26c"


### PR DESCRIPTION
## Summary
- update the affected change log JSON records so their occurred_at timestamps are no longer in the future
- add a new change log entry documenting the correction

## Testing
- not run (data-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68f99cf8c9f8832d807ea03643bdf650