### PR TITLE
Fix collapsed ticket message overflow

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1594,6 +1594,14 @@ body {
   transition: max-height 0.2s ease;
 }
 
+.timeline__message-content {
+  overflow-wrap: anywhere;
+}
+
+.timeline__message-content--collapsed {
+  overflow: hidden;
+}
+
 .timeline__message--collapsed {
   overflow: hidden;
 }

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -32,15 +32,20 @@
     const lessLabel = toggle.dataset.lessLabel || 'Show less';
 
     function collapse() {
-      wrapper.style.maxHeight = `${maxCollapsedHeight}px`;
+      const collapsedHeight = `${maxCollapsedHeight}px`;
+      wrapper.style.maxHeight = collapsedHeight;
+      content.style.maxHeight = collapsedHeight;
       wrapper.classList.add('timeline__message--collapsed');
+      content.classList.add('timeline__message-content--collapsed');
       toggle.setAttribute('aria-expanded', 'false');
       toggle.textContent = moreLabel;
     }
 
     function expand() {
-      wrapper.style.maxHeight = 'none';
+      wrapper.style.maxHeight = '';
+      content.style.maxHeight = '';
       wrapper.classList.remove('timeline__message--collapsed');
+      content.classList.remove('timeline__message-content--collapsed');
       toggle.setAttribute('aria-expanded', 'true');
       toggle.textContent = lessLabel;
     }

--- a/changes/6c4728a5-ecd2-4874-969c-ca6cb9318847.json
+++ b/changes/6c4728a5-ecd2-4874-969c-ca6cb9318847.json
@@ -1,0 +1,7 @@
+{
+  "guid": "6c4728a5-ecd2-4874-969c-ca6cb9318847",
+  "occurred_at": "2025-10-29T12:28:20Z",
+  "change_type": "Fix",
+  "summary": "Corrected collapsed ticket replies to hide overflowed message content.",
+  "content_hash": "446cf06553772ec534f3091c2b58656f4c85408a99e90bda428693fed4295923"
+}


### PR DESCRIPTION
## Summary
- ensure collapsed ticket conversation entries clamp their content height
- add overflow protection styles for timeline message containers
- record the fix in the change log registry

## Testing
- pytest *(fails: requires initialised database pool for Syncro ticket importer tests)*

------
https://chatgpt.com/codex/tasks/task_b_690207727fe8832d9354071ee361c8b3