### PR TITLE
feat: show cart product details modal

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3110,6 +3110,7 @@ async def view_cart(
     items = await cart_repo.list_items(session.id)
     cart_items: list[dict[str, Any]] = []
     total = Decimal("0")
+    cart_items_payload: list[dict[str, Any]] = []
     for item in items:
         unit_price = item.get("unit_price")
         if not isinstance(unit_price, Decimal):
@@ -3121,12 +3122,26 @@ async def view_cart(
         hydrated["unit_price"] = unit_price
         hydrated["line_total"] = line_total
         cart_items.append(hydrated)
+        cart_items_payload.append(
+            {
+                "product_id": hydrated.get("product_id"),
+                "name": hydrated.get("product_name"),
+                "sku": hydrated.get("product_sku"),
+                "vendor_sku": hydrated.get("product_vendor_sku"),
+                "description": hydrated.get("product_description"),
+                "image_url": hydrated.get("product_image_url"),
+                "unit_price": f"{unit_price:.2f}",
+                "quantity": quantity,
+                "line_total": f"{line_total:.2f}",
+            }
+        )
 
     extra = {
         "title": "Cart",
         "cart_items": cart_items,
         "cart_total": total,
         "order_message": order_message,
+        "cart_items_payload": cart_items_payload,
     }
     return await _render_template("shop/cart.html", request, user, extra=extra)
 

--- a/app/static/js/cart.js
+++ b/app/static/js/cart.js
@@ -1,0 +1,139 @@
+(function () {
+  function parseJson(elementId) {
+    const element = document.getElementById(elementId);
+    if (!element) {
+      return [];
+    }
+    try {
+      return JSON.parse(element.textContent || '[]');
+    } catch (error) {
+      console.error('Unable to parse JSON data for', elementId, error);
+      return [];
+    }
+  }
+
+  function openModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.hidden = false;
+    modal.classList.add('is-visible');
+  }
+
+  function closeModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.classList.remove('is-visible');
+    modal.hidden = true;
+  }
+
+  function bindModalDismissal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal || event.target.hasAttribute('data-modal-close')) {
+        closeModal(modal);
+      }
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !modal.hidden) {
+        closeModal(modal);
+      }
+    });
+  }
+
+  function appendDetail(container, label, value) {
+    if (!container || value === undefined || value === null || value === '') {
+      return;
+    }
+    const paragraph = document.createElement('p');
+    paragraph.className = 'modal__text';
+    const strong = document.createElement('strong');
+    strong.textContent = `${label}: `;
+    paragraph.append(strong);
+    paragraph.append(document.createTextNode(String(value)));
+    container.append(paragraph);
+  }
+
+  function renderProductDetails(container, product) {
+    if (!container) {
+      return;
+    }
+    container.innerHTML = '';
+
+    if (!product) {
+      const empty = document.createElement('p');
+      empty.className = 'text-muted';
+      empty.textContent = 'Product details are unavailable.';
+      container.append(empty);
+      return;
+    }
+
+    if (product.image_url) {
+      const image = document.createElement('img');
+      image.src = product.image_url;
+      image.alt = `${product.name || 'Product'} image`;
+      image.className = 'modal__image';
+      container.append(image);
+    }
+
+    appendDetail(container, 'SKU', product.sku);
+    appendDetail(container, 'Vendor SKU', product.vendor_sku);
+    appendDetail(container, 'Unit price', `$${product.unit_price}`);
+    appendDetail(container, 'Quantity in cart', product.quantity);
+    appendDetail(container, 'Line total', `$${product.line_total}`);
+
+    if (product.description) {
+      const descriptionTitle = document.createElement('h3');
+      descriptionTitle.className = 'modal__subtitle';
+      descriptionTitle.textContent = 'Description';
+      container.append(descriptionTitle);
+
+      String(product.description)
+        .split(/\r?\n/)
+        .filter((line) => line.trim().length > 0)
+        .forEach((line) => {
+          const paragraph = document.createElement('p');
+          paragraph.textContent = line;
+          container.append(paragraph);
+        });
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const products = parseJson('cart-items-data');
+    if (!products.length) {
+      return;
+    }
+
+    const modal = document.getElementById('cart-product-details-modal');
+    const modalTitle = document.getElementById('cart-product-details-title');
+    const modalBody = document.getElementById('cart-product-details-body');
+    if (!modal || !modalBody) {
+      return;
+    }
+
+    const itemsById = new Map();
+    products.forEach((product) => {
+      if (product && product.product_id !== undefined) {
+        itemsById.set(Number(product.product_id), product);
+      }
+    });
+
+    bindModalDismissal(modal);
+
+    document.querySelectorAll('[data-cart-product-modal]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const id = Number(button.getAttribute('data-cart-product-modal'));
+        const product = itemsById.get(id);
+        if (modalTitle) {
+          modalTitle.textContent = product?.name || 'Product details';
+        }
+        renderProductDetails(modalBody, product);
+        openModal(modal);
+      });
+    });
+  });
+})();

