### PR TITLE
Fix automation result handling for module failures

### DIFF
--- a/changes/028e12ea-1668-4e16-8150-9024a61bc97d.json
+++ b/changes/028e12ea-1668-4e16-8150-9024a61bc97d.json
@@ -1,0 +1,7 @@
+{
+  "guid": "028e12ea-1668-4e16-8150-9024a61bc97d",
+  "occurred_at": "2024-06-07T00:00:00Z",
+  "change_type": "Fix",
+  "summary": "Propagated module failure states to ticket automations so SMTP errors surface correctly.",
+  "content_hash": "fbf81795db65493a846e517635cecb52285d8f18143d95c6b715ebc1cb5971c4"
+}


### PR DESCRIPTION
## Summary
- propagate module action failure status and error details into automation runs so SMTP failures are not hidden
- cover module failure propagation with a focused automation service test and record the change in the changelog

## Testing
- poetry run pytest tests/test_automations_service.py

------
https://chatgpt.com/codex/tasks/task_b_690204a81620832d9c49ff4beecb3896