### PR TITLE
Fix admin company assignment to use source company context

### DIFF
--- a/changes/67c310b2-a7e9-4d58-9cf5-8afa6b740ba1.json
+++ b/changes/67c310b2-a7e9-4d58-9cf5-8afa6b740ba1.json
@@ -1,0 +1,7 @@
+{
+  "guid": "67c310b2-a7e9-4d58-9cf5-8afa6b740ba1",
+  "occurred_at": "2025-10-30T12:53Z",
+  "change_type": "Fix",
+  "summary": "Ensure admin company assignments prefer the source company when submitting from edit page.",
+  "content_hash": "62dab74ad9da89e774794ab8769e011956ea3a96dec56ba3f8239b070332c053"
+}


### PR DESCRIPTION
## Summary
- prefer the source company ID when assigning users through the admin company edit workflow and keep success messaging consistent
- ensure assignment form state uses the resolved company and extend tests to verify source-company persistence
- record the fix in the change log archive

## Testing
- pytest tests/test_company_memberships.py -k assign

------
https://chatgpt.com/codex/tasks/task_b_69035ec5d58c832d87224f2afe4a195c