### PR TITLE
Enable multi-product shop recommendations

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2043,28 +2043,69 @@ def _sanitize_message(value: str | None) -> str | None:
     return text[:200]
 
 
-async def _resolve_related_product_id_by_sku(
-    sku_value: str | None,
+async def _validate_recommendation_product_ids(
+    raw_ids: Sequence[int | str] | None,
     *,
+    category_id: int | None,
     field_label: str,
     disallow_product_id: int | None = None,
-) -> int | None:
-    sku = (sku_value or "").strip()
-    if not sku:
-        return None
-    product = await shop_repo.get_product_by_sku(sku, include_archived=False)
-    if not product:
+) -> list[int]:
+    values: list[int] = []
+    for raw in raw_ids or []:
+        if raw in (None, ""):
+            continue
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid {field_label.lower()} selection submitted",
+            )
+        if value <= 0:
+            continue
+        values.append(value)
+
+    unique_ids = sorted(set(values))
+    if not unique_ids:
+        return []
+
+    if category_id is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"{field_label} SKU does not match an active product",
+            detail=f"{field_label} products require selecting a category first",
         )
-    product_id = int(product.get("id") or 0)
-    if disallow_product_id is not None and product_id == disallow_product_id:
+
+    candidates = await shop_repo.list_products_by_ids(unique_ids, include_archived=False)
+    found_ids = {int(candidate.get("id") or 0) for candidate in candidates}
+    missing = [str(value) for value in unique_ids if value not in found_ids]
+    if missing:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"{field_label} SKU cannot reference the same product",
+            detail=f"{field_label} selection is no longer available",
         )
