### PR TITLE
Queue background sync tasks for admin operations

### DIFF
--- a/app/services/background.py
+++ b/app/services/background.py
@@ -1,0 +1,104 @@
+"""Utilities for queuing long-running background tasks."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+from uuid import uuid4
+
+from app.core.logging import log_error
+
+T = TypeVar("T")
+
+
+_BACKGROUND_TASKS: dict[str, asyncio.Task[Any]] = {}
+
+
+async def _maybe_await(result: Any) -> None:
+    if inspect.isawaitable(result):
+        await result  # type: ignore[func-returns-value]
+
+
+def queue_background_task(
+    task_factory: Callable[[], Awaitable[T]],
+    *,
+    task_id: str | None = None,
+    description: str | None = None,
+    on_complete: Callable[[T], Any] | None = None,
+    on_error: Callable[[Exception], Any] | None = None,
+) -> str:
+    """Schedule an awaitable produced by ``task_factory`` to run in the background.
+
+    The returned ``task_id`` can be used to correlate logs. Optional callbacks can
+    observe completion or failure outcomes. Callbacks may be synchronous functions
+    or coroutines.
+    """
+
+    loop = asyncio.get_running_loop()
+    resolved_task_id = task_id or uuid4().hex
+
+    async def _execute() -> T:
+        try:
+            awaitable = task_factory()
+        except Exception as exc:  # pragma: no cover - defensive guard
+            await _handle_error(exc)
+            raise
+        try:
+            result = await awaitable
+        except Exception as exc:
+            await _handle_error(exc)
+            raise
+        else:
+            if on_complete is not None:
+                try:
+                    await _maybe_await(on_complete(result))
+                except Exception as callback_exc:  # pragma: no cover - defensive logging
+                    log_error(
+                        "Background task completion callback failed",
+                        task_id=resolved_task_id,
+                        error=str(callback_exc),
+                    )
+            return result
+
+    async def _handle_error(exc: Exception) -> None:
+        if on_error is not None:
+            try:
+                await _maybe_await(on_error(exc))
+            except Exception as callback_exc:  # pragma: no cover - defensive logging
+                log_error(
+                    "Background task error callback failed",
+                    task_id=resolved_task_id,
+                    error=str(callback_exc),
+                )
+        else:
+            log_error(
+                "Background task failed", task_id=resolved_task_id, error=str(exc)
+            )
+
+    task = loop.create_task(
+        _execute(), name=description or f"background-task-{resolved_task_id}"
+    )
+    _BACKGROUND_TASKS[resolved_task_id] = task
+
+    def _cleanup(completed: asyncio.Task[T]) -> None:
+        _BACKGROUND_TASKS.pop(resolved_task_id, None)
+        try:
+            completed.result()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            log_error(
+                "Background task raised an exception",
+                task_id=resolved_task_id,
+                error=str(exc),
+            )
+
+    task.add_done_callback(_cleanup)
+    return resolved_task_id
+
+
+def active_background_tasks() -> dict[str, asyncio.Task[Any]]:
+    """Return a snapshot of the currently scheduled background tasks."""
+
+    return dict(_BACKGROUND_TASKS)
+

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -1206,7 +1206,7 @@ def _summarise_event_error(result: Mapping[str, Any]) -> str:
     return "Unknown error"
 
 
-async def push_companies_to_tacticalrmm(default_site_name: str = "Default") -> dict[str, Any]:
+async def _load_tacticalrmm_settings() -> dict[str, Any]:
     module = await module_repo.get_module("tacticalrmm")
     if not module:
         raise ValueError("Tactical RMM module is not configured")
@@ -1227,6 +1227,19 @@ async def push_companies_to_tacticalrmm(default_site_name: str = "Default") -> d
     api_key = str(settings.get("api_key") or "").strip()
     if not api_key:
         raise ValueError("Tactical RMM API key is not configured")
+    return settings
+
+
+async def ensure_tacticalrmm_ready() -> None:
+    """Validate Tactical RMM configuration before executing operations."""
+
+    await _load_tacticalrmm_settings()
+
+
+async def push_companies_to_tacticalrmm(
+    default_site_name: str = "Default",
+) -> dict[str, Any]:
+    settings = await _load_tacticalrmm_settings()
 
     default_site = str(default_site_name or "").strip() or "Default"
     default_site_key = default_site.casefold()

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -206,6 +206,12 @@
           method: 'POST',
           body: JSON.stringify({}),
         });
+        const status = String(response?.status ?? '').toLowerCase();
+        if (status === 'queued') {
+          const message = response?.message || 'Syncro company import queued. Monitor the webhook monitor for updates.';
+          renderStatus(message, false);
+          return;
+        }
         const fetched = Number(response?.fetched ?? 0);
         const created = Number(response?.created ?? 0);
         const updated = Number(response?.updated ?? 0);

--- a/changes/f8be38ca-0fc9-44fe-828a-6e971485bd77.json
+++ b/changes/f8be38ca-0fc9-44fe-828a-6e971485bd77.json
@@ -1,0 +1,7 @@
+{
+  "guid": "f8be38ca-0fc9-44fe-828a-6e971485bd77",
+  "occurred_at": "2025-10-23T12:07Z",
+  "change_type": "Feature",
+  "summary": "Queued Syncro and Tactical RMM company synchronisation jobs to run asynchronously from the admin tools.",
+  "content_hash": "8171e9acd78b111652ae01fd0481dccde80e4c41af9002f24032076b2af207d4"
+}


### PR DESCRIPTION
## Summary
- add a reusable background task scheduler to queue long-running admin actions
- update the Syncro company import and Tactical RMM synchronisation endpoints to enqueue work and log completion details
- surface queued status messages in the admin UI, extend tests, and record the feature in the change log

## Testing
- pytest tests/test_admin_syncro_company_import.py tests/test_modules_service.py

------
https://chatgpt.com/codex/tasks/task_b_68fa194f7e4c832d8a5fd552efcb2e4d