### PR TITLE
Revamp ticket asset linking workflow

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9765,14 +9765,24 @@ async def _render_ticket_detail(
         else:
             company = await company_repo.get_company_by_id(ticket_company_id)
 
+    modules = await modules_service.list_modules()
+
     module_info: dict[str, Any] | None = None
     module_slug = ticket.get("module_slug")
     if module_slug:
-        modules = await modules_service.list_modules()
         for module in modules:
             if module.get("slug") == module_slug:
                 module_info = module
                 break
+
+    tactical_module = next((module for module in modules if module.get("slug") == "tacticalrmm"), None)
+    tactical_base_url = ""
+    if tactical_module:
+        settings = tactical_module.get("settings") or {}
+        if isinstance(settings, Mapping):
+            base_url = str(settings.get("base_url") or "").strip()
+            if base_url:
+                tactical_base_url = base_url.rstrip("/")
 
     ordered_replies = list(reversed(replies))
 
@@ -9877,6 +9887,22 @@ async def _render_ticket_detail(
         except (TypeError, ValueError):
             continue
 
+    serialisable_ticket_assets: list[dict[str, Any]] = []
+    for asset in ticket_assets:
+        if not isinstance(asset, Mapping):
+            continue
+        asset_identifier = asset.get("asset_id")
+        serialisable_ticket_assets.append(
+            {
+                "id": asset_identifier,
+                "asset_id": asset_identifier,
+                "name": str(asset.get("name") or "").strip() or (f"Asset {asset_identifier}" if asset_identifier else "Asset"),
+                "serial_number": (str(asset.get("serial_number") or "").strip() or None),
+                "status": (str(asset.get("status") or "").strip() or None),
+                "tactical_asset_id": (str(asset.get("tactical_asset_id") or "").strip() or None),
+            }
+        )
+
     asset_options: list[dict[str, Any]] = []
     if ticket_company_id is not None:
         company_assets = await assets_repo.list_company_assets(ticket_company_id)
@@ -9904,6 +9930,10 @@ async def _render_ticket_detail(
                 {
                     "id": asset_id_int,
                     "label": _format_asset_label(asset_row),
+                    "name": str(asset_row.get("name") or "").strip() or f"Asset {asset_id_int}",
+                    "serial_number": str(asset_row.get("serial_number") or "").strip() or None,
+                    "status": str(asset_row.get("status") or "").strip() or None,
+                    "tactical_asset_id": str(asset_row.get("tactical_asset_id") or "").strip() or None,
                 }
             )
 
@@ -9940,6 +9970,8 @@ async def _render_ticket_detail(
         "ticket_assets": ticket_assets,
         "ticket_asset_options": asset_options,
         "ticket_asset_selection": asset_selection,
+        "ticket_asset_linked_data": serialisable_ticket_assets,
+        "tacticalrmm_base_url": tactical_base_url,
         "can_delete_ticket": bool(user.get("is_super_admin")),
         "success_message": success_message,
         "error_message": error_message,

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -427,7 +427,8 @@ async def list_ticket_assets(ticket_id: int) -> list[dict[str, Any]]:
             a.serial_number,
             a.status,
             a.type,
-            a.os_name
+            a.os_name,
+            a.tactical_asset_id
         FROM ticket_assets AS ta
         INNER JOIN assets AS a ON a.id = ta.asset_id
         WHERE ta.ticket_id = %s
@@ -449,6 +450,7 @@ async def list_ticket_assets(ticket_id: int) -> list[dict[str, Any]]:
             "status": str(row.get("status") or "").strip() or None,
             "type": str(row.get("type") or "").strip() or None,
             "os_name": str(row.get("os_name") or "").strip() or None,
+            "tactical_asset_id": str(row.get("tactical_asset_id") or "").strip() or None,
             "linked_at": _make_aware(row.get("created_at")),
         }
         assets.append(asset)

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2002,6 +2002,64 @@ button.header-title-menu__link {
   color: rgba(148, 163, 184, 0.85);
 }
 
+.ticket-assets-linked {
+  margin-top: var(--space-gap-base);
+  padding: var(--space-gap-base);
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.ticket-assets-linked__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-gap-base);
+}
+
+.ticket-assets-linked__item {
+  position: relative;
+  padding: var(--space-gap-base) calc(var(--space-gap-roomy) * 1.75) var(--space-gap-base) var(--space-gap-base);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: 0 16px 32px -22px rgba(14, 165, 233, 0.45);
+}
+
+.ticket-assets-linked__name {
+  color: #e2e8f0;
+  font-weight: 600;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-gap-tight);
+}
+
+.ticket-assets-linked__name:hover,
+.ticket-assets-linked__name:focus {
+  text-decoration: underline;
+}
+
+.ticket-assets-linked__meta {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 0.9rem;
+}
+
+.ticket-assets-linked__remove {
+  position: absolute;
+  top: var(--space-gap-tight);
+  right: var(--space-gap-tight);
+}
+
+.ticket-assets-linked__empty {
+  margin: var(--space-gap-base) 0 0;
+  color: rgba(148, 163, 184, 0.75);
+  font-size: 0.95rem;
+}
+
 .button--ghost {
   background: transparent;
   border: 1px solid rgba(148, 163, 184, 0.4);

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -161,32 +161,109 @@
                 <label class="form-label" for="ticket-assets">Assets</label>
                 <select
                   id="ticket-assets"
-                  name="assetIds"
                   class="form-input"
-                  multiple
-                  size="6"
                   data-ticket-asset-selector
                   data-assets-endpoint-template="/api/companies/{companyId}/assets"
                   data-initial-options='{{ ticket_asset_options | tojson }}'
                   data-selected-assets='{{ ticket_asset_selection | tojson }}'
+                  data-placeholder="Select an asset to link"
+                  data-initial-company-id="{{ ticket.company_id or '' }}"
                   {% if not ticket.company_id %}disabled aria-disabled="true"{% endif %}
                 >
+                  <option value="">Select an asset to link</option>
                   {% for option in ticket_asset_options %}
-                    <option value="{{ option.id }}" {% if option.id in ticket_asset_selection %}selected{% endif %}>{{ option.label }}</option>
+                    <option value="{{ option.id }}">{{ option.label }}</option>
                   {% endfor %}
                 </select>
                 <p
                   class="form-help"
                   data-ticket-asset-help
-                  data-help-enabled="Hold Ctrl (Windows) or ⌘ (macOS) to select multiple assets. Options refresh when the linked company changes."
-                  data-help-disabled="Link the ticket to a company to select assets."
+                  data-help-enabled="Choose an asset to link. Linked devices appear below."
+                  data-help-disabled="Link the ticket to a company before selecting assets."
+                  data-help-empty="No assets are available for the linked company."
+                  data-help-exhausted="All company assets are already linked to this ticket."
                 >
                   {% if not ticket.company_id %}
-                    Link the ticket to a company to select assets.
+                    Link the ticket to a company before selecting assets.
+                  {% elif not ticket_asset_options %}
+                    No assets are available for the linked company.
                   {% else %}
-                    Hold Ctrl (Windows) or ⌘ (macOS) to select multiple assets. Options refresh when the linked company changes.
+                    Choose an asset to link. Linked devices appear below.
                   {% endif %}
                 </p>
+                <div
+                  class="ticket-assets-linked"
+                  data-ticket-linked-assets
+                  data-initial-linked='{{ ticket_asset_linked_data | tojson }}'
+                  data-tactical-base-url="{{ tacticalrmm_base_url or '' }}"
+                  data-empty-message="No assets are linked to this ticket yet."
+                >
+                  <ul class="ticket-assets-linked__list" data-linked-assets-list>
+                    {% for asset in ticket_assets %}
+                      {% set serial_value = asset.serial_number %}
+                      {% set status_value = asset.status %}
+                      {% set status_label = status_value.replace('_', ' ').title() if status_value %}
+                      {% set meta_parts = [] %}
+                      {% if serial_value %}
+                        {% set _ = meta_parts.append('SN ' ~ serial_value) %}
+                      {% endif %}
+                      {% if status_label %}
+                        {% set _ = meta_parts.append(status_label) %}
+                      {% endif %}
+                      {% set base_name = asset.name or ('Asset ' ~ asset.asset_id) %}
+                      {% set display_name = base_name | trim %}
+                      {% if not display_name %}
+                        {% set display_name = 'Asset ' ~ asset.asset_id %}
+                      {% endif %}
+                      {% set tooltip_label = display_name %}
+                      {% if meta_parts %}
+                        {% set tooltip_label = display_name ~ ' · ' ~ (meta_parts | join(' · ')) %}
+                      {% endif %}
+                      {% set tactical_link = None %}
+                      {% if tacticalrmm_base_url and asset.tactical_asset_id %}
+                        {% set tactical_link = tacticalrmm_base_url ~ '/web/agents/' ~ (asset.tactical_asset_id | urlencode) %}
+                      {% endif %}
+                      <li
+                        class="ticket-assets-linked__item"
+                        data-linked-asset
+                        data-asset-id="{{ asset.asset_id }}"
+                        data-tactical-id="{{ asset.tactical_asset_id or '' }}"
+                      >
+                        <input type="hidden" name="assetIds" value="{{ asset.asset_id }}" />
+                        {% if tactical_link %}
+                          <a
+                            href="{{ tactical_link }}"
+                            target="_blank"
+                            rel="noreferrer noopener"
+                            class="ticket-assets-linked__name"
+                            data-linked-asset-name
+                            title="{{ tooltip_label }}"
+                          >
+                            {{ display_name }}
+                          </a>
+                        {% else %}
+                          <span class="ticket-assets-linked__name" data-linked-asset-name title="{{ tooltip_label }}">
+                            {{ display_name }}
+                          </span>
+                        {% endif %}
+                        {% if meta_parts %}
+                          <p class="ticket-assets-linked__meta">{{ meta_parts | join(' · ') }}</p>
+                        {% endif %}
+                        <button
+                          type="button"
+                          class="button button--ghost button--icon ticket-assets-linked__remove"
+                          data-linked-asset-remove
+                        >
+                          <span class="visually-hidden">Remove asset</span>
+                          ×
+                        </button>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                  <p class="ticket-assets-linked__empty" data-linked-assets-empty {% if ticket_assets %}hidden{% endif %}>
+                    No assets are linked to this ticket yet.
+                  </p>
+                </div>
               </div>
               <div class="form-actions">
                 <button type="submit" class="button button--primary">Save changes</button>

--- a/changes/8ea0728d-73b9-42b3-bcf6-60074a4d0d74.json
+++ b/changes/8ea0728d-73b9-42b3-bcf6-60074a4d0d74.json
@@ -1,0 +1,7 @@
+{
+  "guid": "8ea0728d-73b9-42b3-bcf6-60074a4d0d74",
+  "occurred_at": "2025-11-06T05:44Z",
+  "change_type": "Feature",
+  "summary": "Added dropdown-driven asset linking UI with Tactical RMM shortcuts on ticket detail page.",
+  "content_hash": "363b85b60f35d456dcb581627e5221bcf7c346139c79d3b331dcb46babf7ac08"
+}

--- a/docs/screenshots_ticket_assets.html
+++ b/docs/screenshots_ticket_assets.html
@@ -34,22 +34,29 @@
         </div>
         <div class="form-field">
           <label class="form-label" for="ticket-assets">Assets</label>
-          <select
-            id="ticket-assets"
-            class="form-input"
-            multiple
-            size="6"
-          >
-            <option selected>Workstation-1 · SN XYZ123 · Active</option>
-            <option>Workstation-2 · SN XYZ456 · Active</option>
+          <select id="ticket-assets" class="form-input">
+            <option>Select an asset to link</option>
+            <option>Workstation-3 · SN XYZ456 · Active</option>
             <option>Laptop-5 · SN ABC987 · In Repair</option>
             <option>Firewall-Edge · SN FWF1234 · Online</option>
             <option>Server-DB1 · SN DB1928 · Maintenance</option>
-            <option>Server-DB2 · SN DB2736 · Maintenance</option>
           </select>
-          <p class="form-help">
-            Hold Ctrl (Windows) or ⌘ (macOS) to select multiple assets. Options refresh when the linked company changes.
-          </p>
+          <p class="form-help">Choose an asset to link. Linked devices appear below.</p>
+          <div class="ticket-assets-linked">
+            <ul class="ticket-assets-linked__list">
+              <li class="ticket-assets-linked__item">
+                <a class="ticket-assets-linked__name" href="#" title="Workstation-1 · SN XYZ123 · Active">Workstation-1</a>
+                <p class="ticket-assets-linked__meta">SN XYZ123 · Active</p>
+                <button type="button" class="button button--ghost button--icon ticket-assets-linked__remove">×</button>
+              </li>
+              <li class="ticket-assets-linked__item">
+                <a class="ticket-assets-linked__name" href="#" title="Server-DB2 · SN DB2736 · Maintenance">Server-DB2</a>
+                <p class="ticket-assets-linked__meta">SN DB2736 · Maintenance</p>
+                <button type="button" class="button button--ghost button--icon ticket-assets-linked__remove">×</button>
+              </li>
+            </ul>
+            <p class="ticket-assets-linked__empty">No assets are linked to this ticket yet.</p>
+          </div>
         </div>
       </div>
     </div>

--- a/tests/test_tickets_repository.py
+++ b/tests/test_tickets_repository.py
@@ -217,6 +217,7 @@ async def test_list_ticket_assets_formats_records(monkeypatch):
             "status": "online",
             "type": "laptop",
             "os_name": "Windows",
+            "tactical_asset_id": "agent-5",
         }
     ]
     dummy_db = _ListTicketAssetsDB(rows)
@@ -230,6 +231,7 @@ async def test_list_ticket_assets_formats_records(monkeypatch):
     assert assets[0]["name"] == "Device"
     assert assets[0]["serial_number"] == "SER123"
     assert assets[0]["linked_at"].tzinfo is not None
+    assert assets[0]["tactical_asset_id"] == "agent-5"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- convert the ticket asset selector into a dropdown that populates a linked asset list with Tactical RMM shortcuts and unlink controls
- enrich ticket asset data returned to the template and style the new linked asset collection for clarity
- update documentation, regression coverage, and change log for the refreshed asset linking experience

## Testing
- pytest tests/test_tickets_repository.py

------
https://chatgpt.com/codex/tasks/task_b_690c33319cc4832d8221d84618f57d9e