### PR TITLE
Split automation tasks tables by scope

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5060,6 +5060,8 @@ async def admin_automation(request: Request):
         company_lookup[company_id] = str(company.get("name") or f"Company #{company_id}")
 
     prepared_tasks: list[dict[str, Any]] = []
+    global_tasks: list[dict[str, Any]] = []
+    company_tasks: list[dict[str, Any]] = []
     missing_company_ids: set[int] = set()
     for task in tasks:
         serialised_task = _serialise_mapping(task)
@@ -5082,6 +5084,10 @@ async def admin_automation(request: Request):
                     missing_company_ids.add(company_key)
         serialised_task["company_name"] = company_name
         prepared_tasks.append(serialised_task)
+        if company_id is None or company_name.lower() == "all companies":
+            global_tasks.append(serialised_task)
+        else:
+            company_tasks.append(serialised_task)
     command_options = [
         {"value": "sync_staff", "label": "Sync staff directory"},
         {"value": "sync_o365", "label": "Sync Microsoft 365 licenses"},
@@ -5101,6 +5107,8 @@ async def admin_automation(request: Request):
     extra = {
         "title": "System Automation",
         "tasks": prepared_tasks,
+        "global_tasks": global_tasks,
+        "company_tasks": company_tasks,
         "command_options": command_options,
         "company_options": company_options,
     }

--- a/app/templates/admin/automation.html
+++ b/app/templates/admin/automation.html
@@ -3,93 +3,185 @@
 {% block content %}
 <div class="admin-grid">
   <section class="card card--panel">
-    <header class="card__header card__header--actions">
+    <header class="card__header card__header--stacked">
       <div>
         <h2 class="card__title">Scheduled tasks</h2>
         <p class="card__subtitle">Create, monitor, and control background automation jobs.</p>
       </div>
-      <div class="card__controls">
-        <input
-          type="search"
-          class="form-input"
-          placeholder="Filter tasks"
-          aria-label="Filter scheduled tasks"
-          data-table-filter="tasks-table"
-        />
-        <button type="button" class="button" data-task-create>
-          New task
-        </button>
-      </div>
     </header>
-    <div class="table-wrapper">
-      <table class="table" id="tasks-table" data-table>
-        <thead>
-          <tr>
-            <th scope="col" data-sort="string">Name</th>
-            <th scope="col" data-sort="string">Command</th>
-            <th scope="col" data-sort="string">Company</th>
-            <th scope="col" data-sort="string">Cron</th>
-            <th scope="col" data-sort="string">Active</th>
-            <th scope="col" data-sort="date">Last run</th>
-            <th scope="col" data-sort="string">Status</th>
-            <th scope="col" class="table__actions">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for task in tasks %}
-            <tr data-task='{{ task | tojson }}'>
-              <td data-label="Name">{{ task.name }}</td>
-              <td data-label="Command">{{ task.command }}</td>
-              <td data-label="Company" data-value="{{ task.company_name }}">
-                {{ task.company_name }}
-              </td>
-              <td data-label="Cron">{{ task.cron }}</td>
-              <td data-label="Active">
-                <span class="tag {{ 'tag--success' if task.active else 'tag--muted' }}">{{ 'Yes' if task.active else 'No' }}</span>
-              </td>
-              <td data-label="Last run" data-value="{{ task.last_run_iso or '' }}">
-                {% if task.last_run_iso %}
-                  <span data-utc="{{ task.last_run_iso }}"></span>
-                {% else %}
-                  <span class="text-muted">Never</span>
-                {% endif %}
-              </td>
-              <td data-label="Status">{{ task.last_status or '—' }}</td>
-              <td class="table__actions">
-                <div class="table__action-buttons">
-                  <button type="button" class="button button--ghost" data-task-edit>Edit</button>
-                  <button type="button" class="button button--ghost" data-task-run>Run now</button>
-                  <button type="button" class="button button--ghost" data-task-logs>View logs</button>
-                </div>
-              </td>
-            </tr>
-          {% else %}
-            <tr>
-              <td colspan="8" class="table__empty">No tasks configured yet.</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    <div class="table-pagination" data-pagination="tasks-table">
-      <div class="table-pagination__group">
-        <button
-          type="button"
-          class="button button--ghost table-pagination__button"
-          data-page-prev
-          disabled
-        >
-          Previous
-        </button>
-        <button
-          type="button"
-          class="button button--ghost table-pagination__button"
-          data-page-next
-        >
-          Next
-        </button>
-      </div>
-      <p class="table-pagination__status" data-page-info aria-live="polite"></p>
+    {% set global_tasks = global_tasks | default([], true) %}
+    {% set company_tasks = company_tasks | default([], true) %}
+    <div class="card__body card__body--stacked">
+      <section>
+        <h3 class="card__subtitle">All companies</h3>
+        <p class="text-muted">Tasks that execute for every company profile.</p>
+        <div class="table-toolbar">
+          <input
+            type="search"
+            class="form-input"
+            placeholder="Filter all-company tasks"
+            aria-label="Filter all-company tasks"
+            data-table-filter="tasks-table-global"
+          />
+          <button type="button" class="button" data-task-create>
+            New task
+          </button>
+        </div>
+        <div class="table-wrapper">
+          <table class="table" id="tasks-table-global" data-table>
+            <thead>
+              <tr>
+                <th scope="col" data-sort="string">Name</th>
+                <th scope="col" data-sort="string">Command</th>
+                <th scope="col" data-sort="string">Company</th>
+                <th scope="col" data-sort="string">Cron</th>
+                <th scope="col" data-sort="string">Active</th>
+                <th scope="col" data-sort="date">Last run</th>
+                <th scope="col" data-sort="string">Status</th>
+                <th scope="col" class="table__actions">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for task in global_tasks %}
+                <tr data-task='{{ task | tojson }}'>
+                  <td data-label="Name">{{ task.name }}</td>
+                  <td data-label="Command">{{ task.command }}</td>
+                  <td data-label="Company" data-value="{{ task.company_name }}">
+                    {{ task.company_name }}
+                  </td>
+                  <td data-label="Cron">{{ task.cron }}</td>
+                  <td data-label="Active">
+                    <span class="tag {{ 'tag--success' if task.active else 'tag--muted' }}">{{ 'Yes' if task.active else 'No' }}</span>
+                  </td>
+                  <td data-label="Last run" data-value="{{ task.last_run_iso or '' }}">
+                    {% if task.last_run_iso %}
+                      <span data-utc="{{ task.last_run_iso }}"></span>
+                    {% else %}
+                      <span class="text-muted">Never</span>
+                    {% endif %}
+                  </td>
+                  <td data-label="Status">{{ task.last_status or '—' }}</td>
+                  <td class="table__actions">
+                    <div class="table__action-buttons">
+                      <button type="button" class="button button--ghost" data-task-edit>Edit</button>
+                      <button type="button" class="button button--ghost" data-task-run>Run now</button>
+                      <button type="button" class="button button--ghost" data-task-logs>View logs</button>
+                    </div>
+                  </td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td colspan="8" class="table__empty">No global tasks configured yet.</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="table-pagination" data-pagination="tasks-table-global">
+          <div class="table-pagination__group">
+            <button
+              type="button"
+              class="button button--ghost table-pagination__button"
+              data-page-prev
+              disabled
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              class="button button--ghost table-pagination__button"
+              data-page-next
+            >
+              Next
+            </button>
+          </div>
+          <p class="table-pagination__status" data-page-info aria-live="polite"></p>
+        </div>
+      </section>
+      <section class="divider"></section>
+      <section>
+        <h3 class="card__subtitle">Company-specific</h3>
+        <p class="text-muted">Tasks targeted to individual companies.</p>
+        <div class="table-toolbar">
+          <input
+            type="search"
+            class="form-input"
+            placeholder="Filter company tasks"
+            aria-label="Filter company-specific tasks"
+            data-table-filter="tasks-table-company"
+          />
+        </div>
+        <div class="table-wrapper">
+          <table class="table" id="tasks-table-company" data-table>
+            <thead>
+              <tr>
+                <th scope="col" data-sort="string">Name</th>
+                <th scope="col" data-sort="string">Command</th>
+                <th scope="col" data-sort="string">Company</th>
+                <th scope="col" data-sort="string">Cron</th>
+                <th scope="col" data-sort="string">Active</th>
+                <th scope="col" data-sort="date">Last run</th>
+                <th scope="col" data-sort="string">Status</th>
+                <th scope="col" class="table__actions">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for task in company_tasks %}
+                <tr data-task='{{ task | tojson }}'>
+                  <td data-label="Name">{{ task.name }}</td>
+                  <td data-label="Command">{{ task.command }}</td>
+                  <td data-label="Company" data-value="{{ task.company_name }}">
+                    {{ task.company_name }}
+                  </td>
+                  <td data-label="Cron">{{ task.cron }}</td>
+                  <td data-label="Active">
+                    <span class="tag {{ 'tag--success' if task.active else 'tag--muted' }}">{{ 'Yes' if task.active else 'No' }}</span>
+                  </td>
+                  <td data-label="Last run" data-value="{{ task.last_run_iso or '' }}">
+                    {% if task.last_run_iso %}
+                      <span data-utc="{{ task.last_run_iso }}"></span>
+                    {% else %}
+                      <span class="text-muted">Never</span>
+                    {% endif %}
+                  </td>
+                  <td data-label="Status">{{ task.last_status or '—' }}</td>
+                  <td class="table__actions">
+                    <div class="table__action-buttons">
+                      <button type="button" class="button button--ghost" data-task-edit>Edit</button>
+                      <button type="button" class="button button--ghost" data-task-run>Run now</button>
+                      <button type="button" class="button button--ghost" data-task-logs>View logs</button>
+                    </div>
+                  </td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td colspan="8" class="table__empty">No company-specific tasks configured yet.</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="table-pagination" data-pagination="tasks-table-company">
+          <div class="table-pagination__group">
+            <button
+              type="button"
+              class="button button--ghost table-pagination__button"
+              data-page-prev
+              disabled
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              class="button button--ghost table-pagination__button"
+              data-page-next
+            >
+              Next
+            </button>
+          </div>
+          <p class="table-pagination__status" data-page-info aria-live="polite"></p>
+        </div>
+      </section>
     </div>
   </section>
 </div>

--- a/changes/e9802d1c-d95c-4099-8a80-7cbb90ab4bfb.json
+++ b/changes/e9802d1c-d95c-4099-8a80-7cbb90ab4bfb.json
@@ -1,0 +1,7 @@
+{
+  "guid": "e9802d1c-d95c-4099-8a80-7cbb90ab4bfb",
+  "occurred_at": "2025-10-29T05:31:10Z",
+  "change_type": "Feature",
+  "summary": "Split scheduled automation tasks into global and company-specific tables.",
+  "content_hash": "49909a2b5d445a55ed5c7629f0ee564d918e48a349369298cf41bf6e52c926c6"
+}


### PR DESCRIPTION
## Summary
- separate scheduled automation tasks into dedicated global and company-specific tables with individual filters and pagination
- extend the automation admin view to provide grouped task collections for the template
- document the change in the structured change log registry

## Testing
- pytest *(fails: tests/test_imap_service.py::test_resolve_ticket_entities_handles_staff_without_user, tests/test_imap_service.py::test_sync_account_does_not_mark_as_read_on_ticket_failure)*

------
https://chatgpt.com/codex/tasks/task_b_6901a5ae3494832d91e51c6ea25dca11