### PR TITLE
Add portal ticket pages for end-user access

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -121,8 +121,16 @@
             <li class="menu__divider" role="presentation"></li>
           {% endif %}
           {% if can_access_tickets %}
+            {% set show_admin_tickets = (is_helpdesk_technician | default(false)) or (is_super_admin | default(false)) %}
+            {% if show_admin_tickets %}
+              {% set ticket_href = '/admin/tickets' %}
+              {% set ticket_active = current_path.startswith('/admin/tickets') and not current_path.startswith('/admin/tickets/syncro-import') %}
+            {% else %}
+              {% set ticket_href = '/tickets' %}
+              {% set ticket_active = current_path.startswith('/tickets') %}
+            {% endif %}
             <li class="menu__item">
-              <a href="/admin/tickets" {% if current_path.startswith('/admin/tickets') and not current_path.startswith('/admin/tickets/syncro-import') %}aria-current="page"{% endif %}>
+              <a href="{{ ticket_href }}" {% if ticket_active %}aria-current="page"{% endif %}>
                 <span class="menu__icon" aria-hidden="true">
                   <svg viewBox="0 0 24 24" focusable="false"><path d="M4 6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v2.17a.83.83 0 0 1-.83.83 1.5 1.5 0 0 0 0 3 .83.83 0 0 1 .83.83V18a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-2.17A.83.83 0 0 1 4.83 15a1.5 1.5 0 0 0 0-3A.83.83 0 0 1 4 11.17zM9 9v6h6V9z"/></svg>
                 </span>

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -1,0 +1,206 @@
+{% extends "base.html" %}
+
+{% block header_actions %}
+  <a class="button button--ghost" href="/tickets">All tickets</a>
+{% endblock %}
+
+{% block content %}
+  {% if success_message or error_message %}
+    <div class="alert-stack">
+      {% if success_message %}
+        <div class="alert" role="status">{{ success_message }}</div>
+      {% endif %}
+      {% if error_message %}
+        <div class="alert alert--error" role="alert">{{ error_message }}</div>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <div class="management management--single">
+    <section class="management__content">
+      <header class="management__header">
+        <div>
+          <h1 class="management__title">{{ ticket.subject or 'Ticket' }}</h1>
+          <p class="management__subtitle">
+            Ticket #{{ ticket.id }}
+            <span class="badge {{ ticket.status_badge }}">{{ ticket.status_label }}</span>
+          </p>
+        </div>
+        <div class="management__header-actions">
+          <a class="button button--ghost" href="/tickets">Back to tickets</a>
+        </div>
+      </header>
+      <div class="management__body management__body--columns">
+        <div class="management__column management__column--details">
+          <article class="card card--panel">
+            <header class="card__header">
+              <h2 class="card__title">Ticket details</h2>
+            </header>
+            <div class="card__body">
+              <dl class="description-list">
+                <div class="description-list__row">
+                  <dt>Status</dt>
+                  <dd><span class="badge {{ ticket.status_badge }}">{{ ticket.status_label }}</span></dd>
+                </div>
+                <div class="description-list__row">
+                  <dt>Priority</dt>
+                  <dd>{{ ticket.priority_label }}</dd>
+                </div>
+                {% if ticket.company_name %}
+                  <div class="description-list__row">
+                    <dt>Company</dt>
+                    <dd>{{ ticket.company_name }}</dd>
+                  </div>
+                {% endif %}
+                {% if ticket.requester_label %}
+                  <div class="description-list__row">
+                    <dt>Requester</dt>
+                    <dd>{{ ticket.requester_label }}</dd>
+                  </div>
+                {% endif %}
+                {% if ticket.assigned_label %}
+                  <div class="description-list__row">
+                    <dt>Assigned to</dt>
+                    <dd>{{ ticket.assigned_label }}</dd>
+                  </div>
+                {% endif %}
+                <div class="description-list__row">
+                  <dt>Created</dt>
+                  <dd>
+                    {% if ticket.created_iso %}
+                      <span data-utc="{{ ticket.created_iso }}"></span>
+                    {% else %}
+                      <span class="text-muted">—</span>
+                    {% endif %}
+                  </dd>
+                </div>
+                <div class="description-list__row">
+                  <dt>Updated</dt>
+                  <dd>
+                    {% if ticket.updated_iso %}
+                      <span data-utc="{{ ticket.updated_iso }}"></span>
+                    {% else %}
+                      <span class="text-muted">—</span>
+                    {% endif %}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </article>
+        </div>
+        <div class="management__column management__column--timeline">
+          <article class="card card--panel">
+            <header class="card__header">
+              <h2 class="card__title">Description</h2>
+            </header>
+            <div class="card__body">
+              {% if ticket.description_has_content %}
+                <div class="rich-text-viewer">{{ ticket.description_html | safe }}</div>
+              {% else %}
+                <p class="card__empty">No description has been provided yet.</p>
+              {% endif %}
+            </div>
+          </article>
+
+          <article class="card card--panel">
+            <header class="card__header">
+              <h2 class="card__title">Reply</h2>
+            </header>
+            <div class="card__body">
+              {% if can_reply %}
+                {% if reply_error %}
+                  <div class="alert alert--error" role="alert">{{ reply_error }}</div>
+                {% endif %}
+                <form action="/tickets/{{ ticket.id }}/replies" method="post" class="form" novalidate>
+                  {% include "partials/csrf.html" %}
+                  <div class="form-field">
+                    <label class="form-label" for="ticket-reply-body">Message</label>
+                    <textarea
+                      id="ticket-reply-body"
+                      name="body"
+                      class="form-input form-input--textarea"
+                      rows="5"
+                      required
+                    >{{ reply_body }}</textarea>
+                  </div>
+                  <div class="form-actions">
+                    <button type="submit" class="button button--primary">Post reply</button>
+                  </div>
+                </form>
+              {% elif is_watcher %}
+                <p class="text-muted">You're watching this ticket. Reach out to the requester if you need to add further context.</p>
+              {% else %}
+                <p class="text-muted">Only the original requester can reply to this ticket.</p>
+              {% endif %}
+            </div>
+          </article>
+
+          <article class="card card--panel" id="conversation">
+            <header class="card__header">
+              <h2 class="card__title">Conversation history</h2>
+            </header>
+            <div class="card__body">
+              {% if ticket_replies %}
+                <div class="timeline" data-ticket-timeline data-ticket-id="{{ ticket.id }}">
+                  {% for reply in ticket_replies %}
+                    <article class="timeline__event">
+                      <header class="timeline__header">
+                        <div class="timeline__header-main">
+                          <span class="timeline__timestamp">
+                            {% if reply.created_iso %}
+                              <span data-utc="{{ reply.created_iso }}"></span>
+                            {% else %}
+                              <span class="text-muted">—</span>
+                            {% endif %}
+                          </span>
+                          <span class="timeline__action">
+                            {{ reply.author_label }}
+                            {% if reply.is_internal %}
+                              <span class="badge badge--muted">Internal</span>
+                            {% endif %}
+                          </span>
+                          {% if reply.time_summary %}
+                            <span class="timeline__meta text-muted">{{ reply.time_summary }}</span>
+                          {% endif %}
+                        </div>
+                      </header>
+                      <div class="timeline__body">
+                        {% if reply.has_content %}
+                          <div class="timeline__message" data-timeline-message>
+                            <div class="rich-text-viewer timeline__message-content" data-timeline-message-content>
+                              {{ reply.body_html | safe }}
+                            </div>
+                          </div>
+                          <button
+                            type="button"
+                            class="button button--ghost button--small timeline__message-toggle"
+                            data-timeline-message-toggle
+                            data-more-label="Show more"
+                            data-less-label="Show less"
+                            hidden
+                            aria-expanded="false"
+                          >
+                            Show more
+                          </button>
+                        {% else %}
+                          <p class="text-muted">No content provided.</p>
+                        {% endif %}
+                      </div>
+                    </article>
+                  {% endfor %}
+                </div>
+              {% else %}
+                <p class="card__empty">No replies have been posted yet.</p>
+              {% endif %}
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/ticket_detail.js" defer></script>
+{% endblock %}

