### PR TITLE
Add automatic alternate product substitution for shop packages

### DIFF
--- a/app/services/shop_packages.py
+++ b/app/services/shop_packages.py
@@ -22,6 +22,114 @@ def _to_decimal(value: Any) -> Decimal:
     return Decimal(str(value))
 
 
+def _build_product_candidate(
+    source: dict[str, Any],
+    *,
+    substitution_type: str,
+    priority: int,
+) -> dict[str, Any]:
+    candidate: dict[str, Any] = {
+        "product_id": int(source.get("product_id") or 0),
+        "product_name": source.get("product_name"),
+        "product_sku": source.get("product_sku"),
+        "product_vendor_sku": source.get("product_vendor_sku"),
+        "product_image_url": source.get("product_image_url"),
+        "product_description": source.get("product_description"),
+        "product_archived": bool(source.get("product_archived")),
+        "priority": priority,
+        "substitution_type": substitution_type,
+    }
+    price = source.get("product_price")
+    candidate["product_price"] = _to_decimal(price)
+    vip_price = source.get("product_vip_price")
+    candidate["product_vip_price"] = None if vip_price is None else _to_decimal(vip_price)
+    stock_value = source.get("product_stock")
+    try:
+        candidate["product_stock"] = int(stock_value)
+    except (TypeError, ValueError):
+        candidate["product_stock"] = 0
+    alternate_id = source.get("id")
+    candidate["alternate_id"] = int(alternate_id) if alternate_id is not None else 0
+    return candidate
+
+
+def _prepare_package_items(
+    items: Sequence[dict[str, Any]],
+    *,
+    restricted_product_ids: set[int],
+) -> list[dict[str, Any]]:
+    prepared: list[dict[str, Any]] = []
+    for item in items:
+        quantity = int(item.get("quantity") or 0)
+        if quantity < 0:
+            quantity = 0
+        primary_candidate = _build_product_candidate(
+            item,
+            substitution_type="primary",
+            priority=-1,
+        )
+        alternates = sorted(
+            item.get("alternates") or [],
+            key=lambda alternate: (
+                int(alternate.get("priority") or 0),
+                str(alternate.get("product_name") or "").lower(),
+            ),
+        )
+        candidates = [primary_candidate]
+        for alternate in alternates:
+            candidates.append(
+                _build_product_candidate(
+                    alternate,
+                    substitution_type="alternate",
+                    priority=int(alternate.get("priority") or 0),
+                )
+            )
+
+        fallback = primary_candidate
+        selected = None
+        for candidate in candidates:
+            product_id = int(candidate.get("product_id") or 0)
+            archived = bool(candidate.get("product_archived"))
+            restricted = product_id in restricted_product_ids
+            stock = int(candidate.get("product_stock") or 0)
+            if archived or restricted:
+                continue
+            if quantity <= 0 or stock >= quantity:
+                selected = candidate
+                break
+        if selected is None:
+            selected = fallback
+
+        resolved_product_id = int(selected.get("product_id") or 0)
+        resolved_archived = bool(selected.get("product_archived"))
+        resolved_stock = int(selected.get("product_stock") or 0)
+        resolved_restricted = (
+            resolved_archived or resolved_product_id in restricted_product_ids
+        )
+        if quantity <= 0:
+            available_per_package = resolved_stock
+        else:
+            available_per_package = resolved_stock // quantity
+        if available_per_package < 0:
+            available_per_package = 0
+
+        prepared_item = dict(item)
+        prepared_item["quantity"] = quantity
+        prepared_item["primary_product"] = primary_candidate
+        prepared_item["resolved_product"] = selected
+        prepared_item["resolved_product_id"] = resolved_product_id
+        prepared_item["resolved_product_source"] = selected.get(
+            "substitution_type", "primary"
+        )
+        prepared_item["resolved_is_restricted"] = resolved_restricted
+        prepared_item["available_stock_for_quantity"] = available_per_package
+        prepared_item["is_substituted"] = (
+            prepared_item["resolved_product_source"] != "primary"
+        )
+        prepared.append(prepared_item)
+    return prepared
+
+
 def _compute_package_metrics(
     items: Sequence[dict[str, Any]],
     *,
@@ -33,20 +141,23 @@ def _compute_package_metrics(
     restricted = False
 
     for item in items:
-        product_id = int(item.get("product_id") or 0)
         quantity = int(item.get("quantity") or 0)
-        product_archived = bool(item.get("product_archived"))
-        base_price = item.get("product_price")
-        vip_price = item.get("product_vip_price")
-        stock = int(item.get("product_stock") or 0)
-
-        if product_archived:
-            restricted = True
-        if restricted_product_ids and product_id in restricted_product_ids:
-            restricted = True
-
+        resolved = item.get("resolved_product") or {}
         if quantity < 0:
             quantity = 0
+        resolved_product_id = int(resolved.get("product_id") or 0)
+        resolved_archived = bool(resolved.get("product_archived"))
+        resolved_restricted = bool(item.get("resolved_is_restricted"))
+        base_price = resolved.get("product_price")
+        vip_price = resolved.get("product_vip_price")
+        stock = int(resolved.get("product_stock") or 0)
+
+        if (
+            resolved_archived
+            or resolved_restricted
+            or (restricted_product_ids and resolved_product_id in restricted_product_ids)
+        ):
+            restricted = True
 
         price_source = vip_price if is_vip and vip_price is not None else base_price
         if price_source is not None:
@@ -54,7 +165,7 @@ def _compute_package_metrics(
 
         if quantity <= 0:
             stock_levels.append(stock)
-        else:
+        elif quantity > 0:
             stock_levels.append(stock // quantity)
 
     if not stock_levels:
@@ -76,19 +187,30 @@ async def load_admin_packages(*, include_archived: bool = False) -> list[dict[st
     enriched: list[dict[str, Any]] = []
     for package in packages:
         package_items = items_map.get(package["id"], [])
-        price_total, stock_level, restricted = _compute_package_metrics(
+        prepared_items = _prepare_package_items(
             package_items,
+            restricted_product_ids=set(),
+        )
+        price_total, stock_level, restricted = _compute_package_metrics(
+            prepared_items,
             is_vip=False,
             restricted_product_ids=set(),
         )
         enriched.append(
             {
                 **package,
-                "items": package_items,
+                "items": prepared_items,
                 "price_total": price_total,
                 "stock_level": stock_level,
                 "is_restricted": restricted,
-                "active_item_count": sum(1 for item in package_items if not item.get("product_archived")),
+                "active_item_count": sum(
+                    1
+                    for item in prepared_items
+                    if item.get("resolved_product")
+                    and not bool(
+                        (item.get("resolved_product") or {}).get("product_archived")
+                    )
+                ),
             }
         )
     return enriched
@@ -108,6 +230,8 @@ async def load_company_packages(
     for package_items in items_map.values():
         for item in package_items:
             product_ids.add(int(item.get("product_id") or 0))
+            for alternate in item.get("alternates") or []:
+                product_ids.add(int(alternate.get("product_id") or 0))
 
     restricted_products: set[int] = set()
     if company_id is not None and product_ids:
@@ -119,26 +243,43 @@ async def load_company_packages(
     visible_packages: list[dict[str, Any]] = []
     for package in packages:
         package_items = items_map.get(package["id"], [])
-        price_total, stock_level, restricted = _compute_package_metrics(
+        prepared_items = _prepare_package_items(
             package_items,
+            restricted_product_ids=restricted_products,
+        )
+        price_total, stock_level, restricted = _compute_package_metrics(
+            prepared_items,
             is_vip=is_vip,
             restricted_product_ids=restricted_products,
+        )
+        valid_resolutions = all(
+            int(item.get("resolved_product_id") or 0) > 0
+            or int(item.get("quantity") or 0) == 0
+            for item in prepared_items
         )
         is_available = (
             not package.get("archived")
             and not restricted
             and stock_level > 0
-            and bool(package_items)
+            and bool(prepared_items)
+            and valid_resolutions
         )
         visible_packages.append(
             {
                 **package,
-                "items": package_items,
+                "items": prepared_items,
                 "price_total": price_total,
                 "stock_level": stock_level,
                 "is_restricted": restricted,
                 "is_available": is_available,
-                "active_item_count": sum(1 for item in package_items if not item.get("product_archived")),
+                "active_item_count": sum(
+                    1
+                    for item in prepared_items
+                    if item.get("resolved_product")
+                    and not bool(
+                        (item.get("resolved_product") or {}).get("product_archived")
+                    )
+                ),
             }
         )
     return visible_packages
@@ -153,16 +294,25 @@ async def get_package_detail(
     if not package:
         return None
     items = await shop_repo.list_package_items(package_id)
-    price_total, stock_level, restricted = _compute_package_metrics(
+    prepared_items = _prepare_package_items(
         items,
+        restricted_product_ids=set(),
+    )
+    price_total, stock_level, restricted = _compute_package_metrics(
+        prepared_items,
         is_vip=False,
         restricted_product_ids=set(),
     )
     return {
         **package,
-        "items": items,
+        "items": prepared_items,
         "price_total": price_total,
         "stock_level": stock_level,
         "is_restricted": restricted,
-        "active_item_count": sum(1 for item in items if not item.get("product_archived")),
+        "active_item_count": sum(
+            1
+            for item in prepared_items
+            if item.get("resolved_product")
+            and not bool((item.get("resolved_product") or {}).get("product_archived"))
+        ),
     }

--- a/app/static/js/shop_packages.js
+++ b/app/static/js/shop_packages.js
@@ -115,6 +115,34 @@
 
     container.appendChild(createDetailRow('Availability', describeStock(item.product_stock)));
 
+    const selection = item.is_substituted ? 'Alternate product in use' : 'Primary product in use';
+    container.appendChild(createDetailRow('Selection', selection));
+
+    if (item.available_stock_for_quantity !== null && item.available_stock_for_quantity !== undefined) {
+      container.appendChild(
+        createDetailRow(
+          'Packages supported by current stock',
+          Number(item.available_stock_for_quantity),
+        ),
+      );
+    }
+
+    if (item.is_substituted && item.primary_product) {
+      const original = item.primary_product;
+      const originalParts = [];
+      if (original.product_name) {
+        originalParts.push(original.product_name);
+      }
+      if (original.product_sku) {
+        originalParts.push(`(${original.product_sku})`);
+      }
+      if (originalParts.length) {
+        container.appendChild(
+          createDetailRow('Original product', originalParts.join(' ')),
+        );
+      }
+    }
+
     if (item.product_description) {
       const descriptionTitle = document.createElement('h3');
       descriptionTitle.className = 'modal__subtitle';
@@ -149,12 +177,39 @@
         if (!item) {
           return;
         }
-        const productId = item.product_id != null ? String(item.product_id) : '';
-        const key = `${packageId}:${productId}`;
-        itemsByKey.set(key, {
+        const itemId = item.id != null ? String(item.id) : '';
+        const resolved = item.resolved_product || {};
+        const resolvedProductId =
+          resolved.product_id != null ? resolved.product_id : item.product_id;
+        const entry = {
           package_id: pkg.id,
           package_name: pkg.name,
           ...item,
+          product_id: resolvedProductId,
+          product_name: resolved.product_name || item.product_name,
+          product_sku: resolved.product_sku || item.product_sku,
+          product_vendor_sku:
+            resolved.product_vendor_sku || item.product_vendor_sku,
+          product_price:
+            resolved.product_price != null
+              ? resolved.product_price
+              : item.product_price,
+          product_vip_price:
+            resolved.product_vip_price != null
+              ? resolved.product_vip_price
+              : item.product_vip_price,
+          product_stock:
+            resolved.product_stock != null
+              ? resolved.product_stock
+              : item.product_stock,
+          product_image_url:
+            resolved.product_image_url || item.product_image_url,
+          product_description:
+            resolved.product_description || item.product_description,
+        };
+        const key = `${packageId}:${itemId}`;
+        itemsByKey.set(key, {
+          ...entry,
         });
       });
     });

--- a/app/templates/admin/shop_package_detail.html
+++ b/app/templates/admin/shop_package_detail.html
@@ -98,24 +98,115 @@
           <th scope="col" data-sort="string">Product</th>
           <th scope="col" data-sort="string">SKU</th>
           <th scope="col" data-sort="number">Quantity</th>
-          <th scope="col" data-sort="number">Stock</th>
-          <th scope="col" data-sort="string">Status</th>
+          <th scope="col" data-sort="number">Stock (resolved)</th>
+          <th scope="col" data-sort="string">Fulfilment</th>
+          <th scope="col" data-sort="string">Alternates</th>
           <th scope="col" class="table__actions">Actions</th>
         </tr>
       </thead>
       <tbody>
         {% for item in package["items"] %}
+          {% set resolved = item.resolved_product %}
+          {% set primary_product = item.primary_product if item.primary_product is defined else None %}
+          {% set resolved_stock = resolved.product_stock if resolved else item.product_stock %}
+          {% set available_packages = item.available_stock_for_quantity %}
+          {% set alternate_ids = item.alternates | map(attribute='product_id') | list %}
           <tr data-product-id="{{ item.product_id }}">
-            <td data-label="Product">{{ item.product_name }}</td>
+            <td data-label="Product">
+              <div>{{ item.product_name }}</div>
+              {% if item.product_archived %}
+                <span class="badge badge--muted">Primary archived</span>
+              {% endif %}
+            </td>
             <td data-label="SKU">{{ item.product_sku }}</td>
             <td data-label="Quantity" data-value="{{ item.quantity }}">{{ item.quantity }}</td>
-            <td data-label="Stock" data-value="{{ item.product_stock }}">{{ item.product_stock }}</td>
-            <td data-label="Status">
-              {% if item.product_archived %}
-                <span class="badge badge--muted">Archived</span>
-              {% else %}
-                <span class="badge badge--success">Active</span>
+            <td data-label="Stock (resolved)" data-value="{{ resolved_stock }}">
+              <span class="badge {% if resolved_stock <= 0 %}badge--danger{% elif resolved_stock < 5 %}badge--warning{% else %}badge--success{% endif %}">
+                {{ resolved_stock }}
+              </span>
+              {% if available_packages is not none %}
+                <div class="text-muted text-sm">Supports {{ available_packages }} package{% if available_packages != 1 %}s{% endif %}</div>
               {% endif %}
+            </td>
+            <td data-label="Fulfilment">
+              {% if resolved %}
+                <div><strong>{{ resolved.product_name }}</strong></div>
+                <div class="text-muted text-sm">{{ resolved.product_sku }}</div>
+                {% if item.is_substituted %}
+                  <span class="badge badge--info">Using alternate</span>
+                {% else %}
+                  <span class="badge badge--success">Using primary</span>
+                {% endif %}
+                {% if item.resolved_is_restricted %}
+                  <span class="badge badge--warning">Restricted</span>
+                {% endif %}
+                {% if primary_product and item.is_substituted %}
+                  <div class="text-muted text-sm">
+                    Original: {{ primary_product.product_name }}{% if primary_product.product_sku %} ({{ primary_product.product_sku }}){% endif %}
+                  </div>
+                {% endif %}
+              {% else %}
+                <span class="badge badge--muted">Unavailable</span>
+              {% endif %}
+            </td>
+            <td data-label="Alternates">
+              {% if item.alternates %}
+                <ul class="list list--unstyled package-alternates">
+                  {% for alt in item.alternates %}
+                    <li class="package-alternates__item">
+                      <div class="package-alternates__info">
+                        <span>{{ alt.product_name }} ({{ alt.product_sku }})</span>
+                        <span class="badge badge--muted">Priority {{ alt.priority }}</span>
+                      </div>
+                      <form
+                        action="/shop/admin/package/{{ package.id }}/items/{{ item.product_id }}/alternates/{{ alt.product_id }}/remove"
+                        method="post"
+                        class="inline-form"
+                        data-confirm="Remove this alternate product?"
+                      >
+                        {% include "partials/csrf.html" %}
+                        <button type="submit" class="button button--danger button--small">Remove</button>
+                      </form>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <span class="text-muted">No alternates configured.</span>
+              {% endif %}
+              <details class="package-alternates__add">
+                <summary>Add alternate product</summary>
+                <form
+                  action="/shop/admin/package/{{ package.id }}/items/{{ item.product_id }}/alternates/add"
+                  method="post"
+                  class="inline-form package-alternates__form"
+                >
+                  {% include "partials/csrf.html" %}
+                  {% set options = namespace(has_options=False) %}
+                  <label class="visually-hidden" for="alternate-{{ item.product_id }}">Alternate product</label>
+                  <select class="form-input form-input--sm" id="alternate-{{ item.product_id }}" name="alternate_product_id" required>
+                    <option value="">Choose a product</option>
+                    {% for product in products %}
+                      {% if product.id != item.product_id and product.id not in alternate_ids %}
+                        {% set options.has_options = True %}
+                        <option value="{{ product.id }}">{{ product.name }} ({{ product.sku }})</option>
+                      {% endif %}
+                    {% endfor %}
+                  </select>
+                  <label class="visually-hidden" for="priority-{{ item.product_id }}">Alternate priority</label>
+                  <input
+                    class="form-input form-input--sm"
+                    id="priority-{{ item.product_id }}"
+                    type="number"
+                    name="priority"
+                    value="{{ item.alternates|length }}"
+                    min="0"
+                  />
+                  <button type="submit" class="button button--ghost button--small" {% if not options.has_options %}disabled{% endif %}>Add</button>
+                </form>
+                {% if not options.has_options %}
+                  <p class="text-muted text-sm">All available products are already assigned.</p>
+                {% endif %}
+              </details>
             </td>
             <td class="table__actions">
               <div class="table__action-buttons">
@@ -134,7 +225,7 @@
           </tr>
         {% else %}
           <tr>
-            <td colspan="6" class="table__empty">No products assigned to this package.</td>
+            <td colspan="7" class="table__empty">No products assigned to this package.</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/app/templates/shop/packages.html
+++ b/app/templates/shop/packages.html
@@ -69,15 +69,21 @@
                     <summary>Included products</summary>
                     <ul class="list list--bullet package-products">
                       {% for item in package["items"] %}
+                        {% set resolved = item.resolved_product %}
+                        {% set display_name = resolved.product_name if resolved else item.product_name %}
+                        {% set display_sku = resolved.product_sku if resolved else item.product_sku %}
                         <li class="package-product">
                           <button
                             type="button"
                             class="link-button package-product__button"
-                            data-package-product-details="{{ package.id }}:{{ item.product_id }}"
+                            data-package-product-details="{{ package.id }}:{{ item.id }}"
                           >
-                            <span class="package-product__name">{{ item.product_name }}</span>
-                            <span class="package-product__sku">({{ item.product_sku }})</span>
+                            <span class="package-product__name">{{ display_name }}</span>
+                            <span class="package-product__sku">({{ display_sku }})</span>
                             <span class="package-product__quantity">× {{ item.quantity }}</span>
+                            {% if item.is_substituted %}
+                              <span class="badge badge--info package-product__badge">Alternate</span>
+                            {% endif %}
                           </button>
                         </li>
                       {% endfor %}

--- a/changes/3abdc283-53ab-47cd-8937-fb38a17d0548.json
+++ b/changes/3abdc283-53ab-47cd-8937-fb38a17d0548.json
@@ -1,0 +1,7 @@
+{
+  "guid": "3abdc283-53ab-47cd-8937-fb38a17d0548",
+  "occurred_at": "2025-10-31T22:49:34Z",
+  "change_type": "Feature",
+  "summary": "Added automatic alternate product substitutions for shop packages with admin controls and migration support.",
+  "content_hash": "6a61e0dbce3adae1e4b5120aa54e943cf8ce7dd1c4507d6b516a5c5ba2881326"
+}

--- a/migrations/092_shop_package_item_alternates.sql
+++ b/migrations/092_shop_package_item_alternates.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS shop_package_item_alternates (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  package_item_id INT NOT NULL,
+  alternate_product_id INT NOT NULL,
+  priority INT NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_shop_package_item_alternate_item FOREIGN KEY (package_item_id) REFERENCES shop_package_items(id) ON DELETE CASCADE,
+  CONSTRAINT fk_shop_package_item_alternate_product FOREIGN KEY (alternate_product_id) REFERENCES shop_products(id),
+  UNIQUE KEY uq_shop_package_item_alternate (package_item_id, alternate_product_id),
+  KEY idx_shop_package_item_alternate_priority (package_item_id, priority)
+);

--- a/tests/test_shop_packages_service.py
+++ b/tests/test_shop_packages_service.py
@@ -53,6 +53,9 @@ def test_load_admin_packages_computes_totals(monkeypatch):
     assert package["stock_level"] == 3
     assert package["is_restricted"] is False
     assert package["active_item_count"] == 2
+    first_item = package["items"][0]
+    assert first_item["resolved_product"]["product_id"] == 10
+    assert first_item["is_substituted"] is False
 
 
 def test_load_company_packages_marks_restricted(monkeypatch):
@@ -105,6 +108,7 @@ def test_load_company_packages_marks_restricted(monkeypatch):
     assert package["is_available"] is False
     assert package["stock_level"] == 5
     assert package["price_total"] == Decimal("8.99")
+    assert package["items"][0]["resolved_is_restricted"] is True
 
 
 def test_get_package_detail_returns_enriched(monkeypatch):
@@ -139,3 +143,73 @@ def test_get_package_detail_returns_enriched(monkeypatch):
     assert package["stock_level"] == 4
     assert package["is_restricted"] is False
     assert package["active_item_count"] == 1
+    assert package["items"][0]["resolved_product"]["product_id"] == 30
+
+
+def test_load_company_packages_substitutes_when_primary_out_of_stock(monkeypatch):
+    async def fake_list_packages(filters):
+        return [
+            {
+                "id": 5,
+                "name": "Pro kit",
+                "sku": "PKG-5",
+                "archived": False,
+                "product_count": 1,
+            }
+        ]
+
+    async def fake_list_items(package_ids):
+        return {
+            5: [
+                {
+                    "product_id": 100,
+                    "quantity": 2,
+                    "product_price": Decimal("5.00"),
+                    "product_vip_price": Decimal("4.50"),
+                    "product_stock": 0,
+                    "product_archived": False,
+                    "alternates": [
+                        {
+                            "product_id": 101,
+                            "priority": 0,
+                            "product_price": Decimal("6.00"),
+                            "product_vip_price": Decimal("5.50"),
+                            "product_stock": 10,
+                            "product_archived": False,
+                            "product_name": "Alt widget",
+                            "product_sku": "ALT-101",
+                            "product_vendor_sku": None,
+                            "product_image_url": None,
+                            "product_description": None,
+                        }
+                    ],
+                }
+            ]
+        }
+
+    async def fake_get_restricted(*, company_id, product_ids):
+        return set()
+
+    monkeypatch.setattr(packages_service.shop_repo, "list_packages", fake_list_packages)
+    monkeypatch.setattr(
+        packages_service.shop_repo,
+        "list_package_items_for_packages",
+        fake_list_items,
+    )
+    monkeypatch.setattr(
+        packages_service.shop_repo,
+        "get_restricted_product_ids",
+        fake_get_restricted,
+    )
+
+    packages = asyncio.run(
+        packages_service.load_company_packages(company_id=None, is_vip=False)
+    )
+
+    package = packages[0]
+    assert package["is_available"] is True
+    assert package["stock_level"] == 5
+    assert package["price_total"] == Decimal("12.00")
+    resolved_item = package["items"][0]
+    assert resolved_item["resolved_product"]["product_id"] == 101
+    assert resolved_item["is_substituted"] is True


### PR DESCRIPTION
## Summary
- add a migration and repository helpers to store and retrieve alternate products for package items
- update package services, customer views, and admin endpoints to resolve substitutions automatically and expose management actions
- extend UI templates/JS and tests to cover alternate fulfilment scenarios

## Testing
- pytest tests/test_shop_packages_service.py

------
https://chatgpt.com/codex/tasks/task_b_69053b14d400832dbabd45034d4a4580