### PR TITLE
Make integration module cards collapsible

### DIFF
--- a/app/services/change_log.py
+++ b/app/services/change_log.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Sequence
 
+from app.core.database import db
 from app.core.logging import log_error, log_info
 from app.repositories import change_log as change_log_repo
 
@@ -209,6 +210,10 @@ async def sync_change_log_sources(*, base_path: Path | None = None, repository=c
     root = base_path or _project_root()
     changes_dir = root / "changes"
     changes_dir.mkdir(parents=True, exist_ok=True)
+
+    if not db.is_connected():
+        log_info("Skipping change log synchronisation because the database is not connected")
+        return
 
     entries: list[ChangeLogEntry] = []
     for path in sorted(changes_dir.glob("*.json")):

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2972,6 +2972,21 @@ body {
   gap: 1rem;
 }
 
+.card__header--module-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.card__header--module-summary .card__title {
+  margin: 0;
+}
+
+.card__header--module-summary .card__collapsible-meta {
+  align-items: center;
+}
+
 .card__module-info {
   display: flex;
   gap: 0.75rem;
@@ -2990,10 +3005,6 @@ body {
   align-items: flex-end;
 }
 
-.card__module-actions .card__badge {
-  align-self: flex-end;
-}
-
 .card__module-test {
   margin: 0;
 }
@@ -3010,10 +3021,6 @@ body {
 
   .card__module-actions {
     align-items: stretch;
-  }
-
-  .card__module-actions .card__badge {
-    align-self: flex-start;
   }
 }
 

--- a/app/templates/admin/modules.html
+++ b/app/templates/admin/modules.html
@@ -24,26 +24,38 @@
       <div class="management__body management__body--cards">
         {% for module in modules %}
           {% set settings = module.settings or {} %}
-          <article class="card card--panel">
-            <header class="card__header card__header--module">
-              <div class="card__module-info">
-                <span class="card__module-icon" aria-hidden="true">{{ module.icon or '🔌' }}</span>
-                <div>
-                  <h2 class="card__title">{{ module.name }}</h2>
-                  <p class="card__subtitle">{{ module.description }}</p>
+          <details class="card card--panel card-collapsible" data-module-card>
+            <summary class="card__header card__header--collapsible card__header--module-summary">
+              <h2 class="card__title">{{ module.name }}</h2>
+              <div class="card__collapsible-meta">
+                <span
+                  class="badge {{ 'badge--success' if module.enabled else 'badge--danger' }}"
+                  aria-label="Module status"
+                >
+                  {{ 'Enabled' if module.enabled else 'Disabled' }}
+                </span>
+                <span class="card__toggle-icon" aria-hidden="true"></span>
+              </div>
+            </summary>
+            <div class="card-collapsible__content">
+              <header class="card__header card__header--module card__header--module-expanded">
+                <div class="card__module-info">
+                  <span class="card__module-icon" aria-hidden="true">{{ module.icon or '🔌' }}</span>
+                  <div>
+                    <h3 class="card__title">{{ module.name }}</h3>
+                    <p class="card__subtitle">{{ module.description }}</p>
+                  </div>
                 </div>
-              </div>
-              <div class="card__module-actions">
-                <span class="card__badge" aria-label="Module status">{{ 'Enabled' if module.enabled else 'Disabled' }}</span>
-                <form action="/admin/modules/{{ module.slug }}/test" method="post" class="card__module-test">
-                  {% if csrf_token %}
-                    <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-                  {% endif %}
-                  <button type="submit" class="button button--ghost button--small">Run test</button>
-                </form>
-              </div>
-            </header>
-            <form action="/admin/modules/{{ module.slug }}" method="post" class="form card__form">
+                <div class="card__module-actions">
+                  <form action="/admin/modules/{{ module.slug }}/test" method="post" class="card__module-test">
+                    {% if csrf_token %}
+                      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                    {% endif %}
+                    <button type="submit" class="button button--ghost button--small">Run test</button>
+                  </form>
+                </div>
+              </header>
+              <form action="/admin/modules/{{ module.slug }}" method="post" class="form card__form">
               {% if csrf_token %}
                 <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
               {% endif %}
@@ -200,7 +212,8 @@
                 </div>
               </form>
             {% endif %}
-          </article>
+            </div>
+          </details>
         {% endfor %}
       </div>
     </section>

--- a/changes/e09acc04-a63e-4a21-ad2e-386a7e2998eb.json
+++ b/changes/e09acc04-a63e-4a21-ad2e-386a7e2998eb.json
@@ -1,0 +1,7 @@
+{
+  "guid": "e09acc04-a63e-4a21-ad2e-386a7e2998eb",
+  "occurred_at": "2025-10-23T11:28:17Z",
+  "change_type": "Feature",
+  "summary": "Made integration module cards collapsible with module name and status visible by default.",
+  "content_hash": "53cb46493beb368258a5a458ac865a4bb5ef4d9d230796beb3d40feefb5dd45e"
+}


### PR DESCRIPTION
## Summary
- make integration module cards collapsible by default so only module name and status show when collapsed
- add styling updates for the collapsible module headers and reuse existing module controls when expanded
- guard change log synchronisation when the database is unavailable and add a feature entry for the UI change

## Testing
- pytest tests/test_admin_modules_page.py

------
https://chatgpt.com/codex/tasks/task_b_68fa106d018c832da2816c8eed190f2a