### PR TITLE
Fix Decimal serialization in API key admin modal

### DIFF
--- a/app/repositories/api_keys.py
+++ b/app/repositories/api_keys.py
@@ -116,6 +116,9 @@ async def list_api_keys_with_usage(
     normalised: list[dict[str, Any]] = []
     for row in rows:
         info = dict(row)
+        # Normalise numeric aggregation results that may come back as Decimals.
+        usage_count = info.get("usage_count")
+        info["usage_count"] = int(usage_count or 0)
         info["created_at"] = _to_utc(info.get("created_at"))
         info["last_used_at"] = _to_utc(info.get("last_used_at"))
         info["last_seen_at"] = _to_utc(info.get("last_seen_at"))
@@ -156,6 +159,8 @@ async def get_api_key_with_usage(api_key_id: int) -> dict[str, Any] | None:
         return None
     usage_map = await _fetch_usage_by_key([api_key_id])
     info = dict(row)
+    usage_count = info.get("usage_count")
+    info["usage_count"] = int(usage_count or 0)
     info["created_at"] = _to_utc(info.get("created_at"))
     info["last_used_at"] = _to_utc(info.get("last_used_at"))
     info["last_seen_at"] = _to_utc(info.get("last_seen_at"))
@@ -227,7 +232,7 @@ async def _fetch_usage_by_key(key_ids: Iterable[int]) -> dict[int, list[dict[str
         usage.setdefault(key_id, []).append(
             {
                 "ip_address": row["ip_address"],
-                "usage_count": row["usage_count"],
+                "usage_count": int(row.get("usage_count") or 0),
                 "last_used_at": _to_utc(row.get("last_used_at")),
             }
         )

--- a/changes/bc362f3f-ec09-4f62-9af7-275a049c26a2.json
+++ b/changes/bc362f3f-ec09-4f62-9af7-275a049c26a2.json
@@ -1,0 +1,7 @@
+{
+  "guid": "bc362f3f-ec09-4f62-9af7-275a049c26a2",
+  "occurred_at": "2025-10-30T13:45:01Z",
+  "change_type": "Fix",
+  "summary": "Normalised API key usage counts to avoid Decimal serialization errors in admin modal.",
+  "content_hash": "230b36044979d2f1a6d80ef2d5d193cac139775cbe0e525787ed0255f7441c44"
+}


### PR DESCRIPTION
## Summary
- normalise aggregated API key usage counts to integers so Jinja templates can serialise modal payloads
- ensure usage telemetry entries also return integer counts for downstream consumers
- log the fix in the change history

## Testing
- pytest tests/test_admin_change_log_page.py

------
https://chatgpt.com/codex/tasks/task_b_69036b87cda0832dadb54b2e07196b54