### PR TITLE
feat: move message template creation to dedicated page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6704,6 +6704,62 @@ async def admin_message_templates(
     return await _render_template("admin/message_templates.html", request, current_user, extra=extra)
 
 
+@app.get("/admin/message-templates/new", response_class=HTMLResponse)
+async def admin_message_templates_new(request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    content_type_options = [
+        {"value": value, "label": label}
+        for value, label in _MESSAGE_TEMPLATE_CONTENT_TYPES
+    ]
+
+    extra = {
+        "title": "New message template",
+        "page_title": "New message template",
+        "form_heading": "New template",
+        "submit_label": "Save template",
+        "show_reset_button": True,
+        "template": {},
+        "content_type_options": content_type_options,
+        "default_content_type": "text/plain",
+    }
+
+    return await _render_template("admin/message_template_form.html", request, current_user, extra=extra)
+
+
+@app.get("/admin/message-templates/{template_id}/edit", response_class=HTMLResponse)
+async def admin_message_templates_edit(request: Request, template_id: int):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    template_record = await message_templates_service.get_template(template_id)
+    if not template_record:
+        message = "Template not found."
+        encoded = urlencode({"error": message})
+        return RedirectResponse(url=f"/admin/message-templates?{encoded}", status_code=status.HTTP_303_SEE_OTHER)
+
+    content_type_options = [
+        {"value": value, "label": label}
+        for value, label in _MESSAGE_TEMPLATE_CONTENT_TYPES
+    ]
+
+    extra = {
+        "title": f"Edit {template_record.get('name') or 'template'}",
+        "page_title": "Edit message template",
+        "form_heading": "Edit template",
+        "submit_label": "Update template",
+        "show_reset_button": False,
+        "template": template_record,
+        "content_type_options": content_type_options,
+        "default_content_type": template_record.get("content_type") or "text/plain",
+    }
+
+    return await _render_template("admin/message_template_form.html", request, current_user, extra=extra)
+
+
 @app.get("/admin/automation", response_class=HTMLResponse)
 async def admin_automation(request: Request):
     current_user, redirect = await _require_super_admin_page(request)

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1240,21 +1240,12 @@
       });
     }
 
-    document.querySelectorAll('[data-template-edit]').forEach((button) => {
-      button.addEventListener('click', () => {
-        const row = button.closest('tr');
-        if (!row) {
-          return;
-        }
-        const payload = getTemplatePayload(row.dataset.templateJson);
-        if (!payload) {
-          return;
-        }
-        setFormState('edit', payload);
-        slugField.focus();
-      });
-    });
+    if (!idField.value) {
+      setFormState('create');
+    }
+  }
 
+  function bindMessageTemplateDeleteButtons() {
     document.querySelectorAll('[data-template-delete]').forEach((button) => {
       button.addEventListener('click', async () => {
         const row = button.closest('tr');
@@ -1278,8 +1269,6 @@
         }
       });
     });
