### PR TITLE
Add company edit page and paginate companies admin table

### DIFF
--- a/app/services/change_log.py
+++ b/app/services/change_log.py
@@ -211,7 +211,8 @@ async def sync_change_log_sources(*, base_path: Path | None = None, repository=c
     changes_dir = root / "changes"
     changes_dir.mkdir(parents=True, exist_ok=True)
 
-    if not db.is_connected():
+    requires_database = repository is change_log_repo
+    if requires_database and not db.is_connected():
         log_info("Skipping change log synchronisation because the database is not connected")
         return
 

--- a/app/templates/admin/companies.html
+++ b/app/templates/admin/companies.html
@@ -18,7 +18,7 @@
         <header class="card__header">
           <div class="stacked">
             <h2 class="card__title">Companies</h2>
-            <p class="card__subtitle">Update identifiers and VIP status for existing customers.</p>
+            <p class="card__subtitle">Review the customer directory and open a company to edit identifiers or VIP status.</p>
           </div>
           <div class="card__controls">
             <input
@@ -40,14 +40,14 @@
           </div>
         </header>
         <div class="table-wrapper">
-          <table class="table" id="companies-table" data-table>
+          <table class="table" id="companies-table" data-table data-page-size-max="25">
             <thead>
               <tr>
                 <th scope="col" data-sort="string">Name</th>
                 <th scope="col" data-sort="string">Syncro ID</th>
                 <th scope="col" data-sort="string">Xero ID</th>
                 <th scope="col" data-sort="string">Email domains</th>
-                <th scope="col" data-sort="string">VIP</th>
+                <th scope="col" data-sort="number">VIP</th>
                 <th scope="col" class="table__actions">Actions</th>
               </tr>
             </thead>
@@ -56,58 +56,41 @@
                 {% for company in managed_companies %}
                   <tr>
                     <td data-label="Name">{{ company.name }}</td>
-                    <td data-label="Syncro ID">
-                      <input
-                        type="text"
-                        name="syncroCompanyId"
-                        class="form-input"
-                        value="{{ company.syncro_company_id or '' }}"
-                        maxlength="255"
-                        form="company-{{ company.id }}-form"
-                      />
+                    <td data-label="Syncro ID" data-value="{{ company.syncro_company_id or '' }}">
+                      {% if company.syncro_company_id %}
+                        {{ company.syncro_company_id }}
+                      {% else %}
+                        <span class="text-muted">—</span>
+                      {% endif %}
                     </td>
-                    <td data-label="Xero ID">
-                      <input
-                        type="text"
-                        name="xeroId"
-                        class="form-input"
-                        value="{{ company.xero_id or '' }}"
-                        maxlength="255"
-                        form="company-{{ company.id }}-form"
-                      />
+                    <td data-label="Xero ID" data-value="{{ company.xero_id or '' }}">
+                      {% if company.xero_id %}
+                        {{ company.xero_id }}
+                      {% else %}
+                        <span class="text-muted">—</span>
+                      {% endif %}
                     </td>
-                    <td data-label="Email domains">
-                      <textarea
-                        name="emailDomains"
-                        class="form-input form-input--textarea"
-                        rows="2"
-                        placeholder="example.com, example.org"
-                        form="company-{{ company.id }}-form"
-                      >{{ company.email_domains | join(', ') }}</textarea>
+                    <td data-label="Email domains" data-value="{{ company.email_domains | join(', ') }}">
+                      {% if company.email_domains %}
+                        {{ company.email_domains | join(', ') }}
+                      {% else %}
+                        <span class="text-muted">—</span>
+                      {% endif %}
                     </td>
-                    <td data-label="VIP">
-                      <label class="checkbox">
-                        <input
-                          type="checkbox"
-                          name="isVip"
-                          value="1"
-                          form="company-{{ company.id }}-form"
-                          {% if company.is_vip %}checked{% endif %}
-                        />
-                        <span class="visually-hidden">VIP pricing</span>
-                      </label>
+                    {% set is_vip = 1 if company.is_vip else 0 %}
+                    <td data-label="VIP" data-value="{{ is_vip }}">
+                      {% if company.is_vip %}
+                        <span class="tag tag--success">VIP</span>
+                      {% else %}
+                        <span class="tag tag--muted">Standard</span>
+                      {% endif %}
                     </td>
                     <td class="table__actions">
-                      <form
-                        id="company-{{ company.id }}-form"
-                        action="/admin/companies/{{ company.id }}"
-                        method="post"
-                        class="inline-form"
-                      >
-                        {% include "partials/csrf.html" %}
-                        <input type="hidden" name="name" value="{{ company.name }}" />
-                        <button type="submit" class="button button--ghost">Save</button>
-                      </form>
+                      <div class="table__action-buttons">
+                        <a class="button button--ghost" href="/admin/companies/{{ company.id }}/edit">
+                          Edit
+                        </a>
+                      </div>
                     </td>
                   </tr>
                 {% endfor %}
@@ -118,6 +101,26 @@
               {% endif %}
             </tbody>
           </table>
+        </div>
+        <div class="table-pagination" data-pagination="companies-table">
+          <div class="table-pagination__group">
+            <button
+              type="button"
+              class="button button--ghost table-pagination__button"
+              data-page-prev
+              disabled
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              class="button button--ghost table-pagination__button"
+              data-page-next
+            >
+              Next
+            </button>
+          </div>
+          <p class="table-pagination__status" data-page-info aria-live="polite"></p>
         </div>
       </section>
       <div

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -1,0 +1,146 @@
+{% extends "base.html" %}
+
+{% block content %}
+  {% if error_message or success_message %}
+    <div class="stacked" style="margin-bottom: 1.5rem; gap: 1rem;">
+      {% if success_message %}
+        <div class="alert" role="status">{{ success_message }}</div>
+      {% endif %}
+      {% if error_message %}
+        <div class="alert alert--error" role="alert">{{ error_message }}</div>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <div class="admin-grid admin-grid--columns">
+    <section class="card card--panel admin-grid__full">
+      <header class="card__header card__header--actions">
+        <div class="stacked">
+          <h2 class="card__title">{{ form_data.name or company.name }}</h2>
+          <p class="card__subtitle">Manage identifiers, email domains, and VIP status for this company.</p>
+        </div>
+        <div class="card__controls">
+          <a class="button button--ghost" href="/admin/companies">Back to companies</a>
+        </div>
+      </header>
+      <div class="card__body card__body--stacked">
+        <form action="/admin/companies/{{ company.id }}" method="post" class="form" autocomplete="off">
+          {% include "partials/csrf.html" %}
+          <div class="form-field">
+            <label class="form-label" for="edit-company-name">Company name</label>
+            <input
+              id="edit-company-name"
+              name="name"
+              class="form-input"
+              value="{{ form_data.name }}"
+              maxlength="255"
+              required
+            />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-company-syncro">Syncro company ID</label>
+            <input
+              id="edit-company-syncro"
+              name="syncroCompanyId"
+              class="form-input"
+              value="{{ form_data.syncro_company_id }}"
+              maxlength="255"
+            />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-company-xero">Xero ID</label>
+            <input
+              id="edit-company-xero"
+              name="xeroId"
+              class="form-input"
+              value="{{ form_data.xero_id }}"
+              maxlength="255"
+            />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-company-email-domains">Email domains</label>
+            <textarea
+              id="edit-company-email-domains"
+              name="emailDomains"
+              class="form-input form-input--textarea"
+              rows="3"
+              placeholder="example.com, example.org"
+            >{{ form_data.email_domains }}</textarea>
+            <p class="form-help">Use commas or new lines to list domains. Domains are matched case-insensitively.</p>
+          </div>
+          <div class="form-field form-field--checkbox">
+            <label class="checkbox" for="edit-company-vip">
+              <input
+                id="edit-company-vip"
+                type="checkbox"
+                name="isVip"
+                value="1"
+                {% if form_data.is_vip %}checked{% endif %}
+              />
+              <span>VIP pricing</span>
+            </label>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="button">Save changes</button>
+          </div>
+        </form>
+      </div>
+      <div class="card__body card__body--meta">
+        <h3 class="card__subtitle">Company details</h3>
+        <dl class="definition-list">
+          <div class="definition-list__item">
+            <dt>ID</dt>
+            <dd>{{ company.id }}</dd>
+          </div>
+          <div class="definition-list__item">
+            <dt>Syncro ID</dt>
+            <dd>
+              {% if form_data.syncro_company_id %}
+                {{ form_data.syncro_company_id }}
+              {% else %}
+                <span class="text-muted">Not set</span>
+              {% endif %}
+            </dd>
+          </div>
+          <div class="definition-list__item">
+            <dt>Xero ID</dt>
+            <dd>
+              {% if form_data.xero_id %}
+                {{ form_data.xero_id }}
+              {% else %}
+                <span class="text-muted">Not set</span>
+              {% endif %}
+            </dd>
+          </div>
+          <div class="definition-list__item">
+            <dt>VIP status</dt>
+            <dd>
+              {% if form_data.is_vip %}
+                <span class="tag tag--success">VIP</span>
+              {% else %}
+                <span class="tag tag--muted">Standard</span>
+              {% endif %}
+            </dd>
+          </div>
+        </dl>
+      </div>
+      <div class="card__body card__body--meta">
+        <h3 class="card__subtitle">Email domains</h3>
+        {% if email_domain_preview %}
+          <ul class="list" role="list">
+            {% for domain in email_domain_preview %}
+              <li>{{ domain }}</li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="text-muted">No domains registered.</p>
+        {% endif %}
+      </div>
+    </section>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/admin.js" defer></script>
+{% endblock %}

--- a/changes/573c3199-abe1-455a-af86-34d0697abe20.json
+++ b/changes/573c3199-abe1-455a-af86-34d0697abe20.json
@@ -1,0 +1,7 @@
+{
+  "guid": "573c3199-abe1-455a-af86-34d0697abe20",
+  "occurred_at": "2025-10-23T12:26:27Z",
+  "change_type": "Feature",
+  "summary": "Paginated the companies list and moved company settings into a dedicated edit view with clearer context.",
+  "content_hash": "527354b66a625717fb435bb3ae3ceff2a5900ac1c427b6d7756445f449c27467"
+}


### PR DESCRIPTION
## Summary
- add a dedicated company edit page with a full form for identifiers, email domains, and VIP status
- paginate the companies admin table and swap inline editing for an explicit Edit action that links to the new page
- update supporting services and helpers, including safe database fallbacks and a change log entry documenting the feature

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_b_68fa1d5b90d0832d9703222428565fb7