### PR TITLE
Stabilize Xero and notification tests

### DIFF
--- a/changes/393ebca7-bfc0-4e90-a8b1-1bf1c9235aa5.json
+++ b/changes/393ebca7-bfc0-4e90-a8b1-1bf1c9235aa5.json
@@ -1,0 +1,7 @@
+{
+  "guid": "393ebca7-bfc0-4e90-a8b1-1bf1c9235aa5",
+  "occurred_at": "2025-11-02T22:21:10Z",
+  "change_type": "Fix",
+  "summary": "Stabilize notification and shop tests by isolating database access and adjusting Xero async markers",
+  "content_hash": "584449ce4642af192e43fd7b27df939222caaa5000544319c08113a787dc398d"
+}

--- a/tests/test_notifications_service.py
+++ b/tests/test_notifications_service.py
@@ -1,4 +1,7 @@
 import asyncio
+from copy import deepcopy
+
+from app.core.notifications import DEFAULT_NOTIFICATION_EVENTS
 
 from app.services import notifications
 
@@ -23,6 +26,17 @@ def test_emit_notification_sends_email(monkeypatch):
     monkeypatch.setattr(notifications.notifications_repo, "create_notification", fake_create_notification)
     monkeypatch.setattr(notifications.user_repo, "get_user_by_id", fake_get_user_by_id)
     monkeypatch.setattr(notifications.email_service, "send_email", fake_send_email)