-
-    setFormState('create');
   }
 
   function bindRoleForm() {
@@ -2209,6 +2198,7 @@
     bindTicketAiReplaceDescription();
     bindTicketAiRefresh();
     bindMessageTemplateForm();
+    bindMessageTemplateDeleteButtons();
     bindRoleForm();
     bindCompanyAssignForm();
     bindCompanyAssignmentControls();

--- a/app/templates/admin/message_template_form.html
+++ b/app/templates/admin/message_template_form.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+
+{% block header_title %}
+  <div class="header__title-content header__title-content--spread">
+    <span class="header__title-text">{{ page_title }}</span>
+    <a class="button button--ghost button--small header__title-button" href="/admin/message-templates">Back to templates</a>
+  </div>
+{% endblock %}
+
+{% block content %}
+  <section class="card card--panel" aria-labelledby="message-template-form-heading">
+    <header class="card__header card__header--actions">
+      <div>
+        <h2 class="card__title" id="message-template-form-heading" data-template-form-title>{{ form_heading }}</h2>
+        <p class="card__subtitle">
+          Provide a unique slug, friendly name, and body content. You can reuse templates anywhere template variables are supported.
+        </p>
+      </div>
+      {% if show_reset_button %}
+        <button type="button" class="button button--ghost" data-template-reset>
+          Clear form
+        </button>
+      {% endif %}
+    </header>
+    <form id="message-template-form" class="form" autocomplete="off" novalidate>
+      <input type="hidden" id="message-template-id" name="template_id" value="{{ template.id or '' }}" />
+      <div class="form-field">
+        <label class="form-label" for="message-template-slug">Slug</label>
+        <input
+          class="form-input"
+          id="message-template-slug"
+          name="slug"
+          maxlength="120"
+          pattern="^[a-z0-9](?:[a-z0-9._-]{0,118}[a-z0-9])?$"
+          required
+          placeholder="welcome.email"
+          aria-describedby="message-template-slug-help"
+          value="{{ template.slug or '' }}"
+        />
+        <p class="form-help" id="message-template-slug-help">
+          Lowercase letters, numbers, dots, underscores, and hyphens only.
+        </p>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="message-template-name">Name</label>
+        <input
+          class="form-input"
+          id="message-template-name"
+          name="name"
+          maxlength="255"
+          required
+          value="{{ template.name or '' }}"
+        />
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="message-template-description">Description</label>
+        <textarea
+          class="form-input form-input--textarea"
+          id="message-template-description"
+          name="description"
+          rows="3"
+        >{{ template.description or '' }}</textarea>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="message-template-content-type">Content type</label>
+        <select class="form-input" id="message-template-content-type" name="content_type">
+          {% for option in content_type_options %}
+            <option value="{{ option.value }}" {% if option.value == (template.content_type or default_content_type) %}selected{% endif %}>{{ option.label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="form-field">
+        <label class="form-label" for="message-template-content">Content</label>
+        <textarea
+          class="form-input form-input--textarea"
+          id="message-template-content"
+          name="content"
+          rows="12"
+          required
+          aria-describedby="message-template-content-help"
+        >{{ template.content or '' }}</textarea>
+        <p class="form-help" id="message-template-content-help">
+          Supports template variables like <code>{{ '{{ user.first_name }}' }}</code> and <code>{{ '{{ company.name }}' }}</code>.
+        </p>
+      </div>
+      <div class="form-actions">
+        <button type="submit" class="button button--primary" data-template-submit>{{ submit_label }}</button>
+        <a class="button button--ghost" href="/admin/message-templates">Cancel</a>
+      </div>
+    </form>
+  </section>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/admin.js" defer></script>
+{% endblock %}

--- a/app/templates/admin/message_templates.html
+++ b/app/templates/admin/message_templates.html
@@ -1,5 +1,14 @@
 {% extends "base.html" %}
 
+{% block header_title %}
+  <div class="header__title-content header__title-content--spread">
+    <span class="header__title-text">Message templates</span>
+    <a class="button button--primary button--small header__title-button" href="/admin/message-templates/new">
+      New template
+    </a>
+  </div>
+{% endblock %}
+
 {% block content %}
   {% if success_message or error_message %}
     <div class="alert-stack">
@@ -64,7 +73,7 @@
                 </td>
                 <td class="table__actions">
                   <div class="table__action-buttons">
-                    <button type="button" class="button button--ghost" data-template-edit>Edit</button>
+                    <a class="button button--ghost" href="/admin/message-templates/{{ template.id }}/edit">Edit</a>
                     <button type="button" class="button button--danger" data-template-delete>Delete</button>
                   </div>
                 </td>
@@ -87,77 +96,6 @@
           </tbody>
         </table>
       </div>
-    </section>
-
-    <section class="card card--panel" aria-labelledby="message-template-form-heading">
-      <header class="card__header card__header--actions">
-        <div>
-          <h2 class="card__title" id="message-template-form-heading" data-template-form-title>New template</h2>
-          <p class="card__subtitle">
-            Provide a unique slug, friendly name, and body content. You can reuse templates anywhere template variables are supported.
-          </p>
-        </div>
-        <button type="button" class="button button--ghost" data-template-reset>
-          Clear form
-        </button>
-      </header>
-      <form id="message-template-form" class="form" autocomplete="off" novalidate>
-        <input type="hidden" id="message-template-id" name="template_id" />
-        <div class="form-field">
-          <label class="form-label" for="message-template-slug">Slug</label>
-          <input
-            class="form-input"
-            id="message-template-slug"
-            name="slug"
-            maxlength="120"
-            pattern="^[a-z0-9](?:[a-z0-9._-]{0,118}[a-z0-9])?$"
-            required
-            placeholder="welcome.email"
-            aria-describedby="message-template-slug-help"
-          />
-          <p class="form-help" id="message-template-slug-help">
-            Lowercase letters, numbers, dots, underscores, and hyphens only.
-          </p>
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="message-template-name">Name</label>
-          <input class="form-input" id="message-template-name" name="name" maxlength="255" required />
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="message-template-description">Description</label>
-          <textarea
-            class="form-input form-input--textarea"
-            id="message-template-description"
-            name="description"
-            rows="3"
-          ></textarea>
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="message-template-content-type">Content type</label>
-          <select class="form-input" id="message-template-content-type" name="content_type">
-            {% for option in content_type_options %}
-              <option value="{{ option.value }}">{{ option.label }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-field">
-          <label class="form-label" for="message-template-content">Content</label>
-          <textarea
-            class="form-input form-input--textarea"
-            id="message-template-content"
-            name="content"
-            rows="12"
-            required
-            aria-describedby="message-template-content-help"
-          ></textarea>
-          <p class="form-help" id="message-template-content-help">
-            Supports template variables like <code>{{ '{{ user.first_name }}' }}</code> and <code>{{ '{{ company.name }}' }}</code>.
-          </p>
-        </div>
-        <div class="form-actions">
-          <button type="submit" class="button button--primary" data-template-submit>Save template</button>
-        </div>
-      </form>
     </section>
 
     <details class="card card--panel card-collapsible">

--- a/changes/8a566377-58e6-4900-8f01-f1f3d7bf0374.json
+++ b/changes/8a566377-58e6-4900-8f01-f1f3d7bf0374.json
@@ -1,0 +1,7 @@
+{
+  "guid": "8a566377-58e6-4900-8f01-f1f3d7bf0374",
+  "occurred_at": "2025-11-01T05:48Z",
+  "change_type": "Feature",
+  "summary": "Moved message template creation form to a dedicated page with header shortcut.",
+  "content_hash": "0047894b3716c81b890d559fb5745197a0f90d2f5f52e7b29e289d8615d688f8"
+}


### PR DESCRIPTION
## Summary
- add dedicated admin routes for creating and editing message templates with contextual page metadata
- move the message template form into its own template and expose a header shortcut from the listing view
- adjust admin JavaScript bindings for the standalone form workflow and register a change log entry

## Testing
- `pytest tests/test_admin_change_log_page.py`


------
https://chatgpt.com/codex/tasks/task_b_69059e5cfcfc832d916d869c3f0c7467