### PR TITLE
Fix agent API path

### DIFF
--- a/app/api/routes/agent.py
+++ b/app/api/routes/agent.py
@@ -6,7 +6,7 @@ from app.api.dependencies.auth import get_current_user
 from app.schemas.agent import AgentQueryRequest, AgentQueryResponse
 from app.services import agent as agent_service
 
-router = APIRouter(prefix="/agent", tags=["Agent"])
+router = APIRouter(prefix="/api/agent", tags=["Agent"])
 
 
 @router.post("/query", response_model=AgentQueryResponse)

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-27, 10:15 UTC, Fix, Corrected the agent API route to /api/agent/query so dashboard requests reach the service without 404 errors
 - 2025-10-30, 00:55 UTC, Fix, Normalised shop package payloads before JSON serialisation so the packages category renders without server errors
 - 2025-10-23, 01:20 UTC, Feature, Added super admin deletion controls for scheduled and event automations with confirmation prompts and audit logging
 - 2025-10-29, 10:45 UTC, Fix, Redacted TacticalRMM and ntfy credentials in module management while keeping stored keys when left blank

--- a/changes/0969d6a8-08e0-4768-9eed-669e60fb021e.json
+++ b/changes/0969d6a8-08e0-4768-9eed-669e60fb021e.json
@@ -1,0 +1,7 @@
+{
+  "guid": "0969d6a8-08e0-4768-9eed-669e60fb021e",
+  "occurred_at": "2025-12-27T10:15Z",
+  "change_type": "Fix",
+  "summary": "Corrected the agent API route to /api/agent/query so dashboard requests reach the service without 404 errors.",
+  "content_hash": "85e12b46661903b9910a4d7b6fc9ee3df58614f6079d8b48e665c45b87843d37"
+}

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -30,10 +30,10 @@ The MyPortal agent provides a permission-aware assistant that searches knowledge
 
 ## API endpoint
 
-The agent can be accessed programmatically through the new `/agent/query` endpoint.
+The agent can be accessed programmatically through the `/api/agent/query` endpoint.
 
 ```http
-POST /agent/query
+POST /api/agent/query
 Content-Type: application/json
 
 {


### PR DESCRIPTION
## Summary
- align the agent API router with the `/api/agent` prefix so dashboard requests resolve successfully
- update the agent documentation to call out the corrected `/api/agent/query` endpoint
- log the fix in the change history

## Testing
- pytest tests/test_agent_service.py

------
https://chatgpt.com/codex/tasks/task_b_6905ec00b828832dadf9f0c6f95fc138