### PR TITLE
Add package item detail modal to shop packages page

### DIFF
--- a/app/static/js/shop_packages.js
+++ b/app/static/js/shop_packages.js
@@ -1,0 +1,171 @@
+(function () {
+  function parseJson(elementId) {
+    const element = document.getElementById(elementId);
+    if (!element) {
+      return [];
+    }
+    try {
+      return JSON.parse(element.textContent || '[]');
+    } catch (error) {
+      console.error('Unable to parse JSON data for', elementId, error);
+      return [];
+    }
+  }
+
+  function openModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.hidden = false;
+    modal.classList.add('is-visible');
+  }
+
+  function closeModal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.classList.remove('is-visible');
+    modal.hidden = true;
+  }
+
+  function bindModalDismissal(modal) {
+    if (!modal) {
+      return;
+    }
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal || event.target.hasAttribute('data-modal-close')) {
+        closeModal(modal);
+      }
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !modal.hidden) {
+        closeModal(modal);
+      }
+    });
+  }
+
+  function createDetailRow(label, value) {
+    const row = document.createElement('p');
+    row.className = 'modal__text';
+    row.textContent = `${label}: ${value}`;
+    return row;
+  }
+
+  function formatCurrency(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) {
+      return '$0.00';
+    }
+    return `$${number.toFixed(2)}`;
+  }
+
+  function describeStock(stock) {
+    const quantity = Number(stock);
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      return 'Out of stock';
+    }
+    if (quantity < 5) {
+      return `Low stock (${quantity} available)`;
+    }
+    return `In stock (${quantity} available)`;
+  }
+
+  function renderPackageProductDetails(item) {
+    const title = document.getElementById('package-product-details-title');
+    const container = document.getElementById('package-product-details-body');
+    if (!container) {
+      return;
+    }
+
+    container.innerHTML = '';
+
+    if (title) {
+      title.textContent = item && item.product_name ? item.product_name : 'Product details';
+    }
+
+    if (!item) {
+      const empty = document.createElement('p');
+      empty.className = 'text-muted';
+      empty.textContent = 'Product details are unavailable.';
+      container.appendChild(empty);
+      return;
+    }
+
+    if (item.product_image_url) {
+      const image = document.createElement('img');
+      image.src = item.product_image_url;
+      image.alt = `${item.product_name || 'Product'} image`;
+      image.className = 'modal__image';
+      container.appendChild(image);
+    }
+
+    container.appendChild(createDetailRow('Package', item.package_name || 'Package'));
+    container.appendChild(createDetailRow('Included quantity', item.quantity ?? 0));
+    container.appendChild(createDetailRow('SKU', item.product_sku || 'Unavailable'));
+
+    if (item.product_vendor_sku) {
+      container.appendChild(createDetailRow('Vendor SKU', item.product_vendor_sku));
+    }
+
+    container.appendChild(createDetailRow('Unit price', formatCurrency(item.product_price)));
+
+    if (item.product_vip_price !== null && item.product_vip_price !== undefined) {
+      container.appendChild(createDetailRow('VIP price', formatCurrency(item.product_vip_price)));
+    }
+
+    container.appendChild(createDetailRow('Availability', describeStock(item.product_stock)));
+
+    if (item.product_description) {
+      const descriptionTitle = document.createElement('h3');
+      descriptionTitle.className = 'modal__subtitle';
+      descriptionTitle.textContent = 'Description';
+      container.appendChild(descriptionTitle);
+
+      item.product_description.split(/\r?\n/).forEach((line) => {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          return;
+        }
+        const paragraph = document.createElement('p');
+        paragraph.textContent = trimmed;
+        container.appendChild(paragraph);
+      });
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const modal = document.getElementById('package-product-details-modal');
+    bindModalDismissal(modal);
+
+    const packages = parseJson('shop-package-items-data');
+    const itemsByKey = new Map();
+
+    packages.forEach((pkg) => {
+      if (!pkg || !pkg.items) {
+        return;
+      }
+      const packageId = pkg.id != null ? String(pkg.id) : '';
+      pkg.items.forEach((item) => {
+        if (!item) {
+          return;
+        }
+        const productId = item.product_id != null ? String(item.product_id) : '';
+        const key = `${packageId}:${productId}`;
+        itemsByKey.set(key, {
+          package_id: pkg.id,
+          package_name: pkg.name,
+          ...item,
+        });
+      });
+    });
+
+    document.querySelectorAll('[data-package-product-details]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const key = button.getAttribute('data-package-product-details');
+        const item = key ? itemsByKey.get(key) : undefined;
+        renderPackageProductDetails(item);
+        openModal(modal);
+      });
+    });
+  });
+})();

--- a/app/templates/shop/packages.html
+++ b/app/templates/shop/packages.html
@@ -69,7 +69,17 @@
                     <summary>Included products</summary>
                     <ul class="list list--bullet package-products">
                       {% for item in package["items"] %}
-                        <li class="package-product">{{ item.product_name }} ({{ item.product_sku }}) × {{ item.quantity }}</li>
+                        <li class="package-product">
+                          <button
+                            type="button"
+                            class="link-button package-product__button"
+                            data-package-product-details="{{ package.id }}:{{ item.product_id }}"
+                          >
+                            <span class="package-product__name">{{ item.product_name }}</span>
+                            <span class="package-product__sku">({{ item.product_sku }})</span>
+                            <span class="package-product__quantity">× {{ item.quantity }}</span>
+                          </button>
+                        </li>
                       {% endfor %}
                     </ul>
                   </details>
@@ -128,4 +138,32 @@
     </div>
   </section>
 </div>
+
+<div
+  class="modal"
+  id="package-product-details-modal"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="package-product-details-title"
+  hidden
+>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close>
+      <span class="visually-hidden">Close product details</span>
+      &times;
+    </button>
+    <div class="modal__body">
+      <h2 class="modal__title" id="package-product-details-title">Product details</h2>
+      <div id="package-product-details-body" class="modal__details"></div>
+    </div>
+  </div>
+</div>
+
+<script type="application/json" id="shop-package-items-data">{{ packages | tojson }}</script>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+  <script src="/static/js/shop_packages.js" defer></script>
 {% endblock %}

--- a/changes/89204ee1-5bd1-4b62-b88d-7a8c74b49a89.json
+++ b/changes/89204ee1-5bd1-4b62-b88d-7a8c74b49a89.json
@@ -1,0 +1,7 @@
+{
+  "guid": "89204ee1-5bd1-4b62-b88d-7a8c74b49a89",
+  "occurred_at": "2025-10-29T15:10Z",
+  "change_type": "Feature",
+  "summary": "Added modal product details to package item list in customer shop view.",
+  "content_hash": "68a49f3ff180342fefecff367aa4402e65a8b42bae6e2f35a43c7d116740da78"
+}


### PR DESCRIPTION
## Summary
- enable modal product details when clicking included items on the shop packages table
- add client script to render package product information from server-provided data
- log the feature addition in the change history

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69022d7d604c832d9a55285a2670c824