### PR TITLE
Fix IMAP ticket description rendering

### DIFF
--- a/changes/7fb74abb-3bd3-4b03-81e1-ef32a9fea885.json
+++ b/changes/7fb74abb-3bd3-4b03-81e1-ef32a9fea885.json
@@ -1,0 +1,7 @@
+{
+  "guid": "7fb74abb-3bd3-4b03-81e1-ef32a9fea885",
+  "occurred_at": "2025-10-29T04:45:12Z",
+  "change_type": "Fix",
+  "summary": "Improve IMAP email body parsing so ticket descriptions only show formatted HTML and inline images render.",
+  "content_hash": "bc71c97c429c53fde4d6eb6850383c79b05d4862f3735da9886ce574d0e6d559"
+}


### PR DESCRIPTION
## Summary
- prefer sanitised HTML bodies when importing IMAP tickets and embed inline CID images as data URIs
- add regression tests ensuring HTML descriptions are selected and inline images are inlined
- record the change in the JSON change log for ingestion

## Testing
- pytest tests/test_imap_service.py::test_extract_body_prefers_html_over_plain_text tests/test_imap_service.py::test_extract_body_inlines_cid_images

------
https://chatgpt.com/codex/tasks/task_b_69019a47bbd4832dbecb1341ee38cfe5