### PR TITLE
Fix webhook monitor actions and add bulk delete controls

### DIFF
--- a/app/schemas/scheduler.py
+++ b/app/schemas/scheduler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -120,3 +120,8 @@ class ActivateTaskRequest(BaseModel):
 
 class RunTaskResponse(BaseModel):
     accepted: bool = True
+
+
+class WebhookEventsBulkDeleteResponse(BaseModel):
+    status: Literal["failed", "succeeded"]
+    deleted: int

--- a/app/templates/admin/webhooks.html
+++ b/app/templates/admin/webhooks.html
@@ -10,6 +10,22 @@
       </p>
     </div>
     <div class="card__controls">
+      <div class="button-group">
+        <button
+          type="button"
+          class="button button--danger"
+          data-webhook-delete-status="failed"
+        >
+          Delete all failed
+        </button>
+        <button
+          type="button"
+          class="button button--danger"
+          data-webhook-delete-status="succeeded"
+        >
+          Delete all successful
+        </button>
+      </div>
       <input
         type="search"
         class="form-input"
@@ -35,7 +51,12 @@
       </thead>
       <tbody>
         {% for event in events %}
-          <tr data-event="{{ event | tojson | escape }}">
+          <tr
+            data-event-id="{{ event.id }}"
+            data-event-name="{{ event.name }}"
+            data-event-target="{{ event.target_url or '' }}"
+            data-event-status="{{ event.status }}"
+          >
             <td data-label="Name">{{ event.name }}</td>
             <td data-label="Target">{{ event.target_url }}</td>
             <td data-label="Status">{{ event.status }}</td>

--- a/changes/4a3ebba7-94a1-4660-8700-b0798418e472.json
+++ b/changes/4a3ebba7-94a1-4660-8700-b0798418e472.json
@@ -1,0 +1,7 @@
+{
+  "guid": "4a3ebba7-94a1-4660-8700-b0798418e472",
+  "occurred_at": "2025-12-16T00:00Z",
+  "change_type": "Feature",
+  "summary": "Added bulk deletion controls for failed and successful webhook deliveries with admin UI prompts and API support.",
+  "content_hash": "447c21bc6fec431b8b5e3d7e9296c109891e32903df8b9dc179fd16970453f4b"
+}

--- a/changes/96b125f7-80f9-485a-bb9a-0510ea2557e8.json
+++ b/changes/96b125f7-80f9-485a-bb9a-0510ea2557e8.json
@@ -1,0 +1,7 @@
+{
+  "guid": "96b125f7-80f9-485a-bb9a-0510ea2557e8",
+  "occurred_at": "2025-12-16T00:00Z",
+  "change_type": "Fix",
+  "summary": "Corrected webhook queue action buttons to load attempt history and delete events reliably.",
+  "content_hash": "9cd33f21c700518556182fb1699f6383ef59c0d58a0018783153db35dbda3b6d"
+}

--- a/docs/webhook-monitor.md
+++ b/docs/webhook-monitor.md
@@ -29,6 +29,18 @@ and queue state. The following additions expand the operational tooling:
 - When all events are removed the table displays the existing empty-state
   message to confirm the queue is clear.
 
+## Bulk cleanup for completed investigations
+
+- Super admins can bulk-delete events that no longer require attention using
+  the API or the admin UI.
+- `DELETE /scheduler/webhooks?status=failed` removes all failed deliveries.
+- `DELETE /scheduler/webhooks?status=succeeded` removes all successful
+  deliveries.
+- The admin console now surfaces **Delete all failed** and **Delete all
+  successful** controls alongside the delivery queue filter. Each action
+  displays a confirmation prompt, reports how many records were removed, and
+  refreshes the table so administrators can see the updated queue.
+
 These changes complement the retry workflow and keep the monitor focused on
 actionable events while leaving a short retention period for successful
 deliveries.


### PR DESCRIPTION
## Summary
- fix the webhook delivery queue actions so attempts and deletes pull the right event metadata
- add bulk deletion API and admin buttons for failed and successful webhook events
- document the new controls and record change log entries

## Testing
- pytest tests/test_webhook_events_repository.py

------
https://chatgpt.com/codex/tasks/task_b_68fa1cf1fec0832d8740617493efca90