### PR TITLE
Fix sidebar footer icon scaling behind CDN

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -255,6 +255,13 @@ html {
 .sidebar__footer-icon {
   width: 1.25rem;
   height: 1.25rem;
+  min-width: 1.25rem;
+  min-height: 1.25rem;
+  max-width: 1.25rem;
+  max-height: 1.25rem;
+  flex: 0 0 1.25rem;
+  aspect-ratio: 1 / 1;
+  display: block;
   fill: currentColor;
 }
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -333,9 +333,18 @@
               data-force-refresh-broadcast="{{ 'true' if current_user and current_user.get('is_super_admin') else 'false' }}"
               title="Force the browser to fetch the latest version of the application"
             >
-              <svg class="sidebar__footer-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <svg
+                class="sidebar__footer-icon"
+                viewBox="0 0 24 24"
+                width="20"
+                height="20"
+                preserveAspectRatio="xMidYMid meet"
+                aria-hidden="true"
+                focusable="false"
+              >
                 <path
                   d="M21 4.5a1 1 0 0 0-1-1h-5a1 1 0 0 0 0 2h2.59l-1.2 1.2a8 8 0 1 0 2.47 8.2 1 1 0 0 0-1.88-.68 6 6 0 1 1-1.86-6.13L14 9a1 1 0 0 0 1.41 1.41l4-4A1 1 0 0 0 21 5Z"
+                  fill="currentColor"
                 />
               </svg>
               <span class="sr-only">Refresh app</span>
@@ -348,9 +357,18 @@
             rel="noopener noreferrer"
             aria-label="View MyPortal on GitHub"
           >
-            <svg class="sidebar__footer-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <svg
+              class="sidebar__footer-icon"
+              viewBox="0 0 24 24"
+              width="20"
+              height="20"
+              preserveAspectRatio="xMidYMid meet"
+              aria-hidden="true"
+              focusable="false"
+            >
               <path
                 d="M12 .5a11.5 11.5 0 0 0-3.64 22.41c.58.11.79-.25.79-.56v-1.99c-3.22.7-3.9-1.55-3.9-1.55-.53-1.34-1.3-1.7-1.3-1.7-1.07-.74.08-.72.08-.72 1.18.09 1.8 1.22 1.8 1.22 1.05 1.8 2.76 1.28 3.43.98.11-.77.41-1.28.75-1.58-2.57-.29-5.27-1.29-5.27-5.75 0-1.27.45-2.31 1.2-3.13-.12-.29-.52-1.47.11-3.06 0 0 .98-.31 3.2 1.19a11.03 11.03 0 0 1 5.82 0c2.22-1.5 3.2-1.19 3.2-1.19.63 1.59.23 2.77.11 3.06.75.82 1.2 1.86 1.2 3.13 0 4.48-2.71 5.45-5.3 5.74.42.36.8 1.08.8 2.18v3.24c0 .31.21.68.8.56A11.5 11.5 0 0 0 12 .5Z"
+                fill="currentColor"
               />
             </svg>
             <span class="sr-only">GitHub</span>

--- a/changes/544520d0-a981-456e-a5e3-0d785232ff11.json
+++ b/changes/544520d0-a981-456e-a5e3-0d785232ff11.json
@@ -1,0 +1,7 @@
+{
+  "guid": "544520d0-a981-456e-a5e3-0d785232ff11",
+  "occurred_at": "2024-05-26T10:30Z",
+  "change_type": "Fix",
+  "summary": "Stabilised sidebar footer icons so GitHub link and refresh arrow retain size behind CDN optimisations.",
+  "content_hash": "926ed18cc4ec85cbfa13d4b9721e4b4dd00b55c9af317f95dcde204d32067618"
+}


### PR DESCRIPTION
## Summary
- lock the sidebar footer icon dimensions so SVGs remain square even after CDN optimisation
- add explicit sizing metadata to the refresh and GitHub icons in the base template
- record the fix in the change log directory

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6908550fc68c832d93894eb4fa10df09