### PR TITLE
Fix email reply marker trimming

### DIFF
--- a/changes/6999972a-8e25-4544-b50c-698bf4fb5964.json
+++ b/changes/6999972a-8e25-4544-b50c-698bf4fb5964.json
@@ -1,0 +1,7 @@
+{
+  "guid": "6999972a-8e25-4544-b50c-698bf4fb5964",
+  "occurred_at": "2025-10-29T08:02Z",
+  "change_type": "Fix",
+  "summary": "Ensure email reply markers strip quoted history below the latest notification line before AI processing.",
+  "content_hash": "387d91a2c76bc1fc0d3f47a6463781a7e11d26d1c8de2faa231fe7501760d435"
+}

--- a/tests/test_ticket_ai_tags_service.py
+++ b/tests/test_ticket_ai_tags_service.py
@@ -176,3 +176,37 @@ def test_render_tags_prompt_ignores_signatures_and_reply_markers():
     assert "Encryption agent offline for host." in prompt
     assert "Reply ABOVE THIS LINE" not in prompt
     assert "confidential" not in prompt.lower()
+
+
+def test_render_tags_prompt_discards_content_below_latest_reply_marker():
+    ticket = {
+        "id": 10,
+        "subject": "Server disk space alert",
+        "description": "Disk space critically low on server-12.",
+        "status": "open",
+        "priority": "urgent",
+        "category": "Infrastructure",
+        "module_slug": "operations",
+    }
+    replies = [
+        {
+            "ticket_id": 10,
+            "author_id": 8,
+            "body": (
+                "Latest cleanup scheduled for tonight.\n"
+                "--- Reply ABOVE THIS LINE to add a comment ---\n"
+                "Archive rotation queued.\n"
+                "> --- Reply ABOVE THIS LINE to add a comment ---\n"
+                "> Historical note retained only in thread."
+            ),
+            "is_internal": False,
+            "created_at": None,
+        }
+    ]
+
+    prompt = tickets_service._render_tags_prompt(ticket, replies, {})
+
+    assert "Latest cleanup scheduled for tonight." in prompt
+    assert "Archive rotation queued." not in prompt
+    assert "Historical note retained only in thread." not in prompt
+    assert "Reply ABOVE THIS LINE" not in prompt


### PR DESCRIPTION
## Summary
- normalise email reply marker detection so the latest notification line removes quoted history from AI prompts
- unescape HTML entities before stripping reply markers and add tests covering summary and tagging prompts
- record the fix in the change log registry

## Testing
- pytest tests/test_ticket_ai_summary_service.py tests/test_ticket_ai_tags_service.py -q

------
https://chatgpt.com/codex/tasks/task_b_6901c94c6440832d9475d18fbd10df98