### PR TITLE
Rename automation admin page title to System Automation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5099,7 +5099,7 @@ async def admin_automation(request: Request):
         company_options.append({"value": str(company_id), "label": f"Company #{company_id}"})
 
     extra = {
-        "title": "Automation & monitoring",
+        "title": "System Automation",
         "tasks": prepared_tasks,
         "command_options": command_options,
         "company_options": company_options,

--- a/changes/0f0bdc53-5b30-4f36-8aac-9ef6e9d9015e.json
+++ b/changes/0f0bdc53-5b30-4f36-8aac-9ef6e9d9015e.json
@@ -1,0 +1,7 @@
+{
+  "guid": "0f0bdc53-5b30-4f36-8aac-9ef6e9d9015e",
+  "occurred_at": "2025-10-29T04:40Z",
+  "change_type": "Fix",
+  "summary": "Renamed Automation & monitoring admin page title to System Automation.",
+  "content_hash": "4b38c4b6a10dcbb7c3d91d5091278f808b0db6f4eb5de7fbb5c0664b6b775a7c"
+}


### PR DESCRIPTION
## Summary
- update the admin automation view title to "System Automation" to match the new naming
- record the rename in the change log for audit purposes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_69019a8a7058832d95731ebea810d63e