### PR TITLE
Remove template variable guidance from admin message templates

### DIFF
--- a/app/templates/admin/message_templates.html
+++ b/app/templates/admin/message_templates.html
@@ -97,29 +97,6 @@
         </table>
       </div>
     </section>
-
-    <details class="card card--panel card-collapsible">
-      <summary class="card__header card__header--collapsible">
-        <div>
-          <h2 class="card__title">Using template variables</h2>
-          <p class="card__subtitle">Reference automation context safely across email and notification templates.</p>
-        </div>
-        <span class="card__toggle-icon" aria-hidden="true"></span>
-      </summary>
-      <div class="card-collapsible__content">
-        <div class="card__body card__body--stacked">
-          <p>
-            Templates can include any variable exposed by the automation or integration invoking them. Common variables include
-            <code>{{ '{{ user.first_name }}' }}</code>, <code>{{ '{{ company.name }}' }}</code>, and <code>{{ '{{ portal.url }}' }}</code>.
-            HTML templates render exactly as provided, so remember to sanitise any untrusted data before storing it in a template.
-          </p>
-          <p>
-            Review the <a href="/docs/message-templates" target="_blank" rel="noopener">message template documentation</a> for
-            a full list of supported tokens and implementation guidance.
-          </p>
-        </div>
-      </div>
-    </details>
   </div>
 {% endblock %}
 

--- a/changes/fc9abe26-1bbd-4e27-9d3f-635b5cba306f.json
+++ b/changes/fc9abe26-1bbd-4e27-9d3f-635b5cba306f.json
@@ -1,0 +1,7 @@
+{
+  "guid": "fc9abe26-1bbd-4e27-9d3f-635b5cba306f",
+  "occurred_at": "2025-11-01T06:00Z",
+  "change_type": "Fix",
+  "summary": "Removed template variables guidance panel from message templates admin page.",
+  "content_hash": "cc03834c881f9baa77088d2d59c842b855c29f2283fcfba9379f3d13f4f70b7f"
+}


### PR DESCRIPTION
## Summary
- remove the collapsible "Using template variables" card from the admin message templates page
- record the interface adjustment in the change log

## Testing
- pytest *(fails: shop admin update product feature tests due to missing helper and argument signature)*

------
https://chatgpt.com/codex/tasks/task_b_6905a1d46b58832db89487ac504269a8