### PR TITLE
Add conversation entries for imported emails and collapse ticket description

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -223,20 +223,25 @@
           {% set description_html = ticket.description_html if ticket.description_html is defined else '' %}
           {% set has_original_description = ticket.description is defined and ticket.description %}
           {% if description_html or has_original_description %}
-            <article class="card card--panel">
-              <header class="card__header">
+            <details class="card card--panel card-collapsible" data-ticket-description>
+              <summary class="card__header card__header--collapsible">
                 <h2 class="card__title">Description</h2>
-              </header>
-              <div class="card__body">
-                {% if description_html %}
-                  <div class="rich-text-viewer" data-ticket-description>
-                    {{ description_html | safe }}
-                  </div>
-                {% else %}
-                  <p class="card__empty">The ticket description does not contain displayable content.</p>
-                {% endif %}
+                <div class="card__collapsible-meta">
+                  <span class="card__toggle-icon" aria-hidden="true"></span>
+                </div>
+              </summary>
+              <div class="card-collapsible__content">
+                <div class="card__body">
+                  {% if description_html %}
+                    <div class="rich-text-viewer" data-ticket-description>
+                      {{ description_html | safe }}
+                    </div>
+                  {% else %}
+                    <p class="card__empty">The ticket description does not contain displayable content.</p>
+                  {% endif %}
+                </div>
               </div>
-            </article>
+            </details>
           {% endif %}
 
           {% if ticket.ai_summary or ticket.ai_summary_status %}

--- a/changes/b96cb1eb-c1fe-426e-bd19-341074dfa444.json
+++ b/changes/b96cb1eb-c1fe-426e-bd19-341074dfa444.json
@@ -1,0 +1,7 @@
+{
+  "guid": "b96cb1eb-c1fe-426e-bd19-341074dfa444",
+  "occurred_at": "2025-10-29T05:20:30Z",
+  "change_type": "Feature",
+  "summary": "Import email bodies into ticket conversation and collapse description card by default",
+  "content_hash": "5ce2c27351581fb35e5b8add22581ee91cf64d9b30decb9e4b1e7631eb54fe7e"
+}


### PR DESCRIPTION
## Summary
- add a sanitized conversation reply with the original email timestamp whenever IMAP imports create a ticket
- collapse the ticket description panel by default using the existing card-collapsible pattern
- record the feature in the structured change log

## Testing
- pytest *(fails: tests/test_imap_service.py::test_resolve_ticket_entities_handles_staff_without_user NameError: checked is not defined; tests/test_imap_service.py::test_sync_account_does_not_mark_as_read_on_ticket_failure NameError: fake_get_user_by_email is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_6901a2126418832d9f2a5d5376b14043