### PR TITLE
Align API key header action

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -752,6 +752,14 @@ body {
   min-width: 0;
 }
 
+.header__title-content--spread {
+  width: 100%;
+}
+
+.header__title-content--spread .header__title-button {
+  margin-inline-start: auto;
+}
+
 .header__title-text {
   flex: 1 1 auto;
   min-width: 0;

--- a/app/templates/admin/api_keys.html
+++ b/app/templates/admin/api_keys.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block header_title %}
-  <div class="header__title-content">
+  <div class="header__title-content header__title-content--spread">
     <span class="header__title-text">{{ title | default('API credentials') }}</span>
     <button
       type="button"

--- a/changes/7c9d6f25-1d58-479a-ab6b-4038eaae13c9.json
+++ b/changes/7c9d6f25-1d58-479a-ab6b-4038eaae13c9.json
@@ -1,0 +1,7 @@
+{
+  "guid": "7c9d6f25-1d58-479a-ab6b-4038eaae13c9",
+  "occurred_at": "2025-10-30T13:14:32Z",
+  "change_type": "Fix",
+  "summary": "Move the Create key action to the right edge of the API credentials header for consistent alignment.",
+  "content_hash": "478e39d8f3efb985819256359bffe7ebabdddc0342886eeb007419e7331ef48c"
+}


### PR DESCRIPTION
## Summary
- add a header layout helper so the API credentials Create key action aligns to the right edge of the title bar
- update the API credentials template to use the new helper and keep the button within the header title region
- log the UI alignment fix in the change history registry

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000 *(fails: missing mandatory environment configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6903643b13ec832d8edc83f6e8c39789