### PR TITLE
Fix HTML exit impersonation redirect handling

### DIFF
--- a/changes/d657312b-ddb0-4b6d-83c8-5de04f178435.json
+++ b/changes/d657312b-ddb0-4b6d-83c8-5de04f178435.json
@@ -1,0 +1,7 @@
+{
+  "guid": "d657312b-ddb0-4b6d-83c8-5de04f178435",
+  "occurred_at": "2025-10-30T14:24:00Z",
+  "change_type": "Fix",
+  "summary": "Fixed exit impersonation to redirect administrators back to the dashboard when ending impersonation.",
+  "content_hash": "05d522464978489a8cff45ba58f9da4bf123e8da6cb5166aba351efbf5e3dfaf"
+}


### PR DESCRIPTION
## Summary
- redirect HTML clients exiting impersonation back to the admin dashboard while keeping JSON responses for API consumers
- add regression coverage for the HTML redirect behavior and record the fix in the change log

## Testing
- pytest tests/test_auth_impersonation_api.py::test_exit_impersonation_restores_original_session tests/test_auth_impersonation_api.py::test_exit_impersonation_redirects_for_html_accept

------
https://chatgpt.com/codex/tasks/task_b_69037488e3ac832db5d4343144b9320b