### PR TITLE
Stop logging noisy skip messages

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -962,7 +962,6 @@ async def sync_account(account_id: int) -> dict[str, Any]:
         return {"status": "skipped", "reason": "pending_restart"}
     module = await modules_service.get_module("imap", redact=False)
     if not module or not module.get("enabled"):
-        log_info("Skipping IMAP sync because module is disabled", account_id=account_id)
         return {"status": "skipped", "reason": "Module disabled"}
     account = await imap_repo.get_account(account_id)
     if not account or not account.get("active", True):

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -242,11 +242,6 @@ class SchedulerService:
         async with db.acquire_lock(lock_name, timeout=1) as lock_acquired:
             if not lock_acquired:
                 # Another worker is already executing this task, skip silently
-                log_info(
-                    "Scheduled task already running on another worker, skipping",
-                    task_id=task_id,
-                    command=command,
-                )
                 return
 
             log_info("Running scheduled task", task_id=task_id, command=command)


### PR DESCRIPTION
## Summary
- avoid logging IMAP sync skips when the module is disabled
- remove the scheduler log emitted when another worker is already handling a task

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915e9582da083329bf14706e10b24f6)