### PR TITLE
Integrate Redis-backed infrastructure

### DIFF
--- a/app/services/rate_limit_store.py
+++ b/app/services/rate_limit_store.py
@@ -1,0 +1,57 @@
+"""Shared Redis-backed rate limit primitives."""
+from __future__ import annotations
+
+import secrets
+import time
+from typing import Tuple
+
+from redis.asyncio import Redis
+
+
+_RATE_LIMIT_LUA = """
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+local member = ARGV[4]
+redis.call('ZREMRANGEBYSCORE', key, '-inf', now - window)
+local count = redis.call('ZCARD', key)
+if count >= limit then
+    local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+    local retry = 0
+    if oldest[2] then
+        retry = window - (now - tonumber(oldest[2]))
+    end
+    if retry < 0 then retry = 0 end
+    return {0, retry}
+end
+redis.call('ZADD', key, now, member)
+redis.call('EXPIRE', key, math.ceil(window))
+return {1, 0}
+"""
+
+
+async def acquire_slot(
+    redis_client: Redis,
+    *,
+    key: str,
+    limit: int,
+    window_seconds: float,
+) -> tuple[bool, float | None]:
+    """Record an event in Redis and determine if it fits within the limit."""
+
+    now = time.time()
+    member = f"{now:.6f}:{secrets.token_hex(6)}"
+    result: Tuple[int, float] | list[int | float] = await redis_client.eval(
+        _RATE_LIMIT_LUA,
+        1,
+        key,
+        float(now),
+        float(window_seconds),
+        int(limit),
+        member,
+    )
+    allowed = bool(int(result[0]))
+    retry_after_raw = float(result[1]) if len(result) > 1 else 0.0
+    retry_after = retry_after_raw if retry_after_raw > 0 else None
+    return allowed, retry_after

--- a/app/services/realtime.py
+++ b/app/services/realtime.py
@@ -2,11 +2,19 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import secrets
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
 from fastapi import WebSocket
+from redis.asyncio import Redis
+from redis.asyncio.client import PubSub
+from redis.exceptions import RedisError
+
+from app.core.logging import log_warning
 
 
 @dataclass(slots=True)
@@ -24,6 +32,41 @@ class RefreshNotifier:
     def __init__(self) -> None:
         self._connections: set[WebSocket] = set()
         self._lock = asyncio.Lock()
+        self._redis: Redis | None = None
+        self._pubsub: PubSub | None = None
+        self._listener_task: asyncio.Task[None] | None = None
+        self._channel = "refresh:events"
+        self._node_id = secrets.token_hex(8)
+
+    async def start(self, *, redis_client: Redis | None = None) -> None:
+        """Initialise Redis-backed pub/sub if a client is provided."""
+
+        if redis_client is None or self._listener_task is not None:
+            self._redis = redis_client
+            return
+        self._redis = redis_client
+        self._pubsub = self._redis.pubsub(ignore_subscribe_messages=True)
+        await self._pubsub.subscribe(self._channel)
+        self._listener_task = asyncio.create_task(self._listen_for_events())
+
+    async def stop(self) -> None:
+        """Stop listening for Redis events and release resources."""
+
+        if self._listener_task is not None:
+            self._listener_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._listener_task
+            self._listener_task = None
+        if self._pubsub is not None:
+            try:
+                await self._pubsub.unsubscribe(self._channel)
+            except Exception:  # pragma: no cover - defensive cleanup
+                pass
+            try:
+                await self._pubsub.close()
+            except Exception:  # pragma: no cover - defensive cleanup
+                pass
+            self._pubsub = None
 
     async def connect(self, websocket: WebSocket) -> None:
         """Accept a websocket and track it for future broadcasts."""
@@ -38,6 +81,23 @@ class RefreshNotifier:
         async with self._lock:
             self._connections.discard(websocket)
 
+    async def _broadcast_payload(self, payload: Mapping[str, Any]) -> BroadcastResult:
+        async with self._lock:
+            targets = list(self._connections)
+        if not targets:
+            return BroadcastResult(attempted=0, delivered=0, dropped=0)
+        delivered = 0
+        dropped = 0
+        for websocket in targets:
+            try:
+                await websocket.send_json(payload)
+                delivered += 1
+            except Exception:
+                dropped += 1
+                async with self._lock:
+                    self._connections.discard(websocket)
+        return BroadcastResult(attempted=len(targets), delivered=delivered, dropped=dropped)
+
     async def broadcast_refresh(
         self,
         *,
@@ -46,14 +106,6 @@ class RefreshNotifier:
         data: Mapping[str, Any] | None = None,
     ) -> BroadcastResult:
         """Broadcast a refresh signal to all connected clients."""
