### PR TITLE
Add Syncro company importer admin workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ There are no default login credentials; the first visit will prompt you to regis
 - Uptime Kuma integration module to receive monitoring alerts over secure HTTP POST webhooks with shared-secret validation
 - ChatGPT MCP module providing secure ticket triage tools and automations to OpenAI ChatGPT via the Model Context Protocol
 - Syncro ticket importer with super admin UI controls, rate limiting, and REST API access for bulk migrations
+- Syncro company importer to synchronise the customer directory with rate-limited Syncro API requests
 - Realtime refresh channel via `/ws/refresh` with a super-admin broadcast API at `/api/system/refresh`
 
 ## Change Log Management
@@ -42,6 +43,16 @@ There are no default login credentials; the first visit will prompt you to regis
 - The FastAPI startup routine imports those files into the `change_log` database table so updates are queryable alongside other audit data.
 - Historical entries stored in `changes.md` are automatically migrated on startup, ensuring legacy notes remain available without manual intervention.
 - When adding a new feature or fix, create a new GUID-named JSON file in `changes/` with the change metadata; the importer will synchronise it into the database using UTC timestamps.
+
+## Syncro Company Importer
+
+Super administrators can populate and refresh the company directory directly from Syncro at **Admin → Syncro company import**. The workflow:
+
+- Retrieves every customer record from Syncro using the configured rate limit.
+- Matches existing companies by Syncro customer ID or name and updates their names, addresses, and mappings in place.
+- Creates any missing companies and attaches the Syncro identifier so future imports and ticket syncs stay linked.
+
+Progress is surfaced in-page and via the JSON response from `POST /admin/syncro/import-companies`, reporting how many companies were fetched, created, updated, or skipped. The importer requires the Syncro integration module to be enabled with both a base URL and API key.
 
 ## Syncro Ticket Importer
 

