### PR TITLE
Fix Xero invoice creation by wrapping payload in Invoices array

### DIFF
--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -807,11 +807,13 @@ async def sync_billable_tickets(
     response_headers: dict[str, Any] | None = None
     xero_invoice_number: str | None = None
     
+    xero_request_payload = {"Invoices": [invoice_payload]}
+
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
                 api_url,
-                json=invoice_payload,
+                json=xero_request_payload,
                 headers=request_headers,
             )
             response_status = response.status_code
@@ -842,7 +844,7 @@ async def sync_billable_tickets(
                         response_status=response_status,
                         response_body=response_body,
                         request_headers=request_headers,
-                        request_body=invoice_payload,
+                        request_body=xero_request_payload,
                         response_headers=response_headers,
                     )
                 except Exception as record_exc:
@@ -861,7 +863,7 @@ async def sync_billable_tickets(
                         response_status=response_status,
                         response_body=response_body,
                         request_headers=request_headers,
-                        request_body=invoice_payload,
+                        request_body=xero_request_payload,
                         response_headers=response_headers,
                     )
                 except Exception as record_exc:
@@ -1223,11 +1225,13 @@ async def sync_company(company_id: int, auto_send: bool = False) -> dict[str, An
     response_body: str | None = None
     response_headers: dict[str, Any] | None = None
     
+    xero_request_payload = {"Invoices": [invoice_payload]}
+
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
                 api_url,
-                json=invoice_payload,
+                json=xero_request_payload,
                 headers=request_headers,
             )
             response_status = response.status_code
@@ -1246,7 +1250,7 @@ async def sync_company(company_id: int, auto_send: bool = False) -> dict[str, An
                         response_status=response_status,
                         response_body=response_body,
                         request_headers=request_headers,
-                        request_body=invoice_payload,
+                        request_body=xero_request_payload,
                         response_headers=response_headers,
                     )
                 except Exception as record_exc:
@@ -1265,7 +1269,7 @@ async def sync_company(company_id: int, auto_send: bool = False) -> dict[str, An
                         response_status=response_status,
                         response_body=response_body,
                         request_headers=request_headers,
-                        request_body=invoice_payload,
+                        request_body=xero_request_payload,
                         response_headers=response_headers,
                     )
                 except Exception as record_exc:
@@ -1508,11 +1512,13 @@ async def send_order_to_xero(
     response_headers: dict[str, Any] | None = None
     xero_invoice_number: str | None = None
     
+    xero_request_payload = {"Invoices": [xero_payload]}
+
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
                 api_url,
-                json=xero_payload,
+                json=xero_request_payload,
                 headers=request_headers,
             )
             response_status = response.status_code
@@ -1543,7 +1549,7 @@ async def send_order_to_xero(
                         response_status=response_status,
                         response_body=response_body,
                         request_headers=request_headers,
-                        request_body=xero_payload,
+                        request_body=xero_request_payload,
                         response_headers=response_headers,
                     )
                 except Exception as record_exc:
@@ -1562,7 +1568,7 @@ async def send_order_to_xero(
                         response_status=response_status,
                         response_body=response_body,
                         request_headers=request_headers,
-                        request_body=xero_payload,
+                        request_body=xero_request_payload,
                         response_headers=response_headers,
                     )
                 except Exception as record_exc:

--- a/tests/test_xero_auto_send.py
+++ b/tests/test_xero_auto_send.py
@@ -79,11 +79,14 @@ async def test_sync_billable_tickets_auto_send_sets_authorised_status():
         # Verify the invoice payload has AUTHORISED status and SentToContact
         assert mock_client_instance.post.called
         call_args = mock_client_instance.post.call_args
-        invoice_payload = call_args.kwargs.get("json")
-        
-        assert invoice_payload is not None
+        request_payload = call_args.kwargs.get("json")
+
+        assert request_payload is not None
+        assert "Invoices" in request_payload
+        assert len(request_payload["Invoices"]) == 1
+        invoice_payload = request_payload["Invoices"][0]
         assert invoice_payload["Status"] == "AUTHORISED"
-        assert invoice_payload["SentToContact"] is True
+        assert invoice_payload.get("SentToContact") is True
         assert result["status"] == "succeeded"
 
 
@@ -152,9 +155,12 @@ async def test_sync_billable_tickets_draft_status_without_auto_send():
         # Verify the invoice payload has DRAFT status and no SentToContact
         assert mock_client_instance.post.called
         call_args = mock_client_instance.post.call_args
-        invoice_payload = call_args.kwargs.get("json")
-        
-        assert invoice_payload is not None
+        request_payload = call_args.kwargs.get("json")
+
+        assert request_payload is not None
+        assert "Invoices" in request_payload
+        assert len(request_payload["Invoices"]) == 1
+        invoice_payload = request_payload["Invoices"][0]
         assert invoice_payload["Status"] == "DRAFT"
         assert "SentToContact" not in invoice_payload
         assert result["status"] == "succeeded"

--- a/tests/test_xero_shop_orders.py
+++ b/tests/test_xero_shop_orders.py
@@ -219,12 +219,15 @@ async def test_send_order_to_xero_success():
         call_args = mock_client.post.call_args
         
         # Check the invoice payload
-        invoice_payload = call_args[1]["json"]
+        request_payload = call_args[1]["json"]
+        assert "Invoices" in request_payload
+        assert len(request_payload["Invoices"]) == 1
+        invoice_payload = request_payload["Invoices"][0]
         assert invoice_payload["Type"] == "ACCREC"
         assert invoice_payload["Reference"] == "PO-12345"
         assert invoice_payload["Status"] == "DRAFT"
         assert len(invoice_payload["LineItems"]) == 2
-        
+
         # Check that user info line was included
         user_line = invoice_payload["LineItems"][1]
         assert "Test User" in user_line["Description"]


### PR DESCRIPTION
## Summary
- wrap Xero invoice POST payloads in the expected `Invoices` array for billable tickets, company sync, and shop order invoicing
- ensure webhook monitor logging stores the wrapped request body
- adjust existing tests to assert the wrapped payload structure

## Testing
- pytest tests/test_xero_auto_send.py tests/test_xero_shop_orders.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691553ed59088332b4e3942eca1330cb)