### PR TITLE
Enable cart quantity editing

### DIFF
--- a/app/repositories/cart.py
+++ b/app/repositories/cart.py
@@ -84,6 +84,21 @@ async def upsert_item(
     )
 
 
+async def update_item_quantity(
+    session_id: int,
+    product_id: int,
+    quantity: int,
+) -> None:
+    await db.execute(
+        """
+        UPDATE shop_cart_items
+        SET quantity = %s
+        WHERE session_id = %s AND product_id = %s
+        """,
+        (quantity, session_id, product_id),
+    )
+
+
 async def list_items(session_id: int) -> list[dict[str, Any]]:
     rows = await db.fetch_all(
         """

--- a/app/templates/shop/cart.html
+++ b/app/templates/shop/cart.html
@@ -24,12 +24,20 @@
     {% endif %}
   </header>
 
+  {% if cart_error %}
+    <div class="alert alert--error" role="alert">{{ cart_error }}</div>
+  {% endif %}
+
+  {% if cart_message %}
+    <div class="alert alert--success" role="alert">{{ cart_message }}</div>
+  {% endif %}
+
   {% if order_message %}
     <div class="alert alert--info" role="alert">{{ order_message }}</div>
   {% endif %}
 
   {% if cart_items %}
-    <form action="{{ request.url_for('cart_remove_items') }}" method="post" class="cart-remove-form">
+    <form action="{{ request.url_for('cart_update_items') }}" method="post" class="cart-items-form">
       {% include "partials/csrf.html" %}
       <div class="table-wrapper">
         <table class="table" id="cart-table" data-table>
@@ -72,7 +80,19 @@
                 </td>
                 <td data-label="SKU">{{ item.product_sku }}</td>
                 <td data-label="Unit price" data-value="{{ item.unit_price }}">${{ '%.2f'|format(item.unit_price) }}</td>
-                <td data-label="Quantity" data-value="{{ item.quantity }}">{{ item.quantity }}</td>
+                <td data-label="Quantity" data-value="{{ item.quantity }}">
+                  <input
+                    class="form-input form-input--sm"
+                    type="number"
+                    min="0"
+                    max="9999"
+                    step="1"
+                    name="quantity_{{ item.product_id }}"
+                    value="{{ item.quantity }}"
+                    aria-label="Quantity for {{ item.product_name }}"
+                    required
+                  />
+                </td>
                 <td data-label="Line total" data-value="{{ item.line_total }}">${{ '%.2f'|format(item.line_total) }}</td>
               </tr>
             {% endfor %}
@@ -80,7 +100,14 @@
         </table>
       </div>
       <div class="form-actions form-actions--inline">
-        <button type="submit" class="button button--ghost">Remove selected</button>
+        <button type="submit" class="button">Update quantities</button>
+        <button
+          type="submit"
+          class="button button--ghost"
+          formaction="{{ request.url_for('cart_remove_items') }}"
+        >
+          Remove selected
+        </button>
       </div>
     </form>
 

--- a/changes/52377de1-402f-4853-935e-75b81e3383fa.json
+++ b/changes/52377de1-402f-4853-935e-75b81e3383fa.json
@@ -1,0 +1,7 @@
+{
+  "guid": "52377de1-402f-4853-935e-75b81e3383fa",
+  "occurred_at": "2025-10-29T15:15Z",
+  "change_type": "Feature",
+  "summary": "Enabled cart quantity editing with stock-aware validation.",
+  "content_hash": "a96f6b735b5ccad20ebb1d37af6a771492efb785c7b923e9683079b6b19fc25c"
+}

--- a/tests/test_cart_update.py
+++ b/tests/test_cart_update.py
@@ -1,0 +1,233 @@
+from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main as main_module
+from app.core.database import db
+from app.main import app, scheduler_service
+from app.security.session import SessionData
+
+
+@pytest.fixture(autouse=True)
+def mock_startup(monkeypatch):
+    async def fake_connect():
+        return None
+
+    async def fake_disconnect():
+        return None
+
+    async def fake_run_migrations():
+        return None
+
+    async def fake_start():
+        return None
+
+    async def fake_stop():
+        return None
+
+    async def fake_change_log_sync():
+        return None
+
+    async def fake_ensure_modules():
+        return None
+
+    async def fake_refresh_automations():
+        return None
+
+    monkeypatch.setattr(db, "connect", fake_connect)
+    monkeypatch.setattr(db, "disconnect", fake_disconnect)
+    monkeypatch.setattr(db, "run_migrations", fake_run_migrations)
+    monkeypatch.setattr(
+        main_module.change_log_service,
+        "sync_change_log_sources",
+        fake_change_log_sync,
+    )
+    monkeypatch.setattr(
+        main_module.modules_service,
+        "ensure_default_modules",
+        fake_ensure_modules,
+    )
+    monkeypatch.setattr(
+        main_module.automations_service,
+        "refresh_all_schedules",
+        fake_refresh_automations,
+    )
+    monkeypatch.setattr(scheduler_service, "start", fake_start)
+    monkeypatch.setattr(scheduler_service, "stop", fake_stop)
+
+
+@pytest.fixture
+def active_session(monkeypatch):
+    now = datetime.now(timezone.utc)
+    session = SessionData(
+        id=1,
+        user_id=10,
+        session_token="session-token",
+        csrf_token="csrf-token",
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+        last_seen_at=now,
+        ip_address="127.0.0.1",
+        user_agent="pytest",
+        active_company_id=1,
+        pending_totp_secret=None,
+    )
+
+    async def fake_load_session(request, allow_inactive=False):
+        request.state.session = session
+        request.state.active_company_id = session.active_company_id
+        return session
+
+    monkeypatch.setattr(main_module.session_manager, "load_session", fake_load_session)
+    return session
+
+
+@pytest.fixture
+def cart_context(monkeypatch, active_session):
+    async def fake_load_context(request, *, permission_field):
+        return (
+            {"id": active_session.user_id, "email": "user@example.com"},
+            {"company_id": 1, "can_access_cart": True},
+            {"id": 1, "name": "Example"},
+            1,
+            None,
+        )
+
+    monkeypatch.setattr(
+        main_module,
+        "_load_company_section_context",
+        fake_load_context,
+    )
+
+
+def test_update_cart_quantities_success(monkeypatch, active_session, cart_context):
+    recorded_updates: list[tuple[int, int, int]] = []
+    recorded_removals: list[tuple[int, set[int]]] = []
+
+    async def fake_get_item(session_id, product_id):
+        return {"product_id": product_id, "quantity": 1, "product_name": "Widget"}
+
+    async def fake_update_item_quantity(session_id, product_id, quantity):
+        recorded_updates.append((session_id, product_id, quantity))
+
+    async def fake_remove_items(session_id, product_ids):
+        recorded_removals.append((session_id, set(product_ids)))
+
+    async def fake_get_product_by_id(product_id, company_id=None):
+        return {"id": product_id, "stock": 12}
+
+    monkeypatch.setattr(main_module.cart_repo, "get_item", fake_get_item)
+    monkeypatch.setattr(
+        main_module.cart_repo,
+        "update_item_quantity",
+        fake_update_item_quantity,
+    )
+    monkeypatch.setattr(main_module.cart_repo, "remove_items", fake_remove_items)
+    monkeypatch.setattr(
+        main_module.shop_repo,
+        "get_product_by_id",
+        fake_get_product_by_id,
+    )
+
+    with TestClient(app, follow_redirects=False) as client:
+        response = client.post(
+            "/cart/update",
+            data={"quantity_5": "3", "_csrf": active_session.csrf_token},
+        )
+
+    assert response.status_code == 303
+    location = response.headers.get("location")
+    assert location is not None
+    params = parse_qs(urlparse(location).query)
+    assert params.get("cartMessage") == ["Quantities updated."]
+    assert recorded_updates == [(active_session.id, 5, 3)]
+    assert recorded_removals == []
+
+
+def test_update_cart_zero_quantity_removes_item(monkeypatch, active_session, cart_context):
+    recorded_removals: list[tuple[int, set[int]]] = []
+
+    async def fake_remove_items(session_id, product_ids):
+        recorded_removals.append((session_id, set(product_ids)))
+
+    monkeypatch.setattr(main_module.cart_repo, "remove_items", fake_remove_items)
+    async def fake_get_item(session_id, product_id):
+        return {"product_id": product_id, "quantity": 2}
+
+    async def fake_get_product_by_id(product_id, company_id=None):
+        return {"id": product_id, "stock": 5}
+
+    async def fake_update_item_quantity(session_id, product_id, quantity):
+        return None
+
+    monkeypatch.setattr(main_module.cart_repo, "get_item", fake_get_item)
+    monkeypatch.setattr(
+        main_module.shop_repo,
+        "get_product_by_id",
+        fake_get_product_by_id,
+    )
+    monkeypatch.setattr(
+        main_module.cart_repo,
+        "update_item_quantity",
+        fake_update_item_quantity,
+    )
+
+    with TestClient(app, follow_redirects=False) as client:
+        response = client.post(
+            "/cart/update",
+            data={"quantity_7": "0", "_csrf": active_session.csrf_token},
+        )
+
+    assert response.status_code == 303
+    location = response.headers.get("location")
+    params = parse_qs(urlparse(location).query)
+    assert params.get("cartMessage") == ["Items removed."]
+    assert recorded_removals == [(active_session.id, {7})]
+
+
+def test_update_cart_exceeds_stock(monkeypatch, active_session, cart_context):
+    recorded_updates: list[tuple[int, int, int]] = []
+    recorded_removals: list[tuple[int, set[int]]] = []
+
+    async def fake_get_item(session_id, product_id):
+        return {"product_id": product_id, "quantity": 1, "product_name": "Widget"}
+
+    async def fake_update_item_quantity(session_id, product_id, quantity):
+        recorded_updates.append((session_id, product_id, quantity))
+
+    async def fake_remove_items(session_id, product_ids):
+        recorded_removals.append((session_id, set(product_ids)))
+
+    async def fake_get_product_by_id(product_id, company_id=None):
+        return {"id": product_id, "stock": 2}
+
+    monkeypatch.setattr(main_module.cart_repo, "get_item", fake_get_item)
+    monkeypatch.setattr(
+        main_module.cart_repo,
+        "update_item_quantity",
+        fake_update_item_quantity,
+    )
+    monkeypatch.setattr(main_module.cart_repo, "remove_items", fake_remove_items)
+    monkeypatch.setattr(
+        main_module.shop_repo,
+        "get_product_by_id",
+        fake_get_product_by_id,
+    )
+
+    with TestClient(app, follow_redirects=False) as client:
+        response = client.post(
+            "/cart/update",
+            data={"quantity_9": "5", "_csrf": active_session.csrf_token},
+        )
+
+    assert response.status_code == 303
+    location = response.headers.get("location")
+    params = parse_qs(urlparse(location).query)
+    assert params.get("cartError") == [
+        "Unable to increase some quantities due to limited stock."
+    ]
+    assert "cartMessage" not in params
+    assert recorded_updates == []
+    assert recorded_removals == []


### PR DESCRIPTION
## Summary
- add quantity inputs to the cart page and display success or error alerts for cart updates
- introduce a backend endpoint and repository helper to validate and persist cart quantity changes safely
- cover cart quantity updates with API-level tests and record the feature in the change log

## Testing
- pytest tests/test_cart_update.py

------
https://chatgpt.com/codex/tasks/task_b_69022dcd2ae0832d92fa0a23bc3fbb0b