### PR TITLE
Remove email headers from imported conversations

### DIFF
--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -218,12 +218,33 @@ def _strip_signature_block(text: str) -> str:
     return "\n".join(trimmed).strip()
 
 
+_HEADER_PREFIXES = (
+    "subject:",
+    "from:",
+    "reply-to:",
+    "date:",
+)
+
+
 def _strip_conversation_noise(text: str) -> str:
     if not text:
         return ""
     cleaned = _strip_reply_marker(text)
     cleaned = _strip_signature_block(cleaned)
-    return cleaned.strip()
+
+    lines = cleaned.splitlines()
+    filtered_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            filtered_lines.append(line)
+            continue
+        lower = stripped.lower()
+        if any(lower.startswith(prefix) for prefix in _HEADER_PREFIXES):
+            continue
+        filtered_lines.append(line)
+
+    return "\n".join(filtered_lines).strip()
 
 
 def _prepare_prompt_text(value: Any) -> str:

--- a/changes/39b084ae-7803-427e-a637-ed1592ca025a.json
+++ b/changes/39b084ae-7803-427e-a637-ed1592ca025a.json
@@ -1,0 +1,7 @@
+{
+  "guid": "39b084ae-7803-427e-a637-ed1592ca025a",
+  "occurred_at": "2025-10-29T07:46:36Z",
+  "change_type": "Fix",
+  "summary": "Removed email headers from imported conversation history entries.",
+  "content_hash": "9b3144530301aa25f12fcf7efdc461f990591c063f866d79f64876e48f9e7e6d"
+}

--- a/tests/test_ticket_ai_summary_service.py
+++ b/tests/test_ticket_ai_summary_service.py
@@ -195,3 +195,23 @@ def test_render_prompt_ignores_signatures_and_reply_markers():
     assert "Sent from my iPhone" not in prompt
     assert "CONFIDENTIALITY NOTICE" not in prompt
     assert "Unauthorized viewing prohibited." not in prompt
+
+
+def test_strip_conversation_noise_removes_email_headers():
+    text = (
+        "Subject: Weekly Update\n"
+        "From: someone@example.com\n"
+        "Reply-To: reply@example.com\n"
+        "Date: Tue, 1 Jan 2024 10:00:00 +0000\n"
+        "Actual message body line one.\n"
+        "Another line."
+    )
+
+    cleaned = tickets_service._strip_conversation_noise(text)
+
+    assert "Subject:" not in cleaned
+    assert "From:" not in cleaned
+    assert "Reply-To:" not in cleaned
+    assert "Date:" not in cleaned
+    assert "Actual message body line one." in cleaned
+    assert "Another line." in cleaned


### PR DESCRIPTION
## Summary
- strip common email headers before saving conversation history content
- add regression coverage for header removal in the ticket AI summary service
- record the fix in the change log metadata

## Testing
- pytest tests/test_ticket_ai_summary_service.py

------
https://chatgpt.com/codex/tasks/task_b_6901c603ac78832db2112b38c18aadc0