### PR TITLE
Allow editing ticket descriptions and sync with AI summary

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -197,8 +197,12 @@ async def update_ticket(
     if not existing:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
     fields = payload.model_dump(exclude_unset=True)
+    description_marker = object()
+    description_value = fields.pop("description", description_marker)
     if fields:
         await tickets_repo.update_ticket(ticket_id, **fields)
+    if description_value is not description_marker:
+        await tickets_service.update_ticket_description(ticket_id, description_value)
     try:
         await tickets_service.refresh_ticket_ai_summary(ticket_id)
     except RuntimeError:

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -104,6 +104,17 @@ def _truncate_description(description: str | None) -> str | None:
     return _TRUNCATION_NOTICE.lstrip()
 
 
+async def update_ticket_description(
+    ticket_id: int, description: str | None
+) -> TicketRecord | None:
+    """Persist a ticket description after enforcing size limits."""
+
+    return await tickets_repo.update_ticket(
+        ticket_id,
+        description=_truncate_description(description),
+    )
+
+
 async def _safely_call(async_fn: Callable[..., Awaitable[Any]], *args, **kwargs):
     try:
         return await async_fn(*args, **kwargs)

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -221,28 +221,54 @@
 
         <div class="management__column management__column--content">
           {% set description_html = ticket.description_html if ticket.description_html is defined else '' %}
-          {% set has_original_description = ticket.description is defined and ticket.description %}
-          {% if description_html or has_original_description %}
-            <details class="card card--panel card-collapsible" data-ticket-description>
-              <summary class="card__header card__header--collapsible">
-                <h2 class="card__title">Description</h2>
-                <div class="card__collapsible-meta">
-                  <span class="card__toggle-icon" aria-hidden="true"></span>
-                </div>
-              </summary>
-              <div class="card-collapsible__content">
-                <div class="card__body">
+          <details class="card card--panel card-collapsible" data-ticket-description-panel>
+            <summary class="card__header card__header--collapsible">
+              <h2 class="card__title">Description</h2>
+              <div class="card__collapsible-meta">
+                <span class="card__toggle-icon" aria-hidden="true"></span>
+              </div>
+            </summary>
+            <div class="card-collapsible__content">
+              <div class="card__body">
+                <div
+                  class="rich-text-viewer"
+                  data-ticket-description-viewer
+                  {% if not description_html %}hidden{% endif %}
+                >
                   {% if description_html %}
-                    <div class="rich-text-viewer" data-ticket-description>
-                      {{ description_html | safe }}
-                    </div>
-                  {% else %}
-                    <p class="card__empty">The ticket description does not contain displayable content.</p>
+                    {{ description_html | safe }}
                   {% endif %}
                 </div>
+                <p
+                  class="card__empty"
+                  data-ticket-description-empty
+                  {% if description_html %}hidden{% endif %}
+                >
+                  The ticket description does not contain displayable content.
+                </p>
               </div>
-            </details>
-          {% endif %}
+              <form action="/admin/tickets/{{ ticket.id }}/description" method="post" class="form card__form">
+                {% if csrf_token %}
+                  <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                {% endif %}
+                <input type="hidden" name="returnUrl" value="{{ ticket_return_url }}" />
+                <div class="form-field">
+                  <label class="form-label" for="ticket-description-editor">Edit description</label>
+                  <textarea
+                    id="ticket-description-editor"
+                    name="description"
+                    class="form-input form-input--textarea"
+                    rows="8"
+                    data-ticket-description-input
+                  >{{- (ticket.description or '')|replace('\r\n', '\n')|replace('\r', '\n') -}}</textarea>
+                  <p class="form-help">Share customer notes, troubleshooting steps, or context for technicians.</p>
+                </div>
+                <div class="form-actions">
+                  <button type="submit" class="button button--primary">Save description</button>
+                </div>
+              </form>
+            </div>
+          </details>
 
           {% if ticket.ai_summary or ticket.ai_summary_status %}
             <article class="card card--panel" data-ticket-ai-card>
@@ -259,21 +285,36 @@
                     {% endif %}
                   </p>
                 </div>
-                <button
-                  type="button"
-                  class="button button--ghost button--small"
-                  data-ticket-ai-refresh
-                  data-ticket-id="{{ ticket.id }}"
-                  aria-label="Reprocess AI summary and AI tags"
-                  title="Reprocess AI summary and AI tags"
-                >
-                  <span class="sr-only" data-button-label>Reprocess AI summary and AI tags</span>
-                  <span class="button__icon" aria-hidden="true" data-button-icon>
-                    <svg viewBox="0 0 24 24" focusable="false">
-                      <path d="M12 4a8 8 0 0 1 7.75 6.11 1 1 0 0 1-1.94.46A6 6 0 1 0 17 16h1.59l-1.3-1.29a1 1 0 1 1 1.42-1.42l3 3a1 1 0 0 1 0 1.42l-3 3a1 1 0 0 1-1.42-1.42L18.59 18H17a8 8 0 1 1-5-14Z" />
-                    </svg>
-                  </span>
-                </button>
+                  <div class="button-group">
+                    <button
+                      type="button"
+                      class="button button--ghost button--small"
+                      data-ticket-ai-replace-description
+                      data-ticket-id="{{ ticket.id }}"
+                      data-processing-label="Replacing description…"
+                      aria-label="Replace the ticket description with the AI summary"
+                      title="Replace the ticket description with the AI summary"
+                      {% if not ticket.ai_summary %}disabled aria-disabled="true"{% endif %}
+                    >
+                      <span data-button-label>Replace description</span>
+                    </button>
+                    <button
+                      type="button"
+                      class="button button--ghost button--small"
+                      data-ticket-ai-refresh
+                      data-ticket-id="{{ ticket.id }}"
+                      data-processing-label="Reprocessing AI summary and AI tags…"
+                      aria-label="Reprocess AI summary and AI tags"
+                      title="Reprocess AI summary and AI tags"
+                    >
+                      <span class="sr-only" data-button-label>Reprocess AI summary and AI tags</span>
+                      <span class="button__icon" aria-hidden="true" data-button-icon>
+                        <svg viewBox="0 0 24 24" focusable="false">
+                          <path d="M12 4a8 8 0 0 1 7.75 6.11 1 1 0 0 1-1.94.46A6 6 0 1 0 17 16h1.59l-1.3-1.29a1 1 0 1 1 1.42-1.42l3 3a1 1 0 0 1 0 1.42l-3 3a1 1 0 0 1-1.42-1.42L18.59 18H17a8 8 0 1 1-5-14Z" />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
               </header>
               <p
                 class="form-help"

--- a/changes/70dab6d9-3eef-43b1-93b3-0df9a7337a14.json
+++ b/changes/70dab6d9-3eef-43b1-93b3-0df9a7337a14.json
@@ -1,0 +1,7 @@
+{
+  "guid": "70dab6d9-3eef-43b1-93b3-0df9a7337a14",
+  "occurred_at": "2025-10-29T07:28Z",
+  "change_type": "Feature",
+  "summary": "Enabled helpdesk teams to edit ticket descriptions and replace them with AI summaries.",
+  "content_hash": "fce31ec31492fa5ec434ec4b60bde74e77f79aad165b3ce03a9750ea3e8eb76c"
+}


### PR DESCRIPTION
## Summary
- add service helpers and API support for updating ticket descriptions while retaining truncation safeguards
- introduce admin routes, UI controls, and client-side logic that let technicians edit descriptions or overwrite them with the AI summary
- document the feature in the change log and cover the new flows with admin route tests

## Testing
- `pytest tests/test_ticket_access.py`


------
https://chatgpt.com/codex/tasks/task_b_6901bf79cb44832d8c5e1fc3498733b4