### PR TITLE
Render sanitized ticket descriptions in admin detail view

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6139,6 +6139,13 @@ async def _render_ticket_detail(
     if not ticket:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
 
+    sanitized_description = sanitize_rich_text(str(ticket.get("description") or ""))
+    ticket = {
+        **ticket,
+        "description_html": sanitized_description.html,
+        "description_text": sanitized_description.text_content,
+    }
+
     replies = await tickets_repo.list_replies(ticket_id)
     watchers = await tickets_repo.list_watchers(ticket_id)
 

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -220,14 +220,21 @@
         </div>
 
         <div class="management__column management__column--content">
-          {% if ticket.description %}
+          {% set description_html = ticket.description_html if ticket.description_html is defined else '' %}
+          {% set has_original_description = ticket.description is defined and ticket.description %}
+          {% if description_html or has_original_description %}
             <article class="card card--panel">
               <header class="card__header">
                 <h2 class="card__title">Description</h2>
               </header>
               <div class="card__body">
-                {% set safe_description = (ticket.description | e).replace('\n', '<br />') %}
-                <p>{{ safe_description | safe }}</p>
+                {% if description_html %}
+                  <div class="rich-text-viewer" data-ticket-description>
+                    {{ description_html | safe }}
+                  </div>
+                {% else %}
+                  <p class="card__empty">The ticket description does not contain displayable content.</p>
+                {% endif %}
               </div>
             </article>
           {% endif %}

--- a/changes/859c9289-94d6-4434-8f72-e84a4345af04.json
+++ b/changes/859c9289-94d6-4434-8f72-e84a4345af04.json
@@ -1,0 +1,7 @@
+{
+  "guid": "859c9289-94d6-4434-8f72-e84a4345af04",
+  "occurred_at": "2025-10-29T03:25Z",
+  "change_type": "Fix",
+  "summary": "Render ticket descriptions with sanitised HTML instead of escaped markup.",
+  "content_hash": "e37028ba5581517946d5cf21a99012aa0e3a1b532dd95bddc704eb7398a3140b"
+}


### PR DESCRIPTION
## Summary
- sanitize ticket descriptions before rendering so saved HTML displays with restricted tags
- update the ticket detail template to show the sanitized HTML or a safe fallback message
- record the fix in the change log

## Testing
- pytest *(fails: tests/test_imap_service.py::test_resolve_ticket_entities_handles_staff_without_user, tests/test_imap_service.py::test_sync_account_does_not_mark_as_read_on_ticket_failure due to existing NameError fixtures)*

------
https://chatgpt.com/codex/tasks/task_b_69018825b068832dbc40788932b68bf7