### PR TITLE
Add shop packages with storefront support

### DIFF
--- a/app/services/shop_packages.py
+++ b/app/services/shop_packages.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Sequence
+
+from app.repositories import shop as shop_repo
+
+
+def _quantise_price(value: Decimal) -> Decimal:
+    """Normalise prices to two decimal places for consistent display."""
+
+    if value is None:
+        return Decimal("0.00")
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if value is None:
+        return Decimal("0")
+    return Decimal(str(value))
+
+
+def _compute_package_metrics(
+    items: Sequence[dict[str, Any]],
+    *,
+    is_vip: bool,
+    restricted_product_ids: set[int],
+) -> tuple[Decimal, int, bool]:
+    running_total = Decimal("0")
+    stock_levels: list[int] = []
+    restricted = False
+
+    for item in items:
+        product_id = int(item.get("product_id") or 0)
+        quantity = int(item.get("quantity") or 0)
+        product_archived = bool(item.get("product_archived"))
+        base_price = item.get("product_price")
+        vip_price = item.get("product_vip_price")
+        stock = int(item.get("product_stock") or 0)
+
+        if product_archived:
+            restricted = True
+        if restricted_product_ids and product_id in restricted_product_ids:
+            restricted = True
+
+        if quantity < 0:
+            quantity = 0
+
+        price_source = vip_price if is_vip and vip_price is not None else base_price
+        if price_source is not None:
+            running_total += _to_decimal(price_source) * Decimal(quantity)
+
+        if quantity <= 0:
+            stock_levels.append(stock)
+        else:
+            stock_levels.append(stock // quantity)
+
+    if not stock_levels:
+        stock_level = 0
+    else:
+        stock_level = min(stock_levels)
+        if stock_level < 0:
+            stock_level = 0
+
+    return _quantise_price(running_total), stock_level, restricted
+
+
+async def load_admin_packages(*, include_archived: bool = False) -> list[dict[str, Any]]:
+    filters = shop_repo.PackageFilters(include_archived=include_archived)
+    packages = await shop_repo.list_packages(filters)
+    package_ids = [package["id"] for package in packages]
+    items_map = await shop_repo.list_package_items_for_packages(package_ids)
+
+    enriched: list[dict[str, Any]] = []
+    for package in packages:
+        package_items = items_map.get(package["id"], [])
+        price_total, stock_level, restricted = _compute_package_metrics(
+            package_items,
+            is_vip=False,
+            restricted_product_ids=set(),
+        )
+        enriched.append(
+            {
+                **package,
+                "items": package_items,
+                "price_total": price_total,
+                "stock_level": stock_level,
+                "is_restricted": restricted,
+                "active_item_count": sum(1 for item in package_items if not item.get("product_archived")),
+            }
+        )
+    return enriched
+
+
+async def load_company_packages(
+    *,
+    company_id: int | None,
+    is_vip: bool,
+) -> list[dict[str, Any]]:
+    filters = shop_repo.PackageFilters(include_archived=False)
+    packages = await shop_repo.list_packages(filters)
+    package_ids = [package["id"] for package in packages]
+    items_map = await shop_repo.list_package_items_for_packages(package_ids)
+
+    product_ids: set[int] = set()
+    for package_items in items_map.values():
+        for item in package_items:
+            product_ids.add(int(item.get("product_id") or 0))
+
+    restricted_products: set[int] = set()
+    if company_id is not None and product_ids:
+        restricted_products = await shop_repo.get_restricted_product_ids(
+            company_id=company_id,
+            product_ids=product_ids,
+        )
+
+    visible_packages: list[dict[str, Any]] = []
+    for package in packages:
+        package_items = items_map.get(package["id"], [])
+        price_total, stock_level, restricted = _compute_package_metrics(
+            package_items,
+            is_vip=is_vip,
+            restricted_product_ids=restricted_products,
+        )
+        is_available = (
+            not package.get("archived")
+            and not restricted
+            and stock_level > 0
+            and bool(package_items)
+        )
+        visible_packages.append(
+            {
+                **package,
+                "items": package_items,
+                "price_total": price_total,
+                "stock_level": stock_level,
+                "is_restricted": restricted,
+                "is_available": is_available,
+                "active_item_count": sum(1 for item in package_items if not item.get("product_archived")),
+            }
+        )
+    return visible_packages
+
+
+async def get_package_detail(
+    package_id: int,
+    *,
+    include_archived: bool = False,
+) -> dict[str, Any] | None:
+    package = await shop_repo.get_package(package_id, include_archived=include_archived)
+    if not package:
+        return None
+    items = await shop_repo.list_package_items(package_id)
+    price_total, stock_level, restricted = _compute_package_metrics(
+        items,
+        is_vip=False,
+        restricted_product_ids=set(),
+    )
+    return {
+        **package,
+        "items": items,
+        "price_total": price_total,
+        "stock_level": stock_level,
+        "is_restricted": restricted,
+        "active_item_count": sum(1 for item in items if not item.get("product_archived")),
+    }

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block header_actions %}
+  <a class="button button--ghost" href="/admin/shop/packages">Package admin</a>
+{% endblock %}
+
 {% block content %}
 <div class="admin-grid admin-grid--columns">
   <section class="card card--panel">

