### PR TITLE
Fix change log sync database guard

### DIFF
--- a/app/services/change_log.py
+++ b/app/services/change_log.py
@@ -211,7 +211,6 @@ async def sync_change_log_sources(*, base_path: Path | None = None, repository=c
     changes_dir = root / "changes"
     changes_dir.mkdir(parents=True, exist_ok=True)
 
-    if not db.is_connected() and repository is change_log_repo:
     requires_database = repository is change_log_repo
     if requires_database and not db.is_connected():
         log_info("Skipping change log synchronisation because the database is not connected")


### PR DESCRIPTION
## Summary
- ensure the change log synchronisation only checks for a database connection when using the default repository to resolve the startup failure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68fa22d944b4832d897ed02a30794a5c