### PR TITLE
Fix shop package modal data serialization

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2953,9 +2953,12 @@ async def shop_packages_page(
         is_vip=is_vip,
     )
 
+    packages_json = cast(list[dict[str, Any]], _serialise_for_json(packages))
+
     extra = {
         "title": "Shop packages",
         "packages": packages,
+        "packages_json": packages_json,
         "cart_error": cart_error,
     }
     return await _render_template("shop/packages.html", request, user, extra=extra)

--- a/app/templates/shop/packages.html
+++ b/app/templates/shop/packages.html
@@ -159,7 +159,7 @@
   </div>
 </div>
 
-<script type="application/json" id="shop-package-items-data">{{ packages | tojson }}</script>
+<script type="application/json" id="shop-package-items-data">{{ packages_json | tojson }}</script>
 {% endblock %}
 
 {% block scripts %}

--- a/changes/d8ecea80-d977-4e0f-b67c-687eea490b03.json
+++ b/changes/d8ecea80-d977-4e0f-b67c-687eea490b03.json
@@ -1,0 +1,7 @@
+{
+  "guid": "d8ecea80-d977-4e0f-b67c-687eea490b03",
+  "occurred_at": "2025-10-29T15:21Z",
+  "change_type": "Fix",
+  "summary": "Fixed shop package product modal by serializing package items for the popup.",
+  "content_hash": "60deb23a7bf19aa020c184a6606948469a574c8854b3b831e844db8d9ef9fde0"
+}


### PR DESCRIPTION
## Summary
- provide JSON-safe package data to the shop packages template so the product modal can load
- add a change log entry documenting the modal fix

## Testing
- pytest tests/test_shop_packages_service.py

------
https://chatgpt.com/codex/tasks/task_b_69022fe223cc832d88797c7600426c85