### PR TITLE
Highlight required fields across BCP forms

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,6 +13,13 @@
     {% if csrf_token %}
     <meta name="csrf-token" content="{{ csrf_token }}" />
     {% endif %}
+    <style>
+      .form-label.required::after,
+      label.required::after {
+        content: ' *';
+        color: #dc2626;
+      }
+    </style>
     {% block styles %}{% endblock %}
     {% block extra_head %}{% endblock %}
   </head>

--- a/app/templates/bcp/backups.html
+++ b/app/templates/bcp/backups.html
@@ -131,7 +131,7 @@
       <input type="hidden" name="_csrf" value="{{ csrf_token }}">
       <div class="modal-body">
         <div class="form-group">
-          <label for="data_scope" class="form-label">Data for Backup *</label>
+          <label for="data_scope" class="form-label required">Data for Backup</label>
           <input type="text" id="data_scope" name="data_scope" class="form-input" placeholder="e.g., Customer Database, Financial Records" required>
         </div>
 
@@ -174,7 +174,7 @@
       <input type="hidden" name="_csrf" value="{{ csrf_token }}">
       <div class="modal-body">
         <div class="form-group">
-          <label for="edit_data_scope" class="form-label">Data for Backup *</label>
+          <label for="edit_data_scope" class="form-label required">Data for Backup</label>
           <input type="text" id="edit_data_scope" name="data_scope" class="form-input" required>
         </div>
 

--- a/app/templates/bcp/bia_edit.html
+++ b/app/templates/bcp/bia_edit.html
@@ -35,10 +35,10 @@
           <h3 class="form-section-title">Basic Information</h3>
           
           <div class="form-group">
-            <label for="name" class="form-label required">Activity Name *</label>
-            <input 
-              type="text" 
-              id="name" 
+            <label for="name" class="form-label required">Activity Name</label>
+            <input
+              type="text"
+              id="name"
               name="name" 
               class="form-input" 
               value="{{ activity.name if activity else '' }}" 

--- a/app/templates/bcp/emergency_kit.html
+++ b/app/templates/bcp/emergency_kit.html
@@ -251,7 +251,7 @@
     </div>
     <form action="/bcp/emergency-kit" method="post" class="modal-body">
       <div class="form-group">
-        <label for="create_category" class="form-label">Category *</label>
+        <label for="create_category" class="form-label required">Category</label>
         <select id="create_category" name="category" class="form-select" required>
           <option value="Document" {% if active_tab == 'documents' %}selected{% endif %}>Document</option>
           <option value="Equipment" {% if active_tab == 'equipment' %}selected{% endif %}>Equipment</option>
@@ -259,7 +259,7 @@
       </div>
 
       <div class="form-group">
-        <label for="create_name" class="form-label">Name *</label>
+        <label for="create_name" class="form-label required">Name</label>
         <input type="text" id="create_name" name="name" class="form-input" required>
       </div>
 
@@ -289,7 +289,7 @@
     </div>
     <form id="editItemForm" method="post" class="modal-body">
       <div class="form-group">
-        <label for="edit_category" class="form-label">Category *</label>
+        <label for="edit_category" class="form-label required">Category</label>
         <select id="edit_category" name="category" class="form-select" required>
           <option value="Document">Document</option>
           <option value="Equipment">Equipment</option>
@@ -297,7 +297,7 @@
       </div>
 
       <div class="form-group">
-        <label for="edit_name" class="form-label">Name *</label>
+        <label for="edit_name" class="form-label required">Name</label>
         <input type="text" id="edit_name" name="name" class="form-input" required>
       </div>
 

--- a/app/templates/bcp/incident.html
+++ b/app/templates/bcp/incident.html
@@ -468,7 +468,7 @@
         <input type="hidden" name="kind" id="contact_kind" value="">
         
         <div class="form-group">
-          <label for="contact_person_or_org">Name / Organization *</label>
+          <label for="contact_person_or_org" class="form-label required">Name / Organization</label>
           <input type="text" id="contact_person_or_org" name="person_or_org" required class="form-control">
         </div>
         
@@ -510,7 +510,7 @@
         </div>
         
         <div class="form-group">
-          <label for="event_notes">Event Details *</label>
+          <label for="event_notes" class="form-label required">Event Details</label>
           <textarea id="event_notes" name="notes" required class="form-control" rows="4" placeholder="Describe what happened..."></textarea>
         </div>
       </div>

--- a/app/templates/bcp/insurance.html
+++ b/app/templates/bcp/insurance.html
@@ -142,7 +142,7 @@
       <input type="hidden" name="_csrf" value="{{ csrf_token }}">
       <div class="modal-body">
         <div class="form-group">
