### PR TITLE
Add admin refresh control for ticket AI data

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -247,16 +247,34 @@
           {% if ticket.ai_summary or ticket.ai_summary_status %}
             <article class="card card--panel">
               <header class="card__header">
-                <h2 class="card__title">AI Summary</h2>
-                <p class="card__subtitle">
-                  <span class="badge {{ ai_badge_map.get(ai_status_lower, 'badge--warning') }}">{{ ai_status_label }}</span>
-                  {% if ticket.ai_summary_model %}
-                    <span>{{ ticket.ai_summary_model }}</span>
-                  {% endif %}
-                  {% if ticket.ai_summary_updated_at %}
-                    <span>Updated {{ ticket.ai_summary_updated_at.astimezone().strftime('%Y-%m-%d %H:%M') }}</span>
-                  {% endif %}
-                </p>
+                <div>
+                  <h2 class="card__title">AI Summary</h2>
+                  <p class="card__subtitle">
+                    <span class="badge {{ ai_badge_map.get(ai_status_lower, 'badge--warning') }}">{{ ai_status_label }}</span>
+                    {% if ticket.ai_summary_model %}
+                      <span>{{ ticket.ai_summary_model }}</span>
+                    {% endif %}
+                    {% if ticket.ai_summary_updated_at %}
+                      <span>Updated {{ ticket.ai_summary_updated_at.astimezone().strftime('%Y-%m-%d %H:%M') }}</span>
+                    {% endif %}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  class="button button--ghost button--small"
+                  data-ticket-ai-refresh
+                  data-ticket-id="{{ ticket.id }}"
+                  aria-label="Reprocess AI summary and AI tags"
+                  title="Reprocess AI summary and AI tags"
+                >
+                  <span class="sr-only" data-button-label>Reprocess AI summary and AI tags</span>
+                  <span class="button__icon" aria-hidden="true" data-button-icon>
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path d="M12 4a8 8 0 0 1 7.75 6.11 1 1 0 0 1-1.94.46A6 6 0 1 0 17 16h1.59l-1.3-1.29a1 1 0 1 1 1.42-1.42l3 3a1 1 0 0 1 0 1.42l-3 3a1 1 0 0 1-1.42-1.42L18.59 18H17a8 8 0 1 1-5-14Z" />
+                    </svg>
+                  </span>
+                  <span class="button__spinner" aria-hidden="true" data-button-spinner hidden></span>
+                </button>
               </header>
               <div class="card__body">
                 {% if ai_status_lower == 'succeeded' and ticket.ai_summary %}

--- a/changes/7cc170f0-3b65-4c6f-9c9c-2d649083c220.json
+++ b/changes/7cc170f0-3b65-4c6f-9c9c-2d649083c220.json
@@ -1,0 +1,7 @@
+{
+  "guid": "7cc170f0-3b65-4c6f-9c9c-2d649083c220",
+  "occurred_at": "2025-10-29T06:11:00Z",
+  "change_type": "Feature",
+  "summary": "Added admin control to reprocess ticket AI summaries and tags on demand.",
+  "content_hash": "4bff61aa9678f30b98ed96ff1722f4cfdab2219f0a0b53a83a2388a057cc11bc"
+}


### PR DESCRIPTION
## Summary
- add an admin endpoint to queue ticket AI summary and tag regeneration
- surface a refresh affordance in the ticket detail AI Summary card and hook it up via JavaScript
- cover the behaviour with regression tests and record the change in the changelog

## Testing
- pytest tests/test_ticket_access.py::test_admin_reprocess_ticket_ai_triggers_services tests/test_ticket_access.py::test_admin_reprocess_ticket_ai_missing_ticket

------
https://chatgpt.com/codex/tasks/task_b_6901aea4e104832d998055192c5a8498