### PR TITLE
Add Xero integration callback endpoint and documentation

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -26,6 +26,7 @@ from . import (
     users,
     system,
     uptimekuma,
+    xero,
 )
 
 __all__ = [
@@ -56,4 +57,5 @@ __all__ = [
     "users",
     "system",
     "uptimekuma",
+    "xero",
 ]

--- a/app/api/routes/xero.py
+++ b/app/api/routes/xero.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, status
+from loguru import logger
+
+from app.services import modules as modules_service
+
+router = APIRouter(prefix="/api/integration-modules/xero", tags=["Xero"])
+
+
+async def _ensure_module_enabled() -> dict[str, Any]:
+    module = await modules_service.get_module("xero", redact=False)
+    if not module or not module.get("enabled"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Xero module is disabled",
+        )
+    return module
+
+
+@router.post(
+    "/callback",
+    status_code=status.HTTP_202_ACCEPTED,
+    name="xero_receive_callback",
+)
+async def receive_callback(request: Request) -> dict[str, str]:
+    await _ensure_module_enabled()
+
+    body = await request.body()
+    payload: dict[str, Any]
+    if not body:
+        payload = {}
+    else:
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid JSON payload",
+            ) from exc
+
+    xero_headers = {
+        key: value
+        for key, value in request.headers.items()
+        if key.lower().startswith("x-xero-")
+    }
+    remote_addr = request.client.host if request.client else None
+    logger.info(
+        "Received Xero webhook callback",
+        remote_addr=remote_addr,
+        xero_headers=xero_headers,
+        payload_keys=sorted(payload.keys()),
+    )
+    return {"status": "accepted"}
+
+
+@router.get("/callback", name="xero_callback_probe")
+async def probe_callback(request: Request) -> dict[str, str]:
+    """Expose a lightweight probe endpoint for connectivity checks."""
+
+    await _ensure_module_enabled()
+    if request.query_params:
+        logger.info(
+            "Received Xero callback probe",
+            query_params=dict(request.query_params),
+        )
+    return {"status": "ok"}

--- a/app/main.py
+++ b/app/main.py
@@ -69,6 +69,7 @@ from app.api.routes import (
     users,
     system,
     uptimekuma,
+    xero,
 )
 from uuid import uuid4
 
@@ -496,6 +497,7 @@ app.include_router(imap_api.router)
 app.include_router(mcp_api.router)
 app.include_router(system.router)
 app.include_router(uptimekuma.router)
+app.include_router(xero.router)
 
 HELPDESK_PERMISSION_KEY = tickets_service.HELPDESK_PERMISSION_KEY
 ISSUE_TRACKER_PERMISSION_KEY = issues_service.ISSUE_TRACKER_PERMISSION_KEY

--- a/app/templates/admin/modules.html
+++ b/app/templates/admin/modules.html
@@ -212,6 +212,11 @@
                 </div>
               {% elif module.slug == 'xero' %}
                 <div class="form-field">
+                  <label class="form-label" for="xero-callback-url">Callback URL</label>
+                  <input id="xero-callback-url" class="form-input" value="{{ request.url_for('xero_receive_callback') }}" readonly />
+                  <p class="form-help">Provide this URL as the redirect/callback endpoint inside your Xero app configuration.</p>
+                </div>
+                <div class="form-field">
                   <label class="form-label" for="xero-client-id">Client ID</label>
                   <input id="xero-client-id" name="settings.client_id" class="form-input" value="{{ settings.client_id or '' }}" autocomplete="off" />
                 </div>

