### PR TITLE
Fix labour and status template cloning to restore admin modals

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -2083,12 +2083,24 @@
 
     function createRow() {
       if (template instanceof HTMLTemplateElement) {
-        const fragment = template.content.firstElementChild;
-        if (fragment) {
-          return fragment.cloneNode(true);
+        const fragmentClone = template.content.cloneNode(true);
+        const element = fragmentClone.firstElementChild;
+        if (element) {
+          return element;
         }
       }
-      return template.firstElementChild.cloneNode(true);
+      const fallback = template.firstElementChild;
+      if (fallback) {
+        return fallback.cloneNode(true);
+      }
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = template.innerHTML.trim();
+      const derived = wrapper.firstElementChild;
+      if (derived) {
+        return derived.cloneNode(true);
+      }
+      console.error('Ticket status row template is empty.');
+      return document.createElement('tr');
     }
 
     function addStatusRow() {
@@ -2252,12 +2264,24 @@
 
     function createRow() {
       if (template instanceof HTMLTemplateElement) {
-        const fragment = template.content.firstElementChild;
-        if (fragment) {
-          return fragment.cloneNode(true);
+        const fragmentClone = template.content.cloneNode(true);
+        const element = fragmentClone.firstElementChild;
+        if (element) {
+          return element;
         }
       }
-      return template.firstElementChild.cloneNode(true);
+      const fallback = template.firstElementChild;
+      if (fallback) {
+        return fallback.cloneNode(true);
+      }
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = template.innerHTML.trim();
+      const derived = wrapper.firstElementChild;
+      if (derived) {
+        return derived.cloneNode(true);
+      }
+      console.error('Labour type row template is empty.');
+      return document.createElement('tr');
     }
 
     function addRow() {

--- a/changes/db942ecd-1248-4675-8e53-56dc6dc2036f.json
+++ b/changes/db942ecd-1248-4675-8e53-56dc6dc2036f.json
@@ -1,0 +1,7 @@
+{
+  "guid": "db942ecd-1248-4675-8e53-56dc6dc2036f",
+  "occurred_at": "2025-11-03T07:01Z",
+  "change_type": "Fix",
+  "summary": "Prevented template cloning errors from breaking ticket status and labour type modals in the admin workspace.",
+  "content_hash": "babd55fe315575f92845b4f0f6e2475d40ddafe93d9c143067ed42829c167ac3"
+}


### PR DESCRIPTION
## Summary
- prevent the ticket status manager from throwing when template fragments cannot be cloned so the edit modal continues to open
- harden the labour type manager row cloning to guard against empty templates that previously prevented the manage modal from opening
- record the fix in the change log for synchronisation

## Testing
- pytest tests/test_ticket_statuses_service.py tests/test_ticket_portal_pages.py

------
https://chatgpt.com/codex/tasks/task_b_6908504aa498832db5371854064e7b04