### PR TITLE
Remove Shop admin link from sidebar

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -252,16 +252,6 @@
                   <span class="menu__label">Webhook monitor</span>
                 </a>
               </li>
-              {% if not current_path.startswith('/shop') %}
-                <li class="menu__item">
-                  <a href="/admin/shop" {% if current_path.startswith('/admin/shop') %}aria-current="page"{% endif %}>
-                    <span class="menu__icon" aria-hidden="true">
-                      <svg viewBox="0 0 24 24" focusable="false"><path d="M4 7h16l-1.5 12.5A2 2 0 0 1 16.52 21H7.48a2 2 0 0 1-1.98-1.5zM6 3h12a1 1 0 0 1 1 1v2H5V4a1 1 0 0 1 1-1z"/></svg>
-                    </span>
-                    <span class="menu__label">Shop admin</span>
-                  </a>
-                </li>
-              {% endif %}
               <li class="menu__item">
                 <a href="/admin/change-log" {% if current_path.startswith('/admin/change-log') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">

--- a/changes/275b018a-34ef-4748-b3f4-8af6faf6ee62.json
+++ b/changes/275b018a-34ef-4748-b3f4-8af6faf6ee62.json
@@ -1,0 +1,7 @@
+{
+  "guid": "275b018a-34ef-4748-b3f4-8af6faf6ee62",
+  "occurred_at": "2025-10-29T13:38Z",
+  "change_type": "Fix",
+  "summary": "Removed Shop admin link from super admin sidebar navigation.",
+  "content_hash": "fe637d0e060d455db04b39e7b91feb0f8ed874d8d1799f727c2100a3bc2c906c"
+}


### PR DESCRIPTION
## Summary
- remove the Shop admin navigation item from the super admin sidebar
- log the update in the change log registry

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_b_6902186a4b24832d9b462f65b98f5daa