### PR TITLE
Show module icons in collapsed module headers

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2998,6 +2998,14 @@ body {
   line-height: 1;
 }
 
+.card__module-icon--summary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  min-width: 1.75rem;
+}
+
 .card__module-actions {
   display: flex;
   flex-direction: column;

--- a/app/templates/admin/modules.html
+++ b/app/templates/admin/modules.html
@@ -26,6 +26,9 @@
           {% set settings = module.settings or {} %}
           <details class="card card--panel card-collapsible" data-module-card>
             <summary class="card__header card__header--collapsible card__header--module-summary">
+              <span class="card__module-icon card__module-icon--summary" aria-hidden="true">
+                {{ module.icon or '🔌' }}
+              </span>
               <h2 class="card__title">{{ module.name }}</h2>
               <div class="card__collapsible-meta">
                 <span

--- a/changes/df26563c-649f-4bbf-8208-09a892e53947.json
+++ b/changes/df26563c-649f-4bbf-8208-09a892e53947.json
@@ -1,0 +1,7 @@
+{
+  "guid": "df26563c-649f-4bbf-8208-09a892e53947",
+  "occurred_at": "2025-10-23T12:21Z",
+  "change_type": "Fix",
+  "summary": "Displayed module icons in collapsed module headers for easier identification.",
+  "content_hash": "c7eaa07632bd02233810e720c8cb3fa70a20f19a2f9700284369c97f7d739b5f"
+}


### PR DESCRIPTION
## Summary
- display each module's icon within the collapsed integration module header
- add styling to keep the collapsed icon aligned with existing header spacing
- record the UI polish in the change log metadata store

## Testing
- pytest *(fails: RuntimeError: Database pool not initialised when exercising change log pages and ticket registration tests)*

------
https://chatgpt.com/codex/tasks/task_b_68fa1d88a530832d9e577c8725bb5bef