### PR TITLE
Adjust automation table pagination after section toggles

### DIFF
--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -1331,6 +1331,32 @@
     bindTaskActions();
     bindAutomationDeleteActions();
     setupAutomationForm();
+    bindAutomationSectionPagination();
+  }
+
+  function dispatchAutomationTableLayoutRefresh() {
+    const openSections = document.querySelectorAll('details[data-automation-section][open]');
+    openSections.forEach((section) => {
+      section.querySelectorAll('table[data-table]').forEach((table) => {
+        table.dispatchEvent(new CustomEvent('table:layout-change'));
+      });
+    });
+  }
+
+  function bindAutomationSectionPagination() {
+    const sections = document.querySelectorAll('details[data-automation-section]');
+    if (!sections.length) {
+      return;
+    }
+    const scheduleRefresh = () => {
+      window.requestAnimationFrame(() => {
+        dispatchAutomationTableLayoutRefresh();
+      });
+    };
+    sections.forEach((section) => {
+      section.addEventListener('toggle', scheduleRefresh);
+    });
+    scheduleRefresh();
   }
 
   if (document.readyState === 'loading') {

--- a/app/static/js/tables.js
+++ b/app/static/js/tables.js
@@ -91,9 +91,13 @@
       this.externalRefreshListener = () => {
         this.refreshRows();
       };
+      this.layoutRefreshListener = () => {
+        this.handleResize();
+      };
 
       if (this.table) {
         this.table.addEventListener('table:rows-updated', this.externalRefreshListener);
+        this.table.addEventListener('table:layout-change', this.layoutRefreshListener);
       }
 
       this.updateFilterState();

--- a/changes/ba63637d-e066-4957-801d-35ff8a0111f4.json
+++ b/changes/ba63637d-e066-4957-801d-35ff8a0111f4.json
@@ -1,0 +1,7 @@
+{
+  "guid": "ba63637d-e066-4957-801d-35ff8a0111f4",
+  "occurred_at": "2025-11-01T06:23:56Z",
+  "change_type": "Fix",
+  "summary": "Recalculate automation task table pagination when sections collapse or expand.",
+  "content_hash": "5dbf0c387579dc67474cea11cb8069aeb452b984f023a28f8aedbc99be6e8608"
+}


### PR DESCRIPTION
## Summary
- refresh automation tables pagination when their collapsible sections open or close so the visible rows adjust automatically
- extend the shared table controller to respond to layout change events and recalculate page sizes
- log the pagination fix in the change history

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6905a7420ef4832d93e6e3dfbe3f84f1