### PR TITLE
Fix IMAP sync marking read on failed ticket import

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -375,7 +375,9 @@ async def sync_account(account_id: int) -> dict[str, Any]:
             existing_message = await imap_repo.get_message(int(account_id), uid)
             if existing_message and existing_message.get("status") == "imported":
                 continue
-            fetch_result, fetch_data = mailbox.uid("fetch", raw_uid, "(RFC822)")
+            # Use BODY.PEEK so that fetching the message does not set the \\Seen flag
+            # before the ticket import succeeds.
+            fetch_result, fetch_data = mailbox.uid("fetch", raw_uid, "(BODY.PEEK[])")
             if fetch_result != "OK" or not fetch_data:
                 await _record_message(
                     account_id=int(account_id),

--- a/changes/66040401-915a-4049-ad8c-d639c58cb3c1.json
+++ b/changes/66040401-915a-4049-ad8c-d639c58cb3c1.json
@@ -1,0 +1,7 @@
+{
+  "guid": "66040401-915a-4049-ad8c-d639c58cb3c1",
+  "occurred_at": "2025-10-29T03:10Z",
+  "change_type": "Fix",
+  "summary": "Prevent IMAP sync from marking emails as read when ticket creation fails.",
+  "content_hash": "be9a098201039ee2babf1365d1d225ff868f09996dca5b1ba59b81cb782f2fc4"
+}

--- a/tests/test_imap_service.py
+++ b/tests/test_imap_service.py
@@ -98,3 +98,134 @@ async def test_resolve_ticket_entities_falls_back_to_account_company(monkeypatch
     assert company_id == 11
     assert requester_id == 81
     assert (11, "help@tenant.com") in checked
+
+
+async def test_sync_account_does_not_mark_as_read_on_ticket_failure(monkeypatch):
+    recorded_messages: list[dict[str, object]] = []
+    account_updates: list[tuple[int, dict[str, object]]] = []
+
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        assert slug == "imap"
+        return {"enabled": True}
+
+    async def fake_get_account(account_id: int):
+        assert account_id == 7
+        return {
+            "id": account_id,
+            "host": "mail.example.com",
+            "port": 993,
+            "username": "inbox",
+            "password_encrypted": "encrypted",
+            "folder": "INBOX",
+            "process_unread_only": True,
+            "mark_as_read": True,
+            "active": True,
+        }
+
+    async def fake_get_message(account_id: int, uid: str):
+        assert account_id == 7
+        assert uid == "1"
+        return None
+
+    async def fake_upsert_message(**payload):
+        recorded_messages.append(payload)
+
+    async def fake_update_account(account_id: int, **payload):
+        account_updates.append((account_id, payload))
+        return None
+
+    def fake_decrypt_secret(value: str) -> str:
+        assert value == "encrypted"
+        return "password"
+
+    async def fake_create_ticket(**_payload):
+        raise RuntimeError("Ticket creation failed")
+
+    async def fake_get_company_by_email_domain(domain: str):
+        return None
+
+    async def fake_get_staff_by_company_and_email(company_id: int, email: str):
+        return None
+
+    class FakeMailbox:
+        def __init__(self):
+            self.commands: list[tuple[str, tuple[object, ...]]] = []
+            self.stored_flags: list[tuple[object, ...]] = []
+            self.logged_out = False
+            self.selected = None
+
+        def login(self, username: str, password: str) -> None:
+            assert username == "inbox"
+            assert password == "password"
+
+        def select(self, folder: str, readonly: bool = False) -> tuple[str, list[bytes]]:
+            self.selected = (folder, readonly)
+            return "OK", []
+
+        def uid(self, command: str, *args):
+            self.commands.append((command, args))
+            if command == "search":
+                assert args == (None, "UNSEEN")
+                return "OK", [b"1"]
+            if command == "fetch":
+                assert args[1] == "(BODY.PEEK[])"
+                raw_message = (
+                    b"From: Sender <sender@example.com>\r\n"
+                    b"Subject: Help\r\n"
+                    b"Message-ID: <msg-1@example.com>\r\n"
+                    b"\r\n"
+                    b"Body"
+                )
+                return "OK", [(b"1 (RFC822 {5})", raw_message)]
+            if command == "store":
+                self.stored_flags.append(args)
+                return "OK", []
+            raise AssertionError(f"Unexpected command {command!r}")
+
+        def logout(self) -> None:
+            self.logged_out = True
+
+    mailboxes: list[FakeMailbox] = []
+
+    def fake_imap4_ssl(host: str, port: int):
+        assert host == "mail.example.com"
+        assert port == 993
+        mailbox = FakeMailbox()
+        mailboxes.append(mailbox)
+        return mailbox
+
+    monkeypatch.setattr(imap.modules_service, "get_module", fake_get_module)
+    monkeypatch.setattr(imap.imap_repo, "get_account", fake_get_account)
+    monkeypatch.setattr(imap.imap_repo, "get_message", fake_get_message)
+    monkeypatch.setattr(imap.imap_repo, "upsert_message", fake_upsert_message)
+    monkeypatch.setattr(imap.imap_repo, "update_account", fake_update_account)
+    monkeypatch.setattr(imap, "decrypt_secret", fake_decrypt_secret)
+    monkeypatch.setattr(imap.tickets_service, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(
+        imap.company_repo,
+        "get_company_by_email_domain",
+        fake_get_company_by_email_domain,
+    )
+    monkeypatch.setattr(
+        imap.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
+    )
+    monkeypatch.setattr(imap.imaplib, "IMAP4_SSL", fake_imap4_ssl)
+
+    result = await imap.sync_account(7)
+
+    assert result["status"] == "completed_with_errors"
+    assert result["processed"] == 0
+    assert result["errors"] and result["errors"][0]["uid"] == "1"
+
+    assert mailboxes, "Expected IMAP connection"
+    mailbox = mailboxes[0]
+    fetch_commands = [cmd for cmd in mailbox.commands if cmd[0] == "fetch"]
+    assert fetch_commands, "Expected fetch command"
+    assert fetch_commands[0][1][1] == "(BODY.PEEK[])"
+    assert mailbox.stored_flags == []
+
+    assert recorded_messages
+    assert recorded_messages[0]["status"] == "error"
+    assert account_updates and account_updates[0][0] == 7


### PR DESCRIPTION
## Summary
- prevent IMAP synchronisation from marking messages as read before a ticket is created
- add a regression test that exercises the failure path and checks the IMAP commands used
- log the change in the change history registry

## Testing
- pytest tests/test_imap_service.py

------
https://chatgpt.com/codex/tasks/task_b_690183c67b5c832d89dd1a2dda9c09e5