### PR TITLE
Remove unused background task helper

### DIFF
--- a/app/services/background.py
+++ b/app/services/background.py
@@ -96,9 +96,3 @@ def queue_background_task(
     task.add_done_callback(_cleanup)
     return resolved_task_id
 
-
-def active_background_tasks() -> dict[str, asyncio.Task[Any]]:
-    """Return a snapshot of the currently scheduled background tasks."""
-
-    return dict(_BACKGROUND_TASKS)
-


### PR DESCRIPTION
## Summary
- remove the unused `active_background_tasks` helper from `app/services/background.py`
- keep the background task queuing API unchanged while ensuring the task registry still gets cleaned up when jobs finish

## Testing
- pytest tests/test_admin_syncro_company_import.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691bbc6a20c08332816ce10a87b4817f)