### PR TITLE
Move ticket quick actions into modal

### DIFF
--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -12,107 +12,41 @@
     </div>
   {% endif %}
 
-  <div class="management" data-layout>
-    <aside class="management__sidebar">
-      <h2 class="management__heading">Quick actions</h2>
-      <p class="management__intro">Create a ticket that can be routed to automation modules or manual analysts.</p>
-      <form action="/admin/tickets" method="post" class="form management__form">
-        {% if csrf_token %}
-          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-        {% endif %}
-        <div class="form-field">
-          <label class="form-label" for="ticket-subject">Subject</label>
-          <input id="ticket-subject" name="subject" class="form-input" maxlength="255" required />
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="ticket-description">Description</label>
-          <textarea id="ticket-description" name="description" class="form-input" rows="4" placeholder="Include the customer request or diagnostic notes"></textarea>
-        </div>
-        <div class="form-grid">
-          <div class="form-field">
-            <label class="form-label" for="ticket-priority">Priority</label>
-            <select id="ticket-priority" name="priority" class="form-input">
-              <option value="urgent">Urgent</option>
-              <option value="high">High</option>
-              <option value="normal" selected>Normal</option>
-              <option value="low">Low</option>
-            </select>
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="ticket-status">Initial status</label>
-            <select id="ticket-status" name="status" class="form-input">
-              <option value="open" selected>Open</option>
-              <option value="in_progress">In progress</option>
-              <option value="pending">Pending</option>
-              <option value="resolved">Resolved</option>
-              <option value="closed">Closed</option>
-            </select>
-          </div>
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="ticket-module">Module</label>
-          <select id="ticket-module" name="moduleSlug" class="form-input">
-            <option value="">Unassigned</option>
-            {% for module in ticket_modules %}
-              <option value="{{ module.slug }}">{{ module.name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="ticket-company">Company</label>
-          <select id="ticket-company" name="companyId" class="form-input">
-            <option value="">Not linked</option>
-            {% for company in ticket_company_options %}
-              <option value="{{ company.id }}">{{ company.name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="ticket-assigned">Assign to</label>
-          <select id="ticket-assigned" name="assignedUserId" class="form-input">
-            <option value="">Unassigned</option>
-            {% for user in ticket_user_options %}
-              <option value="{{ user.id }}">{{ user.email }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="ticket-category">Category</label>
-          <input id="ticket-category" name="category" class="form-input" maxlength="64" placeholder="Networking, onboarding, escalation…" />
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="ticket-reference">External reference</label>
-          <input id="ticket-reference" name="externalReference" class="form-input" maxlength="128" placeholder="Syncro ID or external case" />
-        </div>
-        <div class="form-actions">
-          <button type="submit" class="button button--primary">Create ticket</button>
-        </div>
-      </form>
-    </aside>
-
+  <div class="management management--single" data-layout>
     <section class="management__content">
       <header class="management__header">
         <div>
           <h1 class="management__title">Ticketing workspace</h1>
           <p class="management__subtitle">Monitor service demand, reply queues, and integration outcomes across connected modules.</p>
         </div>
-        <form method="get" class="management__filters">
-          <label class="visually-hidden" for="ticket-filter-status">Status</label>
-          <select id="ticket-filter-status" name="status" class="form-input">
-            <option value="">All statuses</option>
-            {% for status_option in ticket_available_statuses %}
-              <option value="{{ status_option }}" {% if ticket_filters.status == status_option %}selected{% endif %}>{{ status_option.replace('_', ' ') }}</option>
-            {% endfor %}
-          </select>
-          <label class="visually-hidden" for="ticket-filter-module">Module</label>
-          <select id="ticket-filter-module" name="module" class="form-input">
-            <option value="">All modules</option>
-            {% for module in ticket_modules %}
-              <option value="{{ module.slug }}" {% if ticket_filters.module == module.slug %}selected{% endif %}>{{ module.name }}</option>
-            {% endfor %}
-          </select>
-          <button type="submit" class="button">Apply filters</button>
-        </form>
+        <div class="management__header-actions">
+          <button
+            type="button"
+            class="button button--primary"
+            data-create-ticket-modal-open
+            aria-haspopup="dialog"
+            aria-controls="create-ticket-modal"
+          >
+            New ticket
+          </button>
+          <form method="get" class="management__filters">
+            <label class="visually-hidden" for="ticket-filter-status">Status</label>
+            <select id="ticket-filter-status" name="status" class="form-input">
+              <option value="">All statuses</option>
+              {% for status_option in ticket_available_statuses %}
+                <option value="{{ status_option }}" {% if ticket_filters.status == status_option %}selected{% endif %}>{{ status_option.replace('_', ' ') }}</option>
+              {% endfor %}
+            </select>
+            <label class="visually-hidden" for="ticket-filter-module">Module</label>
+            <select id="ticket-filter-module" name="module" class="form-input">
+              <option value="">All modules</option>
+              {% for module in ticket_modules %}
+                <option value="{{ module.slug }}" {% if ticket_filters.module == module.slug %}selected{% endif %}>{{ module.name }}</option>
+              {% endfor %}
+            </select>
+            <button type="submit" class="button">Apply filters</button>
+          </form>
+        </div>
       </header>
 
       <div class="management__body">
@@ -258,6 +192,114 @@
         </div>
       </div>
     </section>
+  </div>
+
+  <div
+    class="modal"
+    id="create-ticket-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="create-ticket-title"
+    aria-hidden="true"
+    hidden
+  >
+    <div class="modal__content" role="document">
+      <button type="button" class="modal__close" data-modal-close>
+        <span class="visually-hidden">Close create ticket form</span>
+        &times;
+      </button>
+      <h2 class="modal__title" id="create-ticket-title">Create ticket</h2>
+      <p class="modal__subtitle">Create a ticket that can be routed to automation modules or manual analysts.</p>
+      <form action="/admin/tickets" method="post" class="form" autocomplete="off">
+        {% include "partials/csrf.html" %}
+        <div class="form-field">
+          <label class="form-label" for="modal-ticket-subject">Subject</label>
+          <input id="modal-ticket-subject" name="subject" class="form-input" maxlength="255" required />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="modal-ticket-description">Description</label>
+          <textarea
+            id="modal-ticket-description"
+            name="description"
+            class="form-input form-input--textarea"
+            rows="5"
+            placeholder="Include the customer request or diagnostic notes"
+          ></textarea>
+        </div>
+        <div class="form-grid">
+          <div class="form-field">
+            <label class="form-label" for="modal-ticket-priority">Priority</label>
+            <select id="modal-ticket-priority" name="priority" class="form-input">
+              <option value="urgent">Urgent</option>
+              <option value="high">High</option>
+              <option value="normal" selected>Normal</option>
+              <option value="low">Low</option>
+            </select>
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="modal-ticket-status">Initial status</label>
+            <select id="modal-ticket-status" name="status" class="form-input">
+              <option value="open" selected>Open</option>
+              <option value="in_progress">In progress</option>
+              <option value="pending">Pending</option>
+              <option value="resolved">Resolved</option>
+              <option value="closed">Closed</option>
+            </select>
+          </div>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="modal-ticket-module">Module</label>
+          <select id="modal-ticket-module" name="moduleSlug" class="form-input">
+            <option value="">Unassigned</option>
+            {% for module in ticket_modules %}
+              <option value="{{ module.slug }}">{{ module.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="modal-ticket-company">Company</label>
+          <select id="modal-ticket-company" name="companyId" class="form-input">
+            <option value="">Not linked</option>
+            {% for company in ticket_company_options %}
+              <option value="{{ company.id }}">{{ company.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="modal-ticket-assigned">Assign to</label>
+          <select id="modal-ticket-assigned" name="assignedUserId" class="form-input">
+            <option value="">Unassigned</option>
+            {% for user in ticket_user_options %}
+              <option value="{{ user.id }}">{{ user.email }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="modal-ticket-category">Category</label>
+          <input
+            id="modal-ticket-category"
+            name="category"
+            class="form-input"
+            maxlength="64"
+            placeholder="Networking, onboarding, escalation…"
+          />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="modal-ticket-reference">External reference</label>
+          <input
+            id="modal-ticket-reference"
+            name="externalReference"
+            class="form-input"
+            maxlength="128"
+            placeholder="Syncro ID or external case"
+          />
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="button button--primary">Create ticket</button>
+          <button type="button" class="button button--ghost" data-modal-close>Cancel</button>
+        </div>
+      </form>
+    </div>
   </div>
 {% endblock %}
 

--- a/changes/d83cf3de-5c78-467f-9f22-8d7ea8de525d.json
+++ b/changes/d83cf3de-5c78-467f-9f22-8d7ea8de525d.json
@@ -1,0 +1,7 @@
+{
+  "guid": "d83cf3de-5c78-467f-9f22-8d7ea8de525d",
+  "occurred_at": "2025-10-29T03:16Z",
+  "change_type": "Feature",
+  "summary": "Moved quick ticket creation into modal launcher and expanded workspace layout.",
+  "content_hash": "62ea67194b72c701db848b28b9a929fad8b4fe29f04d2c2e5d025a4a93c0178f"
+}


### PR DESCRIPTION
## Summary
- replace the quick actions sidebar on the ticketing workspace with a full-width layout and a primary "New ticket" launcher
- add a reusable modal binding for admin pages and wire it to the new ticket creation dialog
- record the interface update in the change log directory

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_b_690185e27324832d8141dec301728f6c