### PR TITLE
Align Edit statuses button styling with ticket automations link

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -861,6 +861,19 @@ body {
   text-decoration: none;
   font-size: 0.9rem;
   transition: background 0.2s ease, color 0.2s ease;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  text-align: left;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+button.header-title-menu__link {
+  width: 100%;
 }
 
 .header-title-menu__link:hover,

--- a/changes/a5717234-30c5-447f-9bc2-ab5d97dd39d1.json
+++ b/changes/a5717234-30c5-447f-9bc2-ab5d97dd39d1.json
@@ -1,0 +1,7 @@
+{
+  "guid": "a5717234-30c5-447f-9bc2-ab5d97dd39d1",
+  "occurred_at": "2025-10-30T13:01Z",
+  "change_type": "Fix",
+  "summary": "Matched the Edit statuses ticket tool button styling to the Ticket automations link for consistent menu visuals.",
+  "content_hash": "4d4619216bdf47e581361491489c5e3094be0aee26976e6e7df9e11bbe650b1f"
+}


### PR DESCRIPTION
## Summary
- ensure the Edit statuses menu button uses the same visual styling as other ticket tool links
- record the styling fix in the change log for audit tracking

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690360fd80fc832d9d8046d1e22dd063