### PR TITLE
Auto-save ticket status updates

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1408,6 +1408,12 @@ body {
   align-items: center;
 }
 
+.inline-form--submitting {
+  opacity: 0.7;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
 .inline-form__fields {
   display: flex;
   flex-wrap: wrap;

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -324,6 +324,40 @@
     updateState();
   }
 
+  function bindTicketStatusAutoSubmit() {
+    const forms = document.querySelectorAll('[data-ticket-status-form]');
+    if (!forms.length) {
+      return;
+    }
+
+    forms.forEach((form) => {
+      const select = form.querySelector('[data-ticket-status-select]');
+      if (!select) {
+        return;
+      }
+
+      let hasSubmitted = false;
+
+      form.addEventListener('submit', () => {
+        hasSubmitted = true;
+        select.disabled = true;
+        form.classList.add('inline-form--submitting');
+      });
+
+      select.addEventListener('change', () => {
+        if (hasSubmitted) {
+          return;
+        }
+        hasSubmitted = true;
+        if (typeof form.requestSubmit === 'function') {
+          form.requestSubmit();
+        } else {
+          form.submit();
+        }
+      });
+    });
+  }
+
   function parsePermissions(value) {
     return value
       .split(',')
@@ -669,6 +703,7 @@
     bindSyncroTicketImportForms();
     bindSyncroCompanyImportForm();
     bindTicketBulkDelete();
+    bindTicketStatusAutoSubmit();
     bindRoleForm();
     bindCompanyAssignmentControls();
     bindApiKeyCopyButtons();

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -164,17 +164,21 @@
                     <td data-label="Assigned">{{ assigned.email if assigned else '—' }}</td>
                     <td data-label="Updated">{{ ticket.updated_at.astimezone().strftime('%Y-%m-%d %H:%M') if ticket.updated_at else '—' }}</td>
                     <td data-label="Update status">
-                      <form action="/admin/tickets/{{ ticket.id }}/status" method="post" class="inline-form">
+                      <form action="/admin/tickets/{{ ticket.id }}/status" method="post" class="inline-form" data-ticket-status-form>
                         {% if csrf_token %}
                           <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
                         {% endif %}
                         <label class="visually-hidden" for="ticket-status-{{ ticket.id }}">Status</label>
-                        <select id="ticket-status-{{ ticket.id }}" name="status" class="form-input form-input--compact">
+                        <select
+                          id="ticket-status-{{ ticket.id }}"
+                          name="status"
+                          class="form-input form-input--compact"
+                          data-ticket-status-select
+                        >
                           {% for status_option in ticket_available_statuses %}
                             <option value="{{ status_option }}" {% if status_option == (ticket.status or 'open') %}selected{% endif %}>{{ status_option.replace('_', ' ') }}</option>
                           {% endfor %}
                         </select>
-                        <button type="submit" class="button button--ghost">Update</button>
                       </form>
                     </td>
                     <td class="table__actions">

--- a/changes/3d6c3256-9e8d-4c6f-b006-a301edcba266.json
+++ b/changes/3d6c3256-9e8d-4c6f-b006-a301edcba266.json
@@ -1,0 +1,7 @@
+{
+  "guid": "3d6c3256-9e8d-4c6f-b006-a301edcba266",
+  "occurred_at": "2025-10-29T03:31Z",
+  "change_type": "Fix",
+  "summary": "Auto-save ticket status changes directly from the dashboard dropdown.",
+  "content_hash": "fb75e8712a38e5a5c6214f2ff070c8df948b0213c54ca0146a1fbf97105d1e29"
+}


### PR DESCRIPTION
## Summary
- remove the manual update button from the admin ticket dashboard and tag the status selector for scripting
- add JavaScript that automatically submits status changes and disables the selector while submitting, plus a subtle loading state
- log the fix in the change log catalogue

## Testing
- pytest *(fails: NameError: name 'checked' is not defined in tests/test_imap_service.py::test_resolve_ticket_entities_handles_staff_without_user; NameError: name 'fake_get_user_by_email' is not defined in tests/test_imap_service.py::test_sync_account_does_not_mark_as_read_on_ticket_failure)*

------
https://chatgpt.com/codex/tasks/task_b_690189c686e8832db694517388124485