### PR TITLE
Fix Ticket tools dropdown initialization behind Cloudflare

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -542,6 +542,10 @@
     const toggleLookup = new Map();
     const listLookup = new Map();
 
+    function isDetailsMenu(menu) {
+      return typeof HTMLDetailsElement !== 'undefined' && menu instanceof HTMLDetailsElement;
+    }
+
     function getToggle(menu) {
       if (toggleLookup.has(menu)) {
         return toggleLookup.get(menu);
@@ -565,7 +569,7 @@
     }
 
     function isMenuOpen(menu) {
-      return menu.classList.contains('is-open');
+      return menu.classList.contains('is-open') || (isDetailsMenu(menu) && menu.open);
     }
 
     function focusFirstItem(menu) {
@@ -600,6 +604,9 @@
         return;
       }
       menu.classList.remove('is-open');
+      if (isDetailsMenu(menu)) {
+        menu.open = false;
+      }
       const list = getList(menu);
       if (list) {
         list.hidden = true;
@@ -628,6 +635,9 @@
         }
       });
       menu.classList.add('is-open');
+      if (isDetailsMenu(menu)) {
+        menu.open = true;
+      }
       const list = getList(menu);
       if (list) {
         list.hidden = false;
@@ -651,7 +661,9 @@
       }
 
       toggle.addEventListener('click', (event) => {
-        event.preventDefault();
+        if (toggle.tagName !== 'SUMMARY') {
+          event.preventDefault();
+        }
         if (isMenuOpen(menu)) {
           closeMenu(menu, { focusToggle: false });
         } else {
@@ -676,6 +688,29 @@
           }
         }
       });
+      if (isDetailsMenu(menu)) {
+        menu.addEventListener('toggle', () => {
+          if (menu.open) {
+            menus.forEach((other) => {
+              if (other !== menu) {
+                closeMenu(other);
+              }
+            });
+            menu.classList.add('is-open');
+            const list = getList(menu);
+            if (list) {
+              list.hidden = false;
+            }
+          } else {
+            menu.classList.remove('is-open');
+            const list = getList(menu);
+            if (list) {
+              list.hidden = true;
+            }
+          }
+          updateToggle(menu);
+        });
+      }
     });
 
     document.addEventListener('click', (event) => {

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -9,9 +9,8 @@
   <div class="header-title-menu">
     <span class="header-title-menu__label">Ticketing workspace</span>
     {% if show_ticket_tools %}
-      <div class="header-title-menu__dropdown" data-header-menu>
-        <button
-          type="button"
+      <details class="header-title-menu__dropdown" data-header-menu>
+        <summary
           class="header-title-menu__toggle"
           data-header-menu-toggle
           aria-haspopup="true"
@@ -23,7 +22,7 @@
             <path d="M6.2 8.2a1 1 0 0 1 1.4 0L12 12.6l4.4-4.4a1 1 0 0 1 1.4 1.4l-5.1 5.1a1 1 0 0 1-1.4 0L6.2 9.6a1 1 0 0 1 0-1.4z" />
           </svg>
           <span class="visually-hidden">Toggle ticket tools menu</span>
-        </button>
+        </summary>
         <ul class="header-title-menu__list" id="ticket-tools-menu" role="menu" data-header-menu-list>
           {% if show_ticket_automations %}
             <li class="header-title-menu__item" role="none">
@@ -64,7 +63,7 @@
             </li>
           {% endif %}
         </ul>
-      </div>
+      </details>
     {% endif %}
   </div>
 {% endblock %}

--- a/changes/e64a320f-0981-4366-ad0c-e3a11d3864f0.json
+++ b/changes/e64a320f-0981-4366-ad0c-e3a11d3864f0.json
@@ -1,0 +1,7 @@
+{
+  "guid": "e64a320f-0981-4366-ad0c-e3a11d3864f0",
+  "occurred_at": "2025-11-03T11:51:00Z",
+  "change_type": "Fix",
+  "summary": "Hardened the Ticket tools dropdown so it remains functional behind Cloudflare by using details/summary markup with resilient scripting.",
+  "content_hash": "e08baf6a6c6129e1d24b5d53104e51338af237619a29763ab02609f9ae31cc33"
+}


### PR DESCRIPTION
## Summary
- switch the Ticket tools workspace menu to a details/summary structure so it remains usable when JavaScript is deferred by Cloudflare
- update the header menu controller to understand details elements, keeping accessibility and keyboard support intact
- record the regression fix in the change log metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_6908963de904832dbdf12aca6aa6d746