### PR TITLE
Relocate refresh control to sidebar footer

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -211,13 +211,17 @@ html {
   border-radius: 0.75rem;
 }
 
+
 .sidebar__footer {
   margin-top: auto;
   padding-top: var(--space-gap-base);
   display: flex;
+  align-items: center;
+  gap: var(--space-gap-tight);
 }
 
-.sidebar__footer-link {
+.sidebar__footer-link,
+.sidebar__footer-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -229,11 +233,23 @@ html {
   transition: background 0.2s ease, color 0.2s ease;
 }
 
+.sidebar__footer-button {
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
 .sidebar__footer-link:hover,
-.sidebar__footer-link:focus-visible {
+.sidebar__footer-link:focus-visible,
+.sidebar__footer-button:hover,
+.sidebar__footer-button:focus-visible {
   background: rgba(148, 163, 184, 0.25);
   color: #f8fafc;
   outline: none;
+}
+
+.sidebar__footer-button:focus-visible {
+  box-shadow: 0 0 0 2px rgba(148, 163, 184, 0.4);
 }
 
 .sidebar__footer-icon {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -325,6 +325,22 @@
           {% endblock %}
         </ul>
         <div class="sidebar__footer">
+          {% if has_authenticated_user %}
+            <button
+              type="button"
+              class="sidebar__footer-button"
+              data-force-refresh
+              data-force-refresh-broadcast="{{ 'true' if current_user and current_user.get('is_super_admin') else 'false' }}"
+              title="Force the browser to fetch the latest version of the application"
+            >
+              <svg class="sidebar__footer-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  d="M21 4.5a1 1 0 0 0-1-1h-5a1 1 0 0 0 0 2h2.59l-1.2 1.2a8 8 0 1 0 2.47 8.2 1 1 0 0 0-1.88-.68 6 6 0 1 1-1.86-6.13L14 9a1 1 0 0 0 1.41 1.41l4-4A1 1 0 0 0 21 5Z"
+                />
+              </svg>
+              <span class="sr-only">Refresh app</span>
+            </button>
+          {% endif %}
           <a
             class="sidebar__footer-link"
             href="https://github.com/bradhawkins85/MyPortal"
@@ -370,27 +386,11 @@
           {% endset %}
           {% set trimmed_header_actions = header_actions_content | trim %}
           {% if has_authenticated_user %}
-            <div class="header__actions" data-header-actions>
-              <button
-                type="button"
-                class="button button--ghost header__action"
-                data-force-refresh
-                data-force-refresh-broadcast="{{ 'true' if current_user and current_user.get('is_super_admin') else 'false' }}"
-                title="Force the browser to fetch the latest version of the application"
-              >
-                <span class="button__icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false">
-                    <path
-                      d="M21 4.5a1 1 0 0 0-1-1h-5a1 1 0 0 0 0 2h2.59l-1.2 1.2a8 8 0 1 0 2.47 8.2 1 1 0 0 0-1.88-.68 6 6 0 1 1-1.86-6.13L14 9a1 1 0 0 0 1.41 1.41l4-4A1 1 0 0 0 21 5z"
-                    />
-                  </svg>
-                </span>
-                <span class="button__label">Refresh app</span>
-              </button>
-              {% if trimmed_header_actions %}
+            {% if trimmed_header_actions %}
+              <div class="header__actions" data-header-actions>
                 {{ header_actions_content }}
-              {% endif %}
-            </div>
+              </div>
+            {% endif %}
           {% else %}
             {{ header_actions_content }}
           {% endif %}

--- a/changes/06f602b4-9721-4000-a76b-37da30408d1e.json
+++ b/changes/06f602b4-9721-4000-a76b-37da30408d1e.json
@@ -1,0 +1,7 @@
+{
+  "guid": "06f602b4-9721-4000-a76b-37da30408d1e",
+  "occurred_at": "2025-11-03T07:03Z",
+  "change_type": "Fix",
+  "summary": "Moved the refresh control to the sidebar footer beside the GitHub shortcut.",
+  "content_hash": "111b48c35cb2fa4f82535cff5dbcaf5a4a71870da2e935c5ea3d153281e25aed"
+}


### PR DESCRIPTION
## Summary
- move the refresh control into the sidebar footer beside the GitHub shortcut and simplify the header actions container
- update sidebar footer styles to accommodate button interactions and focus states
- record the layout adjustment in the change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690852c88b1c832d8f8fb2500f6ba773