### PR TITLE
Fix Ollama module fallback for blank model settings

### DIFF
--- a/changes/2c8fc5d1-c6a1-4502-bc00-3b3f4848b2ba.json
+++ b/changes/2c8fc5d1-c6a1-4502-bc00-3b3f4848b2ba.json
@@ -1,0 +1,7 @@
+{
+  "guid": "2c8fc5d1-c6a1-4502-bc00-3b3f4848b2ba",
+  "occurred_at": "2025-10-29T06:43Z",
+  "change_type": "Fix",
+  "summary": "Defaulted Ollama model selection when module settings are blank to restore IMAP ticket AI summaries and tags.",
+  "content_hash": "bc6bf69f1156b7749f9a38766c7b30dae17a7402c17c30a619b17abaa1c0def9"
+}


### PR DESCRIPTION
## Summary
- ensure the Ollama integration strips configured URLs/models and falls back to defaults when blank values are supplied
- allow payload-provided models while defaulting to the module configuration and provide constants for defaults
- add regression coverage for the fallback behaviour and record the change log entry

## Testing
- pytest tests/test_modules_service.py::test_invoke_ollama_uses_default_model_when_blank

------
https://chatgpt.com/codex/tasks/task_b_6901b68f5b9c832d8661c6cebb81e505