### PR TITLE
Fix cart upgrade to retain unrelated items

### DIFF
--- a/changes/aaa9e64e-51ed-414d-b01f-3ea61680a8aa.json
+++ b/changes/aaa9e64e-51ed-414d-b01f-3ea61680a8aa.json
@@ -1,0 +1,7 @@
+{
+  "guid": "aaa9e64e-51ed-414d-b01f-3ea61680a8aa",
+  "occurred_at": "2025-11-01T06:10:05Z",
+  "change_type": "Fix",
+  "summary": "Ensure cart upgrades only replace the targeted product so add-ons remain in the cart.",
+  "content_hash": "e727b3b136bab2b99e94f41be161b2c97bfd040a639d25e45535442860c17a2e"
+}


### PR DESCRIPTION
## Summary
- ensure cart upgrades only remove the selected source product from the cart
- add regression coverage to confirm add-ons stay in the cart during upgrades
- record the fix in the change log

## Testing
- pytest tests/test_cart_update.py

------
https://chatgpt.com/codex/tasks/task_b_6905a346cf90832da6b7af1efbbc8101