### PR TITLE
Stop showing serial numbers in admin ticket asset lists

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -164,8 +164,8 @@
                   class="form-input"
                   data-ticket-asset-selector
                   data-assets-endpoint-template="/api/companies/{companyId}/assets"
-                  data-initial-options='{{ ticket_asset_options | tojson }}'
-                  data-selected-assets='{{ ticket_asset_selection | tojson }}'
+                  data-initial-options="{{ ticket_asset_options | tojson | forceescape }}"
+                  data-selected-assets="{{ ticket_asset_selection | tojson | forceescape }}"
                   data-placeholder="Select an asset to link"
                   data-initial-company-id="{{ ticket.company_id or '' }}"
                   {% if not ticket.company_id %}disabled aria-disabled="true"{% endif %}
@@ -194,7 +194,7 @@
                 <div
                   class="ticket-assets-linked"
                   data-ticket-linked-assets
-                  data-initial-linked='{{ ticket_asset_linked_data | tojson }}'
+                  data-initial-linked="{{ ticket_asset_linked_data | tojson | forceescape }}"
                   data-tactical-base-url="{{ tacticalrmm_base_url or '' }}"
                   data-empty-message="No assets are linked to this ticket yet."
                 >
@@ -204,9 +204,6 @@
                       {% set status_value = asset.status %}
                       {% set status_label = status_value.replace('_', ' ').title() if status_value %}
                       {% set meta_parts = [] %}
-                      {% if serial_value %}
-                        {% set _ = meta_parts.append('SN ' ~ serial_value) %}
-                      {% endif %}
                       {% if status_label %}
                         {% set _ = meta_parts.append(status_label) %}
                       {% endif %}
@@ -303,10 +300,7 @@
                     <dd>
                       <div class="tag-list">
                         {% for asset in ticket_assets %}
-                          {% set asset_label = asset.name %}
-                          {% if asset.serial_number %}
-                            {% set asset_label = asset_label ~ ' · SN ' ~ asset.serial_number %}
-                          {% endif %}
+                      {% set asset_label = asset.name %}
                           <span class="tag">{{ asset_label }}</span>
                         {% endfor %}
                       </div>

--- a/changes/1fb7b863-cab3-4369-9955-a792a1b01389.json
+++ b/changes/1fb7b863-cab3-4369-9955-a792a1b01389.json
@@ -1,0 +1,7 @@
+{
+  "guid": "1fb7b863-cab3-4369-9955-a792a1b01389",
+  "occurred_at": "2025-11-06T05:59:46Z",
+  "change_type": "Fix",
+  "summary": "Escaped ticket asset selector datasets so labels with apostrophes remain selectable and link correctly",
+  "content_hash": "5c7b378b0ce6ffd78ae559b3b18a0cb1fca29f400a5ef971f2dc21397a0751de"
+}

--- a/changes/73e7055f-e9cc-4c88-9661-10a647585384.json
+++ b/changes/73e7055f-e9cc-4c88-9661-10a647585384.json
@@ -1,0 +1,7 @@
+{
+  "guid": "73e7055f-e9cc-4c88-9661-10a647585384",
+  "occurred_at": "2025-11-06T06:03Z",
+  "change_type": "Fix",
+  "summary": "Stop displaying asset serial numbers for linked ticket assets in the admin view",
+  "content_hash": "7668f4b0bc4d0cc884ae85ce4474d5f5a02fab0b11815cd84b938d2727569cb8"
+}


### PR DESCRIPTION
## Summary
- stop appending serial numbers when rendering linked ticket assets in the admin ticket detail view
- record the display change in the change log

## Testing
- pytest *(fails: async tests require pytest-asyncio and database pool initialisation in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_690c37295600832d998c0f15f9f2f6f0