### PR TITLE
Fix persistence of product recommendation selections

### DIFF
--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -74,7 +74,7 @@ async def list_products(filters: ProductFilters) -> list[dict[str, Any]]:
 
     rows = await db.fetch_all(sql, tuple(params) if params else None)
     products = [_normalise_product(row) for row in rows]
-    return await _attach_features_to_products(products)
+    products = await _attach_features_to_products(products)
     await _populate_product_recommendations(products)
     return products
 
@@ -156,7 +156,7 @@ async def list_products_by_ids(
     params.extend(identifiers)
     rows = await db.fetch_all(" ".join(query_parts), tuple(params))
     products = [_normalise_product(row) for row in rows]
-    return await _attach_features_to_products(products)
+    products = await _attach_features_to_products(products)
     await _populate_product_recommendations(products)
     return products
 

--- a/changes/208b7ee1-7a19-420b-8556-fa1f6fa7266c.json
+++ b/changes/208b7ee1-7a19-420b-8556-fa1f6fa7266c.json
@@ -1,0 +1,7 @@
+{
+  "guid": "208b7ee1-7a19-420b-8556-fa1f6fa7266c",
+  "occurred_at": "2025-11-01T06:01Z",
+  "change_type": "Fix",
+  "summary": "Fixed product queries so cross-sell and up-sell recommendations persist when editing catalogue items.",
+  "content_hash": "bd361d848ad0029f78ef1c0e4423b0e63437ae9ab0d2e69a1a2ab3d1587cda7a"
+}

--- a/tests/test_shop_repository_recommendations.py
+++ b/tests/test_shop_repository_recommendations.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.repositories import shop as shop_repo
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_list_products_includes_recommendations(monkeypatch):
+    async def fake_fetch_all(sql: str, params: tuple[Any, ...] | None = None):
+        return [
+            {
+                "id": 1,
+                "name": "Example",
+                "sku": "SKU-1",
+                "vendor_sku": "VSKU-1",
+                "description": "",
+                "image_url": None,
+                "price": Decimal("19.99"),
+                "vip_price": None,
+                "stock": 5,
+                "category_id": 3,
+                "archived": 0,
+            }
+        ]
+
+    async def fake_attach(products: list[dict[str, Any]]):
+        return products
+
+    async def fake_populate(products: list[dict[str, Any]]):
+        for product in products:
+            product["cross_sell_product_ids"] = [11, 12]
+            product["upsell_product_ids"] = [21]
+
+    monkeypatch.setattr(shop_repo.db, "fetch_all", fake_fetch_all)
+    monkeypatch.setattr(shop_repo, "_attach_features_to_products", fake_attach)
+    monkeypatch.setattr(shop_repo, "_populate_product_recommendations", fake_populate)
+
+    products = await shop_repo.list_products(shop_repo.ProductFilters(include_archived=True))
+    assert products
+    product = products[0]
+    assert product["cross_sell_product_ids"] == [11, 12]
+    assert product["upsell_product_ids"] == [21]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_list_products_by_ids_includes_recommendations(monkeypatch):
+    async def fake_fetch_all(sql: str, params: tuple[Any, ...] | None = None):
+        return [
+            {
+                "id": 2,
+                "name": "Accessory",
+                "sku": "SKU-2",
+                "vendor_sku": "VSKU-2",
+                "description": "",
+                "image_url": None,
+                "price": Decimal("9.99"),
+                "vip_price": None,
+                "stock": 2,
+                "category_id": 3,
+                "archived": 0,
+            }
+        ]
+
+    async def fake_attach(products: list[dict[str, Any]]):
+        return products
+
+    async def fake_populate(products: list[dict[str, Any]]):
+        for product in products:
+            product["cross_sell_product_ids"] = [1]
+            product["upsell_product_ids"] = [3]
+
+    monkeypatch.setattr(shop_repo.db, "fetch_all", fake_fetch_all)
+    monkeypatch.setattr(shop_repo, "_attach_features_to_products", fake_attach)
+    monkeypatch.setattr(shop_repo, "_populate_product_recommendations", fake_populate)
+
+    products = await shop_repo.list_products_by_ids([2])
+    assert products
+    product = products[0]
+    assert product["cross_sell_product_ids"] == [1]
+    assert product["upsell_product_ids"] == [3]


### PR DESCRIPTION
## Summary
- ensure shop product queries populate recommendation selections before returning results
- add regression coverage to confirm cross- and up-sell IDs are preserved in product listings
- record the fix in the change log

## Testing
- pytest tests/test_shop_repository_recommendations.py

------
https://chatgpt.com/codex/tasks/task_b_6905a157bf18832d8b9b1ad4a6e96ffb