### PR TITLE
Restrict issue tracker access to dedicated permission

### DIFF
--- a/app/api/dependencies/auth.py
+++ b/app/api/dependencies/auth.py
@@ -6,6 +6,7 @@ from app.repositories import company_memberships as membership_repo
 from app.repositories import user_companies as user_company_repo
 from app.repositories import users as user_repo
 from app.security.session import SessionData, session_manager
+from app.services import issues as issues_service
 
 
 async def get_current_session(request: Request) -> SessionData:
@@ -46,6 +47,28 @@ async def require_helpdesk_technician(current_user: dict = Depends(get_current_u
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Helpdesk technician privileges required",
+        )
+    return current_user
+
+
+async def require_issue_tracker_access(current_user: dict = Depends(get_current_user)):
+    if current_user.get("is_super_admin"):
+        return current_user
+    user_id = current_user.get("id")
+    try:
+        user_id_int = int(user_id)
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Issue tracker access required",
+        ) from None
+    has_permission = await membership_repo.user_has_permission(
+        user_id_int, issues_service.ISSUE_TRACKER_PERMISSION_KEY
+    )
+    if not has_permission:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Issue tracker access required",
         )
     return current_user
 

--- a/app/api/routes/issues.py
+++ b/app/api/routes/issues.py
@@ -4,7 +4,7 @@ from typing import Any, Mapping
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
-from app.api.dependencies.auth import require_helpdesk_technician
+from app.api.dependencies.auth import require_issue_tracker_access
 from app.api.dependencies.database import require_database
 from app.core.logging import log_error, log_info
 from app.repositories import companies as company_repo
@@ -84,7 +84,7 @@ async def list_issues(
     company_id: int | None = Query(default=None, ge=1, alias="companyId"),
     company_name: str | None = Query(default=None, alias="companyName", max_length=255),
     _: None = Depends(require_database),
-    current_user: dict[str, Any] = Depends(require_helpdesk_technician),
+    current_user: dict[str, Any] = Depends(require_issue_tracker_access),
 ) -> IssueListResponse:
     del current_user  # Access control handled by dependency
     resolved_company_id = company_id
