### PR TITLE
Make company email domain inputs single-line fields

### DIFF
--- a/app/templates/admin/companies.html
+++ b/app/templates/admin/companies.html
@@ -161,14 +161,14 @@
             </div>
             <div class="form-field">
               <label class="form-label" for="company-email-domains">Email domains</label>
-              <textarea
+              <input
                 id="company-email-domains"
                 name="emailDomains"
-                class="form-input form-input--textarea"
-                rows="2"
+                class="form-input"
+                type="text"
                 placeholder="example.com, example.org"
-              ></textarea>
-              <p class="form-help">Use commas or new lines to list domains for automatic company matching.</p>
+              />
+              <p class="form-help">Use commas to list domains for automatic company matching.</p>
             </div>
             <div class="form-field form-field--checkbox">
               <label class="checkbox" for="company-vip">

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -59,14 +59,15 @@
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-company-email-domains">Email domains</label>
-            <textarea
+            <input
               id="edit-company-email-domains"
               name="emailDomains"
-              class="form-input form-input--textarea"
-              rows="1"
+              class="form-input"
+              type="text"
               placeholder="example.com, example.org"
-            >{{ form_data.email_domains }}</textarea>
-            <p class="form-help">Use commas or new lines to list domains. Domains are matched case-insensitively.</p>
+              value="{{ form_data.email_domains }}"
+            />
+            <p class="form-help">Use commas to list domains. Domains are matched case-insensitively.</p>
           </div>
           <div class="form-field form-field--checkbox">
             <label class="checkbox" for="edit-company-vip">

--- a/changes/048721e9-aeeb-467e-986d-4d59eadc4733.json
+++ b/changes/048721e9-aeeb-467e-986d-4d59eadc4733.json
@@ -1,0 +1,7 @@
+{
+  "guid": "048721e9-aeeb-467e-986d-4d59eadc4733",
+  "occurred_at": "2025-10-30T14:00Z",
+  "change_type": "Fix",
+  "summary": "Switched company email domain fields to single-line inputs in admin forms.",
+  "content_hash": "ecb4cfa34bcea3e9ce5667522ab54d95eb7145705ff81e26bd042914ceac26c9"
+}


### PR DESCRIPTION
## Summary
- replace the multi-line email domain inputs in the admin company create and edit forms with single-line text fields
- adjust helper text to emphasise comma-separated domain entry
- record the update in the change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69036ef5c650832da7b428848f4f3716