### PR TITLE
Add dynamic active asset automation variable

### DIFF
--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -225,7 +225,7 @@ async def _execute_automation(
                     if isinstance(payload_source, Mapping)
                     else {}
                 )
-                module_payload = value_templates.render_value(module_payload, context)
+                module_payload = await value_templates.render_value_async(module_payload, context)
                 if context:
                     module_payload.setdefault("context", context)
                 try:
@@ -289,7 +289,7 @@ async def _execute_automation(
                 payload = {}
             module_slug = automation.get("action_module")
             if module_slug:
-                module_payload = value_templates.render_value(dict(payload), context)
+                module_payload = await value_templates.render_value_async(dict(payload), context)
                 if context:
                     module_payload.setdefault("context", context)
                 result_payload = await modules_service.trigger_module(

--- a/app/services/dynamic_variables.py
+++ b/app/services/dynamic_variables.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from app.repositories import assets as assets_repo
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_int(value: Any) -> int | None:
+    try:
+        candidate = int(value)
+    except (TypeError, ValueError):
+        return None
+    if candidate < 0:
+        return None
+    return candidate
+
+
+def _extract_company_id(
+    context: Mapping[str, Any] | None,
+    base_tokens: Mapping[str, Any] | None,
+) -> int | None:
+    if isinstance(context, Mapping):
+        direct = _coerce_int(context.get("company_id"))
+        if direct is not None:
+            return direct
+        company = context.get("company")
+        if isinstance(company, Mapping):
+            company_id = _coerce_int(company.get("id") or company.get("company_id"))
+            if company_id is not None:
+                return company_id
+        ticket = context.get("ticket")
+        if isinstance(ticket, Mapping):
+            ticket_company = _coerce_int(ticket.get("company_id") or ticket.get("companyId"))
+            if ticket_company is not None:
+                return ticket_company
+            ticket_company_entry = ticket.get("company")
+            if isinstance(ticket_company_entry, Mapping):
+                ticket_company_id = _coerce_int(
+                    ticket_company_entry.get("id") or ticket_company_entry.get("company_id")
+                )
+                if ticket_company_id is not None:
+                    return ticket_company_id
+    if isinstance(base_tokens, Mapping):
+        for key in ("TICKET_COMPANY_ID", "COMPANY_ID"):
+            value = base_tokens.get(key)
+            company_id = _coerce_int(value)
+            if company_id is not None:
+                return company_id
+    return None
+
+
+def _extract_active_asset_requests(tokens: Iterable[str]) -> dict[str, int | None]:
+    requests: dict[str, int | None] = {}
+    for token in tokens:
+        if not token:
+            continue
+        upper = token.upper()
+        if upper == "ACTIVE_ASSETS":
+            requests[token] = None
+            continue
+        if not upper.startswith("ACTIVE_ASSETS:"):
+            continue
+        parts = token.split(":", 1)
+        if len(parts) != 2:
+            continue
+        suffix = parts[1].strip()
+        try:
+            days = int(suffix)
+        except (TypeError, ValueError):
+            continue
+        if days < 0:
+            continue
+        requests[token] = days
+    return requests
+
+
+async def build_dynamic_token_map(
+    tokens: Iterable[str],
+    context: Mapping[str, Any] | None,
+    *,
+    base_tokens: Mapping[str, Any] | None = None,
+) -> dict[str, str]:
+    requests = _extract_active_asset_requests(tokens)
+    if not requests:
+        return {}
+
+    company_id = _extract_company_id(context, base_tokens)
+    now = _utcnow()
+
+    unique_durations: list[int | None] = []
+    for duration in requests.values():
+        if duration not in unique_durations:
+            unique_durations.append(duration)
+
+    counts: dict[int | None, str] = {}
+    for duration in unique_durations:
+        if duration is None:
+            since = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        else:
+            since = now - timedelta(days=duration)
+        count = await assets_repo.count_active_assets(company_id=company_id, since=since)
+        counts[duration] = str(count)
+
+    return {token: counts[duration] for token, duration in requests.items()}

--- a/app/services/notifications.py
+++ b/app/services/notifications.py
@@ -98,7 +98,7 @@ async def emit_notification(
     template = str(event_setting.get("message_template") or "{{ message }}")
     rendered_message: str | None = None
     try:
-        rendered = value_templates.render_string(template, context)
+        rendered = await value_templates.render_string_async(template, context)
     except Exception as exc:  # pragma: no cover - template guard
         logger.error(
             "Failed to render notification message template",
@@ -108,7 +108,7 @@ async def emit_notification(
         rendered = None
 
     if isinstance(rendered, (dict, list)):
-        rendered_message = value_templates.render_value(rendered, context)
+        rendered_message = await value_templates.render_value_async(rendered, context)
         rendered_message = str(rendered_message)
     elif rendered is not None:
         rendered_message = str(rendered)
@@ -236,7 +236,7 @@ async def emit_notification(
             else:
                 payload_source = payload or {}
             try:
-                rendered_payload = value_templates.render_value(payload_source, context)
+                rendered_payload = await value_templates.render_value_async(payload_source, context)
                 if isinstance(rendered_payload, Mapping):
                     payload_data = dict(rendered_payload)
                 else:

--- a/changes/edd29b93-52ea-4c18-aaa1-d8709d0612ad.json
+++ b/changes/edd29b93-52ea-4c18-aaa1-d8709d0612ad.json
@@ -1,0 +1,7 @@
+{
+  "guid": "edd29b93-52ea-4c18-aaa1-d8709d0612ad",
+  "occurred_at": "2025-11-03T13:21:00Z",
+  "change_type": "Feature",
+  "summary": "Added ACTIVE_ASSETS automation variable with day-range support.",
+  "content_hash": "af1a2a020ed578ac01b38e70fbf399a360b4603f58c3a5155834b03e76786ce4"
+}

--- a/docs/automation-variables.md
+++ b/docs/automation-variables.md
@@ -65,6 +65,9 @@ emails or webhook requests). Newly added tokens include:
 | `{{ TICKET_LATEST_REPLY_BODY }}` | Body of the most recent reply. |
 | `{{ TICKET_LATEST_REPLY_AUTHOR_EMAIL }}` | Email for the author of the latest reply. |
 | `{{ TICKET_LATEST_REPLY_AUTHOR_DISPLAY_NAME }}` | Display name for the latest reply author. |
+| `{{ ACTIVE_ASSETS }}` / `{{ ACTIVE_ASSETS:7 }}` | Count of assets that synced in the current month, or within the last `N` days when the `:N` suffix is provided. |
+
+`{{ ACTIVE_ASSETS }}` tokens scope to the company in the current automation context when available (for example a ticket's company). When no company is present the counts cover the entire tenant. The default form returns assets with a Syncro sync timestamp in the current month; append `:N` to evaluate the past `N` days such as `{{ ACTIVE_ASSETS:1 }}` for the past day.
 
 ## Message templates
 

--- a/tests/test_assets_repository.py
+++ b/tests/test_assets_repository.py
@@ -1,0 +1,34 @@
+import asyncio
+from datetime import datetime, timezone
+
+from app.repositories import assets as assets_repo
+
+
+def test_count_active_assets_builds_expected_query(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_one(sql, params=None):
+        captured["sql"] = sql
+        captured["params"] = params
+        return {"total": 7}
+
+    monkeypatch.setattr(assets_repo.db, "fetch_one", fake_fetch_one)
+
+    since = datetime(2024, 4, 20, 15, 30, tzinfo=timezone.utc)
+    result = asyncio.run(assets_repo.count_active_assets(company_id="5", since=since))
+
+    assert result == 7
+    assert "company_id = %s" in captured["sql"]
+    assert "last_sync >= %s" in captured["sql"]
+    assert captured["params"] == (5, "2024-04-20 15:30:00")
+
+
+def test_count_active_assets_handles_empty_results(monkeypatch):
+    async def fake_fetch_one(sql, params=None):
+        return None
+
+    monkeypatch.setattr(assets_repo.db, "fetch_one", fake_fetch_one)
+
+    result = asyncio.run(assets_repo.count_active_assets())
+
+    assert result == 0

--- a/tests/test_value_templates_dynamic.py
+++ b/tests/test_value_templates_dynamic.py
@@ -1,0 +1,42 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from app.services import dynamic_variables, value_templates
+
+
+def test_render_value_async_populates_active_assets(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    async def fake_count_active_assets(*, company_id=None, since=None):
+        calls.append({"company_id": company_id, "since": since})
+        return 5 if len(calls) == 1 else 2
+
+    monkeypatch.setattr(
+        dynamic_variables.assets_repo,
+        "count_active_assets",
+        fake_count_active_assets,
+    )
+
+    fixed_now = datetime(2024, 4, 20, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dynamic_variables, "_utcnow", lambda: fixed_now)
+
+    payload = {
+        "monthly": "{{ ACTIVE_ASSETS }}",
+        "custom": "{{ ACTIVE_ASSETS:7 }}",
+    }
+    context = {"ticket": {"company_id": 42}}
+
+    result = asyncio.run(value_templates.render_value_async(payload, context))
+
+    assert result["monthly"] == "5"
+    assert result["custom"] == "2"
+    assert len(calls) == 2
+
+    first_call = calls[0]
+    second_call = calls[1]
+
+    assert first_call["company_id"] == 42
+    assert first_call["since"] == datetime(2024, 4, 1, tzinfo=timezone.utc)
+
+    assert second_call["company_id"] == 42
+    assert second_call["since"] == fixed_now - timedelta(days=7)


### PR DESCRIPTION
## Summary
- add a reusable dynamic variable provider for active asset counts with optional day ranges
- expose the new ACTIVE_ASSETS token through the async template renderer and document its usage
- cover the behaviour with focused repository and template tests plus a change log entry

## Testing
- `pytest tests/test_assets_repository.py tests/test_value_templates_dynamic.py tests/test_notifications_service.py tests/test_automations_service.py`


------
https://chatgpt.com/codex/tasks/task_b_6908aa4cf670832db9cf4fe3aef47ffd