### PR TITLE
Swap assign staff access dropdown order

### DIFF
--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -108,6 +108,22 @@
           {% include "partials/csrf.html" %}
           <input type="hidden" name="sourceCompanyId" value="{{ company.id }}" />
           <div class="form-field">
+            <label class="form-label" for="assign-company">Company</label>
+            <select
+              id="assign-company"
+              name="companyId"
+              class="form-input"
+              required
+              data-company-select
+            >
+              {% for managed in managed_companies %}
+                <option value="{{ managed.id }}" {% if managed.id == assign_form.company_id %}selected{% endif %}>
+                  {{ managed.name }}
+                </option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="form-field">
             <label class="form-label" for="assign-user">User</label>
             <select id="assign-user" name="userId" class="form-input" required data-user-select>
               <option
@@ -127,22 +143,6 @@
                   data-has-user="{% if option.has_user %}1{% else %}0{% endif %}"
                 >
                   {{ option.label }}
-                </option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="assign-company">Company</label>
-            <select
-              id="assign-company"
-              name="companyId"
-              class="form-input"
-              required
-              data-company-select
-            >
-              {% for managed in managed_companies %}
-                <option value="{{ managed.id }}" {% if managed.id == assign_form.company_id %}selected{% endif %}>
-                  {{ managed.name }}
                 </option>
               {% endfor %}
             </select>

--- a/changes/ad98e4a2-1315-4467-b79c-3d80585abbf5.json
+++ b/changes/ad98e4a2-1315-4467-b79c-3d80585abbf5.json
@@ -1,0 +1,7 @@
+{
+  "guid": "ad98e4a2-1315-4467-b79c-3d80585abbf5",
+  "occurred_at": "2025-10-30T12:37Z",
+  "change_type": "Fix",
+  "summary": "Reordered Assign staff access dropdowns so company selection precedes user selection.",
+  "content_hash": "d1c8a3fdc8e3b587767ea9c467de7f4ddb2fbbc56934767364e16d1ad79aa329"
+}


### PR DESCRIPTION
## Summary
- move the company selector ahead of the user dropdown on the Assign staff access form for consistency with expectations
- record the adjustment in the change log directory for database import

## Testing
- pytest tests/test_admin_change_log_page.py -q

------
https://chatgpt.com/codex/tasks/task_b_69035bc74ea4832d9a90240a42a9a172