### PR TITLE
Remove shop packages navigation entry

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -119,14 +119,6 @@
                 <span class="menu__label">Shop</span>
               </a>
             </li>
-            <li class="menu__item">
-              <a href="/shop/packages" {% if current_path.startswith('/shop/packages') %}aria-current="page"{% endif %}>
-                <span class="menu__icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false"><path d="M3.2 7.6 11.5 12v9.5L3 17a1 1 0 0 1-.5-.86V8.37a1 1 0 0 1 .7-.97Zm17.6 0-8.3 4.4v9.5L21 17a1 1 0 0 0 .5-.86V8.37a1 1 0 0 0-.7-.97ZM12 2l8.7 4.6-8.2 4.34L3 6.6z"/></svg>
-                </span>
-                <span class="menu__label">Packages</span>
-              </a>
-            </li>
           {% endif %}
           {% if can_access_orders %}
             <li class="menu__item">

--- a/changes/8d2f6b60-0f94-4a05-9e49-6ab5a29d8b25.json
+++ b/changes/8d2f6b60-0f94-4a05-9e49-6ab5a29d8b25.json
@@ -1,0 +1,7 @@
+{
+  "guid": "8d2f6b60-0f94-4a05-9e49-6ab5a29d8b25",
+  "occurred_at": "2025-02-14T10:00Z",
+  "change_type": "Fix",
+  "summary": "Removed the /shop/packages navigation link from the primary sidebar to declutter the customer menu.",
+  "content_hash": "ff763acf7a0b99bca8f9d9204a498ea45cd3318d97161fda2fc5fb2651b78488"
+}

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -97,7 +97,6 @@ def test_company_admin_sees_authorised_menu_items(company_admin_context):
     assert response.status_code == 200
     html = response.text
     assert 'href="/shop"' in html
-    assert 'href="/shop/packages"' in html
     assert 'href="/cart"' not in html
     assert 'href="/forms"' in html
     assert 'href="/invoices"' in html


### PR DESCRIPTION
## Summary
- remove the /shop/packages link from the primary sidebar menu
a- update the sidebar menu test and record the change log entry

## Testing
- pytest tests/test_sidebar_menu.py

------
https://chatgpt.com/codex/tasks/task_b_69022e3ecbf4832d9ddff14843a92e96