### PR TITLE
Move Add Company button to admin header

### DIFF
--- a/app/templates/admin/companies.html
+++ b/app/templates/admin/companies.html
@@ -1,5 +1,20 @@
 {% extends "base.html" %}
 
+{% block header_title %}
+  <div class="header__title-content">
+    <span class="header__title-text">Companies</span>
+    <button
+      type="button"
+      class="button button--primary button--small header__title-button"
+      data-add-company-modal-open
+      aria-haspopup="dialog"
+      aria-controls="add-company-modal"
+    >
+      Add Company
+    </button>
+  </div>
+{% endblock %}
+
 {% block content %}
   {% if error_message or success_message %}
     <div class="stacked" style="margin-bottom: 1.5rem; gap: 1rem;">
@@ -28,15 +43,6 @@
               aria-label="Filter companies"
               data-table-filter="companies-table"
             />
-            <button
-              type="button"
-              class="button"
-              data-add-company-modal-open
-              aria-haspopup="dialog"
-              aria-controls="add-company-modal"
-            >
-              Add Company
-            </button>
           </div>
         </header>
         <div class="table-wrapper">

--- a/changes/a98bdb27-ff8c-43e7-9f05-5e9bf948de0d.json
+++ b/changes/a98bdb27-ff8c-43e7-9f05-5e9bf948de0d.json
@@ -1,0 +1,7 @@
+{
+  "guid": "a98bdb27-ff8c-43e7-9f05-5e9bf948de0d",
+  "occurred_at": "2025-10-30T13:14:19Z",
+  "change_type": "Fix",
+  "summary": "Moved the Add Company button into the page header for easier access.",
+  "content_hash": "fd78cc73f27e77dc053598088da0cb10309bdc55cb17a1621d87d7401dc2d8e4"
+}


### PR DESCRIPTION
## Summary
- move the Add Company action into the admin header for the companies page
- remove the duplicate button from the companies card controls
- record the interface update in the changelog directory

## Testing
- uvicorn app.main:app --host 0.0.0.0 --port 8000 *(fails: missing required environment variables)*

------
https://chatgpt.com/codex/tasks/task_b_69036456ae7c832da2391e5de97700b0