### PR TITLE
Auto-assign IMAP tickets to companies and contacts

### DIFF
--- a/changes/20e583a8-7c3a-4c8a-8911-05c9f07f8e60.json
+++ b/changes/20e583a8-7c3a-4c8a-8911-05c9f07f8e60.json
@@ -1,0 +1,7 @@
+{
+  "guid": "20e583a8-7c3a-4c8a-8911-05c9f07f8e60",
+  "occurred_at": "2025-10-29T02:13Z",
+  "change_type": "Feature",
+  "summary": "Automatically map IMAP-imported tickets to companies and contacts based on sender addresses.",
+  "content_hash": "b01d2aeace6643309240d83b7b3d1f029c13fba2f1bae3b8dc8420863675b98b"
+}

--- a/docs/imap.md
+++ b/docs/imap.md
@@ -33,6 +33,10 @@ Each mailbox stores its cron expression. When a mailbox is created or updated th
 
 Manual synchronisation is available through the API or the workspace actions.
 
+## Ticket association
+
+During import the sender address is analysed to automatically associate the ticket with a company. The importer compares the sender's email domain with the configured company email domains and, when a match is found, links the ticket to that company. If the sender already exists as a staff contact for the matched company the ticket requester is also set accordingly. When no domain match exists the importer falls back to the company assigned to the mailbox configuration and still attempts to link the requester by email address.
+
 ## Security
 
 Mailbox passwords are encrypted at rest using the platform secret key. Synchronisation respects the "unread only" and "mark as read" toggles to prevent duplicate imports, and the importer stores processed message UIDs to avoid reprocessing previously ingested mail.

--- a/tests/test_imap_service.py
+++ b/tests/test_imap_service.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services import imap
+
+
+pytestmark = pytest.mark.anyio("asyncio")
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def test_resolve_ticket_entities_matches_company_and_staff(monkeypatch):
+    async def fake_get_company_by_email_domain(domain: str):
+        assert domain == "example.com"
+        return {"id": 5}
+
+    async def fake_get_staff_by_company_and_email(company_id: int, email: str):
+        assert company_id == 5
+        assert email == "user@example.com"
+        return {"id": 42}
+
+    monkeypatch.setattr(
+        imap.company_repo,
+        "get_company_by_email_domain",
+        fake_get_company_by_email_domain,
+    )
+    monkeypatch.setattr(
+        imap.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
+    )
+
+    company_id, requester_id = await imap._resolve_ticket_entities("User <user@example.com>")
+
+    assert company_id == 5
+    assert requester_id == 42
+
+
+async def test_resolve_ticket_entities_matches_company_without_staff(monkeypatch):
+    async def fake_get_company_by_email_domain(domain: str):
+        assert domain == "example.com"
+        return {"id": "7"}
+
+    async def fake_get_staff_by_company_and_email(company_id: int, email: str):
+        assert company_id == 7
+        assert email == "sender@example.com"
+        return None
+
+    monkeypatch.setattr(
+        imap.company_repo,
+        "get_company_by_email_domain",
+        fake_get_company_by_email_domain,
+    )
+    monkeypatch.setattr(
+        imap.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
+    )
+
+    company_id, requester_id = await imap._resolve_ticket_entities("Sender <sender@example.com>")
+
+    assert company_id == 7
+    assert requester_id is None
+
+
+async def test_resolve_ticket_entities_falls_back_to_account_company(monkeypatch):
+    async def fake_get_company_by_email_domain(domain: str):
+        return None
+
+    checked: list[tuple[int, str]] = []
+
+    async def fake_get_staff_by_company_and_email(company_id: int, email: str):
+        checked.append((company_id, email))
+        if email == "help@tenant.com":
+            return {"id": "81"}
+        return None
+
+    monkeypatch.setattr(
+        imap.company_repo,
+        "get_company_by_email_domain",
+        fake_get_company_by_email_domain,
+    )
+    monkeypatch.setattr(
+        imap.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
+    )
+
+    company_id, requester_id = await imap._resolve_ticket_entities(
+        "Support <help@tenant.com>",
+        default_company_id="11",
+    )
+
+    assert company_id == 11
+    assert requester_id == 81
+    assert (11, "help@tenant.com") in checked


### PR DESCRIPTION
## Summary
- resolve IMAP ticket company and requester from the sender email domain, falling back to the mailbox default when necessary
- cover the new resolution logic with focused service tests and document the association flow
- record the behaviour change in the change log catalogue

## Testing
- pytest tests/test_imap_service.py

------
https://chatgpt.com/codex/tasks/task_b_690177a91264832d9374f8a8cec7ab70