### PR TITLE
Expand BCP layout to full width

### DIFF
--- a/app/static/css/bcp.css
+++ b/app/static/css/bcp.css
@@ -47,7 +47,8 @@
   gap: clamp(1.5rem, 3vw, 2.75rem);
   position: relative;
   color: var(--bcp-text);
-  width: min(1100px, 100%);
+  width: 100%;
+  max-width: none;
   margin-inline: auto;
   padding: clamp(1.5rem, 3vw, 2.75rem);
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- allow the BCP theme container to stretch to the full width of the available layout space

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915edbfa1b88332adc1a31112c20656)