### PR TITLE
Align Tactical RMM sync calls with new API schema

### DIFF
--- a/changes/513e3d0c-9b68-4cd9-8299-68288a04aa89.json
+++ b/changes/513e3d0c-9b68-4cd9-8299-68288a04aa89.json
@@ -1,0 +1,7 @@
+{
+  "guid": "513e3d0c-9b68-4cd9-8299-68288a04aa89",
+  "occurred_at": "2025-10-23T10:27Z",
+  "change_type": "Fix",
+  "summary": "Fix Tactical RMM site creation endpoint to prevent HTTP 405 errors during sync.",
+  "content_hash": "78671783ca72a27d0e76cab4291b256ff1de2a6f33059e9d16cf05603430325a"
+}

--- a/changes/fc2eabf5-4410-476d-b287-2495cd53e002.json
+++ b/changes/fc2eabf5-4410-476d-b287-2495cd53e002.json
@@ -1,0 +1,7 @@
+{
+  "guid": "fc2eabf5-4410-476d-b287-2495cd53e002",
+  "occurred_at": "2025-10-23T10:38Z",
+  "change_type": "Fix",
+  "summary": "Align Tactical RMM sync endpoints with published API schema and update authentication header.",
+  "content_hash": "18918aa9021234a37dfa3969ee042a6ca594946443df7e303a632a3d1b63dfef"
+}

--- a/tests/test_modules_service.py
+++ b/tests/test_modules_service.py
@@ -354,6 +354,7 @@ def test_invoke_tacticalrmm_records_success(monkeypatch):
     assert result["event_id"] == 11
     assert result["status"] == "succeeded"
     assert result["status_code"] == 201
+    assert client_factory.captured_kwargs["headers"].get("X-API-KEY") == "abc"
     assert captured_event.get("max_attempts") == 1
     assert "attempt_immediately" not in captured_event
 
@@ -426,10 +427,10 @@ def test_push_companies_to_tacticalrmm_creates_clients_and_sites(monkeypatch):
         for entry in created_sites
     )
 
-    assert call_payloads[0] == {"endpoint": "/api/v3/clients/", "method": "GET"}
-    assert call_payloads[1]["endpoint"] == "/api/v3/clients/"
+    assert call_payloads[0] == {"endpoint": "/clients/", "method": "GET"}
+    assert call_payloads[1]["endpoint"] == "/clients/"
     assert call_payloads[1]["method"] == "POST"
-    assert call_payloads[2]["endpoint"] == "/api/v3/clients/sites/"
+    assert call_payloads[2]["endpoint"] == "/clients/sites/"
     assert call_payloads[2]["method"] == "POST"
     assert len(call_payloads) == 3
 def test_invoke_ntfy_records_success(monkeypatch):


### PR DESCRIPTION
## Summary
- update the Tactical RMM invocation helper to use Swagger-documented endpoints and API key header
- adjust the company synchronisation workflow to call the `/clients/` and `/clients/sites/` routes from the new schema
- log the Tactical RMM API alignment in the change ledger

## Testing
- pytest tests/test_modules_service.py -k tacticalrmm -q

------
https://chatgpt.com/codex/tasks/task_b_68fa02a05624832d82d314574ac7f30f