### PR TITLE
Fix scheduler system update restart handling

### DIFF
--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -223,6 +223,8 @@ class SchedulerService:
             env = os.environ.copy()
             if force_restart:
                 env["FORCE_RESTART"] = "1"
+            else:
+                env["FORCE_RESTART"] = "0"
             process = await asyncio.create_subprocess_exec(
                 str(script_path),
                 stdout=PIPE,

--- a/changes/87e65a8f-f3c6-4599-a6e4-9743207cda91.json
+++ b/changes/87e65a8f-f3c6-4599-a6e4-9743207cda91.json
@@ -1,0 +1,7 @@
+{
+  "guid": "87e65a8f-f3c6-4599-a6e4-9743207cda91",
+  "occurred_at": "2025-10-29T15:13:00Z",
+  "change_type": "Fix",
+  "summary": "Ensure scheduler-run system updates do not force restarts when no repository changes are pulled.",
+  "content_hash": "c048d30b84b39447c200bd4d916aa2d51d31ef3bab32d0de3cabe8a47549e02e"
+}

--- a/tests/test_scheduler_system_update.py
+++ b/tests/test_scheduler_system_update.py
@@ -55,7 +55,7 @@ def test_system_update_sets_force_restart_env(monkeypatch):
     assert output == "ok"
 
 
-def test_system_update_default_env_has_no_force(monkeypatch):
+def test_system_update_default_env_sets_force_restart_false(monkeypatch):
     scheduler = SchedulerService()
     captured: dict[str, dict[str, str] | None] = {}
 
@@ -72,5 +72,5 @@ def test_system_update_default_env_has_no_force(monkeypatch):
     output = asyncio.run(scheduler._run_system_update())
 
     assert captured["env"] is not None
-    assert "FORCE_RESTART" not in captured["env"]
+    assert captured["env"].get("FORCE_RESTART") == "0"
     assert output == "done"


### PR DESCRIPTION
## Summary
- ensure scheduled system updates explicitly set FORCE_RESTART=0 when no restart is requested
- update scheduler tests to cover the non-forced restart flag behaviour
- document the fix in the change log

## Testing
- pytest tests/test_scheduler_system_update.py

------
https://chatgpt.com/codex/tasks/task_b_69022e09b4c8832da0678a949753412c