-    return product_id
+
+    validated: list[int] = []
+    for candidate in candidates:
+        candidate_id = int(candidate.get("id") or 0)
+        if disallow_product_id is not None and candidate_id == disallow_product_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{field_label} products cannot include the item being edited",
+            )
+        candidate_category = candidate.get("category_id")
+        if candidate_category != category_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{field_label} products must match the selected category",
+            )
+        if bool(candidate.get("archived")):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"{field_label} selection is archived and cannot be used",
+            )
+        validated.append(candidate_id)
+
+    return sorted(validated)
 
 
 async def _render_impersonation_dashboard(
@@ -3826,20 +3867,22 @@ async def view_cart(
         for product in base_products:
             base_id = int(product.get("id") or 0)
             base_name = str(product.get("name") or "")
-            cross_id_raw = product.get("cross_sell_product_id")
-            upsell_id_raw = product.get("upsell_product_id")
-            try:
-                cross_id = int(cross_id_raw) if cross_id_raw is not None else 0
-            except (TypeError, ValueError):
-                cross_id = 0
-            try:
-                upsell_id = int(upsell_id_raw) if upsell_id_raw is not None else 0
-            except (TypeError, ValueError):
-                upsell_id = 0
-            if cross_id > 0 and cross_id not in cart_product_id_set and cross_id != base_id:
-                cross_sell_targets.setdefault(cross_id, []).append(base_name)
-            if upsell_id > 0 and upsell_id not in cart_product_id_set and upsell_id != base_id:
-                upsell_targets.setdefault(upsell_id, []).append(base_name)
+            for entry in product.get("cross_sell_products", []) or []:
+                target_id = int(entry.get("id") or 0)
+                if (
+                    target_id > 0
+                    and target_id not in cart_product_id_set
+                    and target_id != base_id
+                ):
+                    cross_sell_targets.setdefault(target_id, []).append(base_name)
+            for entry in product.get("upsell_products", []) or []:
+                target_id = int(entry.get("id") or 0)
+                if (
+                    target_id > 0
+                    and target_id not in cart_product_id_set
+                    and target_id != base_id
+                ):
+                    upsell_targets.setdefault(target_id, []).append(base_name)
 
         target_ids = sorted(set(cross_sell_targets) | set(upsell_targets))
         if target_ids:
@@ -7724,8 +7767,8 @@ async def admin_create_shop_product(
     vip_price: str | None = Form(default=None),
     category_id: str | None = Form(default=None),
     image: UploadFile | None = File(default=None),
-    cross_sell_sku: str | None = Form(default=None),
-    upsell_sku: str | None = Form(default=None),
+    cross_sell_product_ids: list[int] | None = Form(default=None),
+    upsell_product_ids: list[int] | None = Form(default=None),
 ):
     current_user, redirect = await _require_super_admin_page(request)
     if redirect:
@@ -7776,12 +7819,14 @@ async def admin_create_shop_product(
         if not category:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Selected category does not exist")
 
-    cross_sell_product_id = await _resolve_related_product_id_by_sku(
-        cross_sell_sku,
+    cross_sell_ids = await _validate_recommendation_product_ids(
+        cross_sell_product_ids,
+        category_id=category_value,
         field_label="Cross-sell",
     )
-    upsell_product_id = await _resolve_related_product_id_by_sku(
-        upsell_sku,
+    upsell_ids = await _validate_recommendation_product_ids(
+        upsell_product_ids,
+        category_id=category_value,
         field_label="Up-sell",
     )
 
@@ -7807,8 +7852,8 @@ async def admin_create_shop_product(
             vip_price=vip_decimal,
             category_id=category_value,
             image_url=image_url,
-            cross_sell_product_id=cross_sell_product_id,
-            upsell_product_id=upsell_product_id,
+            cross_sell_product_ids=cross_sell_ids,
+            upsell_product_ids=upsell_ids,
         )
     except aiomysql.IntegrityError as exc:
         if stored_path:
@@ -7851,8 +7896,8 @@ async def admin_update_shop_product(
     vip_price: str | None = Form(default=None),
     category_id: str | None = Form(default=None),
     image: UploadFile | None = File(default=None),
-    cross_sell_sku: str | None = Form(default=None),
-    upsell_sku: str | None = Form(default=None),
+    cross_sell_product_ids: list[int] | None = Form(default=None),
+    upsell_product_ids: list[int] | None = Form(default=None),
 ):
     current_user, redirect = await _require_super_admin_page(request)
     if redirect:
@@ -7922,13 +7967,15 @@ async def admin_update_shop_product(
         else:
             await image.close()
 
-    cross_sell_product_id = await _resolve_related_product_id_by_sku(
-        cross_sell_sku,
+    cross_sell_ids = await _validate_recommendation_product_ids(
+        cross_sell_product_ids,
+        category_id=category_value,
         field_label="Cross-sell",
         disallow_product_id=product_id,
     )
-    upsell_product_id = await _resolve_related_product_id_by_sku(
-        upsell_sku,
+    upsell_ids = await _validate_recommendation_product_ids(
+        upsell_product_ids,
+        category_id=category_value,
         field_label="Up-sell",
         disallow_product_id=product_id,
     )
@@ -7945,8 +7992,8 @@ async def admin_update_shop_product(
             vip_price=vip_decimal,
             category_id=category_value,
             image_url=image_url,
-            cross_sell_product_id=cross_sell_product_id,
-            upsell_product_id=upsell_product_id,
+            cross_sell_product_ids=cross_sell_ids,
+            upsell_product_ids=upsell_ids,
         )
     except aiomysql.IntegrityError as exc:
         if stored_path:

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -664,6 +664,15 @@ body {
   min-height: 140px;
 }
 
+.form-input--multiselect {
+  min-height: 160px;
+  padding: 0.5rem;
+}
+
+.form-input--multiselect option {
+  padding: 0.25rem 0.5rem;
+}
+
 .form-actions--stacked {
   justify-content: flex-start;
 }
@@ -2187,7 +2196,13 @@ button.header-title-menu__link {
 .cart-recommendations__grid {
   display: grid;
   gap: calc(var(--space-gap-base) * 1.5);
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+@media (min-width: 1200px) {
+  .cart-recommendations__grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
 }
 
 .cart-recommendations__item {

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -100,13 +100,35 @@
         <label class="form-label" for="product-vendor-sku">Vendor SKU</label>
         <input class="form-input" id="product-vendor-sku" name="vendor_sku" required />
       </div>
-      <div class="form-field">
-        <label class="form-label" for="product-cross-sell-sku">Cross-sell SKU</label>
-        <input class="form-input" id="product-cross-sell-sku" name="cross_sell_sku" />
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="product-cross-sell">Cross-sell products</label>
+        <select
+          class="form-input form-input--multiselect"
+          id="product-cross-sell"
+          name="cross_sell_product_ids"
+          multiple
+          size="6"
+          data-recommendation-select="cross"
+          disabled
+        >
+          <option value="" disabled selected>Select a category to choose products</option>
+        </select>
+        <p class="form-helper">Suggest complementary items from the same category.</p>
       </div>
-      <div class="form-field">
-        <label class="form-label" for="product-upsell-sku">Up-sell SKU</label>
-        <input class="form-input" id="product-upsell-sku" name="upsell_sku" />
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="product-upsell">Up-sell products</label>
+        <select
+          class="form-input form-input--multiselect"
+          id="product-upsell"
+          name="upsell_product_ids"
+          multiple
+          size="6"
+          data-recommendation-select="upsell"
+          disabled
+        >
+          <option value="" disabled selected>Select a category to choose products</option>
+        </select>
+        <p class="form-helper">Highlight upgrade paths within the same category.</p>
       </div>
       <div class="form-field">
         <label class="form-label" for="product-price">Price</label>
@@ -256,13 +278,31 @@
         <label class="form-label" for="edit-product-vendor">Vendor SKU</label>
         <input class="form-input" id="edit-product-vendor" name="vendor_sku" required />
       </div>
-      <div class="form-field">
-        <label class="form-label" for="edit-product-cross-sell">Cross-sell SKU</label>
-        <input class="form-input" id="edit-product-cross-sell" name="cross_sell_sku" />
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="edit-product-cross-sell">Cross-sell products</label>
+        <select
+          class="form-input form-input--multiselect"
+          id="edit-product-cross-sell"
+          name="cross_sell_product_ids"
+          multiple
+          size="6"
+          data-recommendation-select="cross"
+        >
+        </select>
+        <p class="form-helper">Choose add-ons from the same category as this product.</p>
       </div>
-      <div class="form-field">
-        <label class="form-label" for="edit-product-upsell">Up-sell SKU</label>
-        <input class="form-input" id="edit-product-upsell" name="upsell_sku" />
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="edit-product-upsell">Up-sell products</label>
+        <select
+          class="form-input form-input--multiselect"
+          id="edit-product-upsell"
+          name="upsell_product_ids"
+          multiple
+          size="6"
+          data-recommendation-select="upsell"
+        >
+        </select>
+        <p class="form-helper">Offer upgrade paths that remain in the same category.</p>
       </div>
       <div class="form-field form-field--wide">
         <label class="form-label" for="edit-product-description">Description</label>

--- a/changes/d4efdab9-9892-4d57-953d-63523d006e30.json
+++ b/changes/d4efdab9-9892-4d57-953d-63523d006e30.json
@@ -1,0 +1,7 @@
+{
+  "guid": "d4efdab9-9892-4d57-953d-63523d006e30",
+  "occurred_at": "2025-11-01T05:39Z",
+  "change_type": "Feature",
+  "summary": "Enabled category-scoped multi-product recommendations with expanded cart layout",
+  "content_hash": "111db224913e999d3208d17e4c5dda905b5d4823759c30e9a94a17a31cdb8017"
+}

--- a/migrations/094_shop_product_recommendation_links.sql
+++ b/migrations/094_shop_product_recommendation_links.sql
@@ -1,0 +1,45 @@
+ALTER TABLE shop_products
+  DROP FOREIGN KEY fk_shop_products_cross_sell,
+  DROP FOREIGN KEY fk_shop_products_upsell;
+
+CREATE TABLE IF NOT EXISTS shop_product_cross_sells (
+  product_id INT NOT NULL,
+  related_product_id INT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (product_id, related_product_id),
+  CONSTRAINT fk_shop_product_cross_sells_product
+    FOREIGN KEY (product_id) REFERENCES shop_products(id)
+    ON DELETE CASCADE,
+  CONSTRAINT fk_shop_product_cross_sells_related
+    FOREIGN KEY (related_product_id) REFERENCES shop_products(id)
+    ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS shop_product_upsells (
+  product_id INT NOT NULL,
+  related_product_id INT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (product_id, related_product_id),
+  CONSTRAINT fk_shop_product_upsells_product
+    FOREIGN KEY (product_id) REFERENCES shop_products(id)
+    ON DELETE CASCADE,
+  CONSTRAINT fk_shop_product_upsells_related
+    FOREIGN KEY (related_product_id) REFERENCES shop_products(id)
+    ON DELETE CASCADE
+);
+
+INSERT INTO shop_product_cross_sells (product_id, related_product_id)
+SELECT id AS product_id, cross_sell_product_id AS related_product_id
+FROM shop_products
+WHERE cross_sell_product_id IS NOT NULL AND cross_sell_product_id <> id
+ON DUPLICATE KEY UPDATE related_product_id = VALUES(related_product_id);
+
+INSERT INTO shop_product_upsells (product_id, related_product_id)
+SELECT id AS product_id, upsell_product_id AS related_product_id
+FROM shop_products
+WHERE upsell_product_id IS NOT NULL AND upsell_product_id <> id
+ON DUPLICATE KEY UPDATE related_product_id = VALUES(related_product_id);
+
+ALTER TABLE shop_products
+  DROP COLUMN cross_sell_product_id,
+  DROP COLUMN upsell_product_id;


### PR DESCRIPTION
## Summary
- migrate shop recommendation data into dedicated cross-sell and up-sell link tables
- update shop admin workflows with category-scoped multi-select controls for related products
- refresh cart recommendation layout and log the feature change

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69059b471808832db18aed4bf8a739f1