### PR TITLE
Fix Shop admin button visibility on shop page header

### DIFF
--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -2,11 +2,11 @@
 
 {% set cart_allowed = (can_access_cart | default(false)) %}
 {% if not cart_allowed %}
-  {% set cart_allowed = (current_user and current_user.get('is_super_admin')) or (active_membership and active_membership.get('can_access_cart')) %}
+  {% set cart_allowed = (is_super_admin | default(current_user and current_user.get('is_super_admin'))) or (active_membership and active_membership.get('can_access_cart')) %}
 {% endif %}
 
 {% block header_title_content %}
-  {% set is_shop_super_admin = current_user is defined and current_user and current_user.get('is_super_admin') %}
+  {% set is_shop_super_admin = is_super_admin | default(current_user and current_user.get('is_super_admin')) %}
   <div class="header__title-content">
     <span class="header__title-text">{{ super() }}</span>
     {% if is_shop_super_admin %}

--- a/changes/d923eaa5-4d1d-478b-a821-f1999e010a2f.json
+++ b/changes/d923eaa5-4d1d-478b-a821-f1999e010a2f.json
@@ -1,0 +1,7 @@
+{
+  "guid": "d923eaa5-4d1d-478b-a821-f1999e010a2f",
+  "occurred_at": "2025-10-29T13:29Z",
+  "change_type": "Fix",
+  "summary": "Ensure Shop admin shortcut appears for super administrators on the Shop page header",
+  "content_hash": "416b7adedd31c4d4170ba7a5add0fec2c09a207543a6143992fa192cce9ab5f8"
+}


### PR DESCRIPTION
## Summary
- ensure the Shop page header uses the global super-admin flag so the Shop admin shortcut is rendered for eligible users
- record the UI fix in the change log registry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690215f64a00832dafc6b083bc748671