### PR TITLE
Limit Swagger UI link visibility to API keys admin page

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -321,15 +321,17 @@
           {% endset %}
           {% if has_authenticated_user %}
             <div class="header__actions">
-              <a
-                class="button-link"
-                href="/docs"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Open API documentation"
-              >
-                Swagger UI
-              </a>
+              {% if current_path is defined and current_path.startswith('/admin/api-keys') %}
+                <a
+                  class="button-link"
+                  href="/docs"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Open API documentation"
+                >
+                  Swagger UI
+                </a>
+              {% endif %}
               {{ header_actions_content }}
             </div>
           {% else %}


### PR DESCRIPTION
## Summary
- limit the Swagger UI header action so it only appears when viewing the API keys admin page
- guard against missing request context when evaluating the current path

## Testing
- pytest tests/test_admin_change_log_page.py tests/test_notifications_page.py tests/test_sidebar_menu.py

------
https://chatgpt.com/codex/tasks/task_b_690216fde6ac832db1cbef385a824bee