--- a/app/templates/admin/shop_package_detail.html
+++ b/app/templates/admin/shop_package_detail.html
@@ -1,0 +1,172 @@
+{% extends "base.html" %}
+
+{% block header_title_content %}
+  <div class="header__title-content">
+    <span class="header__title-text">{{ super() }}</span>
+  </div>
+{% endblock %}
+
+{% block header_actions %}
+  <a class="button button--ghost" href="/admin/shop/packages">All packages</a>
+  <a class="button button--ghost" href="/admin/shop">Products admin</a>
+{% endblock %}
+
+{% block content %}
+<div class="admin-grid admin-grid--columns">
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Package overview</h2>
+        <p class="card__subtitle">Key metrics for <strong>{{ package.name }}</strong>.</p>
+      </div>
+    </header>
+    <dl class="definition-list">
+      <div class="definition-list__item">
+        <dt>SKU</dt>
+        <dd>{{ package.sku }}</dd>
+      </div>
+      <div class="definition-list__item">
+        <dt>Price</dt>
+        <dd>${{ '%.2f'|format(package.price_total) }}</dd>
+      </div>
+      <div class="definition-list__item">
+        <dt>Stock</dt>
+        <dd>{{ package.stock_level }}</dd>
+      </div>
+      <div class="definition-list__item">
+        <dt>Status</dt>
+        <dd>
+          {% if package.archived %}
+            <span class="badge badge--muted">Archived</span>
+          {% elif not package.items %}
+            <span class="badge badge--warning">No items</span>
+          {% elif package.is_restricted %}
+            <span class="badge badge--warning">Contains archived/restricted products</span>
+          {% else %}
+            <span class="badge badge--success">Active</span>
+          {% endif %}
+        </dd>
+      </div>
+    </dl>
+  </section>
+
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Package settings</h2>
+        <p class="card__subtitle">Update naming, SKU, and descriptive content.</p>
+      </div>
+    </header>
+    <form action="/shop/admin/package/{{ package.id }}/update" method="post" class="form-grid">
+      {% include "partials/csrf.html" %}
+      <div class="form-field">
+        <label class="form-label" for="package-name">Name</label>
+        <input class="form-input" id="package-name" name="name" value="{{ package.name }}" maxlength="255" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="package-sku">SKU</label>
+        <input class="form-input" id="package-sku" name="sku" value="{{ package.sku }}" maxlength="100" required />
+      </div>
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="package-description">Description</label>
+        <textarea class="form-input" id="package-description" name="description" rows="4">{{ package.description or '' }}</textarea>
+      </div>
+      <div class="form-field form-field--checkbox">
+        <label class="checkbox">
+          <input type="checkbox" name="archived" value="1" {% if package.archived %}checked{% endif %} />
+          <span>Archive package</span>
+        </label>
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button">Save changes</button>
+      </div>
+    </form>
+  </section>
+</div>
+
+<section class="card card--panel">
+  <header class="card__header card__header--stacked">
+    <div>
+      <h2 class="card__title">Package items</h2>
+      <p class="card__subtitle">Control the individual products that make up this package.</p>
+    </div>
+  </header>
+  <div class="table-wrapper">
+    <table class="table" data-table id="package-items-table">
+      <thead>
+        <tr>
+          <th scope="col" data-sort="string">Product</th>
+          <th scope="col" data-sort="string">SKU</th>
+          <th scope="col" data-sort="number">Quantity</th>
+          <th scope="col" data-sort="number">Stock</th>
+          <th scope="col" data-sort="string">Status</th>
+          <th scope="col" class="table__actions">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in package.items %}
+          <tr data-product-id="{{ item.product_id }}">
+            <td data-label="Product">{{ item.product_name }}</td>
+            <td data-label="SKU">{{ item.product_sku }}</td>
+            <td data-label="Quantity" data-value="{{ item.quantity }}">{{ item.quantity }}</td>
+            <td data-label="Stock" data-value="{{ item.product_stock }}">{{ item.product_stock }}</td>
+            <td data-label="Status">
+              {% if item.product_archived %}
+                <span class="badge badge--muted">Archived</span>
+              {% else %}
+                <span class="badge badge--success">Active</span>
+              {% endif %}
+            </td>
+            <td class="table__actions">
+              <div class="table__action-buttons">
+                <form action="/shop/admin/package/{{ package.id }}/items/{{ item.product_id }}/update" method="post" class="inline-form">
+                  {% include "partials/csrf.html" %}
+                  <label class="visually-hidden" for="quantity-{{ item.product_id }}">Quantity for {{ item.product_name }}</label>
+                  <input class="form-input form-input--sm" id="quantity-{{ item.product_id }}" type="number" min="1" name="quantity" value="{{ item.quantity }}" required />
+                  <button type="submit" class="button button--ghost">Update</button>
+                </form>
+                <form action="/shop/admin/package/{{ package.id }}/items/{{ item.product_id }}/remove" method="post" class="inline-form" data-confirm="Remove this product from the package?">
+                  {% include "partials/csrf.html" %}
+                  <button type="submit" class="button button--danger">Remove</button>
+                </form>
+              </div>
+            </td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="6" class="table__empty">No products assigned to this package.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section class="card card--panel">
+  <header class="card__header card__header--stacked">
+    <div>
+      <h2 class="card__title">Add product to package</h2>
+      <p class="card__subtitle">Select products to include and specify the quantity per package.</p>
+    </div>
+  </header>
+  <form action="/shop/admin/package/{{ package.id }}/items/add" method="post" class="form-grid">
+    {% include "partials/csrf.html" %}
+    <div class="form-field">
+      <label class="form-label" for="package-product">Product</label>
+      <select class="form-input" id="package-product" name="product_id" required>
+        <option value="">Choose a product</option>
+        {% for product in products %}
+          <option value="{{ product.id }}">{{ product.name }} ({{ product.sku }})</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="form-field">
+      <label class="form-label" for="package-product-quantity">Quantity per package</label>
+      <input class="form-input" id="package-product-quantity" type="number" name="quantity" min="1" value="1" required />
+    </div>
+    <div class="form-actions">
+      <button type="submit" class="button">Add product</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/app/templates/admin/shop_packages.html
+++ b/app/templates/admin/shop_packages.html
@@ -1,0 +1,141 @@
+{% extends "base.html" %}
+
+{% block header_title_content %}
+  <div class="header__title-content">
+    <span class="header__title-text">{{ super() }}</span>
+  </div>
+{% endblock %}
+
+{% block header_actions %}
+  <a class="button button--ghost" href="/admin/shop">Products admin</a>
+{% endblock %}
+
+{% block content %}
+<div class="admin-grid admin-grid--columns">
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Create package</h2>
+        <p class="card__subtitle">Bundle frequently ordered products together for quick ordering.</p>
+      </div>
+    </header>
+    <form action="/shop/admin/package" method="post" class="form-grid">
+      {% include "partials/csrf.html" %}
+      <div class="form-field">
+        <label class="form-label" for="package-name">Name</label>
+        <input class="form-input" id="package-name" name="name" maxlength="255" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="package-sku">SKU</label>
+        <input class="form-input" id="package-sku" name="sku" maxlength="100" required />
+      </div>
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="package-description">Description <span class="text-muted">(optional)</span></label>
+        <textarea class="form-input" id="package-description" name="description" rows="3"></textarea>
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button">Create package</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="card card--panel">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Packages</h2>
+        <p class="card__subtitle">Manage existing bundles, update their contents, and control visibility.</p>
+      </div>
+      <div class="card__controls">
+        <input
+          type="search"
+          class="form-input card__control"
+          placeholder="Search packages"
+          aria-label="Search packages"
+          data-table-filter="admin-packages-table"
+        />
+        <label class="checkbox card__control">
+          <input type="checkbox" id="packages-show-archived" {% if show_archived %}checked{% endif %} />
+          <span>Show archived</span>
+        </label>
+      </div>
+    </header>
+    <div class="table-wrapper">
+      <table class="table" id="admin-packages-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col" data-sort="string">Name</th>
+            <th scope="col" data-sort="string">SKU</th>
+            <th scope="col" data-sort="number">Items</th>
+            <th scope="col" data-sort="number">Price</th>
+            <th scope="col" data-sort="number">Stock</th>
+            <th scope="col" data-sort="string">Status</th>
+            <th scope="col" class="table__actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for package in packages %}
+            <tr data-archived="{{ 'true' if package.archived else 'false' }}" data-package-id="{{ package.id }}">
+              <td data-label="Name">{{ package.name }}</td>
+              <td data-label="SKU">{{ package.sku }}</td>
+              <td data-label="Items" data-value="{{ package.product_count }}">{{ package.product_count }}</td>
+              <td data-label="Price" data-value="{{ package.price_total }}">${{ '%.2f'|format(package.price_total) }}</td>
+              <td data-label="Stock" data-value="{{ package.stock_level }}">{{ package.stock_level }}</td>
+              <td data-label="Status">
+                {% if package.archived %}
+                  <span class="badge badge--muted">Archived</span>
+                {% elif not package.items %}
+                  <span class="badge badge--warning">No items</span>
+                {% elif package.is_restricted %}
+                  <span class="badge badge--warning">Restricted</span>
+                {% else %}
+                  <span class="badge badge--success">Active</span>
+                {% endif %}
+              </td>
+              <td class="table__actions">
+                <div class="table__action-buttons">
+                  <a class="button button--ghost" href="/admin/shop/packages/{{ package.id }}">Edit</a>
+                  <form action="/shop/admin/package/{{ package.id }}/archive" method="post" class="inline-form">
+                    {% include "partials/csrf.html" %}
+                    <input type="hidden" name="archived" value="{{ '0' if package.archived else '1' }}" />
+                    <button type="submit" class="button button--ghost">{{ 'Unarchive' if package.archived else 'Archive' }}</button>
+                  </form>
+                  <form action="/shop/admin/package/{{ package.id }}/delete" method="post" class="inline-form" data-confirm="Delete this package?">
+                    {% include "partials/csrf.html" %}
+                    <button type="submit" class="button button--danger">Delete</button>
+                  </form>
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="7" class="table__empty">No packages available.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div class="table-pagination" data-pagination="admin-packages-table">
+      <div class="table-pagination__group">
+        <button type="button" class="button button--ghost table-pagination__button" data-page-prev disabled>Previous</button>
+        <button type="button" class="button button--ghost table-pagination__button" data-page-next>Next</button>
+      </div>
+      <p class="table-pagination__status" data-page-info aria-live="polite"></p>
+    </div>
+  </section>
+</div>
+
+<script>
+  const showArchivedToggle = document.getElementById('packages-show-archived');
+  if (showArchivedToggle) {
+    showArchivedToggle.addEventListener('change', () => {
+      const url = new URL(window.location.href);
+      if (showArchivedToggle.checked) {
+        url.searchParams.set('showArchived', '1');
+      } else {
+        url.searchParams.delete('showArchived');
+      }
+      window.location.href = url.toString();
+    });
+  }
+</script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -119,6 +119,14 @@
                 <span class="menu__label">Shop</span>
               </a>
             </li>
