### PR TITLE
Add expandable truncation for ticket conversation messages

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1588,6 +1588,33 @@ body {
   gap: var(--space-gap-base);
 }
 
+.timeline__message {
+  position: relative;
+  border-radius: 0.75rem;
+  transition: max-height 0.2s ease;
+}
+
+.timeline__message--collapsed {
+  overflow: hidden;
+}
+
+.timeline__message--collapsed::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  height: 3rem;
+  background: linear-gradient(
+    to bottom,
+    rgba(15, 23, 42, 0),
+    rgba(15, 23, 42, 0.85)
+  );
+  pointer-events: none;
+}
+
+.timeline__message-toggle {
+  align-self: flex-start;
+}
+
 .timeline__body p {
   margin: 0;
 }

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -1,0 +1,79 @@
+(function () {
+  function getLineHeightPx(element) {
+    const computed = window.getComputedStyle(element);
+    const lineHeight = parseFloat(computed.lineHeight);
+    if (!Number.isNaN(lineHeight)) {
+      return lineHeight;
+    }
+
+    const fontSize = parseFloat(computed.fontSize);
+    if (!Number.isNaN(fontSize)) {
+      return fontSize * 1.5;
+    }
+
+    return 24;
+  }
+
+  function initialiseTimelineMessage(wrapper, toggle) {
+    const content = wrapper.querySelector('[data-timeline-message-content]');
+    if (!content) {
+      return;
+    }
+
+    const lineHeight = getLineHeightPx(content);
+    const maxCollapsedHeight = lineHeight * 5;
+    const currentScrollHeight = content.scrollHeight;
+
+    if (currentScrollHeight <= maxCollapsedHeight + 1) {
+      return;
+    }
+
+    const moreLabel = toggle.dataset.moreLabel || 'Show more';
+    const lessLabel = toggle.dataset.lessLabel || 'Show less';
+
+    function collapse() {
+      wrapper.style.maxHeight = `${maxCollapsedHeight}px`;
+      wrapper.classList.add('timeline__message--collapsed');
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.textContent = moreLabel;
+    }
+
+    function expand() {
+      wrapper.style.maxHeight = 'none';
+      wrapper.classList.remove('timeline__message--collapsed');
+      toggle.setAttribute('aria-expanded', 'true');
+      toggle.textContent = lessLabel;
+    }
+
+    collapse();
+    toggle.hidden = false;
+
+    toggle.addEventListener('click', () => {
+      const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+      if (isExpanded) {
+        collapse();
+      } else {
+        expand();
+      }
+    });
+  }
+
+  function ready() {
+    const messageWrappers = document.querySelectorAll('[data-timeline-message]');
+
+    messageWrappers.forEach((wrapper) => {
+      const toggle = wrapper.parentElement?.querySelector('[data-timeline-message-toggle]');
+      if (!(toggle instanceof HTMLButtonElement)) {
+        return;
+      }
+
+      initialiseTimelineMessage(wrapper, toggle);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', ready);
+  } else {
+    ready();
+  }
+})();

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -459,9 +459,28 @@
                         </span>
                       </header>
                       <div class="timeline__body">
-                        <div class="rich-text-viewer">
-                          {{ reply.body | safe }}
+                        <div
+                          class="timeline__message"
+                          data-timeline-message
+                        >
+                          <div
+                            class="rich-text-viewer timeline__message-content"
+                            data-timeline-message-content
+                          >
+                            {{ reply.body | safe }}
+                          </div>
                         </div>
+                        <button
+                          type="button"
+                          class="button button--ghost button--small timeline__message-toggle"
+                          data-timeline-message-toggle
+                          data-more-label="Show more"
+                          data-less-label="Show less"
+                          hidden
+                          aria-expanded="false"
+                        >
+                          Show more
+                        </button>
                       </div>
                     </article>
                   {% endfor %}
@@ -480,4 +499,5 @@
 {% block scripts %}
   {{ super() }}
   <script src="/static/js/rich_text_editor.js" defer></script>
+  <script src="/static/js/ticket_detail.js" defer></script>
 {% endblock %}

--- a/changes/06514b3b-aa6c-47ce-a222-2a7bb5352523.json
+++ b/changes/06514b3b-aa6c-47ce-a222-2a7bb5352523.json
@@ -1,0 +1,7 @@
+{
+  "guid": "06514b3b-aa6c-47ce-a222-2a7bb5352523",
+  "occurred_at": "2025-10-29T07:20Z",
+  "change_type": "Feature",
+  "summary": "Collapsed long ticket conversation messages with expand controls.",
+  "content_hash": "6ef88b07e5ddc693d9a6834517bcbb230b25866386cccf6b5c6508271ae79f12"
+}


### PR DESCRIPTION
## Summary
- clamp long ticket replies in the ticket detail timeline to five lines by default and expose a show more toggle
- add styling and a dedicated script to manage collapsible timeline messages with smooth expansion
- record a change log entry for the conversation history improvements

## Testing
- pytest *(fails: existing IMAP service and ticket importer tests depend on configured database and shared fixtures)*

------
https://chatgpt.com/codex/tasks/task_b_6901bf7c5f5c832da18287d84c7f92f7