--- a/app/templates/tickets/index.html
+++ b/app/templates/tickets/index.html
@@ -1,0 +1,170 @@
+{% extends "base.html" %}
+
+{% block header_actions %}
+  <a class="button button--primary" href="#new-ticket">New ticket</a>
+{% endblock %}
+
+{% block content %}
+  {% if success_message or error_message %}
+    <div class="alert-stack">
+      {% if success_message %}
+        <div class="alert" role="status">{{ success_message }}</div>
+      {% endif %}
+      {% if error_message %}
+        <div class="alert alert--error" role="alert">{{ error_message }}</div>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  <section class="card card--panel">
+    <header class="card__header">
+      <div>
+        <h2 class="card__title">Ticket overview</h2>
+        {% if filters_active %}
+          <p class="card__subtitle">Showing filtered results from your recorded tickets.</p>
+        {% else %}
+          <p class="card__subtitle">Track the latest support conversations raised for your active companies.</p>
+        {% endif %}
+      </div>
+    </header>
+    <div class="card__body">
+      {% if status_summary %}
+        <ul class="status-list" role="list">
+          {% for item in status_summary %}
+            <li class="status-list__item" role="listitem">
+              <span class="status-list__label">{{ item.label }}</span>
+              <span class="status-list__value">{{ item.count }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      {% else %}
+        <p class="card__empty">No tickets have been recorded yet. Create a ticket to start a new conversation.</p>
+      {% endif %}
+    </div>
+  </section>
+
+  <section class="card card--panel">
+    <header class="card__header">
+      <div>
+        <h2 class="card__title">Ticket history</h2>
+        <p class="card__subtitle">Search and filter tickets you have raised or are watching.</p>
+      </div>
+      <div class="card__controls tickets-toolbar">
+        <form method="get" class="tickets-toolbar__form" autocomplete="off">
+          <div class="tickets-toolbar__field">
+            <label class="form-label" for="tickets-status-filter">Status</label>
+            <select id="tickets-status-filter" name="status" class="form-input">
+              <option value="">All statuses</option>
+              {% for option in status_options %}
+                <option value="{{ option.value }}" {% if status_filter and status_filter == option.value %}selected{% endif %}>{{ option.label }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="tickets-toolbar__actions">
+            <button type="submit" class="button">Apply filters</button>
+            {% if filters_active %}
+              <a class="button button--ghost" href="{{ request.url.path }}">Clear</a>
+            {% endif %}
+          </div>
+        </form>
+        <input
+          type="search"
+          class="form-input tickets-toolbar__search"
+          placeholder="Quick filter tickets"
+          name="q"
+          value="{{ search_term or '' }}"
+          aria-label="Filter tickets"
+          data-table-filter="tickets-table"
+        />
+      </div>
+    </header>
+    {% if filters_active and not tickets %}
+      <div class="alert alert--info" role="status">No tickets match the selected filters. Try adjusting the status or search keywords.</div>
+    {% endif %}
+    <div class="table-wrapper">
+      <table class="table" id="tickets-table" data-table>
+        <thead>
+          <tr>
+            <th scope="col" data-sort="int">Ticket</th>
+            <th scope="col" data-sort="string">Subject</th>
+            <th scope="col" data-sort="string">Status</th>
+            <th scope="col" data-sort="string">Priority</th>
+            <th scope="col" data-sort="string">Company</th>
+            <th scope="col" data-sort="date">Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if tickets %}
+            {% for ticket in tickets %}
+              <tr>
+                <td data-label="Ticket">#{{ ticket.id }}</td>
+                <td data-label="Subject">
+                  <a href="/tickets/{{ ticket.id }}">{{ ticket.subject or 'Untitled ticket' }}</a>
+                </td>
+                <td data-label="Status">
+                  <span class="badge {{ ticket.status_badge }}">{{ ticket.status_label }}</span>
+                </td>
+                <td data-label="Priority">{{ ticket.priority_label }}</td>
+                <td data-label="Company">{{ ticket.company_name or '—' }}</td>
+                <td data-label="Updated" data-value="{{ ticket.updated_iso or '' }}">
+                  {% if ticket.updated_iso %}
+                    <span data-utc="{{ ticket.updated_iso }}"></span>
+                  {% else %}
+                    <span class="text-muted">—</span>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          {% else %}
+            <tr>
+              <td colspan="6" class="table__empty">No tickets available.</td>
+            </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="card card--panel" id="new-ticket">
+    <header class="card__header">
+      <div>
+        <h2 class="card__title">Create a ticket</h2>
+        <p class="card__subtitle">Raise a new support request and the team will follow up with updates.</p>
+      </div>
+    </header>
+    <div class="card__body">
+      <form action="/tickets" method="post" class="form" novalidate>
+        {% include "partials/csrf.html" %}
+        <div class="form-field">
+          <label class="form-label" for="ticket-subject">Subject</label>
+          <input
+            id="ticket-subject"
+            name="subject"
+            class="form-input"
+            maxlength="255"
+            required
+            value="{{ form_values.subject if form_values else '' }}"
+          />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="ticket-description">Description</label>
+          <textarea
+            id="ticket-description"
+            name="description"
+            class="form-input form-input--textarea"
+            rows="6"
+            placeholder="Describe the issue, impact, and any troubleshooting already attempted."
+          >{{ form_values.description if form_values else '' }}</textarea>
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="button button--primary">Submit ticket</button>
+        </div>
+      </form>
+    </div>
+  </section>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="/static/js/tables.js" defer></script>
+{% endblock %}

--- a/changes/86ce499b-5901-4365-bf43-ea327726e734.json
+++ b/changes/86ce499b-5901-4365-bf43-ea327726e734.json
@@ -1,0 +1,7 @@
+{
+  "guid": "86ce499b-5901-4365-bf43-ea327726e734",
+  "occurred_at": "2025-01-10T12:00Z",
+  "change_type": "Feature",
+  "summary": "Introduced ticket portal pages so end-users can review and reply to their tickets.",
+  "content_hash": "b1bdef906d7e28ce9c4a8845d6fb10d2d5610e4789fab0492125d1bd656ffc86"
+}

--- a/tests/test_section_permissions.py
+++ b/tests/test_section_permissions.py
@@ -132,3 +132,4 @@ async def test_build_base_context_includes_cart_permission(monkeypatch):
 
     assert context["can_access_cart"] is True
     assert context["can_access_shop"] is True
+    assert context["can_access_tickets"] is True

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -79,6 +79,7 @@ def company_admin_context(monkeypatch):
             "csrf_token": "csrf-token",
             "cart_summary": {"item_count": 0, "total_quantity": 0, "subtotal": 0},
             "notification_unread_count": 0,
+            "can_access_tickets": True,
         }
         if extra:
             context.update(extra)
