### PR TITLE
Fix impersonation candidate query

### DIFF
--- a/app/repositories/company_memberships.py
+++ b/app/repositories/company_memberships.py
@@ -221,7 +221,6 @@ async def list_impersonatable_memberships() -> list[dict[str, Any]]:
             m.id AS membership_id,
             m.user_id,
             m.company_id,
-            m.is_admin,
             m.status,
             u.email,
             u.first_name,

--- a/changes/3950edc3-803a-46c7-8f8a-b3733659e709.json
+++ b/changes/3950edc3-803a-46c7-8f8a-b3733659e709.json
@@ -1,0 +1,7 @@
+{
+  "guid": "3950edc3-803a-46c7-8f8a-b3733659e709",
+  "occurred_at": "2025-10-30T14:16Z",
+  "change_type": "Fix",
+  "summary": "Resolved impersonation candidate lookup by removing legacy is_admin column reference.",
+  "content_hash": "139e72c10bbca152608907b3c65253f5e6c69ef7a2448459a6e48d2689668c20"
+}

--- a/tests/test_impersonation_service.py
+++ b/tests/test_impersonation_service.py
@@ -69,7 +69,6 @@ async def test_list_impersonatable_users_combines_memberships(monkeypatch):
                 "company_name": "Example Co",
                 "role_name": "Support",
                 "permissions": ["tickets.view"],
-                "is_admin": 0,
                 "is_super_admin": 0,
             }
         ]


### PR DESCRIPTION
## Summary
- stop selecting the legacy is_admin column when loading impersonation candidates
- ensure the impersonation service test reflects memberships without the obsolete field
- record the fix in the change log

## Testing
- pytest tests/test_impersonation_service.py tests/test_auth_impersonation_api.py

------
https://chatgpt.com/codex/tasks/task_b_6903725fafa8832db25da204610904ad