### PR TITLE
Record automation ticket descriptions in conversation history

### DIFF
--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -946,13 +946,14 @@ async def create_ticket(
             author_id = int(initial_reply_author_id)
         except (TypeError, ValueError):  # pragma: no cover - defensive
             author_id = None
+        else:
+            if author_id <= 0:
+                author_id = None
     if (
         isinstance(ticket_id, int)
         and ticket_id > 0
         and isinstance(original_description, str)
         and original_description
-        and author_id is not None
-        and author_id > 0
     ):
         try:
             await tickets_repo.create_reply(

--- a/tests/test_tickets_service_create.py
+++ b/tests/test_tickets_service_create.py
@@ -279,6 +279,58 @@ async def test_create_ticket_records_initial_reply(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_create_ticket_records_initial_reply_without_author(monkeypatch):
+    recorded_reply: dict[str, object] = {}
+
+    async def fake_create_ticket(**kwargs):
+        return {"id": 864, **kwargs}
+
+    async def fake_create_reply(**kwargs):
+        recorded_reply.update(kwargs)
+        return {"id": 975, **kwargs}
+
+    async def fake_handle_event(event_name, context):  # pragma: no cover - via test
+        return []
+
+    async def fake_get_company(company_id):
+        return None
+
+    async def fake_get_user(user_id):
+        return None
+
+    async def fake_resolve_status(value):
+        return value or "open"
+
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
+    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
+    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
+
+    ticket = await tickets_service.create_ticket(
+        subject="Automation created",
+        description="System generated details",
+        requester_id=None,
+        company_id=None,
+        assigned_user_id=None,
+        priority="normal",
+        status="open",
+        category=None,
+        module_slug=None,
+        external_reference=None,
+        ticket_number=None,
+        trigger_automations=False,
+    )
+
+    assert ticket["id"] == 864
+    assert recorded_reply["ticket_id"] == 864
+    assert recorded_reply["author_id"] is None
+    assert recorded_reply["body"] == "System generated details"
+    assert recorded_reply["is_internal"] is False
+
+
+@pytest.mark.anyio
 async def test_enrich_ticket_context_includes_relationship_details(monkeypatch):
     ticket = {
         "id": 99,


### PR DESCRIPTION
## Summary
- allow ticket creation to persist the initial description as a reply even when no author is provided
- cover the regression with a service-level test ensuring automation-created tickets record the reply

## Testing
- pytest tests/test_tickets_service_create.py

------
https://chatgpt.com/codex/tasks/task_b_690c0e2d339c8332a01eeadff9e6fb67