### PR TITLE
Fix ticket tools menu dropdown for CDN compatibility

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -962,7 +962,8 @@ html {
   transition: transform 0.2s ease;
 }
 
-[data-header-menu][open] .header-title-menu__icon {
+[data-header-menu][open] .header-title-menu__icon,
+[data-header-menu].is-open .header-title-menu__icon {
   transform: rotate(180deg);
 }
 

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -540,6 +540,7 @@
     }
 
     const toggleLookup = new Map();
+    const listLookup = new Map();
 
     function getToggle(menu) {
       if (toggleLookup.has(menu)) {
@@ -552,19 +553,57 @@
       return toggle;
     }
 
+    function getList(menu) {
+      if (listLookup.has(menu)) {
+        return listLookup.get(menu);
+      }
+      const list = menu.querySelector('[data-header-menu-list]');
+      if (list) {
+        listLookup.set(menu, list);
+      }
+      return list;
+    }
+
+    function isMenuOpen(menu) {
+      return menu.classList.contains('is-open');
+    }
+
+    function focusFirstItem(menu) {
+      const list = getList(menu);
+      if (!list) {
+        return;
+      }
+      const focusable = Array.from(
+        list.querySelectorAll(
+          '[role="menuitem"], a[href]:not([aria-disabled="true"]), button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ),
+      ).find((element) => !element.hasAttribute('disabled') && element.getAttribute('aria-disabled') !== 'true');
+      if (focusable) {
+        try {
+          focusable.focus({ preventScroll: true });
+        } catch (error) {
+          focusable.focus();
+        }
+      }
+    }
+
     function updateToggle(menu) {
       const toggle = getToggle(menu);
       if (toggle) {
-        toggle.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+        toggle.setAttribute('aria-expanded', isMenuOpen(menu) ? 'true' : 'false');
       }
     }
 
     function closeMenu(menu, options) {
       const settings = options || {};
-      if (!menu.open) {
+      if (!isMenuOpen(menu)) {
         return;
       }
-      menu.removeAttribute('open');
+      menu.classList.remove('is-open');
+      const list = getList(menu);
+      if (list) {
+        list.hidden = true;
+      }
       updateToggle(menu);
       if (settings.focusToggle) {
         const toggle = getToggle(menu);
@@ -578,18 +617,64 @@
       }
     }
 
+    function openMenu(menu, options) {
+      const settings = options || {};
+      if (isMenuOpen(menu)) {
+        return;
+      }
+      menus.forEach((other) => {
+        if (other !== menu) {
+          closeMenu(other);
+        }
+      });
+      menu.classList.add('is-open');
+      const list = getList(menu);
+      if (list) {
+        list.hidden = false;
+      }
+      updateToggle(menu);
+      if (settings.focusFirstItem) {
+        focusFirstItem(menu);
+      }
+    }
+
     menus.forEach((menu) => {
+      const list = getList(menu);
+      if (list) {
+        list.hidden = !isMenuOpen(menu);
+      }
       updateToggle(menu);
 
-      menu.addEventListener('toggle', () => {
-        if (menu.open) {
-          menus.forEach((other) => {
-            if (other !== menu) {
-              closeMenu(other);
-            }
-          });
+      const toggle = getToggle(menu);
+      if (!toggle) {
+        return;
+      }
+
+      toggle.addEventListener('click', (event) => {
+        event.preventDefault();
+        if (isMenuOpen(menu)) {
+          closeMenu(menu, { focusToggle: false });
+        } else {
+          openMenu(menu);
         }
-        updateToggle(menu);
+      });
+
+      toggle.addEventListener('keydown', (event) => {
+        if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          if (!isMenuOpen(menu)) {
+            openMenu(menu, { focusFirstItem: true });
+          } else {
+            focusFirstItem(menu);
+          }
+        } else if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          if (isMenuOpen(menu)) {
+            closeMenu(menu, { focusToggle: false });
+          } else {
+            openMenu(menu, { focusFirstItem: true });
+          }
+        }
       });
     });
 

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -9,15 +9,22 @@
   <div class="header-title-menu">
     <span class="header-title-menu__label">Ticketing workspace</span>
     {% if show_ticket_tools %}
-      <details class="header-title-menu__dropdown" data-header-menu>
-        <summary class="header-title-menu__toggle" data-header-menu-toggle aria-haspopup="true">
+      <div class="header-title-menu__dropdown" data-header-menu>
+        <button
+          type="button"
+          class="header-title-menu__toggle"
+          data-header-menu-toggle
+          aria-haspopup="true"
+          aria-controls="ticket-tools-menu"
+          aria-expanded="false"
+        >
           Ticket tools
           <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" class="header-title-menu__icon">
             <path d="M6.2 8.2a1 1 0 0 1 1.4 0L12 12.6l4.4-4.4a1 1 0 0 1 1.4 1.4l-5.1 5.1a1 1 0 0 1-1.4 0L6.2 9.6a1 1 0 0 1 0-1.4z" />
           </svg>
           <span class="visually-hidden">Toggle ticket tools menu</span>
-        </summary>
-        <ul class="header-title-menu__list" role="menu">
+        </button>
+        <ul class="header-title-menu__list" id="ticket-tools-menu" role="menu" data-header-menu-list>
           {% if show_ticket_automations %}
             <li class="header-title-menu__item" role="none">
               <a href="/admin/automations" class="header-title-menu__link" role="menuitem">Ticket automations</a>
@@ -57,7 +64,7 @@
             </li>
           {% endif %}
         </ul>
-      </details>
+      </div>
     {% endif %}
   </div>
 {% endblock %}

--- a/changes/79dd602d-11fd-41a1-804c-b49f63804550.json
+++ b/changes/79dd602d-11fd-41a1-804c-b49f63804550.json
@@ -1,0 +1,7 @@
+{
+  "guid": "79dd602d-11fd-41a1-804c-b49f63804550",
+  "occurred_at": "2025-11-03T07:25:00Z",
+  "change_type": "Fix",
+  "summary": "Fix ticket tools menu not rendering when proxied by CDN",
+  "content_hash": "fa7c7a2ad6401be0a95016f69f69eeb51b4016fd8254298eb65ef10dc9607b57"
+}


### PR DESCRIPTION
## Summary
- replace the ticket tools header dropdown with a custom button-driven menu that works when responses are cached behind CDNs
- enhance the shared header menu script to manage non-`<details>` menus, including accessibility focus handling
- document the fix in the change log for import into the database

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690858487124832db67a8e32822036fc