### PR TITLE
Add endpoint-scoped API key permissions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -98,6 +98,7 @@ from app.repositories import webhook_events as webhook_events_repo
 from app.repositories import user_companies as user_company_repo
 from app.repositories import users as user_repo
 from app.repositories import issues as issues_repo
+from app.schemas.api_keys import ALLOWED_API_KEY_HTTP_METHODS
 from app.schemas.tickets import SyncroTicketImportRequest
 from app.security.csrf import CSRFMiddleware
 from app.security.encryption import encrypt_secret
@@ -1376,6 +1377,73 @@ def _extract_audit_service(action: Any) -> str:
     return text.split(".", 1)[0]
 
 
+def _parse_permission_lines(value: str | None) -> tuple[list[dict[str, Any]], list[str]]:
+    if value is None:
+        return [], []
+    entries: dict[str, set[str]] = {}
+    errors: list[str] = []
+    allowed_methods = ", ".join(sorted(ALLOWED_API_KEY_HTTP_METHODS))
+    for index, raw_line in enumerate(str(value).splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        if " " not in line:
+            errors.append(f"Line {index}: Enter values as 'METHOD /path'.")
+            continue
+        method_part, path_part = line.split(None, 1)
+        path = path_part.strip()
+        if not path.startswith("/"):
+            errors.append(f"Line {index}: Paths must start with '/'.")
+            continue
+        raw_methods = [token.strip().upper() for token in method_part.split(",")]
+        methods = [token for token in raw_methods if token]
+        if not methods:
+            errors.append(f"Line {index}: Provide at least one HTTP method.")
+            continue
+        invalid = [token for token in methods if token not in ALLOWED_API_KEY_HTTP_METHODS]
+        if invalid:
+            errors.append(
+                f"Line {index}: Unsupported method(s) {', '.join(invalid)}. Allowed methods: {allowed_methods}."
+            )
+            continue
+        entries.setdefault(path, set()).update(methods)
+    parsed = [
+        {"path": path, "methods": sorted(methods)}
+        for path, methods in sorted(entries.items(), key=lambda item: item[0])
+    ]
+    return parsed, errors
+
+
+def _format_api_key_permissions(
+    permissions: list[dict[str, Any]] | None,
+) -> tuple[list[dict[str, Any]], str, str]:
+    display_entries: list[dict[str, Any]] = []
+    if permissions:
+        for entry in permissions:
+            path = str(entry.get("path", "")).strip()
+            methods = sorted(
+                {str(method).strip().upper() for method in entry.get("methods", []) if str(method).strip()}
+            )
+            if not path or not methods:
+                continue
+            display_entries.append({"path": path, "methods": methods})
+    display_entries.sort(key=lambda item: item["path"])
+    permissions_text = "\n".join(
+        f"{', '.join(entry['methods'])} {entry['path']}" for entry in display_entries
+    )
+    if display_entries:
+        summary_parts = [
+            f"{', '.join(entry['methods'])} {entry['path']}" for entry in display_entries[:2]
+        ]
+        remaining = len(display_entries) - 2
+        if remaining > 0:
+            summary_parts.append(f"+{remaining} more")
+        access_summary = ", ".join(summary_parts)
+    else:
+        access_summary = "All endpoints"
+    return display_entries, permissions_text, access_summary
+
+
 def _prepare_api_key_rows(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], dict[str, int]]:
     today = date.today()
     prepared: list[dict[str, Any]] = []
