### PR TITLE
Update scheduler to reflect Xero sync outcome

### DIFF
--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -214,7 +214,19 @@ class SchedulerService:
                     company_id = task.get("company_id")
                     if company_id:
                         result = await xero_service.sync_company(int(company_id))
-                        details = json.dumps(result, default=str) if result else None
+                        if result:
+                            details = json.dumps(result, default=str)
+                            result_status = str(
+                                result.get("status")
+                                or result.get("event_status")
+                                or ""
+                            ).strip().lower()
+                            if result_status in {"failed", "error"}:
+                                status = "failed"
+                            elif result_status == "skipped":
+                                status = "skipped"
+                        else:
+                            details = None
                     else:
                         status = "skipped"
                         details = "Company context required"


### PR DESCRIPTION
## Summary
- update the scheduler's Xero automation handler to derive the task status from the sync result payload
- ensure skipped and failed Xero runs surface the correct status in scheduled task history

## Testing
- pytest tests/test_scheduler_system_update.py -q

------
https://chatgpt.com/codex/tasks/task_b_690a8ebeeb148332a72fe957033d3f99