### PR TITLE
Record ticket descriptions as initial replies

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -316,6 +316,7 @@ async def create_ticket(
         module_slug=module_slug,
         external_reference=external_reference,
         trigger_automations=True,
+        initial_reply_author_id=session.user_id,
     )
     await tickets_repo.add_watcher(ticket["id"], session.user_id)
     try:

--- a/app/main.py
+++ b/app/main.py
@@ -4871,6 +4871,7 @@ async def portal_create_ticket(request: Request):
             module_slug=None,
             external_reference=None,
             trigger_automations=True,
+            initial_reply_author_id=requester_id,
         )
         await tickets_repo.add_watcher(ticket["id"], requester_id)
         try:
@@ -10010,6 +10011,7 @@ async def admin_create_ticket(request: Request):
             module_slug=module_slug,
             external_reference=str(form.get("externalReference", "")).strip() or None,
             trigger_automations=True,
+            initial_reply_author_id=current_user.get("id"),
         )
         await tickets_repo.add_watcher(created["id"], current_user.get("id"))
         await tickets_service.refresh_ticket_ai_summary(created["id"])

--- a/changes/77cbfc67-4865-4e5c-bf3c-037ae786ae3c.json
+++ b/changes/77cbfc67-4865-4e5c-bf3c-037ae786ae3c.json
@@ -1,0 +1,7 @@
+{
+  "guid": "77cbfc67-4865-4e5c-bf3c-037ae786ae3c",
+  "occurred_at": "2025-11-01T13:22:00Z",
+  "change_type": "Fix",
+  "summary": "Record initial ticket descriptions as first conversation replies for new tickets.",
+  "content_hash": "ea6e9254e94a501c9b703b3545a7807f923a65ce5a24ab5ffc9a711dc6c04f9c"
+}

--- a/tests/test_tickets_service_create.py
+++ b/tests/test_tickets_service_create.py
@@ -163,6 +163,58 @@ async def test_create_ticket_truncates_long_description(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_create_ticket_records_initial_reply(monkeypatch):
+    recorded_reply: dict[str, object] = {}
+
+    async def fake_create_ticket(**kwargs):
+        return {"id": 135, **kwargs}
+
+    async def fake_create_reply(**kwargs):
+        recorded_reply.update(kwargs)
+        return {"id": 246, **kwargs}
+
+    async def fake_handle_event(event_name, context):  # pragma: no cover - via test
+        return []
+
+    async def fake_get_company(company_id):
+        return None
+
+    async def fake_get_user(user_id):
+        return None
+
+    async def fake_resolve_status(value):
+        return value or "open"
+
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
+    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
+    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
+
+    ticket = await tickets_service.create_ticket(
+        subject="VPN issue",
+        description="Cannot connect to VPN",
+        requester_id=12,
+        company_id=4,
+        assigned_user_id=None,
+        priority="normal",
+        status="open",
+        category=None,
+        module_slug=None,
+        external_reference=None,
+        ticket_number=None,
+        initial_reply_author_id=12,
+    )
+
+    assert ticket["id"] == 135
+    assert recorded_reply["ticket_id"] == 135
+    assert recorded_reply["author_id"] == 12
+    assert recorded_reply["body"] == "Cannot connect to VPN"
+    assert recorded_reply["is_internal"] is False
+
+
+@pytest.mark.anyio
 async def test_enrich_ticket_context_includes_relationship_details(monkeypatch):
     ticket = {
         "id": 99,


### PR DESCRIPTION
## Summary
- capture ticket descriptions as initial conversation replies when creating tickets via the API, portal, or admin flows
- extend ticket creation service to persist the reply and guard against failures
- cover the behaviour with a dedicated test and document the fix in the change log

## Testing
- pytest tests/test_tickets_service_create.py

------
https://chatgpt.com/codex/tasks/task_b_690608c733a0832d92ceae65328e265d