### PR TITLE
Fix issue tracker migration foreign keys

### DIFF
--- a/changes/969be035-0886-4af1-b1f2-ad997e2dd525.json
+++ b/changes/969be035-0886-4af1-b1f2-ad997e2dd525.json
@@ -1,0 +1,7 @@
+{
+  "guid": "969be035-0886-4af1-b1f2-ad997e2dd525",
+  "occurred_at": "2025-10-30T00:00Z",
+  "change_type": "Fix",
+  "summary": "Align issue tracker migration foreign keys with existing INT identifiers",
+  "content_hash": "64874531ae5ee003df90969748ef881ab03dd9d25da42e8847f4a810a8bc8cc9"
+}

--- a/migrations/087_issue_tracker.sql
+++ b/migrations/087_issue_tracker.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS issue_definitions (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     description TEXT NULL,
-    created_by BIGINT UNSIGNED NULL,
-    updated_by BIGINT UNSIGNED NULL,
+    created_by INT NULL,
+    updated_by INT NULL,
     created_at_utc DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     updated_at_utc DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     UNIQUE KEY uniq_issue_definitions_name (name),
@@ -13,12 +13,12 @@ CREATE TABLE IF NOT EXISTS issue_definitions (
 );
 
 CREATE TABLE IF NOT EXISTS issue_company_statuses (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    issue_id BIGINT UNSIGNED NOT NULL,
-    company_id BIGINT UNSIGNED NOT NULL,
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    issue_id INT NOT NULL,
+    company_id INT NOT NULL,
     status VARCHAR(32) NOT NULL,
     notes TEXT NULL,
-    updated_by BIGINT UNSIGNED NULL,
+    updated_by INT NULL,
     created_at_utc DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     updated_at_utc DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     UNIQUE KEY uniq_issue_company (issue_id, company_id),


### PR DESCRIPTION
## Summary
- align the issue tracker migration to use INT identifiers so foreign keys match existing users and companies tables
- record the fix in the change log history

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69035ea7fa24832d88cad82d3ea23930