### PR TITLE
Move Syncro company import controls to modules page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4631,9 +4631,10 @@ async def import_syncro_companies(request: Request):
             status_code=status.HTTP_202_ACCEPTED,
         )
     message = f"Syncro company import queued. Task ID: {task_id[:8]}"
-    redirect_url = str(request.url_for("admin_syncro_company_import_page"))
+    redirect_url = str(request.url_for("admin_modules_page"))
     if message:
         redirect_url = f"{redirect_url}?{urlencode({'success': message})}"
+    redirect_url = f"{redirect_url}#module-syncro"
     return RedirectResponse(redirect_url, status_code=status.HTTP_303_SEE_OTHER)
 
 

--- a/app/templates/admin/modules.html
+++ b/app/templates/admin/modules.html
@@ -24,7 +24,9 @@
       <div class="management__body management__body--cards">
         {% for module in modules %}
           {% set settings = module.settings or {} %}
-          <details class="card card--panel card-collapsible" data-module-card>
+          {% set module_feedback = ((success_message or '') ~ ' ' ~ (error_message or '')).lower() %}
+          {% set highlight_module = module.slug == 'syncro' and 'syncro' in module_feedback %}
+          <details class="card card--panel card-collapsible" data-module-card id="module-{{ module.slug }}" {% if highlight_module %}open{% endif %}>
             <summary class="card__header card__header--collapsible card__header--module-summary">
               <h2 class="card__title">{{ module.name }}</h2>
               <div class="card__collapsible-meta">
@@ -38,6 +40,10 @@
               </div>
             </summary>
             <div class="card-collapsible__content">
+              {% if module.slug == 'syncro' %}
+                {% set syncro_is_ready = module.enabled %}
+                <div class="alert-stack" data-syncro-company-import-status hidden></div>
+              {% endif %}
               <header class="card__header card__header--module card__header--module-expanded">
                 <div class="card__module-info">
                   <span class="card__module-icon" aria-hidden="true">{{ module.icon or '🔌' }}</span>
@@ -196,6 +202,46 @@
                 <button type="submit" class="button button--primary">Update module</button>
               </div>
             </form>
+            {% if module.slug == 'syncro' %}
+              <form
+                action="/admin/syncro/import-companies"
+                method="post"
+                class="form card__form"
+                data-syncro-company-import
+              >
+                {% if csrf_token %}
+                  <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                {% endif %}
+                <div class="form-field">
+                  <p class="form-help">
+                    Pull the complete Syncro customer list. Existing companies are matched by Syncro ID or name
+                    and updated in place.
+                  </p>
+                </div>
+                <div class="form-field">
+                  <p class="form-help">
+                    The importer will create new companies, update addresses, and attach Syncro identifiers where
+                    missing.
+                  </p>
+                </div>
+                {% if not syncro_is_ready %}
+                  <div class="form-field">
+                    <p class="form-help form-help--error">
+                      Enable the Syncro module and configure the base URL and API key before running imports.
+                    </p>
+                  </div>
+                {% endif %}
+                <div class="form-actions">
+                  <button
+                    type="submit"
+                    class="button button--secondary"
+                    {% if not syncro_is_ready %}disabled{% endif %}
+                  >
+                    Import Syncro companies
+                  </button>
+                </div>
+              </form>
+            {% endif %}
             {% if module.slug == 'tacticalrmm' %}
               <form action="/admin/modules/tacticalrmm/push-companies" method="post" class="form card__form">
                 {% if csrf_token %}
@@ -218,5 +264,10 @@
       </div>
     </section>
   </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/admin.js" defer></script>
 {% endblock %}
 

--- a/app/templates/admin/syncro_company_import.html
+++ b/app/templates/admin/syncro_company_import.html
@@ -47,8 +47,6 @@
       </header>
 
       <div class="management__body management__body--stacked">
-        <div class="alert-stack" data-syncro-company-import-status hidden></div>
-
         {% if not is_configured %}
           <div class="alert alert--error" role="alert">
             Configure the Syncro module with a base URL and API key before running imports.
@@ -61,18 +59,16 @@
             <div>
               <h2 class="card__title">Import Syncro companies</h2>
               <p class="card__subtitle">
-                Pull the complete Syncro customer list. Existing companies are matched by Syncro ID or name and updated in place.
+                Syncro company imports now live on the integration modules page alongside the Syncro configuration.
               </p>
             </div>
           </header>
-          <form class="card__form" data-syncro-company-import method="post" action="/admin/syncro/import-companies">
-            <p class="card__subtitle text-muted">
-              The importer will create new companies, update addresses, and attach Syncro identifiers where missing.
+          <div class="card__body card__body--stacked">
+            <p class="text-muted">
+              Queue imports directly from the Syncro module card to keep configuration and data synchronisation controls together.
             </p>
-            <div class="form-actions">
-              <button type="submit" class="button button--primary" {% if not is_configured %}disabled{% endif %}>Import companies</button>
-            </div>
-          </form>
+            <a class="button button--secondary" href="/admin/modules#module-syncro">Open Syncro module settings</a>
+          </div>
         </article>
       </div>
     </section>
@@ -81,6 +77,5 @@
 
 {% block scripts %}
   {{ super() }}
-  <script src="/static/js/admin.js" defer></script>
 {% endblock %}
 

--- a/tests/test_admin_syncro_company_import.py
+++ b/tests/test_admin_syncro_company_import.py
@@ -152,7 +152,8 @@ def test_import_companies_form_redirect(monkeypatch):
     location = response.headers.get("location")
     assert location is not None
     parsed = urlparse(location)
-    assert parsed.path == "/admin/companies/syncro-import"
+    assert parsed.path == "/admin/modules"
+    assert parsed.fragment == "module-syncro"
     params = parse_qs(parsed.query)
     expected_task_id = captured["task_id"][:8]
     assert params["success"] == [f"Syncro company import queued. Task ID: {expected_task_id}"]


### PR DESCRIPTION
## Summary
- surface the Syncro company import action directly within the modules dashboard card
- update the legacy Syncro company import page to link users to the module configuration view
- redirect post-import feedback back to the modules page and adjust coverage for the new location

## Testing
- pytest tests/test_admin_syncro_company_import.py

------
https://chatgpt.com/codex/tasks/task_b_68fa1da94650832d9d13f8db839aafc0