### PR TITLE
Remove duplicated module header in expanded cards

### DIFF
--- a/app/templates/admin/modules.html
+++ b/app/templates/admin/modules.html
@@ -49,11 +49,7 @@
               {% endif %}
               <header class="card__header card__header--module card__header--module-expanded">
                 <div class="card__module-info">
-                  <span class="card__module-icon" aria-hidden="true">{{ module.icon or '🔌' }}</span>
-                  <div>
-                    <h3 class="card__title">{{ module.name }}</h3>
-                    <p class="card__subtitle">{{ module.description }}</p>
-                  </div>
+                  <p class="card__subtitle">{{ module.description }}</p>
                 </div>
                 <div class="card__module-actions">
                   <form action="/admin/modules/{{ module.slug }}/test" method="post" class="card__module-test">

--- a/changes/c4d76a9d-634e-4d2a-afd9-c131074aa1d0.json
+++ b/changes/c4d76a9d-634e-4d2a-afd9-c131074aa1d0.json
@@ -1,0 +1,7 @@
+{
+  "guid": "c4d76a9d-634e-4d2a-afd9-c131074aa1d0",
+  "occurred_at": "2025-10-29T02:27Z",
+  "change_type": "Fix",
+  "summary": "Removed duplicate module icon and header from expanded admin module cards.",
+  "content_hash": "2a7304cddfad60f6582922e39ba5a1a5d8b2b42326bda7ae735f9d6a89d2de69"
+}


### PR DESCRIPTION
## Summary
- remove the duplicate icon and heading from expanded module cards in the admin modules page
- record the UI fix in the change log feed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69017b509c50832daa11248a433cd063