### PR TITLE
Fix audit import for risk creation route

### DIFF
--- a/app/api/routes/bcp.py
+++ b/app/api/routes/bcp.py
@@ -1224,8 +1224,9 @@ async def create_risk(
 ):
     """Create a new risk."""
     user, company_id = await _require_bcp_edit(request)
-    
+
     from app.services.risk_calculator import calculate_risk
+    from app.services import audit
     
     # Validate likelihood and impact
     if not (1 <= likelihood <= 4):


### PR DESCRIPTION
## Summary
- import the audit service in the risk creation route
- ensure audit logging executes when creating a new risk

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691339a175408332a970c3e5a59b3f89)