### PR TITLE
Auto-discover Xero tenant ID during module tests

### DIFF
--- a/app/templates/admin/modules.html
+++ b/app/templates/admin/modules.html
@@ -247,8 +247,15 @@
                   <p class="form-help">Tokens are encrypted before storage. Leave blank or enter ******** to keep the existing value.</p>
                 </div>
                 <div class="form-field">
-                  <label class="form-label" for="xero-tenant-id">Tenant ID</label>
-                  <input id="xero-tenant-id" name="settings.tenant_id" class="form-input" value="{{ settings.tenant_id or '' }}" autocomplete="off" />
+                  <label class="form-label" for="xero-company-name">Company name</label>
+                  <input
+                    id="xero-company-name"
+                    name="settings.company_name"
+                    class="form-input"
+                    value="{{ settings.company_name or '' }}"
+                    readonly
+                  />
+                  <p class="form-help">Update the <code>XERO_COMPANY_NAME</code> value in your environment file to change the linked tenant.</p>
                 </div>
                 <div class="form-field form-field--inline">
                   <label class="form-label" for="xero-hourly-rate">Default hourly rate</label>

--- a/tests/test_xero_module.py
+++ b/tests/test_xero_module.py
@@ -53,11 +53,10 @@ def test_coerce_settings_xero_includes_company_name():
     }
     payload = {
         "company_name": "New Company Name",
-        "tenant_id": "new-tenant",
     }
     result = modules_service._coerce_settings("xero", payload, existing)
     assert result["company_name"] == "New Company Name"
-    assert result["tenant_id"] == "new-tenant"
+    assert result["tenant_id"] == "existing-tenant"
     # Verify secrets are preserved
     assert result["client_secret"] == "super-secret"
     assert result["refresh_token"] == "refresh-token"


### PR DESCRIPTION
## Summary
- sync the Xero company name from the environment and drop manual tenant ID defaults
- call the Xero connections endpoint during module validation to persist the matching tenant ID
- update the admin module form and tests to reflect the new tenant discovery flow

## Testing
- pytest tests/test_xero_module.py

------
https://chatgpt.com/codex/tasks/task_b_6909f7fe5e588332bb61af14a01a97f1