### PR TITLE
Simplify ticket workspace status control

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1435,44 +1435,10 @@ body {
 
 .ticket-status {
   display: inline-flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-gap-tight);
-}
-
-.ticket-status__toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: calc(var(--space-gap-tight) * 0.75);
-  padding: 0;
-  border: none;
-  background: none;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
-}
-
-.ticket-status__toggle:focus-visible {
-  outline: 2px solid rgba(148, 163, 184, 0.6);
-  outline-offset: 2px;
-}
-
-.ticket-status__chevron {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  border-left: 0.35rem solid transparent;
-  border-right: 0.35rem solid transparent;
-  border-top: 0.4rem solid rgba(148, 163, 184, 0.7);
-  transition: transform 0.2s ease;
-}
-
-.ticket-status--open .ticket-status__chevron {
-  transform: rotate(180deg);
+  width: 100%;
 }
 
 .ticket-status__form {
-  margin-top: calc(var(--space-gap-tight) * 0.9);
   width: 100%;
 }
 

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -358,97 +358,6 @@
     });
   }
 
-  function bindTicketStatusDropdowns() {
-    const containers = document.querySelectorAll('[data-ticket-status]');
-    if (!containers.length) {
-      return;
-    }
-
-    const documentHandlers = new WeakMap();
-
-    const closeContainer = (container) => {
-      if (!container) {
-        return;
-      }
-      const form = container.querySelector('[data-ticket-status-form]');
-      const toggle = container.querySelector('[data-ticket-status-toggle]');
-      if (form) {
-        form.hidden = true;
-      }
-      if (toggle) {
-        toggle.setAttribute('aria-expanded', 'false');
-      }
-      container.classList.remove('ticket-status--open');
-      const handler = documentHandlers.get(container);
-      if (handler) {
-        document.removeEventListener('click', handler);
-      }
-    };
-
-    const closeAll = (except) => {
-      containers.forEach((container) => {
-        if (container !== except) {
-          closeContainer(container);
-        }
-      });
-    };
-
-    containers.forEach((container) => {
-      const toggle = container.querySelector('[data-ticket-status-toggle]');
-      const form = container.querySelector('[data-ticket-status-form]');
-      if (!toggle || !form) {
-        return;
-      }
-
-      const select = form.querySelector('[data-ticket-status-select]');
-
-      const handleDocumentClick = (event) => {
-        if (!container.contains(event.target)) {
-          closeContainer(container);
-        }
-      };
-
-      documentHandlers.set(container, handleDocumentClick);
-      closeContainer(container);
-
-      toggle.addEventListener('click', (event) => {
-        event.preventDefault();
-        const isOpen = container.classList.contains('ticket-status--open');
-        if (isOpen) {
-          closeContainer(container);
-          return;
-        }
-        closeAll(container);
-        container.classList.add('ticket-status--open');
-        form.hidden = false;
-        toggle.setAttribute('aria-expanded', 'true');
-        window.setTimeout(() => {
-          document.addEventListener('click', handleDocumentClick);
-        }, 0);
-        if (select) {
-          window.requestAnimationFrame(() => {
-            select.focus();
-          });
-        }
-      });
-
-      form.addEventListener('submit', () => {
-        closeContainer(container);
-        toggle.focus();
-      });
-
-      if (select) {
-        select.addEventListener('keydown', (event) => {
-          if (event.key === 'Escape') {
-            event.stopPropagation();
-            closeContainer(container);
-            toggle.focus();
-          }
-        });
-      }
-    });
-  }
-
   function parsePermissions(value) {
     return value
       .split(',')
@@ -794,7 +703,6 @@
     bindSyncroTicketImportForms();
     bindSyncroCompanyImportForm();
     bindTicketBulkDelete();
-    bindTicketStatusDropdowns();
     bindTicketStatusAutoSubmit();
     bindRoleForm();
     bindCompanyAssignmentControls();

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -156,26 +156,15 @@
                       'closed': 'badge--muted'
                     } %}
                     <td data-label="Status" data-value="{{ ticket_status }}">
-                      <div class="ticket-status" data-ticket-status>
-                        <button
-                          type="button"
-                          class="ticket-status__toggle"
-                          data-ticket-status-toggle
-                          aria-haspopup="listbox"
-                          aria-expanded="false"
-                          aria-controls="ticket-status-form-{{ ticket.id }}"
-                        >
-                          <span class="badge {{ status_badge_map.get(ticket_status, 'badge--muted') }}">{{ status_label }}</span>
-                          <span class="ticket-status__chevron" aria-hidden="true"></span>
-                          <span class="visually-hidden">Change ticket status</span>
-                        </button>
+                      <div class="ticket-status">
+                        <span class="visually-hidden" id="ticket-status-label-{{ ticket.id }}">Ticket status</span>
                         <form
                           id="ticket-status-form-{{ ticket.id }}"
                           action="/admin/tickets/{{ ticket.id }}/status"
                           method="post"
                           class="inline-form ticket-status__form"
                           data-ticket-status-form
-                          hidden
+                          aria-labelledby="ticket-status-label-{{ ticket.id }}"
                         >
                           {% if csrf_token %}
                             <input type="hidden" name="_csrf" value="{{ csrf_token }}" />

--- a/changes/07ec2044-3d67-4eaa-8d78-c2a1f324efff.json
+++ b/changes/07ec2044-3d67-4eaa-8d78-c2a1f324efff.json
@@ -1,0 +1,7 @@
+{
+  "guid": "07ec2044-3d67-4eaa-8d78-c2a1f324efff",
+  "occurred_at": "2025-12-21T09:45Z",
+  "change_type": "Fix",
+  "summary": "Simplified ticket status control to show only the dropdown in the workspace table",
+  "content_hash": "2ac5f255f2744f98fdf9a4196bb3a9df25f156eaefe4f6317073f592a44265d0"
+}


### PR DESCRIPTION
## Summary
- replace the ticket status badge toggle in the ticketing workspace table with the inline dropdown control
- remove the unused dropdown toggle script and supporting styles after simplifying the control
- record the change in the JSON change log

## Testing
- pytest tests/test_ticket_access.py

------
https://chatgpt.com/codex/tasks/task_b_6901a5fb71b0832da30a01fdaacdf4f3