### PR TITLE
Fix upgrade script to read FORCE_RESTART from environment file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,7 @@ FAIL2BAN_LOG_PATH=
 SYSTEMD_SERVICE_NAME=myportal
 SERVICE_USER=
 APP_RESTART_COMMAND=
+FORCE_RESTART=0
 
 # Integration modules (defaults can be overridden via admin UI)
 OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/changes/8ec554bf-3632-4509-85d2-5d6eca0a4a2f.json
+++ b/changes/8ec554bf-3632-4509-85d2-5d6eca0a4a2f.json
@@ -1,0 +1,7 @@
+{
+  "guid": "8ec554bf-3632-4509-85d2-5d6eca0a4a2f",
+  "occurred_at": "2025-10-29T14:47:00Z",
+  "change_type": "Fix",
+  "summary": "Fix upgrade script to respect FORCE_RESTART flag from environment file.",
+  "content_hash": "e7279d10523332c9eeca24fb1d5fad5a77f80d15e8be434a07bd403d06dc08bf"
+}

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -310,7 +310,7 @@ else
 fi
 
 POST_PULL_HEAD=$(git rev-parse HEAD)
-FORCE_RESTART="${FORCE_RESTART:-0}"
+FORCE_RESTART="$(read_env_var "FORCE_RESTART" "0")"
 
 reset_project_permissions "$SERVICE_USER"
 

--- a/tests/test_upgrade_script.py
+++ b/tests/test_upgrade_script.py
@@ -11,4 +11,5 @@ def test_upgrade_script_prefers_project_virtualenv():
     assert 'RESTART_FLAG_FILE' in contents
     assert 'Flagged pending dependency install and service restart' in contents
     assert 'FORCE_RESTART' in contents
+    assert 'FORCE_RESTART="$(read_env_var "FORCE_RESTART" "0")"' in contents
     assert 'flagging dependency install and service restart' in contents


### PR DESCRIPTION
## Summary
- load FORCE_RESTART via the upgrade script's read_env_var helper so .env values apply
- document the FORCE_RESTART flag in the sample environment configuration and extend coverage
- record the change in the change-log feed

## Testing
- pytest tests/test_upgrade_script.py tests/test_scheduler_system_update.py

------
https://chatgpt.com/codex/tasks/task_b_69022860c250832dbbe5c40728259b1e