### PR TITLE
Fix Manage labour types modal visibility

### DIFF
--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -537,6 +537,8 @@
   </template>
 </div>
 
+</div>
+
 <div
   class="modal"
   id="edit-labour-types-modal"

--- a/changes/e66ca5c8-d04b-4f4d-a0e1-9ea24fe9acfa.json
+++ b/changes/e66ca5c8-d04b-4f4d-a0e1-9ea24fe9acfa.json
@@ -1,0 +1,7 @@
+{
+  "guid": "e66ca5c8-d04b-4f4d-a0e1-9ea24fe9acfa",
+  "occurred_at": "2025-11-03T07:30Z",
+  "change_type": "Fix",
+  "summary": "Resolved Manage labour types modal not opening by closing the ticket status modal wrapper.",
+  "content_hash": "eee1146e083e33cecb208d69d37ad2fd0450787870dab547f5ddf86ba25765ce"
+}


### PR DESCRIPTION
## Summary
- close the ticket status modal wrapper so the Manage labour types dialog renders independently
- log the modal fix in the change log for auditing

## Testing
- pytest tests/test_ticket_portal_pages.py

------
https://chatgpt.com/codex/tasks/task_b_69085642cb30832d92b3d3cf0816b78b