### PR TITLE
Fix admin shop layout overflow

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1515,8 +1515,14 @@ button.header-title-menu__link {
 }
 
 .admin-grid--columns {
-  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(min(420px, 100%), 1fr));
   align-items: flex-start;
+}
+
+@media (min-width: 1500px) {
+  .admin-grid--columns {
+    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  }
 }
 
 .stats-grid {

--- a/changes/fed5f284-4dd4-4d21-ab4a-9718f3e033fe.json
+++ b/changes/fed5f284-4dd4-4d21-ab4a-9718f3e033fe.json
@@ -1,0 +1,7 @@
+{
+  "guid": "fed5f284-4dd4-4d21-ab4a-9718f3e033fe",
+  "occurred_at": "2025-11-01T05:55Z",
+  "change_type": "Fix",
+  "summary": "Adjusted admin shop layout to prevent product form and catalogue table from overflowing horizontally.",
+  "content_hash": "2461f5510e1848961d8044ac25590ce36d42fb4d06955b516db9c4855c2b4cc0"
+}


### PR DESCRIPTION
## Summary
- update the admin grid columns to auto-fit available width so the add product form and catalogue table stay within the viewport
- document the layout fix in the change log for auditing

## Testing
- pytest *(fails: tests/test_shop_admin_update_product_features.py::test_admin_update_shop_product_updates_features, tests/test_shop_admin_update_product_features.py::test_admin_update_shop_product_invalid_feature_json, tests/test_shop_admin_update_shop_product_rejects_blank_feature_name)*

------
https://chatgpt.com/codex/tasks/task_b_6905a036e490832d8189646693e5f621