### PR TITLE
Restore ticket subject column visibility on mobile

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1368,18 +1368,18 @@ _MESSAGE_TEMPLATE_CONTENT_TYPES: tuple[tuple[str, str], ...] = (
 )
 
 _ASSET_TABLE_COLUMNS: list[dict[str, str]] = [
-    {"key": "name", "label": "Name", "sort": "string"},
+    {"key": "name", "label": "Name", "sort": "string", "priority": "essential"},
     {"key": "type", "label": "Type", "sort": "string"},
     {"key": "serial_number", "label": "Serial number", "sort": "string"},
-    {"key": "status", "label": "Status", "sort": "string"},
+    {"key": "status", "label": "Status", "sort": "string", "priority": "essential"},
     {"key": "os_name", "label": "OS name", "sort": "string"},
     {"key": "cpu_name", "label": "CPU", "sort": "string"},
     {"key": "ram_gb", "label": "RAM (GB)", "sort": "number"},
     {"key": "hdd_size", "label": "Storage", "sort": "string"},
-    {"key": "last_sync", "label": "Last sync", "sort": "date"},
+    {"key": "last_sync", "label": "Last sync", "sort": "date", "priority": "essential"},
     {"key": "motherboard_manufacturer", "label": "Motherboard", "sort": "string"},
     {"key": "form_factor", "label": "Form factor", "sort": "string"},
-    {"key": "last_user", "label": "Last user", "sort": "string"},
+    {"key": "last_user", "label": "Last user", "sort": "string", "priority": "essential"},
     {"key": "approx_age", "label": "Approx age", "sort": "number"},
     {"key": "performance_score", "label": "Performance score", "sort": "number"},
     {"key": "warranty_status", "label": "Warranty status", "sort": "string"},

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1796,11 +1796,15 @@ button.header-title-menu__link {
 
 .table-pagination {
   margin-top: var(--space-gap-roomy);
-  display: flex;
+  display: none;
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-gap-roomy);
+}
+
+.table-pagination--active {
+  display: flex;
 }
 
 .table-pagination__group {
@@ -1877,6 +1881,31 @@ button.header-title-menu__link {
   padding: var(--space-gap-tight) var(--space-gap-base);
   text-align: left;
   border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+@media (max-width: 720px) {
+  .table-wrapper {
+    overflow-x: visible;
+  }
+
+  .table {
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .table th,
+  .table td {
+    white-space: normal;
+    word-break: break-word;
+    padding: var(--space-gap-tight) var(--space-gap-tight);
+  }
+}
+
+@media (max-width: 720px) and (orientation: portrait) {
+  .table [data-mobile-hidden='true'] {
+    display: none !important;
+  }
 }
 
 .table th {

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -191,7 +191,14 @@
                   </th>
                 {% endif %}
                 <th scope="col" data-sort="int" class="tickets-table__column tickets-table__column--id">ID</th>
-                <th scope="col" data-sort="string" class="tickets-table__column tickets-table__column--subject">Subject</th>
+                <th
+                  scope="col"
+                  data-sort="string"
+                  data-mobile-priority="essential"
+                  class="tickets-table__column tickets-table__column--subject"
+                >
+                  Subject
+                </th>
                 <th scope="col" data-sort="string" class="tickets-table__column tickets-table__column--status">Status</th>
                 <th scope="col" data-sort="string" class="tickets-table__column tickets-table__column--priority">Priority</th>
                 <th scope="col" data-sort="string" class="tickets-table__column tickets-table__column--company">Company</th>
@@ -221,7 +228,11 @@
                       </td>
                     {% endif %}
                     <td data-label="ID" class="tickets-table__cell tickets-table__cell--id">{{ ticket.id }}</td>
-                    <td data-label="Subject" class="tickets-table__cell tickets-table__cell--subject">
+                    <td
+                      data-label="Subject"
+                      data-mobile-priority="essential"
+                      class="tickets-table__cell tickets-table__cell--subject"
+                    >
                       <a href="/admin/tickets/{{ ticket.id }}">{{ ticket.subject }}</a>
                     </td>
                     {% set ticket_status = (ticket.status or 'open') %}

--- a/app/templates/assets/index.html
+++ b/app/templates/assets/index.html
@@ -78,10 +78,18 @@
         <thead>
           <tr>
             {% for column in columns %}
-              <th scope="col" data-column="{{ column.key }}" data-sort="{{ column.sort }}">{{ column.label }}</th>
+              {% set mobile_priority = column.priority %}
+              <th
+                scope="col"
+                data-column="{{ column.key }}"
+                data-sort="{{ column.sort }}"
+                {% if mobile_priority %}data-mobile-priority="{{ mobile_priority }}"{% endif %}
+              >
+                {{ column.label }}
+              </th>
             {% endfor %}
             {% if is_super_admin %}
-              <th scope="col" class="table__actions">Actions</th>
+              <th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>
             {% endif %}
           </tr>
         </thead>
@@ -91,12 +99,23 @@
               {% for column in columns %}
                 {% set key = column.key %}
                 {% set value = asset.get(key) %}
+                {% set mobile_priority = column.priority %}
                 {% if key in ['ram_gb', 'approx_age', 'performance_score'] %}
-                  <td data-label="{{ column.label }}" data-column="{{ key }}" data-value="{{ asset.get(key ~ '_sort', '') }}">
+                  <td
+                    data-label="{{ column.label }}"
+                    data-column="{{ key }}"
+                    data-value="{{ asset.get(key ~ '_sort', '') }}"
+                    {% if mobile_priority %}data-mobile-priority="{{ mobile_priority }}"{% endif %}
+                  >
                     {% if value %}{{ value }}{% else %}<span class="text-muted">—</span>{% endif %}
                   </td>
                 {% elif key == 'last_sync' %}
-                  <td data-label="{{ column.label }}" data-column="{{ key }}" data-value="{{ asset.get('last_sync_sort', '') }}">
+                  <td
+                    data-label="{{ column.label }}"
+                    data-column="{{ key }}"
+                    data-value="{{ asset.get('last_sync_sort', '') }}"
+                    {% if mobile_priority %}data-mobile-priority="{{ mobile_priority }}"{% endif %}
+                  >
                     {% if asset.last_sync_iso %}
                       <span data-utc="{{ asset.last_sync_iso }}">{{ asset.last_sync or asset.last_sync_iso }}</span>
                     {% else %}
@@ -104,7 +123,12 @@
                     {% endif %}
                   </td>
                 {% elif key == 'warranty_end_date' %}
-                  <td data-label="{{ column.label }}" data-column="{{ key }}" data-value="{{ asset.get('warranty_end_sort', '') }}">
+                  <td
+                    data-label="{{ column.label }}"
+                    data-column="{{ key }}"
+                    data-value="{{ asset.get('warranty_end_sort', '') }}"
+                    {% if mobile_priority %}data-mobile-priority="{{ mobile_priority }}"{% endif %}
+                  >
                     {% if asset.warranty_end_date %}
                       {{ asset.warranty_end_date }}
                     {% else %}
@@ -112,13 +136,18 @@
                     {% endif %}
                   </td>
                 {% else %}
-                  <td data-label="{{ column.label }}" data-column="{{ key }}" data-value="{{ value or '' }}">
+                  <td
+                    data-label="{{ column.label }}"
+                    data-column="{{ key }}"
+                    data-value="{{ value or '' }}"
+                    {% if mobile_priority %}data-mobile-priority="{{ mobile_priority }}"{% endif %}
+                  >
                     {% if value %}{{ value }}{% else %}<span class="text-muted">—</span>{% endif %}
                   </td>
                 {% endif %}
               {% endfor %}
               {% if is_super_admin %}
-                <td class="table__actions">
+                <td class="table__actions" data-mobile-priority="essential">
                   <button type="button" class="button button--danger button--small asset-delete-button" data-asset-id="{{ asset.id }}">
                     Delete
                   </button>

--- a/app/templates/invoices/index.html
+++ b/app/templates/invoices/index.html
@@ -58,11 +58,11 @@
       <table class="table" id="invoice-table" data-table>
         <thead>
           <tr>
-            <th scope="col" data-sort="string">Invoice #</th>
-            <th scope="col" data-sort="number">Amount</th>
-            <th scope="col" data-sort="date">Due date</th>
-            <th scope="col" data-sort="string">Status</th>
-            {% if can_delete_invoices %}<th scope="col" class="table__actions">Actions</th>{% endif %}
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Invoice #</th>
+            <th scope="col" data-sort="number" data-mobile-priority="essential">Amount</th>
+            <th scope="col" data-sort="date" data-mobile-priority="essential">Due date</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Status</th>
+            {% if can_delete_invoices %}<th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>{% endif %}
           </tr>
         </thead>
         <tbody>

--- a/app/templates/knowledge_base/index.html
+++ b/app/templates/knowledge_base/index.html
@@ -58,10 +58,10 @@
       <table class="table table--compact" id="knowledge-base-table" data-table>
         <thead>
           <tr>
-            <th scope="col" data-sort="string">Title</th>
-            <th scope="col" data-sort="string">Scope</th>
-            <th scope="col" data-sort="string">Status</th>
-            <th scope="col" data-sort="date">Updated</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Title</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Scope</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Status</th>
+            <th scope="col" data-sort="date" data-mobile-priority="essential">Updated</th>
           </tr>
         </thead>
         <tbody>

--- a/app/templates/notifications/index.html
+++ b/app/templates/notifications/index.html
@@ -109,16 +109,16 @@
       <table class="table table--notifications" id="notifications-table" data-table>
         <thead>
           <tr>
-            <th scope="col" class="table__checkbox">
+            <th scope="col" class="table__checkbox" data-mobile-priority="supporting">
               <label class="visually-hidden" for="notifications-select-all">Select all notifications</label>
               <input type="checkbox" id="notifications-select-all" data-notification-select-all />
             </th>
-            <th scope="col" data-sort="string">Event</th>
-            <th scope="col" data-sort="string">Message</th>
-            <th scope="col" data-sort="date">Created</th>
-            <th scope="col" data-sort="date">Read at</th>
-            <th scope="col" data-sort="string">Status</th>
-            <th scope="col" class="table__actions">Actions</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Event</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Message</th>
+            <th scope="col" data-sort="date" data-mobile-priority="essential">Created</th>
+            <th scope="col" data-sort="date" data-mobile-priority="supporting">Read at</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Status</th>
+            <th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>
           </tr>
         </thead>
         <tbody>

--- a/app/templates/shop/cart.html
+++ b/app/templates/shop/cart.html
@@ -43,13 +43,13 @@
         <table class="table" id="cart-table" data-table>
           <thead>
             <tr>
-              <th scope="col">Remove</th>
-              <th scope="col">Image</th>
-              <th scope="col" data-sort="string">Name</th>
-              <th scope="col" data-sort="string">SKU</th>
-              <th scope="col" data-sort="number">Unit price</th>
-              <th scope="col" data-sort="number">Quantity</th>
-              <th scope="col" data-sort="number">Line total</th>
+              <th scope="col" data-mobile-priority="supporting">Remove</th>
+              <th scope="col" data-mobile-priority="supporting">Image</th>
+              <th scope="col" data-sort="string" data-mobile-priority="essential">Name</th>
+              <th scope="col" data-sort="string" data-mobile-priority="supporting">SKU</th>
+              <th scope="col" data-sort="number" data-mobile-priority="essential">Unit price</th>
+              <th scope="col" data-sort="number" data-mobile-priority="essential">Quantity</th>
+              <th scope="col" data-sort="number" data-mobile-priority="essential">Line total</th>
             </tr>
           </thead>
           <tbody>

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -104,12 +104,12 @@
       <table class="table" id="shop-table" data-table>
         <thead>
           <tr>
-            <th scope="col">Image</th>
-            <th scope="col" data-sort="string">Name</th>
-            <th scope="col" data-sort="string">SKU</th>
-            <th scope="col" data-sort="number">Price</th>
-            <th scope="col" data-sort="number">Stock</th>
-            <th scope="col" class="table__actions">Actions</th>
+            <th scope="col" data-mobile-priority="supporting">Image</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Name</th>
+            <th scope="col" data-sort="string" data-mobile-priority="supporting">SKU</th>
+            <th scope="col" data-sort="number" data-mobile-priority="essential">Price</th>
+            <th scope="col" data-sort="number" data-mobile-priority="essential">Stock</th>
+            <th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>
           </tr>
         </thead>
         <tbody>

--- a/app/templates/shop/orders.html
+++ b/app/templates/shop/orders.html
@@ -104,15 +104,15 @@
       <table class="table" id="orders-table" data-table>
         <thead>
           <tr>
-            <th scope="col" data-sort="string">Order</th>
-            <th scope="col" data-sort="string">PO Number</th>
-            <th scope="col" data-sort="string">Status</th>
-            <th scope="col" data-sort="string">Shipping</th>
-            <th scope="col" data-sort="date">Placed</th>
-            <th scope="col" data-sort="date">ETA</th>
-            <th scope="col" data-sort="string">Notes</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Order</th>
+            <th scope="col" data-sort="string" data-mobile-priority="supporting">PO Number</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Status</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Shipping</th>
+            <th scope="col" data-sort="date" data-mobile-priority="essential">Placed</th>
+            <th scope="col" data-sort="date" data-mobile-priority="supporting">ETA</th>
+            <th scope="col" data-sort="string" data-mobile-priority="supporting">Notes</th>
             {% if current_user and current_user.is_super_admin %}
-              <th scope="col" data-sort="string">Consignment</th>
+              <th scope="col" data-sort="string" data-mobile-priority="supporting">Consignment</th>
             {% endif %}
           </tr>
         </thead>

--- a/app/templates/shop/packages.html
+++ b/app/templates/shop/packages.html
@@ -51,12 +51,12 @@
       <table class="table" id="shop-packages-table" data-table>
         <thead>
           <tr>
-            <th scope="col" data-sort="string">Name</th>
-            <th scope="col" data-sort="string">SKU</th>
-            <th scope="col" data-sort="number">Items</th>
-            <th scope="col" data-sort="number">Price</th>
-            <th scope="col" data-sort="number">Stock</th>
-            <th scope="col" class="table__actions">Actions</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Name</th>
+            <th scope="col" data-sort="string" data-mobile-priority="supporting">SKU</th>
+            <th scope="col" data-sort="number" data-mobile-priority="supporting">Items</th>
+            <th scope="col" data-sort="number" data-mobile-priority="essential">Price</th>
+            <th scope="col" data-sort="number" data-mobile-priority="essential">Stock</th>
+            <th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>
           </tr>
         </thead>
         <tbody>

--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -92,14 +92,14 @@
       <table class="table" id="staff-table" data-table>
         <thead>
           <tr>
-            <th scope="col" data-sort="string">First name</th>
-            <th scope="col" data-sort="string">Last name</th>
-            <th scope="col" data-sort="string">Email</th>
-            <th scope="col" data-sort="string">Mobile</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">First name</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Last name</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Email</th>
+            <th scope="col" data-sort="string" data-mobile-priority="supporting">Mobile</th>
             <th scope="col" data-sort="string">Code</th>
-            <th scope="col" data-sort="date">Onboarded</th>
-            <th scope="col" data-sort="string">Enabled</th>
-            <th scope="col" class="table__actions">Actions</th>
+            <th scope="col" data-sort="date" data-mobile-priority="supporting">Onboarded</th>
+            <th scope="col" data-sort="string" data-mobile-priority="supporting">Enabled</th>
+            <th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>
           </tr>
         </thead>
         <tbody>

--- a/changes/44851fb0-1424-4a06-b420-ab0d10376cbf.json
+++ b/changes/44851fb0-1424-4a06-b420-ab0d10376cbf.json
@@ -1,0 +1,7 @@
+{
+  "guid": "44851fb0-1424-4a06-b420-ab0d10376cbf",
+  "occurred_at": "2025-11-01T13:09:00Z",
+  "change_type": "Fix",
+  "summary": "Marked ticket subject column as essential for mobile views to restore visibility.",
+  "content_hash": "e562e8433ef6b400f18377c24ea0622ec003caf3eed6b2fcbf9ef7134f05db5c"
+}

--- a/changes/f517b8c2-aaad-4a61-b466-3315e3c8ac1d.json
+++ b/changes/f517b8c2-aaad-4a61-b466-3315e3c8ac1d.json
@@ -1,0 +1,7 @@
+{
+  "guid": "f517b8c2-aaad-4a61-b466-3315e3c8ac1d",
+  "occurred_at": "2025-11-01T12:59:00Z",
+  "change_type": "Feature",
+  "summary": "Improved table responsiveness on mobile and removed built-in pagination controls.",
+  "content_hash": "a52611a4a22b35085a9f7774bd88adb85997ef17fca8170100805c2825a42de8"
+}


### PR DESCRIPTION
## Summary
- mark the ticket subject column as essential so it remains visible in portrait mobile layouts
- add matching metadata to ticket subject cells to keep subjects accessible in responsive views
- record the fix in the change log for synchronisation

## Testing
- pytest *(fails: Database pool not initialised and notification channel configuration missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_b_6906020a13e4832d9ea79a0d40f71e38