### PR TITLE
Allow watchers to view tickets they follow

### DIFF
--- a/changes/82a49e79-48e7-4146-bd5b-de94f121688e.json
+++ b/changes/82a49e79-48e7-4146-bd5b-de94f121688e.json
@@ -1,0 +1,7 @@
+{
+  "guid": "82a49e79-48e7-4146-bd5b-de94f121688e",
+  "occurred_at": "2025-11-01T12:15Z",
+  "change_type": "Fix",
+  "summary": "Allow non-helpdesk users to access tickets they request or watch regardless of company filters.",
+  "content_hash": "0bd50b0c687735660b42d8834d9fc7bc206e63ae802080224341f3ac60758a74"
+}


### PR DESCRIPTION
## Summary
- allow ticket detail responses to be shown to non-helpdesk users who are requesters or watchers
- add repository helpers so requester/watchers can list and count tickets without company scoping
- expand ticket access tests and record the change in the change log

## Testing
- pytest tests/test_ticket_access.py

------
https://chatgpt.com/codex/tasks/task_b_6905f96e4988832da40c1f54b54a8965