### PR TITLE
Auto-select company when creating company automations

### DIFF
--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -496,13 +496,26 @@
               </select>
             </div>
             <div class="form-field">
-              <label class="form-label" for="task-company">Company</label>
-              <select class="form-input" id="task-company" name="companyId">
-                {% for option in automation_company_options %}
-                  <option value="{{ option.value }}">{{ option.label }}</option>
-                {% endfor %}
-              </select>
+              <label class="form-label" for="task-company-display">Company</label>
+              <input
+                class="form-input"
+                id="task-company-display"
+                type="text"
+                value="{{ (automation_company_options[0].label if automation_company_options else 'All companies') }}"
+                readonly
+                aria-readonly="true"
+                tabindex="-1"
+              />
               <p class="form-help">Automations created here run only for this company.</p>
+              <input
+                type="hidden"
+                id="task-company"
+                name="companyId"
+                value="{{ (automation_company_options[0].value if automation_company_options else '') }}"
+                data-company-name="{{ (automation_company_options[0].label if automation_company_options else 'All companies') }}"
+                data-default-value="{{ (automation_company_options[0].value if automation_company_options else '') }}"
+                data-default-name="{{ (automation_company_options[0].label if automation_company_options else 'All companies') }}"
+              />
             </div>
             <div class="form-field">
               <label class="form-label" for="task-cron">Cron expression</label>

--- a/changes/1d96e9bc-b98f-4a96-adf2-3d0e71823210.json
+++ b/changes/1d96e9bc-b98f-4a96-adf2-3d0e71823210.json
@@ -1,0 +1,7 @@
+{
+  "guid": "1d96e9bc-b98f-4a96-adf2-3d0e71823210",
+  "occurred_at": "2025-11-01T06:47Z",
+  "change_type": "Fix",
+  "summary": "Auto-select the current company when creating automations from the company edit page and hide the company dropdown.",
+  "content_hash": "c3dcfcba53af8f41c8046039f83b07135ea3cf5c5b6502867a7aa10cdf36030c"
+}


### PR DESCRIPTION
## Summary
- hide the company selector on the company automation modal and prefill it with the current company context
- update the automation modal logic to read the hidden company assignment when generating task names and populating forms
- record the change in the change log registry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6905ac2cd560832d993f201f01552449