### PR TITLE
Fix mobile sidebar layout orientation

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -3474,19 +3474,36 @@ button.header-title-menu__link {
 
   .layout__sidebar {
     width: 100%;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
     padding: var(--space-gap-roomy);
-  }
-
-  .menu {
-    flex-direction: row;
-    gap: 0.5rem;
   }
 
   .layout__main {
     max-width: 100vw;
+  }
+}
+
+@media (max-width: 720px) {
+  .layout__sidebar {
+    width: min(260px, 86vw);
+    max-width: 86vw;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: var(--space-gap-base);
+  }
+
+  .layout__sidebar .brand {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .menu {
+    flex-direction: column;
+    gap: var(--space-gap-tight);
+  }
+
+  .menu__item a {
+    width: 100%;
   }
 }
 

--- a/changes/9ea25288-600e-47fc-a986-eac3ad594278.json
+++ b/changes/9ea25288-600e-47fc-a986-eac3ad594278.json
@@ -1,0 +1,7 @@
+{
+  "guid": "9ea25288-600e-47fc-a986-eac3ad594278",
+  "occurred_at": "2025-11-01T11:15Z",
+  "change_type": "Fix",
+  "summary": "Restored the sidebar menu to a vertical stack on small screens so mobile navigation stays usable",
+  "content_hash": "b39a27d687c872a510d1bbf0d39a6546d30c7d605690c2f758e06dbeac3fee90"
+}


### PR DESCRIPTION
## Summary
- keep the primary sidebar layout vertical by default on mobile breakpoints
- ensure sidebar brand and menu items expand to the full width of the drawer on small screens
- record the mobile navigation fix in the change log registry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6905eb3246d4832d898bf1ee41369ce6