### PR TITLE
Apply dark theme styling to BCP experience

### DIFF
--- a/app/static/css/bcp.css
+++ b/app/static/css/bcp.css
@@ -1,34 +1,35 @@
+.bcp-theme,
 .bcp-page {
-  --bcp-surface: rgba(241, 245, 249, 0.82);
-  --bcp-surface-strong: rgba(226, 232, 240, 0.68);
-  --bcp-card: rgba(255, 255, 255, 0.98);
-  --bcp-card-soft: rgba(248, 250, 252, 0.96);
-  --bcp-border: rgba(15, 23, 42, 0.08);
-  --bcp-border-strong: rgba(15, 23, 42, 0.12);
-  --bcp-text: #0f172a;
-  --bcp-text-muted: #475569;
-  --bcp-text-soft: #64748b;
-  --bcp-heading: #0f172a;
-  --bcp-primary: #2563eb;
-  --bcp-primary-strong: #1d4ed8;
-  --bcp-primary-soft: rgba(37, 99, 235, 0.08);
-  --bcp-primary-surface: rgba(37, 99, 235, 0.12);
-  --bcp-success: #059669;
-  --bcp-success-soft: rgba(5, 150, 105, 0.12);
-  --bcp-danger: #dc2626;
-  --bcp-danger-soft: rgba(220, 38, 38, 0.12);
-  --bcp-warning: #f59e0b;
-  --bcp-warning-soft: rgba(245, 158, 11, 0.16);
-  --bcp-info: #0ea5e9;
-  --bcp-info-soft: rgba(14, 165, 233, 0.18);
+  --bcp-surface: rgba(7, 16, 31, 0.88);
+  --bcp-surface-strong: rgba(9, 20, 39, 0.92);
+  --bcp-card: rgba(15, 23, 42, 0.92);
+  --bcp-card-soft: rgba(30, 41, 59, 0.88);
+  --bcp-border: rgba(148, 163, 184, 0.25);
+  --bcp-border-strong: rgba(148, 163, 184, 0.35);
+  --bcp-text: #e2e8f0;
+  --bcp-text-muted: rgba(203, 213, 225, 0.85);
+  --bcp-text-soft: rgba(148, 163, 184, 0.8);
+  --bcp-heading: #f8fafc;
+  --bcp-primary: #60a5fa;
+  --bcp-primary-strong: #3b82f6;
+  --bcp-primary-soft: rgba(59, 130, 246, 0.18);
+  --bcp-primary-surface: rgba(59, 130, 246, 0.24);
+  --bcp-success: #34d399;
+  --bcp-success-soft: rgba(52, 211, 153, 0.2);
+  --bcp-danger: #f87171;
+  --bcp-danger-soft: rgba(248, 113, 113, 0.22);
+  --bcp-warning: #fbbf24;
+  --bcp-warning-soft: rgba(251, 191, 36, 0.22);
+  --bcp-info: #38bdf8;
+  --bcp-info-soft: rgba(56, 189, 248, 0.22);
   --bcp-radius-lg: 1.25rem;
   --bcp-radius-md: 0.85rem;
   --bcp-radius-sm: 0.55rem;
-  --bcp-shadow: 0 25px 80px -45px rgba(15, 23, 42, 0.65);
-  --bcp-shadow-card: 0 22px 60px -48px rgba(15, 23, 42, 0.65);
-  --bcp-shadow-hover: 0 20px 45px -40px rgba(37, 99, 235, 0.65);
+  --bcp-shadow: 0 25px 80px -45px rgba(2, 6, 23, 0.85);
+  --bcp-shadow-card: 0 22px 60px -48px rgba(2, 6, 23, 0.85);
+  --bcp-shadow-hover: 0 20px 45px -40px rgba(59, 130, 246, 0.55);
   color: var(--bcp-text);
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), var(--bcp-surface));
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.97), var(--bcp-surface));
   border-radius: var(--bcp-radius-lg);
   padding: clamp(1.5rem, 3vw, 2.75rem);
   margin: clamp(1rem, 2vw, 2.5rem);
@@ -40,13 +41,23 @@
   overflow: hidden;
 }
 
