### PR TITLE
Fix refresh app button fallback behaviour

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -263,12 +263,10 @@
 
     const hasServiceWorker = typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
     const hasCacheAPI = typeof window !== 'undefined' && 'caches' in window;
+    const supportsEnhancedRefresh = hasServiceWorker || hasCacheAPI;
 
-    if (!hasServiceWorker && !hasCacheAPI) {
-      trigger.disabled = true;
-      trigger.setAttribute('aria-disabled', 'true');
-      trigger.title = 'Force refresh is not supported in this browser';
-      return;
+    if (!supportsEnhancedRefresh) {
+      trigger.title = 'Reloads the app to request the latest files';
     }
 
     const toast = createToastController(document.querySelector('[data-global-toast]'));
@@ -410,9 +408,14 @@
       trigger.disabled = true;
       trigger.setAttribute('aria-busy', 'true');
 
-      toast.show('Refreshing the application and clearing cached assets…', {
-        variant: 'info',
-      });
+      toast.show(
+        supportsEnhancedRefresh
+          ? 'Refreshing the application and clearing cached assets…'
+          : 'Refreshing the application with a clean request…',
+        {
+          variant: 'info',
+        },
+      );
 
       let hadError = false;
       try {
@@ -428,8 +431,13 @@
           variant: 'warning',
           autoHideMs: 6000,
         });
-      } else {
+      } else if (supportsEnhancedRefresh) {
         toast.show('Cached assets cleared. Reloading with the latest version…', {
+          variant: 'success',
+          autoHideMs: 4000,
+        });
+      } else {
+        toast.show('Reloading the application to request the latest files…', {
           variant: 'success',
           autoHideMs: 4000,
         });

--- a/changes/d681c12c-f314-4f02-9537-6282a7b8903a.json
+++ b/changes/d681c12c-f314-4f02-9537-6282a7b8903a.json
@@ -1,0 +1,7 @@
+{
+  "guid": "d681c12c-f314-4f02-9537-6282a7b8903a",
+  "occurred_at": "2025-11-01T13:20Z",
+  "change_type": "Fix",
+  "summary": "Ensure the Refresh app control reloads the portal even when cache clearing APIs are unavailable.",
+  "content_hash": "c7365c1a3064264992e90e7a5e0b4a9d970f3fc7022159506f49d31d3f3645c5"
+}


### PR DESCRIPTION
## Summary
- keep the Refresh app control active in browsers without service worker or Cache API support and adjust user messaging
- add a change log entry documenting the Refresh app fallback fix

## Testing
- pytest tests/test_pwa.py

------
https://chatgpt.com/codex/tasks/task_b_6906087397a8832dac78200a4f247249