### PR TITLE
Fix base template block closure

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -325,6 +325,7 @@
               {% block header_title_content %}
                 {{ title | default('Dashboard') }}
               {% endblock %}
+              {% endblock %}
             </div>
           </div>
           {% set has_authenticated_user = current_user is defined and current_user and current_user.get('id') %}

--- a/changes/1cf60c02-4989-4874-9181-4691f05b45a7.json
+++ b/changes/1cf60c02-4989-4874-9181-4691f05b45a7.json
@@ -1,0 +1,7 @@
+{
+  "guid": "1cf60c02-4989-4874-9181-4691f05b45a7",
+  "occurred_at": "2025-10-29T13:19:19Z",
+  "change_type": "Fix",
+  "summary": "Fix base layout header block to restore template rendering",
+  "content_hash": "6ed2408fabc2cc8dfe18ddd5cec9649cbf838c749f33aac5b5314c741f686ca7"
+}


### PR DESCRIPTION
## Summary
- add the missing endblock for the header title region in the base template to resolve rendering failures
- log the fix in the change log feed

## Testing
- `python - <<'PY'
from jinja2 import Environment, FileSystemLoader, select_autoescape
from types import SimpleNamespace

env = Environment(
    loader=FileSystemLoader('app/templates'),
    autoescape=select_autoescape(['html', 'xml'])
)

template = env.get_template('admin/automation.html')

request = SimpleNamespace(url=SimpleNamespace(path='/admin/automation', query=''))

context = {
    'app_name': 'MyPortal',
    'title': 'System Automation',
    'request': request,
    'current_user': {'is_super_admin': True},
    'available_companies': [],
    'active_company': None,
    'active_company_id': None,
    'active_membership': None,
    'csrf_token': None,
    'staff_permission': 0,
    'is_super_admin': True,
    'is_helpdesk_technician': False,
    'is_company_admin': True,
    'integration_modules': {},
    'syncro_module_enabled': False,
    'enable_auto_refresh': False,
    'cart_summary': {'item_count':0,'total_quantity':0,'subtotal':0},
    'notification_unread_count': 0,
    'global_tasks': [],
    'company_tasks': [],
    'command_options': [],
    'company_options': [],
}

rendered = template.render(context)
print(rendered[:200])
PY`

------
https://chatgpt.com/codex/tasks/task_b_69021399a49c832d87bf407b8c7a1c0e