### PR TITLE
Lock company display field on automation forms

### DIFF
--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -510,6 +510,11 @@
     const commandField = query('task-command');
     const companyField = query('task-company');
     const companyDisplayField = query('task-company-display');
+    if (companyDisplayField) {
+      companyDisplayField.readOnly = true;
+      companyDisplayField.setAttribute('aria-readonly', 'true');
+      companyDisplayField.setAttribute('tabindex', '-1');
+    }
     const defaults = getCompanyContext();
     const cronField = query('task-cron');
     const descriptionField = query('task-description');

--- a/changes/e11957a6-5d13-4ad5-89dd-794c7897debe.json
+++ b/changes/e11957a6-5d13-4ad5-89dd-794c7897debe.json
@@ -1,0 +1,7 @@
+{
+  "guid": "e11957a6-5d13-4ad5-89dd-794c7897debe",
+  "occurred_at": "2024-04-26T15:30Z",
+  "change_type": "Fix",
+  "summary": "Locked the task-company-display field on automation forms to prevent manual edits.",
+  "content_hash": "ab5e62f77a4ea825dbb3c19405704d7dbcd042fd454c734a551fecc07839bfc4"
+}


### PR DESCRIPTION
## Summary
- ensure the task-company-display input is forced to a read-only state on automation forms
- log the automation form safeguard in the change history

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_6905af5fa4ec832db49f0297c2facf31