### PR TITLE
Make ticket watcher migration idempotent

### DIFF
--- a/migrations/128_ticket_watchers_email_support.sql
+++ b/migrations/128_ticket_watchers_email_support.sql
@@ -2,29 +2,28 @@
 -- This allows watchers to be identified either by user_id or email address
 
 -- Add email column to ticket_watchers
-ALTER TABLE ticket_watchers 
-ADD COLUMN email VARCHAR(255) NULL AFTER user_id;
+ALTER TABLE ticket_watchers
+ADD COLUMN IF NOT EXISTS email VARCHAR(255) NULL AFTER user_id;
 
 -- Make user_id nullable to support email-only watchers
 ALTER TABLE ticket_watchers 
 MODIFY COLUMN user_id INT NULL;
 
 -- Drop the old unique constraint
-ALTER TABLE ticket_watchers 
-DROP INDEX uq_ticket_watchers_ticket_user;
+ALTER TABLE ticket_watchers
+DROP INDEX IF EXISTS uq_ticket_watchers_ticket_user;
 
--- Add unique constraint for user_id based watchers (where user_id IS NOT NULL)
--- This ensures a user can only watch a ticket once
-ALTER TABLE ticket_watchers 
-ADD UNIQUE INDEX uq_ticket_watchers_ticket_user (ticket_id, user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ticket_watchers_ticket_user
+    ON ticket_watchers (ticket_id, user_id);
 
--- Add unique constraint for email based watchers (where email IS NOT NULL)
--- This ensures an email can only watch a ticket once
-ALTER TABLE ticket_watchers 
-ADD UNIQUE INDEX uq_ticket_watchers_ticket_email (ticket_id, email(191));
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ticket_watchers_ticket_email
+    ON ticket_watchers (ticket_id, email(191));
 
 -- Add check constraint to ensure at least one of user_id or email is set
 -- Note: MySQL 8.0.16+ supports CHECK constraints
-ALTER TABLE ticket_watchers 
-ADD CONSTRAINT chk_ticket_watchers_identity 
+ALTER TABLE ticket_watchers
+DROP CHECK IF EXISTS chk_ticket_watchers_identity;
+
+ALTER TABLE ticket_watchers
+ADD CONSTRAINT chk_ticket_watchers_identity
 CHECK (user_id IS NOT NULL OR email IS NOT NULL);


### PR DESCRIPTION
## Summary
- make the ticket watcher email migration resilient to re-execution by guarding column and index changes
- drop and recreate the ticket watcher identity check constraint so the migration can run safely more than once

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69154a0769148332b6cd4a2972041541)