### PR TITLE
Add ticket reply time tracking with billable totals

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -270,6 +270,8 @@ async def add_reply(
         author_id=session.user_id,
         body=sanitised_body.html,
         is_internal=payload.is_internal if has_helpdesk_access else False,
+        minutes_spent=payload.minutes_spent if has_helpdesk_access else None,
+        is_billable=payload.is_billable if has_helpdesk_access else False,
     )
     try:
         await tickets_service.refresh_ticket_ai_summary(ticket_id)

--- a/app/main.py
+++ b/app/main.py
@@ -6209,17 +6209,44 @@ async def _render_ticket_detail(
 
     ordered_replies = list(reversed(replies))
 
+    total_billable_minutes = 0
+    total_non_billable_minutes = 0
     enriched_replies: list[dict[str, Any]] = []
     for reply in ordered_replies:
         author_id = reply.get("author_id")
         author = user_lookup.get(author_id) if author_id else None
         sanitized_reply = sanitize_rich_text(str(reply.get("body") or ""))
+        minutes_value = reply.get("minutes_spent")
+        minutes_spent: int | None = None
+        if minutes_value is not None:
+            try:
+                candidate = int(minutes_value)
+            except (TypeError, ValueError):
+                minutes_spent = None
+            else:
+                if candidate >= 0:
+                    minutes_spent = candidate
+        billable_flag = bool(reply.get("is_billable"))
+        if minutes_spent is not None:
+            if billable_flag:
+                total_billable_minutes += minutes_spent
+            else:
+                total_non_billable_minutes += minutes_spent
+        if minutes_spent is not None:
+            minutes_label = "minute" if minutes_spent == 1 else "minutes"
+            billing_label = "Billable" if billable_flag else "Non-billable"
+            time_summary = f"{minutes_spent} {minutes_label} · {billing_label}"
+        else:
+            time_summary = None
         enriched_replies.append(
             {
                 **reply,
                 "author": author,
                 "body": sanitized_reply.html,
                 "text_body": sanitized_reply.text_content,
+                "minutes_spent": minutes_spent,
+                "is_billable": billable_flag,
+                "time_summary": time_summary,
             }
         )
 
@@ -6282,6 +6309,8 @@ async def _render_ticket_detail(
         "ticket_requester": user_lookup.get(ticket.get("requester_id")),
         "ticket_replies": enriched_replies,
         "ticket_watchers": enriched_watchers,
+        "ticket_billable_minutes": total_billable_minutes,
+        "ticket_non_billable_minutes": total_non_billable_minutes,
         "ticket_available_statuses": available_statuses,
         "ticket_company_options": companies,
         "ticket_user_options": technician_users,
@@ -6917,6 +6946,38 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
     body_raw = str(body_value) if isinstance(body_value, str) else ""
     sanitized_body = sanitize_rich_text(body_raw)
     is_internal = str(form.get("isInternal", "")).lower() in {"1", "true", "on", "yes"}
+    minutes_input_raw = form.get("minutesSpent", "")
+    minutes_input = str(minutes_input_raw).strip() if isinstance(minutes_input_raw, str) else ""
+    minutes_spent: int | None = None
+    if minutes_input:
+        try:
+            minutes_candidate = int(minutes_input)
+        except (TypeError, ValueError):
+            return await _render_ticket_detail(
+                request,
+                current_user,
+                ticket_id=ticket_id,
+                error_message="Enter the time spent in minutes as a whole number.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        if minutes_candidate < 0:
+            return await _render_ticket_detail(
+                request,
+                current_user,
+                ticket_id=ticket_id,
+                error_message="Minutes cannot be negative.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        if minutes_candidate > 1440:
+            return await _render_ticket_detail(
+                request,
+                current_user,
+                ticket_id=ticket_id,
+                error_message="Minutes cannot exceed 1440 per reply.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        minutes_spent = minutes_candidate
+    is_billable = str(form.get("isBillable", "")).lower() in {"1", "true", "on", "yes"}
     if not sanitized_body.has_rich_content:
         return await _render_ticket_detail(
             request,
@@ -6935,6 +6996,8 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
             author_id=author_id if isinstance(author_id, int) else None,
             body=sanitized_body.html,
             is_internal=is_internal,
+            minutes_spent=minutes_spent,
+            is_billable=is_billable,
         )
         if isinstance(author_id, int):
             await tickets_repo.add_watcher(ticket_id, author_id)

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -38,6 +38,8 @@ class TicketUpdate(BaseModel):
 class TicketReplyCreate(BaseModel):
     body: str = Field(..., min_length=1)
     is_internal: bool = False
+    minutes_spent: Optional[int] = Field(default=None, ge=0)
+    is_billable: bool = False
 
 
 class TicketReply(BaseModel):
@@ -46,6 +48,8 @@ class TicketReply(BaseModel):
     author_id: Optional[int]
     body: str
     is_internal: bool
+    minutes_spent: Optional[int] = Field(default=None, ge=0)
+    is_billable: bool = False
     created_at: datetime
 
     class Config:

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1580,6 +1580,11 @@ body {
   font-size: 0.95rem;
 }
 
+.timeline__meta {
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.9rem;
+}
+
 .timeline__body {
   color: rgba(226, 232, 240, 0.85);
   font-size: 0.95rem;

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -214,6 +214,14 @@
                     {% endif %}
                   </dd>
                 </div>
+                <div class="definition-list__item">
+                  <dt>Billable minutes</dt>
+                  <dd>{{ ticket_billable_minutes }}</dd>
+                </div>
+                <div class="definition-list__item">
+                  <dt>Non-billable minutes</dt>
+                  <dd>{{ ticket_non_billable_minutes }}</dd>
+                </div>
               </dl>
             </div>
           </article>
@@ -457,11 +465,33 @@
                   <input type="hidden" name="body" data-rich-text-value required />
                 </div>
               </div>
-              <div class="form-field form-field--checkbox">
-                <label class="checkbox">
-                  <input type="checkbox" name="isInternal" value="true" />
-                  <span>Mark as internal note</span>
-                </label>
+              <div class="form-field">
+                <label class="form-label" for="ticket-reply-minutes">Minutes spent</label>
+                <input
+                  id="ticket-reply-minutes"
+                  name="minutesSpent"
+                  class="form-input"
+                  type="number"
+                  min="0"
+                  max="1440"
+                  step="1"
+                  inputmode="numeric"
+                />
+                <p class="form-help">Log how many minutes this update required.</p>
+              </div>
+              <div class="form-grid form-grid--auto">
+                <div class="form-field form-field--checkbox">
+                  <label class="checkbox">
+                    <input type="checkbox" name="isInternal" value="true" />
+                    <span>Mark as internal note</span>
+                  </label>
+                </div>
+                <div class="form-field form-field--checkbox">
+                  <label class="checkbox">
+                    <input type="checkbox" name="isBillable" value="true" />
+                    <span>Billable</span>
+                  </label>
+                </div>
               </div>
               <div class="form-actions">
                 <button type="submit" class="button button--primary">Post reply</button>
@@ -488,6 +518,9 @@
                             <span class="badge badge--muted">Internal</span>
                           {% endif %}
                         </span>
+                        {% if reply.time_summary %}
+                          <span class="timeline__meta text-muted">{{ reply.time_summary }}</span>
+                        {% endif %}
                       </header>
                       <div class="timeline__body">
                         <div

--- a/changes/e2724b90-b569-461e-a807-d9c17369c4a2.json
+++ b/changes/e2724b90-b569-461e-a807-d9c17369c4a2.json
@@ -1,0 +1,7 @@
+{
+  "guid": "e2724b90-b569-461e-a807-d9c17369c4a2",
+  "occurred_at": "2025-10-29T13:01Z",
+  "change_type": "Feature",
+  "summary": "Added billable and non-billable time tracking for ticket replies, including admin totals and timeline context.",
+  "content_hash": "f276a6bbeec9f383e15d34d37799b1ff38e654f8251286d13e5b17b1aa0f2f33"
+}

--- a/migrations/085_ticket_reply_time_tracking.sql
+++ b/migrations/085_ticket_reply_time_tracking.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ticket_replies
+    ADD COLUMN minutes_spent INT NULL;
+
+ALTER TABLE ticket_replies
+    ADD COLUMN is_billable TINYINT(1) NOT NULL DEFAULT 0;

--- a/tests/test_ticket_access.py
+++ b/tests/test_ticket_access.py
@@ -475,6 +475,8 @@ def test_non_admin_reply_forces_public_visibility(monkeypatch, active_session):
 
     async def fake_create_reply(**kwargs):
         assert kwargs["is_internal"] is False
+        assert kwargs.get("minutes_spent") is None
+        assert kwargs.get("is_billable") is False
         return {
             "id": 55,
             "ticket_id": ticket["id"],
@@ -776,6 +778,8 @@ def test_helpdesk_reply_preserves_internal_flag(monkeypatch, active_session):
 
     async def fake_create_reply(**kwargs):
         assert kwargs["is_internal"] is True
+        assert kwargs.get("minutes_spent") is None
+        assert kwargs.get("is_billable") is False
         return {
             "id": 91,
             "ticket_id": ticket["id"],

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -385,9 +385,13 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
     assert reply_calls[0]["external_reference"] == "1"
     assert reply_calls[0]["is_internal"] is False
     assert reply_calls[0]["author_id"] == 21
+    assert reply_calls[0].get("minutes_spent") is None
+    assert reply_calls[0].get("is_billable", False) is False
     assert reply_calls[1]["external_reference"] == "2"
     assert reply_calls[1]["is_internal"] is True
     assert reply_calls[1]["author_id"] == 31
+    assert reply_calls[1].get("minutes_spent") is None
+    assert reply_calls[1].get("is_billable", False) is False
     assert added_watchers == [(400, 31)]
 
 
@@ -451,6 +455,8 @@ async def test_import_ticket_skips_existing_comment_replies(monkeypatch):
     assert summary.updated == 1
     assert len(reply_calls) == 1
     assert reply_calls[0]["external_reference"] == "2"
+    assert reply_calls[0].get("minutes_spent") is None
+    assert reply_calls[0].get("is_billable", False) is False
 @pytest.mark.anyio
 async def test_import_from_request_records_webhook_success(monkeypatch):
     summary = ticket_importer.TicketImportSummary(mode="single", fetched=1, created=1)

--- a/tests/test_tickets_repository.py
+++ b/tests/test_tickets_repository.py
@@ -149,6 +149,8 @@ async def test_create_reply_returns_inserted_record(monkeypatch):
         "author_id": 4,
         "body": "Reply",
         "is_internal": 0,
+        "minutes_spent": 15,
+        "is_billable": 1,
         "created_at": None,
     }
     dummy_db = _DummyTicketDB(fetched)
@@ -162,6 +164,8 @@ async def test_create_reply_returns_inserted_record(monkeypatch):
     )
 
     assert record["id"] == 42
+    assert record["minutes_spent"] == 15
+    assert record["is_billable"] is True
     assert dummy_db.fetch_sql == "SELECT * FROM ticket_replies WHERE id = %s"
     assert dummy_db.fetch_params == (42,)
 
@@ -183,6 +187,8 @@ async def test_create_reply_falls_back_when_fetch_missing(monkeypatch):
     assert record["author_id"] is None
     assert record["body"] == "Internal"
     assert record["is_internal"] == 1
+    assert record["minutes_spent"] is None
+    assert record["is_billable"] is False
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- add minutes_spent and is_billable tracking to ticket replies including schema, repository, and migration updates
- update the admin ticket detail form and timeline to capture minutes, mark billable replies, and display billable/non-billable totals
- refresh CSS, change log metadata, and automated tests to cover the new time tracking behaviour

## Testing
- pytest tests/test_tickets_repository.py tests/test_ticket_access.py tests/test_ticket_importer.py

------
https://chatgpt.com/codex/tasks/task_b_69020e79d404832d91f28ffa2b0620ea