### PR TITLE
Implement BCP export page with PDF download

### DIFF
--- a/app/templates/bcp/export.html
+++ b/app/templates/bcp/export.html
@@ -1,0 +1,209 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="page-container">
+  <section class="card">
+    <div class="card-header">
+      <div>
+        <h2 class="card-title">Export Business Continuity Plan</h2>
+        <p class="text-muted text-sm">Generate a PDF report that mirrors the official Business Queensland template.</p>
+      </div>
+      <a href="/bcp" class="btn btn-secondary">Back to Overview</a>
+    </div>
+    <div class="card-body export-layout">
+      <div class="export-summary">
+        <h3 class="section-heading">Plan Summary</h3>
+        <dl class="summary-grid">
+          <div>
+            <dt>Plan title</dt>
+            <dd>{{ plan.title }}</dd>
+          </div>
+          <div>
+            <dt>Version</dt>
+            <dd>{{ plan.version or 'Not set' }}</dd>
+          </div>
+          <div>
+            <dt>Last reviewed</dt>
+            <dd>{{ plan.last_reviewed.strftime('%Y-%m-%d') if plan.last_reviewed else 'Not reviewed yet' }}</dd>
+          </div>
+          <div>
+            <dt>Next review</dt>
+            <dd>{{ plan.next_review.strftime('%Y-%m-%d') if plan.next_review else 'Not scheduled' }}</dd>
+          </div>
+        </dl>
+        <p class="text-muted">
+          The PDF includes plan overview, risk management, BIA, incident response, recovery and rehearse/maintain sections,
+          matching the template order with automated tables and contact details.
+        </p>
+      </div>
+      <form class="export-form" method="get" action="/bcp/export/pdf">
+        <h3 class="section-heading">Download PDF Report</h3>
+        <div class="form-group">
+          <label class="form-label" for="event_log_limit">Event log entries</label>
+          <input
+            class="form-input"
+            type="number"
+            id="event_log_limit"
+            name="event_log_limit"
+            min="1"
+            max="{{ max_event_log_limit }}"
+            value="{{ default_event_log_limit }}"
+            required
+          >
+          <p class="form-hint">Choose how many recent incident log entries to include (maximum {{ max_event_log_limit }}).</p>
+        </div>
+        <button type="submit" class="btn btn-primary w-full md:w-auto">Download PDF</button>
+        <p class="attribution">Adapted from the Business Queensland Business continuity plan – Template (CC BY 4.0)</p>
+      </form>
+    </div>
+  </section>
+
+  {% if export_links %}
+  <section class="card">
+    <div class="card-header">
+      <h3 class="card-title">Other export formats</h3>
+      <p class="text-muted text-sm">Supplement the PDF with CSV extracts for deeper analysis.</p>
+    </div>
+    <div class="card-body">
+      <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {% for option in export_links %}
+        <div class="export-option">
+          <h4>{{ option.title }}</h4>
+          <p>{{ option.description }}</p>
+          <a class="btn btn-light" href="{{ option.href }}">Download</a>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+  </section>
+  {% endif %}
+</div>
+
+<style>
+.export-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 2rem;
+}
+
+@media (min-width: 900px) {
+  .export-layout {
+    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.section-heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #111827;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.summary-grid dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6b7280;
+  margin-bottom: 0.25rem;
+}
+
+.summary-grid dd {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+}
+
+.export-form {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  background-color: #f9fafb;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.export-form .form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-label {
+  font-weight: 600;
+  color: #374151;
+}
+
+.form-input {
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.form-hint {
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin: 0;
+}
+
+.attribution {
+  font-size: 0.75rem;
+  color: #9ca3af;
+  margin: 0;
+}
+
+.export-option {
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background-color: #ffffff;
+}
+
+.export-option h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #111827;
+  margin: 0;
+}
+
+.export-option p {
+  font-size: 0.9rem;
+  color: #4b5563;
+  flex-grow: 1;
+  margin: 0;
+}
+
+.export-option .btn {
+  align-self: flex-start;
+}
+
+.btn-light {
+  background-color: #eef2ff;
+  color: #3730a3;
+  border: none;
+}
+
+.btn-light:hover {
+  background-color: #e0e7ff;
+}
+</style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace the BCP export placeholder with a page that requires export permissions and surfaces plan metadata
- add a configurable PDF download form that targets the /bcp/export/pdf endpoint and highlights included content
- provide quick links to related CSV exports so operators can grab supporting data sets

## Testing
- pytest tests/test_bcp_permissions.py::TestBCPExportPermission::test_user_with_export_permission_has_access[asyncio] tests/test_bcp_permissions.py::TestBCPExportPermission::test_user_without_export_permission_denied[asyncio]


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691339e8b3b4833284608613cb6d3c46)