### PR TITLE
Fix AI reprocess button on ticket detail page

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -479,5 +479,6 @@
 
 {% block scripts %}
   {{ super() }}
+  <script src="/static/js/admin.js" defer></script>
   <script src="/static/js/rich_text_editor.js" defer></script>
 {% endblock %}

--- a/changes/17431b46-7023-4cfb-988b-d8bdeaffa2b4.json
+++ b/changes/17431b46-7023-4cfb-988b-d8bdeaffa2b4.json
@@ -1,0 +1,7 @@
+{
+  "guid": "17431b46-7023-4cfb-988b-d8bdeaffa2b4",
+  "occurred_at": "2025-10-29T07:21:45.971256+00:00",
+  "change_type": "Fix",
+  "summary": "Load admin client script on ticket detail page so AI reprocess button works",
+  "content_hash": ""
+}


### PR DESCRIPTION
## Summary
- load the shared admin client script on the ticket detail page so the AI reprocess controls are bound
- record the fix in the change log

## Testing
- pytest tests/test_ticket_access.py::test_admin_reprocess_ticket_ai_triggers_services

------
https://chatgpt.com/codex/tasks/task_b_6901bfea4298832d9483154bfc60273c