### PR TITLE
Fix Syncro company import button behaviour

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -672,6 +672,19 @@ def _parse_int_in_range(value: Any, *, default: int, minimum: int, maximum: int)
     return parsed
 
 
+def _request_prefers_json(request: Request) -> bool:
+    accept = (request.headers.get("accept") or "").lower()
+    if "application/json" in accept:
+        return True
+    requested_with = (request.headers.get("x-requested-with") or "").lower()
+    if requested_with == "xmlhttprequest":
+        return True
+    content_type = (request.headers.get("content-type") or "").lower()
+    if "application/json" in content_type:
+        return True
+    return False
+
+
 async def _resolve_initial_company_id(user: dict[str, Any]) -> int | None:
     raw_company = user.get("company_id")
     if raw_company is not None:
@@ -4580,7 +4593,17 @@ async def import_syncro_companies(request: Request):
         request_path=str(request.url),
     )
     summary = await company_importer.import_all_companies()
-    return JSONResponse(summary.as_dict())
+    summary_data = summary.as_dict()
+    if _request_prefers_json(request):
+        return JSONResponse(summary_data)
+    message = (
+        f"Imported {summary.fetched} compan{'y' if summary.fetched == 1 else 'ies'} "
+        f"(created {summary.created}, updated {summary.updated}, skipped {summary.skipped})."
+    )
+    redirect_url = str(request.url_for("admin_syncro_company_import_page"))
+    if message:
+        redirect_url = f"{redirect_url}?{urlencode({'success': message})}"
+    return RedirectResponse(redirect_url, status_code=status.HTTP_303_SEE_OTHER)
 
 
 @app.post("/admin/syncro/import-tickets")

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -23,6 +23,8 @@
     const csrfToken = getCsrfToken();
     const headers = {
       'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
       ...(config.headers || {}),
     };
     if (csrfToken) {
@@ -56,6 +58,8 @@
     if (csrfToken) {
       headers['X-CSRF-Token'] = csrfToken;
     }
+    headers['Accept'] = 'application/json';
+    headers['X-Requested-With'] = 'XMLHttpRequest';
     const response = await fetch(url, {
       method: 'POST',
       body: formData,
@@ -200,6 +204,7 @@
         renderStatus('Import in progress…', false);
         const response = await requestJson('/admin/syncro/import-companies', {
           method: 'POST',
+          body: JSON.stringify({}),
         });
         const fetched = Number(response?.fetched ?? 0);
         const created = Number(response?.created ?? 0);

--- a/app/templates/admin/syncro_company_import.html
+++ b/app/templates/admin/syncro_company_import.html
@@ -65,7 +65,7 @@
               </p>
             </div>
           </header>
-          <form class="card__form" data-syncro-company-import>
+          <form class="card__form" data-syncro-company-import method="post" action="/admin/syncro/import-companies">
             <p class="card__subtitle text-muted">
               The importer will create new companies, update addresses, and attach Syncro identifiers where missing.
             </p>

--- a/changes/b5633dfc-36c7-4d1b-a170-79f3763eb6b0.json
+++ b/changes/b5633dfc-36c7-4d1b-a170-79f3763eb6b0.json
@@ -1,0 +1,7 @@
+{
+  "guid": "b5633dfc-36c7-4d1b-a170-79f3763eb6b0",
+  "occurred_at": "2025-02-14T10:00:00Z",
+  "change_type": "Fix",
+  "summary": "Restored Syncro company import button so admin requests trigger the importer via AJAX or form fallback.",
+  "content_hash": "f68d0d6022e3fcbc32e53a83965e571a36ecb43e1a141b19500dd031c3d68252"
+}

--- a/tests/test_admin_syncro_company_import.py
+++ b/tests/test_admin_syncro_company_import.py
@@ -1,0 +1,133 @@
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import pytest
+from fastapi.testclient import TestClient
+from urllib.parse import parse_qs, urlparse
+
+import app.main as main_module
+from app.core.database import db
+from app.main import app, company_importer, scheduler_service
+
+
+class DummySummary:
+    def __init__(self, *, fetched: int, created: int, updated: int, skipped: int):
+        self.fetched = fetched
+        self.created = created
+        self.updated = updated
+        self.skipped = skipped
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "fetched": self.fetched,
+            "created": self.created,
+            "updated": self.updated,
+            "skipped": self.skipped,
+        }
+
+
+@pytest.fixture(autouse=True)
+def disable_startup(monkeypatch):
+    class DummyCursor:
+        async def execute(self, *args, **kwargs):
+            return None
+
+        async def fetchone(self):
+            return None
+
+        async def fetchall(self):
+            return []
+
+        @property
+        def lastrowid(self):  # type: ignore[override]
+            return 0
+
+    class DummyCursorContext:
+        async def __aenter__(self):
+            return DummyCursor()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyConnection:
+        def cursor(self, *args, **kwargs):
+            return DummyCursorContext()
+
+    @asynccontextmanager
+    async def fake_acquire() -> AsyncIterator[DummyConnection]:
+        yield DummyConnection()
+
+    async def fake_connect():
+        db._pool = object()  # type: ignore[attr-defined]
+        return None
+
+    async def fake_disconnect():
+        db._pool = None  # type: ignore[attr-defined]
+        return None
+
+    async def fake_run_migrations():
+        return None
+
+    async def fake_start():
+        return None
+
+    async def fake_stop():
+        return None
+
+    monkeypatch.setattr(db, "connect", fake_connect)
+    monkeypatch.setattr(db, "disconnect", fake_disconnect)
+    monkeypatch.setattr(db, "acquire", fake_acquire)
+    monkeypatch.setattr(db, "run_migrations", fake_run_migrations)
+    monkeypatch.setattr(scheduler_service, "start", fake_start)
+    monkeypatch.setattr(scheduler_service, "stop", fake_stop)
+    monkeypatch.setattr(main_module.settings, "enable_csrf", False)
+
+
+@pytest.fixture(autouse=True)
+def super_admin_context(monkeypatch):
+    async def fake_require_super_admin_page(request):
+        return {"id": 1, "email": "admin@example.com", "is_super_admin": True}, None
+
+    async def fake_load_syncro_module():
+        return {"enabled": True}
+
+    monkeypatch.setattr(main_module, "_require_super_admin_page", fake_require_super_admin_page)
+    monkeypatch.setattr(main_module, "_load_syncro_module", fake_load_syncro_module)
+
+
+def test_import_companies_returns_json(monkeypatch):
+    async def fake_import_all_companies():
+        return DummySummary(fetched=2, created=1, updated=1, skipped=0)
+
+    monkeypatch.setattr(company_importer, "import_all_companies", fake_import_all_companies)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/admin/syncro/import-companies",
+            headers={"accept": "application/json"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"fetched": 2, "created": 1, "updated": 1, "skipped": 0}
+
+
+def test_import_companies_form_redirect(monkeypatch):
+    async def fake_import_all_companies():
+        return DummySummary(fetched=1, created=1, updated=0, skipped=0)
+
+    monkeypatch.setattr(company_importer, "import_all_companies", fake_import_all_companies)
+
+    with TestClient(app, follow_redirects=False) as client:
+        response = client.post(
+            "/admin/syncro/import-companies",
+            headers={"accept": "text/html"},
+            data={},
+        )
+
+    assert response.status_code == 303
+    location = response.headers.get("location")
+    assert location is not None
+    parsed = urlparse(location)
+    assert parsed.path == "/admin/companies/syncro-import"
+    params = parse_qs(parsed.query)
+    assert params["success"] == ["Imported 1 company (created 1, updated 0, skipped 0)."]


### PR DESCRIPTION
## Summary
- ensure the Syncro company import endpoint returns JSON for AJAX requests and redirects with a flash message for form submissions
- update the admin Syncro company import form and JavaScript helpers to send JSON headers/payloads so the button triggers the importer reliably
- add regression coverage for the admin import endpoint and record the fix in the change log

## Testing
- pytest tests/test_admin_syncro_company_import.py

------
https://chatgpt.com/codex/tasks/task_b_68fa0fb05d58832dbcc1ca93e085a00e