### PR TITLE
Adjust Swagger UI button placement on API credentials page

### DIFF
--- a/app/templates/admin/api_keys.html
+++ b/app/templates/admin/api_keys.html
@@ -3,15 +3,18 @@
 {% block header_title %}
   <div class="header__title-content">
     <span class="header__title-text">{{ title | default('API credentials') }}</span>
-    <a
-      class="button button--ghost button--small header__title-button"
-      href="/docs"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      Swagger UI
-    </a>
   </div>
+{% endblock %}
+
+{% block header_actions %}
+  <a
+    class="button button--ghost button--small"
+    href="/docs"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    Swagger UI
+  </a>
 {% endblock %}
 
 {% block content %}

--- a/changes/f858aa98-68f2-433d-8936-7f73084c6acb.json
+++ b/changes/f858aa98-68f2-433d-8936-7f73084c6acb.json
@@ -1,0 +1,7 @@
+{
+  "guid": "f858aa98-68f2-433d-8936-7f73084c6acb",
+  "occurred_at": "2025-10-29T13:47Z",
+  "change_type": "Fix",
+  "summary": "Moved the Swagger UI button to the header actions area on the API credentials page.",
+  "content_hash": "6cdce8d66072c7320ae684381beacaf5e84752493280bb82b4a8c31402e3fcdf"
+}


### PR DESCRIPTION
## Summary
- move the Swagger UI button on the API credentials view into the header actions area so it aligns at the far right of the title bar
- log the UI adjustment in the change history

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69021a878a98832db2e498d80afb4e47