@@ -128,7 +128,7 @@ async def list_issues(
 async def create_issue(
     payload: IssueCreate,
     _: None = Depends(require_database),
-    current_user: dict[str, Any] = Depends(require_helpdesk_technician),
+    current_user: dict[str, Any] = Depends(require_issue_tracker_access),
 ) -> IssueResponse:
     user_id = _extract_user_id(current_user)
     try:
@@ -187,7 +187,7 @@ async def create_issue(
 async def update_issue_status(
     payload: IssueStatusUpdate,
     _: None = Depends(require_database),
-    current_user: dict[str, Any] = Depends(require_helpdesk_technician),
+    current_user: dict[str, Any] = Depends(require_issue_tracker_access),
 ) -> IssueStatusResponse:
     user_id = _extract_user_id(current_user)
     try:
@@ -230,7 +230,7 @@ async def update_issue(
     issue_name: str,
     payload: IssueUpdate,
     _: None = Depends(require_database),
-    current_user: dict[str, Any] = Depends(require_helpdesk_technician),
+    current_user: dict[str, Any] = Depends(require_issue_tracker_access),
 ) -> IssueResponse:
     issue = await issues_repo.get_issue_by_name(issue_name)
     if not issue or issue.get("issue_id") is None:

--- a/app/services/issues.py
+++ b/app/services/issues.py
@@ -18,6 +18,7 @@ STATUS_OPTIONS: list[tuple[str, str]] = [
 ]
 
 DEFAULT_STATUS = "new"
+ISSUE_TRACKER_PERMISSION_KEY = "issue_tracker.access"
 _STATUS_LOOKUP = {value: label for value, label in STATUS_OPTIONS}
 
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -84,7 +84,7 @@
           {% set can_manage_licenses = (can_manage_licenses | default(false)) or is_super_admin or membership.get('can_manage_licenses') %}
           {% set can_manage_invoices = (can_manage_invoices | default(false)) or is_super_admin or membership.get('can_manage_invoices') %}
           {% set can_manage_staff = (can_manage_staff | default(false)) or is_super_admin or membership.get('can_manage_staff') or (staff_permission > 0) %}
-          {% set can_manage_issues = is_super_admin or (is_helpdesk_technician | default(false)) %}
+          {% set can_manage_issues = has_issue_tracker_access | default(is_super_admin or (is_helpdesk_technician | default(false))) %}
           {% set has_company_section = can_access_tickets or can_manage_issues or can_access_shop or can_access_cart or can_access_orders or can_access_forms or can_manage_assets or can_manage_licenses or can_manage_invoices or can_manage_staff %}
           {% set is_company_admin = membership.get('is_admin') %}
           {% set has_admin_access = is_super_admin or is_company_admin %}

--- a/changes/cf8ef9d8-db88-41de-ae19-25f7d71c370f.json
+++ b/changes/cf8ef9d8-db88-41de-ae19-25f7d71c370f.json
@@ -1,0 +1,7 @@
+{
+  "guid": "cf8ef9d8-db88-41de-ae19-25f7d71c370f",
+  "occurred_at": "2025-11-01T06:27Z",
+  "change_type": "Feature",
+  "summary": "Restricted issue tracker assignments to dedicated permission and super admins.",
+  "content_hash": "295ae794686a63c94e3ccf3ac626e5ca9efbe445f091785384577ef9826d3831"
+}

--- a/docs/issues-api.md
+++ b/docs/issues-api.md
@@ -1,6 +1,6 @@
 # Issue Tracker API
 
-The Issue Tracker API exposes CRUD-style endpoints that allow technicians and automation clients to manage shared issues and the status of each company assignment. All endpoints require an authenticated session with helpdesk technician access or super-admin privileges. Requests must include a valid CSRF token when invoked from browser contexts.
+The Issue Tracker API exposes CRUD-style endpoints that allow technicians and automation clients to manage shared issues and the status of each company assignment. All endpoints require an authenticated session with the Issue Tracker permission (`issue_tracker.access`) or super-admin privileges. Requests must include a valid CSRF token when invoked from browser contexts.
 
 ## Base Path
 
@@ -10,7 +10,7 @@ The Issue Tracker API exposes CRUD-style endpoints that allow technicians and au
 
 ## Authentication
 
-These endpoints require a valid session cookie. API clients should authenticate using the standard session workflow before making requests. Responses will return HTTP 401 if the session is missing or expired, and HTTP 403 if the user lacks helpdesk technician permissions.
+These endpoints require a valid session cookie. API clients should authenticate using the standard session workflow before making requests. Responses will return HTTP 401 if the session is missing or expired, and HTTP 403 if the user lacks the Issue Tracker permission.
 
 ## List issues
 

--- a/tests/test_issues_api.py
+++ b/tests/test_issues_api.py
@@ -66,7 +66,7 @@ def active_session(monkeypatch):
 
 def _override_dependencies(active_session):
     app.dependency_overrides[database_dependencies.require_database] = lambda: None
-    app.dependency_overrides[auth_dependencies.require_helpdesk_technician] = lambda: {
+    app.dependency_overrides[auth_dependencies.require_issue_tracker_access] = lambda: {
         "id": active_session.user_id,
         "email": "tech@example.com",
         "is_super_admin": False,


### PR DESCRIPTION
## Summary
- add a dedicated `issue_tracker.access` permission for admin issue tracker views and API
- surface issue tracker access to the layout template and documentation, updating navigation logic
- record the feature update in the change log entries

## Testing
- pytest tests/test_issues_api.py

------
https://chatgpt.com/codex/tasks/task_b_6905a7473d74832dbc90851ee47d4eb8