-
-        async with self._lock:
-            # Snapshot the current connections so that we do not hold the
-            # internal lock while sending messages.
-            targets = list(self._connections)
-
-        if not targets:
-            return BroadcastResult(attempted=0, delivered=0, dropped=0)
 
         payload: dict[str, Any] = {
             "type": "refresh",
@@ -80,25 +132,53 @@ class RefreshNotifier:
         if data:
             payload["data"] = dict(data)
 
-        delivered = 0
-        dropped = 0
-        for websocket in targets:
-            try:
-                await websocket.send_json(payload)
-                delivered += 1
-            except Exception:
-                dropped += 1
-                # Stop tracking this websocket because it no longer accepts
-                # messages.  We intentionally ignore errors here to keep the
-                # broadcast resilient.
-                async with self._lock:
-                    self._connections.discard(websocket)
+        result = await self._broadcast_payload(payload)
+        await self._publish_to_redis(payload)
+        return result
 
-        return BroadcastResult(
-            attempted=len(targets),
-            delivered=delivered,
-            dropped=dropped,
-        )
+    async def _publish_to_redis(self, payload: Mapping[str, Any]) -> None:
+        if self._redis is None:
+            return
+        envelope = {"source": self._node_id, "payload": dict(payload)}
+        try:
+            await self._redis.publish(self._channel, json.dumps(envelope))
+        except RedisError as exc:
+            log_warning("Failed to publish refresh event to Redis", error=str(exc))
+
+    async def _listen_for_events(self) -> None:
+        if self._pubsub is None:
+            return
+        while True:
+            try:
+                message = await self._pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:  # pragma: no cover - defensive logging
+                log_warning("Redis refresh subscriber error", error=str(exc))
+                await asyncio.sleep(1.0)
+                continue
+            if not message:
+                await asyncio.sleep(0.05)
+                continue
+            data = message.get("data")
+            if not data:
+                continue
+            if isinstance(data, bytes):
+                try:
+                    data = data.decode("utf-8")
+                except UnicodeDecodeError:
+                    continue
+            try:
+                envelope = json.loads(data)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(envelope, dict):
+                continue
+            if envelope.get("source") == self._node_id:
+                continue
+            payload = envelope.get("payload")
+            if isinstance(payload, dict):
+                await self._broadcast_payload(payload)
 
 
 refresh_notifier = RefreshNotifier()

--- a/app/services/redis.py
+++ b/app/services/redis.py
@@ -1,0 +1,61 @@
+"""Redis client utilities."""
+from __future__ import annotations
+
+from redis.asyncio import Redis
+from redis.asyncio.connection import ConnectionPool
+
+from app.core.config import get_settings
+from app.core.logging import log_warning
+
+
+__all__ = ["get_redis_client", "close_redis_client"]
+
+
+_redis_pool: ConnectionPool | None = None
+_redis_client: Redis | None = None
+
+
+def get_redis_client() -> Redis | None:
+    """Return a shared Redis client when a connection URL is configured."""
+
+    global _redis_client, _redis_pool
+    if _redis_client is not None:
+        return _redis_client
+
+    settings = get_settings()
+    redis_url = settings.redis_url
+    if not redis_url:
+        return None
+
+    try:
+        _redis_pool = ConnectionPool.from_url(redis_url, decode_responses=True)
+        _redis_client = Redis(connection_pool=_redis_pool)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log_warning("Unable to configure Redis client", error=str(exc))
+        _redis_pool = None
+        _redis_client = None
+        return None
+
+    return _redis_client
+
+
+async def close_redis_client() -> None:
+    """Close the shared Redis client and release the connection pool."""
+
+    global _redis_client, _redis_pool
+    client = _redis_client
+    pool = _redis_pool
+    _redis_client = None
+    _redis_pool = None
+
+    if client is not None:
+        try:
+            await client.aclose()
+        except Exception:  # pragma: no cover - defensive cleanup
+            pass
+
+    if pool is not None:
+        try:
+            await pool.disconnect()
+        except Exception:  # pragma: no cover - defensive cleanup
+            pass


### PR DESCRIPTION
## Summary
- add shared Redis client helpers along with Lua-backed rate limit storage
- wire Redis into the general and endpoint rate limiters, Syncro API limiter, realtime refresh channel, and message-template caching
- start and stop the Redis features during FastAPI startup/shutdown so caches and websocket notifications stay in sync across workers

## Testing
- `pytest tests/test_endpoint_rate_limiting.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ac6fa8294833288cfe04571655d9e)