### PR TITLE
Fix compliance page crash when controls lack descriptions

### DIFF
--- a/app/repositories/essential8.py
+++ b/app/repositories/essential8.py
@@ -62,7 +62,7 @@ async def list_company_compliance(
         item["control"] = {
             "id": row["control_id"],
             "name": row["control_name"],
-            "description": row["control_description"],
+            "description": row["control_description"] or "",
             "control_order": row["control_order"],
         }
         # Remove the flattened control fields
@@ -99,7 +99,7 @@ async def get_company_compliance(
     item["control"] = {
         "id": row["control_id"],
         "name": row["control_name"],
-        "description": row["control_description"],
+        "description": row["control_description"] or "",
         "control_order": row["control_order"],
     }
     # Remove the flattened control fields

--- a/app/templates/compliance/index.html
+++ b/app/templates/compliance/index.html
@@ -66,7 +66,8 @@
             <td>
               <strong>{{ record.control.name }}</strong>
               <br>
-              <small style="color: #6b7280;">{{ record.control.description[:100] }}{% if record.control.description|length > 100 %}...{% endif %}</small>
+              {% set control_description = record.control.description or '' %}
+              <small style="color: #6b7280;">{{ control_description[:100] }}{% if control_description|length > 100 %}...{% endif %}</small>
             </td>
             <td>
               <span class="badge badge--{{ record.status }}">


### PR DESCRIPTION
## Summary
- ensure Essential 8 control descriptions default to empty strings when missing
- guard the compliance template against missing control descriptions during rendering

## Testing
- not run (pytest requires async plugin in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69115b7e52088332abb6086d953d3ef6)