### PR TITLE
Adjust cart total placement and styling on cart page

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2044,6 +2044,13 @@ body {
   align-items: flex-end;
 }
 
+.cart-checkout__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-gap-tight);
+}
+
 .cart-summary {
   display: flex;
   justify-content: flex-end;
@@ -2057,13 +2064,13 @@ body {
 
 .cart-summary__totals dt {
   font-weight: 600;
-  color: #0f172a;
+  color: #fff;
 }
 
 .cart-summary__totals dd {
   margin: 0;
   font-weight: 700;
-  color: #0f172a;
+  color: #fff;
 }
 
 .cart-table__image img {

--- a/app/templates/shop/cart.html
+++ b/app/templates/shop/cart.html
@@ -86,14 +86,6 @@
 
     <form action="{{ request.url_for('cart_place_order') }}" method="post" class="cart-checkout form-grid">
       {% include "partials/csrf.html" %}
-      <div class="cart-summary">
-        <dl class="cart-summary__totals">
-          <div>
-            <dt>Total</dt>
-            <dd>${{ '%.2f'|format(cart_total) }}</dd>
-          </div>
-        </dl>
-      </div>
       <div class="form-field">
         <label class="form-label" for="cart-po-number">PO number</label>
         <input
@@ -104,8 +96,18 @@
           placeholder="Optional purchase order reference"
         />
       </div>
-      <div class="form-actions">
-        <button type="submit" class="button">Place order</button>
+      <div class="cart-checkout__actions">
+        <div class="cart-summary">
+          <dl class="cart-summary__totals">
+            <div>
+              <dt>Total</dt>
+              <dd>${{ '%.2f'|format(cart_total) }}</dd>
+            </div>
+          </dl>
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="button">Place order</button>
+        </div>
       </div>
     </form>
   {% else %}


### PR DESCRIPTION
## Summary
- move the cart total into a dedicated checkout actions container so it appears directly above the Place order button
- update the cart total styles to use white text for better contrast against the cart card background

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690225cc0e54832d88fa8a47d5a99000