### PR TITLE
Randomize All Products display order in shop

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2905,6 +2905,9 @@ async def shop_page(
 
         products = [product for product in products if _product_has_price(product)]
 
+        if category_id is None:
+            secrets.SystemRandom().shuffle(products)
+
     categories = await categories_task
 
     extra = {

--- a/changes/970edc1c-b148-478b-832f-3674bdccc43d.json
+++ b/changes/970edc1c-b148-478b-832f-3674bdccc43d.json
@@ -1,0 +1,7 @@
+{
+  "guid": "970edc1c-b148-478b-832f-3674bdccc43d",
+  "occurred_at": "2025-10-29T14:46Z",
+  "change_type": "Feature",
+  "summary": "Randomised the All Products shop listing per visit without affecting pagination order.",
+  "content_hash": "17a75afa58584e607f811375d64504634b9fc2c5ff7ae1b7f82a5a82e7d4dca7"
+}


### PR DESCRIPTION
## Summary
- shuffle the All Products listing once per request so each visit presents a new order while pagination stays stable
- record the change in the change log directory

## Testing
- pytest tests/test_shop_service.py

------
https://chatgpt.com/codex/tasks/task_b_6902282ee2b4832db1c17c6db9031b20