+.bcp-theme {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.75rem);
+  position: relative;
+  color: var(--bcp-text);
+  width: 100%;
+  min-height: 100%;
+}
+
 .bcp-page::before {
   content: "";
   position: absolute;
   inset: -30% -20% auto auto;
   width: clamp(240px, 40vw, 420px);
   height: clamp(240px, 40vw, 420px);
-  background: radial-gradient(circle at center, rgba(37, 99, 235, 0.16), transparent 70%);
+  background: radial-gradient(circle at center, rgba(37, 99, 235, 0.22), transparent 70%);
   pointer-events: none;
   z-index: 0;
 }
@@ -153,9 +164,9 @@
 }
 
 .bcp-page .help-card {
-  background: linear-gradient(140deg, rgba(219, 234, 254, 0.6), rgba(191, 219, 254, 0.35));
-  border: 1px solid rgba(37, 99, 235, 0.25);
-  box-shadow: 0 18px 45px -35px rgba(37, 99, 235, 0.55);
+  background: linear-gradient(140deg, rgba(59, 130, 246, 0.25), rgba(30, 64, 175, 0.32));
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  box-shadow: 0 18px 45px -35px rgba(59, 130, 246, 0.55);
 }
 
 .bcp-page .help-title {
@@ -169,14 +180,14 @@
 }
 
 .bcp-page .help-text {
-  color: var(--bcp-primary-strong);
+  color: rgba(191, 219, 254, 0.85);
   font-size: 0.95rem;
   line-height: 1.7;
 }
 
