### PR TITLE
Add template variable guidance to new message template form

### DIFF
--- a/app/templates/admin/message_template_form.html
+++ b/app/templates/admin/message_template_form.html
@@ -89,6 +89,29 @@
       </div>
     </form>
   </section>
+
+  <details class="card card--panel card-collapsible">
+    <summary class="card__header card__header--collapsible">
+      <div>
+        <h2 class="card__title">Using template variables</h2>
+        <p class="card__subtitle">Reference automation context safely across email and notification templates.</p>
+      </div>
+      <span class="card__toggle-icon" aria-hidden="true"></span>
+    </summary>
+    <div class="card-collapsible__content">
+      <div class="card__body card__body--stacked">
+        <p>
+          Templates can include any variable exposed by the automation or integration invoking them. Common variables include
+          <code>{{ '{{ user.first_name }}' }}</code>, <code>{{ '{{ company.name }}' }}</code>, and <code>{{ '{{ portal.url }}' }}</code>.
+          HTML templates render exactly as provided, so remember to sanitise any untrusted data before storing it in a template.
+        </p>
+        <p>
+          Review the <a href="/docs/message-templates" target="_blank" rel="noopener">message template documentation</a> for
+          a full list of supported tokens and implementation guidance.
+        </p>
+      </div>
+    </div>
+  </details>
 {% endblock %}
 
 {% block scripts %}

--- a/changes/813c541a-4f47-4ee7-946b-e17d8c1f23a4.json
+++ b/changes/813c541a-4f47-4ee7-946b-e17d8c1f23a4.json
@@ -1,0 +1,7 @@
+{
+  "guid": "813c541a-4f47-4ee7-946b-e17d8c1f23a4",
+  "occurred_at": "2025-11-01T05:54Z",
+  "change_type": "Feature",
+  "summary": "Added template variable guidance to new message template form.",
+  "content_hash": "0ab01dd3b992e2c13e4d2b9b900a4b9a828aed25885fcab6e30b42b61b14c938"
+}


### PR DESCRIPTION
## Summary
- add template variable usage guidance to the new message template form so admins can reference tokens while editing
- record the feature addition in the change log metadata files

## Testing
- `pytest` *(fails: 3 known shop admin update product feature tests due to missing SKU helper and new parameters)*

------
https://chatgpt.com/codex/tasks/task_b_6905a062269c832d95cc4baa23df9eb4