### PR TITLE
Add ticket status editor and validation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6843,12 +6843,29 @@ async def _render_tickets_dashboard(
     dashboard_endpoint = "/api/tickets/dashboard"
     if query_params:
         dashboard_endpoint = f"{dashboard_endpoint}?{urlencode(query_params)}"
+    status_definitions_payload = [
+        {
+            "tech_status": definition.tech_status,
+            "tech_label": definition.tech_label,
+            "public_status": definition.public_status,
+        }
+        for definition in dashboard.status_definitions
+    ]
+    status_label_map = {
+        definition.tech_status: definition.tech_label for definition in dashboard.status_definitions
+    }
+    public_status_map = {
+        definition.tech_status: definition.public_status for definition in dashboard.status_definitions
+    }
     extra = {
         "title": "Ticketing workspace",
         "tickets": dashboard.tickets,
         "ticket_total": dashboard.total,
         "ticket_status_counts": dashboard.status_counts,
         "ticket_available_statuses": dashboard.available_statuses,
+        "ticket_status_definitions": status_definitions_payload,
+        "ticket_status_label_map": status_label_map,
+        "ticket_public_status_map": public_status_map,
         "ticket_filters": {"status": status_filter, "module": module_filter},
         "ticket_modules": dashboard.modules,
         "ticket_company_options": dashboard.companies,
@@ -6997,9 +7014,13 @@ async def _render_ticket_detail(
         watcher_user = user_lookup.get(watcher.get("user_id"))
         enriched_watchers.append({**watcher, "user": watcher_user})
 
-    available_statuses = sorted(
-        {"open", "in_progress", "pending", "resolved", "closed", ticket.get("status") or "open"}
-    )
+    status_definitions = await tickets_service.list_status_definitions()
+    status_label_map = {definition.tech_status: definition.tech_label for definition in status_definitions}
+    public_status_map = {definition.tech_status: definition.public_status for definition in status_definitions}
+    available_statuses = [definition.tech_status for definition in status_definitions]
+    ticket_status_slug = ticket.get("status") or "open"
+    if ticket_status_slug not in available_statuses:
+        available_statuses.append(ticket_status_slug)
 
     companies = await company_repo.list_companies()
     technician_users = await membership_repo.list_users_with_permission(
@@ -7056,6 +7077,16 @@ async def _render_ticket_detail(
         "ticket_billable_minutes": total_billable_minutes,
         "ticket_non_billable_minutes": total_non_billable_minutes,
         "ticket_available_statuses": available_statuses,
+        "ticket_status_definitions": [
+            {
+                "tech_status": definition.tech_status,
+                "tech_label": definition.tech_label,
+                "public_status": definition.public_status,
+            }
+            for definition in status_definitions
+        ],
+        "ticket_status_label_map": status_label_map,
+        "ticket_public_status_map": public_status_map,
         "ticket_company_options": companies,
         "ticket_user_options": technician_users,
         "ticket_requester_options": requester_options,
@@ -7137,7 +7168,7 @@ async def admin_create_ticket(request: Request):
     description = (str(form.get("description", "")).strip() or None)
     priority = (str(form.get("priority", "")).strip() or "normal")
     module_slug = (str(form.get("moduleSlug", "")).strip() or None)
-    status_value = (str(form.get("status", "")).strip() or "open")
+    status_raw = str(form.get("status", "")).strip()
     company_raw = form.get("companyId")
     assigned_raw = form.get("assignedUserId")
     try:
@@ -7156,6 +7187,10 @@ async def admin_create_ticket(request: Request):
             status_code=status.HTTP_400_BAD_REQUEST,
         )
     try:
+        if status_raw:
+            status_value = await tickets_service.validate_status_choice(status_raw)
+        else:
+            status_value = await tickets_service.resolve_status_or_default(None)
         created = await tickets_service.create_ticket(
             subject=subject,
             description=description,
@@ -7174,11 +7209,18 @@ async def admin_create_ticket(request: Request):
         await tickets_service.refresh_ticket_ai_tags(created["id"])
     except Exception as exc:  # pragma: no cover - defensive logging
         log_error("Failed to create ticket", error=str(exc))
+        if isinstance(exc, ValueError):
+            error_detail = str(exc)
+            status_code_value = status.HTTP_400_BAD_REQUEST
+        else:
+            log_error("Failed to create ticket", error=str(exc))
+            error_detail = "Unable to create ticket. Please try again."
+            status_code_value = status.HTTP_500_INTERNAL_SERVER_ERROR
         return await _render_tickets_dashboard(
             request,
             current_user,
-            error_message="Unable to create ticket. Please try again.",
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            error_message=error_detail,
+            status_code=status_code_value,
         )
     return RedirectResponse(
         url="/admin/tickets?success=" + quote("Ticket created."),
@@ -7192,22 +7234,25 @@ async def admin_update_ticket_status(ticket_id: int, request: Request):
     if redirect:
         return redirect
     form = await request.form()
-    status_value = str(form.get("status", "")).strip()
+    status_raw = str(form.get("status", "")).strip()
     return_url_raw = form.get("returnUrl")
     return_url = str(return_url_raw).strip() if isinstance(return_url_raw, str) else None
-    if not status_value:
+    try:
+        status_value = await tickets_service.validate_status_choice(status_raw)
+    except ValueError as exc:
+        error_message = str(exc)
         if return_url and return_url.startswith(f"/admin/tickets/{ticket_id}"):
             return await _render_ticket_detail(
                 request,
                 current_user,
                 ticket_id=ticket_id,
-                error_message="Select a status to apply.",
+                error_message=error_message,
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
         return await _render_tickets_dashboard(
             request,
             current_user,
-            error_message="Select a status to apply.",
+            error_message=error_message,
             status_code=status.HTTP_400_BAD_REQUEST,
         )
     ticket = await tickets_repo.get_ticket(ticket_id)
@@ -7228,6 +7273,49 @@ async def admin_update_ticket_status(ticket_id: int, request: Request):
         separator = "&" if "?" in return_url else "?"
         destination = f"{return_url}{separator}success={message}"
     return RedirectResponse(url=destination, status_code=status.HTTP_303_SEE_OTHER)
+
+
+@app.post("/admin/tickets/statuses", response_class=HTMLResponse)
+async def admin_replace_ticket_statuses(request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    form = await request.form()
+    tech_labels = form.getlist("techLabel")
+    public_labels = form.getlist("publicLabel")
+    existing_slugs = form.getlist("existingSlug")
+
+    statuses: list[dict[str, Any]] = []
+    max_length = max(len(tech_labels), len(public_labels), len(existing_slugs))
+    for index in range(max_length):
+        tech_label = tech_labels[index] if index < len(tech_labels) else ""
+        public_status = public_labels[index] if index < len(public_labels) else ""
+        existing_slug = existing_slugs[index] if index < len(existing_slugs) else None
+        if not tech_label and not public_status:
+            continue
+        statuses.append(
+            {
+                "techLabel": tech_label,
+                "publicStatus": public_status,
+                "existingSlug": existing_slug,
+            }
+        )
+
+    try:
+        await tickets_service.replace_ticket_statuses(statuses)
+    except ValueError as exc:
+        return await _render_tickets_dashboard(
+            request,
+            current_user,
+            error_message=str(exc),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    return RedirectResponse(
+        url="/admin/tickets?success=" + quote("Ticket statuses updated."),
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
 
 
 @app.post("/admin/tickets/{ticket_id}/description", response_class=HTMLResponse)
@@ -7347,7 +7435,7 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
     def _clean_text(value: Any) -> str:
         return str(value).strip() if isinstance(value, str) else ""
 
-    status_value = _clean_text(form.get("status")).lower()
+    status_raw = _clean_text(form.get("status"))
     priority_value = _clean_text(form.get("priority")).lower()
     requester_raw = form.get("requesterId")
     assigned_raw = form.get("assignedUserId")
@@ -7357,15 +7445,19 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
     return_url_raw = form.get("returnUrl")
     return_url = _clean_text(return_url_raw)
 
-    allowed_statuses = {"open", "in_progress", "pending", "resolved", "closed", (ticket.get("status") or "open").lower()}
-    if status_value not in allowed_statuses:
-        return await _render_ticket_detail(
-            request,
-            current_user,
-            ticket_id=ticket_id,
-            error_message="Select a valid status.",
-            status_code=status.HTTP_400_BAD_REQUEST,
-        )
+    if status_raw:
+        try:
+            status_value = await tickets_service.validate_status_choice(status_raw)
+        except ValueError as exc:
+            return await _render_ticket_detail(
+                request,
+                current_user,
+                ticket_id=ticket_id,
+                error_message=str(exc),
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+    else:
+        status_value = ticket.get("status") or await tickets_service.resolve_status_or_default(None)
 
     default_priorities = {"urgent", "high", "normal", "low"}
     ticket_priority = (ticket.get("priority") or "normal").lower()

--- a/app/repositories/ticket_statuses.py
+++ b/app/repositories/ticket_statuses.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Sequence
+
+import aiomysql
+
+from app.core.database import db
+
+DEFAULT_STATUS_DEFINITIONS: list[dict[str, str]] = [
+    {"tech_status": "open", "tech_label": "Open", "public_status": "Open"},
+    {"tech_status": "in_progress", "tech_label": "In progress", "public_status": "In progress"},
+    {"tech_status": "pending", "tech_label": "Pending", "public_status": "Pending"},
+    {"tech_status": "resolved", "tech_label": "Resolved", "public_status": "Resolved"},
+    {"tech_status": "closed", "tech_label": "Closed", "public_status": "Closed"},
+]
+
+_SLUG_PATTERN = re.compile(r"[^a-z0-9]+")
+
+
+def slugify_status_label(value: str) -> str:
+    """Convert a status label into a canonical slug value."""
+
+    if not isinstance(value, str):
+        return ""
+    normalised = value.strip().lower()
+    if not normalised:
+        return ""
+    slug = _SLUG_PATTERN.sub("_", normalised)
+    slug = re.sub(r"_+", "_", slug).strip("_")
+    return slug
+
+
+def _normalise_row(row: dict[str, Any]) -> dict[str, str]:
+    slug = str(row.get("tech_status") or "").strip().lower()
+    label = str(row.get("tech_label") or "").strip()
+    public = str(row.get("public_status") or "").strip()
+    return {
+        "tech_status": slug,
+        "tech_label": label or slug.replace("_", " ").title(),
+        "public_status": public or label or slug.replace("_", " ").title(),
+    }
+
+
+async def list_statuses() -> list[dict[str, str]]:
+    rows = await db.fetch_all(
+        "SELECT tech_status, tech_label, public_status FROM ticket_statuses ORDER BY tech_label ASC"
+    )
+    return [_normalise_row(row) for row in rows]
+
+
+async def ensure_default_statuses() -> list[dict[str, str]]:
+    existing = await list_statuses()
+    if existing:
+        return existing
+    async with db.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await conn.begin()
+            try:
+                for definition in DEFAULT_STATUS_DEFINITIONS:
+                    await cursor.execute(
+                        """
+                        INSERT INTO ticket_statuses (tech_status, tech_label, public_status, created_at, updated_at)
+                        VALUES (%s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
+                        ON DUPLICATE KEY UPDATE
+                            tech_label = VALUES(tech_label),
+                            public_status = VALUES(public_status),
+                            updated_at = UTC_TIMESTAMP(6)
+                        """,
+                        (
+                            definition["tech_status"],
+                            definition["tech_label"],
+                            definition["public_status"],
+                        ),
+                    )
+                await conn.commit()
+            except Exception:
+                await conn.rollback()
+                raise
+    return await list_statuses()
+
+
+async def status_exists(slug: str) -> bool:
+    if not slug:
+        return False
+    row = await db.fetch_one(
+        "SELECT 1 FROM ticket_statuses WHERE tech_status = %s",
+        (slug,),
+    )
+    return bool(row)
+
+
+async def replace_statuses(definitions: Sequence[dict[str, Any]]) -> list[dict[str, str]]:
+    if not definitions:
+        return await list_statuses()
+
+    async with db.acquire() as conn:
+        async with conn.cursor(aiomysql.DictCursor) as cursor:
+            await conn.begin()
+            try:
+                await cursor.execute("SELECT tech_status FROM ticket_statuses")
+                current_rows = await cursor.fetchall()
+                current_slugs = {str(row["tech_status"]).strip().lower() for row in current_rows}
+
+                encountered: set[str] = set()
+
+                for definition in definitions:
+                    slug = str(definition.get("tech_status") or "").strip().lower()
+                    label = str(definition.get("tech_label") or "").strip()
+                    public_status = str(definition.get("public_status") or "").strip() or label
+                    original_slug = str(definition.get("original_slug") or "").strip().lower() or slug
+
+                    if original_slug and original_slug in current_slugs:
+                        if slug == original_slug:
+                            await cursor.execute(
+                                """
+                                UPDATE ticket_statuses
+                                SET tech_label = %s,
+                                    public_status = %s,
+                                    updated_at = UTC_TIMESTAMP(6)
+                                WHERE tech_status = %s
+                                """,
+                                (label, public_status, original_slug),
+                            )
+                        else:
+                            if slug in current_slugs and slug != original_slug:
+                                raise ValueError("Tech status values must be unique.")
+                            if slug in encountered:
+                                raise ValueError("Tech status values must be unique.")
+                            await cursor.execute(
+                                """
+                                UPDATE ticket_statuses
+                                SET tech_status = %s,
+                                    tech_label = %s,
+                                    public_status = %s,
+                                    updated_at = UTC_TIMESTAMP(6)
+                                WHERE tech_status = %s
+                                """,
+                                (slug, label, public_status, original_slug),
+                            )
+                            await cursor.execute(
+                                "UPDATE tickets SET status = %s WHERE status = %s",
+                                (slug, original_slug),
+                            )
+                            current_slugs.discard(original_slug)
+                            current_slugs.add(slug)
+                    else:
+                        if slug in current_slugs or slug in encountered:
+                            raise ValueError("Tech status values must be unique.")
+                        await cursor.execute(
+                            """
+                            INSERT INTO ticket_statuses (tech_status, tech_label, public_status, created_at, updated_at)
+                            VALUES (%s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
+                            """,
+                            (slug, label, public_status),
+                        )
+                        current_slugs.add(slug)
+
+                    encountered.add(slug)
+
+                slugs_to_remove = current_slugs - encountered
+                if slugs_to_remove:
+                    placeholders = ", ".join(["%s"] * len(slugs_to_remove))
+                    await cursor.execute(
+                        f"SELECT status, COUNT(*) AS usage_count FROM tickets WHERE status IN ({placeholders}) GROUP BY status",
+                        tuple(slugs_to_remove),
+                    )
+                    usage_rows = await cursor.fetchall()
+                    in_use: dict[str, int] = {}
+                    for row in usage_rows:
+                        status_value = str(row.get("status") or "").strip().lower()
+                        try:
+                            count = int(row.get("usage_count") or 0)
+                        except (TypeError, ValueError):
+                            count = 0
+                        if count:
+                            in_use[status_value] = count
+                    if in_use:
+                        raise ValueError(
+                            "Cannot remove ticket statuses that are still assigned to tickets: "
+                            + ", ".join(sorted(in_use.keys()))
+                        )
+                    await cursor.execute(
+                        f"DELETE FROM ticket_statuses WHERE tech_status IN ({placeholders})",
+                        tuple(slugs_to_remove),
+                    )
+
+                await conn.commit()
+            except Exception:
+                await conn.rollback()
+                raise
+
+    return await list_statuses()
+
+
+async def get_status_definition(slug: str) -> dict[str, str] | None:
+    if not slug:
+        return None
+    row = await db.fetch_one(
+        "SELECT tech_status, tech_label, public_status FROM ticket_statuses WHERE tech_status = %s",
+        (slug,),
+    )
+    return _normalise_row(row) if row else None

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -151,6 +151,33 @@ class TicketDashboardResponse(BaseModel):
     filters: TicketSearchFilters
 
 
+class TicketStatusDefinitionModel(BaseModel):
+    tech_status: str = Field(alias="techStatus")
+    tech_label: str = Field(alias="techLabel")
+    public_status: str = Field(alias="publicStatus")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class TicketStatusUpdateInput(BaseModel):
+    tech_label: str = Field(..., alias="techLabel", min_length=1, max_length=128)
+    public_status: str = Field(..., alias="publicStatus", min_length=1, max_length=128)
+    existing_slug: str | None = Field(default=None, alias="existingSlug", max_length=64)
+    tech_status: str | None = Field(default=None, alias="techStatus", max_length=64)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class TicketStatusUpdateRequest(BaseModel):
+    statuses: list[TicketStatusUpdateInput] = Field(default_factory=list)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class TicketStatusListResponse(BaseModel):
+    statuses: list[TicketStatusDefinitionModel] = Field(default_factory=list)
+
+
 class TicketWatcherUpdate(BaseModel):
     user_ids: list[int] = Field(default_factory=list)
 

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -751,17 +751,37 @@
     try {
       const parsed = JSON.parse(table.dataset.ticketStatusOptions || '[]');
       if (Array.isArray(parsed)) {
-        statusOptions = parsed.map((value) => String(value));
+        statusOptions = parsed
+          .map((item) => {
+            if (!item || typeof item !== 'object') {
+              return null;
+            }
+            const value = String(item.tech_status || item.techStatus || '').trim();
+            if (!value) {
+              return null;
+            }
+            const label = String(item.tech_label || item.techLabel || '')
+              .trim()
+              || value.replace(/_/g, ' ');
+            return { value, label };
+          })
+          .filter(Boolean);
       }
     } catch (error) {
       statusOptions = [];
     }
     if (!statusOptions.length) {
-      statusOptions = ['open', 'in_progress', 'pending', 'resolved', 'closed'];
+      statusOptions = [
+        { value: 'open', label: 'Open' },
+        { value: 'in_progress', label: 'In progress' },
+        { value: 'pending', label: 'Pending' },
+        { value: 'resolved', label: 'Resolved' },
+        { value: 'closed', label: 'Closed' },
+      ];
     }
 
-    const statusLabels = statusOptions.reduce((acc, value) => {
-      acc[value] = value.replace(/_/g, ' ');
+    const statusLabels = statusOptions.reduce((acc, option) => {
+      acc[option.value] = option.label;
       return acc;
     }, {});
 
@@ -889,8 +909,10 @@
       select.className = 'form-input form-input--compact';
       select.setAttribute('data-ticket-status-select', '');
 
-      const uniqueOptions = Array.from(new Set([...statusOptions, normalisedStatus]));
-      uniqueOptions.forEach((option) => {
+      const optionValues = Array.from(
+        new Set([...statusOptions.map((option) => option.value), normalisedStatus])
+      );
+      optionValues.forEach((option) => {
         const optionElement = document.createElement('option');
         optionElement.value = option;
         optionElement.textContent = statusLabels[option] || option.replace(/_/g, ' ');
@@ -1390,6 +1412,175 @@
     });
   }
 
+  function bindTicketStatusManager() {
+    const modal = document.getElementById('edit-ticket-statuses-modal');
+    if (!modal) {
+      return;
+    }
+
+    const form = modal.querySelector('[data-ticket-statuses-form]');
+    const list = form ? form.querySelector('[data-statuses-list]') : null;
+    const template = modal.querySelector('#ticket-status-row-template');
+    const errorContainer = modal.querySelector('[data-status-error]');
+
+    if (!form || !list || !template) {
+      return;
+    }
+
+    function clearError() {
+      if (errorContainer) {
+        errorContainer.hidden = true;
+        errorContainer.textContent = '';
+      }
+    }
+
+    function showError(message) {
+      if (errorContainer) {
+        errorContainer.textContent = message;
+        errorContainer.hidden = false;
+      }
+    }
+
+    function updateRowIdentifiers() {
+      const rows = Array.from(list.querySelectorAll('[data-status-row]'));
+      rows.forEach((row, index) => {
+        const labels = Array.from(row.querySelectorAll('label'));
+        const techInput = row.querySelector('input[name="techLabel"]');
+        const publicInput = row.querySelector('input[name="publicLabel"]');
+        if (techInput) {
+          const techId = `status-tech-${index}`;
+          techInput.id = techId;
+          if (labels[0]) {
+            labels[0].setAttribute('for', techId);
+          }
+        }
+        if (publicInput) {
+          const publicId = `status-public-${index}`;
+          publicInput.id = publicId;
+          if (labels[1]) {
+            labels[1].setAttribute('for', publicId);
+          }
+        }
+      });
+    }
+
+    function updateRemoveButtons() {
+      const rows = Array.from(list.querySelectorAll('[data-status-row]'));
+      const disableRemoval = rows.length <= 1;
+      rows.forEach((row) => {
+        const removeButton = row.querySelector('[data-status-remove]');
+        if (removeButton) {
+          removeButton.disabled = disableRemoval;
+        }
+      });
+    }
+
+    function createRow() {
+      if (template instanceof HTMLTemplateElement) {
+        const fragment = template.content.firstElementChild;
+        if (fragment) {
+          return fragment.cloneNode(true);
+        }
+      }
+      return template.firstElementChild.cloneNode(true);
+    }
+
+    function addStatusRow() {
+      const row = createRow();
+      const techInput = row.querySelector('input[name="techLabel"]');
+      const publicInput = row.querySelector('input[name="publicLabel"]');
+      const slugInput = row.querySelector('input[name="existingSlug"]');
+      if (techInput) {
+        techInput.value = '';
+      }
+      if (publicInput) {
+        publicInput.value = '';
+      }
+      if (slugInput) {
+        slugInput.value = '';
+      }
+      list.appendChild(row);
+      updateRowIdentifiers();
+      updateRemoveButtons();
+      clearError();
+      if (techInput) {
+        techInput.focus();
+      }
+    }
+
+    function removeStatusRow(button) {
+      const row = button.closest('[data-status-row]');
+      if (!row) {
+        return;
+      }
+      const rows = list.querySelectorAll('[data-status-row]');
+      if (rows.length <= 1) {
+        return;
+      }
+      row.remove();
+      updateRowIdentifiers();
+      updateRemoveButtons();
+      clearError();
+    }
+
+    form.addEventListener('click', (event) => {
+      const addTrigger = event.target.closest('[data-add-status]');
+      if (addTrigger) {
+        event.preventDefault();
+        addStatusRow();
+        return;
+      }
+      const removeTrigger = event.target.closest('[data-status-remove]');
+      if (removeTrigger) {
+        event.preventDefault();
+        removeStatusRow(removeTrigger);
+      }
+    });
+
+    form.addEventListener('input', () => {
+      clearError();
+    });
+
+    form.addEventListener('submit', (event) => {
+      clearError();
+      const rows = Array.from(list.querySelectorAll('[data-status-row]'));
+      const seen = new Set();
+      for (const row of rows) {
+        const techInput = row.querySelector('input[name="techLabel"]');
+        const publicInput = row.querySelector('input[name="publicLabel"]');
+        if (techInput) {
+          techInput.value = techInput.value.trim();
+        }
+        if (publicInput) {
+          publicInput.value = publicInput.value.trim();
+        }
+        if (!techInput || !techInput.value) {
+          continue;
+        }
+        const slug = techInput.value
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '_')
+          .replace(/^_+|_+$/g, '');
+        if (!slug) {
+          showError('Tech status labels must include letters or numbers.');
+          techInput.focus();
+          event.preventDefault();
+          return;
+        }
+        if (seen.has(slug)) {
+          showError('Tech status values must be unique.');
+          techInput.focus();
+          event.preventDefault();
+          return;
+        }
+        seen.add(slug);
+      }
+    });
+
+    updateRowIdentifiers();
+    updateRemoveButtons();
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     bindSyncroTicketImportForms();
     bindSyncroCompanyImportForm();
@@ -1403,8 +1594,10 @@
     bindCompanyAssignmentControls();
     bindApiKeyCopyButtons();
     bindConfirmationButtons();
+    bindTicketStatusManager();
     bindModal({ modalId: 'add-company-modal', triggerSelector: '[data-add-company-modal-open]' });
     bindModal({ modalId: 'create-ticket-modal', triggerSelector: '[data-create-ticket-modal-open]' });
     bindModal({ modalId: 'create-api-key-modal', triggerSelector: '[data-create-api-key-modal-open]' });
+    bindModal({ modalId: 'edit-ticket-statuses-modal', triggerSelector: '[data-edit-ticket-statuses-open]' });
   });
 })();

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -33,9 +33,10 @@
           {% set ai_status_label = ai_status_lower.replace('_', ' ') | title %}
           {% set tag_status_value = ticket.ai_tags_status if ticket.ai_tags_status is not none else 'skipped' %}
           {% set tag_status_lower = tag_status_value | lower %}
+          {% set ticket_status_label = ticket_status_label_map.get(ticket_status, ticket_status.replace('_', ' ').title()) %}
           <p class="management__subtitle">
             Ticket #{{ ticket.id }}
-            <span class="badge {{ status_badge_map.get(ticket_status, 'badge--muted') }}">{{ ticket_status.replace('_', ' ') }}</span>
+            <span class="badge {{ status_badge_map.get(ticket_status, 'badge--muted') }}">{{ ticket_status_label }}</span>
           </p>
         </div>
         <div class="management__header-actions">
@@ -70,10 +71,12 @@
               <div class="form-field">
                 <label class="form-label" for="ticket-status-detail">Status</label>
                 <select id="ticket-status-detail" name="status" class="form-input">
-                  {% for status_option in ticket_available_statuses %}
-                    {% set status_value = status_option.lower() %}
-                    <option value="{{ status_value }}" {% if status_value == ticket_status.lower() %}selected{% endif %}>
-                      {{ status_option.replace('_', ' ') }}
+                  {% if ticket_status not in ticket_status_label_map %}
+                    <option value="{{ ticket_status }}" selected>{{ ticket_status_label }}</option>
+                  {% endif %}
+                  {% for status_option in ticket_status_definitions %}
+                    <option value="{{ status_option.tech_status }}" {% if status_option.tech_status == ticket_status %}selected{% endif %}>
+                      {{ status_option.tech_label }}
                     </option>
                   {% endfor %}
                 </select>

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -3,7 +3,8 @@
 {% block header_title %}
   {% set show_ticket_automations = is_super_admin %}
   {% set show_syncro_import = syncro_module_enabled and (is_super_admin or (is_helpdesk_technician | default(false))) %}
-  {% set show_ticket_tools = show_ticket_automations or show_syncro_import %}
+  {% set show_ticket_status_editor = is_super_admin %}
+  {% set show_ticket_tools = show_ticket_automations or show_syncro_import or show_ticket_status_editor %}
   <div class="header-title-menu">
     <span class="header-title-menu__label">Ticketing workspace</span>
     {% if show_ticket_tools %}
@@ -24,6 +25,20 @@
           {% if show_syncro_import %}
             <li class="header-title-menu__item" role="none">
               <a href="/admin/tickets/syncro-import" class="header-title-menu__link" role="menuitem">Syncro ticket import</a>
+            </li>
+          {% endif %}
+          {% if show_ticket_status_editor %}
+            <li class="header-title-menu__item" role="none">
+              <button
+                type="button"
+                class="header-title-menu__link"
+                role="menuitem"
+                data-edit-ticket-statuses-open
+                aria-haspopup="dialog"
+                aria-controls="edit-ticket-statuses-modal"
+              >
+                Edit statuses
+              </button>
             </li>
           {% endif %}
         </ul>
@@ -65,8 +80,17 @@
             <label class="visually-hidden" for="ticket-filter-status">Status</label>
             <select id="ticket-filter-status" name="status" class="form-input">
               <option value="">All statuses</option>
+              {% set status_namespace = namespace(seen=[]) %}
+              {% for status_option in ticket_status_definitions %}
+                {% set option_value = status_option.tech_status %}
+                <option value="{{ option_value }}" {% if ticket_filters.status == option_value %}selected{% endif %}>{{ status_option.tech_label }}</option>
+                {% set status_namespace.seen = status_namespace.seen + [option_value] %}
+              {% endfor %}
               {% for status_option in ticket_available_statuses %}
-                <option value="{{ status_option }}" {% if ticket_filters.status == status_option %}selected{% endif %}>{{ status_option.replace('_', ' ') }}</option>
+                {% if status_option not in status_namespace.seen %}
+                  {% set fallback_label = ticket_status_label_map.get(status_option, status_option.replace('_', ' ').title()) %}
+                  <option value="{{ status_option }}" {% if ticket_filters.status == status_option %}selected{% endif %}>{{ fallback_label }}</option>
+                {% endif %}
               {% endfor %}
             </select>
             <label class="visually-hidden" for="ticket-filter-module">Module</label>
@@ -145,7 +169,7 @@
             data-table-refresh-handler="tickets"
             data-table-refresh-success="Tickets updated."
             data-table-refresh-error="Unable to refresh tickets automatically."
-            data-ticket-status-options='{{ ticket_available_statuses | tojson }}'
+            data-ticket-status-options='{{ ticket_status_definitions | tojson }}'
             data-csrf-token="{{ csrf_token or '' }}"
             data-can-bulk-delete="{{ 'true' if can_bulk_delete_tickets else 'false' }}"
             data-bulk-delete-form-id="tickets-bulk-delete-form"
@@ -198,7 +222,7 @@
                       <a href="/admin/tickets/{{ ticket.id }}">{{ ticket.subject }}</a>
                     </td>
                     {% set ticket_status = (ticket.status or 'open') %}
-                    {% set status_label = ticket_status.replace('_', ' ').title() %}
+                    {% set status_label = ticket_status_label_map.get(ticket_status, ticket_status.replace('_', ' ').title()) %}
                     {% set status_badge_map = {
                       'open': 'badge--warning',
                       'in_progress': 'badge--warning',
@@ -227,8 +251,11 @@
                             class="form-input form-input--compact"
                             data-ticket-status-select
                           >
-                            {% for status_option in ticket_available_statuses %}
-                              <option value="{{ status_option }}" {% if status_option == (ticket.status or 'open') %}selected{% endif %}>{{ status_option.replace('_', ' ') }}</option>
+                            {% if ticket_status not in ticket_status_label_map %}
+                              <option value="{{ ticket_status }}" selected>{{ status_label }}</option>
+                            {% endif %}
+                            {% for status_option in ticket_status_definitions %}
+                              <option value="{{ status_option.tech_status }}" {% if status_option.tech_status == ticket_status %}selected{% endif %}>{{ status_option.tech_label }}</option>
                             {% endfor %}
                           </select>
                         </form>
@@ -300,11 +327,17 @@
           <div class="form-field">
             <label class="form-label" for="modal-ticket-status">Initial status</label>
             <select id="modal-ticket-status" name="status" class="form-input">
-              <option value="open" selected>Open</option>
-              <option value="in_progress">In progress</option>
-              <option value="pending">Pending</option>
-              <option value="resolved">Resolved</option>
-              <option value="closed">Closed</option>
+              {% if ticket_status_definitions %}
+                {% for status_option in ticket_status_definitions %}
+                  <option value="{{ status_option.tech_status }}" {% if loop.first %}selected{% endif %}>{{ status_option.tech_label }}</option>
+                {% endfor %}
+              {% else %}
+                <option value="open" selected>Open</option>
+                <option value="in_progress">In progress</option>
+                <option value="pending">Pending</option>
+                <option value="resolved">Resolved</option>
+                <option value="closed">Closed</option>
+              {% endif %}
             </select>
           </div>
         </div>
@@ -360,6 +393,119 @@
           <button type="button" class="button button--ghost" data-modal-close>Cancel</button>
         </div>
       </form>
+    </div>
+  </div>
+
+  <div
+    class="modal"
+    id="edit-ticket-statuses-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="edit-ticket-statuses-title"
+    aria-hidden="true"
+    hidden
+  >
+    <div class="modal__content" role="document">
+      <button type="button" class="modal__close" data-modal-close>
+        <span class="visually-hidden">Close ticket status editor</span>
+        &times;
+      </button>
+      <h2 class="modal__title" id="edit-ticket-statuses-title">Edit ticket statuses</h2>
+      <p class="modal__subtitle">Define the technician-facing labels and public labels for each ticket status.</p>
+      <div class="alert alert--error" role="alert" data-status-error hidden></div>
+      <form action="/admin/tickets/statuses" method="post" class="form" data-ticket-statuses-form>
+        {% include "partials/csrf.html" %}
+        <div class="table-wrapper">
+          <table class="table table--compact" data-ticket-statuses-table>
+            <thead>
+              <tr>
+                <th scope="col">Tech status (technician label)</th>
+                <th scope="col">Public status (customer label)</th>
+                <th scope="col" class="table__actions">Actions</th>
+              </tr>
+            </thead>
+            <tbody data-statuses-list>
+              {% if ticket_status_definitions %}
+                {% for status_option in ticket_status_definitions %}
+                  <tr data-status-row>
+                    <td data-label="Tech status">
+                      <label class="visually-hidden" for="status-tech-{{ loop.index0 }}">Tech status</label>
+                      <input
+                        id="status-tech-{{ loop.index0 }}"
+                        name="techLabel"
+                        class="form-input"
+                        maxlength="128"
+                        value="{{ status_option.tech_label }}"
+                        required
+                      />
+                      <input type="hidden" name="existingSlug" value="{{ status_option.tech_status }}" />
+                    </td>
+                    <td data-label="Public status">
+                      <label class="visually-hidden" for="status-public-{{ loop.index0 }}">Public status</label>
+                      <input
+                        id="status-public-{{ loop.index0 }}"
+                        name="publicLabel"
+                        class="form-input"
+                        maxlength="128"
+                        value="{{ status_option.public_status }}"
+                        required
+                      />
+                    </td>
+                    <td class="table__actions">
+                      <button
+                        type="button"
+                        class="button button--ghost"
+                        data-status-remove
+                        {% if ticket_status_definitions | length <= 1 %}disabled{% endif %}
+                      >
+                        Remove
+                      </button>
+                    </td>
+                  </tr>
+                {% endfor %}
+              {% else %}
+                <tr data-status-row>
+                  <td data-label="Tech status">
+                    <label class="visually-hidden" for="status-tech-0">Tech status</label>
+                    <input id="status-tech-0" name="techLabel" class="form-input" maxlength="128" required />
+                    <input type="hidden" name="existingSlug" value="" />
+                  </td>
+                  <td data-label="Public status">
+                    <label class="visually-hidden" for="status-public-0">Public status</label>
+                    <input id="status-public-0" name="publicLabel" class="form-input" maxlength="128" required />
+                  </td>
+                  <td class="table__actions">
+                    <button type="button" class="button button--ghost" data-status-remove disabled>Remove</button>
+                  </td>
+                </tr>
+              {% endif %}
+            </tbody>
+          </table>
+        </div>
+        <div class="form-actions form-actions--secondary">
+          <button type="button" class="button button--ghost" data-add-status>Add status</button>
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="button button--primary">Save changes</button>
+          <button type="button" class="button button--ghost" data-modal-close>Cancel</button>
+        </div>
+      </form>
+      <template id="ticket-status-row-template">
+        <tr data-status-row>
+          <td data-label="Tech status">
+            <label class="visually-hidden">Tech status</label>
+            <input name="techLabel" class="form-input" maxlength="128" required />
+            <input type="hidden" name="existingSlug" value="" />
+          </td>
+          <td data-label="Public status">
+            <label class="visually-hidden">Public status</label>
+            <input name="publicLabel" class="form-input" maxlength="128" required />
+          </td>
+          <td class="table__actions">
+            <button type="button" class="button button--ghost" data-status-remove>Remove</button>
+          </td>
+        </tr>
+      </template>
     </div>
   </div>
 {% endblock %}

--- a/changes/bf50e3dc-2697-4e6e-b6f0-4b5ff7c57f63.json
+++ b/changes/bf50e3dc-2697-4e6e-b6f0-4b5ff7c57f63.json
@@ -1,0 +1,7 @@
+{
+  "guid": "bf50e3dc-2697-4e6e-b6f0-4b5ff7c57f63",
+  "occurred_at": "2025-10-30T12:39Z",
+  "change_type": "Feature",
+  "summary": "Added ticket status editor with API endpoints and repository safeguards.",
+  "content_hash": "15c362becdff1b943b6e9b14f31a2e13b04cd55610e40ec202b7b890679b6556"
+}

--- a/migrations/087_ticket_statuses.sql
+++ b/migrations/087_ticket_statuses.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS ticket_statuses (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    tech_status VARCHAR(64) NOT NULL,
+    tech_label VARCHAR(128) NOT NULL,
+    public_status VARCHAR(128) NOT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT UTC_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT UTC_TIMESTAMP(6) ON UPDATE UTC_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_ticket_statuses_status (tech_status)
+);
+
+INSERT INTO ticket_statuses (tech_status, tech_label, public_status)
+VALUES
+    ('open', 'Open', 'Open'),
+    ('in_progress', 'In progress', 'In progress'),
+    ('pending', 'Pending', 'Pending'),
+    ('resolved', 'Resolved', 'Resolved'),
+    ('closed', 'Closed', 'Closed')
+ON DUPLICATE KEY UPDATE
+    tech_label = VALUES(tech_label),
+    public_status = VALUES(public_status),
+    updated_at = UTC_TIMESTAMP(6);

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -33,9 +33,11 @@ def _no_ticket_update_events(monkeypatch):
 
 
 def test_normalise_status_mapping():
-    assert ticket_importer._normalise_status("In Progress") == "in_progress"
-    assert ticket_importer._normalise_status("Waiting on customer") == "pending"
-    assert ticket_importer._normalise_status("Completed") == "resolved"
+    allowed = {"open", "in_progress", "pending", "resolved", "closed"}
+    default = "open"
+    assert ticket_importer._normalise_status("In Progress", allowed, default) == "in_progress"
+    assert ticket_importer._normalise_status("Waiting on customer", allowed, default) == "pending"
+    assert ticket_importer._normalise_status("Completed", allowed, default) == "resolved"
 
 
 def test_normalise_priority_mapping():

--- a/tests/test_ticket_statuses_service.py
+++ b/tests/test_ticket_statuses_service.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.repositories import ticket_statuses as ticket_status_repo
+from app.services import tickets as tickets_service
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_replace_ticket_statuses_normalises_and_persists(monkeypatch):
+    captured: list[dict[str, str]] = []
+
+    async def fake_replace_statuses(definitions):
+        captured.extend(definitions)
+        return [
+            {
+                "tech_status": item["tech_status"],
+                "tech_label": item["tech_label"],
+                "public_status": item["public_status"],
+            }
+            for item in definitions
+        ]
+
+    monkeypatch.setattr(ticket_status_repo, "replace_statuses", fake_replace_statuses)
+
+    results = await tickets_service.replace_ticket_statuses(
+        [
+            {
+                "techLabel": "In Progress",
+                "publicStatus": "Working",
+                "existingSlug": "in_progress",
+            },
+            {
+                "techLabel": "Waiting on Customer",
+                "publicStatus": "Awaiting customer",
+            },
+        ]
+    )
+
+    assert [definition.tech_status for definition in results] == [
+        "in_progress",
+        "waiting_on_customer",
+    ]
+    assert captured[0]["original_slug"] == "in_progress"
+    assert captured[1]["tech_status"] == "waiting_on_customer"
+
+
+@pytest.mark.anyio
+async def test_replace_ticket_statuses_rejects_duplicate_slugs(monkeypatch):
+    replace_mock = AsyncMock(return_value=[])
+    monkeypatch.setattr(ticket_status_repo, "replace_statuses", replace_mock)
+
+    with pytest.raises(ValueError):
+        await tickets_service.replace_ticket_statuses(
+            [
+                {"techLabel": "Pending Vendor", "publicStatus": "Waiting"},
+                {"techLabel": "pending_vendor", "publicStatus": "Waiting"},
+            ]
+        )
+
+    replace_mock.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_validate_status_choice_accepts_existing_status(monkeypatch):
+    async def fake_exists(slug: str) -> bool:
+        return slug == "waiting_on_vendor"
+
+    monkeypatch.setattr(ticket_status_repo, "status_exists", fake_exists)
+
+    slug = await tickets_service.validate_status_choice("Waiting on vendor")
+    assert slug == "waiting_on_vendor"
+
+
+@pytest.mark.anyio
+async def test_validate_status_choice_rejects_unknown_status(monkeypatch):
+    async def fake_exists(slug: str) -> bool:
+        return False
+
+    monkeypatch.setattr(ticket_status_repo, "status_exists", fake_exists)
+
+    with pytest.raises(ValueError):
+        await tickets_service.validate_status_choice("does-not-exist")
+
+
+@pytest.mark.anyio
+async def test_resolve_status_or_default_uses_first_definition(monkeypatch):
+    async def fake_exists(slug: str) -> bool:
+        return False
+
+    async def fake_list_definitions():
+        return [
+            tickets_service.TicketStatusDefinition(
+                tech_status="queued",
+                tech_label="Queued",
+                public_status="Queued",
+            ),
+            tickets_service.TicketStatusDefinition(
+                tech_status="on_hold",
+                tech_label="On hold",
+                public_status="On hold",
+            ),
+        ]
+
+    monkeypatch.setattr(ticket_status_repo, "status_exists", fake_exists)
+    monkeypatch.setattr(tickets_service, "list_status_definitions", fake_list_definitions)
+
+    slug = await tickets_service.resolve_status_or_default(None)
+    assert slug == "queued"
+
+
+def test_slugify_status_label_handles_various_input():
+    assert ticket_status_repo.slugify_status_label("In Progress") == "in_progress"
+    assert ticket_status_repo.slugify_status_label("  ---  ") == ""
+    assert ticket_status_repo.slugify_status_label("Awaiting / Vendor") == "awaiting_vendor"

--- a/tests/test_tickets_dashboard_api.py
+++ b/tests/test_tickets_dashboard_api.py
@@ -1,12 +1,52 @@
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
+import pytest
 from fastapi.testclient import TestClient
 
-from app.api.routes.tickets import require_helpdesk_technician
+from app.api.routes.tickets import require_helpdesk_technician, require_super_admin
 from app.main import app
+from app.main import automations_service, change_log_service, modules_service, scheduler_service
+from app.core.database import db
 from app.services import tickets as tickets_service
+from app.security.session import SessionData, session_manager
+
+
+@pytest.fixture(autouse=True)
+def _mock_startup(monkeypatch):
+    async def fake_connect():
+        return None
+
+    async def fake_disconnect():
+        return None
+
+    async def fake_run_migrations():
+        return None
+
+    async def fake_sync_change_log_sources(*args, **kwargs):
+        return None
+
+    async def fake_ensure_default_modules(*args, **kwargs):
+        return None
+
+    async def fake_refresh_all_schedules(*args, **kwargs):
+        return None
+
+    async def fake_scheduler_start(*args, **kwargs):
+        return None
+
+    async def fake_scheduler_stop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(db, "connect", fake_connect)
+    monkeypatch.setattr(db, "disconnect", fake_disconnect)
+    monkeypatch.setattr(db, "run_migrations", fake_run_migrations)
+    monkeypatch.setattr(change_log_service, "sync_change_log_sources", fake_sync_change_log_sources)
+    monkeypatch.setattr(modules_service, "ensure_default_modules", fake_ensure_default_modules)
+    monkeypatch.setattr(automations_service, "refresh_all_schedules", fake_refresh_all_schedules)
+    monkeypatch.setattr(scheduler_service, "start", fake_scheduler_start)
+    monkeypatch.setattr(scheduler_service, "stop", fake_scheduler_stop)
 
 
 def test_ticket_dashboard_endpoint(monkeypatch):
@@ -29,6 +69,13 @@ def test_ticket_dashboard_endpoint(monkeypatch):
         total=1,
         status_counts=Counter({"open": 1}),
         available_statuses=["open", "in_progress"],
+        status_definitions=[
+            tickets_service.TicketStatusDefinition(
+                tech_status="open",
+                tech_label="Open",
+                public_status="Open",
+            )
+        ],
         modules=[],
         companies=[{"id": 301, "name": "Acme Corp"}],
         technicians=[{"id": 22, "email": "tech@example.com"}],
@@ -58,3 +105,81 @@ def test_ticket_dashboard_endpoint(monkeypatch):
     kwargs = load_state_mock.await_args.kwargs
     assert kwargs["status_filter"] == "open"
     assert kwargs["module_filter"] == "ops"
+
+
+def test_list_ticket_statuses_endpoint(monkeypatch):
+    client = TestClient(app)
+
+    sample_statuses = [
+        tickets_service.TicketStatusDefinition(
+            tech_status="open",
+            tech_label="Open",
+            public_status="Open",
+        ),
+        tickets_service.TicketStatusDefinition(
+            tech_status="waiting_on_customer",
+            tech_label="Waiting on customer",
+            public_status="Awaiting response",
+        ),
+    ]
+
+    list_mock = AsyncMock(return_value=sample_statuses)
+    monkeypatch.setattr(tickets_service, "list_status_definitions", list_mock)
+
+    app.dependency_overrides[require_helpdesk_technician] = lambda: {"id": 7, "is_super_admin": False}
+    try:
+        response = client.get("/api/tickets/statuses")
+    finally:
+        app.dependency_overrides.pop(require_helpdesk_technician, None)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["statuses"][0]["techStatus"] == "open"
+    assert payload["statuses"][1]["publicStatus"] == "Awaiting response"
+    list_mock.assert_awaited_once()
+
+
+def test_replace_ticket_statuses_endpoint_handles_errors(monkeypatch):
+    replace_mock = AsyncMock(side_effect=ValueError("Tech status values must be unique."))
+    monkeypatch.setattr(tickets_service, "replace_ticket_statuses", replace_mock)
+
+    now = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+    session = SessionData(
+        id=1,
+        user_id=1,
+        session_token="session-token",
+        csrf_token="csrf-token",
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+        last_seen_at=now,
+        ip_address=None,
+        user_agent=None,
+        active_company_id=None,
+        pending_totp_secret=None,
+    )
+
+    async def fake_load_session(request, *, allow_inactive=False):
+        return session
+
+    monkeypatch.setattr(session_manager, "load_session", fake_load_session)
+
+    app.dependency_overrides[require_super_admin] = lambda: {"id": 1, "is_super_admin": True}
+    try:
+        with TestClient(app) as client:
+            client.cookies.set("myportal_session_csrf", session.csrf_token)
+            response = client.put(
+                "/api/tickets/statuses",
+                json={
+                    "statuses": [
+                        {"techLabel": "Pending", "publicStatus": "Pending"},
+                        {"techLabel": "Pending", "publicStatus": "Pending"},
+                    ]
+                },
+                headers={"X-CSRF-Token": session.csrf_token},
+            )
+    finally:
+        app.dependency_overrides.pop(require_super_admin, None)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Tech status values must be unique."
+    replace_mock.assert_awaited_once()

--- a/tests/test_tickets_service_create.py
+++ b/tests/test_tickets_service_create.py
@@ -31,10 +31,14 @@ async def test_create_ticket_triggers_automations(monkeypatch):
         recorded["context"] = context
         return []
 
+    async def fake_resolve_status(value):
+        return value or "open"
+
     monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
     monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
     monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
 
     ticket = await tickets_service.create_ticket(
         subject="Printer offline",
@@ -76,10 +80,14 @@ async def test_create_ticket_can_skip_automations(monkeypatch):
         called = True
         return []
 
+    async def fake_resolve_status(value):
+        return value or "open"
+
     monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
     monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
     monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
 
     ticket = await tickets_service.create_ticket(
         subject="Laptop setup",
@@ -119,10 +127,14 @@ async def test_create_ticket_truncates_long_description(monkeypatch):
     async def fake_get_user(user_id):
         return None
 
+    async def fake_resolve_status(value):
+        return value or "open"
+
     monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
     monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
     monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
 
     long_description = "A" * (tickets_service._MAX_TICKET_DESCRIPTION_BYTES + 512)
 


### PR DESCRIPTION
## Summary
- add persistence layer and migration for configurable ticket statuses
- expose API and admin workflows for listing and replacing ticket statuses
- update UI, documentation, and tests to cover the new status editor tool

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6903559bb9fc832d802bab02b9fbeec8