### PR TITLE
Move tickets menu entry above shop

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -56,6 +56,7 @@
           {% set membership = active_membership or {} %}
           {% set is_super_admin = is_super_admin | default(current_user.get('is_super_admin') if current_user else False) %}
           {% set staff_permission = staff_permission | default(membership.get('staff_permission', 0) or 0) %}
+          {% set can_access_tickets = (can_access_tickets | default(false)) or is_super_admin or (is_helpdesk_technician | default(false)) %}
           {% set can_access_shop = (can_access_shop | default(false)) or is_super_admin or membership.get('can_access_shop') %}
           {% set can_access_cart = (can_access_cart | default(false)) or is_super_admin or membership.get('can_access_cart') %}
           {% set can_access_orders = (can_access_orders | default(false)) or is_super_admin or membership.get('can_access_orders') %}
@@ -64,7 +65,7 @@
           {% set can_manage_licenses = (can_manage_licenses | default(false)) or is_super_admin or membership.get('can_manage_licenses') %}
           {% set can_manage_invoices = (can_manage_invoices | default(false)) or is_super_admin or membership.get('can_manage_invoices') %}
           {% set can_manage_staff = (can_manage_staff | default(false)) or is_super_admin or membership.get('can_manage_staff') or (staff_permission > 0) %}
-          {% set has_company_section = can_access_shop or can_access_cart or can_access_orders or can_access_forms or can_manage_assets or can_manage_licenses or can_manage_invoices or can_manage_staff %}
+          {% set has_company_section = can_access_tickets or can_access_shop or can_access_cart or can_access_orders or can_access_forms or can_manage_assets or can_manage_licenses or can_manage_invoices or can_manage_staff %}
           {% set is_company_admin = membership.get('is_admin') %}
           {% set has_admin_access = is_super_admin or is_company_admin %}
           <li class="menu__item">
@@ -98,6 +99,16 @@
           </li>
           {% if has_company_section %}
             <li class="menu__divider" role="presentation"></li>
+          {% endif %}
+          {% if can_access_tickets %}
+            <li class="menu__item">
+              <a href="/admin/tickets" {% if current_path.startswith('/admin/tickets') and not current_path.startswith('/admin/tickets/syncro-import') %}aria-current="page"{% endif %}>
+                <span class="menu__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false"><path d="M4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v2.17a.83.83 0 0 1-.83.83 1.5 1.5 0 0 0 0 3 .83.83 0 0 1 .83.83V18a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2.17A.83.83 0 0 1 4.83 15a1.5 1.5 0 0 0 0-3A.83.83 0 0 1 4 11.17zM9 9v6h6V9z"/></svg>
+                </span>
+                <span class="menu__label">Tickets</span>
+              </a>
+            </li>
           {% endif %}
           {% if can_access_shop %}
             <li class="menu__item">
@@ -242,15 +253,7 @@
                 </a>
               </li>
             {% endif %}
-            {% if is_super_admin or is_helpdesk_technician %}
-              <li class="menu__item">
-                <a href="/admin/tickets" {% if current_path.startswith('/admin/tickets') and not current_path.startswith('/admin/tickets/syncro-import') %}aria-current="page"{% endif %}>
-                  <span class="menu__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false"><path d="M4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v2.17a.83.83 0 0 1-.83.83 1.5 1.5 0 0 0 0 3 .83.83 0 0 1 .83.83V18a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2.17A.83.83 0 0 1 4.83 15a1.5 1.5 0 0 0 0-3A.83.83 0 0 1 4 11.17zM9 9v6h6V9z"/></svg>
-                  </span>
-                  <span class="menu__label">Tickets</span>
-                </a>
-              </li>
+            {% if is_super_admin or (is_helpdesk_technician | default(false)) %}
               {% if syncro_module_enabled %}
                 <li class="menu__item">
                   <a href="/admin/tickets/syncro-import" {% if current_path.startswith('/admin/tickets/syncro-import') %}aria-current="page"{% endif %}>

--- a/changes/324db1d4-d9cd-4d46-9a16-728f5269d6de.json
+++ b/changes/324db1d4-d9cd-4d46-9a16-728f5269d6de.json
@@ -1,0 +1,7 @@
+{
+  "guid": "324db1d4-d9cd-4d46-9a16-728f5269d6de",
+  "occurred_at": "2025-10-23T11:29Z",
+  "change_type": "Feature",
+  "summary": "Moved Tickets navigation entry above Shop in the sidebar to highlight helpdesk access.",
+  "content_hash": "3703b028a3aac5072235adf4dabd53b587f613cab886d6e51fe60123fa2da3a8"
+}

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -23,9 +23,21 @@ def mock_startup(monkeypatch):
     async def fake_stop():
         return None
 
+    async def fake_change_log_sync():
+        return None
+
+    async def fake_ensure_modules():
+        return None
+
+    async def fake_refresh_automations():
+        return None
+
     monkeypatch.setattr(db, "connect", fake_connect)
     monkeypatch.setattr(db, "disconnect", fake_disconnect)
     monkeypatch.setattr(db, "run_migrations", fake_run_migrations)
+    monkeypatch.setattr(main_module.change_log_service, "sync_change_log_sources", fake_change_log_sync)
+    monkeypatch.setattr(main_module.modules_service, "ensure_default_modules", fake_ensure_modules)
+    monkeypatch.setattr(main_module.automations_service, "refresh_all_schedules", fake_refresh_automations)
     monkeypatch.setattr(scheduler_service, "start", fake_start)
     monkeypatch.setattr(scheduler_service, "stop", fake_stop)
 


### PR DESCRIPTION
## Summary
- expose a dedicated `can_access_tickets` flag so the company section renders ticket navigation outside the admin block
- move the Tickets link ahead of Shop in the sidebar while keeping Syncro import under the admin heading
- extend the sidebar menu test fixture to stub startup services and document the feature in the change log

## Testing
- pytest tests/test_sidebar_menu.py


------
https://chatgpt.com/codex/tasks/task_b_68fa1157cf34832d842e5c992a86b489