### PR TITLE
Add GitHub sidebar shortcut

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -211,6 +211,37 @@ html {
   border-radius: 0.75rem;
 }
 
+.sidebar__footer {
+  margin-top: auto;
+  padding-top: var(--space-gap-base);
+  display: flex;
+}
+
+.sidebar__footer-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  color: #e5e7eb;
+  background: rgba(148, 163, 184, 0.08);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.sidebar__footer-link:hover,
+.sidebar__footer-link:focus-visible {
+  background: rgba(148, 163, 184, 0.25);
+  color: #f8fafc;
+  outline: none;
+}
+
+.sidebar__footer-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: currentColor;
+}
+
 .impersonation-exit {
   display: flex;
   flex-direction: column;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -324,6 +324,22 @@
           {% endif %}
           {% endblock %}
         </ul>
+        <div class="sidebar__footer">
+          <a
+            class="sidebar__footer-link"
+            href="https://github.com/bradhawkins85/MyPortal"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="View MyPortal on GitHub"
+          >
+            <svg class="sidebar__footer-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path
+                d="M12 .5a11.5 11.5 0 0 0-3.64 22.41c.58.11.79-.25.79-.56v-1.99c-3.22.7-3.9-1.55-3.9-1.55-.53-1.34-1.3-1.7-1.3-1.7-1.07-.74.08-.72.08-.72 1.18.09 1.8 1.22 1.8 1.22 1.05 1.8 2.76 1.28 3.43.98.11-.77.41-1.28.75-1.58-2.57-.29-5.27-1.29-5.27-5.75 0-1.27.45-2.31 1.2-3.13-.12-.29-.52-1.47.11-3.06 0 0 .98-.31 3.2 1.19a11.03 11.03 0 0 1 5.82 0c2.22-1.5 3.2-1.19 3.2-1.19.63 1.59.23 2.77.11 3.06.75.82 1.2 1.86 1.2 3.13 0 4.48-2.71 5.45-5.3 5.74.42.36.8 1.08.8 2.18v3.24c0 .31.21.68.8.56A11.5 11.5 0 0 0 12 .5Z"
+              />
+            </svg>
+            <span class="sr-only">GitHub</span>
+          </a>
+        </div>
       </nav>
       <main class="layout__main">
         <header class="layout__header">

--- a/changes/42e864f1-6ce1-430f-b514-ef6f0da140a8.json
+++ b/changes/42e864f1-6ce1-430f-b514-ef6f0da140a8.json
@@ -1,0 +1,7 @@
+{
+  "guid": "42e864f1-6ce1-430f-b514-ef6f0da140a8",
+  "occurred_at": "2025-11-03T06:47Z",
+  "change_type": "Feature",
+  "summary": "Added GitHub repository shortcut icon to the sidebar footer.",
+  "content_hash": "b2b84612672cad61ff33e6b42f1117715c554f5d7f57c84e7c5db0f010fc6b8a"
+}


### PR DESCRIPTION
## Summary
- add a GitHub shortcut icon to the sidebar footer that links to the repository
- style the new sidebar footer control for consistent hover and focus states
- record the UI addition in the change log catalogue

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69084f968598832d86badcd243f7c983