### PR TITLE
Fix mobile layout overflow on small screens

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -31,6 +31,12 @@ body {
   overflow-x: hidden;
 }
 
+html {
+  width: 100%;
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+
 .layout {
   display: flex;
   width: 100%;
@@ -1030,6 +1036,8 @@ button.header-title-menu__link {
     var(--layout-content-padding-inline)
     var(--layout-content-padding-bottom);
   overflow-y: auto;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
 .dashboard {
@@ -1380,6 +1388,13 @@ button.header-title-menu__link {
 @media (max-width: 720px) {
   .layout__sidebar {
     width: min(260px, 86vw);
+  }
+
+  .layout,
+  .layout__main,
+  .layout__content {
+    width: 100%;
+    max-width: 100vw;
   }
 }
 

--- a/changes/3ea4e94d-0d8d-4ae3-ad0e-f281b573e02c.json
+++ b/changes/3ea4e94d-0d8d-4ae3-ad0e-f281b573e02c.json
@@ -1,0 +1,7 @@
+{
+  "guid": "3ea4e94d-0d8d-4ae3-ad0e-f281b573e02c",
+  "occurred_at": "2025-11-01T12:08:31Z",
+  "change_type": "Fix",
+  "summary": "Prevented horizontal overflow on mobile layout to match device width.",
+  "content_hash": "9f0829140d40bfcbc6715eebd305dc00e5d52e35708de0c6288179003a73af67"
+}


### PR DESCRIPTION
## Summary
- constrain the document and layout containers to the viewport width to avoid horizontal overflow on small screens
- ensure the main content wrapper hides horizontal overflow and enforce 100% width on narrow viewports
- record the fix in the change log

## Testing
- pytest *(fails: database pool not initialised; notifications service missing email/sms settings)*

------
https://chatgpt.com/codex/tasks/task_b_6905f7926180832da038b43cb22e94dc