+            <li class="menu__item">
+              <a href="/shop/packages" {% if current_path.startswith('/shop/packages') %}aria-current="page"{% endif %}>
+                <span class="menu__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false"><path d="M3.2 7.6 11.5 12v9.5L3 17a1 1 0 0 1-.5-.86V8.37a1 1 0 0 1 .7-.97Zm17.6 0-8.3 4.4v9.5L21 17a1 1 0 0 0 .5-.86V8.37a1 1 0 0 0-.7-.97ZM12 2l8.7 4.6-8.2 4.34L3 6.6z"/></svg>
+                </span>
+                <span class="menu__label">Packages</span>
+              </a>
+            </li>
           {% endif %}
           {% if can_access_cart %}
             <li class="menu__item">

--- a/app/templates/shop/packages.html
+++ b/app/templates/shop/packages.html
@@ -1,0 +1,148 @@
+{% extends "base.html" %}
+
+{% set cart_allowed = (can_access_cart | default(false)) %}
+{% if not cart_allowed %}
+  {% set cart_allowed = (is_super_admin | default(current_user and current_user.get('is_super_admin'))) or (active_membership and active_membership.get('can_access_cart')) %}
+{% endif %}
+
+{% set is_shop_super_admin = is_super_admin | default(current_user and current_user.get('is_super_admin')) %}
+
+{% block header_title_content %}
+  <div class="header__title-content">
+    <span class="header__title-text">{{ super() }}</span>
+  </div>
+{% endblock %}
+
+{% block header_actions %}
+  <a class="button button--ghost" href="/shop">Products</a>
+  {% if cart_allowed %}
+    <a class="button button--ghost" href="/cart">
+      View cart{% if cart_summary.total_quantity %} ({{ cart_summary.total_quantity }}){% endif %}
+    </a>
+  {% endif %}
+  {% if is_shop_super_admin %}
+    <a class="button button--ghost" href="/admin/shop/packages">Package admin</a>
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+{% if cart_error %}
+  <div class="alert alert--error" role="alert">{{ cart_error }}</div>
+{% endif %}
+
+<div class="shop-layout">
+  <aside class="card card--panel shop-layout__sidebar">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Packages</h2>
+        <p class="card__subtitle">Curated bundles assembled by our team for repeat ordering.</p>
+      </div>
+    </header>
+    <div class="package-summary">
+      <p>Each package automatically keeps its price and stock in sync with the included products.</p>
+      <ul class="list list--bullet">
+        <li>Price equals the sum of the current product prices.</li>
+        <li>Stock reflects the lowest stocked product within the bundle.</li>
+        <li>Adding a package adds all contained products to your cart.</li>
+      </ul>
+    </div>
+  </aside>
+
+  <section class="card card--panel shop-layout__content">
+    <header class="card__header">
+      <div>
+        <h2 class="card__title">Available packages</h2>
+        <p class="card__subtitle">Choose a package to automatically add multiple products to your order.</p>
+      </div>
+      <div class="card__controls shop-toolbar">
+        <input
+          type="search"
+          class="form-input card__control"
+          placeholder="Filter packages"
+          aria-label="Filter packages"
+          data-table-filter="shop-packages-table"
+        />
+      </div>
+    </header>
+    <div class="table-wrapper">
+      <table class="table" id="shop-packages-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col" data-sort="string">Name</th>
+            <th scope="col" data-sort="string">SKU</th>
+            <th scope="col" data-sort="number">Items</th>
+            <th scope="col" data-sort="number">Price</th>
+            <th scope="col" data-sort="number">Stock</th>
+            <th scope="col" class="table__actions">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for package in packages if package.is_available %}
+            <tr data-package-id="{{ package.id }}" data-stock="{{ package.stock_level }}">
+              <td data-label="Name">
+                <div class="package-name">
+                  <strong>{{ package.name }}</strong>
+                  <details class="package-details">
+                    <summary>Included products</summary>
+                    <ul class="list list--bullet">
+                      {% for item in package.items %}
+                        <li>{{ item.product_name }} ({{ item.product_sku }}) × {{ item.quantity }}</li>
+                      {% endfor %}
+                    </ul>
+                  </details>
+                </div>
+              </td>
+              <td data-label="SKU">{{ package.sku }}</td>
+              <td data-label="Items" data-value="{{ package.product_count }}">{{ package.product_count }}</td>
+              <td data-label="Price" data-value="{{ package.price_total }}">${{ '%.2f'|format(package.price_total) }}</td>
+              <td data-label="Stock" data-value="{{ package.stock_level }}">
+                <span class="badge {% if package.stock_level == 0 %}badge--danger{% elif package.stock_level < 5 %}badge--warning{% else %}badge--success{% endif %}">
+                  {{ package.stock_level }}
+                </span>
+              </td>
+              <td class="table__actions">
+                <div class="table__action-buttons">
+                  {% if package.stock_level > 0 %}
+                    {% if cart_allowed %}
+                      <form action="/cart/add-package" method="post" class="inline-form">
+                        {% include "partials/csrf.html" %}
+                        <input type="hidden" name="packageId" value="{{ package.id }}" />
+                        <label class="visually-hidden" for="package-qty-{{ package.id }}">Quantity for {{ package.name }}</label>
+                        <input
+                          class="form-input form-input--sm"
+                          id="package-qty-{{ package.id }}"
+                          type="number"
+                          name="quantity"
+                          min="1"
+                          max="{{ package.stock_level }}"
+                          value="1"
+                        />
+                        <button type="submit" class="button">Add to cart</button>
+                      </form>
+                    {% else %}
+                      <span class="badge badge--muted">Cart access required</span>
+                    {% endif %}
+                  {% else %}
+                    <span class="badge badge--muted">Out of stock</span>
+                  {% endif %}
+                </div>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="6" class="table__empty">No packages are currently available.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div class="table-pagination" data-pagination="shop-packages-table">
+      <div class="table-pagination__group">
+        <button type="button" class="button button--ghost table-pagination__button" data-page-prev disabled>Previous</button>
+        <button type="button" class="button button--ghost table-pagination__button" data-page-next>Next</button>
+      </div>
+      <p class="table-pagination__status" data-page-info aria-live="polite"></p>
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/changes/1100f32b-c17e-4d88-8f28-2923f211ac72.json
+++ b/changes/1100f32b-c17e-4d88-8f28-2923f211ac72.json
@@ -1,0 +1,7 @@
+{
+  "guid": "1100f32b-c17e-4d88-8f28-2923f211ac72",
+  "occurred_at": "2025-10-29T14:03Z",
+  "change_type": "Feature",
+  "summary": "Introduced shop packages with bundle admin and storefront support.",
+  "content_hash": "6ba70db38ca002fe1c21d712baca59af0ad8fa07b3510ddfc4b9ae608d797946"
+}

