### PR TITLE
Remove admin knowledge and forms sidebar entries

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -219,19 +219,6 @@
                 </a>
               </li>
               <li class="menu__item">
-                <a href="/admin/knowledge-base" {% if current_path.startswith('/admin/knowledge-base') %}aria-current="page"{% endif %}>
-                  <span class="menu__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v19.5a.5.5 0 0 1-.74.44L14 20l-3.26 1.94A.5.5 0 0 1 10 21.5V19H7a3 3 0 0 1-3-3V5a3 3 0 0 1 3-3zm9 7h-2V7a1 1 0 0 0-2 0v2H9a1 1 0 0 0 0 2h2v2a1 1 0 0 0 2 0v-2h2a1 1 0 0 0 0-2z"/></svg>
-                  </span>
-                  <span class="menu__label">Knowledge base admin</span>
-                <a href="/admin/forms" {% if current_path.startswith('/admin/forms') %}aria-current="page"{% endif %}>
-                  <span class="menu__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false"><path d="M6 2h9l5 5v15H6a1 1 0 0 1-1-1V3a1 1 0 0 1 1-1zm8 7h4.5L14 4.5V9z"/></svg>
-                  </span>
-                  <span class="menu__label">Forms admin</span>
-                </a>
-              </li>
-              <li class="menu__item">
                 <a href="/admin/api-keys" {% if current_path.startswith('/admin/api-keys') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" focusable="false"><path d="M7 10a5 5 0 0 1 9.58-2.15l4.47 4.47a1 1 0 0 1 0 1.41l-1.42 1.42a1 1 0 0 1-1.41 0l-.62-.62-1.41 1.41a1 1 0 0 1-1.41 0l-.59-.59-.59.59a1 1 0 0 1-1.41 0l-.88-.88A5 5 0 0 1 7 10zm5-3a3 3 0 1 0 2.85 4H16a1 1 0 0 1 .7.29l.91.91 1.42-1.42-1.56-1.56A1 1 0 0 1 18 9h.59l-1.28-1.28A5 5 0 0 0 12 7z"/></svg>

--- a/changes/bed1a62b-aa83-48cb-9f69-bece58fb139e.json
+++ b/changes/bed1a62b-aa83-48cb-9f69-bece58fb139e.json
@@ -1,0 +1,7 @@
+{
+  "guid": "bed1a62b-aa83-48cb-9f69-bece58fb139e",
+  "occurred_at": "2025-10-29T13:26Z",
+  "change_type": "Fix",
+  "summary": "Removed Knowledge Base and Forms admin entries from the sidebar navigation.",
+  "content_hash": "71be602ab1a1373ba4b40dd90acc717ccbfa9626d4a12b72c8dc6ba15ed1cf5b"
+}


### PR DESCRIPTION
## Summary
- remove the Knowledge Base admin and Forms admin links from the primary sidebar navigation
- document the sidebar adjustment in the change log

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_69021570ca90832d812d29dbd7d240eb