-          <label for="policy_type" class="form-label">Type *</label>
+          <label for="policy_type" class="form-label required">Type</label>
           <input type="text" id="policy_type" name="policy_type" class="form-input" placeholder="e.g., Property, Liability, Business Interruption" required>
         </div>
 
@@ -195,7 +195,7 @@
       <input type="hidden" name="_csrf" value="{{ csrf_token }}">
       <div class="modal-body">
         <div class="form-group">
-          <label for="edit_policy_type" class="form-label">Type *</label>
+          <label for="edit_policy_type" class="form-label required">Type</label>
           <input type="text" id="edit_policy_type" name="policy_type" class="form-input" required>
         </div>
 

--- a/app/templates/bcp/insurance_claims.html
+++ b/app/templates/bcp/insurance_claims.html
@@ -139,7 +139,7 @@
     <form method="post" action="/bcp/insurance-claims">
       <div class="modal-body">
         <div class="form-group">
-          <label for="insurer" class="required">Insurer</label>
+          <label for="insurer" class="form-label required">Insurer</label>
           <input type="text" id="insurer" name="insurer" class="form-control" required>
         </div>
         <div class="form-group">
@@ -173,7 +173,7 @@
     <form method="post" id="editClaimForm">
       <div class="modal-body">
         <div class="form-group">
-          <label for="edit_insurer" class="required">Insurer</label>
+          <label for="edit_insurer" class="form-label required">Insurer</label>
           <input type="text" id="edit_insurer" name="insurer" class="form-control" required>
         </div>
         <div class="form-group">

--- a/app/templates/bcp/market_changes.html
+++ b/app/templates/bcp/market_changes.html
@@ -131,7 +131,7 @@
     <form method="post" action="/bcp/market-changes">
       <div class="modal-body">
         <div class="form-group">
-          <label for="change" class="required">Market Change</label>
+          <label for="change" class="form-label required">Market Change</label>
           <textarea id="change" name="change" class="form-control" rows="3" required placeholder="Describe the market change"></textarea>
         </div>
         <div class="form-group">
@@ -161,7 +161,7 @@
     <form method="post" id="editChangeForm">
       <div class="modal-body">
         <div class="form-group">
-          <label for="edit_change" class="required">Market Change</label>
+          <label for="edit_change" class="form-label required">Market Change</label>
           <textarea id="edit_change" name="change" class="form-control" rows="3" required></textarea>
         </div>
         <div class="form-group">

--- a/app/templates/bcp/overview.html
+++ b/app/templates/bcp/overview.html
@@ -246,7 +246,7 @@
       <input type="hidden" name="_csrf" value="{{ csrf_token }}">
       <div class="modal-body">
         <div class="form-group">
-          <label for="title" class="form-label">Title</label>
+          <label for="title" class="form-label required">Title</label>
           <input type="text" id="title" name="title" class="form-input" value="{{ plan.title }}" required>
         </div>
 
@@ -279,7 +279,7 @@
       <input type="hidden" name="_csrf" value="{{ csrf_token }}">
       <div class="modal-body">
         <div class="form-group">
-          <label for="objective_text" class="form-label">Objective</label>
+          <label for="objective_text" class="form-label required">Objective</label>
           <textarea id="objective_text" name="objective_text" class="form-input" rows="3" required></textarea>
         </div>
       </div>
@@ -302,12 +302,12 @@
       <input type="hidden" name="_csrf" value="{{ csrf_token }}">
       <div class="modal-body">
         <div class="form-group">
-          <label for="copy_number" class="form-label">Copy #</label>
+          <label for="copy_number" class="form-label required">Copy #</label>
           <input type="text" id="copy_number" name="copy_number" class="form-input" required>
         </div>
 
         <div class="form-group">
-          <label for="name" class="form-label">Name</label>
+          <label for="name" class="form-label required">Name</label>
           <input type="text" id="name" name="name" class="form-input" required>
         </div>
 

--- a/app/templates/bcp/recovery.html
+++ b/app/templates/bcp/recovery.html
@@ -196,7 +196,7 @@
     <form id="actionForm" method="post" action="/bcp/recovery">
       <div class="modal-body">
         <div class="form-group">
-          <label for="action">Action <span class="required">*</span></label>
+          <label for="action" class="form-label required">Action</label>
           <textarea id="action" name="action" class="form-control" rows="3" required></textarea>
         </div>
 