--- a/docs/shop-packages.md
+++ b/docs/shop-packages.md
@@ -1,0 +1,32 @@
+# Shop packages
+
+The shop now supports curated product bundles that simplify ordering for common workflows. Packages are managed from **Admin → Shop → Package admin** and surface to end users on the `/shop/packages` page.
+
+## Key behaviours
+
+- Package price is calculated automatically as the sum of the current product prices in the bundle. VIP companies see their negotiated pricing when browsing packages.
+- Available stock is derived from the lowest stocked item after considering its quantity within the package. If any product runs out, the package is unavailable for ordering.
+- Packages respect existing per-company product exclusions.
+- When a package is added to the cart each underlying product is inserted with the appropriate quantity, preserving stock validation and checkout workflows.
+
+## Administration endpoints
+
+The following form-driven endpoints are exposed for super administrators and documented in the internal Swagger UI:
+
+- `GET /admin/shop/packages` – list and search packages, toggle archived bundles, and link to the detail editor.
+- `GET /admin/shop/packages/{package_id}` – view package metrics, edit metadata, and manage bundled products.
+- `POST /shop/admin/package` – create a new package by supplying a name, SKU, and optional description.
+- `POST /shop/admin/package/{package_id}/update` – update metadata and archive status.
+- `POST /shop/admin/package/{package_id}/archive` – archive or restore a package from the list view.
+- `POST /shop/admin/package/{package_id}/delete` – permanently remove a package and its associations.
+- `POST /shop/admin/package/{package_id}/items/add` – attach a product to the package with a quantity per bundle.
+- `POST /shop/admin/package/{package_id}/items/{product_id}/update` – adjust the quantity of an existing package item.
+- `POST /shop/admin/package/{package_id}/items/{product_id}/remove` – remove a product from the package.
+
+All routes enforce super-admin access and automatically emit audit-friendly log entries via the existing logging framework.
+
+## Front-of-house experience
+
+Users with shop access can browse `/shop/packages` for available bundles. The page follows the standard three-panel layout with filtering, stock badges, and quick add-to-cart forms. Packages obey company restrictions, and availability reflects current stock in real time.
+
+When testing or seeding data remember to run the new SQL migration `086_shop_packages.sql` so that the required tables exist. The migration runner executes automatically on application start.

