### PR TITLE
Combine ticket status control into single column

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1427,6 +1427,54 @@ body {
   gap: calc(var(--space-gap-roomy) * 1.1);
 }
 
+.ticket-status {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-gap-tight);
+}
+
+.ticket-status__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(var(--space-gap-tight) * 0.75);
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+.ticket-status__toggle:focus-visible {
+  outline: 2px solid rgba(148, 163, 184, 0.6);
+  outline-offset: 2px;
+}
+
+.ticket-status__chevron {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 0.35rem solid transparent;
+  border-right: 0.35rem solid transparent;
+  border-top: 0.4rem solid rgba(148, 163, 184, 0.7);
+  transition: transform 0.2s ease;
+}
+
+.ticket-status--open .ticket-status__chevron {
+  transform: rotate(180deg);
+}
+
+.ticket-status__form {
+  margin-top: calc(var(--space-gap-tight) * 0.9);
+  width: 100%;
+}
+
+.ticket-status__form .form-input {
+  width: 100%;
+  min-width: 10rem;
+}
+
 .inline-panel {
   margin-top: var(--space-gap-roomy);
   padding: calc(var(--space-gap-roomy) * 1.1);

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -358,6 +358,97 @@
     });
   }
 
+  function bindTicketStatusDropdowns() {
+    const containers = document.querySelectorAll('[data-ticket-status]');
+    if (!containers.length) {
+      return;
+    }
+
+    const documentHandlers = new WeakMap();
+
+    const closeContainer = (container) => {
+      if (!container) {
+        return;
+      }
+      const form = container.querySelector('[data-ticket-status-form]');
+      const toggle = container.querySelector('[data-ticket-status-toggle]');
+      if (form) {
+        form.hidden = true;
+      }
+      if (toggle) {
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+      container.classList.remove('ticket-status--open');
+      const handler = documentHandlers.get(container);
+      if (handler) {
+        document.removeEventListener('click', handler);
+      }
+    };
+
+    const closeAll = (except) => {
+      containers.forEach((container) => {
+        if (container !== except) {
+          closeContainer(container);
+        }
+      });
+    };
+
+    containers.forEach((container) => {
+      const toggle = container.querySelector('[data-ticket-status-toggle]');
+      const form = container.querySelector('[data-ticket-status-form]');
+      if (!toggle || !form) {
+        return;
+      }
+
+      const select = form.querySelector('[data-ticket-status-select]');
+
+      const handleDocumentClick = (event) => {
+        if (!container.contains(event.target)) {
+          closeContainer(container);
+        }
+      };
+
+      documentHandlers.set(container, handleDocumentClick);
+      closeContainer(container);
+
+      toggle.addEventListener('click', (event) => {
+        event.preventDefault();
+        const isOpen = container.classList.contains('ticket-status--open');
+        if (isOpen) {
+          closeContainer(container);
+          return;
+        }
+        closeAll(container);
+        container.classList.add('ticket-status--open');
+        form.hidden = false;
+        toggle.setAttribute('aria-expanded', 'true');
+        window.setTimeout(() => {
+          document.addEventListener('click', handleDocumentClick);
+        }, 0);
+        if (select) {
+          window.requestAnimationFrame(() => {
+            select.focus();
+          });
+        }
+      });
+
+      form.addEventListener('submit', () => {
+        closeContainer(container);
+        toggle.focus();
+      });
+
+      if (select) {
+        select.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') {
+            event.stopPropagation();
+            closeContainer(container);
+            toggle.focus();
+          }
+        });
+      }
+    });
+  }
+
   function parsePermissions(value) {
     return value
       .split(',')
@@ -703,6 +794,7 @@
     bindSyncroTicketImportForms();
     bindSyncroCompanyImportForm();
     bindTicketBulkDelete();
+    bindTicketStatusDropdowns();
     bindTicketStatusAutoSubmit();
     bindRoleForm();
     bindCompanyAssignmentControls();

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -119,7 +119,6 @@
                 <th scope="col" data-sort="string">Company</th>
                 <th scope="col" data-sort="string">Assigned</th>
                 <th scope="col" data-sort="string">Updated</th>
-                <th scope="col">Update status</th>
                 <th scope="col" class="table__actions">Actions</th>
               </tr>
             </thead>
@@ -156,31 +155,49 @@
                       'resolved': 'badge--success',
                       'closed': 'badge--muted'
                     } %}
