### PR TITLE
Allow embedded images in ticket conversations

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -250,7 +250,7 @@ async def add_reply(
     if not has_helpdesk_access and ticket.get("requester_id") != session.user_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
     sanitised_body = sanitize_rich_text(payload.body)
-    if not sanitised_body.text_content:
+    if not sanitised_body.has_rich_content:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Reply body cannot be empty.",

--- a/app/main.py
+++ b/app/main.py
@@ -6767,7 +6767,7 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
     body_raw = str(body_value) if isinstance(body_value, str) else ""
     sanitized_body = sanitize_rich_text(body_raw)
     is_internal = str(form.get("isInternal", "")).lower() in {"1", "true", "on", "yes"}
-    if not sanitized_body.text_content:
+    if not sanitized_body.has_rich_content:
         return await _render_ticket_detail(
             request,
             current_user,

--- a/changes/6d0d41ba-90e2-402a-b033-506c1b912898.json
+++ b/changes/6d0d41ba-90e2-402a-b033-506c1b912898.json
@@ -1,0 +1,7 @@
+{
+  "guid": "6d0d41ba-90e2-402a-b033-506c1b912898",
+  "occurred_at": "2025-10-29T03:35Z",
+  "change_type": "Fix",
+  "summary": "Allow ticket descriptions and replies to render embedded images by permitting safe <img> HTML content.",
+  "content_hash": "e4c4cb5b28c4d1d3c1df6d66cbf0d6d8b8f2af6b73e1cd399da1d4e4503757f0"
+}

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -1,0 +1,31 @@
+from app.services.sanitization import sanitize_rich_text
+
+
+def test_sanitize_rich_text_keeps_images_with_safe_attributes():
+    content = '<img src="https://example.com/image.png" alt="Example" />'
+
+    result = sanitize_rich_text(content)
+
+    assert "<img" in result.html
+    assert 'src="https://example.com/image.png"' in result.html
+    assert "alt=\"Example\"" in result.html
+    assert result.text_content == ""
+    assert result.has_rich_content is True
+
+
+def test_sanitize_rich_text_strips_unsafe_image_attributes():
+    content = '<img src="javascript:alert(1)" onerror="alert(2)" />'
+
+    result = sanitize_rich_text(content)
+
+    assert "javascript" not in result.html
+    assert "onerror" not in result.html
+    assert result.has_rich_content is False
+
+
+def test_sanitize_rich_text_marks_plain_text_as_content():
+    result = sanitize_rich_text("Hello world")
+
+    assert result.html == "Hello world"
+    assert result.text_content == "Hello world"
+    assert result.has_rich_content is True


### PR DESCRIPTION
## Summary
- allow the HTML sanitizer to preserve safe <img> tags so ticket descriptions and replies can render embedded images
- expose a has_rich_content flag so validation accepts image-only bodies and ensure both UI and API checks use it
- add coverage for the new sanitization behaviour and record the change in the change log

## Testing
- pytest tests/test_sanitization.py

------
https://chatgpt.com/codex/tasks/task_b_69018aafcbd8832d81d145031a809daf