### PR TITLE
Restore API Docs navigation link

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -709,6 +709,12 @@ body {
   text-overflow: ellipsis;
 }
 
+.header__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-gap-tight);
+}
+
 .header-actions {
   display: flex;
   align-items: center;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -343,7 +343,26 @@
             </button>
             <div class="header__title">{{ title | default('Dashboard') }}</div>
           </div>
-          {% block header_actions %}{% endblock %}
+          {% set has_authenticated_user = current_user is defined and current_user and current_user.get('id') %}
+          {% set header_actions_content %}
+            {% block header_actions %}{% endblock %}
+          {% endset %}
+          {% if has_authenticated_user %}
+            <div class="header__actions">
+              <a
+                class="button-link"
+                href="/docs"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Open API documentation"
+              >
+                Swagger UI
+              </a>
+              {{ header_actions_content }}
+            </div>
+          {% else %}
+            {{ header_actions_content }}
+          {% endif %}
         </header>
         <section class="layout__content">
           {% block content %}{% endblock %}

--- a/changes/45f42767-a8c4-4c0b-9518-e2ec059c93fc.json
+++ b/changes/45f42767-a8c4-4c0b-9518-e2ec059c93fc.json
@@ -1,0 +1,7 @@
+{
+  "guid": "45f42767-a8c4-4c0b-9518-e2ec059c93fc",
+  "occurred_at": "2025-10-29T12:50Z",
+  "change_type": "Fix",
+  "summary": "Restored the API Docs menu link for authenticated users so the Swagger UI remains accessible after sign-in.",
+  "content_hash": "9d6e08b3fb61f79dd0812e876e46549552b21f524c39fcdd0ea4d5e4b8dd6c85"
+}


### PR DESCRIPTION
## Summary
- render a persistent Swagger UI link in the authenticated header so the API Docs menu remains available after login
- add flexbox styling for the shared header action container to keep layout spacing consistent
- record the fix in the change log registry for auditing

## Testing
- pytest *(fails: database pool not initialised in ticket importer tests)*

------
https://chatgpt.com/codex/tasks/task_b_69020ce457c8832d88907bfcb41421d2