### PR TITLE
Defer restart automation to cron-managed flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 /uploads
 /private_uploads
 stock_feed.xml
+var/

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ For a hardened systemd configuration that runs MyPortal as a managed Linux servi
 
 ## Updating from GitHub
 
-Use the Python-focused automation scripts to stay current: `scripts/upgrade.sh` pulls the latest code and `scripts/restart.sh` reinstalls dependencies before restarting the ASGI service. If you prefer to run the steps manually, execute the following commands:
+Use the Python-focused automation scripts to stay current. `scripts/upgrade.sh` pulls the latest code and drops a restart flag at `var/state/restart_required.flag`. Schedule `scripts/process_update_flag.sh` from cron (see `deploy/cron/process_update_flag.cron`) to check for the flag every minute, reinstall dependencies, and restart the ASGI service when required. If you prefer to run the steps manually, execute the following commands:
 
 ```bash
 git pull origin main

--- a/changes/8f475a5a-ae80-42a8-94ef-349379bd52e8.json
+++ b/changes/8f475a5a-ae80-42a8-94ef-349379bd52e8.json
@@ -1,0 +1,7 @@
+{
+  "guid": "8f475a5a-ae80-42a8-94ef-349379bd52e8",
+  "occurred_at": "2025-10-29T02:19Z",
+  "change_type": "Feature",
+  "summary": "Deferred dependency installation to cron-managed restart flag after Git pulls.",
+  "content_hash": "d9fa29cf2defdf8e5ace92b3595a651f85127b5319a4a219edbd5a03339e2400"
+}

--- a/deploy/cron/process_update_flag.cron
+++ b/deploy/cron/process_update_flag.cron
@@ -1,0 +1,3 @@
+# Replace /opt/myportal with the absolute path to your deployment root.
+# This entry checks for the restart flag every minute and applies updates when needed.
+* * * * * root /usr/bin/env bash /opt/myportal/scripts/process_update_flag.sh >> /var/log/myportal/process_update_flag.log 2>&1

--- a/scripts/process_update_flag.sh
+++ b/scripts/process_update_flag.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+FLAG_DIR="${PROJECT_ROOT}/var/state"
+RESTART_FLAG_FILE="${FLAG_DIR}/restart_required.flag"
+LOCK_FILE="${FLAG_DIR}/restart.lock"
+
+mkdir -p "$FLAG_DIR"
+chmod 750 "$FLAG_DIR" >/dev/null 2>&1 || true
+
+if [[ ! -f "$RESTART_FLAG_FILE" ]]; then
+  exit 0
+fi
+
+(
+  flock -n 200 || exit 0
+
+  if [[ ! -f "$RESTART_FLAG_FILE" ]]; then
+    exit 0
+  fi
+
+  echo "Update flag found at $RESTART_FLAG_FILE. Running restart helper." >&2
+  if "${SCRIPT_DIR}/restart.sh"; then
+    rm -f "$RESTART_FLAG_FILE"
+    echo "Restart helper completed successfully; cleared $RESTART_FLAG_FILE" >&2
+  else
+    status=$?
+    echo "Error: restart helper exited with status ${status}. Leaving $RESTART_FLAG_FILE in place." >&2
+    exit "$status"
+  fi
+) 200>"$LOCK_FILE"

--- a/tests/test_process_update_flag_script.py
+++ b/tests/test_process_update_flag_script.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_process_update_flag_script_mentions_restart_helper():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "process_update_flag.sh"
+    contents = script_path.read_text()
+    assert "restart_required.flag" in contents
+    assert "restart.sh" in contents
+    assert "flock" in contents

--- a/tests/test_upgrade_script.py
+++ b/tests/test_upgrade_script.py
@@ -8,6 +8,7 @@ def test_upgrade_script_prefers_project_virtualenv():
     assert '"${VENV_DIR}/bin/python"' in contents
     assert '"${VENV_DIR}/Scripts/python.exe"' in contents
     assert 'command -v python3' in contents and 'command -v python' in contents
-    assert 'Run scripts/restart.sh to reinstall dependencies and restart the service.' in contents
+    assert 'RESTART_FLAG_FILE' in contents
+    assert 'Flagged pending dependency install and service restart' in contents
     assert 'FORCE_RESTART' in contents
-    assert 'running restart helper' in contents
+    assert 'flagging dependency install and service restart' in contents


### PR DESCRIPTION
## Summary
- update the upgrade helper to set a restart flag instead of installing dependencies immediately
- add a cron-friendly helper and template entry to process the restart flag via scripts/restart.sh
- document the new flow and cover it with regression tests plus a change log entry

## Testing
- pytest tests/test_upgrade_script.py tests/test_process_update_flag_script.py tests/test_scheduler_system_update.py

------
https://chatgpt.com/codex/tasks/task_b_690178ff5958832dbee4d3134b5ca293