### PR TITLE
Improve AI reprocess feedback

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -245,7 +245,7 @@
           {% endif %}
 
           {% if ticket.ai_summary or ticket.ai_summary_status %}
-            <article class="card card--panel">
+            <article class="card card--panel" data-ticket-ai-card>
               <header class="card__header">
                 <div>
                   <h2 class="card__title">AI Summary</h2>
@@ -273,9 +273,15 @@
                       <path d="M12 4a8 8 0 0 1 7.75 6.11 1 1 0 0 1-1.94.46A6 6 0 1 0 17 16h1.59l-1.3-1.29a1 1 0 1 1 1.42-1.42l3 3a1 1 0 0 1 0 1.42l-3 3a1 1 0 0 1-1.42-1.42L18.59 18H17a8 8 0 1 1-5-14Z" />
                     </svg>
                   </span>
-                  <span class="button__spinner" aria-hidden="true" data-button-spinner hidden></span>
                 </button>
               </header>
+              <p
+                class="form-help"
+                role="status"
+                aria-live="polite"
+                data-ticket-ai-status
+                hidden
+              ></p>
               <div class="card__body">
                 {% if ai_status_lower == 'succeeded' and ticket.ai_summary %}
                   {% set resolution_label = resolution_label_map.get(ticket.ai_resolution_state) %}

--- a/changes/2323b82d-322a-413e-acd2-dc50b25a9719.json
+++ b/changes/2323b82d-322a-413e-acd2-dc50b25a9719.json
@@ -1,0 +1,7 @@
+{
+  "guid": "2323b82d-322a-413e-acd2-dc50b25a9719",
+  "occurred_at": "2025-10-29T07:14Z",
+  "change_type": "Fix",
+  "summary": "Improved ticket AI reprocess control with inline status feedback and removed loading animation.",
+  "content_hash": "14e3a66016ada71593cb9afc69ec194b5f24f13003fe82a54960de2db494e8fa"
+}


### PR DESCRIPTION
## Summary
- add inline status messaging when reprocessing ticket AI content and avoid unnecessary reloads
- remove the loading spinner from the AI reprocess control while keeping accessibility cues
- record the update in the change log for deployment visibility

## Testing
- pytest *(fails: existing test suite expects database pool and IMAP fixtures that are not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_6901be2dca2c832da0126a05634c1720