--- a/app/services/company_importer.py
+++ b/app/services/company_importer.py
@@ -1,0 +1,259 @@
+"""Utilities to synchronise companies from Syncro into MyPortal."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.logging import log_error, log_info
+from app.repositories import companies as company_repo
+from app.services import syncro
+
+
+@dataclass(slots=True)
+class CompanyImportSummary:
+    """Summarises the results of a Syncro company import."""
+
+    fetched: int = 0
+    created: int = 0
+    updated: int = 0
+    skipped: int = 0
+
+    def record(self, outcome: str) -> None:
+        if outcome == "created":
+            self.created += 1
+        elif outcome == "updated":
+            self.updated += 1
+        else:
+            self.skipped += 1
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "fetched": self.fetched,
+            "created": self.created,
+            "updated": self.updated,
+            "skipped": self.skipped,
+        }
+
+
+def _coerce_syncro_id(customer: dict[str, Any]) -> str | None:
+    for key in ("id", "customer_id", "customerId"):
+        if customer.get(key) is None:
+            continue
+        raw_value = str(customer[key]).strip()
+        if raw_value:
+            return raw_value
+    return None
+
+
+def _extract_name(customer: dict[str, Any]) -> str | None:
+    candidates = (
+        customer.get("business_name"),
+        customer.get("company_name"),
+        customer.get("name"),
+    )
+    for candidate in candidates:
+        if not candidate:
+            continue
+        text = str(candidate).strip()
+        if text:
+            return text
+
+    first = str(
+        customer.get("first_name")
+        or customer.get("firstname")
+        or customer.get("primary_contact_first_name")
+        or ""
+    ).strip()
+    last = str(
+        customer.get("last_name")
+        or customer.get("lastname")
+        or customer.get("primary_contact_last_name")
+        or ""
+    ).strip()
+    joined = " ".join(part for part in (first, last) if part)
+    if joined:
+        return joined
+
+    contact = customer.get("primary_contact") or customer.get("contact_name")
+    if contact:
+        text = str(contact).strip()
+        if text:
+            return text
+    return None
+
+
+def _normalise_address_part(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _extract_address(customer: dict[str, Any]) -> str | None:
+    parts: list[str] = []
+    candidate_keys = (
+        "business_address",
+        "address",
+        "address1",
+        "address_1",
+        "street",
+        "address2",
+        "address_2",
+        "city",
+        "state",
+        "province",
+        "zip",
+        "zipcode",
+        "postal_code",
+        "country",
+    )
+
+    for key in candidate_keys:
+        value = customer.get(key)
+        if isinstance(value, dict):
+            nested_parts = [
+                _normalise_address_part(v)
+                for v in (
+                    value.get("line1"),
+                    value.get("line2"),
+                    value.get("city"),
+                    value.get("state"),
+                    value.get("postal_code"),
+                    value.get("country"),
+                )
+            ]
+            for part in nested_parts:
+                if part and part not in parts:
+                    parts.append(part)
+            continue
+
+        part = _normalise_address_part(value)
+        if part and part not in parts:
+            parts.append(part)
+
+    location = customer.get("location")
+    if isinstance(location, dict):
+        for key in ("address1", "city", "state", "zip", "country"):
+            part = _normalise_address_part(location.get(key))
+            if part and part not in parts:
+                parts.append(part)
+
+    if not parts:
+        return None
+    return ", ".join(parts)
+
+
+def _should_update(existing_value: Any, new_value: str | None) -> bool:
+    if new_value is None:
+        return False
+    existing_text = str(existing_value or "").strip()
+    return existing_text != new_value.strip()
+
+
+async def _upsert_company(customer: dict[str, Any]) -> str:
+    if not isinstance(customer, dict):
+        return "skipped"
+
+    syncro_id = _coerce_syncro_id(customer)
+    name = _extract_name(customer)
+    if not syncro_id or not name:
+        return "skipped"
+
+    address = _extract_address(customer)
+
+    existing = await company_repo.get_company_by_syncro_id(syncro_id)
+    if not existing:
+        existing = await company_repo.get_company_by_name(name)
+
+    if existing:
+        updates: dict[str, Any] = {}
+        if _should_update(existing.get("name"), name):
+            updates["name"] = name
+        if _should_update(existing.get("address"), address):
+            updates["address"] = address
+        if _should_update(existing.get("syncro_company_id"), syncro_id):
+            updates["syncro_company_id"] = syncro_id
+        if not updates:
+            return "skipped"
+        await company_repo.update_company(int(existing["id"]), **updates)
+        return "updated"
+
+    payload = {"name": name, "syncro_company_id": syncro_id}
+    if address:
+        payload["address"] = address
+    await company_repo.create_company(**payload)
+    return "created"
+
+
+def _extract_total_pages(meta: dict[str, Any] | None) -> int | None:
+    if not isinstance(meta, dict):
+        return None
+    candidates = (
+        meta.get("total_pages"),
+        meta.get("totalPages"),
+        meta.get("total"),
+    )
+    for candidate in candidates:
+        try:
+            if candidate is None:
+                continue
+            value = int(candidate)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return None
+
+
+async def import_all_companies(
+    *, rate_limiter: syncro.AsyncRateLimiter | None = None, per_page: int = 200
+) -> CompanyImportSummary:
+    summary = CompanyImportSummary()
+    limiter = rate_limiter or await syncro.get_rate_limiter()
+    log_info("Starting Syncro company import", per_page=per_page)
+
+    page = 1
+    total_pages: int | None = None
+
+    while True:
+        try:
+            customers, meta = await syncro.list_customers(
+                page=page, per_page=per_page, rate_limiter=limiter
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            log_error("Failed to fetch Syncro customers", page=page, error=str(exc))
+            raise
+
+        if not customers:
+            break
+
+        summary.fetched += len(customers)
+        for customer in customers:
+            try:
+                outcome = await _upsert_company(customer)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                log_error(
+                    "Failed to import Syncro customer",
+                    syncro_id=_coerce_syncro_id(customer),
+                    error=str(exc),
+                )
+                summary.skipped += 1
+                continue
+            summary.record(outcome)
+
+        if total_pages is None:
+            total_pages = _extract_total_pages(meta)
+        if total_pages is not None and page >= total_pages:
+            break
+        page += 1
+
+    log_info(
+        "Completed Syncro company import",
+        fetched=summary.fetched,
+        created=summary.created,
+        updated=summary.updated,
+        skipped=summary.skipped,
+    )
+    return summary
+

--- a/app/services/syncro.py
+++ b/app/services/syncro.py
@@ -399,6 +399,34 @@ async def get_assets(customer_id: str | int) -> list[dict[str, Any]]:
     return results
 
 
+async def list_customers(
+    *,
+    page: int = 1,
+    per_page: int = 100,
+    rate_limiter: AsyncRateLimiter | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Fetch a page of Syncro customers with pagination metadata."""
+
+    params = {"page": page, "per_page": per_page}
+    payload = await _request(
+        "GET",
+        "/customers",
+        params=params,
+        rate_limiter=rate_limiter,
+    )
+    customers = _extract_collection(payload, "customers", "data")
+    meta: dict[str, Any] = {}
+    if isinstance(payload, dict):
+        candidate = payload.get("meta")
+        if isinstance(candidate, dict):
+            meta = candidate
+        else:
+            pagination = payload.get("pagination")
+            if isinstance(pagination, dict):
+                meta = pagination
+    return customers, meta
+
+
 async def list_tickets(
     *,
     page: int = 1,

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -162,6 +162,64 @@
     });
   }
 
