### PR TITLE
Fix: purge stray dist-info artifacts during upgrade

### DIFF
--- a/changes/f807106b-ac38-4516-a824-c74b0891f4b8.json
+++ b/changes/f807106b-ac38-4516-a824-c74b0891f4b8.json
@@ -1,0 +1,7 @@
+{
+  "guid": "f807106b-ac38-4516-a824-c74b0891f4b8",
+  "occurred_at": "2025-10-23T11:21:56Z",
+  "change_type": "Fix",
+  "summary": "Purged stray ~?portal dist-info artifacts before and after upgrades.",
+  "content_hash": "dcff27c46d975f6b79b0e1ddeb22f9fbf1e39bf34a04c3a276e074806f2401dc"
+}


### PR DESCRIPTION
## Summary
- remove unexpected `~?portal-*.dist-info` artifacts from the virtual environment before running upgrade tasks
- ensure the cleanup also runs after the script exits by registering an EXIT trap
- log the fix in the change history

## Testing
- bash -n scripts/upgrade.sh

------
https://chatgpt.com/codex/tasks/task_b_68fa0f3b1558832d8f10a6576f90fd5c