### PR TITLE
Relocate Shop admin control to shop header

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -709,6 +709,21 @@ body {
   text-overflow: ellipsis;
 }
 
+.header__title-content {
+  display: flex;
+  align-items: center;
+  gap: var(--space-gap-tight);
+  min-width: 0;
+}
+
+.header__title-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .header__actions {
   display: flex;
   align-items: center;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -288,14 +288,16 @@
                   <span class="menu__label">Webhook monitor</span>
                 </a>
               </li>
-              <li class="menu__item">
-                <a href="/admin/shop" {% if current_path.startswith('/admin/shop') %}aria-current="page"{% endif %}>
-                  <span class="menu__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false"><path d="M4 7h16l-1.5 12.5A2 2 0 0 1 16.52 21H7.48a2 2 0 0 1-1.98-1.5zM6 3h12a1 1 0 0 1 1 1v2H5V4a1 1 0 0 1 1-1z"/></svg>
-                  </span>
-                  <span class="menu__label">Shop admin</span>
-                </a>
-              </li>
+              {% if not current_path.startswith('/shop') %}
+                <li class="menu__item">
+                  <a href="/admin/shop" {% if current_path.startswith('/admin/shop') %}aria-current="page"{% endif %}>
+                    <span class="menu__icon" aria-hidden="true">
+                      <svg viewBox="0 0 24 24" focusable="false"><path d="M4 7h16l-1.5 12.5A2 2 0 0 1 16.52 21H7.48a2 2 0 0 1-1.98-1.5zM6 3h12a1 1 0 0 1 1 1v2H5V4a1 1 0 0 1 1-1z"/></svg>
+                    </span>
+                    <span class="menu__label">Shop admin</span>
+                  </a>
+                </li>
+              {% endif %}
               <li class="menu__item">
                 <a href="/admin/change-log" {% if current_path.startswith('/admin/change-log') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">
@@ -341,7 +343,11 @@
                 <path d="M3 6.25A1.25 1.25 0 0 1 4.25 5h15.5a1.25 1.25 0 1 1 0 2.5H4.25A1.25 1.25 0 0 1 3 6.25Zm0 5.75A1.25 1.25 0 0 1 4.25 10h15.5a1.25 1.25 0 1 1 0 2.5H4.25A1.25 1.25 0 0 1 3 11.75ZM4.25 15h15.5a1.25 1.25 0 1 1 0 2.5H4.25a1.25 1.25 0 1 1 0-2.5Z" />
               </svg>
             </button>
-            <div class="header__title">{{ title | default('Dashboard') }}</div>
+            <div class="header__title">
+              {% block header_title_content %}
+                {{ title | default('Dashboard') }}
+              {% endblock %}
+            </div>
           </div>
           {% set has_authenticated_user = current_user is defined and current_user and current_user.get('id') %}
           {% set header_actions_content %}

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -5,6 +5,16 @@
   {% set cart_allowed = (current_user and current_user.get('is_super_admin')) or (active_membership and active_membership.get('can_access_cart')) %}
 {% endif %}
 
+{% block header_title_content %}
+  {% set is_shop_super_admin = current_user is defined and current_user and current_user.get('is_super_admin') %}
+  <div class="header__title-content">
+    <span class="header__title-text">{{ super() }}</span>
+    {% if is_shop_super_admin %}
+      <a class="button button--ghost" href="/admin/shop">Shop admin</a>
+    {% endif %}
+  </div>
+{% endblock %}
+
 {% block header_actions %}
   {% if cart_allowed %}
     <a class="button button--ghost" href="/cart">

--- a/changes/8c896b9e-b0c0-4efe-b982-826c91fffac7.json
+++ b/changes/8c896b9e-b0c0-4efe-b982-826c91fffac7.json
@@ -1,0 +1,7 @@
+{
+  "guid": "8c896b9e-b0c0-4efe-b982-826c91fffac7",
+  "occurred_at": "2025-10-29T13:04:47Z",
+  "change_type": "Fix",
+  "summary": "Relocated Shop admin entry into shop header and removed duplicate sidebar link on storefront page.",
+  "content_hash": "99813b2aeb6ea7171d414e997306c8b8a905a2649ce5b42fa65126e01e8f7bae"
+}


### PR DESCRIPTION
## Summary
- move the Shop admin navigation entry from the sidebar into the shop page header and hide it from the left menu while browsing the storefront
- add flex-based styling hooks so the header title can display both the page title and the Shop admin button cleanly
- record the UI relocation as a fix in the change log registry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6902103a6344832db1d568d8f64ae3dc