### PR TITLE
Fix agent to surface shop packages

### DIFF
--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -22,6 +22,7 @@ class ProductFilters:
 @dataclass(slots=True)
 class PackageFilters:
     include_archived: bool = False
+    search_term: str | None = None
 
 
 async def list_categories() -> list[dict[str, Any]]:
@@ -179,6 +180,11 @@ async def list_packages(filters: PackageFilters) -> list[dict[str, Any]]:
     conditions: list[str] = []
     if not filters.include_archived:
         conditions.append("pkg.archived = 0")
+    if filters.search_term:
+        search = f"%{filters.search_term.strip()}%"
+        if search.strip("%"):
+            conditions.append("(pkg.name LIKE %s OR pkg.sku LIKE %s OR pkg.description LIKE %s)")
+            params.extend([search, search, search])
     if conditions:
         query.append("WHERE " + " AND ".join(conditions))
     query.append("GROUP BY pkg.id")

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -35,10 +35,19 @@ class AgentSourceProduct(BaseModel):
     recommendations: list[str] = Field(default_factory=list)
 
 
+class AgentSourcePackage(BaseModel):
+    id: Optional[int] = None
+    name: str
+    sku: Optional[str] = None
+    description: Optional[str] = None
+    product_count: Optional[int] = None
+
+
 class AgentSources(BaseModel):
     knowledge_base: list[AgentSourceArticle] = Field(default_factory=list)
     tickets: list[AgentSourceTicket] = Field(default_factory=list)
     products: list[AgentSourceProduct] = Field(default_factory=list)
+    packages: list[AgentSourcePackage] = Field(default_factory=list)
 
 
 class AgentContextCompany(BaseModel):

--- a/app/static/js/agent.js
+++ b/app/static/js/agent.js
@@ -94,6 +94,25 @@
     return `${label}${meta}`;
   }
 
+  function formatPackageSource(item) {
+    const sku = item.sku ? escapeHtml(item.sku) : null;
+    const name = escapeHtml(item.name || (sku ? sku : 'Package'));
+    const description = item.description ? escapeHtml(item.description) : null;
+    const productCount = typeof item.product_count === 'number' ? item.product_count : Number.parseInt(item.product_count, 10);
+    const label = sku ? `[${sku}] ${name}` : name;
+    const metaParts = [];
+    if (!Number.isNaN(productCount) && Number.isFinite(productCount)) {
+      const count = Math.max(0, productCount);
+      const plural = count === 1 ? 'item' : 'items';
+      metaParts.push(`Includes ${count} ${plural}`);
+    }
+    if (description) {
+      metaParts.push(description);
+    }
+    const meta = metaParts.length ? `<div class="agent-sources__meta">${metaParts.join('<br />')}</div>` : '';
+    return `${label}${meta}`;
+  }
+
   function renderSources(container, sources) {
     if (!container) {
       return;
@@ -113,6 +132,9 @@
     }
     if (Array.isArray(sources.products)) {
       groups.push(createSourceList('Products', sources.products, formatProductSource));
+    }
+    if (Array.isArray(sources.packages)) {
+      groups.push(createSourceList('Packages', sources.packages, formatPackageSource));
     }
 
     const usable = groups.filter((group) => group);

--- a/changes/19a829e2-78a8-454b-9f85-19692dcdd291.json
+++ b/changes/19a829e2-78a8-454b-9f85-19692dcdd291.json
@@ -1,0 +1,7 @@
+{
+  "guid": "19a829e2-78a8-454b-9f85-19692dcdd291",
+  "occurred_at": "2025-11-01T11:33Z",
+  "change_type": "Fix",
+  "summary": "Ensure the portal agent suggests matching shop packages alongside products.",
+  "content_hash": "0b744dddde84163fb0ac57c27c90113e6c9a315e3fe11fe591c1cb1d67fed0dd"
+}

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -60,6 +60,16 @@ async def test_execute_agent_query_returns_sources(monkeypatch):
         }
     ]
 
+    package_rows = [
+        {
+            "id": 91,
+            "name": "Remote Office Bundle",
+            "sku": "PKG-100",
+            "description": "Includes workstation, monitors, and accessories",
+            "product_count": 4,
+        }
+    ]
+
     monkeypatch.setattr(
         agent_service.knowledge_base_service,
         "build_access_context",
@@ -79,6 +89,11 @@ async def test_execute_agent_query_returns_sources(monkeypatch):
         agent_service.shop_repo,
         "list_products",
         AsyncMock(return_value=product_rows),
+    )
+    monkeypatch.setattr(
+        agent_service.shop_repo,
+        "list_packages",
+        AsyncMock(return_value=package_rows),
     )
 
     async def fake_trigger(slug, payload, *, background):
@@ -109,6 +124,7 @@ async def test_execute_agent_query_returns_sources(monkeypatch):
     assert result["sources"]["knowledge_base"][0]["slug"] == "network-guide"
     assert result["sources"]["tickets"][0]["id"] == 42
     assert result["sources"]["products"][0]["sku"] == "HW-001"
+    assert result["sources"]["packages"][0]["sku"] == "PKG-100"
     assert result["context"]["companies"][0]["company_id"] == 1
 
 


### PR DESCRIPTION
## Summary
- allow the shop repository to filter packages by search term so agent lookups can find bundles
- return packages in the agent service prompt/response and render them in the dashboard UI
- cover the new behavior with tests and record the change in the change log

## Testing
- pytest tests/test_agent_service.py

------
https://chatgpt.com/codex/tasks/task_b_6905ef5bae40832da80b6e5abb9577da