### PR TITLE
Run system update during application startup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3088,6 +3088,10 @@ async def _render_company_edit_page(
 
 @app.on_event("startup")
 async def on_startup() -> None:
+    try:
+        await scheduler_service.run_system_update()
+    except Exception as exc:
+        log_error("Startup system update failed", error=str(exc))
     await db.connect()
     await db.run_migrations()
     async def _bootstrap_default_bcp_template() -> None:

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -326,7 +326,7 @@ class SchedulerService:
                 elif command == "update_stock_feed":
                     await products_service.update_stock_feed()
                 elif command == "system_update":
-                    output = await self._run_system_update(force_restart=force_restart)
+                    output = await self.run_system_update(force_restart=force_restart)
                     if output:
                         details = output
                 elif command == "create_scheduled_ticket":
@@ -578,6 +578,15 @@ class SchedulerService:
         if not task:
             raise ValueError(f"Task {task_id} not found")
         await self._run_task(task, force_restart=True)
+
+    async def run_system_update(self, *, force_restart: bool = False) -> str | None:
+        """Public helper to execute the system update script.
+
+        This wraps the private implementation so that other parts of the
+        application can reuse the same update mechanism used by scheduled
+        tasks.
+        """
+        return await self._run_system_update(force_restart=force_restart)
 
     async def _run_system_update(self, *, force_restart: bool = False) -> str | None:
         script_path = _PROJECT_ROOT / "scripts" / "upgrade.sh"

--- a/tests/test_scheduler_system_update.py
+++ b/tests/test_scheduler_system_update.py
@@ -27,7 +27,7 @@ def test_run_now_forces_restart_flag(monkeypatch):
         recorded["force_restart"] = force_restart
         return "ok"
 
-    monkeypatch.setattr(SchedulerService, "_run_system_update", fake_run_system_update)
+    monkeypatch.setattr(SchedulerService, "run_system_update", fake_run_system_update)
 
     asyncio.run(scheduler.run_now(7))
 


### PR DESCRIPTION
## Summary
- run the existing system update script when the application starts and log failures
- expose a public scheduler helper so other components can trigger the system update logic
- adjust the scheduler unit test to patch the new helper

## Testing
- pytest tests/test_scheduler_system_update.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69166cccce148332af6538d49515a06d)