### PR TITLE
Remove ticket automation status controls

### DIFF
--- a/app/templates/admin/automations.html
+++ b/app/templates/admin/automations.html
@@ -125,17 +125,6 @@
                     <td class="table__actions">
                       <div class="table__action-buttons">
                         <a class="button button--ghost" href="/admin/automations/{{ automation.id }}/edit">Edit</a>
-                        <form action="/admin/automations/{{ automation.id }}/status" method="post" class="inline-form">
-                          {% if csrf_token %}
-                            <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-                          {% endif %}
-                          <label class="visually-hidden" for="automation-status-{{ automation.id }}">Status</label>
-                          <select id="automation-status-{{ automation.id }}" name="status" class="form-input form-input--compact">
-                            <option value="active" {% if automation.status == 'active' %}selected{% endif %}>Active</option>
-                            <option value="inactive" {% if automation.status != 'active' %}selected{% endif %}>Inactive</option>
-                          </select>
-                          <button type="submit" class="button button--ghost">Update</button>
-                        </form>
                         <form action="/admin/automations/{{ automation.id }}/execute" method="post" class="inline-form">
                           {% if csrf_token %}
                             <input type="hidden" name="_csrf" value="{{ csrf_token }}" />

--- a/changes/f98df8d7-84fc-48f2-acd3-2fe9bff9ad6b.json
+++ b/changes/f98df8d7-84fc-48f2-acd3-2fe9bff9ad6b.json
@@ -1,0 +1,7 @@
+{
+  "guid": "f98df8d7-84fc-48f2-acd3-2fe9bff9ad6b",
+  "occurred_at": "2025-10-29T12:27Z",
+  "change_type": "Fix",
+  "summary": "Removed inline status controls from ticket automation list to simplify row actions.",
+  "content_hash": "a594fb0bf41697a6670a5eed2eca1691e6244cae3d1f7c9c296c8e97238e020f"
+}


### PR DESCRIPTION
## Summary
- remove the inline status dropdown and update action from the ticket automations table
- record the interface adjustment in the change log registry

## Testing
- pytest *(fails: RuntimeError: Database pool not initialised in ticket importer tests)*

------
https://chatgpt.com/codex/tasks/task_b_690207eb3144832db59484d8882ae330