### PR TITLE
Ensure ticket watcher indexes persist when adding email support

### DIFF
--- a/migrations/128_ticket_watchers_email_support.sql
+++ b/migrations/128_ticket_watchers_email_support.sql
@@ -10,6 +10,13 @@ ALTER TABLE ticket_watchers
 MODIFY COLUMN user_id INT NULL;
 
 -- Drop the old unique constraint
+-- Ensure foreign keys retain necessary supporting indexes before dropping the composite key
+CREATE INDEX IF NOT EXISTS idx_ticket_watchers_ticket_id
+    ON ticket_watchers (ticket_id);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_watchers_user_id
+    ON ticket_watchers (user_id);
+
 ALTER TABLE ticket_watchers
 DROP INDEX IF EXISTS uq_ticket_watchers_ticket_user;
 


### PR DESCRIPTION
## Summary
- ensure the ticket_watchers migration retains separate indexes for ticket_id and user_id
- allow the migration to recreate unique indexes after adding email support without violating FK requirements

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69154b5b287083328ebba7f20d6236fa)