### PR TITLE
Add cart recommendations for shop products

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2163,6 +2163,76 @@ button.header-title-menu__link {
   border-radius: 0.75rem;
 }
 
+.cart-recommendations {
+  margin-top: calc(var(--space-gap-roomy) * 1.25);
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--space-gap-base) * 2);
+}
+
+.cart-recommendations__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-gap-base);
+}
+
+.cart-recommendations__heading {
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.cart-recommendations__grid {
+  display: grid;
+  gap: calc(var(--space-gap-base) * 1.5);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.cart-recommendations__item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-gap-tight);
+  padding: calc(var(--space-gap-base) * 1.5);
+  border-radius: 1rem;
+  background: rgba(148, 163, 184, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+}
+
+.cart-recommendations__image {
+  width: 100%;
+  max-height: 140px;
+  object-fit: contain;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.35);
+  padding: 0.75rem;
+}
+
+.cart-recommendations__name {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.cart-recommendations__price {
+  margin: 0;
+  font-weight: 600;
+  color: #fff;
+}
+
+.cart-recommendations__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.cart-recommendations__form {
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
 .orders-summary {
   display: grid;
   gap: calc(var(--space-gap-roomy) * 1.25);

--- a/app/static/js/shop_admin.js
+++ b/app/static/js/shop_admin.js
@@ -153,6 +153,10 @@
         editForm.querySelector('#edit-product-name').value = product.name || '';
         editForm.querySelector('#edit-product-sku').value = product.sku || '';
         editForm.querySelector('#edit-product-vendor').value = product.vendor_sku || '';
+        editForm.querySelector('#edit-product-cross-sell').value =
+          product.cross_sell_product_sku || '';
+        editForm.querySelector('#edit-product-upsell').value =
+          product.upsell_product_sku || '';
         editForm.querySelector('#edit-product-description').value = product.description || '';
         editForm.querySelector('#edit-product-price').value = product.price != null ? product.price : '';
         editForm.querySelector('#edit-product-vip').value = product.vip_price != null ? product.vip_price : '';

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -101,6 +101,14 @@
         <input class="form-input" id="product-vendor-sku" name="vendor_sku" required />
       </div>
       <div class="form-field">
+        <label class="form-label" for="product-cross-sell-sku">Cross-sell SKU</label>
+        <input class="form-input" id="product-cross-sell-sku" name="cross_sell_sku" />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="product-upsell-sku">Up-sell SKU</label>
+        <input class="form-input" id="product-upsell-sku" name="upsell_sku" />
+      </div>
+      <div class="form-field">
         <label class="form-label" for="product-price">Price</label>
         <input class="form-input" id="product-price" name="price" type="number" step="0.01" required />
       </div>
@@ -247,6 +255,14 @@
       <div class="form-field">
         <label class="form-label" for="edit-product-vendor">Vendor SKU</label>
         <input class="form-input" id="edit-product-vendor" name="vendor_sku" required />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-product-cross-sell">Cross-sell SKU</label>
+        <input class="form-input" id="edit-product-cross-sell" name="cross_sell_sku" />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="edit-product-upsell">Up-sell SKU</label>
+        <input class="form-input" id="edit-product-upsell" name="upsell_sku" />
       </div>
       <div class="form-field form-field--wide">
         <label class="form-label" for="edit-product-description">Description</label>

--- a/app/templates/shop/cart.html
+++ b/app/templates/shop/cart.html
@@ -142,6 +142,72 @@
   {% endif %}
 </section>
 
+{% set recommendations = cart_recommendations or {'cross_sell': [], 'upsell': []} %}
+{% set cross_recommendations = recommendations.cross_sell %}
+{% set upsell_recommendations = recommendations.upsell %}
+{% if cart_items and (cross_recommendations or upsell_recommendations) %}
+  <section class="card card--panel cart-recommendations">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Recommended add-ons</h2>
+        <p class="card__subtitle">Boost your order with curated upgrades and companion products.</p>
+      </div>
+    </header>
+
+    {% if upsell_recommendations %}
+      <div class="cart-recommendations__section">
+        <h3 class="cart-recommendations__heading">Upgrade options</h3>
+        <div class="cart-recommendations__grid">
+          {% for item in upsell_recommendations %}
+            <article class="cart-recommendations__item">
+              {% if item.image_url %}
+                <img src="{{ item.image_url }}" alt="" class="cart-recommendations__image" loading="lazy" />
+              {% endif %}
+              <h4 class="cart-recommendations__name">{{ item.name }}</h4>
+              <p class="cart-recommendations__price">${{ '%.2f'|format(item.price) }}</p>
+              {% if item.source_names %}
+                <p class="cart-recommendations__meta">Upgrade for {{ item.source_names | join(', ') }}</p>
+              {% endif %}
+              <form action="{{ request.url_for('add_to_cart') }}" method="post" class="cart-recommendations__form">
+                {% include "partials/csrf.html" %}
+                <input type="hidden" name="productId" value="{{ item.product_id }}" />
+                <input type="hidden" name="quantity" value="1" />
+                <button type="submit" class="button button--primary">Upgrade</button>
+              </form>
+            </article>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
+
+    {% if cross_recommendations %}
+      <div class="cart-recommendations__section">
+        <h3 class="cart-recommendations__heading">Suggested add-ons</h3>
+        <div class="cart-recommendations__grid">
+          {% for item in cross_recommendations %}
+            <article class="cart-recommendations__item">
+              {% if item.image_url %}
+                <img src="{{ item.image_url }}" alt="" class="cart-recommendations__image" loading="lazy" />
+              {% endif %}
+              <h4 class="cart-recommendations__name">{{ item.name }}</h4>
+              <p class="cart-recommendations__price">${{ '%.2f'|format(item.price) }}</p>
+              {% if item.source_names %}
+                <p class="cart-recommendations__meta">Pairs with {{ item.source_names | join(', ') }}</p>
+              {% endif %}
+              <form action="{{ request.url_for('add_to_cart') }}" method="post" class="cart-recommendations__form">
+                {% include "partials/csrf.html" %}
+                <input type="hidden" name="productId" value="{{ item.product_id }}" />
+                <input type="hidden" name="quantity" value="1" />
+                <button type="submit" class="button">Add</button>
+              </form>
+            </article>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
+  </section>
+{% endif %}
+
 <div
   class="modal"
   id="cart-product-details-modal"

--- a/changes/5663770c-f543-4945-a193-ca2611daccea.json
+++ b/changes/5663770c-f543-4945-a193-ca2611daccea.json
@@ -1,0 +1,7 @@
+{
+  "guid": "5663770c-f543-4945-a193-ca2611daccea",
+  "occurred_at": "2025-10-31T23:31:31Z",
+  "change_type": "Feature",
+  "summary": "Added shop product cross-sell and up-sell recommendations in cart",
+  "content_hash": "02d59e347fef89a48f3cf2adf94b315e3d7ee3f5a9c875cc440d25541e92da6e"
+}

--- a/migrations/093_shop_product_recommendations.sql
+++ b/migrations/093_shop_product_recommendations.sql
@@ -1,0 +1,9 @@
+ALTER TABLE shop_products
+  ADD COLUMN IF NOT EXISTS cross_sell_product_id INT NULL AFTER category_id,
+  ADD COLUMN IF NOT EXISTS upsell_product_id INT NULL AFTER cross_sell_product_id,
+  ADD CONSTRAINT fk_shop_products_cross_sell
+    FOREIGN KEY (cross_sell_product_id) REFERENCES shop_products(id)
+    ON DELETE SET NULL,
+  ADD CONSTRAINT fk_shop_products_upsell
+    FOREIGN KEY (upsell_product_id) REFERENCES shop_products(id)
+    ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- add cross-sell and up-sell relationships to shop products, including database migration and admin form fields
- surface cart recommendations by fetching related products and presenting upgrade/add-on actions in the cart UI
- style the new recommendation section and log the feature in the change history

## Testing
- pytest tests/test_cart_update.py tests/test_shop_service.py

------
https://chatgpt.com/codex/tasks/task_b_6905451200e4832d9f97af6a303d7a7c