### PR TITLE
Add Ollama-powered agent search to dashboard

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    agent,
     api_keys,
     audit_logs,
     auth,
@@ -28,6 +29,7 @@ from . import (
 )
 
 __all__ = [
+    "agent",
     "api_keys",
     "audit_logs",
     "auth",

--- a/app/api/routes/agent.py
+++ b/app/api/routes/agent.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+
+from app.api.dependencies.auth import get_current_user
+from app.schemas.agent import AgentQueryRequest, AgentQueryResponse
+from app.services import agent as agent_service
+
+router = APIRouter(prefix="/agent", tags=["Agent"])
+
+
+@router.post("/query", response_model=AgentQueryResponse)
+async def query_agent(
+    payload: AgentQueryRequest,
+    request: Request,
+    current_user: dict = Depends(get_current_user),
+) -> AgentQueryResponse:
+    active_company_id = getattr(request.state, "active_company_id", None)
+    memberships = getattr(request.state, "available_companies", None)
+    result = await agent_service.execute_agent_query(
+        payload.query,
+        current_user,
+        active_company_id=active_company_id,
+        memberships=memberships,
+    )
+    return AgentQueryResponse(**result)

--- a/app/main.py
+++ b/app/main.py
@@ -42,6 +42,7 @@ from pydantic import ValidationError
 from starlette.datastructures import FormData, URL
 
 from app.api.routes import (
+    agent,
     api_keys,
     audit_logs,
     auth,
@@ -229,6 +230,10 @@ tags_metadata = [
     {
         "name": "Knowledge Base",
         "description": "Permission-scoped articles with Ollama-assisted semantic search.",
+    },
+    {
+        "name": "Agent",
+        "description": "AI-assisted portal agent powered by the Ollama module with permission-aware context.",
     },
     {
         "name": "Licenses",
@@ -463,6 +468,7 @@ async def authenticated_swagger_ui(request: Request) -> Response:
     )
 
 app.include_router(auth.router)
+app.include_router(agent.router)
 app.include_router(users.router)
 app.include_router(companies.router)
 app.include_router(licenses_api.router)

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field, constr
+
+
+class AgentSourceArticle(BaseModel):
+    slug: str
+    title: str
+    summary: Optional[str] = None
+    excerpt: Optional[str] = None
+    updated_at: Optional[str] = None
+    url: Optional[str] = None
+
+
+class AgentSourceTicket(BaseModel):
+    id: int
+    subject: str
+    status: str
+    priority: str
+    updated_at: Optional[str] = None
+    summary: Optional[str] = None
+    company_id: Optional[int] = None
+
+
+class AgentSourceProduct(BaseModel):
+    id: Optional[int] = None
+    name: str
+    sku: Optional[str] = None
+    vendor_sku: Optional[str] = None
+    price: Optional[str] = None
+    description: Optional[str] = None
+    recommendations: list[str] = Field(default_factory=list)
+
+
+class AgentSources(BaseModel):
+    knowledge_base: list[AgentSourceArticle] = Field(default_factory=list)
+    tickets: list[AgentSourceTicket] = Field(default_factory=list)
+    products: list[AgentSourceProduct] = Field(default_factory=list)
+
+
+class AgentContextCompany(BaseModel):
+    company_id: int
+    company_name: str
+
+
+class AgentContext(BaseModel):
+    companies: list[AgentContextCompany] = Field(default_factory=list)
+
+
+class AgentQueryRequest(BaseModel):
+    query: constr(strip_whitespace=True, min_length=1, max_length=2000)
+
+
+class AgentQueryResponse(BaseModel):
+    query: str
+    status: str
+    answer: Optional[str] = None
+    model: Optional[str] = None
+    event_id: Optional[int] = None
+    message: Optional[str] = None
+    generated_at: datetime
+    sources: AgentSources
+    context: AgentContext

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Mapping, Sequence
+
+from app.core.logging import log_error
+from app.repositories import shop as shop_repo
+from app.repositories import tickets as tickets_repo
+from app.services import company_access
+from app.services import knowledge_base as knowledge_base_service
+from app.services import modules as modules_service
+
+_KB_RESULT_LIMIT = 5
+_TICKET_RESULT_LIMIT = 5
+_PRODUCT_RESULT_LIMIT = 5
+_MAX_SNIPPET_LENGTH = 320
+
+
+def _utc_iso(dt: datetime | None) -> str | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _format_currency(amount: Decimal | None) -> str | None:
+    if amount is None:
+        return None
+    quantized = amount.quantize(Decimal("0.01"))
+    return f"${quantized:,.2f}"
+
+
+def _truncate(value: str | None, limit: int = _MAX_SNIPPET_LENGTH) -> str | None:
+    if not value:
+        return None
+    text = " ".join(str(value).split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _normalise_memberships(
+    memberships: Sequence[Mapping[str, Any]] | None,
+) -> list[Mapping[str, Any]]:
+    if not memberships:
+        return []
+    normalised: list[Mapping[str, Any]] = []
+    for membership in memberships:
+        if isinstance(membership, Mapping):
+            normalised.append(membership)
+    return normalised
+
+
+def _extract_company_ids(memberships: Sequence[Mapping[str, Any]]) -> list[int]:
+    identifiers: list[int] = []
+    for membership in memberships:
+        company_id = membership.get("company_id")
+        try:
+            company_id_int = int(company_id)
+        except (TypeError, ValueError):
+            continue
+        if company_id_int > 0:
+            identifiers.append(company_id_int)
+    return sorted(set(identifiers))
+
+
+def _can_access_shop(memberships: Sequence[Mapping[str, Any]], *, is_super_admin: bool) -> bool:
+    if is_super_admin:
+        return True
+    for membership in memberships:
+        if any(
+            bool(membership.get(flag))
+            for flag in ("can_access_shop", "can_access_orders", "can_access_cart")
+        ):
+            return True
+    return False
+
+
+def _company_summary(memberships: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    summary: list[dict[str, Any]] = []
+    for membership in memberships:
+        try:
+            company_id = int(membership.get("company_id"))
+        except (TypeError, ValueError):
+            continue
+        summary.append(
+            {
+                "company_id": company_id,
+                "company_name": membership.get("company_name") or f"Company #{company_id}",
+            }
+        )
+    return summary
+
+
+async def execute_agent_query(
+    query: str,
+    user: Mapping[str, Any],
+    *,
+    active_company_id: int | None = None,
+    memberships: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Execute an agent query using the configured Ollama module."""
+
+    query_text = (query or "").strip()
+    if not query_text:
+        return {
+            "query": "",
+            "status": "error",
+            "answer": None,
+            "model": None,
+            "event_id": None,
+            "message": "Query must not be empty.",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "sources": {"knowledge_base": [], "tickets": [], "products": []},
+            "context": {"companies": []},
+        }
+
+    resolved_memberships = _normalise_memberships(memberships)
+    if not resolved_memberships:
+        try:
+            resolved_memberships = await company_access.list_accessible_companies(user)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            log_error("Agent failed to load accessible companies", error=str(exc))
+            resolved_memberships = []
+
+    accessible_company_ids = _extract_company_ids(resolved_memberships)
+    company_context = _company_summary(resolved_memberships)
+    is_super_admin = bool(user.get("is_super_admin"))
+
+    kb_context = await knowledge_base_service.build_access_context(user)
+    try:
+        kb_search = await knowledge_base_service.search_articles(
+            query_text,
+            kb_context,
+            limit=_KB_RESULT_LIMIT,
+            use_ollama=False,
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        log_error("Agent knowledge base search failed", error=str(exc))
+        kb_results: list[dict[str, Any]] = []
+    else:
+        kb_results = list(kb_search.get("results") or [])
+
+    knowledge_base_sources: list[dict[str, Any]] = []
+    for article in kb_results[:_KB_RESULT_LIMIT]:
+        slug = str(article.get("slug") or "").strip()
+        if not slug:
+            continue
+        knowledge_base_sources.append(
+            {
+                "slug": slug,
+                "title": article.get("title") or slug.replace("-", " ").title(),
+                "summary": _truncate(article.get("summary")),
+                "excerpt": _truncate(article.get("excerpt")),
+                "updated_at": article.get("updated_at_iso"),
+                "url": f"/knowledge-base/articles/{slug}",
+            }
+        )
+
+    user_id_value = user.get("id")
+    ticket_sources: list[dict[str, Any]] = []
+    try:
+        user_id = int(user_id_value)
+    except (TypeError, ValueError):
+        user_id = 0
+    if user_id > 0:
+        try:
+            tickets = await tickets_repo.list_tickets_for_user(
+                user_id,
+                company_ids=accessible_company_ids,
+                search=query_text,
+                limit=_TICKET_RESULT_LIMIT,
+            )
+        except Exception as exc:  # pragma: no cover - defensive guard
+            log_error("Agent ticket lookup failed", error=str(exc))
+            tickets = []
+        for ticket in tickets[:_TICKET_RESULT_LIMIT]:
+            subject = ticket.get("subject")
+            if not isinstance(subject, str) or not subject.strip():
+                subject = f"Ticket #{ticket.get('id')}"
+            status = ticket.get("status") or "unknown"
+            priority = ticket.get("priority") or "normal"
+            ticket_sources.append(
+                {
+                    "id": ticket.get("id"),
+                    "subject": subject.strip(),
+                    "status": str(status).strip() or "unknown",
+                    "priority": str(priority).strip() or "normal",
+                    "updated_at": _utc_iso(ticket.get("updated_at")),
+                    "summary": _truncate(ticket.get("ai_summary") or ticket.get("description")),
+                    "company_id": ticket.get("company_id"),
+                }
+            )
+
+    product_sources: list[dict[str, Any]] = []
+    include_products = _can_access_shop(resolved_memberships, is_super_admin=is_super_admin)
+    if include_products:
+        company_scope: int | None = None
+        if active_company_id:
+            try:
+                company_scope = int(active_company_id)
+            except (TypeError, ValueError):
+                company_scope = None
+        if company_scope is None and accessible_company_ids:
+            company_scope = accessible_company_ids[0]
+
+        filters = shop_repo.ProductFilters(
+            include_archived=False,
+            company_id=company_scope,
+            search_term=query_text,
+        )
+        try:
+            products = await shop_repo.list_products(filters)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            log_error("Agent product lookup failed", error=str(exc))
+            products = []
+        for product in products[:_PRODUCT_RESULT_LIMIT]:
+            recommendations: list[str] = []
+            for related in product.get("cross_sell_products", [])[:2]:
+                name = related.get("name")
+                if isinstance(name, str) and name.strip():
+                    recommendations.append(name.strip())
+            for related in product.get("upsell_products", [])[:2]:
+                if len(recommendations) >= 4:
+                    break
+                name = related.get("name")
+                if isinstance(name, str) and name.strip():
+                    recommendations.append(name.strip())
+            price_value = product.get("price")
+            price_display = None
+            if isinstance(price_value, Decimal):
+                price_display = _format_currency(price_value)
+            name_value = product.get("name")
+            if not isinstance(name_value, str) or not name_value.strip():
+                name_value = f"Product #{product.get('id')}"
+            product_sources.append(
+                {
+                    "id": product.get("id"),
+                    "name": name_value.strip(),
+                    "sku": product.get("sku"),
+                    "vendor_sku": product.get("vendor_sku"),
+                    "price": price_display,
+                    "description": _truncate(product.get("description")),
+                    "recommendations": recommendations,
+                }
+            )
+
+    context_sections: list[str] = [
+        "You are the MyPortal Agent. Answer the user using only the supplied context.",
+        "If the portal context does not contain the answer, say so and recommend contacting support.",
+        "Never reference systems, data, or permissions outside the provided information.",
+        "Use Markdown and cite sources inline with [KB:slug], [Ticket:#id], or [Product:SKU].",
+        f"User query: {query_text}",
+        "",
+    ]
+
+    if company_context:
+        company_lines = ", ".join(
+            f"{entry['company_name']} (#{entry['company_id']})" for entry in company_context
+        )
+        context_sections.extend([
+            "Companies available to the user:",
+            company_lines,
+            "",
+        ])
+
+    if knowledge_base_sources:
+        context_sections.append("Knowledge base articles:")
+        for article in knowledge_base_sources:
+            summary = article["summary"] or article["excerpt"] or "No summary available"
+            context_sections.append(
+                f"- [KB:{article['slug']}] {article['title']}: {summary}"
+            )
+        context_sections.append("")
+
+    if ticket_sources:
+        context_sections.append("Tickets created by or watched by the user:")
+        for ticket in ticket_sources:
+            summary = ticket["summary"] or "No summary available"
+            context_sections.append(
+                f"- [Ticket:#{ticket['id']}] {ticket['subject']} (status: {ticket['status']}, priority: {ticket['priority']}): {summary}"
+            )
+        context_sections.append("")
+
+    if product_sources:
+        context_sections.append("Products and hardware recommendations available to the user:")
+        for product in product_sources:
+            parts = [
+                f"[Product:{product['sku']}] {product['name']}" if product.get("sku") else product.get("name", "Product"),
+            ]
+            if product.get("price"):
+                parts.append(f"Price: {product['price']}")
+            if product.get("description"):
+                parts.append(product["description"])
+            if product.get("recommendations"):
+                recos = ", ".join(product["recommendations"])
+                parts.append(f"Recommended with: {recos}")
+            context_sections.append("- " + " — ".join(parts))
+        context_sections.append("")
+
+    if len(context_sections) == 6:  # only preamble, query, and blank line
+        context_sections.append("No portal records matched the query. Explain the absence to the user.")
+
+    prompt = "\n".join(context_sections)
+
+    module_status = "skipped"
+    model_name: str | None = None
+    answer_text: str | None = None
+    event_id: int | None = None
+    message: str | None = None
+
+    try:
+        module_response = await modules_service.trigger_module(
+            "ollama",
+            {"prompt": prompt},
+            background=False,
+        )
+    except ValueError as exc:
+        module_status = "error"
+        message = str(exc)
+    except Exception as exc:  # pragma: no cover - network or module failure
+        module_status = "error"
+        message = "Failed to contact Ollama module"
+        log_error("Agent Ollama invocation failed", error=str(exc))
+    else:
+        module_status = str(module_response.get("status") or "unknown")
+        event_candidate = module_response.get("event_id")
+        if isinstance(event_candidate, int):
+            event_id = event_candidate
+        payload = module_response.get("response")
+        if isinstance(payload, Mapping):
+            answer_text = payload.get("response") or payload.get("message")
+            model_name = payload.get("model") or module_response.get("model")
+        elif isinstance(module_response.get("response"), str):
+            answer_text = str(module_response["response"]).strip()
+            model_name = module_response.get("model")
+        else:
+            answer_text = module_response.get("message")
+            model_name = module_response.get("model")
+
+    return {
+        "query": query_text,
+        "status": module_status,
+        "answer": answer_text,
+        "model": model_name,
+        "event_id": event_id,
+        "message": message,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "sources": {
+            "knowledge_base": knowledge_base_sources,
+            "tickets": ticket_sources,
+            "products": product_sources,
+        },
+        "context": {"companies": company_context},
+    }

--- a/app/services/knowledge_base.py
+++ b/app/services/knowledge_base.py
@@ -641,7 +641,13 @@ def _render_prompt(query: str, articles: list[Mapping[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-async def search_articles(query: str, context: ArticleAccessContext, *, limit: int = 8) -> dict[str, Any]:
+async def search_articles(
+    query: str,
+    context: ArticleAccessContext,
+    *,
+    limit: int = 8,
+    use_ollama: bool = True,
+) -> dict[str, Any]:
     candidates = await kb_repo.list_articles(include_unpublished=context.is_super_admin)
     visible: list[dict[str, Any]] = []
     lowered = query.lower()
@@ -682,7 +688,7 @@ async def search_articles(query: str, context: ArticleAccessContext, *, limit: i
     ollama_status = "skipped"
     ollama_model: str | None = None
     ollama_summary: str | None = None
-    if results:
+    if results and use_ollama:
         prompt_articles = visible[: min(3, len(visible))]
         prompt = _render_prompt(query, prompt_articles)
         try:

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1042,6 +1042,198 @@ button.header-title-menu__link {
   box-sizing: border-box;
 }
 
+.dashboard__section--agent {
+  margin-bottom: clamp(var(--space-gap-base), 2vw, 2rem);
+}
+
+.agent-panel {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-gap-tight), 1vw, var(--space-gap-base));
+}
+
+.agent-panel--busy {
+  opacity: 0.85;
+}
+
+.agent-panel__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-gap-tight);
+}
+
+.agent-panel__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.agent-panel__subtitle {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.92rem;
+  max-width: 60ch;
+}
+
+.agent-panel__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-gap-tight);
+}
+
+.agent-panel__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.agent-panel__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-gap-tight);
+  align-items: stretch;
+}
+
+.agent-panel__input {
+  flex: 1 1 280px;
+  min-height: 2.75rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  color: #f8fafc;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.agent-panel__input:focus-visible {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.65);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.agent-panel__input:disabled {
+  opacity: 0.75;
+}
+
+.agent-panel__submit {
+  padding-inline: clamp(1rem, 2vw, 1.65rem);
+  min-height: 2.75rem;
+}
+
+.agent-panel__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.agent-panel__status {
+  min-height: 1.5rem;
+  font-size: 0.85rem;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.agent-panel__results {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-gap-tight), 1vw, var(--space-gap-base));
+}
+
+.agent-answer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-gap-tight);
+}
+
+.agent-answer__heading,
+.agent-sources__heading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.agent-answer__body {
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: rgba(248, 250, 252, 0.92);
+  white-space: pre-wrap;
+}
+
+.agent-answer__paragraph {
+  margin: 0 0 var(--space-gap-tight);
+}
+
+.agent-sources {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-gap-base);
+}
+
+.agent-sources__lists {
+  display: grid;
+  gap: clamp(var(--space-gap-tight), 1vw, var(--space-gap-base));
+}
+
+.agent-sources__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-gap-tight);
+}
+
+.agent-sources__title {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.75);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.agent-sources__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-gap-tight);
+}
+
+.agent-sources__item {
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: rgba(248, 250, 252, 0.88);
+}
+
+.agent-sources__item a {
+  color: #38bdf8;
+  text-decoration: none;
+}
+
+.agent-sources__item a:hover,
+.agent-sources__item a:focus-visible {
+  text-decoration: underline;
+}
+
+.agent-sources__meta {
+  margin-top: 0.15rem;
+  font-size: 0.82rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+@media (max-width: 720px) {
+  .agent-panel__controls {
+    flex-direction: column;
+  }
+
+  .agent-panel__submit {
+    width: 100%;
+  }
+
+  .agent-panel__input {
+    width: 100%;
+  }
+}
+
 .dashboard__lead {
   font-size: 1rem;
   color: rgba(229, 231, 235, 0.85);

--- a/app/static/js/agent.js
+++ b/app/static/js/agent.js
@@ -1,0 +1,283 @@
+(function () {
+  'use strict';
+
+  function escapeHtml(value) {
+    if (value == null) {
+      return '';
+    }
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function renderSimpleText(container, text) {
+    if (!container) {
+      return;
+    }
+    container.innerHTML = '';
+    if (!text) {
+      container.hidden = true;
+      return;
+    }
+    const paragraph = document.createElement('p');
+    paragraph.className = 'agent-answer__paragraph';
+    paragraph.innerHTML = escapeHtml(text).replace(/\n{2,}/g, '</p><p class="agent-answer__paragraph">').replace(/\n/g, '<br />');
+    container.appendChild(paragraph);
+    container.hidden = false;
+  }
+
+  function createSourceList(title, items, formatter) {
+    if (!items || items.length === 0) {
+      return null;
+    }
+    const section = document.createElement('section');
+    section.className = 'agent-sources__group';
+    const heading = document.createElement('h4');
+    heading.className = 'agent-sources__title';
+    heading.textContent = title;
+    section.appendChild(heading);
+
+    const list = document.createElement('ul');
+    list.className = 'agent-sources__list';
+    items.forEach((item) => {
+      const entry = document.createElement('li');
+      entry.className = 'agent-sources__item';
+      entry.innerHTML = formatter(item);
+      list.appendChild(entry);
+    });
+    section.appendChild(list);
+    return section;
+  }
+
+  function formatKnowledgeBaseSource(item) {
+    const title = escapeHtml(item.title || item.slug);
+    const slug = escapeHtml(item.slug);
+    const summary = escapeHtml(item.summary || item.excerpt || '');
+    const url = item.url ? escapeHtml(item.url) : null;
+    const linkStart = url ? `<a href="${url}">` : '';
+    const linkEnd = url ? '</a>' : '';
+    return `${linkStart}[KB:${slug}] ${title}${linkEnd}${summary ? `<div class="agent-sources__meta">${summary}</div>` : ''}`;
+  }
+
+  function formatTicketSource(item) {
+    const id = escapeHtml(item.id);
+    const subject = escapeHtml(item.subject || `Ticket #${item.id}`);
+    const status = escapeHtml(item.status || 'unknown');
+    const priority = escapeHtml(item.priority || 'normal');
+    const summary = escapeHtml(item.summary || '');
+    return `[#${id}] ${subject}<div class="agent-sources__meta">Status: ${status} • Priority: ${priority}${summary ? `<br />${summary}` : ''}</div>`;
+  }
+
+  function formatProductSource(item) {
+    const sku = item.sku ? escapeHtml(item.sku) : null;
+    const name = escapeHtml(item.name || (sku ? sku : 'Product'));
+    const price = item.price ? escapeHtml(item.price) : null;
+    const description = item.description ? escapeHtml(item.description) : null;
+    const recommendations = Array.isArray(item.recommendations) && item.recommendations.length
+      ? item.recommendations.map(escapeHtml).join(', ')
+      : null;
+    const label = sku ? `[${sku}] ${name}` : name;
+    const metaParts = [];
+    if (price) {
+      metaParts.push(`Price: ${price}`);
+    }
+    if (description) {
+      metaParts.push(description);
+    }
+    if (recommendations) {
+      metaParts.push(`Recommended with: ${recommendations}`);
+    }
+    const meta = metaParts.length ? `<div class="agent-sources__meta">${metaParts.join('<br />')}</div>` : '';
+    return `${label}${meta}`;
+  }
+
+  function renderSources(container, sources) {
+    if (!container) {
+      return;
+    }
+    container.innerHTML = '';
+    if (!sources) {
+      container.hidden = true;
+      return;
+    }
+
+    const groups = [];
+    if (Array.isArray(sources.knowledge_base)) {
+      groups.push(createSourceList('Knowledge base', sources.knowledge_base, formatKnowledgeBaseSource));
+    }
+    if (Array.isArray(sources.tickets)) {
+      groups.push(createSourceList('Tickets', sources.tickets, formatTicketSource));
+    }
+    if (Array.isArray(sources.products)) {
+      groups.push(createSourceList('Products', sources.products, formatProductSource));
+    }
+
+    const usable = groups.filter((group) => group);
+    if (usable.length === 0) {
+      container.hidden = true;
+      return;
+    }
+    usable.forEach((group) => container.appendChild(group));
+    container.hidden = false;
+  }
+
+  function formatStatus(result) {
+    if (!result || typeof result !== 'object') {
+      return '';
+    }
+    const parts = [];
+    if (result.status) {
+      const statusText = String(result.status).toLowerCase();
+      if (statusText === 'succeeded') {
+        parts.push('Answer generated successfully.');
+      } else if (statusText === 'skipped') {
+        parts.push('The Ollama module is disabled; showing recent context.');
+      } else {
+        parts.push('The agent could not generate a response.');
+      }
+    }
+    if (result.model) {
+      parts.push(`Model: ${result.model}`);
+    }
+    if (result.generated_at) {
+      const generatedDate = new Date(result.generated_at);
+      if (!Number.isNaN(generatedDate.getTime())) {
+        parts.push(`Generated at ${generatedDate.toLocaleString()}`);
+      }
+    }
+    if (result.event_id) {
+      parts.push(`Webhook event #${result.event_id}`);
+    }
+    if (result.message) {
+      parts.push(result.message);
+    }
+    return parts.join(' ');
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const panel = document.querySelector('[data-agent-panel]');
+    if (!panel) {
+      return;
+    }
+
+    const form = panel.querySelector('[data-agent-form]');
+    const input = panel.querySelector('[data-agent-input]');
+    const submitButton = panel.querySelector('[data-agent-submit]');
+    const status = panel.querySelector('[data-agent-status]');
+    const results = panel.querySelector('[data-agent-results]');
+    const answer = panel.querySelector('[data-agent-answer]');
+    const answerBody = panel.querySelector('[data-agent-answer-body]');
+    const sources = panel.querySelector('[data-agent-sources]');
+    const sourcesLists = panel.querySelector('[data-agent-source-lists]');
+
+    if (!form || !input) {
+      return;
+    }
+
+    const defaultStatus = 'Enter a question to ask the agent.';
+    if (status) {
+      status.textContent = defaultStatus;
+    }
+
+    function setBusy(isBusy) {
+      if (submitButton) {
+        submitButton.disabled = isBusy;
+      }
+      if (input) {
+        input.disabled = isBusy;
+      }
+      panel.classList.toggle('agent-panel--busy', Boolean(isBusy));
+    }
+
+    function resetResults() {
+      if (answer) {
+        answer.hidden = true;
+      }
+      if (answerBody) {
+        answerBody.textContent = '';
+      }
+      if (sources) {
+        sources.hidden = true;
+      }
+      if (sourcesLists) {
+        sourcesLists.innerHTML = '';
+      }
+      if (results) {
+        results.hidden = true;
+      }
+    }
+
+    async function handleSubmit(event) {
+      event.preventDefault();
+      const query = input.value.trim();
+      if (!query) {
+        if (status) {
+          status.textContent = 'Please enter a question for the agent.';
+        }
+        return;
+      }
+
+      setBusy(true);
+      resetResults();
+      if (status) {
+        status.textContent = 'Contacting the agent…';
+      }
+
+      try {
+        const response = await fetch('/api/agent/query', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ query }),
+        });
+
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(text || `Request failed with status ${response.status}`);
+        }
+
+        const payload = await response.json();
+        if (status) {
+          status.textContent = formatStatus(payload) || defaultStatus;
+        }
+
+        if (payload && typeof payload === 'object') {
+          if (payload.answer) {
+            renderSimpleText(answerBody, payload.answer);
+            if (answer) {
+              answer.hidden = false;
+            }
+          } else if (answer) {
+            answer.hidden = true;
+          }
+
+          if (payload.sources) {
+            renderSources(sourcesLists, payload.sources);
+            if (sources && sourcesLists && !sourcesLists.hidden && sourcesLists.children.length > 0) {
+              sources.hidden = false;
+            } else if (sources) {
+              sources.hidden = true;
+            }
+          }
+
+          if (results) {
+            const answerVisible = answer && !answer.hidden;
+            const sourcesVisible = sources && !sources.hidden;
+            results.hidden = !(answerVisible || sourcesVisible);
+          }
+        }
+      } catch (error) {
+        if (status) {
+          status.textContent = 'Unable to contact the agent. Please try again later.';
+        }
+        resetResults();
+      } finally {
+        setBusy(false);
+      }
+    }
+
+    form.addEventListener('submit', handleSubmit);
+  });
+})();

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -3,6 +3,48 @@
 {% block content %}
 {% set overview = overview or {} %}
 <div class="dashboard">
+  <section class="dashboard__section dashboard__section--agent">
+    <div class="card card--panel agent-panel" data-agent-panel>
+      <div class="agent-panel__header">
+        <h2 class="agent-panel__title">Agent</h2>
+        <p class="agent-panel__subtitle">
+          Ask the MyPortal agent for summaries across knowledge base articles, your tickets, and available hardware.
+        </p>
+      </div>
+      <form class="agent-panel__form" data-agent-form novalidate>
+        <label class="agent-panel__label" for="agent-query">Ask the agent</label>
+        <div class="agent-panel__controls">
+          <input
+            id="agent-query"
+            name="query"
+            class="agent-panel__input"
+            type="search"
+            placeholder="Search for setup steps, ticket history, or device recommendations…"
+            maxlength="2000"
+            required
+            data-agent-input
+          />
+          <button type="submit" class="button button--primary agent-panel__submit" data-agent-submit>
+            Ask
+          </button>
+        </div>
+        <p class="agent-panel__hint">
+          The agent only replies with information that is available to you inside MyPortal.
+        </p>
+      </form>
+      <div class="agent-panel__status" data-agent-status aria-live="polite"></div>
+      <div class="agent-panel__results" data-agent-results hidden>
+        <article class="agent-answer" data-agent-answer hidden>
+          <h3 class="agent-answer__heading">Answer</h3>
+          <div class="agent-answer__body" data-agent-answer-body></div>
+        </article>
+        <section class="agent-sources" data-agent-sources hidden>
+          <h3 class="agent-sources__heading">Sources</h3>
+          <div class="agent-sources__lists" data-agent-source-lists></div>
+        </section>
+      </div>
+    </div>
+  </section>
   <section class="dashboard__section">
     <div class="dashboard__section-header">
       <h1 class="dashboard__title">Consolidated overview</h1>
@@ -112,4 +154,9 @@
     {% endif %}
   </section>
 </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/agent.js" defer></script>
 {% endblock %}

--- a/changes/49de45d1-b067-45af-a084-8121907a409c.json
+++ b/changes/49de45d1-b067-45af-a084-8121907a409c.json
@@ -1,0 +1,7 @@
+{
+  "guid": "49de45d1-b067-45af-a084-8121907a409c",
+  "occurred_at": "2025-11-01T11:05Z",
+  "change_type": "Feature",
+  "summary": "Added dashboard agent powered by Ollama with API endpoint and documentation.",
+  "content_hash": "de5e63ecb74531ccecd35e7c3179eb6e7b16707bcd42749c8a8a0a8dc34870d0"
+}

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,0 +1,101 @@
+# MyPortal Agent
+
+The MyPortal agent provides a permission-aware assistant that searches knowledge base articles, tickets requested or watched by the signed-in user, and available hardware or product recommendations. Responses are generated through the Ollama integration module, and the agent never surfaces content outside of the user's entitlements.
+
+## Prerequisites
+
+1. **Ollama runtime** – Install and expose an Ollama instance reachable by the application server. The default configuration expects `http://127.0.0.1:11434`.
+2. **Portal configuration** – Ensure the following environment variables are defined (already included in `.env.example`):
+   - `OLLAMA_BASE_URL` – HTTP(S) endpoint for your Ollama host.
+   - `OLLAMA_MODEL` – Default model name (for example `llama3`).
+3. **Database connectivity** – Run migrations through the existing startup process so the `tickets`, `knowledge_base`, and `shop` tables are available. SQLite fallback is supported when MySQL credentials are not configured.
+4. **Webhook monitoring** – The agent records Ollama requests in the webhook monitor (`/admin/webhooks`). Ensure the monitoring tables are migrated and accessible to administrators.
+
+## Enabling the agent
+
+1. Sign in as a super administrator and navigate to **Admin → Modules**.
+2. Locate the **Ollama** module, configure the base URL, model, and prompt if required, and set the module to **Enabled**.
+3. The change takes effect immediately; no service restart is required. The install (`scripts/install_production.sh`) and upgrade (`scripts/upgrade.sh`) scripts already provision the integration module catalogue during deployment.
+4. Verify connectivity from the webhook monitor. Each agent request registers a manual webhook event named `module.ollama.generate`. Failed events are retried by the existing monitoring service.
+
+## Using the agent
+
+- The dashboard now includes an **Agent** panel above the existing overview cards. Enter a question such as _"How do I reset the VPN appliance?"_ to search for matching knowledge base articles, your own tickets, and relevant product recommendations.
+- Results show a structured answer (rendered in Markdown-style text) followed by cited sources. Source identifiers use `[KB:slug]`, `[Ticket:#id]`, or `[Product:SKU]` markers.
+- The agent only operates on data available to the current user:
+  - Knowledge base visibility is enforced through the existing permission scopes.
+  - Tickets are limited to records requested by or watched by the user and scoped to their accessible companies.
+  - Products are retrieved only when the user or their company memberships allow shop access.
+- Responses include the Ollama model used, the UTC generation timestamp (rendered in the user's local timezone via the browser), and the webhook event identifier for auditing.
+
+## API endpoint
+
+The agent can be accessed programmatically through the new `/agent/query` endpoint.
+
+```http
+POST /agent/query
+Content-Type: application/json
+
+{
+  "query": "Summarise my open firewall tickets"
+}
+```
+
+Successful responses return:
+
+```json
+{
+  "query": "Summarise my open firewall tickets",
+  "status": "succeeded",
+  "answer": "…",
+  "model": "llama3",
+  "event_id": 4182,
+  "generated_at": "2025-01-07T10:52:00.000000+00:00",
+  "sources": {
+    "knowledge_base": [
+      {
+        "slug": "network-hardening",
+        "title": "Network hardening checklist",
+        "summary": "",
+        "excerpt": "",
+        "updated_at": "2024-12-11T08:30:00Z",
+        "url": "/knowledge-base/articles/network-hardening"
+      }
+    ],
+    "tickets": [
+      {
+        "id": 512,
+        "subject": "Firewall throughput alerts",
+        "status": "open",
+        "priority": "high",
+        "summary": "",
+        "updated_at": "2025-01-06T23:15:12+00:00"
+      }
+    ],
+    "products": []
+  },
+  "context": {
+    "companies": [
+      { "company_id": 42, "company_name": "Contoso" }
+    ]
+  }
+}
+```
+
+HTTP `401` is returned when the caller is unauthenticated. If the Ollama module is disabled the response status is `skipped` and the payload only contains the contextual sources.
+
+## Security notes
+
+- The agent never forwards raw credentials or third-party data to Ollama. Only sanitized snippets from authorised portal entities are included in the prompt.
+- When no accessible context is found the agent instructs Ollama to explain that no answer is available, avoiding hallucinated responses.
+- Responses are rendered as escaped HTML in the browser, ensuring that Markdown returned by Ollama cannot inject unsafe tags.
+
+## Troubleshooting
+
+| Symptom | Resolution |
+| --- | --- |
+| Agent status reads *"The Ollama module is disabled"* | Enable the Ollama module or verify the configuration in **Admin → Modules**. |
+| Agent returns *"Unable to contact the agent"* | Check network reachability to the Ollama host and review webhook events for failures. |
+| Products do not appear as sources | Confirm the user’s company membership has `can_access_shop`, `can_access_cart`, or `can_access_orders` enabled. |
+
+For persistent issues consult the webhook monitor (`/admin/webhooks`) or the application logs generated by the systemd service created during installation.

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -1,0 +1,119 @@
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services import agent as agent_service
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_execute_agent_query_returns_sources(monkeypatch):
+    user = {"id": 7, "is_super_admin": False}
+    memberships = [
+        {
+            "company_id": 1,
+            "company_name": "Contoso",
+            "can_access_shop": True,
+        }
+    ]
+
+    kb_result = {
+        "results": [
+            {
+                "slug": "network-guide",
+                "title": "Network setup guide",
+                "summary": "Step-by-step instructions",
+                "excerpt": "Use the documented VLAN layout.",
+                "updated_at_iso": "2025-01-05T09:00:00Z",
+            }
+        ]
+    }
+
+    ticket_rows = [
+        {
+            "id": 42,
+            "subject": "Firewall reboot",
+            "status": "open",
+            "priority": "high",
+            "description": "Customer reported outage",
+            "updated_at": datetime(2025, 1, 6, 12, 0, tzinfo=timezone.utc),
+            "company_id": 1,
+        }
+    ]
+
+    product_rows = [
+        {
+            "id": 55,
+            "name": "Secure Router",
+            "sku": "HW-001",
+            "vendor_sku": "SR-001",
+            "price": Decimal("199.99"),
+            "description": "Recommended for branch offices",
+            "cross_sell_products": [],
+            "upsell_products": [],
+        }
+    ]
+
+    monkeypatch.setattr(
+        agent_service.knowledge_base_service,
+        "build_access_context",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        agent_service.knowledge_base_service,
+        "search_articles",
+        AsyncMock(return_value=kb_result),
+    )
+    monkeypatch.setattr(
+        agent_service.tickets_repo,
+        "list_tickets_for_user",
+        AsyncMock(return_value=ticket_rows),
+    )
+    monkeypatch.setattr(
+        agent_service.shop_repo,
+        "list_products",
+        AsyncMock(return_value=product_rows),
+    )
+
+    async def fake_trigger(slug, payload, *, background):
+        assert slug == "ollama"
+        assert background is False
+        prompt = payload.get("prompt")
+        assert prompt
+        assert "Knowledge base" in prompt
+        return {
+            "status": "succeeded",
+            "model": "llama3",
+            "response": {"response": "Answer text"},
+            "event_id": 918,
+        }
+
+    monkeypatch.setattr(agent_service.modules_service, "trigger_module", fake_trigger)
+
+    result = await agent_service.execute_agent_query(
+        "network setup",
+        user,
+        active_company_id=1,
+        memberships=memberships,
+    )
+
+    assert result["status"] == "succeeded"
+    assert result["answer"] == "Answer text"
+    assert result["model"] == "llama3"
+    assert result["sources"]["knowledge_base"][0]["slug"] == "network-guide"
+    assert result["sources"]["tickets"][0]["id"] == 42
+    assert result["sources"]["products"][0]["sku"] == "HW-001"
+    assert result["context"]["companies"][0]["company_id"] == 1
+
+
+@pytest.mark.anyio
+async def test_execute_agent_query_rejects_blank(monkeypatch):
+    result = await agent_service.execute_agent_query("   ", {"id": 1}, memberships=[])
+    assert result["status"] == "error"
+    assert result["answer"] is None


### PR DESCRIPTION
## Summary
- add an agent panel to the dashboard with new UI, styling, and client-side logic for querying Ollama
- implement backend agent orchestration, API schemas, and ticket/product lookup helpers that respect user permissions
- document the setup process, register the new feature in the change log, and cover the service with automated tests

## Testing
- pytest tests/test_agent_service.py tests/test_knowledge_base_service.py

------
https://chatgpt.com/codex/tasks/task_b_6905e74bc9d8832da057ad1869fbbd2f