### PR TITLE
Make shop category admin panel always expanded

### DIFF
--- a/app/static/js/shop_admin.js
+++ b/app/static/js/shop_admin.js
@@ -59,34 +59,6 @@
     const container = document.body;
     submitOnChange(container);
 
-    const categoriesCollapsible = document.getElementById('product-categories-collapsible');
-    const CATEGORIES_STORAGE_KEY = 'shopAdminCategoriesExpanded';
-    if (categoriesCollapsible) {
-      const isEmpty = categoriesCollapsible.dataset.empty === 'true';
-      try {
-        const stored = window.localStorage.getItem(CATEGORIES_STORAGE_KEY);
-        if (stored === 'true') {
-          categoriesCollapsible.open = true;
-        } else if (stored === 'false') {
-          categoriesCollapsible.open = false;
-        } else if (isEmpty) {
-          categoriesCollapsible.open = true;
-        }
-      } catch (error) {
-        console.warn('Unable to read saved category toggle state', error);
-      }
-      categoriesCollapsible.addEventListener('toggle', () => {
-        try {
-          window.localStorage.setItem(
-            CATEGORIES_STORAGE_KEY,
-            categoriesCollapsible.open ? 'true' : 'false',
-          );
-        } catch (error) {
-          console.warn('Unable to persist category toggle state', error);
-        }
-      });
-    }
-
     const products = parseJson('admin-products-data', []);
     const restrictions = parseJson('admin-product-restrictions', {});
     const productsById = new Map(products.map((product) => [product.id, product]));

--- a/app/templates/admin/shop_categories.html
+++ b/app/templates/admin/shop_categories.html
@@ -15,60 +15,50 @@
 
 {% block content %}
   <div class="admin-grid admin-grid--columns">
-    <section class="card card--panel admin-grid__full">
-      <details
-        class="card-collapsible"
-        id="product-categories-collapsible"
-        data-empty="{{ 'true' if categories|length == 0 else 'false' }}"
-        open
-      >
-        <summary class="card__header card__header--collapsible">
-          <div>
-            <h2 class="card__title">Categories</h2>
-            <p class="card__subtitle">
-              Group products for faster browsing and targeted visibility rules.
-            </p>
-          </div>
-          <div class="card__collapsible-meta">
-            <span class="badge badge--muted">{{ categories|length }} total</span>
-            <span class="card__toggle-icon" aria-hidden="true"></span>
-          </div>
-        </summary>
-        <div class="card-collapsible__content" id="product-categories-panel">
-          <form action="/shop/admin/category" method="post" class="form-grid">
-            {% if csrf_token %}
-            <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-            {% endif %}
-            <div class="form-field form-field--wide">
-              <label class="form-label" for="category-name">Category name</label>
-              <input class="form-input" id="category-name" name="name" required />
-            </div>
-            <div class="form-actions">
-              <button type="submit" class="button">Add category</button>
-            </div>
-          </form>
-          <ul class="category-list">
-            {% for category in categories %}
-              <li class="category-list__item">
-                <span>{{ category.name }}</span>
-                <form
-                  action="/shop/admin/category/{{ category.id }}/delete"
-                  method="post"
-                  class="inline-form"
-                  data-confirm="Delete this category?"
-                >
-                  {% if csrf_token %}
-                  <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-                  {% endif %}
-                  <button type="submit" class="button button--danger">Delete</button>
-                </form>
-              </li>
-            {% else %}
-              <li class="category-list__item category-list__item--empty">No categories defined.</li>
-            {% endfor %}
-          </ul>
+    <section class="card card--panel admin-grid__full" aria-labelledby="product-categories-heading">
+      <header class="card__header">
+        <div>
+          <h2 class="card__title" id="product-categories-heading">Categories</h2>
+          <p class="card__subtitle">
+            Group products for faster browsing and targeted visibility rules.
+          </p>
         </div>
-      </details>
+        <span class="badge badge--muted">{{ categories|length }} total</span>
+      </header>
+      <div class="card__body">
+        <form action="/shop/admin/category" method="post" class="form-grid">
+          {% if csrf_token %}
+          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+          {% endif %}
+          <div class="form-field form-field--wide">
+            <label class="form-label" for="category-name">Category name</label>
+            <input class="form-input" id="category-name" name="name" required />
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="button">Add category</button>
+          </div>
+        </form>
+        <ul class="category-list">
+          {% for category in categories %}
+            <li class="category-list__item">
+              <span>{{ category.name }}</span>
+              <form
+                action="/shop/admin/category/{{ category.id }}/delete"
+                method="post"
+                class="inline-form"
+                data-confirm="Delete this category?"
+              >
+                {% if csrf_token %}
+                <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                {% endif %}
+                <button type="submit" class="button button--danger">Delete</button>
+              </form>
+            </li>
+          {% else %}
+            <li class="category-list__item category-list__item--empty">No categories defined.</li>
+          {% endfor %}
+        </ul>
+      </div>
     </section>
   </div>
 {% endblock %}

--- a/changes/45174e33-eaa8-4826-b3bb-7d1376985b4d.json
+++ b/changes/45174e33-eaa8-4826-b3bb-7d1376985b4d.json
@@ -1,0 +1,7 @@
+{
+  "guid": "45174e33-eaa8-4826-b3bb-7d1376985b4d",
+  "occurred_at": "2025-11-01T06:23Z",
+  "change_type": "Fix",
+  "summary": "Made the product category management panel always visible instead of collapsible.",
+  "content_hash": "1c2075f6bf6c2dbe7159e066d43f04700482e0e7eae5d0e87d5211e601cb6406"
+}


### PR DESCRIPTION
## Summary
- make the product categories admin card a static panel instead of a collapsible section
- remove the unused JavaScript that persisted the category collapsible state
- record the fix in the change log directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6905a6e20ef4832d938e1eef075252da