### PR TITLE
Add transcription status summary to call recordings page

### DIFF
--- a/app/api/routes/call_recordings.py
+++ b/app/api/routes/call_recordings.py
@@ -8,6 +8,7 @@ from app.repositories import call_recordings as call_recordings_repo
 from app.schemas.call_recordings import (
     CallRecordingCreate,
     CallRecordingResponse,
+    CallRecordingStatusSummary,
     CallRecordingUpdate,
     LinkRecordingRequest,
     TranscriptionRequest,
@@ -54,6 +55,21 @@ async def count_call_recordings(
         linked_ticket_id=linked_ticket_id,
     )
     return {"count": count}
+
+
+@router.get("/status-summary", response_model=CallRecordingStatusSummary)
+async def summarize_call_recording_statuses(
+    search: str | None = None,
+    linked_ticket_id: int | None = Query(default=None, alias="linkedTicketId"),
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    """Return a breakdown of call recordings by transcription status (super admin only)."""
+    summary = await call_recordings_repo.summarize_transcription_statuses(
+        search=search,
+        linked_ticket_id=linked_ticket_id,
+    )
+    return CallRecordingStatusSummary.model_validate(summary)
 
 
 @router.post("/sync", response_model=dict[str, int | str | list[str]])

--- a/app/schemas/call_recordings.py
+++ b/app/schemas/call_recordings.py
@@ -82,3 +82,12 @@ class LinkRecordingRequest(BaseModel):
 class TranscriptionRequest(BaseModel):
     recording_id: int = Field(validation_alias="recordingId")
     force: bool = False  # Force re-transcription even if already done
+
+
+class CallRecordingStatusSummary(BaseModel):
+    total: int = 0
+    completed: int = 0
+    pending: int = 0
+    processing: int = 0
+    failed: int = 0
+    unknown: int = 0

--- a/app/templates/admin/call_recordings.html
+++ b/app/templates/admin/call_recordings.html
@@ -62,6 +62,34 @@
       </header>
 
       <div class="management__body">
+        <!-- Transcription Status Summary -->
+        <div class="status-summary" id="status-summary" aria-live="polite">
+          <div class="status-summary__item status-summary__item--total">
+            <span class="status-summary__label">Total Recordings</span>
+            <span class="status-summary__value" data-status="total">—</span>
+          </div>
+          <div class="status-summary__item status-summary__item--completed">
+            <span class="status-summary__label">Completed</span>
+            <span class="status-summary__value" data-status="completed">—</span>
+          </div>
+          <div class="status-summary__item status-summary__item--pending">
+            <span class="status-summary__label">Pending</span>
+            <span class="status-summary__value" data-status="pending">—</span>
+          </div>
+          <div class="status-summary__item status-summary__item--processing">
+            <span class="status-summary__label">Processing</span>
+            <span class="status-summary__value" data-status="processing">—</span>
+          </div>
+          <div class="status-summary__item status-summary__item--failed">
+            <span class="status-summary__label">Failed</span>
+            <span class="status-summary__value" data-status="failed">—</span>
+          </div>
+          <div class="status-summary__item status-summary__item--unknown">
+            <span class="status-summary__label">Unknown</span>
+            <span class="status-summary__value" data-status="unknown">—</span>
+          </div>
+        </div>
+
         <!-- Filters -->
         <div class="filters-bar">
           <label class="form-label">
@@ -202,6 +230,64 @@
     let currentSearch = '';
     let currentStatusFilter = '';
     let currentLinkedFilter = '';
+    let statusSummaryRequestId = 0;
+
+    const STATUS_SUMMARY_KEYS = ['total', 'completed', 'pending', 'processing', 'failed', 'unknown'];
+
+    function renderStatusSummary(summary, { loading = false } = {}) {
+      const container = document.getElementById('status-summary');
+      if (!container) return;
+
+      STATUS_SUMMARY_KEYS.forEach((key) => {
+        const el = container.querySelector(`[data-status="${key}"]`);
+        if (!el) return;
+
+        if (loading) {
+          el.textContent = '—';
+          el.setAttribute('aria-busy', 'true');
+          return;
+        }
+
+        const value = summary && typeof summary[key] === 'number' ? summary[key] : null;
+        if (value === null) {
+          el.textContent = '—';
+          el.removeAttribute('aria-busy');
+        } else {
+          el.textContent = value.toLocaleString();
+          el.removeAttribute('aria-busy');
+        }
+      });
+    }
+
+    async function loadStatusSummary() {
+      const container = document.getElementById('status-summary');
+      if (!container) return;
+
+      const requestId = ++statusSummaryRequestId;
+      renderStatusSummary(null, { loading: true });
+
+      try {
+        const params = new URLSearchParams();
+        if (currentSearch) params.append('search', currentSearch);
+        if (currentLinkedFilter) params.append('linkedTicketId', currentLinkedFilter);
+
+        const queryString = params.toString();
+        const response = await fetch(queryString ? `/api/call-recordings/status-summary?${queryString}` : '/api/call-recordings/status-summary');
+        if (!response.ok) {
+          throw new Error(`Failed to load status summary: ${response.status}`);
+        }
+
+        const summary = await response.json();
+        if (requestId === statusSummaryRequestId) {
+          renderStatusSummary(summary);
+        }
+      } catch (error) {
+        console.error('Error loading status summary:', error);
+        if (requestId === statusSummaryRequestId) {
+          renderStatusSummary(null);
+        }
+      }
+    }
 
     // Format date as yyyy-mm-dd hh:MM
     function formatDateTime(dateString) {
@@ -222,6 +308,8 @@
     async function loadRecordings() {
       const tbody = document.getElementById('recordings-tbody');
       tbody.innerHTML = '<tr><td colspan="6" class="data-table__loading">Loading...</td></tr>';
+
+      loadStatusSummary();
 
       try {
         const params = new URLSearchParams({
@@ -585,6 +673,85 @@
   </script>
 
   <style>
+    .status-summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .status-summary__item {
+      position: relative;
+      padding: 1rem 1.25rem;
+      border-radius: 0.75rem;
+      border: 1px solid var(--color-border);
+      background: rgba(15, 23, 42, 0.65);
+      box-shadow: 0 12px 20px rgba(15, 23, 42, 0.25);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .status-summary__item::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      opacity: 0.25;
+    }
+
+    .status-summary__item--total::before {
+      background: linear-gradient(135deg, rgba(14, 165, 233, 0.7), rgba(37, 99, 235, 0.6));
+    }
+
+    .status-summary__item--completed::before {
+      background: linear-gradient(135deg, rgba(34, 197, 94, 0.7), rgba(22, 163, 74, 0.6));
+    }
+
+    .status-summary__item--pending::before {
+      background: linear-gradient(135deg, rgba(245, 158, 11, 0.7), rgba(217, 119, 6, 0.6));
+    }
+
+    .status-summary__item--processing::before {
+      background: linear-gradient(135deg, rgba(59, 130, 246, 0.7), rgba(14, 116, 144, 0.6));
+    }
+
+    .status-summary__item--failed::before {
+      background: linear-gradient(135deg, rgba(239, 68, 68, 0.7), rgba(220, 38, 38, 0.6));
+    }
+
+    .status-summary__item--unknown::before {
+      background: linear-gradient(135deg, rgba(148, 163, 184, 0.6), rgba(100, 116, 139, 0.6));
+    }
+
+    .status-summary__item:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 14px 24px rgba(15, 23, 42, 0.3);
+    }
+
+    .status-summary__label {
+      position: relative;
+      display: block;
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--color-text-muted);
+      margin-bottom: 0.35rem;
+      z-index: 1;
+    }
+
+    .status-summary__value {
+      position: relative;
+      font-size: 2rem;
+      font-weight: 700;
+      color: #f9fafb;
+      line-height: 1;
+      z-index: 1;
+    }
+
+    .status-summary__value[aria-busy="true"] {
+      opacity: 0.6;
+    }
+
     .filters-bar {
       display: flex;
       gap: 1rem;

--- a/tests/test_call_recordings.py
+++ b/tests/test_call_recordings.py
@@ -251,13 +251,39 @@ async def test_list_call_recordings_sorted_by_created_at():
 async def test_count_call_recordings():
     """Test counting call recordings."""
     from app.repositories import call_recordings as repo
-    
+
     with patch.object(repo.db, "fetch_one", new_callable=AsyncMock) as mock_fetch_one:
         mock_fetch_one.return_value = {"count": 42}
-        
+
         result = await repo.count_call_recordings()
-        
+
         assert result == 42
+
+
+@pytest.mark.asyncio
+async def test_summarize_transcription_statuses():
+    """Test summarizing transcription statuses for call recordings."""
+    from app.repositories import call_recordings as repo
+
+    with patch.object(repo.db, "fetch_all", new_callable=AsyncMock) as mock_fetch_all:
+        mock_fetch_all.return_value = [
+            {"status": "completed", "count": 5},
+            {"status": "pending", "count": 2},
+            {"status": None, "count": 1},
+            {"status": "unexpected", "count": 3},
+        ]
+
+        result = await repo.summarize_transcription_statuses()
+
+    assert result == {
+        "pending": 2,
+        "processing": 0,
+        "completed": 5,
+        "failed": 0,
+        "unknown": 4,
+        "total": 11,
+    }
+    mock_fetch_all.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a status summary banner above the Call Recordings & Transcriptions table with styling and live updates
- expose a new API endpoint and repository helper that aggregates call recording counts by transcription status
- cover the repository helper with unit tests

## Testing
- pytest tests/test_call_recordings.py::test_summarize_transcription_statuses *(fails: async plugin not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6911b842724c8332a8f7d58346382ac5)