--- a/migrations/086_shop_packages.sql
+++ b/migrations/086_shop_packages.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS shop_packages (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  sku VARCHAR(100) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  description TEXT NULL,
+  archived TINYINT(1) NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_shop_packages_sku (sku)
+);
+
+CREATE TABLE IF NOT EXISTS shop_package_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  package_id INT NOT NULL,
+  product_id INT NOT NULL,
+  quantity INT NOT NULL DEFAULT 1,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_shop_package FOREIGN KEY (package_id) REFERENCES shop_packages(id) ON DELETE CASCADE,
+  CONSTRAINT fk_shop_package_product FOREIGN KEY (product_id) REFERENCES shop_products(id),
+  UNIQUE KEY uq_shop_package_product (package_id, product_id)
+);

--- a/tests/test_shop_packages_service.py
+++ b/tests/test_shop_packages_service.py
@@ -1,0 +1,141 @@
+import asyncio
+from decimal import Decimal
+
+from app.services import shop_packages as packages_service
+
+
+def test_load_admin_packages_computes_totals(monkeypatch):
+    async def fake_list_packages(filters):
+        return [
+            {
+                "id": 1,
+                "name": "Starter bundle",
+                "sku": "PKG-1",
+                "archived": False,
+                "product_count": 2,
+            }
+        ]
+
+    async def fake_list_items(package_ids):
+        return {
+            1: [
+                {
+                    "product_id": 10,
+                    "quantity": 2,
+                    "product_price": Decimal("5.00"),
+                    "product_vip_price": Decimal("4.50"),
+                    "product_stock": 6,
+                    "product_archived": False,
+                },
+                {
+                    "product_id": 11,
+                    "quantity": 1,
+                    "product_price": Decimal("3.00"),
+                    "product_vip_price": None,
+                    "product_stock": 4,
+                    "product_archived": False,
+                },
+            ]
+        }
+
+    monkeypatch.setattr(packages_service.shop_repo, "list_packages", fake_list_packages)
+    monkeypatch.setattr(
+        packages_service.shop_repo,
+        "list_package_items_for_packages",
+        fake_list_items,
+    )
+
+    packages = asyncio.run(packages_service.load_admin_packages())
+
+    assert len(packages) == 1
+    package = packages[0]
+    assert package["price_total"] == Decimal("13.00")
+    assert package["stock_level"] == 3
+    assert package["is_restricted"] is False
+    assert package["active_item_count"] == 2
+
+
+def test_load_company_packages_marks_restricted(monkeypatch):
+    async def fake_list_packages(filters):
+        return [
+            {
+                "id": 2,
+                "name": "VIP bundle",
+                "sku": "PKG-2",
+                "archived": False,
+                "product_count": 1,
+            }
+        ]
+
+    async def fake_list_items(package_ids):
+        return {
+            2: [
+                {
+                    "product_id": 20,
+                    "quantity": 1,
+                    "product_price": Decimal("9.99"),
+                    "product_vip_price": Decimal("8.99"),
+                    "product_stock": 5,
+                    "product_archived": False,
+                }
+            ]
+        }
+
+    async def fake_get_restricted(*, company_id, product_ids):
+        return {20}
+
+    monkeypatch.setattr(packages_service.shop_repo, "list_packages", fake_list_packages)
+    monkeypatch.setattr(
+        packages_service.shop_repo,
+        "list_package_items_for_packages",
+        fake_list_items,
+    )
+    monkeypatch.setattr(
+        packages_service.shop_repo,
+        "get_restricted_product_ids",
+        fake_get_restricted,
+    )
+
+    packages = asyncio.run(
+        packages_service.load_company_packages(company_id=3, is_vip=True)
+    )
+
+    package = packages[0]
+    assert package["is_restricted"] is True
+    assert package["is_available"] is False
+    assert package["stock_level"] == 5
+    assert package["price_total"] == Decimal("8.99")
+
+
+def test_get_package_detail_returns_enriched(monkeypatch):
+    async def fake_get_package(package_id, include_archived=False):
+        return {
+            "id": package_id,
+            "name": "Ops kit",
+            "sku": "PKG-OPS",
+            "archived": False,
+            "product_count": 1,
+        }
+
+    async def fake_list_items(package_id):
+        return [
+            {
+                "product_id": 30,
+                "quantity": 3,
+                "product_price": Decimal("2.00"),
+                "product_vip_price": None,
+                "product_stock": 12,
+                "product_archived": False,
+            }
+        ]
+
+    monkeypatch.setattr(packages_service.shop_repo, "get_package", fake_get_package)
+    monkeypatch.setattr(packages_service.shop_repo, "list_package_items", fake_list_items)
+
+    package = asyncio.run(packages_service.get_package_detail(7))
+
+    assert package is not None
+    assert package["price_total"] == Decimal("6.00")
+    assert package["stock_level"] == 4
+    assert package["is_restricted"] is False
+    assert package["active_item_count"] == 1

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -97,6 +97,7 @@ def test_company_admin_sees_authorised_menu_items(company_admin_context):
     assert response.status_code == 200
     html = response.text
     assert 'href="/shop"' in html
+    assert 'href="/shop/packages"' in html
     assert 'href="/cart"' in html
     assert 'href="/forms"' in html
     assert 'href="/invoices"' in html


### PR DESCRIPTION
## Summary
- add shop package data model, repository helpers, and service utilities for price and stock calculations
- expose admin package management UI with create, update, archive, and item management flows plus supporting routes and docs
- surface customer-facing packages catalogue with cart integration and automated stock validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69021bf40f1c832d8502749a8084ffb5