### PR TITLE
Fix default ticket status selection for new entries

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -2155,6 +2155,8 @@
       clearError();
       const rows = Array.from(list.querySelectorAll('[data-status-row]'));
       const seen = new Set();
+      const selectedDefaultRadio = form.querySelector('input[name="defaultStatus"]:checked');
+      let selectedDefaultSlug = '';
       for (const row of rows) {
         const techInput = row.querySelector('input[name="techLabel"]');
         const publicInput = row.querySelector('input[name="publicLabel"]');
@@ -2184,6 +2186,12 @@
           return;
         }
         seen.add(slug);
+        if (selectedDefaultRadio && row.contains(selectedDefaultRadio)) {
+          selectedDefaultSlug = slug;
+        }
+      }
+      if (selectedDefaultRadio && selectedDefaultSlug) {
+        selectedDefaultRadio.value = selectedDefaultSlug;
       }
     });
 

--- a/tests/test_tickets_dashboard_api.py
+++ b/tests/test_tickets_dashboard_api.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.api.routes.tickets import require_helpdesk_technician, require_super_admin
+import app.main as main_module
 from app.main import app
 from app.main import automations_service, change_log_service, modules_service, scheduler_service
 from app.core.database import db
@@ -183,3 +184,14 @@ def test_replace_ticket_statuses_endpoint_handles_errors(monkeypatch):
     assert response.status_code == 400
     assert response.json()["detail"] == "Tech status values must be unique."
     replace_mock.assert_awaited_once()
+
+def test_build_ticket_status_payloads_marks_new_default():
+    payloads = main_module._build_ticket_status_payloads(
+        ["Awaiting reply"],
+        ["Awaiting reply"],
+        [""],
+        "awaiting_reply",
+    )
+
+    assert payloads
+    assert payloads[0]["isDefault"] is True


### PR DESCRIPTION
## Summary
- ensure the ticket status editor radios send the slug of the selected default before submitting
- normalize status payloads server-side so new or renamed statuses can become the default
- cover the new parsing helper with a focused test

## Testing
- pytest tests/test_tickets_dashboard_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691aaf7a8748833297ba560ffe02f454)