--- a/app/templates/shop/cart.html
+++ b/app/templates/shop/cart.html
@@ -39,7 +39,6 @@
               <th scope="col">Image</th>
               <th scope="col" data-sort="string">Name</th>
               <th scope="col" data-sort="string">SKU</th>
-              <th scope="col" data-sort="string">Description</th>
               <th scope="col" data-sort="number">Unit price</th>
               <th scope="col" data-sort="number">Quantity</th>
               <th scope="col" data-sort="number">Line total</th>
@@ -61,15 +60,17 @@
                     <span class="text-muted">—</span>
                   {% endif %}
                 </td>
-                <td data-label="Name">{{ item.product_name }}</td>
-                <td data-label="SKU">{{ item.product_sku }}</td>
-                <td data-label="Description">
-                  {% if item.product_description %}
-                    {{ item.product_description.replace('\n', '<br />') | safe }}
-                  {% else %}
-                    <span class="text-muted">—</span>
-                  {% endif %}
+                <td data-label="Name">
+                  <button
+                    type="button"
+                    class="link-button"
+                    data-cart-product-modal="{{ item.product_id }}"
+                    aria-haspopup="dialog"
+                  >
+                    {{ item.product_name }}
+                  </button>
                 </td>
+                <td data-label="SKU">{{ item.product_sku }}</td>
                 <td data-label="Unit price" data-value="{{ item.unit_price }}">${{ '%.2f'|format(item.unit_price) }}</td>
                 <td data-label="Quantity" data-value="{{ item.quantity }}">{{ item.quantity }}</td>
                 <td data-label="Line total" data-value="{{ item.line_total }}">${{ '%.2f'|format(item.line_total) }}</td>
@@ -111,9 +112,28 @@
     <p class="text-muted">Your cart is empty.</p>
   {% endif %}
 </section>
+
+<div
+  class="modal"
+  id="cart-product-details-modal"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="cart-product-details-title"
+  hidden
+>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close aria-label="Close product details">
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <h2 class="modal__title" id="cart-product-details-title">Product details</h2>
+    <div id="cart-product-details-body" class="modal__body"></div>
+  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
   {{ super() }}
+  <script type="application/json" id="cart-items-data">{{ cart_items_payload | tojson }}</script>
   <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/cart.js" defer></script>
 {% endblock %}

--- a/changes/f25a2127-61d5-4a81-8edd-c20cd47e6c4f.json
+++ b/changes/f25a2127-61d5-4a81-8edd-c20cd47e6c4f.json
@@ -1,0 +1,7 @@
+{
+  "guid": "f25a2127-61d5-4a81-8edd-c20cd47e6c4f",
+  "occurred_at": "2025-10-29T14:28Z",
+  "change_type": "Feature",
+  "summary": "Show product details from the cart in an on-demand modal dialog.",
+  "content_hash": "9a4ec5d02d4ab0438042dce35aa7068e63ea201335ba9e04bc513eb5e5327c07"
+}


### PR DESCRIPTION
## Summary
- remove the inline description column from the cart table and trigger a modal when clicking a product name
- expose a serialised product payload for the cart page and render the product details modal client-side
- record the feature in the change log

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6902239ff544832da28fbfd20d0682b0