### PR TITLE
Hide inactive scheduled tasks by default

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8256,11 +8256,11 @@ async def admin_message_templates_edit(request: Request, template_id: int):
 
 
 @app.get("/admin/automation", response_class=HTMLResponse)
-async def admin_automation(request: Request):
+async def admin_automation(request: Request, show_inactive: bool = Query(default=False)):
     current_user, redirect = await _require_super_admin_page(request)
     if redirect:
         return redirect
-    tasks = await scheduled_tasks_repo.list_tasks(include_inactive=True)
+    tasks = await scheduled_tasks_repo.list_tasks(include_inactive=show_inactive)
     companies = await company_repo.list_companies()
 
     company_lookup: dict[int, str] = {}
@@ -8327,6 +8327,7 @@ async def admin_automation(request: Request):
         "global_tasks": global_tasks,
         "command_options": command_options,
         "company_options": company_options,
+        "show_inactive_tasks": show_inactive,
     }
     return await _render_template("admin/automation.html", request, current_user, extra=extra)
 

--- a/app/templates/admin/automation.html
+++ b/app/templates/admin/automation.html
@@ -26,6 +26,7 @@
     </header>
     {% set global_tasks = global_tasks | default([], true) %}
     {% set company_tasks = company_tasks | default([], true) %}
+    {% set show_inactive_tasks = show_inactive_tasks | default(false, true) %}
     <div class="card__body card__body--stacked">
       <details class="card-collapsible" data-automation-section="global" open>
         <summary class="card__header card__header--collapsible">
@@ -46,6 +47,19 @@
               aria-label="Filter all-company tasks"
               data-table-filter="tasks-table-global"
             />
+            <form method="get" action="{{ request.url.path }}" class="inline-form" data-show-inactive-form>
+              <label class="form-checkbox-label">
+                <input
+                  type="checkbox"
+                  name="show_inactive"
+                  value="1"
+                  class="form-checkbox"
+                  {% if show_inactive_tasks %}checked{% endif %}
+                  onchange="this.form.submit()"
+                />
+                <span class="form-checkbox-text">Show inactive tasks</span>
+              </label>
+            </form>
           </div>
           <div class="table-wrapper">
             <table class="table" id="tasks-table-global" data-table>
@@ -91,7 +105,13 @@
                 </tr>
               {% else %}
                 <tr>
-                  <td colspan="8" class="table__empty">No global tasks configured yet.</td>
+                  <td colspan="8" class="table__empty">
+                    {% if show_inactive_tasks %}
+                      No global tasks configured yet.
+                    {% else %}
+                      No active global tasks. Enable "Show inactive tasks" to review archived entries.
+                    {% endif %}
+                  </td>
                 </tr>
               {% endfor %}
             </tbody>

--- a/tests/test_admin_automation_inactive_tasks.py
+++ b/tests/test_admin_automation_inactive_tasks.py
@@ -1,0 +1,128 @@
+"""Tests for hiding inactive scheduled tasks on the automation admin page."""
+"""Tests covering inactive scheduled task visibility on the automation page."""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import status
+from starlette.requests import Request
+from starlette.responses import HTMLResponse
+
+from app import main
+
+
+async def _dummy_receive() -> dict[str, Any]:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _make_request(path: str = "/admin/automation") -> Request:
+    scope = {"type": "http", "method": "GET", "path": path, "headers": []}
+    return Request(scope, _dummy_receive)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_admin_automation_hides_inactive_by_default(monkeypatch):
+    """Inactive tasks should be hidden unless explicitly requested."""
+    request = _make_request()
+    current_user = {"id": 1, "is_super_admin": True}
+
+    monkeypatch.setattr(
+        main,
+        "_require_super_admin_page",
+        AsyncMock(return_value=(current_user, None)),
+    )
+    list_tasks_mock = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "name": "Active Task",
+                "command": "sync_staff",
+                "company_id": None,
+                "active": 1,
+                "last_run_at": None,
+            }
+        ]
+    )
+    monkeypatch.setattr(main.scheduled_tasks_repo, "list_tasks", list_tasks_mock)
+    monkeypatch.setattr(
+        main.company_repo,
+        "list_companies",
+        AsyncMock(return_value=[{"id": 1, "name": "Example Co"}]),
+    )
+
+    captured: dict[str, Any] = {}
+
+    async def fake_render_template(template_name, request_obj, user_obj, *, extra):
+        captured["template"] = template_name
+        captured["extra"] = extra
+        return HTMLResponse("ok")
+
+    monkeypatch.setattr(main, "_render_template", fake_render_template)
+
+    response = await main.admin_automation(request, show_inactive=False)
+
+    assert response.status_code == status.HTTP_200_OK
+    list_tasks_mock.assert_called_once_with(include_inactive=False)
+    extra = captured.get("extra", {})
+    assert extra.get("show_inactive_tasks") is False
+
+
+@pytest.mark.anyio("asyncio")
+async def test_admin_automation_shows_inactive_when_requested(monkeypatch):
+    """Setting show_inactive to true should include inactive rows."""
+    request = _make_request("/admin/automation?show_inactive=1")
+    current_user = {"id": 1, "is_super_admin": True}
+
+    monkeypatch.setattr(
+        main,
+        "_require_super_admin_page",
+        AsyncMock(return_value=(current_user, None)),
+    )
+    list_tasks_mock = AsyncMock(
+        return_value=[
+            {
+                "id": 1,
+                "name": "Active Task",
+                "command": "sync_staff",
+                "company_id": None,
+                "active": 1,
+                "last_run_at": None,
+            },
+            {
+                "id": 2,
+                "name": "Inactive Task",
+                "command": "sync_o365",
+                "company_id": None,
+                "active": 0,
+                "last_run_at": None,
+            },
+        ]
+    )
+    monkeypatch.setattr(main.scheduled_tasks_repo, "list_tasks", list_tasks_mock)
+    monkeypatch.setattr(
+        main.company_repo,
+        "list_companies",
+        AsyncMock(return_value=[{"id": 1, "name": "Example Co"}]),
+    )
+
+    captured: dict[str, Any] = {}
+
+    async def fake_render_template(template_name, request_obj, user_obj, *, extra):
+        captured["template"] = template_name
+        captured["extra"] = extra
+        return HTMLResponse("ok")
+
+    monkeypatch.setattr(main, "_render_template", fake_render_template)
+
+    response = await main.admin_automation(request, show_inactive=True)
+
+    assert response.status_code == status.HTTP_200_OK
+    list_tasks_mock.assert_called_once_with(include_inactive=True)
+    extra = captured.get("extra", {})
+    assert extra.get("show_inactive_tasks") is True


### PR DESCRIPTION
## Summary
- hide inactive scheduled tasks on the automation admin page and gate the listing behind a toggle
- update the template UI to include the new toggle and improved empty-state messaging
- add regression tests covering the new behaviour alongside the existing repository tests

## Testing
- pytest tests/test_admin_automation_inactive_tasks.py tests/test_company_edit_inactive_tasks.py tests/test_scheduled_tasks_hide_inactive.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691aac7d789483328464e8d31e36bb17)