### PR TITLE
Fix MariaDB timestamp defaults in migrations

### DIFF
--- a/changes/8dbf9393-358d-48d4-a7d3-ecf5ac910971.json
+++ b/changes/8dbf9393-358d-48d4-a7d3-ecf5ac910971.json
@@ -1,0 +1,7 @@
+{
+  "guid": "8dbf9393-358d-48d4-a7d3-ecf5ac910971",
+  "occurred_at": "2025-10-30T12:54Z",
+  "change_type": "Fix",
+  "summary": "Restore MariaDB compatibility by using CURRENT_TIMESTAMP defaults in migration DDL.",
+  "content_hash": "1c33c0224d60a757b166d7a8d06ee0b59d305ee11ab604f58e2088bdb3ce8315"
+}

--- a/migrations/082_imap_accounts.sql
+++ b/migrations/082_imap_accounts.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS imap_accounts (
   active TINYINT(1) NOT NULL DEFAULT 1,
   scheduled_task_id INT NULL,
   last_synced_at DATETIME NULL,
-  created_at TIMESTAMP(6) NOT NULL DEFAULT UTC_TIMESTAMP(6),
+  created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   updated_at TIMESTAMP(6) NULL DEFAULT NULL,
   FOREIGN KEY (company_id) REFERENCES companies(id) ON DELETE SET NULL,
   FOREIGN KEY (scheduled_task_id) REFERENCES scheduled_tasks(id) ON DELETE SET NULL
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS imap_account_messages (
   status VARCHAR(32) NOT NULL,
   error TEXT NULL,
   processed_at DATETIME NULL,
-  created_at TIMESTAMP(6) NOT NULL DEFAULT UTC_TIMESTAMP(6),
+  created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   UNIQUE KEY uq_imap_account_messages_account_uid (account_id, message_uid),
   FOREIGN KEY (account_id) REFERENCES imap_accounts(id) ON DELETE CASCADE,
   FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE SET NULL

--- a/migrations/087_ticket_statuses.sql
+++ b/migrations/087_ticket_statuses.sql
@@ -3,8 +3,8 @@ CREATE TABLE IF NOT EXISTS ticket_statuses (
     tech_status VARCHAR(64) NOT NULL,
     tech_label VARCHAR(128) NOT NULL,
     public_status VARCHAR(128) NOT NULL,
-    created_at DATETIME(6) NOT NULL DEFAULT UTC_TIMESTAMP(6),
-    updated_at DATETIME(6) NOT NULL DEFAULT UTC_TIMESTAMP(6) ON UPDATE UTC_TIMESTAMP(6),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     PRIMARY KEY (id),
     UNIQUE KEY uq_ticket_statuses_status (tech_status)
 );
@@ -19,4 +19,4 @@ VALUES
 ON DUPLICATE KEY UPDATE
     tech_label = VALUES(tech_label),
     public_status = VALUES(public_status),
-    updated_at = UTC_TIMESTAMP(6);
+    updated_at = CURRENT_TIMESTAMP(6);


### PR DESCRIPTION
## Summary
- replace UTC_TIMESTAMP defaults in migrations 082 and 087 with CURRENT_TIMESTAMP for MariaDB compatibility
- update seed update statement to use CURRENT_TIMESTAMP
- record the fix in the changes log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69035fb52ee8832dbc6b44ade882b49c