### PR TITLE
Add ability to cancel pending staff access assignments

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1388,6 +1388,34 @@
       });
     });
 
+    document.querySelectorAll('[data-remove-pending-assignment]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const { companyId, staffId } = button.dataset;
+        if (!companyId || !staffId) {
+          return;
+        }
+        if (!confirm('Cancel this pending staff access?')) {
+          return;
+        }
+        const row = button.closest('tr');
+        const formData = new FormData();
+        button.disabled = true;
+        try {
+          await requestForm(
+            `/admin/companies/assignment/${companyId}/${staffId}/pending/remove`,
+            formData,
+          );
+          if (row) {
+            row.remove();
+          }
+        } catch (error) {
+          alert(`Unable to cancel pending access: ${error.message}`);
+        } finally {
+          button.disabled = false;
+        }
+      });
+    });
+
     document.querySelectorAll('[data-remove-assignment]').forEach((button) => {
       button.addEventListener('click', async () => {
         const { companyId, userId } = button.dataset;

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -329,7 +329,20 @@
                     {% endfor %}
                     <td class="table__actions">
                       {% if assignment.is_pending %}
-                        <span class="text-muted">Pending sign-up</span>
+                        <div class="stacked">
+                          <span class="text-muted">Pending sign-up</span>
+                          {% if assignment.staff_id %}
+                            <button
+                              type="button"
+                              class="button button--danger button--small"
+                              data-remove-pending-assignment
+                              data-company-id="{{ assignment.company_id }}"
+                              data-staff-id="{{ assignment.staff_id }}"
+                            >
+                              Cancel pending access
+                            </button>
+                          {% endif %}
+                        </div>
                       {% else %}
                         <button
                           type="button"

--- a/changes/c4163961-f6e1-4450-b8cb-c4b6965fc62e.json
+++ b/changes/c4163961-f6e1-4450-b8cb-c4b6965fc62e.json
@@ -1,0 +1,7 @@
+{
+  "guid": "c4163961-f6e1-4450-b8cb-c4b6965fc62e",
+  "occurred_at": "2025-10-30T14:02Z",
+  "change_type": "Feature",
+  "summary": "Added admin tooling to cancel pending staff permission assignments before sign-up.",
+  "content_hash": "d4cf226953b74ef65a8891a9a494820b4766d135390ac10efddf06eb5466c78a"
+}

--- a/docs/admin-company-memberships.md
+++ b/docs/admin-company-memberships.md
@@ -1,0 +1,13 @@
+# Admin company membership endpoints
+
+The admin portal exposes a collection of POST endpoints that allow super administrators to manage staff access to customer companies. All requests must include a valid authenticated session with super administrator privileges and a CSRF token when invoked from browser contexts.
+
+| Endpoint | Description |
+| --- | --- |
+| `POST /admin/companies/assignment/{company_id}/{user_id}/permission` | Toggle granular company permissions such as licence ordering or shop access for an existing membership. |
+| `POST /admin/companies/assignment/{company_id}/{user_id}/staff-permission` | Adjust the staff permission level that governs knowledge base and ticket capabilities for an assigned user. |
+| `POST /admin/companies/assignment/{company_id}/{user_id}/role` | Update the membership role associated with the company assignment. |
+| `POST /admin/companies/assignment/{company_id}/{user_id}/remove` | Remove an active membership. The user immediately loses access to the company. |
+| `POST /admin/companies/assignment/{company_id}/{staff_id}/pending/remove` | Cancel a pending staff access assignment before the staff member completes portal sign-up. |
+
+All endpoints return a JSON payload with a `success` flag on completion. Validation errors return `400 Bad Request`, missing resources return `404 Not Found`, and insufficient privileges return `303 See Other` redirects to the login screen.


### PR DESCRIPTION
## Summary
- add a super-admin endpoint that cancels pending staff company assignments and records an audit trail
- update the company membership table UI/JS so pending rows can be removed and document the admin endpoints
- add regression coverage and log the change in the change log registry

## Testing
- pytest tests/test_company_memberships.py

------
https://chatgpt.com/codex/tasks/task_b_69036ec372b8832dbfbfba691e924ea3