### PR TITLE
Fix shop product list indentation causing startup failure

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2906,8 +2906,8 @@ async def shop_page(
         products = [product for product in products if _product_has_price(product)]
 
     products = cast(list[dict[str, Any]], _serialise_for_json(products))
-        if category_id is None:
-            secrets.SystemRandom().shuffle(products)
+    if category_id is None:
+        secrets.SystemRandom().shuffle(products)
 
     categories = await categories_task
 

--- a/changes/4ae167d5-822a-4c55-a411-1c69b7cc2503.json
+++ b/changes/4ae167d5-822a-4c55-a411-1c69b7cc2503.json
@@ -1,0 +1,7 @@
+{
+  "guid": "4ae167d5-822a-4c55-a411-1c69b7cc2503",
+  "occurred_at": "2025-10-29T14:57:35Z",
+  "change_type": "Fix",
+  "summary": "Fix shop product shuffle indentation to prevent startup failure",
+  "content_hash": "3ee7f58d8c011dd3b5d6808ee4eb718ac7fd54dfbcfa86cf28184374c7fab7ec"
+}


### PR DESCRIPTION
## Summary
- correct the shop product shuffle block indentation so the module imports without errors when no category filter is used
- log the fix in the change history with a new change entry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69022aa90b4c832d979437bd24616181