### PR TITLE
Add Tactical RMM asset sync and ticket asset linking

### DIFF
--- a/app/repositories/companies.py
+++ b/app/repositories/companies.py
@@ -42,6 +42,18 @@ async def get_company_by_syncro_id(syncro_company_id: str) -> Optional[dict[str,
     return company
 
 
+async def get_company_by_tactical_id(tactical_client_id: str) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one(
+        "SELECT * FROM companies WHERE tacticalrmm_client_id = %s",
+        (tactical_client_id,),
+    )
+    if not row:
+        return None
+    company = _normalise_company(row)
+    company["email_domains"] = await get_email_domains_for_company(company["id"])
+    return company
+
+
 async def get_company_by_name(name: str) -> Optional[dict[str, Any]]:
     row = await db.fetch_one(
         "SELECT * FROM companies WHERE LOWER(name) = LOWER(%s) LIMIT 1",

--- a/app/schemas/assets.py
+++ b/app/schemas/assets.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class AssetResponse(BaseModel):
+    id: int
+    company_id: int
+    name: str
+    type: Optional[str] = None
+    serial_number: Optional[str] = None
+    status: Optional[str] = None
+    os_name: Optional[str] = None
+    cpu_name: Optional[str] = None
+    ram_gb: Optional[float] = None
+    hdd_size: Optional[str] = None
+    last_sync: Optional[datetime] = None
+    motherboard_manufacturer: Optional[str] = None
+    form_factor: Optional[str] = None
+    last_user: Optional[str] = None
+    approx_age: Optional[float] = None
+    performance_score: Optional[float] = None
+    warranty_status: Optional[str] = None
+    warranty_end_date: Optional[date] = None
+    syncro_asset_id: Optional[str] = None
+    tactical_asset_id: Optional[str] = None

--- a/app/schemas/companies.py
+++ b/app/schemas/companies.py
@@ -12,6 +12,7 @@ class CompanyBase(BaseModel):
     address: Optional[str] = None
     is_vip: Optional[int] = None
     syncro_company_id: Optional[str] = None
+    tacticalrmm_client_id: Optional[str] = None
     xero_id: Optional[str] = None
     email_domains: list[str] = Field(default_factory=list)
 
@@ -33,6 +34,7 @@ class CompanyUpdate(BaseModel):
     address: Optional[str] = None
     is_vip: Optional[int] = None
     syncro_company_id: Optional[str] = None
+    tacticalrmm_client_id: Optional[str] = None
     xero_id: Optional[str] = None
     email_domains: Optional[list[str]] = None
 

--- a/app/services/asset_importer.py
+++ b/app/services/asset_importer.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
-from app.core.logging import log_info
+from app.core.logging import log_error, log_info
 from app.repositories import assets as assets_repo
 from app.repositories import companies as company_repo
-from app.services import syncro
+from app.services import syncro, tacticalrmm
 
 
 def _clean_string(value: Any) -> str | None:
@@ -85,3 +86,121 @@ async def import_assets_for_company(
         total=len(assets),
     )
     return processed
+
+
+async def import_tactical_assets_for_company(
+    company_id: int,
+    *,
+    tactical_client_id: str | None = None,
+) -> int:
+    company = await company_repo.get_company_by_id(company_id)
+    if not company:
+        raise ValueError(f"Company {company_id} not found")
+    client_identifier = tactical_client_id or company.get("tacticalrmm_client_id")
+    if not client_identifier:
+        raise tacticalrmm.TacticalRMMConfigurationError("Company is missing a Tactical RMM mapping")
+
+    client_id = str(client_identifier).strip()
+    log_info(
+        "Starting Tactical RMM asset import",
+        company_id=company_id,
+        tactical_client_id=client_id,
+    )
+    agents = await tacticalrmm.fetch_agents(client_id)
+    processed = 0
+    seen: set[tuple[str | None, str | None, str]] = set()
+
+    for agent in agents:
+        if not isinstance(agent, Mapping):
+            continue
+        details = tacticalrmm.extract_agent_details(agent)
+        name = _clean_string(details.get("name")) or "Asset"
+        serial = _clean_string(details.get("serial_number"))
+        tactical_id = _clean_string(details.get("tactical_asset_id"))
+        dedupe_key = (tactical_id, serial, name.lower())
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        await assets_repo.upsert_asset(
+            company_id=company_id,
+            name=name,
+            type=_clean_string(details.get("type")),
+            serial_number=serial,
+            status=_clean_string(details.get("status")),
+            os_name=_clean_string(details.get("os_name")),
+            cpu_name=_clean_string(details.get("cpu_name")),
+            ram_gb=details.get("ram_gb"),
+            hdd_size=_clean_string(details.get("hdd_size")),
+            last_sync=details.get("last_sync"),
+            motherboard_manufacturer=_clean_string(details.get("motherboard_manufacturer")),
+            form_factor=_clean_string(details.get("form_factor")),
+            last_user=_clean_string(details.get("last_user")),
+            approx_age=details.get("approx_age"),
+            performance_score=details.get("performance_score"),
+            warranty_status=_clean_string(details.get("warranty_status")),
+            warranty_end_date=details.get("warranty_end_date"),
+            tactical_asset_id=tactical_id,
+            match_name=True,
+        )
+        processed += 1
+
+    log_info(
+        "Completed Tactical RMM asset import",
+        company_id=company_id,
+        tactical_client_id=client_id,
+        processed=processed,
+        total=len(agents),
+    )
+    return processed
+
+
+async def import_all_tactical_assets() -> dict[str, Any]:
+    companies = await company_repo.list_companies()
+    summary: dict[str, Any] = {
+        "processed": 0,
+        "companies": {},
+        "skipped": [],
+    }
+
+    for company in companies:
+        raw_company_id = company.get("id")
+        try:
+            company_id = int(raw_company_id)
+        except (TypeError, ValueError):
+            continue
+        client_identifier = _clean_string(company.get("tacticalrmm_client_id"))
+        if not client_identifier:
+            summary["skipped"].append(
+                {"company_id": company_id, "reason": "missing_mapping"}
+            )
+            continue
+        try:
+            processed = await import_tactical_assets_for_company(
+                company_id,
+                tactical_client_id=client_identifier,
+            )
+        except tacticalrmm.TacticalRMMConfigurationError as exc:
+            log_error(
+                "Skipping Tactical RMM asset import",
+                company_id=company_id,
+                error=str(exc),
+            )
+            summary["skipped"].append(
+                {"company_id": company_id, "reason": str(exc)}
+            )
+            continue
+        except tacticalrmm.TacticalRMMAPIError as exc:
+            log_error(
+                "Tactical RMM asset import failed",
+                company_id=company_id,
+                error=str(exc),
+            )
+            summary["skipped"].append(
+                {"company_id": company_id, "reason": str(exc)}
+            )
+            continue
+
+        summary["companies"][company_id] = {"processed": processed}
+        summary["processed"] += processed
+
+    return summary

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -153,6 +153,17 @@ class SchedulerService:
                 company_id = task.get("company_id")
                 if company_id:
                     await asset_importer.import_assets_for_company(int(company_id))
+            elif command == "sync_tactical_assets":
+                company_id = task.get("company_id")
+                if company_id:
+                    processed = await asset_importer.import_tactical_assets_for_company(int(company_id))
+                    details = json.dumps(
+                        {"company_id": int(company_id), "processed": processed},
+                        default=str,
+                    )
+                else:
+                    summary = await asset_importer.import_all_tactical_assets()
+                    details = json.dumps(summary, default=str)
             elif command == "sync_o365":
                 company_id = task.get("company_id")
                 if company_id:

--- a/app/services/tacticalrmm.py
+++ b/app/services/tacticalrmm.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from time import monotonic
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlparse
+
+from app.core.logging import log_error, log_info
+from app.repositories import integration_modules as module_repo
+from app.services import modules as modules_service
+from app.services.modules import _coerce_settings
+
+
+class TacticalRMMConfigurationError(RuntimeError):
+    """Raised when the Tactical RMM module is missing or misconfigured."""
+
+
+class TacticalRMMAPIError(RuntimeError):
+    """Raised when Tactical RMM responds with an error payload."""
+
+
+_MODULE_SETTINGS_CACHE: dict[str, Any] | None = None
+_MODULE_SETTINGS_EXPIRY: float = 0.0
+_MODULE_SETTINGS_LOCK = asyncio.Lock()
+
+
+def _clean_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    if isinstance(value, (int, float)):
+        text = str(value)
+        return text.strip() or None
+    return None
+
+
+async def _load_settings() -> dict[str, Any]:
+    global _MODULE_SETTINGS_CACHE, _MODULE_SETTINGS_EXPIRY
+    now = monotonic()
+    if _MODULE_SETTINGS_CACHE and now < _MODULE_SETTINGS_EXPIRY:
+        return _MODULE_SETTINGS_CACHE
+    async with _MODULE_SETTINGS_LOCK:
+        now = monotonic()
+        if _MODULE_SETTINGS_CACHE and now < _MODULE_SETTINGS_EXPIRY:
+            return _MODULE_SETTINGS_CACHE
+        module = await module_repo.get_module("tacticalrmm")
+        if not module:
+            raise TacticalRMMConfigurationError("Tactical RMM module is not configured")
+        raw_settings: Mapping[str, Any] | None
+        if isinstance(module.get("settings"), Mapping):
+            raw_settings = module["settings"]  # type: ignore[index]
+        else:
+            raw_settings = None
+            if isinstance(module.get("settings"), str):
+                try:
+                    raw_settings = json.loads(module["settings"])  # type: ignore[index]
+                except json.JSONDecodeError:
+                    raw_settings = None
+        settings = _coerce_settings("tacticalrmm", raw_settings, module)
+        base_url = _clean_text(settings.get("base_url"))
+        api_key = _clean_text(settings.get("api_key"))
+        if not base_url:
+            raise TacticalRMMConfigurationError("Tactical RMM base URL is not configured")
+        if not api_key:
+            raise TacticalRMMConfigurationError("Tactical RMM API key is not configured")
+        verify_ssl = bool(settings.get("verify_ssl", True))
+        cached = {
+            "base_url": base_url.rstrip("/"),
+            "api_key": api_key,
+            "verify_ssl": verify_ssl,
+        }
+        _MODULE_SETTINGS_CACHE = cached
+        _MODULE_SETTINGS_EXPIRY = now + 30.0
+        return cached
+
+
+async def _call_endpoint(endpoint: str) -> Any:
+    payload = {"endpoint": endpoint, "method": "GET"}
+    try:
+        result = await modules_service.trigger_module("tacticalrmm", payload, background=False)
+    except ValueError as exc:
+        raise TacticalRMMConfigurationError(str(exc)) from exc
+    status = str(result.get("status") or "").lower()
+    if status == "skipped":
+        reason = result.get("reason") or "Tactical RMM module is disabled"
+        raise TacticalRMMConfigurationError(str(reason))
+    if status not in {"succeeded", "ok"}:
+        error_message = (
+            result.get("error")
+            or result.get("last_error")
+            or result.get("reason")
+            or "Tactical RMM request failed"
+        )
+        raise TacticalRMMAPIError(str(error_message))
+    return result.get("response")
+
+
+def _normalise_next_url(next_value: Any, base_url: str) -> str | None:
+    if not next_value:
+        return None
+    if isinstance(next_value, Mapping):
+        for key in ("url", "next", "next_url", "href"):
+            candidate = next_value.get(key)
+            if candidate:
+                next_value = candidate
+                break
+    if isinstance(next_value, Sequence) and not isinstance(next_value, (str, bytes, bytearray)):
+        for candidate in next_value:
+            resolved = _normalise_next_url(candidate, base_url)
+            if resolved:
+                return resolved
+        return None
+    if not isinstance(next_value, str):
+        next_value = str(next_value)
+    if not next_value:
+        return None
+    if next_value.startswith("http://") or next_value.startswith("https://"):
+        parsed = urlparse(next_value)
+        path = parsed.path.lstrip("/")
+        query = f"?{parsed.query}" if parsed.query else ""
+        return f"{path}{query}" if path or query else None
+    return next_value.lstrip("/")
+
+
+def _extract_agent_page(response: Any, base_url: str) -> tuple[list[Mapping[str, Any]], str | None]:
+    if isinstance(response, list):
+        return [item for item in response if isinstance(item, Mapping)], None
+    if isinstance(response, Mapping):
+        for key in ("results", "agents", "items", "data"):
+            value = response.get(key)
+            if isinstance(value, list):
+                next_link = response.get("next") or response.get("next_url") or response.get("nextLink")
+                if not next_link:
+                    pagination = response.get("links") or response.get("pagination")
+                    if isinstance(pagination, Mapping):
+                        next_link = pagination.get("next") or pagination.get("next_url")
+                next_endpoint = _normalise_next_url(next_link, base_url)
+                return [item for item in value if isinstance(item, Mapping)], next_endpoint
+        # Some endpoints may return a single agent
+        if all(key in response for key in ("id", "hostname", "client")):
+            return [response], None
+    return [], None
+
+
+def _coerce_ram_gb(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if numeric > 1024:
+            numeric = numeric / 1024.0
+        return round(numeric, 2)
+    text = str(value).strip()
+    if not text:
+        return None
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)", text)
+    if not match:
+        return None
+    number = float(match.group(1))
+    lowered = text.lower()
+    if "mb" in lowered and "gb" not in lowered:
+        number = number / 1024.0
+    return round(number, 2)
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        text = str(value).strip()
+        match = re.search(r"([0-9]+(?:\.[0-9]+)?)", text)
+        if not match:
+            return None
+        try:
+            return float(match.group(1))
+        except ValueError:
+            return None
+
+
+def extract_agent_details(agent: Mapping[str, Any]) -> dict[str, Any]:
+    hardware = agent.get("hardware") if isinstance(agent.get("hardware"), Mapping) else {}
+
+    def _lookup(source: Mapping[str, Any], *keys: str) -> Any:
+        for key in keys:
+            if key in source and source[key] not in (None, ""):
+                return source[key]
+        return None
+
+    name = _clean_text(
+        _lookup(
+            agent,
+            "agent_name",
+            "hostname",
+            "name",
+            "computername",
+        )
+    )
+    client_info = agent.get("client") if isinstance(agent.get("client"), Mapping) else {}
+    site_info = agent.get("site") if isinstance(agent.get("site"), Mapping) else {}
+    details = {
+        "name": name or "Agent",
+        "type": _clean_text(_lookup(agent, "monitoring_type", "agent_type", "type")),
+        "serial_number": _clean_text(
+            _lookup(agent, "serial_number", "serial", "bios_serial")
+            or _lookup(hardware, "serial", "serial_number")
+        ),
+        "status": _clean_text(_lookup(agent, "status", "agent_status", "monitoring_status")),
+        "os_name": _clean_text(_lookup(agent, "os", "operating_system", "os_name", "os_version")),
+        "cpu_name": _clean_text(
+            _lookup(agent, "cpu_model", "processor")
+            or _lookup(hardware, "cpu_model", "cpu", "processor")
+        ),
+        "ram_gb": _coerce_ram_gb(
+            _lookup(agent, "ram_gb", "ram", "total_ram")
+            or _lookup(hardware, "ram", "total_ram", "memory")
+        ),
+        "hdd_size": _clean_text(
+            _lookup(agent, "total_disk", "hdd_size")
+            or _lookup(hardware, "total_disk", "storage_total", "disk")
+        ),
+        "last_sync": _lookup(
+            agent,
+            "last_seen",
+            "last_checkin",
+            "checkin_time",
+            "last_sync",
+            "last_agent_checkin",
+        ),
+        "motherboard_manufacturer": _clean_text(
+            _lookup(hardware, "motherboard_manufacturer", "board_manufacturer")
+        ),
+        "form_factor": _clean_text(
+            _lookup(agent, "chassis", "form_factor")
+            or _lookup(hardware, "chassis_type", "form_factor")
+        ),
+        "last_user": _clean_text(
+            _lookup(agent, "logged_in_user", "last_logged_in_user", "current_user")
+        ),
+        "approx_age": _coerce_float(
+            _lookup(hardware, "system_age_years", "age_years")
+            or _lookup(agent, "system_age", "device_age")
+        ),
+        "performance_score": _coerce_float(
+            _lookup(agent, "performance_score")
+            or _lookup(hardware, "performance_score")
+        ),
+        "warranty_status": _clean_text(_lookup(agent, "warranty_status")),
+        "warranty_end_date": _lookup(agent, "warranty_expires", "warranty_end", "warranty_expiration"),
+        "tactical_asset_id": _clean_text(
+            _lookup(agent, "agent_id", "id", "pk")
+        ),
+        "client_id": _clean_text(
+            _lookup(client_info, "id", "pk", "client_id")
+            or _lookup(agent, "client_id", "client")
+        ),
+        "client_name": _clean_text(
+            _lookup(client_info, "name", "client")
+            or _lookup(agent, "client_name", "client")
+        ),
+        "site_name": _clean_text(
+            _lookup(site_info, "name", "site")
+            or _lookup(agent, "site", "site_name")
+        ),
+    }
+    if not details["tactical_asset_id"] and details.get("client_id") and details.get("name"):
+        details["tactical_asset_id"] = f"{details['client_id']}::{details['name']}"
+    return details
+
+
+async def fetch_agents(client_id: str | None = None) -> list[Mapping[str, Any]]:
+    settings = await _load_settings()
+    base_url = settings["base_url"]
+    endpoints: list[str]
+    if client_id:
+        endpoints = [
+            f"clients/{client_id}/agents/",
+            f"agents/?client={client_id}",
+        ]
+    else:
+        endpoints = ["agents/"]
+
+    collected: list[Mapping[str, Any]] = []
+    log_info("Fetching Tactical RMM agents", client_id=client_id)
+    for endpoint in endpoints:
+        try:
+            response = await _call_endpoint(endpoint)
+        except TacticalRMMAPIError as exc:
+            log_error("Failed to fetch Tactical RMM agents", endpoint=endpoint, error=str(exc))
+            continue
+        page_items, next_endpoint = _extract_agent_page(response, base_url)
+        if page_items:
+            collected.extend(page_items)
+        seen_endpoints: set[str] = set()
+        while next_endpoint and next_endpoint not in seen_endpoints:
+            seen_endpoints.add(next_endpoint)
+            try:
+                response = await _call_endpoint(next_endpoint)
+            except TacticalRMMAPIError as exc:
+                log_error("Failed to fetch Tactical RMM agents page", endpoint=next_endpoint, error=str(exc))
+                break
+            page_items, next_endpoint = _extract_agent_page(response, base_url)
+            if page_items:
+                collected.extend(page_items)
+        if collected:
+            break
+    return collected

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -48,6 +48,16 @@
             />
           </div>
           <div class="form-field">
+            <label class="form-label" for="edit-company-tactical">Tactical RMM client ID</label>
+            <input
+              id="edit-company-tactical"
+              name="tacticalClientId"
+              class="form-input"
+              value="{{ form_data.tacticalrmm_client_id }}"
+              maxlength="255"
+            />
+          </div>
+          <div class="form-field">
             <label class="form-label" for="edit-company-xero">Xero ID</label>
             <input
               id="edit-company-xero"

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -157,6 +157,37 @@
                   placeholder="Syncro ID or external case"
                 />
               </div>
+              <div class="form-field">
+                <label class="form-label" for="ticket-assets">Assets</label>
+                <select
+                  id="ticket-assets"
+                  name="assetIds"
+                  class="form-input"
+                  multiple
+                  size="6"
+                  data-ticket-asset-selector
+                  data-assets-endpoint-template="/api/companies/{companyId}/assets"
+                  data-initial-options='{{ ticket_asset_options | tojson }}'
+                  data-selected-assets='{{ ticket_asset_selection | tojson }}'
+                  {% if not ticket.company_id %}disabled aria-disabled="true"{% endif %}
+                >
+                  {% for option in ticket_asset_options %}
+                    <option value="{{ option.id }}" {% if option.id in ticket_asset_selection %}selected{% endif %}>{{ option.label }}</option>
+                  {% endfor %}
+                </select>
+                <p
+                  class="form-help"
+                  data-ticket-asset-help
+                  data-help-enabled="Hold Ctrl (Windows) or ⌘ (macOS) to select multiple assets. Options refresh when the linked company changes."
+                  data-help-disabled="Link the ticket to a company to select assets."
+                >
+                  {% if not ticket.company_id %}
+                    Link the ticket to a company to select assets.
+                  {% else %}
+                    Hold Ctrl (Windows) or ⌘ (macOS) to select multiple assets. Options refresh when the linked company changes.
+                  {% endif %}
+                </p>
+              </div>
               <div class="form-actions">
                 <button type="submit" class="button button--primary">Save changes</button>
               </div>
@@ -189,6 +220,22 @@
                   <dt>Module</dt>
                   <dd>{{ ticket_module.name if ticket_module else (ticket.module_slug or '—') }}</dd>
                 </div>
+                {% if ticket_assets %}
+                  <div class="definition-list__item">
+                    <dt>Assets</dt>
+                    <dd>
+                      <div class="tag-list">
+                        {% for asset in ticket_assets %}
+                          {% set asset_label = asset.name %}
+                          {% if asset.serial_number %}
+                            {% set asset_label = asset_label ~ ' · SN ' ~ asset.serial_number %}
+                          {% endif %}
+                          <span class="tag">{{ asset_label }}</span>
+                        {% endfor %}
+                      </div>
+                    </dd>
+                  </div>
+                {% endif %}
                 <div class="definition-list__item">
                   <dt>Created</dt>
                   <dd>{{ ticket.created_at.astimezone().strftime('%Y-%m-%d %H:%M') if ticket.created_at else '—' }}</dd>

--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,4 @@
+- 2025-12-23, 14:30 UTC, Feature, Added Tactical RMM asset sync, ticket asset linking UI, and scheduler automation.
 - 2025-12-27, 10:15 UTC, Fix, Corrected the agent API route to /api/agent/query so dashboard requests reach the service without 404 errors
 - 2025-10-30, 00:55 UTC, Fix, Normalised shop package payloads before JSON serialisation so the packages category renders without server errors
 - 2025-10-23, 01:20 UTC, Feature, Added super admin deletion controls for scheduled and event automations with confirmation prompts and audit logging

--- a/changes/51f79fc8-9d33-4ef8-bab6-e9c4ec4f30a8.json
+++ b/changes/51f79fc8-9d33-4ef8-bab6-e9c4ec4f30a8.json
@@ -1,0 +1,7 @@
+{
+  "guid": "51f79fc8-9d33-4ef8-bab6-e9c4ec4f30a8",
+  "occurred_at": "2025-12-23T14:30Z",
+  "change_type": "Feature",
+  "summary": "Added Tactical RMM asset sync, ticket asset linking UI, and scheduler automation.",
+  "content_hash": "04cf37ebbcbd0c4751e50d8f9b51c5774328f96e301e72cbd8e7c783f9fcea90"
+}

--- a/docs/companies-api.md
+++ b/docs/companies-api.md
@@ -1,0 +1,48 @@
+# Companies API
+
+## List company assets
+
+`GET /api/companies/{company_id}/assets` returns the hardware assets that belong to the specified company. The endpoint is restricted to super administrators and is primarily consumed by the admin ticket workspace when technicians link assets to tickets.
+
+### Query parameters
+
+None. The company is identified by the path segment.
+
+### Response
+
+The response is an array of asset records ordered alphabetically by name. Each record can include identifiers from Syncro and Tactical RMM along with hardware metadata.
+
+```json
+[
+  {
+    "id": 12,
+    "company_id": 7,
+    "name": "FS-LAPTOP-03",
+    "type": "Laptop",
+    "serial_number": "ABC123456",
+    "status": "active",
+    "os_name": "Windows 11 Pro",
+    "cpu_name": "Intel Core i7-1255U",
+    "ram_gb": 16.0,
+    "hdd_size": "512 GB",
+    "last_sync": "2025-12-23T10:15:00Z",
+    "last_user": "alice@example.com",
+    "approx_age": 1.5,
+    "performance_score": 87.0,
+    "warranty_status": "In warranty",
+    "warranty_end_date": "2026-06-01",
+    "syncro_asset_id": "98765",
+    "tactical_asset_id": "dd0c1e28-ffab-4f29-97c8-0f63a5d151f0"
+  }
+]
+```
+
+### Error responses
+
+* `404 Not Found` – Returned when the company does not exist.
+* `403 Forbidden` – Returned when the caller is not a super administrator.
+
+### Notes
+
+* Numeric values such as `ram_gb`, `approx_age`, and `performance_score` are normalised to floating-point numbers. Missing values are returned as `null`.
+* Timestamps are emitted in UTC ISO-8601 format. The UI is responsible for rendering them in the viewer's local timezone.

--- a/docs/screenshots_ticket_assets.html
+++ b/docs/screenshots_ticket_assets.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Ticket asset selector preview</title>
+    <link rel="stylesheet" href="../app/static/css/app.css" />
+    <style>
+      body {
+        background: #0f172a;
+        padding: 2rem;
+      }
+      .card {
+        max-width: 720px;
+        margin: 0 auto;
+      }
+    </style>
+  </head>
+  <body class="app-body">
+    <div class="card card--panel">
+      <header class="card__header">
+        <h1 class="card__title">Ticket assets preview</h1>
+        <p class="card__subtitle">Assets now appear below the external reference field with multi-select support.</p>
+      </header>
+      <div class="card__body card__body--stacked">
+        <div class="form-field">
+          <label class="form-label" for="ticket-reference-detail">External reference</label>
+          <input
+            id="ticket-reference-detail"
+            class="form-input"
+            maxlength="128"
+            value="SYNCRO-12345"
+            placeholder="Syncro ID or external case"
+          />
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="ticket-assets">Assets</label>
+          <select
+            id="ticket-assets"
+            class="form-input"
+            multiple
+            size="6"
+          >
+            <option selected>Workstation-1 · SN XYZ123 · Active</option>
+            <option>Workstation-2 · SN XYZ456 · Active</option>
+            <option>Laptop-5 · SN ABC987 · In Repair</option>
+            <option>Firewall-Edge · SN FWF1234 · Online</option>
+            <option>Server-DB1 · SN DB1928 · Maintenance</option>
+            <option>Server-DB2 · SN DB2736 · Maintenance</option>
+          </select>
+          <p class="form-help">
+            Hold Ctrl (Windows) or ⌘ (macOS) to select multiple assets. Options refresh when the linked company changes.
+          </p>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/migrations/097_tacticalrmm_assets.sql
+++ b/migrations/097_tacticalrmm_assets.sql
@@ -1,0 +1,23 @@
+ALTER TABLE companies
+  ADD COLUMN tacticalrmm_client_id VARCHAR(255) DEFAULT NULL,
+  ADD KEY companies_tacticalrmm_client_id (tacticalrmm_client_id);
+
+ALTER TABLE assets
+  ADD COLUMN tactical_asset_id VARCHAR(255) DEFAULT NULL,
+  ADD UNIQUE KEY assets_company_tactical_id (company_id, tactical_asset_id);
+
+CREATE TABLE IF NOT EXISTS ticket_assets (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  ticket_id INT NOT NULL,
+  asset_id INT NOT NULL,
+  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  UNIQUE KEY ticket_asset_unique (ticket_id, asset_id),
+  CONSTRAINT fk_ticket_assets_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
+  CONSTRAINT fk_ticket_assets_asset FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE
+);
+
+INSERT INTO scheduled_tasks (name, command, cron, active)
+SELECT 'Sync Tactical RMM assets', 'sync_tactical_assets', '0 * * * *', 0
+WHERE NOT EXISTS (
+  SELECT 1 FROM scheduled_tasks WHERE command = 'sync_tactical_assets'
+);

--- a/tests/test_asset_importer.py
+++ b/tests/test_asset_importer.py
@@ -1,0 +1,115 @@
+import pytest
+
+from app.services import asset_importer, tacticalrmm
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_import_tactical_assets_for_company_upserts(monkeypatch):
+    company_record = {"id": 7, "tacticalrmm_client_id": "abc"}
+    agents = [
+        {"id": 101},
+        {"id": 102},
+        {"id": 101},  # duplicate agent to ensure dedupe
+    ]
+
+    async def fake_get_company(company_id):
+        assert company_id == 7
+        return company_record
+
+    async def fake_fetch_agents(client_id):
+        assert client_id == "abc"
+        return agents
+
+    detail_map = {
+        101: {
+            "name": "Workstation-1",
+            "type": "server",
+            "serial_number": "XYZ",
+            "status": "online",
+            "os_name": "Windows",
+            "cpu_name": "Xeon",
+            "ram_gb": 16.0,
+            "hdd_size": "512 GB",
+            "last_sync": "2024-01-01T10:00:00Z",
+            "motherboard_manufacturer": "Dell",
+            "form_factor": "Tower",
+            "last_user": "Alice",
+            "approx_age": 2,
+            "performance_score": 92,
+            "warranty_status": "active",
+            "warranty_end_date": "2025-01-01",
+            "tactical_asset_id": "agent-101",
+        },
+        102: {
+            "name": "Laptop-2",
+            "type": "laptop",
+            "serial_number": "ABC",
+            "status": "offline",
+            "os_name": "Ubuntu",
+            "cpu_name": "Ryzen",
+            "ram_gb": 32.0,
+            "hdd_size": "1 TB",
+            "last_sync": "2024-01-02T12:00:00Z",
+            "motherboard_manufacturer": "Lenovo",
+            "form_factor": "Notebook",
+            "last_user": "Bob",
+            "approx_age": 1,
+            "performance_score": 88,
+            "warranty_status": "active",
+            "warranty_end_date": "2024-12-31",
+            "tactical_asset_id": "agent-102",
+        },
+    }
+
+    def fake_extract(agent):
+        identifier = agent.get("id")
+        return detail_map[identifier]
+
+    captured: list[dict[str, object]] = []
+
+    async def fake_upsert_asset(**kwargs):
+        captured.append(kwargs)
+
+    monkeypatch.setattr(asset_importer.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(asset_importer.tacticalrmm, "fetch_agents", fake_fetch_agents)
+    monkeypatch.setattr(asset_importer.tacticalrmm, "extract_agent_details", fake_extract)
+    monkeypatch.setattr(asset_importer.assets_repo, "upsert_asset", fake_upsert_asset)
+
+    processed = await asset_importer.import_tactical_assets_for_company(7)
+
+    assert processed == 2
+    assert len(captured) == 2
+    ids = {entry["tactical_asset_id"] for entry in captured}
+    assert ids == {"agent-101", "agent-102"}
+    assert all(entry.get("match_name") is True for entry in captured)
+
+
+@pytest.mark.anyio
+async def test_import_all_tactical_assets_summarises(monkeypatch):
+    companies = [
+        {"id": 1, "tacticalrmm_client_id": "c1"},
+        {"id": 2, "tacticalrmm_client_id": "c2"},
+        {"id": 3, "name": "No mapping"},
+    ]
+
+    async def fake_list_companies():
+        return companies
+
+    async def fake_import(company_id, *, tactical_client_id=None):
+        if company_id == 2:
+            raise tacticalrmm.TacticalRMMAPIError("boom")
+        return 5
+
+    monkeypatch.setattr(asset_importer.company_repo, "list_companies", fake_list_companies)
+    monkeypatch.setattr(asset_importer, "import_tactical_assets_for_company", fake_import)
+
+    summary = await asset_importer.import_all_tactical_assets()
+
+    assert summary["processed"] == 5
+    assert summary["companies"] == {1: {"processed": 5}}
+    assert {item["company_id"] for item in summary["skipped"]} == {2, 3}


### PR DESCRIPTION
## Summary
- add Tactical RMM asset client, importer flow, and scheduler automation for Tactical RMM syncs
- expose company asset API and extend ticket edit experience to manage linked assets
- document the new endpoints, add change-log entry, and capture updated UI preview

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_b_690924d8d9d0832da96c4eca112fa9c9