@@ -1394,6 +1462,9 @@ def _prepare_api_key_rows(rows: list[dict[str, Any]]) -> tuple[list[dict[str, An
                     "last_used_iso": _to_iso(entry.get("last_used_at")),
                 }
             )
+        display_permissions, permissions_text, access_summary = _format_api_key_permissions(
+            row.get("permissions")
+        )
         expiry_iso = None
         if isinstance(expiry, date):
             expiry_iso = datetime.combine(expiry, time.min, tzinfo=timezone.utc).isoformat()
@@ -1410,6 +1481,10 @@ def _prepare_api_key_rows(rows: list[dict[str, Any]]) -> tuple[list[dict[str, An
                 "usage_count": row.get("usage_count", 0),
                 "is_expired": is_expired,
                 "usage": usage_entries,
+                "permissions": display_permissions,
+                "permissions_text": permissions_text,
+                "access_summary": access_summary,
+                "is_restricted": bool(display_permissions),
             }
         )
     stats = {
@@ -1551,6 +1626,7 @@ async def _render_api_keys_dashboard(
         "status_message": status_message,
         "errors": errors or [],
         "new_api_key": new_api_key,
+        "allowed_methods": sorted(ALLOWED_API_KEY_HTTP_METHODS),
     }
     return await _render_template("admin/api_keys.html", request, current_user, extra=extra)
 async def _load_license_context(
@@ -5575,9 +5651,13 @@ async def admin_create_api_key_page(request: Request):
     description = (str(form.get("description", "")).strip() or None)
     expiry_raw = form.get("expiry_date")
     expiry_date = _parse_input_date(expiry_raw) if expiry_raw else None
+    permissions_raw = form.get("permissions")
+    permissions_text = str(permissions_raw).strip() if permissions_raw is not None else ""
+    parsed_permissions, permission_errors = _parse_permission_lines(permissions_text)
     errors: list[str] = []
     if expiry_raw and expiry_date is None:
         errors.append("Enter an expiry date in YYYY-MM-DD format.")
+    errors.extend(permission_errors)
     if errors:
         return await _render_api_keys_dashboard(
             request,
@@ -5590,6 +5670,7 @@ async def admin_create_api_key_page(request: Request):
         raw_key, row = await api_key_repo.create_api_key(
             description=description,
             expiry_date=expiry_date,
+            permissions=parsed_permissions,
         )
     except Exception as exc:  # pragma: no cover - defensive logging
         log_error("Failed to create API key from admin form", error=str(exc))
@@ -5609,8 +5690,12 @@ async def admin_create_api_key_page(request: Request):
         new_value={
             "description": description,
             "expiry_date": expiry_date.isoformat() if isinstance(expiry_date, date) else None,
+            "permissions": parsed_permissions,
         },
         request=request,
+    )
+    display_permissions, permissions_text_value, access_summary = _format_api_key_permissions(
+        row.get("permissions")
     )
     new_api_key = {
         "id": row["id"],
@@ -5622,6 +5707,9 @@ async def admin_create_api_key_page(request: Request):
             if row.get("expiry_date")
             else None
         ),
+        "permissions": display_permissions,
+        "permissions_text": permissions_text_value,
+        "access_summary": access_summary,
     }
     status_message = "New API key created. Store the value securely; it will not be shown again."
     return await _render_api_keys_dashboard(
@@ -5659,7 +5747,11 @@ async def admin_rotate_api_key_page(request: Request):
     expiry_date = _parse_input_date(expiry_raw) if expiry_raw else None
     if expiry_raw and expiry_date is None:
         errors.append("Enter a valid expiry date in YYYY-MM-DD format.")
+    permissions_raw = form.get("permissions")
+    permissions_text = str(permissions_raw).strip() if permissions_raw is not None else ""
+    parsed_permissions, permission_errors = _parse_permission_lines(permissions_text)
     retire_previous = _parse_bool(form.get("retire_previous"), default=True)
+    errors.extend(permission_errors)
     if errors:
         return await _render_api_keys_dashboard(
             request,
@@ -5680,10 +5772,12 @@ async def admin_rotate_api_key_page(request: Request):
         )
     final_description = description if description is not None else existing.get("description")
     final_expiry = expiry_date if expiry_date is not None else existing.get("expiry_date")
+    permissions = parsed_permissions if permissions_raw is not None else existing.get("permissions", [])
     try:
         raw_key, row = await api_key_repo.create_api_key(
             description=final_description,
             expiry_date=final_expiry,
+            permissions=permissions,
         )
     except Exception as exc:  # pragma: no cover - defensive logging
         log_error("Failed to rotate API key from admin form", api_key_id=api_key_id, error=str(exc))
@@ -5708,6 +5802,7 @@ async def admin_rotate_api_key_page(request: Request):
         new_value={
             "description": final_description,
             "expiry_date": final_expiry.isoformat() if isinstance(final_expiry, date) else None,
+            "permissions": permissions,
         },
         metadata=metadata,
         request=request,
@@ -5731,6 +5826,9 @@ async def admin_rotate_api_key_page(request: Request):
             metadata={"rotated_to": row["id"]},
             request=request,
         )
+    display_permissions, permissions_text_value, access_summary = _format_api_key_permissions(
+        row.get("permissions")
+    )
     new_api_key = {
         "id": row["id"],
         "value": raw_key,
@@ -5742,6 +5840,9 @@ async def admin_rotate_api_key_page(request: Request):
             else None
         ),
         "rotated_from": api_key_id,
+        "permissions": display_permissions,
+        "permissions_text": permissions_text_value,
+        "access_summary": access_summary,
     }
     status_message = (
         "API key rotated. Copy the replacement key below and distribute it to integrated services."

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1431,6 +1431,9 @@
     const usageCountElement = modal.querySelector('[data-api-key-usage-count]');
     const usageListElement = modal.querySelector('[data-api-key-usage-list]');
     const usageEmptyElement = modal.querySelector('[data-api-key-usage-empty]');
+    const accessElement = modal.querySelector('[data-api-key-access]');
+    const permissionsListElement = modal.querySelector('[data-api-key-permissions-list]');
+    const permissionsEmptyElement = modal.querySelector('[data-api-key-permissions-empty]');
     const rotateForm = modal.querySelector('[data-api-key-rotate-form]');
     const revokeForm = modal.querySelector('[data-api-key-revoke-form]');
     const rotateIdInput = modal.querySelector('[data-api-key-rotate-id]');
@@ -1438,6 +1441,9 @@
     const descriptionInput = rotateForm ? rotateForm.querySelector('#modal-rotate-description') : null;
     const expiryInput = rotateForm ? rotateForm.querySelector('#modal-rotate-expiry') : null;
     const retireInput = rotateForm ? rotateForm.querySelector('#modal-rotate-retire') : null;
+    const permissionsInput = rotateForm
+      ? rotateForm.querySelector('[data-api-key-rotate-permissions]')
+      : null;
 
     function formatDateTime(iso, fallbackText = '—') {
       if (!iso) {
@@ -1494,6 +1500,36 @@
       }
       usageListElement.hidden = true;
       usageEmptyElement.hidden = false;
+    }
+
+    function renderPermissionsList(permissions) {
+      if (!permissionsListElement || !permissionsEmptyElement) {
+        return;
+      }
+      permissionsListElement.innerHTML = '';
+      if (Array.isArray(permissions) && permissions.length > 0) {
+        permissionsListElement.hidden = false;
+        permissionsEmptyElement.hidden = true;
+        permissions.forEach((entry) => {
+          const item = document.createElement('li');
+          const label = document.createElement('span');
+          label.className = 'usage-list__ip';
+          const path = (entry.path || '').trim() || '/';
+          const methods = Array.isArray(entry.methods) && entry.methods.length > 0
+            ? entry.methods.join(', ')
+            : '—';
+          label.textContent = path;
+          const methodsElement = document.createElement('span');
+          methodsElement.className = 'usage-list__count';
+          methodsElement.textContent = methods;
+          item.appendChild(label);
+          item.appendChild(methodsElement);
+          permissionsListElement.appendChild(item);
+        });
+        return;
+      }
+      permissionsListElement.hidden = true;
+      permissionsEmptyElement.hidden = false;
     }
 
     function populateModal(trigger) {
@@ -1553,6 +1589,11 @@
       }
 
       renderUsageList(payload.usage);
+      renderPermissionsList(payload.permissions);
+
+      if (accessElement) {
+        accessElement.textContent = payload.access_summary || 'All endpoints';
+      }
 
       if (rotateIdInput) {
         rotateIdInput.value = payload.id || '';
@@ -1568,6 +1609,9 @@
       }
       if (retireInput) {
         retireInput.checked = true;
+      }
+      if (permissionsInput) {
+        permissionsInput.value = payload.permissions_text || '';
       }
       if (rotateForm) {
         rotateForm.dataset.apiKeyId = payload.id || '';

--- a/app/templates/admin/api_keys.html
+++ b/app/templates/admin/api_keys.html
@@ -130,6 +130,16 @@
           <p class="secret-card__hint">
             This value is only shown once. Update downstream services before rotating again.
           </p>
+          <p class="secret-card__hint">
+            Access scope: {{ new_api_key.access_summary or 'All endpoints' }}.
+          </p>
+          {% if new_api_key.permissions %}
+            <div class="tag-list">
+              {% for permission in new_api_key.permissions %}
+                <span class="tag">{{ permission.methods | join(', ') }} {{ permission.path }}</span>
+              {% endfor %}
+            </div>
+          {% endif %}
         </div>
       </section>
     {% endif %}
@@ -150,6 +160,7 @@
           <tr>
             <th scope="col" data-sort="string">Description</th>
             <th scope="col" data-sort="string">Preview</th>
+            <th scope="col" data-sort="string">Access scope</th>
             <th scope="col" data-sort="date">Created</th>
             <th scope="col" data-sort="date">Expiry</th>
             <th scope="col" data-sort="date">Last seen</th>
@@ -169,6 +180,13 @@
                   {% endif %}
                 </td>
                 <td data-label="Preview">{{ key.key_preview }}</td>
+                <td data-label="Access scope" data-value="{{ key.access_summary }}">
+                  {% if key.is_restricted %}
+                    {{ key.access_summary }}
+                  {% else %}
+                    <span class="badge badge--muted">Unrestricted</span>
+                  {% endif %}
+                </td>
                 <td data-label="Created" data-utc="{{ key.created_iso or '' }}" data-value="{{ key.created_iso or '' }}">
                   {{ key.created_iso or '—' }}
                 </td>
@@ -200,7 +218,11 @@
                     "last_seen_iso": key.last_seen_iso,
                     "usage_count": key.usage_count,
                     "usage": key.usage or [],
-                    "is_expired": key.is_expired
+                    "is_expired": key.is_expired,
+                    "permissions": key.permissions or [],
+                    "permissions_text": key.permissions_text or "",
+                    "access_summary": key.access_summary,
+                    "is_restricted": key.is_restricted
                   } %}
                   <div class="table__action-buttons">
                     <button
@@ -404,12 +426,22 @@
           <dt class="definition-list__label">Usage count</dt>
           <dd class="definition-list__value" data-api-key-usage-count>0</dd>
         </div>
+        <div class="definition-list__item">
+          <dt class="definition-list__label">Access scope</dt>
+          <dd class="definition-list__value" data-api-key-access>All endpoints</dd>
+        </div>
       </dl>
 
       <section aria-labelledby="api-key-usage-heading">
         <h3 id="api-key-usage-heading">Recent usage</h3>
         <p class="text-muted" data-api-key-usage-empty>No recorded usage yet.</p>
         <ul class="usage-list" data-api-key-usage-list hidden></ul>
+      </section>
+
+      <section aria-labelledby="api-key-permissions-heading">
+        <h3 id="api-key-permissions-heading">Endpoint access</h3>
+        <p class="text-muted" data-api-key-permissions-empty>All endpoints permitted.</p>
+        <ul class="usage-list" data-api-key-permissions-list hidden></ul>
       </section>
 
       <form
@@ -446,6 +478,21 @@
             />
             <p class="form-help">Defaults to the existing expiry.</p>
           </div>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="modal-rotate-permissions">Endpoint permissions</label>
+          <textarea
+            class="form-input"
+            id="modal-rotate-permissions"
+            name="permissions"
+            rows="4"
+            placeholder="Example: GET /api/orders"
+            data-api-key-rotate-permissions
+          ></textarea>
+          <p class="form-help">
+            One entry per line using "METHOD /path" (methods: {{ allowed_methods | join(', ') }}).
+            Leave blank to keep unrestricted access.
+          </p>
         </div>
         <div class="form-field form-field--checkbox">
           <label class="form-checkbox" for="modal-rotate-retire">
@@ -533,6 +580,20 @@
           placeholder="YYYY-MM-DD"
         />
         <p class="form-hint">Leave blank to create a non-expiring credential.</p>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="modal-api-key-permissions">Endpoint permissions</label>
+        <textarea
+          class="form-input"
+          id="modal-api-key-permissions"
+          name="permissions"
+          rows="4"
+          placeholder="Example: GET /api/orders"
+        ></textarea>
+        <p class="form-hint">
+          One entry per line using "METHOD /path" (methods: {{ allowed_methods | join(', ') }}).
+          Leave blank to grant this key full access.
+        </p>
       </div>
       <div class="form-actions">
         <button type="submit" class="button button--primary">Create key</button>

--- a/changes/6ed38d52-9c3b-4452-b712-4f851732b46e.json
+++ b/changes/6ed38d52-9c3b-4452-b712-4f851732b46e.json
@@ -1,0 +1,7 @@
+{
+  "guid": "6ed38d52-9c3b-4452-b712-4f851732b46e",
+  "occurred_at": "2025-10-30T14:00Z",
+  "change_type": "Feature",
+  "summary": "Added endpoint-scoped API key permissions and admin management tools.",
+  "content_hash": "d7d2d253ec8c49cf9bb0d4b813028425706bf79ee3695d6bca87bb13a4c30846"
+}

--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -1,0 +1,56 @@
+# API key management
+
+Super administrators can issue API keys for service integrations via the **Admin → API credentials**
+dashboard or programmatically through the `/api/api-keys` endpoints. Keys may now be scoped to
+specific HTTP methods on individual endpoints, allowing fine-grained access control for downstream
+systems.
+
+## Defining endpoint permissions
+
+Each API key can optionally include a `permissions` collection. When present, the key is limited to
+the listed path templates and HTTP methods. Leave the collection empty (or omit it entirely) to
+grant unrestricted access.
+
+Example configuration:
+
+```json
+{
+  "permissions": [
+    { "path": "/api/orders", "methods": ["GET"] },
+    { "path": "/api/orders/{orderNumber}", "methods": ["GET", "PATCH"] }
+  ]
+}
+```
+
+Path values must match the FastAPI route template (including parameter placeholders). Supported
+methods are `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, and `OPTIONS`.
+
+## Admin console workflow
+
+The create and rotate forms in the API credentials dashboard accept one entry per line in the
+`METHOD /path` format, for example:
+
+```
+GET /api/orders
+GET,POST /api/orders/{orderNumber}
+```
+
+Lines may contain multiple comma-separated methods targeting the same path. Leaving the field blank
+produces an unrestricted credential.
+
+When viewing an existing key, the detail modal displays its current endpoint permissions and allows
+rotating the credential while editing the list. Keys without any explicit permissions are marked as
+"Unrestricted" in the overview table.
+
+## API schema updates
+
+The following REST endpoints now accept and return the `permissions` field:
+
+- `POST /api/api-keys`
+- `GET /api/api-keys`
+- `GET /api/api-keys/{id}`
+- `POST /api/api-keys/{id}/rotate`
+
+Each response includes the resolved permissions for the key, ensuring API consumers can audit the
+configured scope. During rotation, omitting the field retains the previous configuration, providing
+backward compatibility with existing automation.

--- a/migrations/089_api_key_permissions.sql
+++ b/migrations/089_api_key_permissions.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS api_key_endpoint_permissions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    api_key_id INT NOT NULL,
+    route VARCHAR(255) NOT NULL,
+    method VARCHAR(16) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_api_key_endpoint_permissions (api_key_id, route, method),
+    CONSTRAINT fk_api_key_endpoint_permissions_key
+        FOREIGN KEY (api_key_id) REFERENCES api_keys(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_key_endpoint_permissions_route
+    ON api_key_endpoint_permissions (route);
+CREATE INDEX IF NOT EXISTS idx_api_key_endpoint_permissions_method
+    ON api_key_endpoint_permissions (method);

--- a/tests/test_api_key_permissions.py
+++ b/tests/test_api_key_permissions.py
@@ -1,0 +1,119 @@
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.dependencies import api_keys as api_key_dependency
+from app.api.dependencies import database as database_dependencies
+from app.repositories import api_keys as api_key_repo
+
+
+@pytest.fixture
+def test_app(monkeypatch):
+    app = FastAPI()
+
+    @app.api_route("/protected", methods=["GET", "POST"])
+    async def protected(_: dict = Depends(api_key_dependency.require_api_key)):
+        return {"status": "ok"}
+
+    app.dependency_overrides[database_dependencies.require_database] = lambda: None
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def usage_calls(monkeypatch):
+    calls: list[tuple[int, str]] = []
+
+    async def record(api_key_id: int, ip_address: str) -> None:
+        calls.append((api_key_id, ip_address))
+
+    monkeypatch.setattr(api_key_repo, "record_api_key_usage", record)
+    return calls
+
+
+def test_missing_header_returns_unauthorised(test_app, usage_calls, monkeypatch):
+    async def fake_get_api_key_record(_: str):
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(api_key_repo, "get_api_key_record", fake_get_api_key_record)
+
+    with TestClient(test_app) as client:
+        response = client.get("/protected")
+
+    assert response.status_code == 401
+    assert usage_calls == []
+
+
+def test_invalid_key_returns_forbidden(test_app, usage_calls, monkeypatch):
+    async def fake_get_api_key_record(_: str):
+        return None
+
+    monkeypatch.setattr(api_key_repo, "get_api_key_record", fake_get_api_key_record)
+
+    with TestClient(test_app) as client:
+        response = client.get("/protected", headers={"x-api-key": "invalid"})
+
+    assert response.status_code == 403
+    assert usage_calls == []
+
+
+def test_permission_denied_when_method_not_allowed(test_app, usage_calls, monkeypatch):
+    async def fake_get_api_key_record(_: str):
+        return {
+            "id": 1,
+            "permissions": [{"path": "/protected", "methods": ["GET"]}],
+        }
+
+    monkeypatch.setattr(api_key_repo, "get_api_key_record", fake_get_api_key_record)
+
+    with TestClient(test_app) as client:
+        response = client.post("/protected", headers={"x-api-key": "key"})
+
+    assert response.status_code == 403
+    assert usage_calls == []
+
+
+def test_permission_denied_when_path_not_allowed(test_app, usage_calls, monkeypatch):
+    async def fake_get_api_key_record(_: str):
+        return {
+            "id": 2,
+            "permissions": [{"path": "/other", "methods": ["GET"]}],
+        }
+
+    monkeypatch.setattr(api_key_repo, "get_api_key_record", fake_get_api_key_record)
+
+    with TestClient(test_app) as client:
+        response = client.get("/protected", headers={"x-api-key": "key"})
+
+    assert response.status_code == 403
+    assert usage_calls == []
+
+
+def test_access_allowed_when_permission_matches(test_app, usage_calls, monkeypatch):
+    async def fake_get_api_key_record(_: str):
+        return {
+            "id": 3,
+            "permissions": [{"path": "/protected", "methods": ["GET"]}],
+        }
+
+    monkeypatch.setattr(api_key_repo, "get_api_key_record", fake_get_api_key_record)
+
+    with TestClient(test_app) as client:
+        response = client.get("/protected", headers={"x-api-key": "key"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert usage_calls == [(3, "testclient")]
+
+
+def test_unrestricted_keys_allow_all_routes(test_app, usage_calls, monkeypatch):
+    async def fake_get_api_key_record(_: str):
+        return {"id": 4, "permissions": []}
+
+    monkeypatch.setattr(api_key_repo, "get_api_key_record", fake_get_api_key_record)
+
+    with TestClient(test_app) as client:
+        response = client.post("/protected", headers={"x-api-key": "key"})
+
+    assert response.status_code == 200
+    assert usage_calls == [(4, "testclient")]


### PR DESCRIPTION
## Summary
- add database support and repository helpers for storing API key endpoint/method permissions
- extend API and admin UI to manage scoped credentials and display access summaries
- document the workflow and cover request validation with targeted tests

## Testing
- pytest tests/test_api_key_permissions.py

------
https://chatgpt.com/codex/tasks/task_b_69036d04c670832d808837e84b00ed34