### PR TITLE
Move scheduled task deletion into modal

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -528,6 +528,12 @@ body {
   justify-content: flex-end;
 }
 
+.form-actions__group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-gap-tight);
+}
+
 .automation-actions {
   display: flex;
   flex-direction: column;

--- a/app/templates/admin/automation.html
+++ b/app/templates/admin/automation.html
@@ -58,12 +58,8 @@
               <td class="table__actions">
                 <div class="table__action-buttons">
                   <button type="button" class="button button--ghost" data-task-edit>Edit</button>
-                  <button type="button" class="button button--ghost" data-task-toggle>
-                    {{ 'Disable' if task.active else 'Enable' }}
-                  </button>
                   <button type="button" class="button button--ghost" data-task-run>Run now</button>
                   <button type="button" class="button button--ghost" data-task-logs>View logs</button>
-                  <button type="button" class="button button--danger" data-task-delete>Delete</button>
                 </div>
               </td>
             </tr>
@@ -170,8 +166,19 @@
           </label>
         </div>
         <div class="form-actions">
-          <button type="submit" class="button">Save task</button>
-          <button type="button" class="button button--ghost" data-task-reset>Clear form</button>
+          <div class="form-actions__group">
+            <button type="submit" class="button">Save task</button>
+            <button type="button" class="button button--ghost" data-task-reset>Clear form</button>
+          </div>
+          <button
+            type="button"
+            class="button button--danger"
+            data-task-delete-modal
+            hidden
+            aria-hidden="true"
+          >
+            Delete task
+          </button>
         </div>
       </form>
     </div>

--- a/changes/67393e42-c430-40ed-a342-6ac18ecb046b.json
+++ b/changes/67393e42-c430-40ed-a342-6ac18ecb046b.json
@@ -1,0 +1,7 @@
+{
+  "guid": "67393e42-c430-40ed-a342-6ac18ecb046b",
+  "occurred_at": "2025-10-29T04:46Z",
+  "change_type": "Fix",
+  "summary": "Moved scheduled task deletion controls into the modal and removed inline disable toggle.",
+  "content_hash": "0f90d32bd1b5bf04ce6008072a9636fcbde6021d936c12fa0196af2f3f55872c"
+}


### PR DESCRIPTION
## Summary
- move the scheduled task delete control from the table actions into the modal editor and remove the inline disable toggle
- update the automation management script to drive the modal delete flow and adjust spacing styles for grouped form actions
- record the UI adjustment in the change log registry

## Testing
- pytest *(fails: tests/test_imap_service.py::test_resolve_ticket_entities_handles_staff_without_user NameError: name 'checked' is not defined; tests/test_imap_service.py::test_sync_account_does_not_mark_as_read_on_ticket_failure NameError: name 'fake_get_user_by_email' is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_69019b3cae64832db45ce3e0a877f7df