### PR TITLE
Fix ticket bulk selection controls

### DIFF
--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -261,3 +261,9 @@
   </div>
 {% endblock %}
 
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/admin.js" defer></script>
+{% endblock %}
+

--- a/changes/f4c37fe1-cba8-4389-905e-77e1acb35ff5.json
+++ b/changes/f4c37fe1-cba8-4389-905e-77e1acb35ff5.json
@@ -1,0 +1,7 @@
+{
+  "guid": "f4c37fe1-cba8-4389-905e-77e1acb35ff5",
+  "occurred_at": "2025-10-29T03:15Z",
+  "change_type": "Fix",
+  "summary": "Restored ticket bulk selection controls on the admin ticket table.",
+  "content_hash": "d470bad54c993754319179e729bfd35483e26caded99650e9070669a17475287"
+}


### PR DESCRIPTION
## Summary
- load the admin table interaction scripts on the ticket management page so bulk selection works again
- record the fix in the change log registry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69018631273c832d87f285756df9b2b8