### PR TITLE
Fix package cart redirect URL

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4036,7 +4036,10 @@ async def add_package_to_cart(request: Request) -> RedirectResponse:
         added_by=user.get("id") if user else None,
     )
 
-    return RedirectResponse(url=request.url_for("shop_packages_page"), status_code=status.HTTP_303_SEE_OTHER)
+    return RedirectResponse(
+        url=f"{request.url_for('shop_page')}?category=packages",
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
 
 
 @app.get("/cart", response_class=HTMLResponse, name="cart_page")

--- a/changes/9bea82e7-3bc0-49a6-91b1-1795c402818f.json
+++ b/changes/9bea82e7-3bc0-49a6-91b1-1795c402818f.json
@@ -1,0 +1,7 @@
+{
+  "guid": "9bea82e7-3bc0-49a6-91b1-1795c402818f",
+  "occurred_at": "2025-11-03T11:53:04Z",
+  "change_type": "Fix",
+  "summary": "Redirected package cart success flow to the packages category view on the main shop page.",
+  "content_hash": "bcf0ce9544fda5ae0903c6ff5194bcd6e0adaf6d537b1f2c311a82ba6246d2c7"
+}


### PR DESCRIPTION
## Summary
- redirect package add-to-cart success flow back to the main shop page filtered to packages
- record the change in the change log

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_69089710fd84832d880c62276afc858e