### PR TITLE
Collapse company memberships panel by default

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1358,6 +1358,10 @@ button.header-title-menu__link {
   gap: var(--space-gap-roomy);
 }
 
+.card__controls--align-end {
+  justify-content: flex-end;
+}
+
 .card__control {
   margin: 0;
 }

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -216,22 +216,26 @@
         </div>
       </details>
 
-      <section class="card card--panel admin-grid__full">
-        <header class="card__header card__header--stacked">
-          <div>
-            <h2 class="card__title">Company memberships</h2>
-            <p class="card__subtitle">Manage staff access and permissions for this company.</p>
-          </div>
-          <div class="card__controls">
-            <input
-              type="search"
-              class="form-input"
-              placeholder="Filter memberships"
-              aria-label="Filter memberships"
-              data-table-filter="company-assignments"
-            />
-          </div>
-        </header>
+    <details class="card card--panel card-collapsible admin-grid__full" data-company-memberships-panel>
+      <summary class="card__header card__header--collapsible card__header--stacked">
+        <div>
+          <h2 class="card__title">Company memberships</h2>
+          <p class="card__subtitle">Manage staff access and permissions for this company.</p>
+        </div>
+        <div class="card__collapsible-meta" aria-hidden="true">
+          <span class="card__toggle-icon"></span>
+        </div>
+      </summary>
+      <div class="card-collapsible__content">
+        <div class="card__controls card__controls--align-end">
+          <input
+            type="search"
+            class="form-input"
+            placeholder="Filter memberships"
+            aria-label="Filter memberships"
+            data-table-filter="company-assignments"
+          />
+        </div>
         <div class="table-wrapper">
           <table class="table" id="company-assignments" data-table>
             <thead>
@@ -369,7 +373,8 @@
             </tbody>
           </table>
         </div>
-      </section>
+      </div>
+    </details>
     {% endif %}
   </div>
   {% if is_super_admin %}

--- a/changes/b1ade309-da4c-4613-8c1f-6e65374362dd.json
+++ b/changes/b1ade309-da4c-4613-8c1f-6e65374362dd.json
@@ -1,0 +1,7 @@
+{
+  "guid": "b1ade309-da4c-4613-8c1f-6e65374362dd",
+  "occurred_at": "2025-10-30T14:09:49Z",
+  "change_type": "Feature",
+  "summary": "Collapse company memberships panel by default in admin company editor.",
+  "content_hash": "f1add5b4c9c1469b017b31507bd7b84eae3b1fde68cc8fc952adf722203a7a66"
+}


### PR DESCRIPTION
## Summary
- collapse the company memberships table into a reusable collapsible card on the company admin page so it loads closed by default
- add a utility class to right-align collapsible card controls and capture the update in the change log registry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690371135998832da1c47a98d76cef91