### PR TITLE
Fix Swagger UI button placement on API keys admin page

### DIFF
--- a/app/templates/admin/api_keys.html
+++ b/app/templates/admin/api_keys.html
@@ -1,5 +1,19 @@
 {% extends "base.html" %}
 
+{% block header_title %}
+  <div class="header__title-content">
+    <span class="header__title-text">{{ title | default('API credentials') }}</span>
+    <a
+      class="button button--ghost button--small header__title-button"
+      href="/docs"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Swagger UI
+    </a>
+  </div>
+{% endblock %}
+
 {% block content %}
 <div class="admin-grid admin-grid--columns">
   <section class="card card--panel admin-grid__full">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -321,17 +321,6 @@
           {% endset %}
           {% if has_authenticated_user %}
             <div class="header__actions">
-              {% if current_path is defined and current_path.startswith('/admin/api-keys') %}
-                <a
-                  class="button-link"
-                  href="/docs"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="Open API documentation"
-                >
-                  Swagger UI
-                </a>
-              {% endif %}
               {{ header_actions_content }}
             </div>
           {% else %}

--- a/changes/668e1148-8a94-4fae-b79e-fca172dd511e.json
+++ b/changes/668e1148-8a94-4fae-b79e-fca172dd511e.json
@@ -1,0 +1,7 @@
+{
+  "guid": "668e1148-8a94-4fae-b79e-fca172dd511e",
+  "occurred_at": "2025-10-29T13:39Z",
+  "change_type": "Fix",
+  "summary": "Moved the Swagger UI action into the API credentials header bar so the documentation button stays visible.",
+  "content_hash": "6decbe0f3f27c850af71a3f72aecc671be7afbb1169539441cc3ec98a2426060"
+}


### PR DESCRIPTION
## Summary
- move the Swagger UI action into the API credentials header title block so it renders as a primary button
- remove the fallback header action link in the shared layout to avoid duplicate Swagger UI entries
- log the fix in the change history for automated ingestion

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6902184abe40832d8a57996aa3565caa