### PR TITLE
Remove ticket description viewer from admin ticket details

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -230,15 +230,6 @@
             </summary>
             <div class="card-collapsible__content">
               <div class="card__body">
-                <div
-                  class="rich-text-viewer"
-                  data-ticket-description-viewer
-                  {% if not description_html %}hidden{% endif %}
-                >
-                  {% if description_html %}
-                    {{ description_html | safe }}
-                  {% endif %}
-                </div>
                 <p
                   class="card__empty"
                   data-ticket-description-empty
@@ -253,7 +244,6 @@
                 {% endif %}
                 <input type="hidden" name="returnUrl" value="{{ ticket_return_url }}" />
                 <div class="form-field">
-                  <label class="form-label" for="ticket-description-editor">Edit description</label>
                   <textarea
                     id="ticket-description-editor"
                     name="description"

--- a/changes/7b0ca327-9a3c-4876-968d-18fe6d85cda8.json
+++ b/changes/7b0ca327-9a3c-4876-968d-18fe6d85cda8.json
@@ -1,0 +1,7 @@
+{
+  "guid": "7b0ca327-9a3c-4876-968d-18fe6d85cda8",
+  "occurred_at": "2025-10-29T12:42:55Z",
+  "change_type": "Fix",
+  "summary": "Removed the ticket description rich text preview and label on the ticket details form.",
+  "content_hash": "bb8cf9af9501ad7ec9144c4d81e47e947bc2b9596397f8175b737cc7889e39e8"
+}


### PR DESCRIPTION
## Summary
- remove the rich text description preview from the ticket details admin view
- drop the form label above the ticket description editor for a simplified layout
- record the change in the change log registry

## Testing
- not run (environment configuration for application startup is unavailable without required secrets)


------
https://chatgpt.com/codex/tasks/task_b_69020b72685c832d8ec68368b920d7fb