@@ -97,6 +98,7 @@ def test_company_admin_sees_authorised_menu_items(company_admin_context):
 
     assert response.status_code == 200
     html = response.text
+    assert 'href="/tickets"' in html
     assert 'href="/shop"' in html
     assert 'href="/cart"' not in html
     assert 'href="/forms"' in html

--- a/tests/test_ticket_portal_pages.py
+++ b/tests/test_ticket_portal_pages.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import status
+from fastapi.responses import HTMLResponse
+from starlette.requests import Request
+
+from app import main
+from app.services.tickets import TicketStatusDefinition
+
+
+async def _dummy_receive() -> dict[str, Any]:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _make_request(path: str = "/tickets") -> Request:
+    scope = {"type": "http", "method": "GET", "path": path, "headers": []}
+    request = Request(scope, _dummy_receive)
+    return request
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_render_portal_tickets_page_formats_results(monkeypatch):
+    request = _make_request()
+    request.state.active_company_id = 22
+    user = {"id": 5, "company_id": 22}
+
+    statuses = [
+        TicketStatusDefinition(tech_status="open", tech_label="Open", public_status="Open"),
+        TicketStatusDefinition(tech_status="closed", tech_label="Closed", public_status="Closed"),
+    ]
+    listed_tickets = [
+        {
+            "id": 41,
+            "subject": "Printer offline",
+            "status": "open",
+            "priority": "high",
+            "company_id": 22,
+            "updated_at": datetime(2025, 1, 10, 9, 30, tzinfo=timezone.utc),
+            "created_at": datetime(2025, 1, 9, 16, 45, tzinfo=timezone.utc),
+        }
+    ]
+
+    monkeypatch.setattr(
+        main.company_access,
+        "list_accessible_companies",
+        AsyncMock(return_value=[{"company_id": 22, "company_name": "Example"}]),
+    )
+    list_mock = AsyncMock(return_value=listed_tickets)
+    count_mock = AsyncMock(return_value=1)
+    monkeypatch.setattr(main.tickets_repo, "list_tickets_for_user", list_mock)
+    monkeypatch.setattr(main.tickets_repo, "count_tickets_for_user", count_mock)
+    monkeypatch.setattr(main.tickets_service, "list_status_definitions", AsyncMock(return_value=statuses))
+
+    captured: dict[str, Any] = {}
+
+    async def fake_render_template(template_name, request_obj, user_obj, *, extra):
+        captured["template"] = template_name
+        captured["extra"] = extra
+        return HTMLResponse("OK")
+
+    monkeypatch.setattr(main, "_render_template", fake_render_template)
+
+    response = await main._render_portal_tickets_page(
+        request,
+        user,
+        status_filter="open",
+        search_term=" printer ",
+    )
+
+    assert isinstance(response, HTMLResponse)
+    assert response.status_code == status.HTTP_200_OK
+    list_mock.assert_awaited_once()
+    count_mock.assert_awaited_once()
+    assert captured["template"] == "tickets/index.html"
+
+    extra = captured["extra"]
+    assert extra["tickets_total"] == 1
+    assert extra["status_filter"] == "open"
+    assert extra["search_term"] == "printer"
+    assert extra["filters_active"] is True
+    assert extra["tickets"] == [
+        {
+            "id": 41,
+            "subject": "Printer offline",
+            "status": "open",
+            "status_label": "Open",
+            "status_badge": "badge--warning",
+            "priority_label": "High",
+            "company_name": "Example",
+            "company_id": 22,
+            "updated_iso": "2025-01-10T09:30:00+00:00",
+            "created_iso": "2025-01-09T16:45:00+00:00",
+        }
+    ]
+    assert extra["status_summary"] == [
+        {"slug": "open", "label": "Open", "count": 1},
+    ]
+    option_labels = {option["value"]: option["label"] for option in extra["status_options"]}
+    assert option_labels == {"open": "Open", "closed": "Closed"}
+
+
+@pytest.mark.anyio("asyncio")
+async def test_render_portal_ticket_detail_includes_replies(monkeypatch):
+    request = _make_request("/tickets/41")
+    user = {"id": 5, "is_super_admin": False}
+
+    ticket = {
+        "id": 41,
+        "subject": "Printer offline",
+        "description": "Needs toner",
+        "status": "open",
+        "priority": "high",
+        "company_id": 22,
+        "requester_id": 5,
+        "assigned_user_id": 9,
+        "created_at": datetime(2025, 1, 9, 16, 45, tzinfo=timezone.utc),
+        "updated_at": datetime(2025, 1, 10, 9, 30, tzinfo=timezone.utc),
+    }
+    replies = [
+        {
+            "id": 101,
+            "author_id": 9,
+            "body": "Replaced toner",
+            "minutes_spent": 15,
+            "is_billable": True,
+            "is_internal": False,
+            "created_at": datetime(2025, 1, 10, 10, 0, tzinfo=timezone.utc),
+        }
+    ]
+
+    class DummySanitized:
+        def __init__(self, html: str, has_content: bool):
+            self.html = html
+            self.text_content = html
+            self.has_rich_content = has_content
+
+    def fake_sanitize(value: str | None) -> DummySanitized:
+        text = (value or "").strip()
+        if not text:
+            return DummySanitized("", False)
+        return DummySanitized(f"<p>{text}</p>", True)
+
+    async def fake_get_user_by_id(identifier: int) -> dict[str, Any] | None:
+        if identifier == 5:
+            return {"id": 5, "first_name": "Pat", "last_name": "Requester", "email": "pat@example.com"}
+        if identifier == 9:
+            return {"id": 9, "first_name": "Taylor", "last_name": "Agent", "email": "agent@example.com"}
+        return None
+
+    monkeypatch.setattr(main, "sanitize_rich_text", fake_sanitize)
+    monkeypatch.setattr(main.tickets_repo, "get_ticket", AsyncMock(return_value=ticket))
+    monkeypatch.setattr(main.tickets_repo, "list_replies", AsyncMock(return_value=replies))
+    monkeypatch.setattr(main.tickets_repo, "is_ticket_watcher", AsyncMock())
+    monkeypatch.setattr(main.tickets_service, "get_public_status_map", AsyncMock(return_value={"open": "Open"}))
+    monkeypatch.setattr(
+        main.tickets_service,
+        "format_reply_time_summary",
+        lambda minutes, is_billable: f"{minutes} minutes" if minutes is not None else "",
+    )
+    monkeypatch.setattr(main, "_is_helpdesk_technician", AsyncMock(return_value=False))
+    monkeypatch.setattr(main.company_repo, "get_company_by_id", AsyncMock(return_value={"id": 22, "name": "Example"}))
+    monkeypatch.setattr(main.user_repo, "get_user_by_id", AsyncMock(side_effect=fake_get_user_by_id))
+
+    captured: dict[str, Any] = {}
+
+    async def fake_render_template(template_name, request_obj, user_obj, *, extra):
+        captured["template"] = template_name
+        captured["extra"] = extra
+        return HTMLResponse("OK")
+
+    monkeypatch.setattr(main, "_render_template", fake_render_template)
+
+    response = await main._render_portal_ticket_detail(request, user, ticket_id=41)
+
+    assert isinstance(response, HTMLResponse)
+    assert response.status_code == status.HTTP_200_OK
+    assert captured["template"] == "tickets/detail.html"
+
+    extra = captured["extra"]
+    ticket_payload = extra["ticket"]
+    assert ticket_payload["status_badge"] == "badge--warning"
+    assert ticket_payload["priority_label"] == "High"
+    assert ticket_payload["description_html"] == "<p>Needs toner</p>"
+    assert ticket_payload["description_has_content"] is True
+    assert ticket_payload["requester_label"] == "Pat Requester"
+    assert ticket_payload["assigned_label"] == "Taylor Agent"
+    assert extra["can_reply"] is True
+    assert extra["ticket_replies"] == [
+        {
+            "id": 101,
+            "author": {"id": 9, "first_name": "Taylor", "last_name": "Agent", "email": "agent@example.com"},
+            "author_label": "Taylor Agent",
+            "created_iso": "2025-01-10T10:00:00+00:00",
+            "body_html": "<p>Replaced toner</p>",
+            "has_content": True,
+            "time_summary": "15 minutes",
+            "is_internal": False,
+        }
+    ]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_render_portal_ticket_detail_denies_unrelated_user(monkeypatch):
+    request = _make_request("/tickets/41")
+    user = {"id": 99, "is_super_admin": False}
+
+    ticket = {
+        "id": 41,
+        "status": "open",
+        "priority": "normal",
+        "company_id": 22,
+        "requester_id": 5,
+        "assigned_user_id": None,
+        "description": "",
+        "created_at": datetime(2025, 1, 9, 16, 45, tzinfo=timezone.utc),
+        "updated_at": datetime(2025, 1, 10, 9, 30, tzinfo=timezone.utc),
+    }
+
+    list_replies_mock = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(main.tickets_repo, "get_ticket", AsyncMock(return_value=ticket))
+    monkeypatch.setattr(main.tickets_repo, "list_replies", list_replies_mock)
+    monkeypatch.setattr(main.tickets_repo, "is_ticket_watcher", AsyncMock(return_value=False))
+    monkeypatch.setattr(main, "_is_helpdesk_technician", AsyncMock(return_value=False))
+
+    with pytest.raises(main.HTTPException) as exc_info:
+        await main._render_portal_ticket_detail(request, user, ticket_id=41)
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    list_replies_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add authenticated portal ticket list, detail, and reply flows with new templates
- expose the ticket access flag in base context and route the navigation to the correct portal view
- cover the new portal behaviour with focused tests and record the change log entry

## Testing
- pytest tests/test_ticket_portal_pages.py tests/test_sidebar_menu.py tests/test_section_permissions.py

------
https://chatgpt.com/codex/tasks/task_b_6905fc7e77f8832dae009b0d3d7f25da