+  function bindSyncroCompanyImportForm() {
+    const form = document.querySelector('[data-syncro-company-import]');
+    if (!form) {
+      return;
+    }
+
+    const statusRegion = document.querySelector('[data-syncro-company-import-status]');
+
+    const renderStatus = (message, isError) => {
+      if (!statusRegion) {
+        if (message) {
+          alert(message);
+        }
+        return;
+      }
+      statusRegion.innerHTML = '';
+      if (!message) {
+        statusRegion.hidden = true;
+        return;
+      }
+      const alertBox = document.createElement('div');
+      alertBox.className = isError ? 'alert alert--error' : 'alert';
+      alertBox.setAttribute('role', isError ? 'alert' : 'status');
+      alertBox.textContent = message;
+      statusRegion.appendChild(alertBox);
+      statusRegion.hidden = false;
+    };
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const submitButton = form.querySelector('button[type="submit"]');
+      if (submitButton) {
+        submitButton.disabled = true;
+      }
+      try {
+        renderStatus('Import in progress…', false);
+        const response = await requestJson('/admin/syncro/import-companies', {
+          method: 'POST',
+        });
+        const fetched = Number(response?.fetched ?? 0);
+        const created = Number(response?.created ?? 0);
+        const updated = Number(response?.updated ?? 0);
+        const skipped = Number(response?.skipped ?? 0);
+        renderStatus(
+          `Imported ${fetched} compan${fetched === 1 ? 'y' : 'ies'} (created ${created}, updated ${updated}, skipped ${skipped}).`,
+          false,
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unable to import companies.';
+        renderStatus(message, true);
+      } finally {
+        if (submitButton) {
+          submitButton.disabled = false;
+        }
+      }
+    });
+  }
+
   function parsePermissions(value) {
     return value
       .split(',')
@@ -497,6 +555,7 @@
 
   document.addEventListener('DOMContentLoaded', () => {
     bindSyncroTicketImportForms();
+    bindSyncroCompanyImportForm();
     bindRoleForm();
     bindCompanyAssignmentControls();
     bindApiKeyCopyButtons();

--- a/app/templates/admin/syncro_company_import.html
+++ b/app/templates/admin/syncro_company_import.html
@@ -1,0 +1,86 @@
+{% extends "base.html" %}
+
+{% block content %}
+  {% if success_message or error_message %}
+    <div class="alert-stack">
+      {% if success_message %}
+        <div class="alert" role="status">{{ success_message }}</div>
+      {% endif %}
+      {% if error_message %}
+        <div class="alert alert--error" role="alert">{{ error_message }}</div>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  {% set module = syncro_module or {} %}
+  {% set base_url = module.base_url or '' %}
+  {% set effective_base_url = module.effective_base_url or '' %}
+  {% set has_api_key = module.has_api_key %}
+  {% set rate_limit = module.rate_limit_per_minute or 180 %}
+  {% set is_configured = effective_base_url and has_api_key %}
+
+  <div class="management management--single" data-layout>
+    <section class="management__content">
+      <header class="management__header">
+        <div>
+          <h1 class="management__title">Syncro company import</h1>
+          <p class="management__subtitle">
+            Synchronise the Syncro customer directory with MyPortal. Imports reuse the module rate limit and require the Syncro integration to be configured.
+          </p>
+        </div>
+        <div class="management__header-actions">
+          <dl class="definition-list">
+            <div class="definition-list__item">
+              <dt class="definition-list__label">Base URL</dt>
+              <dd class="definition-list__value">{{ effective_base_url or 'Not configured' }}</dd>
+            </div>
+            <div class="definition-list__item">
+              <dt class="definition-list__label">API key</dt>
+              <dd class="definition-list__value">{{ 'Configured' if has_api_key else 'Missing' }}</dd>
+            </div>
+            <div class="definition-list__item">
+              <dt class="definition-list__label">Rate limit</dt>
+              <dd class="definition-list__value">{{ rate_limit }} requests/minute</dd>
+            </div>
+          </dl>
+        </div>
+      </header>
+
+      <div class="management__body management__body--stacked">
+        <div class="alert-stack" data-syncro-company-import-status hidden></div>
+
+        {% if not is_configured %}
+          <div class="alert alert--error" role="alert">
+            Configure the Syncro module with a base URL and API key before running imports.
+            <a href="/admin/modules" class="alert__link">Open module settings</a>
+          </div>
+        {% endif %}
+
+        <article class="card card--panel">
+          <header class="card__header">
+            <div>
+              <h2 class="card__title">Import Syncro companies</h2>
+              <p class="card__subtitle">
+                Pull the complete Syncro customer list. Existing companies are matched by Syncro ID or name and updated in place.
+              </p>
+            </div>
+          </header>
+          <form class="card__form" data-syncro-company-import>
+            <p class="card__subtitle text-muted">
+              The importer will create new companies, update addresses, and attach Syncro identifiers where missing.
+            </p>
+            <div class="form-actions">
+              <button type="submit" class="button button--primary" {% if not is_configured %}disabled{% endif %}>Import companies</button>
+            </div>
+          </form>
+        </article>
+      </div>
+    </section>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/admin.js" defer></script>
+{% endblock %}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -191,6 +191,16 @@
               </a>
             </li>
             {% if is_super_admin %}
+              {% if syncro_module_enabled %}
+                <li class="menu__item">
+                  <a href="/admin/companies/syncro-import" {% if current_path.startswith('/admin/companies/syncro-import') %}aria-current="page"{% endif %}>
+                    <span class="menu__icon" aria-hidden="true">
+                      <svg viewBox="0 0 24 24" focusable="false"><path d="M4 3h6v6H4v12H2V4a1 1 0 0 1 1-1zm8 0h7a1 1 0 0 1 1 1v17h-3v-6h-4v6h-3V4a1 1 0 0 1 1-1zm1 2v4h3V5z"/></svg>
+                    </span>
+                    <span class="menu__label">Syncro company import</span>
+                  </a>
+                </li>
+              {% endif %}
               <li class="menu__item">
                 <a href="/admin/companies" {% if current_path.startswith('/admin/companies') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">

--- a/changes/d64f8309-7508-4c3e-b466-109465b268bb.json
+++ b/changes/d64f8309-7508-4c3e-b466-109465b268bb.json
@@ -1,0 +1,7 @@
+{
+  "guid": "d64f8309-7508-4c3e-b466-109465b268bb",
+  "occurred_at": "2025-10-23T10:56Z",
+  "change_type": "Feature",
+  "summary": "Added Syncro company importer with admin UI and REST endpoint to synchronise customer records.",
+  "content_hash": "b009e309c10fb8532c18f515d73fb99e38772e1d026524ed981123f17c0159ad"
+}

--- a/tests/test_company_importer.py
+++ b/tests/test_company_importer.py
@@ -1,0 +1,119 @@
+import pytest
+
+from app.services import company_importer
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_extract_address_collates_parts():
+    address = company_importer._extract_address(  # type: ignore[attr-defined]
+        {
+            "address1": "123 High St",
+            "city": "London",
+            "state": "Greater London",
+            "zip": "E1 6AN",
+            "country": "UK",
+        }
+    )
+    assert address == "123 High St, London, Greater London, E1 6AN, UK"
+
+
+@pytest.mark.anyio
+async def test_import_all_companies_creates_and_updates(monkeypatch):
+    records: list[dict[str, object]] = [
+        {
+            "id": 1,
+            "name": "Acme Old",
+            "address": "Old Street",
+            "syncro_company_id": "100",
+        }
+    ]
+
+    async def fake_get_company_by_syncro_id(syncro_id: str):
+        for record in records:
+            if record.get("syncro_company_id") == syncro_id:
+                return dict(record)
+        return None
+
+    async def fake_get_company_by_name(name: str):
+        for record in records:
+            if str(record.get("name", "")).lower() == name.lower():
+                return dict(record)
+        return None
+
+    async def fake_create_company(**payload):
+        payload.setdefault("id", len(records) + 1)
+        records.append(dict(payload))
+        return dict(payload)
+
+    async def fake_update_company(company_id: int, **updates):
+        for record in records:
+            if record.get("id") == company_id:
+                record.update(updates)
+                return dict(record)
+        raise AssertionError("Company not found")
+
+    pages = {
+        1: (
+            [
+                {
+                    "id": 100,
+                    "business_name": "Acme Corporation",
+                    "address1": "10 Downing St",
+                    "city": "London",
+                },
+                {
+                    "id": 200,
+                    "name": "Beta Industries",
+                    "address": "1 Beta Way",
+                },
+            ],
+            {"total_pages": 2},
+        ),
+        2: (
+            [
+                {
+                    "id": 300,
+                    "name": "",
+                }
+            ],
+            {"total_pages": 2},
+        ),
+    }
+
+    async def fake_list_customers(*, page: int, per_page: int, rate_limiter):
+        return pages.get(page, ([], {"total_pages": 2}))
+
+    class DummyLimiter:
+        async def acquire(self):
+            return None
+
+    async def fake_get_rate_limiter():
+        return DummyLimiter()
+
+    monkeypatch.setattr(company_importer.company_repo, "get_company_by_syncro_id", fake_get_company_by_syncro_id)
+    monkeypatch.setattr(company_importer.company_repo, "get_company_by_name", fake_get_company_by_name)
+    monkeypatch.setattr(company_importer.company_repo, "create_company", fake_create_company)
+    monkeypatch.setattr(company_importer.company_repo, "update_company", fake_update_company)
+    monkeypatch.setattr(company_importer.syncro, "list_customers", fake_list_customers)
+    monkeypatch.setattr(company_importer.syncro, "get_rate_limiter", fake_get_rate_limiter)
+
+    summary = await company_importer.import_all_companies()
+
+    assert summary.fetched == 3
+    assert summary.created == 1
+    assert summary.updated == 1
+    assert summary.skipped == 1
+
+    created = next((r for r in records if r.get("syncro_company_id") == "200"), None)
+    assert created is not None
+    assert created["name"] == "Beta Industries"
+
+    updated = next((r for r in records if r.get("syncro_company_id") == "100"), None)
+    assert updated is not None
+    assert updated["name"] == "Acme Corporation"
+    assert "10 Downing" in str(updated.get("address"))
+


### PR DESCRIPTION
## Summary
- add a Syncro company importer service with pagination helpers on the Syncro client
- expose super-admin endpoints and UI to trigger a full Syncro company import and surface progress
- document the importer, add automated tests, and record the change log entry

## Testing
- pytest tests/test_company_importer.py

------
https://chatgpt.com/codex/tasks/task_b_68fa07dfdb68832db7efcd4b97ae537e