### PR TITLE
Ensure cart upsells replace base items

### DIFF
--- a/app/templates/shop/cart.html
+++ b/app/templates/shop/cart.html
@@ -172,6 +172,11 @@
                 {% include "partials/csrf.html" %}
                 <input type="hidden" name="productId" value="{{ item.product_id }}" />
                 <input type="hidden" name="quantity" value="1" />
+                {% if item.source_product_ids %}
+                  {% for source_id in item.source_product_ids %}
+                    <input type="hidden" name="upgradeFrom" value="{{ source_id }}" />
+                  {% endfor %}
+                {% endif %}
                 <button type="submit" class="button button--primary">Upgrade</button>
               </form>
             </article>

--- a/changes/7988de5e-d2f1-4218-960e-341948e47835.json
+++ b/changes/7988de5e-d2f1-4218-960e-341948e47835.json
@@ -1,0 +1,7 @@
+{
+  "guid": "7988de5e-d2f1-4218-960e-341948e47835",
+  "occurred_at": "2025-11-01T05:52:36Z",
+  "change_type": "Fix",
+  "summary": "Upsell upgrades now replace original cart items and redirect users back to the cart page.",
+  "content_hash": "37ac167afab494b06e16c1229b1a3a7727e9f323dec1be52dd6837e89eaa4767"
+}


### PR DESCRIPTION
## Summary
- ensure cart additions and upsell upgrades redirect back to the cart with contextual messages
- remove the original product when an upsell upgrade is applied and surface the relationship in cart recommendations
- cover the new behaviour with unit tests and record the change in the change log

## Testing
- pytest tests/test_cart_update.py

------
https://chatgpt.com/codex/tasks/task_b_69059f5be160832d813af1857e9c76da