### PR TITLE
Add Tactical RMM company sync action

### DIFF
--- a/app/templates/admin/modules.html
+++ b/app/templates/admin/modules.html
@@ -184,6 +184,22 @@
                 <button type="submit" class="button button--primary">Update module</button>
               </div>
             </form>
+            {% if module.slug == 'tacticalrmm' %}
+              <form action="/admin/modules/tacticalrmm/push-companies" method="post" class="form card__form">
+                {% if csrf_token %}
+                  <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                {% endif %}
+                <div class="form-field">
+                  <p class="form-help">
+                    Push all companies from My Portal to Tactical RMM. Missing clients will be created with a
+                    <strong>Default</strong> site, and existing clients gain the Default site when absent.
+                  </p>
+                </div>
+                <div class="form-actions">
+                  <button type="submit" class="button button--secondary">Push companies to Tactical RMM</button>
+                </div>
+              </form>
+            {% endif %}
           </article>
         {% endfor %}
       </div>

--- a/changes/97a434c9-df17-4742-8a42-68146de90337.json
+++ b/changes/97a434c9-df17-4742-8a42-68146de90337.json
@@ -1,0 +1,7 @@
+{
+  "guid": "97a434c9-df17-4742-8a42-68146de90337",
+  "occurred_at": "2025-10-23T07:24Z",
+  "change_type": "Feature",
+  "summary": "Added Tactical RMM module action to push companies and ensure a Default site exists in TRMM.",
+  "content_hash": "324cf6da324e36eb5c09844fad0d8679cff50d05647516526b4b397ba089784f"
+}


### PR DESCRIPTION
## Summary
- add a Tactical RMM synchronisation helper that pushes companies and ensures a Default site exists
- expose an admin action and UI control to trigger the Tactical RMM company push from module settings
- cover the new workflow with unit tests and record the change in the change log

## Testing
- pytest *(fails: Database pool not initialised)*

------
https://chatgpt.com/codex/tasks/task_b_68f9d5a7ad74832da9f189143cfef5eb