### PR TITLE
Add super admin impersonation support

### DIFF
--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from datetime import datetime
 from typing import Optional
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, EmailStr, Field, field_validator
@@ -56,6 +57,9 @@ class SessionInfo(BaseModel):
     user_agent: Optional[str] = None
     csrf_token: str
     active_company_id: Optional[int] = None
+    impersonator_user_id: Optional[int] = None
+    impersonator_session_id: Optional[int] = None
+    impersonation_started_at: Optional[datetime] = None
 
 
 class LoginResponse(BaseModel):
@@ -65,6 +69,17 @@ class LoginResponse(BaseModel):
 
 class SessionResponse(LoginResponse):
     pass
+
+
+class ImpersonationRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_id: int = Field(
+        validation_alias=AliasChoices("user_id", "userId"),
+        serialization_alias="user_id",
+        description="Identifier of the user to impersonate.",
+        ge=1,
+    )
 
 
 class PasswordResetRequest(BaseModel):

--- a/app/services/impersonation.py
+++ b/app/services/impersonation.py
@@ -1,0 +1,248 @@
+"""Utilities that support privileged user impersonation flows."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from fastapi import Request
+
+from app.core.logging import log_error, log_info
+from app.repositories import auth as auth_repo
+from app.repositories import company_memberships as membership_repo
+from app.repositories import users as user_repo
+from app.security.session import SessionData, session_manager
+from app.services import audit as audit_service
+from app.services import company_access
+
+
+class ImpersonationError(Exception):
+    """Base class for impersonation failures."""
+
+
+class NotImpersonatingError(ImpersonationError):
+    """Raised when an exit is attempted without an active impersonation."""
+
+
+class NotImpersonatableError(ImpersonationError):
+    """Raised when the target user does not satisfy impersonation criteria."""
+
+
+class AlreadyImpersonatingError(ImpersonationError):
+    """Raised when an actor already operates under an impersonated session."""
+
+
+class SelfImpersonationError(ImpersonationError):
+    """Raised when an actor attempts to impersonate their own account."""
+
+
+class OriginalSessionUnavailableError(ImpersonationError):
+    """Raised when the original session cannot be restored."""
+
+
+def _parse_permissions(raw: Any) -> list[str]:
+    if isinstance(raw, str):
+        try:
+            decoded = json.loads(raw)
+        except (TypeError, ValueError):
+            return []
+        if isinstance(decoded, list):
+            return [str(item) for item in decoded if isinstance(item, (str, bytes))]
+        return []
+    if isinstance(raw, Iterable):
+        return [str(item) for item in raw if isinstance(item, (str, bytes))]
+    return []
+
+
+def _membership_grants_permissions(membership: dict[str, Any]) -> bool:
+    permissions = membership.get("permissions")
+    parsed = _parse_permissions(permissions)
+    if parsed:
+        return True
+    return bool(membership.get("is_admin"))
+
+
+async def user_is_impersonatable(user_id: int) -> bool:
+    memberships = await membership_repo.list_memberships_for_user(user_id, status="active")
+    for membership in memberships:
+        if _membership_grants_permissions(membership):
+            return True
+    user = await user_repo.get_user_by_id(user_id)
+    return bool(user and user.get("is_super_admin"))
+
+
+async def list_impersonatable_users() -> list[dict[str, Any]]:
+    memberships = await membership_repo.list_impersonatable_memberships()
+    aggregated: dict[int, dict[str, Any]] = {}
+    for row in memberships:
+        try:
+            user_id = int(row.get("user_id"))
+        except (TypeError, ValueError):
+            continue
+        entry = aggregated.setdefault(
+            user_id,
+            {
+                "id": user_id,
+                "email": row.get("email"),
+                "first_name": row.get("first_name"),
+                "last_name": row.get("last_name"),
+                "is_super_admin": bool(row.get("is_super_admin", 0)),
+                "memberships": [],
+                "has_permissions": False,
+            },
+        )
+        membership_info = {
+            "company_id": row.get("company_id"),
+            "company_name": row.get("company_name"),
+            "role_name": row.get("role_name"),
+            "is_admin": bool(row.get("is_admin")),
+            "permissions": _parse_permissions(row.get("permissions")),
+        }
+        entry["memberships"].append(membership_info)
+        if not entry["has_permissions"] and (
+            membership_info["permissions"] or membership_info["is_admin"]
+        ):
+            entry["has_permissions"] = True
+
+    # Include super administrators without memberships.
+    try:
+        users = await user_repo.list_users()
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log_error("Failed to list users for impersonation", error=str(exc))
+        users = []
+    for user in users:
+        if not user.get("is_super_admin"):
+            continue
+        try:
+            user_id = int(user.get("id"))
+        except (TypeError, ValueError):
+            continue
+        entry = aggregated.setdefault(
+            user_id,
+            {
+                "id": user_id,
+                "email": user.get("email"),
+                "first_name": user.get("first_name"),
+                "last_name": user.get("last_name"),
+                "is_super_admin": True,
+                "memberships": [],
+                "has_permissions": True,
+            },
+        )
+        entry["has_permissions"] = True
+
+    eligible: list[dict[str, Any]] = []
+    for entry in aggregated.values():
+        if entry["has_permissions"] or entry["is_super_admin"]:
+            eligible.append(entry)
+
+    def _sort_key(record: dict[str, Any]) -> tuple[str, int]:
+        email = str(record.get("email") or "").lower()
+        return (email, record["id"])
+
+    eligible.sort(key=_sort_key)
+    return eligible
+
+
+async def start_impersonation(
+    *,
+    request: Request,
+    actor_user: dict[str, Any],
+    actor_session: SessionData,
+    target_user_id: int,
+) -> tuple[dict[str, Any], SessionData]:
+    if actor_session.impersonator_user_id is not None:
+        raise AlreadyImpersonatingError("Actor already has an active impersonation session")
+    try:
+        actor_id = int(actor_user.get("id"))
+    except (TypeError, ValueError):
+        raise NotImpersonatableError("Invalid actor context")
+    if actor_id == target_user_id:
+        raise SelfImpersonationError("Cannot impersonate the currently authenticated account")
+    if not actor_user.get("is_super_admin"):
+        raise NotImpersonatableError("Only super administrators can impersonate users")
+    target_user = await user_repo.get_user_by_id(target_user_id)
+    if not target_user:
+        raise NotImpersonatableError("User not found")
+    if not await user_is_impersonatable(target_user_id):
+        raise NotImpersonatableError("User does not have assigned permissions")
+
+    active_company_id = await company_access.first_accessible_company_id(target_user)
+    impersonated_session = await session_manager.create_session(
+        target_user_id,
+        request,
+        active_company_id=active_company_id,
+        impersonator_user_id=actor_id,
+        impersonator_session_id=actor_session.id,
+    )
+    if active_company_id is not None:
+        target_user["company_id"] = active_company_id
+
+    await audit_service.log_action(
+        action="impersonation.start",
+        user_id=actor_id,
+        entity_type="user",
+        entity_id=target_user_id,
+        metadata={
+            "impersonated_session_id": impersonated_session.id,
+            "impersonator_session_id": actor_session.id,
+        },
+        request=request,
+    )
+    log_info(
+        "Impersonation session created",
+        actor_id=actor_id,
+        target_user_id=target_user_id,
+        impersonated_session_id=impersonated_session.id,
+    )
+    return target_user, impersonated_session
+
+
+async def end_impersonation(
+    *,
+    request: Request,
+    session: SessionData,
+) -> tuple[dict[str, Any], SessionData]:
+    if session.impersonator_session_id is None or session.impersonator_user_id is None:
+        raise NotImpersonatingError("No impersonation session to exit")
+
+    original_record = await auth_repo.get_session_by_id(session.impersonator_session_id)
+    if not original_record or int(original_record.get("is_active", 0)) != 1:
+        await auth_repo.deactivate_session(session.id)
+        raise OriginalSessionUnavailableError("Original session is no longer available")
+
+    original_session = session_manager.hydrate_session(original_record)
+    current_time = datetime.now(timezone.utc)
+    await auth_repo.update_session(
+        original_session.id,
+        last_seen_at=current_time,
+        expires_at=current_time + session_manager.session_ttl,
+    )
+
+    impersonator_user = await user_repo.get_user_by_id(original_session.user_id)
+    if not impersonator_user:
+        await auth_repo.deactivate_session(session.id)
+        raise OriginalSessionUnavailableError("Original user record is unavailable")
+    if original_session.active_company_id is not None:
+        impersonator_user["company_id"] = original_session.active_company_id
+
+    await auth_repo.deactivate_session(session.id)
+    await audit_service.log_action(
+        action="impersonation.stop",
+        user_id=session.impersonator_user_id,
+        entity_type="user",
+        entity_id=session.user_id,
+        metadata={
+            "restored_session_id": original_session.id,
+            "impersonated_session_id": session.id,
+        },
+        request=request,
+    )
+    log_info(
+        "Impersonation session exited",
+        actor_id=session.impersonator_user_id,
+        impersonated_user_id=session.user_id,
+        restored_session_id=original_session.id,
+    )
+    return impersonator_user, original_session

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -199,6 +199,49 @@ body {
   line-height: 1.6;
 }
 
+.menu__item--impersonation {
+  padding: var(--space-gap-tight) var(--space-compact-inline);
+  background: rgba(148, 163, 184, 0.08);
+  border-radius: 0.75rem;
+}
+
+.impersonation-exit {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-gap-tight);
+}
+
+.impersonation-exit__button {
+  width: 100%;
+  justify-content: center;
+}
+
+.impersonation-exit__context {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #fef2f2;
+  line-height: 1.4;
+}
+
+.impersonation-exit__separator {
+  margin: 0 0.35rem;
+}
+
+.impersonation-access-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.impersonation-access-list li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
 .button,
 .button-link {
   border-radius: 0.75rem;

--- a/app/templates/admin/impersonation.html
+++ b/app/templates/admin/impersonation.html
@@ -1,0 +1,134 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <div class="admin-grid admin-grid--columns">
+    <section class="card card--panel admin-grid__full">
+      <header class="card__header card__header--stacked">
+        <div>
+          <h2 class="card__title">Impersonate a user</h2>
+          <p class="card__subtitle">
+            Select an account with assigned permissions to preview the portal experience from their perspective.
+          </p>
+        </div>
+        <div class="card__controls">
+          <input
+            type="search"
+            class="form-input"
+            placeholder="Filter users"
+            aria-label="Filter users"
+            data-table-filter="impersonation-table"
+          />
+        </div>
+      </header>
+      {% if impersonation_success or impersonation_error %}
+        <div class="stacked" style="gap: 0.75rem; margin-bottom: 1.25rem;">
+          {% if impersonation_success %}
+            <div class="alert" role="status">{{ impersonation_success }}</div>
+          {% endif %}
+          {% if impersonation_error %}
+            <div class="alert alert--error" role="alert">{{ impersonation_error }}</div>
+          {% endif %}
+        </div>
+      {% endif %}
+      <div class="table-wrapper">
+        <table class="table" id="impersonation-table" data-table>
+          <thead>
+            <tr>
+              <th scope="col" data-sort="string">Name</th>
+              <th scope="col" data-sort="string">Email</th>
+              <th scope="col" data-sort="string">Access summary</th>
+              <th scope="col" class="table__actions">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for candidate in impersonation_candidates %}
+              {% set is_self = candidate.id == current_user.id %}
+              {% set name_parts = [] %}
+              {% if candidate.first_name %}
+                {% set _ = name_parts.append(candidate.first_name) %}
+              {% endif %}
+              {% if candidate.last_name %}
+                {% set _ = name_parts.append(candidate.last_name) %}
+              {% endif %}
+              {% set display_name = " ".join(name_parts) if name_parts else None %}
+              {% set memberships = candidate.memberships or [] %}
+              <tr data-candidate-id="{{ candidate.id }}">
+                <td data-label="Name" data-sort-value="{{ display_name or candidate.email }}">
+                  {% if display_name %}
+                    {{ display_name }}
+                  {% else %}
+                    <span class="text-muted">—</span>
+                  {% endif %}
+                  {% if candidate.is_super_admin %}
+                    <span class="tag tag--muted" style="margin-left: 0.35rem;">Super admin</span>
+                  {% endif %}
+                </td>
+                <td data-label="Email" data-sort-value="{{ candidate.email or '' }}">
+                  {{ candidate.email or '—' }}
+                </td>
+                <td data-label="Access summary">
+                  {% if memberships %}
+                    <ul class="impersonation-access-list">
+                      {% for membership in memberships %}
+                        {% set company_label = membership.company_name or ('Company #' ~ membership.company_id) %}
+                        {% set role_label = membership.role_name or 'Assigned role' %}
+                        <li>
+                          {{ role_label }}
+                          {% if company_label %}
+                            <span class="text-muted">@ {{ company_label }}</span>
+                          {% endif %}
+                          {% if membership.permissions %}
+                            <span class="tag tag--muted">{{ membership.permissions|length }} permissions</span>
+                          {% elif membership.is_admin %}
+                            <span class="tag tag--muted">Company admin</span>
+                          {% endif %}
+                        </li>
+                      {% endfor %}
+                    </ul>
+                  {% elif candidate.is_super_admin %}
+                    <span class="tag tag--muted">Global access</span>
+                  {% else %}
+                    <span class="text-muted">No assigned permissions</span>
+                  {% endif %}
+                </td>
+                <td class="table__actions">
+                  <form action="/admin/impersonation" method="post" class="inline-form">
+                    {% include "partials/csrf.html" %}
+                    <input type="hidden" name="userId" value="{{ candidate.id }}" />
+                    <button
+                      type="submit"
+                      class="button"
+                      {% if is_self %}disabled{% endif %}
+                    >
+                      Impersonate
+                    </button>
+                  </form>
+                </td>
+              </tr>
+            {% else %}
+              <tr>
+                <td colspan="4" class="table__empty">No eligible users were found.</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div class="table-pagination" data-pagination="impersonation-table">
+        <div class="table-pagination__group">
+          <button type="button" class="button button--ghost table-pagination__button" data-page-prev disabled>
+            Previous
+          </button>
+          <button type="button" class="button button--ghost table-pagination__button" data-page-next>
+            Next
+          </button>
+        </div>
+        <p class="table-pagination__status" data-page-info aria-live="polite"></p>
+      </div>
+    </section>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -51,6 +51,25 @@
         </div>
         {% endif %}
         <ul class="menu">
+          {% if is_impersonating %}
+            <li class="menu__item menu__item--impersonation" data-impersonation-banner>
+              <form action="/auth/impersonation/exit" method="post" class="impersonation-exit">
+                {% if csrf_token %}
+                  <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                {% endif %}
+                <button type="submit" class="button button--danger impersonation-exit__button">
+                  Exit Impersonation
+                </button>
+                <p class="impersonation-exit__context">
+                  Viewing as {{ current_user.first_name or current_user.email }}
+                  {% if impersonator_user %}
+                    <span class="impersonation-exit__separator">•</span>
+                    Started by {{ impersonator_user.first_name or impersonator_user.email }}
+                  {% endif %}
+                </p>
+              </form>
+            </li>
+          {% endif %}
           {% block sidebar_menu %}
           {% set current_path = request.url.path if request is defined else '' %}
           {% set membership = active_membership or {} %}
@@ -202,6 +221,16 @@
                 <span class="menu__label">My profile</span>
               </a>
             </li>
+            {% if is_super_admin %}
+              <li class="menu__item">
+                <a href="/admin/impersonation" {% if current_path.startswith('/admin/impersonation') %}aria-current="page"{% endif %}>
+                  <span class="menu__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false"><path d="M5 3a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v4h-2V4H7v16h10v-3h2v4a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2z"/><path d="M16.59 11 14 13.59 15.41 15 21 9.41 15.41 4 14 5.41 16.59 8H9v2z"/></svg>
+                  </span>
+                  <span class="menu__label">Impersonation</span>
+                </a>
+              </li>
+            {% endif %}
             {% if is_super_admin %}
               <li class="menu__item">
                 <a href="/admin/companies" {% if current_path.startswith('/admin/companies') %}aria-current="page"{% endif %}>

--- a/changes/aa6eac04-f253-4a41-ae09-ffe0fae267aa.json
+++ b/changes/aa6eac04-f253-4a41-ae09-ffe0fae267aa.json
@@ -1,0 +1,7 @@
+{
+  "guid": "aa6eac04-f253-4a41-ae09-ffe0fae267aa",
+  "occurred_at": "2025-10-30T13:31:00Z",
+  "change_type": "Feature",
+  "summary": "Added super-admin impersonation workspace and API endpoints to mirror user permissions.",
+  "content_hash": "250296dabdbc4b8487396240caff9db53212be284b2ebfb33b8b4a0a4228d5e4"
+}

--- a/changes/ade5f6ef-1157-4e97-8501-242381e2e35e.json
+++ b/changes/ade5f6ef-1157-4e97-8501-242381e2e35e.json
@@ -1,0 +1,7 @@
+{
+  "guid": "ade5f6ef-1157-4e97-8501-242381e2e35e",
+  "occurred_at": "2025-10-30T14:05Z",
+  "change_type": "Fix",
+  "summary": "Fixed impersonation exit API test harness to simulate active session cookies.",
+  "content_hash": "9c0a48212013e812bf737fcb69b1137c8a647484198fd128218fc0fadfdccbe7"
+}

--- a/docs/impersonation.md
+++ b/docs/impersonation.md
@@ -1,0 +1,35 @@
+# Administrator impersonation
+
+Super administrators can temporarily impersonate any user with company-level permissions. This feature makes it easier to audit
+role assignments, troubleshoot access issues, and validate theme visibility without exchanging credentials.
+
+## Starting an impersonation session
+
+Use the **Administration ▸ Impersonation** workspace to search for eligible accounts. The table is filterable and sortable, and
+summarises each user's company roles. Selecting **Impersonate** issues a POST request to `/auth/impersonate` and switches the
+browser session to the selected user.
+
+```http
+POST /auth/impersonate
+Content-Type: application/json
+X-CSRF-Token: <csrf-token>
+
+{
+  "user_id": 42
+}
+```
+
+Successful responses contain an updated `LoginResponse` payload including the impersonated session metadata.
+
+## Ending impersonation
+
+While impersonating, a red **Exit Impersonation** button appears at the top of the left navigation. Submitting the button (or
+calling the API directly) restores the original super administrator session.
+
+```http
+POST /auth/impersonation/exit
+X-CSRF-Token: <csrf-token>
+```
+
+Both APIs are documented in Swagger under the **Auth** tag. Audit logs capture impersonation start and stop events alongside the
+original and impersonated session identifiers.

--- a/migrations/088_session_impersonation.sql
+++ b/migrations/088_session_impersonation.sql
@@ -1,0 +1,103 @@
+SET @db_name = DATABASE();
+
+SET @impersonator_user_stmt = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = @db_name
+        AND TABLE_NAME = 'user_sessions'
+        AND COLUMN_NAME = 'impersonator_user_id'
+    ),
+    'SELECT 1',
+    'ALTER TABLE user_sessions ADD COLUMN impersonator_user_id INT NULL AFTER pending_totp_secret'
+  )
+);
+PREPARE stmt FROM @impersonator_user_stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @impersonator_session_stmt = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = @db_name
+        AND TABLE_NAME = 'user_sessions'
+        AND COLUMN_NAME = 'impersonator_session_id'
+    ),
+    'SELECT 1',
+    'ALTER TABLE user_sessions ADD COLUMN impersonator_session_id INT NULL AFTER impersonator_user_id'
+  )
+);
+PREPARE stmt FROM @impersonator_session_stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @impersonation_started_stmt = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = @db_name
+        AND TABLE_NAME = 'user_sessions'
+        AND COLUMN_NAME = 'impersonation_started_at'
+    ),
+    'SELECT 1',
+    'ALTER TABLE user_sessions ADD COLUMN impersonation_started_at DATETIME NULL AFTER impersonator_session_id'
+  )
+);
+PREPARE stmt FROM @impersonation_started_stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @impersonator_session_index_stmt = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.STATISTICS
+      WHERE TABLE_SCHEMA = @db_name
+        AND TABLE_NAME = 'user_sessions'
+        AND INDEX_NAME = 'idx_user_sessions_impersonator_session'
+    ),
+    'SELECT 1',
+    'CREATE INDEX idx_user_sessions_impersonator_session ON user_sessions (impersonator_session_id)'
+  )
+);
+PREPARE stmt FROM @impersonator_session_index_stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @impersonator_user_fk_stmt = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+      WHERE TABLE_SCHEMA = @db_name
+        AND TABLE_NAME = 'user_sessions'
+        AND CONSTRAINT_NAME = 'fk_user_sessions_impersonator_user'
+    ),
+    'SELECT 1',
+    'ALTER TABLE user_sessions ADD CONSTRAINT fk_user_sessions_impersonator_user FOREIGN KEY (impersonator_user_id) REFERENCES users(id) ON DELETE SET NULL'
+  )
+);
+PREPARE stmt FROM @impersonator_user_fk_stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @impersonator_session_fk_stmt = (
+  SELECT IF(
+    EXISTS (
+      SELECT 1
+      FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+      WHERE TABLE_SCHEMA = @db_name
+        AND TABLE_NAME = 'user_sessions'
+        AND CONSTRAINT_NAME = 'fk_user_sessions_impersonator_session'
+    ),
+    'SELECT 1',
+    'ALTER TABLE user_sessions ADD CONSTRAINT fk_user_sessions_impersonator_session FOREIGN KEY (impersonator_session_id) REFERENCES user_sessions(id) ON DELETE SET NULL'
+  )
+);
+PREPARE stmt FROM @impersonator_session_fk_stmt;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/tests/test_auth_impersonation_api.py
+++ b/tests/test_auth_impersonation_api.py
@@ -1,0 +1,218 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import Request
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import auth as auth_dependencies
+from app.core.database import db
+from app.main import app, scheduler_service
+from app.security.session import SessionData, session_manager
+from app.services import impersonation as impersonation_service
+
+
+@pytest.fixture(autouse=True)
+def mock_startup(monkeypatch):
+    async def fake_connect():
+        return None
+
+    async def fake_disconnect():
+        return None
+
+    async def fake_run_migrations():
+        return None
+
+    async def fake_start():
+        return None
+
+    async def fake_stop():
+        return None
+
+    monkeypatch.setattr(db, "connect", fake_connect)
+    monkeypatch.setattr(db, "disconnect", fake_disconnect)
+    monkeypatch.setattr(db, "run_migrations", fake_run_migrations)
+    monkeypatch.setattr(scheduler_service, "start", fake_start)
+    monkeypatch.setattr(scheduler_service, "stop", fake_stop)
+
+
+@pytest.fixture
+def active_session(monkeypatch):
+    now = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+    session = SessionData(
+        id=10,
+        user_id=1,
+        session_token="session-token",
+        csrf_token="csrf-token",
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+        last_seen_at=now,
+        ip_address=None,
+        user_agent=None,
+        active_company_id=None,
+        pending_totp_secret=None,
+        impersonator_user_id=None,
+        impersonator_session_id=None,
+        impersonation_started_at=None,
+    )
+
+    async def fake_load_session(request, *, allow_inactive=False):
+        request.state.session = session
+        return session
+
+    monkeypatch.setattr(session_manager, "load_session", fake_load_session)
+    return session
+
+
+def test_impersonate_user_returns_login_response(monkeypatch, active_session):
+    new_now = datetime(2025, 1, 1, 12, 5, tzinfo=timezone.utc)
+    impersonated_session = SessionData(
+        id=99,
+        user_id=5,
+        session_token="impersonated",
+        csrf_token="csrf-imp",
+        created_at=new_now,
+        expires_at=new_now + timedelta(hours=1),
+        last_seen_at=new_now,
+        ip_address=None,
+        user_agent=None,
+        active_company_id=None,
+        pending_totp_secret=None,
+        impersonator_user_id=1,
+        impersonator_session_id=10,
+        impersonation_started_at=new_now,
+    )
+    impersonated_user = {"id": 5, "email": "user@example.com"}
+
+    async def fake_start_impersonation(**kwargs):
+        return impersonated_user, impersonated_session
+
+    applied_sessions = []
+
+    def fake_apply_cookies(response, session):
+        applied_sessions.append(session.id)
+
+    monkeypatch.setattr(impersonation_service, "start_impersonation", fake_start_impersonation)
+    monkeypatch.setattr(session_manager, "apply_session_cookies", fake_apply_cookies)
+
+    async def override_current_session(request: Request):
+        request.state.session = active_session
+        return active_session
+
+    app.dependency_overrides[auth_dependencies.require_super_admin] = lambda: {
+        "id": 1,
+        "email": "admin@example.com",
+        "is_super_admin": True,
+    }
+    app.dependency_overrides[auth_dependencies.get_current_session] = override_current_session
+
+    try:
+        with TestClient(app) as client:
+            client.cookies.set(session_manager.session_cookie_name, active_session.session_token)
+            client.cookies.set(session_manager.csrf_cookie_name, active_session.csrf_token)
+            response = client.post(
+                "/auth/impersonate",
+                json={"user_id": 5},
+                headers={"X-CSRF-Token": active_session.csrf_token},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["user"]["id"] == impersonated_user["id"]
+    assert payload["session"]["impersonator_user_id"] == active_session.user_id
+    assert applied_sessions == [impersonated_session.id]
+
+
+def test_impersonate_user_conflict(monkeypatch, active_session):
+    async def fake_start_impersonation(**kwargs):
+        raise impersonation_service.AlreadyImpersonatingError("active")
+
+    monkeypatch.setattr(impersonation_service, "start_impersonation", fake_start_impersonation)
+    monkeypatch.setattr(session_manager, "apply_session_cookies", lambda *args, **kwargs: None)
+
+    async def override_current_session(request: Request):
+        request.state.session = active_session
+        return active_session
+
+    app.dependency_overrides[auth_dependencies.require_super_admin] = lambda: {
+        "id": 1,
+        "email": "admin@example.com",
+        "is_super_admin": True,
+    }
+    app.dependency_overrides[auth_dependencies.get_current_session] = override_current_session
+
+    try:
+        with TestClient(app) as client:
+            client.cookies.set(session_manager.session_cookie_name, active_session.session_token)
+            client.cookies.set(session_manager.csrf_cookie_name, active_session.csrf_token)
+            response = client.post(
+                "/auth/impersonate",
+                json={"user_id": 5},
+                headers={"X-CSRF-Token": active_session.csrf_token},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 409
+
+
+def test_exit_impersonation_restores_original_session(monkeypatch, active_session):
+    impersonated_session = SessionData(
+        id=40,
+        user_id=5,
+        session_token="impersonated",
+        csrf_token="csrf-imp",
+        created_at=active_session.created_at,
+        expires_at=active_session.expires_at,
+        last_seen_at=active_session.last_seen_at,
+        ip_address=None,
+        user_agent=None,
+        active_company_id=None,
+        pending_totp_secret=None,
+        impersonator_user_id=active_session.user_id,
+        impersonator_session_id=active_session.id,
+        impersonation_started_at=active_session.created_at,
+    )
+    restored_session = active_session
+    restored_user = {"id": active_session.user_id, "email": "admin@example.com"}
+
+    async def fake_end_impersonation(**kwargs):
+        return restored_user, restored_session
+
+    applied_sessions = []
+
+    def fake_apply_cookies(response, session):
+        applied_sessions.append(session.id)
+
+    monkeypatch.setattr(impersonation_service, "end_impersonation", fake_end_impersonation)
+    monkeypatch.setattr(session_manager, "apply_session_cookies", fake_apply_cookies)
+
+    async def fake_load_impersonated_session(request, *, allow_inactive=False):
+        request.state.session = impersonated_session
+        return impersonated_session
+
+    monkeypatch.setattr(session_manager, "load_session", fake_load_impersonated_session)
+
+    async def override_impersonated_session(request: Request):
+        request.state.session = impersonated_session
+        return impersonated_session
+
+    app.dependency_overrides[auth_dependencies.get_current_session] = override_impersonated_session
+
+    try:
+        with TestClient(app) as client:
+            client.cookies.set(session_manager.session_cookie_name, impersonated_session.session_token)
+            client.cookies.set(session_manager.csrf_cookie_name, impersonated_session.csrf_token)
+            response = client.post(
+                "/auth/impersonation/exit",
+                headers={"X-CSRF-Token": impersonated_session.csrf_token},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["user"]["id"] == restored_user["id"]
+    assert payload["session"]["user_id"] == restored_session.user_id
+    assert applied_sessions == [restored_session.id]

--- a/tests/test_impersonation_service.py
+++ b/tests/test_impersonation_service.py
@@ -1,0 +1,247 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.security.session import SessionData
+from app.services import impersonation as impersonation_service
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_user_is_impersonatable_checks_membership(monkeypatch):
+    async def fake_list_memberships(user_id, *, status="active"):
+        assert user_id == 5
+        assert status == "active"
+        return [
+            {"permissions": ["tickets.view"], "is_admin": False},
+        ]
+
+    monkeypatch.setattr(
+        impersonation_service.membership_repo,
+        "list_memberships_for_user",
+        fake_list_memberships,
+    )
+    async def fake_get_user(user_id):
+        return {"id": user_id, "is_super_admin": False}
+
+    monkeypatch.setattr(
+        impersonation_service.user_repo,
+        "get_user_by_id",
+        fake_get_user,
+    )
+
+    assert await impersonation_service.user_is_impersonatable(5)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_user_is_impersonatable_super_admin(monkeypatch):
+    async def fake_list_memberships(user_id, *, status="active"):
+        assert user_id == 7
+        return []
+
+    async def fake_get_user(user_id):
+        return {"id": user_id, "is_super_admin": True}
+
+    monkeypatch.setattr(
+        impersonation_service.membership_repo,
+        "list_memberships_for_user",
+        fake_list_memberships,
+    )
+    monkeypatch.setattr(impersonation_service.user_repo, "get_user_by_id", fake_get_user)
+
+    assert await impersonation_service.user_is_impersonatable(7)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_list_impersonatable_users_combines_memberships(monkeypatch):
+    async def fake_list_memberships():
+        return [
+            {
+                "user_id": 2,
+                "email": "user@example.com",
+                "first_name": "End",
+                "last_name": "User",
+                "company_id": 9,
+                "company_name": "Example Co",
+                "role_name": "Support",
+                "permissions": ["tickets.view"],
+                "is_admin": 0,
+                "is_super_admin": 0,
+            }
+        ]
+
+    async def fake_list_users():
+        return [
+            {"id": 1, "email": "admin@example.com", "is_super_admin": True},
+            {"id": 2, "email": "user@example.com", "is_super_admin": False},
+        ]
+
+    monkeypatch.setattr(
+        impersonation_service.membership_repo,
+        "list_impersonatable_memberships",
+        fake_list_memberships,
+    )
+    monkeypatch.setattr(impersonation_service.user_repo, "list_users", fake_list_users)
+
+    results = await impersonation_service.list_impersonatable_users()
+    assert len(results) == 2
+    assert results[0]["email"] == "admin@example.com"
+    assert results[0]["has_permissions"]
+    assert results[1]["memberships"][0]["company_name"] == "Example Co"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_start_impersonation_creates_new_session(monkeypatch):
+    actor_user = {"id": 1, "email": "admin@example.com", "is_super_admin": True}
+    now = datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc)
+    actor_session = SessionData(
+        id=11,
+        user_id=1,
+        session_token="original",
+        csrf_token="csrf",
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+        last_seen_at=now,
+        ip_address=None,
+        user_agent=None,
+        active_company_id=None,
+        pending_totp_secret=None,
+        impersonator_user_id=None,
+        impersonator_session_id=None,
+        impersonation_started_at=None,
+    )
+
+    async def fake_get_user(user_id):
+        assert user_id == 42
+        return {"id": user_id, "email": "user@example.com"}
+
+    async def fake_is_impersonatable(user_id):
+        assert user_id == 42
+        return True
+
+    async def fake_first_company(user):
+        assert user["id"] == 42
+        return 17
+
+    created_session = SessionData(
+        id=99,
+        user_id=42,
+        session_token="impersonated",
+        csrf_token="csrf-imp",
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+        last_seen_at=now,
+        ip_address=None,
+        user_agent=None,
+        active_company_id=17,
+        pending_totp_secret=None,
+        impersonator_user_id=1,
+        impersonator_session_id=11,
+        impersonation_started_at=now,
+    )
+
+    async def fake_create_session(user_id, request, *, active_company_id, impersonator_user_id, impersonator_session_id):
+        assert user_id == 42
+        assert active_company_id == 17
+        assert impersonator_user_id == 1
+        assert impersonator_session_id == 11
+        return created_session
+
+    async def fake_log_action(**kwargs):
+        return None
+
+    monkeypatch.setattr(impersonation_service.user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(impersonation_service, "user_is_impersonatable", fake_is_impersonatable)
+    monkeypatch.setattr(impersonation_service.company_access, "first_accessible_company_id", fake_first_company)
+    monkeypatch.setattr(impersonation_service.session_manager, "create_session", fake_create_session)
+    monkeypatch.setattr(impersonation_service.audit_service, "log_action", fake_log_action)
+    monkeypatch.setattr(impersonation_service, "log_info", lambda *args, **kwargs: None)
+
+    target_user, impersonated_session = await impersonation_service.start_impersonation(
+        request=None,
+        actor_user=actor_user,
+        actor_session=actor_session,
+        target_user_id=42,
+    )
+
+    assert target_user["company_id"] == 17
+    assert impersonated_session.id == 99
+
+
+@pytest.mark.anyio("asyncio")
+async def test_end_impersonation_restores_original_session(monkeypatch):
+    now = datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc)
+    impersonated_session = SessionData(
+        id=50,
+        user_id=42,
+        session_token="impersonated",
+        csrf_token="csrf-imp",
+        created_at=now - timedelta(hours=1),
+        expires_at=now + timedelta(hours=1),
+        last_seen_at=now,
+        ip_address=None,
+        user_agent=None,
+        active_company_id=23,
+        pending_totp_secret=None,
+        impersonator_user_id=1,
+        impersonator_session_id=22,
+        impersonation_started_at=now - timedelta(minutes=5),
+    )
+
+    original_record = {
+        "id": 22,
+        "user_id": 1,
+        "session_token": "original",
+        "csrf_token": "csrf",
+        "created_at": now - timedelta(hours=2),
+        "expires_at": now + timedelta(hours=1),
+        "last_seen_at": now - timedelta(minutes=10),
+        "ip_address": None,
+        "user_agent": None,
+        "active_company_id": 5,
+        "pending_totp_secret": None,
+        "impersonator_user_id": None,
+        "impersonator_session_id": None,
+        "impersonation_started_at": None,
+        "is_active": 1,
+    }
+
+    async def fake_get_session(session_id):
+        assert session_id == 22
+        return original_record
+
+    calls = {}
+
+    async def fake_update_session(session_id, **kwargs):
+        calls["update"] = (session_id, kwargs)
+
+    async def fake_deactivate_session(session_id):
+        calls.setdefault("deactivate", []).append(session_id)
+
+    async def fake_get_user(user_id):
+        assert user_id == 1
+        return {"id": 1, "email": "admin@example.com", "is_super_admin": True}
+
+    async def fake_log_action(**kwargs):
+        calls["log"] = kwargs
+
+    monkeypatch.setattr(impersonation_service.auth_repo, "get_session_by_id", fake_get_session)
+    monkeypatch.setattr(impersonation_service.auth_repo, "update_session", fake_update_session)
+    monkeypatch.setattr(impersonation_service.auth_repo, "deactivate_session", fake_deactivate_session)
+    monkeypatch.setattr(impersonation_service.user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(impersonation_service.audit_service, "log_action", fake_log_action)
+    monkeypatch.setattr(impersonation_service, "log_info", lambda *args, **kwargs: None)
+
+    restored_user, restored_session = await impersonation_service.end_impersonation(
+        request=None,
+        session=impersonated_session,
+    )
+
+    assert restored_user["email"] == "admin@example.com"
+    assert restored_session.id == 22
+    assert calls["deactivate"] == [50]
+    assert calls["log"]["entity_id"] == 42


### PR DESCRIPTION
## Summary
- add backend impersonation services, session handling, and auth endpoints so super admins can assume eligible user identities
- expose impersonation management in the admin UI with navigation exit controls and supporting styles & docs
- cover the feature with database migration, change log entry, and targeted API/service tests

## Testing
- pytest tests/test_impersonation_service.py tests/test_auth_impersonation_api.py -q

------
https://chatgpt.com/codex/tasks/task_b_6903651d9810832dac8ca537986f9128