### PR TITLE
Auto paginate the staff roster table

### DIFF
--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -155,6 +155,26 @@
         </tbody>
       </table>
     </div>
+    <div class="table-pagination" data-pagination="staff-table">
+      <div class="table-pagination__group">
+        <button
+          type="button"
+          class="button button--ghost table-pagination__button"
+          data-page-prev
+          disabled
+        >
+          Previous
+        </button>
+        <button
+          type="button"
+          class="button button--ghost table-pagination__button"
+          data-page-next
+        >
+          Next
+        </button>
+      </div>
+      <p class="table-pagination__status" data-page-info aria-live="polite"></p>
+    </div>
   </section>
 </div>
 

--- a/changes/054e0114-900f-4702-9eeb-c69755de1af1.json
+++ b/changes/054e0114-900f-4702-9eeb-c69755de1af1.json
@@ -1,0 +1,7 @@
+{
+  "guid": "054e0114-900f-4702-9eeb-c69755de1af1",
+  "occurred_at": "2025-10-30T12:13:43Z",
+  "change_type": "Feature",
+  "summary": "Auto paginated the Current staff table to size rows dynamically based on the viewport height",
+  "content_hash": "db110fce1061339f15daaf6569c60ff00bff087bd2acf713ca579f0cb51a99c4"
+}


### PR DESCRIPTION
## Summary
- add pagination controls to the Current staff table so viewport-aware paging activates
- log the UI enhancement in the change log archive

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690355eef1b8832d805af4fa1e303052