### PR TITLE
Align Create issue header action

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -750,6 +750,7 @@ body {
   align-items: center;
   gap: var(--space-gap-tight);
   min-width: 0;
+  width: 100%;
 }
 
 .header__title-text {
@@ -760,6 +761,10 @@ body {
   display: flex;
   align-items: center;
   gap: var(--space-gap-tight);
+}
+
+.header__title-content .header__title-button {
+  margin-left: auto;
 }
 
 .header__title > * {

--- a/changes/0fea7f0e-7b8c-4425-9939-5c2692974fa1.json
+++ b/changes/0fea7f0e-7b8c-4425-9939-5c2692974fa1.json
@@ -1,0 +1,7 @@
+{
+  "guid": "0fea7f0e-7b8c-4425-9939-5c2692974fa1",
+  "occurred_at": "2025-10-30T13:13:18Z",
+  "change_type": "Fix",
+  "summary": "Align Create issue header action to the right edge for consistent layout.",
+  "content_hash": "fe06040b44978fc7e247f283c7ac6742f3aab2200d4a3031fca68c8adf6ebe6e"
+}


### PR DESCRIPTION
## Summary
- ensure header title sections expand so their action buttons align to the right edge
- record the layout adjustment in the change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690364196c50832dbfc4101fd7e060f7