### PR TITLE
Improve feedback when manually running scheduled tasks

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1606,6 +1606,12 @@ body {
   text-transform: capitalize;
 }
 
+.status__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .status--active {
   background: rgba(134, 239, 172, 0.18);
   color: #bbf7d0;
@@ -1618,6 +1624,16 @@ body {
 
 .status--suspended {
   background: rgba(248, 113, 113, 0.18);
+  color: #fecaca;
+}
+
+.status--processing {
+  background: rgba(96, 165, 250, 0.2);
+  color: #bfdbfe;
+}
+
+.status--error {
+  background: rgba(248, 113, 113, 0.22);
   color: #fecaca;
 }
 
@@ -3452,6 +3468,36 @@ body {
 .button__label {
   display: inline-flex;
   align-items: center;
+}
+
+.button--processing {
+  cursor: wait;
+  opacity: 0.75;
+}
+
+@keyframes spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.button__spinner,
+.status__spinner {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  border: 0.2rem solid currentColor;
+  border-top-color: transparent;
+  animation: spinner-rotate 0.8s linear infinite;
+}
+
+.button__spinner {
+  margin-right: 0.5rem;
+}
+
+.status__spinner {
+  margin-right: 0.35rem;
 }
 
 

--- a/changes/a3a6390c-ae47-4f43-98ee-f672276eec39.json
+++ b/changes/a3a6390c-ae47-4f43-98ee-f672276eec39.json
@@ -1,0 +1,7 @@
+{
+  "guid": "a3a6390c-ae47-4f43-98ee-f672276eec39",
+  "occurred_at": "2025-10-29T03:21Z",
+  "change_type": "Fix",
+  "summary": "Show inline progress when manually running scheduled tasks and refresh automatically on completion.",
+  "content_hash": "0a42455d188a1442c4e44ec9064db1a6e377cfc4fa65c99407040200459f9a99"
+}


### PR DESCRIPTION
## Summary
- replace Run now alerts with inline progress handling and an automatic refresh once manual runs complete
- add shared spinner styles for buttons and status badges to reflect processing state
- log the UI behaviour change in the change log registry

## Testing
- pytest *(fails: tests/test_imap_service.py::test_resolve_ticket_entities_handles_staff_without_user - NameError: name 'checked' is not defined; tests/test_imap_service.py::test_sync_account_does_not_mark_as_read_on_ticket_failure - NameError: name 'fake_get_user_by_email' is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_690186c47db8832db078f6039c22a4d2