### PR TITLE
Reorder administration menu entries

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -218,7 +218,7 @@
                 <span class="menu__icon" aria-hidden="true">
                   <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a5 5 0 1 1-5 5 5 5 0 0 1 5-5zm0 12c-4 0-7 2-7 5v1h14v-1c0-3-3-5-7-5z"/></svg>
                 </span>
-                <span class="menu__label">My profile</span>
+                <span class="menu__label">My Profile</span>
               </a>
             </li>
             {% if is_super_admin %}
@@ -230,8 +230,30 @@
                   <span class="menu__label">Impersonation</span>
                 </a>
               </li>
-            {% endif %}
-            {% if is_super_admin %}
+              <li class="menu__item">
+                <a href="/admin/automation" {% if current_path.startswith('/admin/automation') %}aria-current="page"{% endif %}>
+                  <span class="menu__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false"><path d="M12 1a3 3 0 0 1 3 3v.18a3 3 0 0 1 2.12 2.12H17a3 3 0 0 1 3 3v.18a3 3 0 0 1 0 5.03V15a3 3 0 0 1-3 3h-.18a3 3 0 0 1-2.12 2.12V21a3 3 0 0 1-6 0v-.88A3 3 0 0 1 6.58 18H6a3 3 0 0 1-3-3v-.67a3 3 0 0 1 0-4.66V9a3 3 0 0 1 3-3h.18A3 3 0 0 1 8.3 3.18V3a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v1.5a1 1 0 0 1-.78.98 3 3 0 0 0-2.29 2.29 1 1 0 0 1-.98.78H6a1 1 0 0 0-1 1v.88a1 1 0 0 1-.58.91 1 1 0 0 0 0 1.82 1 1 0 0 1 .58.91V15a1 1 0 0 0 1 1h1.5a1 1 0 0 1 .98.78 3 3 0 0 0 2.29 2.29 1 1 0 0 1 .78.98V21a1 1 0 0 0 2 0v-1.5a1 1 0 0 1 .78-.98 3 3 0 0 0 2.29-2.29 1 1 0 0 1 .98-.78H17a1 1 0 0 0 1-1v-1.5a1 1 0 0 1 .58-.91 1 1 0 0 0 0-1.82 1 1 0 0 1-.58-.91V9a1 1 0 0 0-1-1h-1.5a1 1 0 0 1-.98-.78 3 3 0 0 0-2.29-2.29 1 1 0 0 1-.78-.98V3a1 1 0 0 0-1-1z"/></svg>
+                  </span>
+                  <span class="menu__label">System Automation</span>
+                </a>
+              </li>
+              <li class="menu__item">
+                <a href="/admin/message-templates" {% if current_path.startswith('/admin/message-templates') %}aria-current="page"{% endif %}>
+                  <span class="menu__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false"><path d="M4 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v16l-4-3-4 3-4-3-4 3z"/><path d="M7 6h10v2H7zm0 4h10v2H7zm0 4h6v2H7z"/></svg>
+                  </span>
+                  <span class="menu__label">Message Templates</span>
+                </a>
+              </li>
+              <li class="menu__item">
+                <a href="/admin/webhooks" {% if current_path.startswith('/admin/webhooks') %}aria-current="page"{% endif %}>
+                  <span class="menu__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false"><path d="M4 4a2 2 0 0 1 2-2h3a2 2 0 0 1 1.73 1H13a2 2 0 0 1 1.73 1H18a2 2 0 0 1 2 2v3a2 2 0 0 1-1 1.73V13a2 2 0 0 1-1 1.73V18a2 2 0 0 1-2 2h-3a2 2 0 0 1-1.73-1H11a2 2 0 0 1-1.73 1H6a2 2 0 0 1-2-2v-3a2 2 0 0 1 1-1.73V11a2 2 0 0 1 1-1.73V6a2 2 0 0 1-2-2zm2 0v3.5a1.5 1.5 0 0 0 0 3V14a1.5 1.5 0 0 0 0 3V18h3.5a1.5 1.5 0 0 0 3 0H16a1.5 1.5 0 0 0 3 0v-3.5a1.5 1.5 0 0 0 0-3V6a1.5 1.5 0 0 0-3 0h-3.5a1.5 1.5 0 0 0-3 0z"/></svg>
+                  </span>
+                  <span class="menu__label">Webhook Monitor</span>
+                </a>
+              </li>
               <li class="menu__item">
                 <a href="/admin/companies" {% if current_path.startswith('/admin/companies') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">
@@ -241,29 +263,11 @@
                 </a>
               </li>
               <li class="menu__item">
-                <a href="/admin/roles" {% if current_path.startswith('/admin/roles') %}aria-current="page"{% endif %}>
-                  <span class="menu__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false"><path d="M10.67 3.5a1 1 0 0 1 1.66 0l1.36 2.04a1 1 0 0 0 .63.43l2.35-.5a1 1 0 0 1 1.07 1.25L16.7 8.5a1 1 0 0 0 .21.95l1.67 1.8a1 1 0 0 1-.26 1.52l-2.3.5a1 1 0 0 0-.63.43L14.33 15a1 1 0 0 1-1.66 0l-1.36-2.04a1 1 0 0 0-.63-.43l-2.35.5a1 1 0 0 1-1.07-1.25L7.3 11.5a1 1 0 0 0-.21-.95L5.42 8.75a1 1 0 0 1 .26-1.52l2.3-.5a1 1 0 0 0 .63-.43z"/></svg>
-                  </span>
-                  <span class="menu__label">Roles</span>
-                </a>
-              </li>
-              <li class="menu__item">
                 <a href="/admin/api-keys" {% if current_path.startswith('/admin/api-keys') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" focusable="false"><path d="M7 10a5 5 0 0 1 9.58-2.15l4.47 4.47a1 1 0 0 1 0 1.41l-1.42 1.42a1 1 0 0 1-1.41 0l-.62-.62-1.41 1.41a1 1 0 0 1-1.41 0l-.59-.59-.59.59a1 1 0 0 1-1.41 0l-.88-.88A5 5 0 0 1 7 10zm5-3a3 3 0 1 0 2.85 4H16a1 1 0 0 1 .7.29l.91.91 1.42-1.42-1.56-1.56A1 1 0 0 1 18 9h.59l-1.28-1.28A5 5 0 0 0 12 7z"/></svg>
                   </span>
-                  <span class="menu__label">API keys</span>
-                </a>
-              </li>
-            {% endif %}
-            {% if is_super_admin %}
-              <li class="menu__item">
-                <a href="/admin/automation" {% if current_path.startswith('/admin/automation') %}aria-current="page"{% endif %}>
-                  <span class="menu__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false"><path d="M12 1a3 3 0 0 1 3 3v.18a3 3 0 0 1 2.12 2.12H17a3 3 0 0 1 3 3v.18a3 3 0 0 1 0 5.03V15a3 3 0 0 1-3 3h-.18a3 3 0 0 1-2.12 2.12V21a3 3 0 0 1-6 0v-.88A3 3 0 0 1 6.58 18H6a3 3 0 0 1-3-3v-.67a3 3 0 0 1 0-4.66V9a3 3 0 0 1 3-3h.18A3 3 0 0 1 8.3 3.18V3a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v1.5a1 1 0 0 1-.78.98 3 3 0 0 0-2.29 2.29 1 1 0 0 1-.98.78H6a1 1 0 0 0-1 1v.88a1 1 0 0 1-.58.91 1 1 0 0 0 0 1.82 1 1 0 0 1 .58.91V15a1 1 0 0 0 1 1h1.5a1 1 0 0 1 .98.78 3 3 0 0 0 2.29 2.29 1 1 0 0 1 .78.98V21a1 1 0 0 0 2 0v-1.5a1 1 0 0 1 .78-.98 3 3 0 0 0 2.29-2.29 1 1 0 0 1 .98-.78H17a1 1 0 0 0 1-1v-1.5a1 1 0 0 1 .58-.91 1 1 0 0 0 0-1.82 1 1 0 0 1-.58-.91V9a1 1 0 0 0-1-1h-1.5a1 1 0 0 1-.98-.78 3 3 0 0 0-2.29-2.29 1 1 0 0 1-.78-.98V3a1 1 0 0 0-1-1z"/></svg>
-                  </span>
-                  <span class="menu__label">System Automation</span>
+                  <span class="menu__label">API Keys</span>
                 </a>
               </li>
               <li class="menu__item">
@@ -275,19 +279,11 @@
                 </a>
               </li>
               <li class="menu__item">
-                <a href="/admin/message-templates" {% if current_path.startswith('/admin/message-templates') %}aria-current="page"{% endif %}>
+                <a href="/admin/roles" {% if current_path.startswith('/admin/roles') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false"><path d="M4 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v16l-4-3-4 3-4-3-4 3z"/><path d="M7 6h10v2H7zm0 4h10v2H7zm0 4h6v2H7z"/></svg>
+                    <svg viewBox="0 0 24 24" focusable="false"><path d="M10.67 3.5a1 1 0 0 1 1.66 0l1.36 2.04a1 1 0 0 0 .63.43l2.35-.5a1 1 0 0 1 1.07 1.25L16.7 8.5a1 1 0 0 0 .21.95l1.67 1.8a1 1 0 0 1-.26 1.52l-2.3.5a1 1 0 0 0-.63.43L14.33 15a1 1 0 0 1-1.66 0l-1.36-2.04a1 1 0 0 0-.63-.43l-2.35.5a1 1 0 0 1-1.07-1.25L7.3 11.5a1 1 0 0 0-.21-.95L5.42 8.75a1 1 0 0 1 .26-1.52l2.3-.5a1 1 0 0 0 .63-.43z"/></svg>
                   </span>
-                  <span class="menu__label">Message templates</span>
-                </a>
-              </li>
-              <li class="menu__item">
-                <a href="/admin/webhooks" {% if current_path.startswith('/admin/webhooks') %}aria-current="page"{% endif %}>
-                  <span class="menu__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false"><path d="M4 4a2 2 0 0 1 2-2h3a2 2 0 0 1 1.73 1H13a2 2 0 0 1 1.73 1H18a2 2 0 0 1 2 2v3a2 2 0 0 1-1 1.73V13a2 2 0 0 1-1 1.73V18a2 2 0 0 1-2 2h-3a2 2 0 0 1-1.73-1H11a2 2 0 0 1-1.73 1H6a2 2 0 0 1-2-2v-3a2 2 0 0 1 1-1.73V11a2 2 0 0 1 1-1.73V6a2 2 0 0 1-2-2zm2 0v3.5a1.5 1.5 0 0 0 0 3V14a1.5 1.5 0 0 0 0 3V18h3.5a1.5 1.5 0 0 0 3 0H16a1.5 1.5 0 0 0 3 0v-3.5a1.5 1.5 0 0 0 0-3V6a1.5 1.5 0 0 0-3 0h-3.5a1.5 1.5 0 0 0-3 0z"/></svg>
-                  </span>
-                  <span class="menu__label">Webhook monitor</span>
+                  <span class="menu__label">Roles</span>
                 </a>
               </li>
               <li class="menu__item">
@@ -295,7 +291,7 @@
                   <span class="menu__icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" focusable="false"><path d="M5 4a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v14.5a.5.5 0 0 1-.76.43L12 16l-6.24 2.93A.5.5 0 0 1 5 18.5zM7 6v9.62l5-2.35 5 2.35V6z"/></svg>
                   </span>
-                  <span class="menu__label">Change log</span>
+                  <span class="menu__label">Change Log</span>
                 </a>
               </li>
               <li class="menu__item">
@@ -303,7 +299,7 @@
                   <span class="menu__icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" focusable="false"><path d="M5 4h14a1 1 0 0 1 1 1v15l-8-3-8 3V5a1 1 0 0 1 1-1z"/></svg>
                   </span>
-                  <span class="menu__label">Audit trail</span>
+                  <span class="menu__label">Audit Trail</span>
                 </a>
               </li>
             {% else %}


### PR DESCRIPTION
## Summary
- reorder the Administration navigation entries to match the requested sequence
- align the Administration labels with the requested capitalization for each item

## Testing
- pytest *(fails: shop admin product feature tests due to missing `_resolve_related_product_id_by_sku` and unexpected `cross_sell_sku` argument in `admin_update_shop_product`)*

------
https://chatgpt.com/codex/tasks/task_b_6905a4adcf30832d83e977c65ab0350f