### PR TITLE
Collapse cross-service audit correlations section

### DIFF
--- a/app/templates/admin/api_keys.html
+++ b/app/templates/admin/api_keys.html
@@ -303,50 +303,57 @@
     </div>
   </section>
 
-  <section class="card card--panel admin-grid__full">
-    <header class="card__header card__header--stacked">
+  <details class="card card--panel card-collapsible admin-grid__full" data-correlation-panel>
+    <summary class="card__header card__header--collapsible">
       <div>
         <h2 class="card__title">Cross-service audit correlations</h2>
         <p class="card__subtitle">
           Correlate privileged activity across services to trace credential usage and follow-on automation.
         </p>
       </div>
-      <form method="get" class="filter-grid">
-        <input type="hidden" name="search" value="{{ filters.search }}" />
-        <input type="hidden" name="order_by" value="{{ filters.order_by }}" />
-        <input type="hidden" name="order_direction" value="{{ filters.order_direction }}" />
-        {% if filters.include_expired %}
-          <input type="hidden" name="include_expired" value="1" />
-        {% endif %}
-        <div class="form-field">
-          <label class="form-label" for="correlation-search">Search correlations</label>
-          <input
-            class="form-input"
-            id="correlation-search"
-            name="correlation_search"
-            value="{{ filters.correlation_search }}"
-            placeholder="Key fingerprint, company, or task"
-          />
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="correlation-service">Service filter</label>
-          <select class="form-input" id="correlation-service" name="service_filter">
-            <option value="">All services</option>
-            {% for option in service_options %}
-              <option value="{{ option.value }}" {% if option.value == filters.service_filter %}selected{% endif %}>
-                {{ option.label }}
-              </option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-actions form-actions--inline">
-          <button type="submit" class="button">Filter correlations</button>
-        </div>
-      </form>
-    </header>
+      <div class="card__collapsible-meta">
+        <span class="card__toggle-icon" aria-hidden="true"></span>
+      </div>
+    </summary>
 
-    <div class="table-wrapper">
-      <table class="table" id="correlations-table" data-table>
+    <div class="card-collapsible__content">
+      <header class="card__header card__header--stacked">
+        <form method="get" class="filter-grid">
+          <input type="hidden" name="search" value="{{ filters.search }}" />
+          <input type="hidden" name="order_by" value="{{ filters.order_by }}" />
+          <input type="hidden" name="order_direction" value="{{ filters.order_direction }}" />
+          {% if filters.include_expired %}
+            <input type="hidden" name="include_expired" value="1" />
+          {% endif %}
+          <div class="form-field">
+            <label class="form-label" for="correlation-search">Search correlations</label>
+            <input
+              class="form-input"
+              id="correlation-search"
+              name="correlation_search"
+              value="{{ filters.correlation_search }}"
+              placeholder="Key fingerprint, company, or task"
+            />
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="correlation-service">Service filter</label>
+            <select class="form-input" id="correlation-service" name="service_filter">
+              <option value="">All services</option>
+              {% for option in service_options %}
+                <option value="{{ option.value }}" {% if option.value == filters.service_filter %}selected{% endif %}>
+                  {{ option.label }}
+                </option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="form-actions form-actions--inline">
+            <button type="submit" class="button">Filter correlations</button>
+          </div>
+        </form>
+      </header>
+
+      <div class="table-wrapper">
+        <table class="table" id="correlations-table" data-table>
         <thead>
           <tr>
             <th scope="col" data-sort="string">Signal</th>
@@ -425,9 +432,10 @@
             </tr>
           {% endif %}
         </tbody>
-      </table>
+        </table>
+      </div>
     </div>
-  </section>
+  </details>
 </div>
 {% endblock %}
 

--- a/changes/2d26f0d1-eee5-44a2-8d25-d202a27239f5.json
+++ b/changes/2d26f0d1-eee5-44a2-8d25-d202a27239f5.json
@@ -1,0 +1,7 @@
+{
+  "guid": "2d26f0d1-eee5-44a2-8d25-d202a27239f5",
+  "occurred_at": "2025-10-29T14:02Z",
+  "change_type": "Feature",
+  "summary": "Collapsed the cross-service audit correlations panel by default on the API credentials admin page.",
+  "content_hash": "21a1d91f9bc04eab4a607cf3f7b8e3d67a63e5eeb7a2617049e60134d5b54594"
+}


### PR DESCRIPTION
## Summary
- collapse the cross-service audit correlations panel on the API key admin page by default while keeping the filter controls inside the expanded card
- document the change in the change log registry

## Testing
- pytest tests

------
https://chatgpt.com/codex/tasks/task_b_69021dac6f0c832d85834ce7bc7d11dc