### PR TITLE
Show staff entries in assign access dropdown

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1205,14 +1205,27 @@
         if (!entry || typeof entry !== 'object') {
           return;
         }
-        const { id, email } = entry;
-        if (id === undefined || email === undefined) {
+        const value = entry.value ?? entry.id;
+        const label = entry.label ?? entry.email;
+        if (value === undefined || label === undefined) {
           return;
         }
         const option = document.createElement('option');
-        option.value = String(id);
-        option.textContent = String(email);
-        if (desiredSelection && String(id) === String(desiredSelection)) {
+        option.value = String(value);
+        option.textContent = String(label);
+        if (entry.user_id !== undefined && entry.user_id !== null) {
+          option.dataset.userId = String(entry.user_id);
+        }
+        if (entry.staff_id !== undefined && entry.staff_id !== null) {
+          option.dataset.staffId = String(entry.staff_id);
+        }
+        if (entry.has_user !== undefined) {
+          option.dataset.hasUser = entry.has_user ? '1' : '0';
+          if (!entry.has_user) {
+            option.dataset.requiresInvite = '1';
+          }
+        }
+        if (desiredSelection && String(value) === String(desiredSelection)) {
           option.selected = true;
           hasSelection = true;
         }
@@ -1233,6 +1246,19 @@
     companySelect.addEventListener('change', () => {
       const selectedCompanyId = companySelect.value;
       populateUsers(selectedCompanyId, undefined);
+    });
+
+    userSelect.addEventListener('change', () => {
+      const selectedOption = userSelect.selectedOptions[0];
+      if (!selectedOption) {
+        return;
+      }
+      if (selectedOption.dataset.requiresInvite === '1') {
+        const staffName = selectedOption.textContent || 'This staff member';
+        alert(
+          `${staffName} does not have a portal account yet. Invite them from the staff page before assigning access.`,
+        );
+      }
     });
   }
 

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -103,7 +103,7 @@
           autocomplete="off"
           data-company-assign-form
           data-initial-company-id="{{ assign_form.company_id }}"
-          data-initial-user-id="{{ assign_form.user_id or '' }}"
+          data-initial-user-id="{{ assign_form.user_value or '' }}"
         >
           {% include "partials/csrf.html" %}
           <input type="hidden" name="sourceCompanyId" value="{{ company.id }}" />
@@ -113,14 +113,20 @@
               <option
                 value=""
                 disabled
-                {% if not assign_form.user_id %}selected{% endif %}
+                {% if not assign_form.user_value %}selected{% endif %}
                 data-placeholder
               >
                 Select a user
               </option>
               {% for option in assign_user_options %}
-                <option value="{{ option.id }}" {% if option.id == assign_form.user_id %}selected{% endif %}>
-                  {{ option.email }}
+                <option
+                  value="{{ option.value }}"
+                  {% if option.value == assign_form.user_value %}selected{% endif %}
+                  {% if option.staff_id is not none %}data-staff-id="{{ option.staff_id }}"{% endif %}
+                  {% if option.user_id is not none %}data-user-id="{{ option.user_id }}"{% endif %}
+                  data-has-user="{% if option.has_user %}1{% else %}0{% endif %}"
+                >
+                  {{ option.label }}
                 </option>
               {% endfor %}
             </select>

--- a/changes/4a9e8111-33b1-419c-a15e-55720d6408af.json
+++ b/changes/4a9e8111-33b1-419c-a15e-55720d6408af.json
@@ -1,0 +1,7 @@
+{
+  "guid": "4a9e8111-33b1-419c-a15e-55720d6408af",
+  "occurred_at": "2025-10-30T12:28Z",
+  "change_type": "Fix",
+  "summary": "Show company staff in the assign staff access dropdown and guide admins to invite missing portal users.",
+  "content_hash": "03b5d04bdd055381e71c6749ec7247246690845cb0204c00d34e6d9d91315dec"
+}


### PR DESCRIPTION
## Summary
- populate the assign staff access user dropdown with staff directory entries, including indicators for inactive or invite-required records
- validate staff selections on the server by resolving or rejecting staff identifiers and reuse the data from the staff repository
- update the automated test coverage and add a changelog entry documenting the fix

## Testing
- pytest tests/test_company_memberships.py

------
https://chatgpt.com/codex/tasks/task_b_69035869a730832d883fce88eacc4a28