@@ -410,8 +410,5 @@ window.onclick = function(event) {
   border-top: 1px solid #e5e7eb;
 }
 
-.required {
-  color: #ef4444;
-}
 </style>
 {% endblock %}

--- a/app/templates/bcp/recovery_contacts.html
+++ b/app/templates/bcp/recovery_contacts.html
@@ -132,7 +132,7 @@
     <form method="post" action="/bcp/recovery-contacts">
       <div class="modal-body">
         <div class="form-group">
-          <label for="org_name" class="required">Organisation</label>
+          <label for="org_name" class="form-label required">Organisation</label>
           <input type="text" id="org_name" name="org_name" class="form-control" required>
         </div>
         <div class="form-group">
@@ -166,7 +166,7 @@
     <form method="post" id="editContactForm">
       <div class="modal-body">
         <div class="form-group">
-          <label for="edit_org_name" class="required">Organisation</label>
+          <label for="edit_org_name" class="form-label required">Organisation</label>
           <input type="text" id="edit_org_name" name="org_name" class="form-control" required>
         </div>
         <div class="form-group">

--- a/app/templates/bcp/roles.html
+++ b/app/templates/bcp/roles.html
@@ -159,7 +159,7 @@
     <form action="/bcp/roles" method="post">
       <div class="modal-body">
         <div class="form-group">
-          <label for="role_title">Title *</label>
+          <label for="role_title" class="form-label required">Title</label>
           <input type="text" id="role_title" name="title" required class="form-control" placeholder="e.g., Team Leader, Communications Officer">
         </div>
         
@@ -187,7 +187,7 @@
     <form id="editRoleForm" method="post">
       <div class="modal-body">
         <div class="form-group">
-          <label for="edit_role_title">Title *</label>
+          <label for="edit_role_title" class="form-label required">Title</label>
           <input type="text" id="edit_role_title" name="title" required class="form-control">
         </div>
         
@@ -214,7 +214,7 @@
     <form id="assignUserForm" method="post">
       <div class="modal-body">
         <div class="form-group">
-          <label for="assign_user_id">User *</label>
+          <label for="assign_user_id" class="form-label required">User</label>
           <select id="assign_user_id" name="user_id" required class="form-control">
             <option value="">Select a user...</option>
             {% for user in all_users %}
@@ -260,7 +260,7 @@
     <form id="editAssignmentForm" method="post">
       <div class="modal-body">
         <div class="form-group">
-          <label for="edit_assign_user_id">User *</label>
+          <label for="edit_assign_user_id" class="form-label required">User</label>
           <select id="edit_assign_user_id" name="user_id" required class="form-control">
             {% for user in all_users %}
             <option value="{{ user.id }}">

--- a/app/templates/bcp/schedules.html
+++ b/app/templates/bcp/schedules.html
@@ -196,7 +196,7 @@
     <form method="POST" action="/bcp/training">
       <div class="modal-body">
         <div class="form-group">
-          <label for="training_date" class="form-label">Training Date *</label>
+          <label for="training_date" class="form-label required">Training Date</label>
           <input type="datetime-local" id="training_date" name="training_date" class="form-control" required>
         </div>
         <div class="form-group">
@@ -226,7 +226,7 @@
     <form method="POST" id="editTrainingForm">
       <div class="modal-body">
         <div class="form-group">
-          <label for="edit_training_date" class="form-label">Training Date *</label>
+          <label for="edit_training_date" class="form-label required">Training Date</label>
           <input type="datetime-local" id="edit_training_date" name="training_date" class="form-control" required>
         </div>
         <div class="form-group">
@@ -256,7 +256,7 @@
     <form method="POST" action="/bcp/review">
       <div class="modal-body">
         <div class="form-group">
-          <label for="review_date" class="form-label">Review Date *</label>
+          <label for="review_date" class="form-label required">Review Date</label>
           <input type="datetime-local" id="review_date" name="review_date" class="form-control" required>
         </div>
         <div class="form-group">
@@ -286,7 +286,7 @@
     <form method="POST" id="editReviewForm">
       <div class="modal-body">
         <div class="form-group">
-          <label for="edit_review_date" class="form-label">Review Date *</label>
+          <label for="edit_review_date" class="form-label required">Review Date</label>
           <input type="datetime-local" id="edit_review_date" name="review_date" class="form-control" required>
         </div>
         <div class="form-group">


### PR DESCRIPTION
## Summary
- add a global style rule so required labels automatically show a red asterisk
- tag required inputs across BCP templates with the shared required label class for consistent indicators

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691339510d98833285673455930edf4b)