### PR TITLE
Add IMAP mailbox cloning and priority ordering

### DIFF
--- a/app/schemas/imap.py
+++ b/app/schemas/imap.py
@@ -16,6 +16,7 @@ class IMAPAccountBase(BaseModel):
     mark_as_read: bool = True
     active: bool = True
     company_id: int | None = None
+    priority: int = Field(100, ge=0, le=32767)
 
 
 class IMAPAccountCreate(IMAPAccountBase):
@@ -34,6 +35,7 @@ class IMAPAccountUpdate(BaseModel):
     mark_as_read: bool | None = None
     active: bool | None = None
     company_id: int | None = None
+    priority: int | None = Field(default=None, ge=0, le=32767)
 
 
 class IMAPAccountResponse(BaseModel):
@@ -48,6 +50,7 @@ class IMAPAccountResponse(BaseModel):
     mark_as_read: bool
     active: bool
     company_id: int | None
+    priority: int
     last_synced_at: datetime | None
     scheduled_task_id: int | None
 

--- a/app/templates/admin/imap.html
+++ b/app/templates/admin/imap.html
@@ -34,6 +34,11 @@
             <input type="text" name="name" class="form-input" value="{{ editing_account.name if is_editing else '' }}" maxlength="255" required />
           </label>
           <label class="form-field">
+            <span class="form-label">Priority</span>
+            <input type="number" name="priority" class="form-input" value="{{ editing_account.priority if is_editing else 100 }}" min="0" step="1" required />
+            <span class="form-help">Lower numbers run first when multiple mailboxes are scheduled.</span>
+          </label>
+          <label class="form-field">
             <span class="form-label">IMAP host</span>
             <input type="text" name="host" class="form-input" value="{{ editing_account.host if is_editing else '' }}" maxlength="255" required />
           </label>
@@ -113,6 +118,7 @@
           <table class="table" id="imap-accounts-table" data-table>
             <thead>
               <tr>
+                <th scope="col" data-sort="number">Priority</th>
                 <th scope="col" data-sort="string">Name</th>
                 <th scope="col" data-sort="string">Host</th>
                 <th scope="col" data-sort="string">Folder</th>
@@ -127,6 +133,9 @@
               {% if accounts %}
                 {% for account in accounts %}
                   <tr>
+                    <td data-value="{{ account.priority }}">
+                      <code>{{ account.priority }}</code>
+                    </td>
                     <td data-value="{{ account.name|lower }}">
                       <strong>{{ account.name }}</strong>
                       <div class="table__meta">{{ account.username }}</div>
@@ -152,6 +161,12 @@
                     </td>
                     <td class="table__actions">
                       <div class="button-group">
+                        <form action="/admin/modules/imap/accounts/{{ account.id }}/clone" method="post" class="inline-form">
+                          {% if csrf_token %}
+                            <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                          {% endif %}
+                          <button type="submit" class="button button--small button--ghost">Clone</button>
+                        </form>
                         <a class="button button--small button--ghost" href="/admin/modules/imap?accountId={{ account.id }}">Edit</a>
                         <form action="/admin/modules/imap/accounts/{{ account.id }}/sync" method="post" class="inline-form">
                           {% if csrf_token %}
@@ -171,7 +186,7 @@
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="8" class="table__empty">No IMAP mailboxes configured yet.</td>
+                  <td colspan="9" class="table__empty">No IMAP mailboxes configured yet.</td>
                 </tr>
               {% endif %}
             </tbody>

--- a/changes/1c55bbfa-f4ca-4347-b11e-bcfffbd437ea.json
+++ b/changes/1c55bbfa-f4ca-4347-b11e-bcfffbd437ea.json
@@ -1,0 +1,7 @@
+{
+  "guid": "1c55bbfa-f4ca-4347-b11e-bcfffbd437ea",
+  "occurred_at": "2025-10-29T08:05:54.410728+00:00",
+  "change_type": "Feature",
+  "summary": "Add IMAP mailbox cloning and priority scheduling",
+  "content_hash": "0c677031a32c2790fbfeba791ad3be647c95be05c92ddd378df9b49125e72f44"
+}

--- a/docs/imap.md
+++ b/docs/imap.md
@@ -8,9 +8,11 @@ Administrators can manage mailboxes at `/admin/modules/imap`. The workspace allo
 
 - Creating mailboxes with encrypted credentials
 - Selecting a source folder and optional company association
+- Setting a mailbox priority to control processing order
 - Choosing to only process unread messages and whether to mark processed mail as read
 - Configuring a cron schedule per mailbox
 - Triggering manual synchronisation or deleting existing mailboxes
+- Cloning existing configurations to rapidly provision new mailboxes
 
 ## API endpoints
 
@@ -24,12 +26,13 @@ All IMAP endpoints require super administrator access.
 | `PUT` | `/api/imap/accounts/{accountId}` | Update mailbox configuration. |
 | `DELETE` | `/api/imap/accounts/{accountId}` | Remove a mailbox and its processing schedule. |
 | `POST` | `/api/imap/accounts/{accountId}/sync` | Run an immediate synchronisation for a mailbox. |
+| `POST` | `/api/imap/accounts/{accountId}/clone` | Duplicate an existing mailbox configuration. |
 
 Responses expose scheduled task identifiers and the last synchronisation timestamp so external tooling can audit ingestion.
 
 ## Scheduling
 
-Each mailbox stores its cron expression. When a mailbox is created or updated the platform provisions a scheduled task using the `imap_sync:{id}` command so that the background scheduler can trigger the importer at the requested cadence.
+Each mailbox stores its cron expression and a priority. When a mailbox is created or updated the platform provisions a scheduled task using the `imap_sync:{id}` command so that the background scheduler can trigger the importer at the requested cadence. Bulk synchronisation processes mailboxes in ascending priority order (so 0 runs before 10) so critical inboxes ingest mail first.
 
 Manual synchronisation is available through the API or the workspace actions.
 

--- a/migrations/083_imap_priority.sql
+++ b/migrations/083_imap_priority.sql
@@ -1,0 +1,6 @@
+ALTER TABLE imap_accounts
+    ADD COLUMN priority SMALLINT NOT NULL DEFAULT 100 AFTER id;
+
+UPDATE imap_accounts
+SET priority = 100
+WHERE priority IS NULL;


### PR DESCRIPTION
## Summary
- add a configurable priority to IMAP mailbox records and ensure bulk sync executes higher priority connectors first
- expose mailbox cloning through the IMAP API, admin UI, and service layer so existing configurations can be duplicated quickly
- document the new behaviour, add a migration for the priority column, and extend tests for cloning and priority ordering

## Testing
- pytest *(fails: database pool not initialised in ticket importer tests)*

------
https://chatgpt.com/codex/tasks/task_b_6901c9cf791c832d9e960ee92392036a