### PR TITLE
Ensure ticket AI processing covers new creations

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -528,6 +528,13 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                     module_slug="imap",
                     external_reference=message_id,
                 )
+                ticket_id = ticket.get("id") if isinstance(ticket, Mapping) else None
+                if ticket_id is not None:
+                    try:
+                        await tickets_service.refresh_ticket_ai_summary(int(ticket_id))
+                    except RuntimeError:
+                        pass
+                    await tickets_service.refresh_ticket_ai_tags(int(ticket_id))
             except Exception as exc:  # pragma: no cover - defensive logging
                 error_text = str(exc)
                 errors.append({"uid": uid, "error": error_text})

--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -634,6 +634,12 @@ async def _upsert_ticket(
             trigger_automations=True,
         )
         created_id = created.get("id")
+        if created_id is not None:
+            try:
+                await tickets_service.refresh_ticket_ai_summary(int(created_id))
+            except RuntimeError:
+                pass
+            await tickets_service.refresh_ticket_ai_tags(int(created_id))
         ticket_db_id = int(created_id) if created_id is not None else None
         if created_id is not None and any((created_at, updated_at, closed_at)):
             timestamp_updates: dict[str, Any] = {}

--- a/changes/5a596234-852d-43e1-8db5-4802ad74d705.json
+++ b/changes/5a596234-852d-43e1-8db5-4802ad74d705.json
@@ -1,0 +1,7 @@
+{
+  "guid": "5a596234-852d-43e1-8db5-4802ad74d705",
+  "occurred_at": "2025-10-29T05:31Z",
+  "change_type": "Feature",
+  "summary": "Routed new ticket creations through AI summary/tag refresh and removed signatures from AI prompts.",
+  "content_hash": "9f2c0ceb0ff93e425f8dd47b61c818354059632f1f74e4cc2eb547637cb2a236"
+}


### PR DESCRIPTION
## Summary
- ensure AI prompts strip reply separators, signatures, and disclaimers before summarisation/tagging
- trigger AI summary and tag refresh when tickets are created via IMAP ingestion or Syncro imports
- add regression tests covering the new prompt cleanup logic and record the change log entry

## Testing
- pytest tests/test_ticket_ai_summary_service.py tests/test_ticket_ai_tags_service.py tests/test_tickets_service_create.py

------
https://chatgpt.com/codex/tasks/task_b_6901a54e2af4832db5e91932b48c8165