### PR TITLE
Remove parse_humanized_hours helper

### DIFF
--- a/app/services/time_utils.py
+++ b/app/services/time_utils.py
@@ -1,6 +1,4 @@
-"""
-Utility functions for working with time and duration.
-"""
+"""Utility functions for working with time and duration."""
 
 
 def humanize_hours(hours: int | None) -> str:
@@ -75,56 +73,3 @@ def humanize_hours(hours: int | None) -> str:
         month_str = f"{months} month" if months == 1 else f"{months} months"
         week_str = f"{remainder_weeks} week" if remainder_weeks == 1 else f"{remainder_weeks} weeks"
         return f"{month_str}, {week_str}"
-
-
-def parse_humanized_hours(humanized: str) -> int | None:
-    """
-    Parse a humanized time string back to hours.
-    
-    This is a simple implementation that handles basic cases.
-    For more complex parsing, consider using a library like dateparser.
-    
-    Args:
-        humanized: Human-readable time string
-        
-    Returns:
-        Number of hours, or None if parsing fails
-        
-    Examples:
-        >>> parse_humanized_hours("2 hours")
-        2
-        >>> parse_humanized_hours("1 day")
-        24
-        >>> parse_humanized_hours("2 weeks")
-        336
-        >>> parse_humanized_hours("Immediate")
-        0
-    """
-    if not humanized or humanized == "-":
-        return None
-    
-    if humanized.lower() == "immediate":
-        return 0
-    
-    # Simple parser - handles basic formats
-    humanized = humanized.lower().strip()
-    
-    try:
-        # Try to parse simple formats like "2 hours", "3 days", "1 week"
-        parts = humanized.split()
-        if len(parts) >= 2:
-            value = int(parts[0])
-            unit = parts[1].rstrip('s')  # Remove trailing 's' for plural
-            
-            if unit == "hour":
-                return value
-            elif unit == "day":
-                return value * 24
-            elif unit == "week":
-                return value * 168
-            elif unit == "month":
-                return value * 730
-    except (ValueError, IndexError):
-        pass
-    
-    return None

--- a/tests/test_time_utils.py
+++ b/tests/test_time_utils.py
@@ -15,9 +15,8 @@ spec = importlib.util.spec_from_file_location(
 time_utils_module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(time_utils_module)
 
-# Extract the functions
+# Extract the function under test
 humanize_hours = time_utils_module.humanize_hours
-parse_humanized_hours = time_utils_module.parse_humanized_hours
 
 
 def test_humanize_hours_none():
@@ -108,63 +107,6 @@ def test_humanize_hours_edge_cases():
     result = humanize_hours(169)
     # 169 hours = 1 week + 1 hour, but our function only shows day remainders for weeks
     assert result == "1 week"  # This is the actual behavior
-
-
-def test_parse_humanized_hours_none():
-    """Test parsing None or empty string."""
-    assert parse_humanized_hours(None) is None
-    assert parse_humanized_hours("") is None
-    assert parse_humanized_hours("-") is None
-
-
-def test_parse_humanized_hours_immediate():
-    """Test parsing 'Immediate'."""
-    assert parse_humanized_hours("Immediate") == 0
-    assert parse_humanized_hours("immediate") == 0
-
-
-def test_parse_humanized_hours_hours():
-    """Test parsing hours."""
-    assert parse_humanized_hours("1 hour") == 1
-    assert parse_humanized_hours("2 hours") == 2
-    assert parse_humanized_hours("24 hours") == 24
-
-
-def test_parse_humanized_hours_days():
-    """Test parsing days."""
-    assert parse_humanized_hours("1 day") == 24
-    assert parse_humanized_hours("2 days") == 48
-    assert parse_humanized_hours("7 days") == 168
-
-
-def test_parse_humanized_hours_weeks():
-    """Test parsing weeks."""
-    assert parse_humanized_hours("1 week") == 168
-    assert parse_humanized_hours("2 weeks") == 336
-
-
-def test_parse_humanized_hours_months():
-    """Test parsing months."""
-    assert parse_humanized_hours("1 month") == 730
-    assert parse_humanized_hours("2 months") == 1460
-
-
-def test_humanize_parse_round_trip():
-    """Test that humanize and parse are (mostly) inverse operations."""
-    # Test simple cases that should round-trip perfectly
-    test_hours = [0, 1, 24, 48, 168, 336, 730]
-    
-    for hours in test_hours:
-        humanized = humanize_hours(hours)
-        # Note: parse_humanized_hours is simplified and may not handle complex formats
-        # This test verifies basic round-tripping works for simple cases
-        if "," not in humanized and humanized not in ["-", "Immediate"]:
-            # Only test simple single-unit cases
-            continue
-        elif humanized == "-":
-            assert parse_humanized_hours(humanized) is None
-        elif humanized == "Immediate":
-            assert parse_humanized_hours(humanized) == 0
 
 
 def test_humanize_hours_real_world_examples():


### PR DESCRIPTION
## Summary
- remove the unused `parse_humanized_hours` helper from `time_utils`
- trim the time utility test suite to only cover the humanization behavior

## Testing
- pytest tests/test_time_utils.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691bbfdd1fbc8332ac64dc71755b749f)