### PR TITLE
Fix webhook queue controls when CSRF cookie names vary

### DIFF
--- a/changes/794dfeb3-383e-444a-a4b5-82eef06c84f9.json
+++ b/changes/794dfeb3-383e-444a-a4b5-82eef06c84f9.json
@@ -1,0 +1,7 @@
+{
+  "guid": "794dfeb3-383e-444a-a4b5-82eef06c84f9",
+  "occurred_at": "2025-10-23T13:00Z",
+  "change_type": "Fix",
+  "summary": "Restored webhook queue admin actions when CSRF cookies use custom session names",
+  "content_hash": "6508d82ee35b90719fa1f6f327f3f0a67e0b117d7ab45189d1e94bc3bb58042a"
+}


### PR DESCRIPTION
## Summary
- ensure the webhook queue admin script reads CSRF tokens from the meta tag and only adds the header when available
- update the request helper to respect existing headers and avoid overwriting credentials for webhook actions
- record the fix in the change log catalogue

## Testing
- pytest tests/test_webhook_events_repository.py

------
https://chatgpt.com/codex/tasks/task_b_68fa258433a8832d9fa5609ba13bba11