### PR TITLE
Move automation new task button into header

### DIFF
--- a/app/templates/admin/automation.html
+++ b/app/templates/admin/automation.html
@@ -1,5 +1,20 @@
 {% extends "base.html" %}
 
+{% block header_title %}
+  <div class="header__title-content">
+    <span class="header__title-text">{{ title | default('System Automation') }}</span>
+    <button
+      type="button"
+      class="button button--primary button--small header__title-button"
+      data-task-create
+      aria-haspopup="dialog"
+      aria-controls="task-editor-modal"
+    >
+      New task
+    </button>
+  </div>
+{% endblock %}
+
 {% block content %}
 <div class="admin-grid">
   <section class="card card--panel">
@@ -23,9 +38,6 @@
             aria-label="Filter all-company tasks"
             data-table-filter="tasks-table-global"
           />
-          <button type="button" class="button" data-task-create>
-            New task
-          </button>
         </div>
         <div class="table-wrapper">
           <table class="table" id="tasks-table-global" data-table>

--- a/changes/a93b4a7e-aa7d-4c48-a7a0-bf38fa5b6547.json
+++ b/changes/a93b4a7e-aa7d-4c48-a7a0-bf38fa5b6547.json
@@ -1,0 +1,7 @@
+{
+  "guid": "a93b4a7e-aa7d-4c48-a7a0-bf38fa5b6547",
+  "occurred_at": "2025-10-30T14:19:00Z",
+  "change_type": "Fix",
+  "summary": "Moved scheduled task creation button into the admin header for easier access.",
+  "content_hash": "156f1fc274b79c17fe347b81f65b6005191a795970fd8623ad0e8216a697dacd"
+}


### PR DESCRIPTION
## Summary
- move the automation "New task" action into the admin header beside the page title for quicker access
- remove the duplicate toolbar button from the scheduled tasks table
- add a change-log entry capturing the UI adjustment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_69037334fd5c832d9a8cf8a88d204330