### PR TITLE
Remove cart navigation entry

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -128,16 +128,6 @@
               </a>
             </li>
           {% endif %}
-          {% if can_access_cart %}
-            <li class="menu__item">
-              <a href="/cart" {% if current_path.startswith('/cart') %}aria-current="page"{% endif %}>
-                <span class="menu__icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false"><path d="M3 3h2l1.24 2.76A2 2 0 0 0 8.08 7H19a1 1 0 0 1 .98 1.2l-1.5 7A2 2 0 0 1 16.53 16H9a2 2 0 0 1-1.9-1.37L4.28 5H3zm6 16a2 2 0 1 0 2 2 2 2 0 0 0-2-2zm8 0a2 2 0 1 0 2 2 2 2 0 0 0-2-2z"/></svg>
-                </span>
-                <span class="menu__label">Cart</span>
-              </a>
-            </li>
-          {% endif %}
           {% if can_access_orders %}
             <li class="menu__item">
               <a href="/orders" {% if current_path.startswith('/orders') %}aria-current="page"{% endif %}>

--- a/changes/488d388a-781f-4c33-b999-7a43b1d000da.json
+++ b/changes/488d388a-781f-4c33-b999-7a43b1d000da.json
@@ -1,0 +1,7 @@
+{
+  "guid": "488d388a-781f-4c33-b999-7a43b1d000da",
+  "occurred_at": "2025-10-29T14:28Z",
+  "change_type": "Fix",
+  "summary": "Removed the Cart menu item from the sidebar to streamline navigation",
+  "content_hash": "0f1b64d5a58ae85e8f6073cf3c7dc454ffb7d48901ef5f7baa98b056c14b4a0e"
+}

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -98,7 +98,7 @@ def test_company_admin_sees_authorised_menu_items(company_admin_context):
     html = response.text
     assert 'href="/shop"' in html
     assert 'href="/shop/packages"' in html
-    assert 'href="/cart"' in html
+    assert 'href="/cart"' not in html
     assert 'href="/forms"' in html
     assert 'href="/invoices"' in html
     assert 'href="/staff"' in html


### PR DESCRIPTION
## Summary
- hide the cart link from the primary sidebar navigation
- update sidebar regression test to reflect the new menu layout
- log the navigation change in the change log feed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69022430baf8832db9278f46c46642be