### PR TITLE
Display package item totals for shop packages

### DIFF
--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -122,9 +122,14 @@
                 </td>
                 <td data-label="Name">
                   <div class="package-name">
+                    {% set item_count = product.get('items', []) | sum(attribute='quantity') %}
+                    {% if item_count == 0 %}
+                      {% set item_count = product.product_count %}
+                    {% endif %}
                     <strong>{{ product.name }}</strong>
                     <p class="package-meta">
                       Includes {{ product.product_count }} {{ 'product' if product.product_count == 1 else 'products' }}
+                      ({{ item_count }} {{ 'item' if item_count == 1 else 'items' }})
                     </p>
                     <details class="package-details">
                       <summary>Included products</summary>

--- a/changes/99b0bd39-4024-4586-8e4a-db980882e300.json
+++ b/changes/99b0bd39-4024-4586-8e4a-db980882e300.json
@@ -1,0 +1,7 @@
+{
+  "guid": "99b0bd39-4024-4586-8e4a-db980882e300",
+  "occurred_at": "2025-10-29T15:03Z",
+  "change_type": "Feature",
+  "summary": "Display package item totals alongside product counts on shop page.",
+  "content_hash": "c23927be7b479fba07ee7d5134db583192242d2ebe0ba2574abc59d44190351d"
+}


### PR DESCRIPTION
## Summary
- compute package item totals so the shop package list shows both product and item counts
- record the feature update in the change log archive

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69022c347890832d8d22a6996f3af634