### PR TITLE
Collapse Roles administration menu guidance panel

### DIFF
--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -105,14 +105,16 @@
     </form>
   </section>
 
-  <section class="card card--panel">
-    <header class="card__header">
+  <details class="card card--panel card-collapsible" data-roles-admin-menu>
+    <summary class="card__header card__header--collapsible">
       <div>
         <h2 class="card__title">Roles administration menu</h2>
         <p class="card__subtitle">Understand how the administration menu supports secure, least-privilege access control.</p>
       </div>
-    </header>
-    <div class="card__body card__body--stacked">
+      <span class="card__toggle-icon" aria-hidden="true"></span>
+    </summary>
+    <div class="card-collapsible__content">
+      <div class="card__body card__body--stacked">
       <p>
         The Roles administration menu is the central hub for defining reusable permission sets that can be applied to any
         company membership. Super administrators can review every existing role in the table above, inspect its granted
@@ -164,8 +166,9 @@
         </div>
       </dl>
       <p class="text-muted">New permissions will be documented here as they become available.</p>
+      </div>
     </div>
-  </section>
+  </details>
 </div>
 {% endblock %}
 

--- a/changes/b978e494-e6cb-49e3-bbf6-6a418e8c8ad9.json
+++ b/changes/b978e494-e6cb-49e3-bbf6-6a418e8c8ad9.json
@@ -1,0 +1,7 @@
+{
+  "guid": "b978e494-e6cb-49e3-bbf6-6a418e8c8ad9",
+  "occurred_at": "2025-10-30T12:11:34Z",
+  "change_type": "Fix",
+  "summary": "Collapsed the Roles administration guidance panel by default for quicker page scanning.",
+  "content_hash": "12442e18da39cbf38f6aa5fbafc4f4d50e3783f85cc458e4ccf949f904724f56"
+}


### PR DESCRIPTION
## Summary
- collapse the Roles administration menu guidance content into a default-collapsed panel for quicker scanning
- record the update in the change log registry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690355babfe8832d9168ab5ceaebaee6