### PR TITLE
Fix ticket tools dropdown visibility

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -709,7 +709,7 @@ body {
   align-items: center;
   gap: var(--space-gap-tight);
   flex-wrap: wrap;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .header__title-text {

--- a/changes/21a02f0f-bed7-4e03-a142-a7e48d16b793.json
+++ b/changes/21a02f0f-bed7-4e03-a142-a7e48d16b793.json
@@ -1,0 +1,7 @@
+{
+  "guid": "21a02f0f-bed7-4e03-a142-a7e48d16b793",
+  "occurred_at": "2025-10-29T13:26:05Z",
+  "change_type": "Fix",
+  "summary": "Fix ticket tools dropdown being clipped by header overflow",
+  "content_hash": "cfd5506431520cd15c54e4fd3719dbaf08521ff286c58b162aa27670caf77386"
+}


### PR DESCRIPTION
## Summary
- allow header title actions to overflow so the ticket tools dropdown can display its menu
- document the fix in the change log with a new GUID entry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6902154c11a8832d9938d3bbe4f04ee9