### PR TITLE
Fix CSRF token handling for company admin forms

### DIFF
--- a/app/templates/admin/companies.html
+++ b/app/templates/admin/companies.html
@@ -104,6 +104,7 @@
                         method="post"
                         class="inline-form"
                       >
+                        {% include "partials/csrf.html" %}
                         <input type="hidden" name="name" value="{{ company.name }}" />
                         <button type="submit" class="button button--ghost">Save</button>
                       </form>
@@ -136,6 +137,7 @@
           <h2 class="modal__title" id="add-company-title">Add a company</h2>
           <p class="modal__subtitle">Create a new customer record with optional Syncro and Xero identifiers.</p>
           <form action="/admin/companies" method="post" class="form" autocomplete="off">
+            {% include "partials/csrf.html" %}
             <div class="form-field">
               <label class="form-label" for="company-name">Company name</label>
               <input id="company-name" name="name" class="form-input" required maxlength="255" />
@@ -184,6 +186,7 @@
           </div>
         </header>
         <form action="/admin/companies/assign" method="post" class="form-grid" autocomplete="off">
+          {% include "partials/csrf.html" %}
           <div class="form-field">
             <label class="form-label" for="assign-user">User</label>
             <select id="assign-user" name="userId" class="form-input" required>

--- a/changes/2b6b57f5-9922-478e-a2e8-0065fc0e3257.json
+++ b/changes/2b6b57f5-9922-478e-a2e8-0065fc0e3257.json
@@ -1,0 +1,7 @@
+{
+  "guid": "2b6b57f5-9922-478e-a2e8-0065fc0e3257",
+  "occurred_at": "2025-12-05T00:00Z",
+  "change_type": "Fix",
+  "summary": "Embedded CSRF tokens in company admin forms so email domain saves succeed without client-side scripts.",
+  "content_hash": "a8a620066fda8d0073d8d4106831dfcb8abdb71ceddcb60016848cc5aeec7522"
+}


### PR DESCRIPTION
## Summary
- embed the shared CSRF field partial in each company admin POST form so submissions carry tokens
- log the fix in the change history registry

## Testing
- pytest tests/test_csrf_middleware.py

------
https://chatgpt.com/codex/tasks/task_b_68fa1020e444832d8834cfdbe9322de8