--- a/changes/fcb60eb5-7f9c-4567-bebd-520cb9f1ec2f.json
+++ b/changes/fcb60eb5-7f9c-4567-bebd-520cb9f1ec2f.json
@@ -1,0 +1,7 @@
+{
+  "guid": "fcb60eb5-7f9c-4567-bebd-520cb9f1ec2f",
+  "occurred_at": "2025-02-14T00:00:00Z",
+  "change_type": "Feature",
+  "summary": "Documented and exposed the Xero integration callback endpoint.",
+  "content_hash": "ee33a740fd35a670d447a85697fde057201439e1566339f921833048fce1f910"
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,10 @@ file. The template at `.env.example` lists every supported key alongside
 recommended defaults. Copy the template to `.env` (or point your process manager
 at a dedicated path) and edit values as required for the deployment target.
 
+For integration-specific guidance refer to the dedicated documentation under
+`docs/`. For example, [docs/xero.md](xero.md) outlines the callback URL and
+credential requirements for the Xero module.
+
 ## UI Auto Refresh
 
 `ENABLE_AUTO_REFRESH` controls whether browser clients automatically poll the

--- a/docs/xero.md
+++ b/docs/xero.md
@@ -1,0 +1,30 @@
+# Xero Integration
+
+The Xero module synchronises invoices and customer metadata between MyPortal and
+Xero. Before MyPortal can refresh OAuth tokens or receive webhook
+notifications, register an application inside the Xero developer portal and
+record the generated credentials inside **Admin → Integration modules → Xero**.
+
+## Callback URL
+
+Xero requires a callback URL (also called a redirect URI) for OAuth flows and
+webhook notifications. MyPortal exposes a dedicated endpoint at:
+
+```
+https://<your-domain>/api/integration-modules/xero/callback
+```
+
+This URL is displayed inside the Xero module configuration panel so that it can
+be copied without leaving the admin interface. Paste the fully-qualified URL
+into the **Redirect URI** field within your Xero application settings.
+
+The endpoint accepts POST requests and responds with HTTP 202 to acknowledge
+callbacks from Xero. A lightweight GET handler is also available for diagnostic
+probes and returns HTTP 200 when the integration module is enabled.
+
+## Security
+
+Callbacks are only accepted when the Xero module is enabled. Disable the module
+from the admin interface to immediately stop accepting inbound requests. Any
+headers prefixed with `X-Xero-` are logged for troubleshooting without
+persisting the full payload, ensuring sensitive information remains protected.

--- a/tests/test_xero_api.py
+++ b/tests/test_xero_api.py
@@ -1,0 +1,96 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main as main_module
+from app.core.database import db
+from app.main import app, scheduler_service
+from app.services import modules as modules_service
+
+
+@pytest.fixture(autouse=True)
+def mock_startup(monkeypatch):
+    async def fake_connect():
+        return None
+
+    async def fake_disconnect():
+        return None
+
+    async def fake_run_migrations():
+        return None
+
+    async def fake_start():
+        return None
+
+    async def fake_stop():
+        return None
+
+    monkeypatch.setattr(db, "connect", fake_connect)
+    monkeypatch.setattr(db, "disconnect", fake_disconnect)
+    monkeypatch.setattr(db, "run_migrations", fake_run_migrations)
+    monkeypatch.setattr(scheduler_service, "start", fake_start)
+    monkeypatch.setattr(scheduler_service, "stop", fake_stop)
+    monkeypatch.setattr(main_module.settings, "enable_csrf", False)
+
+
+def test_xero_callback_accepts_payload(monkeypatch):
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        assert slug == "xero"
+        assert redact is False
+        return {"enabled": True, "slug": "xero"}
+
+    monkeypatch.setattr(modules_service, "get_module", fake_get_module)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/integration-modules/xero/callback",
+            json={"events": []},
+        )
+
+    assert response.status_code == 202
+    assert response.json()["status"] == "accepted"
+
+
+def test_xero_callback_rejects_invalid_json(monkeypatch):
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        return {"enabled": True, "slug": "xero"}
+
+    monkeypatch.setattr(modules_service, "get_module", fake_get_module)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/integration-modules/xero/callback",
+            data="{",
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid JSON payload"
+
+
+def test_xero_callback_disabled_module(monkeypatch):
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        return {"enabled": False, "slug": "xero"}
+
+    monkeypatch.setattr(modules_service, "get_module", fake_get_module)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/integration-modules/xero/callback",
+            json={},
+        )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Xero module is disabled"
+
+
+def test_xero_callback_probe(monkeypatch):
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        return {"enabled": True, "slug": "xero"}
+
+    monkeypatch.setattr(modules_service, "get_module", fake_get_module)
+
+    with TestClient(app) as client:
+        response = client.get("/api/integration-modules/xero/callback")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- add a dedicated Xero callback endpoint and register the router with the FastAPI app
- expose the callback URL in the admin module configuration UI and document it under docs/xero.md
- add regression coverage for the callback handlers and record the feature in the change log

## Testing
- pytest tests/test_xero_api.py

------
https://chatgpt.com/codex/tasks/task_b_6907f96af478832db5b4886f95d102fe