+    
+    async def fake_get_event_setting(event_type: str):
+        base = deepcopy(DEFAULT_NOTIFICATION_EVENTS.get(event_type, {}))
+        base["event_type"] = event_type
+        return base
+
+    monkeypatch.setattr(
+        notifications.notification_event_settings,
+        "get_event_setting",
+        fake_get_event_setting,
+    )
 
     asyncio.run(
         notifications.emit_notification(
@@ -60,6 +74,17 @@ def test_emit_notification_sends_sms(monkeypatch):
     monkeypatch.setattr(notifications.notifications_repo, "create_notification", fake_create_notification)
     monkeypatch.setattr(notifications.user_repo, "get_user_by_id", fake_get_user_by_id)
     monkeypatch.setattr(notifications.sms_service, "send_sms", fake_send_sms)
+
+    async def fake_get_event_setting(event_type: str):
+        base = deepcopy(DEFAULT_NOTIFICATION_EVENTS.get(event_type, {}))
+        base["event_type"] = event_type
+        return base
+
+    monkeypatch.setattr(
+        notifications.notification_event_settings,
+        "get_event_setting",
+        fake_get_event_setting,
+    )
 
     asyncio.run(
         notifications.emit_notification(

--- a/tests/test_shop_service.py
+++ b/tests/test_shop_service.py
@@ -19,7 +19,11 @@ def test_send_discord_stock_notification_enqueues_event(monkeypatch):
         "get_settings",
         _fake_settings_with_webhook,
     )
+    async def fake_emit_notification(**kwargs):
+        return None
+
     monkeypatch.setattr(shop_service.webhook_monitor, "enqueue_event", fake_enqueue_event)
+    monkeypatch.setattr(shop_service, "emit_notification", fake_emit_notification)
 
     product = {"id": 10, "name": "Widget+", "sku": "SKU-1"}
 
@@ -49,8 +53,12 @@ def test_maybe_send_discord_stock_notification_returns_event(monkeypatch):
         "get_settings",
         _fake_settings_with_webhook,
     )
+    async def fake_emit_notification(**kwargs):
+        return None
+
     monkeypatch.setattr(shop_service.webhook_monitor, "enqueue_event", fake_enqueue_event)
     monkeypatch.setattr(shop_service.shop_repo, "get_product_by_id", fake_get_product_by_id)
+    monkeypatch.setattr(shop_service, "emit_notification", fake_emit_notification)
 
     event = asyncio.run(
         shop_service.maybe_send_discord_stock_notification_by_id(

--- a/tests/test_xero_module.py
+++ b/tests/test_xero_module.py
@@ -1,0 +1,104 @@
+import pytest
+from decimal import Decimal
+
+from app.services import modules as modules_service
+from app.services import xero as xero_service
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_coerce_settings_xero_preserves_secrets():
+    existing = {
+        "settings": {
+            "client_id": "existing-id",
+            "client_secret": "super-secret",
+            "refresh_token": "refresh-token",
+            "default_hourly_rate": "120.00",
+        }
+    }
+    payload = {
+        "client_id": "new-id",
+        "client_secret": "********",
+        "default_hourly_rate": "175",
+    }
+    result = modules_service._coerce_settings("xero", payload, existing)
+    assert result["client_secret"] == "super-secret"
+    assert result["refresh_token"] == "refresh-token"
+    assert result["client_id"] == "new-id"
+    assert result["default_hourly_rate"] == "175.00"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_build_ticket_invoices_groups_billable_minutes():
+    async def fake_fetch_ticket(ticket_id: int):
+        return {"id": ticket_id, "company_id": 1, "subject": f"Ticket {ticket_id}"}
+
+    async def fake_fetch_replies(ticket_id: int):
+        if ticket_id == 1:
+            return [
+                {"minutes_spent": 30, "is_billable": True},
+                {"minutes_spent": 15, "is_billable": False},
+            ]
+        return [
+            {"minutes_spent": 45, "is_billable": False},
+            {"minutes_spent": 10, "is_billable": False},
+        ]
+
+    async def fake_fetch_company(company_id: int):
+        return {"id": company_id, "name": "Acme Corp", "xero_id": "abc-123"}
+
+    invoices = await xero_service.build_ticket_invoices(
+        [1, "2"],
+        hourly_rate=Decimal("150"),
+        account_code="400",
+        tax_type="OUTPUT",
+        line_amount_type="Exclusive",
+        reference_prefix="Support",
+        fetch_ticket=fake_fetch_ticket,
+        fetch_replies=fake_fetch_replies,
+        fetch_company=fake_fetch_company,
+    )
+
+    assert len(invoices) == 1
+    invoice = invoices[0]
+    assert invoice["context"]["total_billable_minutes"] == 30
+    assert invoice["line_items"][0]["UnitAmount"] == 150.0
+    assert invoice["line_items"][0]["Quantity"] == 0.5
+
+
+@pytest.mark.anyio("asyncio")
+async def test_build_order_invoice_returns_payload_with_context():
+    async def fake_fetch_summary(order_number: str, company_id: int):
+        return {"order_number": order_number, "status": "placed"}
+
+    async def fake_fetch_items(order_number: str, company_id: int):
+        return [
+            {
+                "quantity": 2,
+                "price": Decimal("19.99"),
+                "product_name": "Widget",
+                "sku": "WID-1",
+            }
+        ]
+
+    async def fake_fetch_company(company_id: int):
+        return {"id": company_id, "name": "Acme Corp", "xero_id": "xyz-789"}
+
+    invoice = await xero_service.build_order_invoice(
+        "SO-100",
+        1,
+        account_code="400",
+        tax_type=None,
+        line_amount_type="Exclusive",
+        fetch_summary=fake_fetch_summary,
+        fetch_items=fake_fetch_items,
+        fetch_company=fake_fetch_company,
+    )
+
+    assert invoice is not None
+    assert invoice["line_items"][0]["Quantity"] == 2
+    assert invoice["context"]["order"]["order_number"] == "SO-100"
+    assert invoice["context"]["company"]["xero_id"] == "xyz-789"


### PR DESCRIPTION
## Summary
- isolate database access in notification and shop tests to avoid touching the global pool during startup
- mock notification event settings so email and SMS channels remain enabled in unit tests
- pin the Xero module tests to the asyncio backend with updated fixtures and record the change in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6907d5413d54832d800ece07eb41b6a5