-.bcp-page .btn,
-.bcp-page .btn:link,
-.bcp-page .btn:visited {
+.bcp-theme .btn,
+.bcp-theme .btn:link,
+.bcp-theme .btn:visited {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -185,68 +196,69 @@
   font-size: 0.95rem;
   font-weight: 600;
   border-radius: 0.65rem;
-  border: 1px solid transparent;
+  border: 1px solid rgba(148, 163, 184, 0.28);
   text-decoration: none;
   cursor: pointer;
   transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease;
-  background: rgba(15, 23, 42, 0.02);
+  background: rgba(15, 23, 42, 0.55);
   color: var(--bcp-heading);
 }
 
-.bcp-page .btn:hover,
-.bcp-page .btn:focus-visible {
+.bcp-theme .btn:hover,
+.bcp-theme .btn:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 12px 28px -22px rgba(15, 23, 42, 0.65);
+  box-shadow: 0 12px 28px -22px rgba(2, 6, 23, 0.9);
+  border-color: rgba(148, 163, 184, 0.45);
 }
 
-.bcp-page .btn-primary {
+.bcp-theme .btn-primary {
   background: linear-gradient(135deg, var(--bcp-primary), var(--bcp-primary-strong));
   color: #fff;
   border-color: transparent;
   box-shadow: 0 15px 28px -22px rgba(37, 99, 235, 0.8);
 }
 
-.bcp-page .btn-primary:hover,
-.bcp-page .btn-primary:focus-visible {
+.bcp-theme .btn-primary:hover,
+.bcp-theme .btn-primary:focus-visible {
   box-shadow: 0 18px 35px -20px rgba(29, 78, 216, 0.8);
 }
 
-.bcp-page .btn-secondary {
-  background: rgba(15, 23, 42, 0.06);
+.bcp-theme .btn-secondary {
+  background: rgba(30, 41, 59, 0.8);
+  color: var(--bcp-text);
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.bcp-theme .btn-secondary:hover,
+.bcp-theme .btn-secondary:focus-visible {
+  border-color: rgba(148, 163, 184, 0.55);
+  background: rgba(30, 41, 59, 0.95);
+}
+
+.bcp-theme .btn-light {
+  background: rgba(148, 163, 184, 0.2);
   color: var(--bcp-heading);
-  border-color: rgba(15, 23, 42, 0.12);
+  border-color: rgba(148, 163, 184, 0.45);
 }
 
-.bcp-page .btn-secondary:hover,
-.bcp-page .btn-secondary:focus-visible {
-  border-color: rgba(15, 23, 42, 0.25);
-  background: rgba(15, 23, 42, 0.1);
-}
-
-.bcp-page .btn-light {
-  background: rgba(199, 210, 254, 0.65);
-  color: #312e81;
-  border-color: rgba(79, 70, 229, 0.2);
-}
-
-.bcp-page .btn-danger {
+.bcp-theme .btn-danger {
   background: linear-gradient(135deg, #ef4444, #dc2626);
   color: #fff;
 }
 
-.bcp-page .btn-warning {
+.bcp-theme .btn-warning {
   background: linear-gradient(135deg, #f59e0b, #d97706);
   color: #fff7ed;
   border-color: transparent;
 }
 
-.bcp-page .btn-sm {
+.bcp-theme .btn-sm {
   padding: 0.35rem 0.75rem;
   font-size: 0.8rem;
   border-radius: 0.55rem;
 }
 
-.bcp-page .btn-icon {
+.bcp-theme .btn-icon {
   background: none;
   border: none;
   color: var(--bcp-text-soft);
@@ -254,25 +266,25 @@
   border-radius: 0.5rem;
 }
 
-.bcp-page .btn-icon:hover,
-.bcp-page .btn-icon:focus-visible {
+.bcp-theme .btn-icon:hover,
+.bcp-theme .btn-icon:focus-visible {
   color: var(--bcp-primary);
   background: rgba(37, 99, 235, 0.08);
 }
 
-.bcp-page .btn-icon.btn-danger:hover,
-.bcp-page .btn-icon.btn-danger:focus-visible {
+.bcp-theme .btn-icon.btn-danger:hover,
+.bcp-theme .btn-icon.btn-danger:focus-visible {
   color: var(--bcp-danger);
   background: var(--bcp-danger-soft);
 }
 
-.bcp-page .btn-group {
+.bcp-theme .btn-group {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 0.5rem;
 }
 
-.bcp-page .button-group {
+.bcp-theme .button-group {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 0.75rem;
@@ -290,11 +302,11 @@
   letter-spacing: 0.02em;
 }
 
-.bcp-page .badge-primary { background: rgba(37, 99, 235, 0.2); color: var(--bcp-primary-strong); }
-.bcp-page .badge-secondary { background: rgba(100, 116, 139, 0.22); color: #334155; }
-.bcp-page .badge-danger { background: rgba(220, 38, 38, 0.2); color: var(--bcp-danger); }
-.bcp-page .badge-success { background: rgba(16, 185, 129, 0.22); color: #047857; }
-.bcp-page .badge-warning { background: rgba(245, 158, 11, 0.22); color: #b45309; }
+.bcp-page .badge-primary { background: rgba(37, 99, 235, 0.22); color: var(--bcp-primary-strong); }
+.bcp-page .badge-secondary { background: rgba(148, 163, 184, 0.25); color: var(--bcp-text); }
+.bcp-page .badge-danger { background: rgba(220, 38, 38, 0.25); color: #fecaca; }
+.bcp-page .badge-success { background: rgba(16, 185, 129, 0.25); color: #bbf7d0; }
+.bcp-page .badge-warning { background: rgba(245, 158, 11, 0.25); color: #fde68a; }
 
 .bcp-page .status-badge {
   border-radius: 999px;
@@ -337,12 +349,12 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-weight: 700;
-  background: rgba(226, 232, 240, 0.45);
-  color: var(--bcp-text-soft);
+  background: rgba(30, 41, 59, 0.75);
+  color: var(--bcp-text-muted);
 }
 
 .bcp-page .table tbody tr:hover {
-  background: rgba(226, 232, 240, 0.35);
+  background: rgba(59, 130, 246, 0.12);
 }
 
 .bcp-page .table tbody tr:last-child td {
@@ -371,17 +383,18 @@
   display: inline-flex;
   align-items: center;
   gap: 0.65rem;
-  background: var(--bcp-card-soft);
+  background: rgba(30, 41, 59, 0.85);
   padding: 0.75rem 1rem;
   border-radius: var(--bcp-radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .bcp-page .sort-controls select {
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.45);
   border-radius: 0.55rem;
   padding: 0.4rem 0.75rem;
-  background: #fff;
+  background: rgba(15, 23, 42, 0.9);
+  color: var(--bcp-text);
   font-size: 0.9rem;
 }
 
@@ -405,7 +418,7 @@
 .bcp-page .items-center { align-items: center; }
 .bcp-page .justify-between { justify-content: space-between; }
 
-.bcp-page .form-value {
+.bcp-theme .form-value {
   margin: 0;
   font-weight: 500;
   color: var(--bcp-heading);
@@ -597,9 +610,9 @@
 }
 
 .bcp-page .recovery-card {
-  background: rgba(248, 250, 252, 0.8);
+  background: var(--bcp-card-soft);
   border-radius: var(--bcp-radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid var(--bcp-border);
   padding: 1rem 1.25rem;
   display: flex;
   flex-direction: column;
@@ -697,11 +710,11 @@
   display: flex;
   gap: 0.85rem;
   align-items: flex-start;
-  background: #fff;
+  background: rgba(15, 23, 42, 0.75);
 }
 
-.bcp-page .checklist-item:hover { background: rgba(226, 232, 240, 0.35); }
-.bcp-page .checklist-item.completed { background: var(--bcp-success-soft); border-color: rgba(34, 197, 94, 0.4); }
+.bcp-page .checklist-item:hover { background: rgba(59, 130, 246, 0.18); }
+.bcp-page .checklist-item.completed { background: rgba(34, 197, 94, 0.15); border-color: rgba(34, 197, 94, 0.6); }
 
 .bcp-page .checklist-content {
   flex: 1;
@@ -779,13 +792,13 @@
 .bcp-page .heatmap-label { font-size: 0.85rem; color: var(--bcp-text-soft); font-weight: 500; }
 
 .bcp-page .legend-grid { display: grid; gap: 1.25rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
-.bcp-page .legend-section { padding: 1.1rem; background: rgba(248, 250, 252, 0.7); border-radius: var(--bcp-radius-md); border: 1px solid rgba(148, 163, 184, 0.25); }
+.bcp-page .legend-section { padding: 1.1rem; background: rgba(15, 23, 42, 0.78); border-radius: var(--bcp-radius-md); border: 1px solid var(--bcp-border); }
 .bcp-page .legend-heading { margin: 0 0 0.85rem; font-size: 1rem; font-weight: 600; color: var(--bcp-heading); }
 .bcp-page .legend-items { display: flex; flex-direction: column; gap: 0.8rem; }
 .bcp-page .legend-item { display: flex; gap: 0.75rem; align-items: flex-start; }
 .bcp-page .legend-badge { display: inline-flex; align-items: center; justify-content: center; width: 2.25rem; height: 2.25rem; border-radius: 0.5rem; font-weight: 600; color: #fff; background: var(--bcp-primary); flex-shrink: 0; }
 
-.bcp-page details.risk-details { background: rgba(226, 232, 240, 0.35); padding: 0.75rem 1rem; border-radius: var(--bcp-radius-sm); border: 1px solid rgba(148, 163, 184, 0.3); }
+.bcp-page details.risk-details { background: rgba(30, 41, 59, 0.78); padding: 0.75rem 1rem; border-radius: var(--bcp-radius-sm); border: 1px solid rgba(148, 163, 184, 0.35); }
 .bcp-page details.risk-details summary { cursor: pointer; color: var(--bcp-primary-strong); font-weight: 600; }
 .bcp-page .risk-description { font-weight: 600; margin-bottom: 0.5rem; color: var(--bcp-heading); }
 .bcp-page .severity-filters {
@@ -802,15 +815,16 @@
 
 .bcp-page .empty-state h3 { margin: 0.75rem 0 0.35rem; color: var(--bcp-heading); }
 
-.bcp-page .modal,
-.bcp-page dialog.modal {
+.bcp-theme .modal,
+.bcp-theme dialog.modal {
   position: fixed;
   inset: 0;
   display: none;
   align-items: center;
   justify-content: center;
   padding: 1.5rem;
-  background: rgba(15, 23, 42, 0.55);
+  background: rgba(2, 6, 23, 0.75);
+  backdrop-filter: blur(12px);
   border: none;
   max-width: none;
   width: 100%;
@@ -818,20 +832,20 @@
   z-index: 1200;
 }
 
-.bcp-page dialog[open],
-.bcp-page .modal.show,
-.bcp-page .modal[style*="display: flex"],
-.bcp-page .modal[style*="display:flex"],
-.bcp-page .modal[style*="display: block"],
-.bcp-page dialog.modal[open] {
+.bcp-theme dialog[open],
+.bcp-theme .modal.show,
+.bcp-theme .modal[style*="display: flex"],
+.bcp-theme .modal[style*="display:flex"],
+.bcp-theme .modal[style*="display: block"],
+.bcp-theme dialog.modal[open] {
   display: flex;
 }
 
-.bcp-page .modal::backdrop { background: rgba(15, 23, 42, 0.55); }
+.bcp-theme .modal::backdrop { background: rgba(2, 6, 23, 0.75); }
 
-.bcp-page .modal-content,
-.bcp-page dialog.modal > form,
-.bcp-page dialog.modal > div {
+.bcp-theme .modal-content,
+.bcp-theme dialog.modal > form,
+.bcp-theme dialog.modal > div {
   background: var(--bcp-card);
   border-radius: var(--bcp-radius-md);
   width: min(640px, 92vw);
@@ -841,39 +855,39 @@
   border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
-.bcp-page .modal-header,
-.bcp-page .modal-footer {
+.bcp-theme .modal-header,
+.bcp-theme .modal-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
   padding: 1.25rem 1.5rem;
-  background: rgba(248, 250, 252, 0.85);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.88);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
 }
 
-.bcp-page .modal-footer {
-  border-top: 1px solid rgba(148, 163, 184, 0.18);
+.bcp-theme .modal-footer {
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
   border-bottom: none;
 }
 
-.bcp-page .modal-title {
+.bcp-theme .modal-title {
   margin: 0;
   font-size: 1.25rem;
   font-weight: 600;
   color: var(--bcp-heading);
 }
 
-.bcp-page .modal-body {
+.bcp-theme .modal-body {
   padding: 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.bcp-page .modal-close,
-.bcp-page .modal-header button,
-.bcp-page .close {
+.bcp-theme .modal-close,
+.bcp-theme .modal-header button,
+.bcp-theme .close {
   border: none;
   background: none;
   color: var(--bcp-text-soft);
@@ -883,92 +897,96 @@
   border-radius: 0.5rem;
 }
 
-.bcp-page .modal-close:hover,
-.bcp-page .modal-header button:hover,
-.bcp-page .close:hover {
+.bcp-theme .modal-close:hover,
+.bcp-theme .modal-header button:hover,
+.bcp-theme .close:hover {
   color: var(--bcp-primary);
-  background: rgba(37, 99, 235, 0.08);
+  background: rgba(59, 130, 246, 0.2);
 }
 
-.bcp-page .form-group {
+.bcp-theme .form-group {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.bcp-page .form-section {
+.bcp-theme .form-section {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
   padding: 1.25rem 1.5rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: var(--bcp-radius-md);
-  background: rgba(248, 250, 252, 0.7);
+  background: rgba(15, 23, 42, 0.78);
 }
 
-.bcp-page .form-section + .form-section {
+.bcp-theme .form-section + .form-section {
   margin-top: 1.5rem;
 }
 
-.bcp-page .form-section-title {
+.bcp-theme .form-section-title {
   margin: 0;
   font-size: 1.15rem;
   font-weight: 600;
   color: var(--bcp-heading);
 }
 
-.bcp-page .form-section-description {
+.bcp-theme .form-section-description {
   margin: -0.5rem 0 0;
   color: var(--bcp-text-soft);
   line-height: 1.6;
 }
 
-.bcp-page .form-row {
+.bcp-theme .form-row {
   display: flex;
   gap: 1rem;
   flex-wrap: wrap;
 }
 
-.bcp-page .form-row .form-group {
+.bcp-theme .form-row .form-group {
   flex: 1;
   min-width: 220px;
 }
 
-.bcp-page .form-label {
+.bcp-theme .form-label {
   font-weight: 600;
   color: var(--bcp-heading);
 }
 
-.bcp-page .form-input,
-.bcp-page .form-textarea,
-.bcp-page .form-control,
-.bcp-page select,
-.bcp-page textarea,
-.bcp-page input[type="text"],
-.bcp-page input[type="number"],
-.bcp-page input[type="email"],
-.bcp-page input[type="tel"],
-.bcp-page input[type="date"] {
+.bcp-theme .form-input,
+.bcp-theme .form-textarea,
+.bcp-theme .form-control,
+.bcp-theme select,
+.bcp-theme textarea,
+.bcp-theme input[type="text"],
+.bcp-theme input[type="number"],
+.bcp-theme input[type="email"],
+.bcp-theme input[type="tel"],
+.bcp-theme input[type="date"] {
   border: 1px solid rgba(148, 163, 184, 0.5);
   border-radius: 0.65rem;
   padding: 0.65rem 0.85rem;
   font-size: 1rem;
-  background: #fff;
-  color: var(--bcp-heading);
+  background: rgba(15, 23, 42, 0.9);
+  color: var(--bcp-text);
   transition: border-color 0.18s ease, box-shadow 0.18s ease;
 }
 
-.bcp-page .form-input:focus,
-.bcp-page .form-textarea:focus,
-.bcp-page select:focus,
-.bcp-page textarea:focus,
-.bcp-page input:focus {
+.bcp-theme .form-input:focus,
+.bcp-theme .form-textarea:focus,
+.bcp-theme select:focus,
+.bcp-theme textarea:focus,
+.bcp-theme input:focus {
   outline: none;
   border-color: var(--bcp-primary);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.22);
 }
 
-.bcp-page .form-hint { font-size: 0.85rem; color: var(--bcp-text-soft); }
+.bcp-theme ::placeholder {
+  color: rgba(148, 163, 184, 0.65);
+}
+
+.bcp-theme .form-hint { font-size: 0.85rem; color: var(--bcp-text-soft); }
 
 .bcp-page .list-disc { list-style: disc; }
 .bcp-page .list-inside { padding-left: 1.25rem; }
@@ -980,9 +998,9 @@
 .bcp-page .risk-details p,
 .bcp-page .help-text ul,
 .bcp-page .help-text ol {
-  background: rgba(248, 250, 252, 0.85);
+  background: rgba(15, 23, 42, 0.78);
   border-radius: var(--bcp-radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   padding: 0.85rem 1rem;
   line-height: 1.6;
 }
@@ -1006,7 +1024,7 @@
   border-radius: var(--bcp-radius-md);
   padding: 2rem;
   text-align: center;
-  background: rgba(248, 250, 252, 0.85);
+  background: rgba(15, 23, 42, 0.8);
   color: var(--bcp-text-soft);
 }
 
@@ -1032,12 +1050,12 @@
   padding: 0.85rem 1rem;
   border-radius: var(--bcp-radius-sm);
   border: 1px solid rgba(148, 163, 184, 0.35);
-  background: #fff;
+  background: rgba(15, 23, 42, 0.75);
   cursor: pointer;
   transition: background 0.18s ease;
 }
 
-.bcp-page .checkbox-label:hover { background: rgba(226, 232, 240, 0.35); }
+.bcp-page .checkbox-label:hover { background: rgba(59, 130, 246, 0.15); }
 
 .bcp-page .checkbox,
 .bcp-page .checkbox-label input[type="checkbox"],
@@ -1069,7 +1087,7 @@
   transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
 }
 
-.bcp-page .severity-filter:hover { background: rgba(226, 232, 240, 0.35); border-color: rgba(148, 163, 184, 0.5); }
+.bcp-page .severity-filter:hover { background: rgba(59, 130, 246, 0.18); border-color: rgba(59, 130, 246, 0.45); }
 .bcp-page .severity-filter-active { background: var(--bcp-primary); color: #fff; border-color: transparent; }
 
 .bcp-page .filter-badge { background: var(--bcp-primary-soft); color: var(--bcp-primary-strong); font-weight: 600; padding: 0.25rem 0.75rem; }
@@ -1079,7 +1097,7 @@
   .bcp-page .export-layout { grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr); align-items: start; }
 }
 
-.bcp-page .export-form { background: rgba(37, 99, 235, 0.08); border-radius: var(--bcp-radius-md); border: 1px solid rgba(37, 99, 235, 0.18); padding: 1.5rem; gap: 1.1rem; }
+.bcp-page .export-form { background: rgba(37, 99, 235, 0.15); border-radius: var(--bcp-radius-md); border: 1px solid rgba(37, 99, 235, 0.35); padding: 1.5rem; gap: 1.1rem; }
 
 .bcp-page .export-download-button {
   width: 100%;
@@ -1156,9 +1174,9 @@
 }
 
 @media (max-width: 640px) {
-  .bcp-page .modal-content,
-  .bcp-page dialog.modal > form,
-  .bcp-page dialog.modal > div {
+  .bcp-theme .modal-content,
+  .bcp-theme dialog.modal > form,
+  .bcp-theme dialog.modal > div {
     width: 100%;
     max-height: 92vh;
   }

--- a/app/templates/bcp/layout.html
+++ b/app/templates/bcp/layout.html
@@ -6,5 +6,7 @@
 {% endblock %}
 
 {% block content %}
-  {% block bcp_content %}{% endblock %}
+  <div class="bcp-theme">
+    {% block bcp_content %}{% endblock %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- refresh the BCP palette to use light text on dark surfaces and adjust component styling to match
- scope BCP pages inside a new wrapper so shared buttons, forms, and modal content inherit the updated theme
- restyle BCP modal overlays and content to align with the rest of the portal’s dark theme

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6913b90616288332983c66c798e21f18)