-                    <td data-label="Status">
-                      <span class="badge {{ status_badge_map.get(ticket_status, 'badge--muted') }}">{{ status_label }}</span>
+                    <td data-label="Status" data-value="{{ ticket_status }}">
+                      <div class="ticket-status" data-ticket-status>
+                        <button
+                          type="button"
+                          class="ticket-status__toggle"
+                          data-ticket-status-toggle
+                          aria-haspopup="listbox"
+                          aria-expanded="false"
+                          aria-controls="ticket-status-form-{{ ticket.id }}"
+                        >
+                          <span class="badge {{ status_badge_map.get(ticket_status, 'badge--muted') }}">{{ status_label }}</span>
+                          <span class="ticket-status__chevron" aria-hidden="true"></span>
+                          <span class="visually-hidden">Change ticket status</span>
+                        </button>
+                        <form
+                          id="ticket-status-form-{{ ticket.id }}"
+                          action="/admin/tickets/{{ ticket.id }}/status"
+                          method="post"
+                          class="inline-form ticket-status__form"
+                          data-ticket-status-form
+                          hidden
+                        >
+                          {% if csrf_token %}
+                            <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                          {% endif %}
+                          <label class="visually-hidden" for="ticket-status-{{ ticket.id }}">Status</label>
+                          <select
+                            id="ticket-status-{{ ticket.id }}"
+                            name="status"
+                            class="form-input form-input--compact"
+                            data-ticket-status-select
+                          >
+                            {% for status_option in ticket_available_statuses %}
+                              <option value="{{ status_option }}" {% if status_option == (ticket.status or 'open') %}selected{% endif %}>{{ status_option.replace('_', ' ') }}</option>
+                            {% endfor %}
+                          </select>
+                        </form>
+                      </div>
                     </td>
                     <td data-label="Priority">{{ ticket.priority or 'normal' }}</td>
                     <td data-label="Company">{{ company.name if company else (ticket.company_id or '—') }}</td>
                     <td data-label="Assigned">{{ assigned.email if assigned else '—' }}</td>
                     <td data-label="Updated">{{ ticket.updated_at.astimezone().strftime('%Y-%m-%d %H:%M') if ticket.updated_at else '—' }}</td>
-                    <td data-label="Update status">
-                      <form action="/admin/tickets/{{ ticket.id }}/status" method="post" class="inline-form" data-ticket-status-form>
-                        {% if csrf_token %}
-                          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-                        {% endif %}
-                        <label class="visually-hidden" for="ticket-status-{{ ticket.id }}">Status</label>
-                        <select
-                          id="ticket-status-{{ ticket.id }}"
-                          name="status"
-                          class="form-input form-input--compact"
-                          data-ticket-status-select
-                        >
-                          {% for status_option in ticket_available_statuses %}
-                            <option value="{{ status_option }}" {% if status_option == (ticket.status or 'open') %}selected{% endif %}>{{ status_option.replace('_', ' ') }}</option>
-                          {% endfor %}
-                        </select>
-                      </form>
-                    </td>
                     <td class="table__actions">
                       <a href="/admin/tickets/{{ ticket.id }}" class="button button--ghost">Open</a>
                     </td>

--- a/changes/4d84cb8c-cbc6-4cb6-923c-8e9a9f738d52.json
+++ b/changes/4d84cb8c-cbc6-4cb6-923c-8e9a9f738d52.json
@@ -1,0 +1,7 @@
+{
+  "guid": "4d84cb8c-cbc6-4cb6-923c-8e9a9f738d52",
+  "occurred_at": "2025-10-29T03:44Z",
+  "change_type": "Feature",
+  "summary": "Combined ticket status display with inline update dropdown on the admin tickets table",
+  "content_hash": "3372c63096bdd67cae3028a3e5c1b7da8eda7c3ca78a302fa923f71bffdd616a"
+}


### PR DESCRIPTION
## Summary
- merge the admin ticket table status display and updater into a single dropdown column
- add client-side controls that toggle the inline status form on demand while preserving auto-submit behaviour
- style the consolidated status control and record the update in the change log

## Testing
- `pytest` *(fails: tests/test_imap_service.py::test_resolve_ticket_entities_handles_staff_without_user, tests/test_imap_service.py::test_sync_account_does_not_mark_as_read_on_ticket_failure due to missing test fixtures)*

------
https://chatgpt.com/codex/tasks/task_b_69018cbc1dc0832d98c100e6a160e780