### PR TITLE
Add service worker update banner and fix force refresh control

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1156,6 +1156,53 @@ button.header-title-menu__link {
   overflow-x: hidden;
 }
 
+.update-banner {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.85);
+  padding: var(--space-gap-tight);
+  margin-bottom: var(--space-gap-base);
+  box-shadow: 0 18px 35px -25px rgba(15, 23, 42, 0.8);
+}
+
+.update-banner__body {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-gap-tight);
+}
+
+.update-banner__copy {
+  flex: 1 1 240px;
+  color: #e2e8f0;
+}
+
+.update-banner__title {
+  margin: 0 0 0.15rem;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.update-banner__message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.update-banner__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-gap-tight);
+  flex: 0 0 auto;
+}
+
+@media (max-width: 640px) {
+  .update-banner__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
 .dashboard {
   max-width: 1100px;
   margin: 0 auto;

--- a/app/static/js/pwa.js
+++ b/app/static/js/pwa.js
@@ -52,6 +52,10 @@
 })();
 
 window.addEventListener('pwa:update-available', (event) => {
+  if (window.__MYPORTAL_HAS_UPDATE_HANDLER__) {
+    return;
+  }
+
   if (!event || !event.detail || typeof event.detail.applyUpdate !== 'function') {
     return;
   }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -29,6 +29,7 @@
     data-low-stock-threshold="{{ low_stock_threshold | default(5) }}"
     data-super-admin="{{ 'true' if current_user and current_user.is_super_admin else 'false' }}"
   >
+    {% set has_authenticated_user = current_user is defined and current_user and current_user.get('id') %}
     <div class="layout" data-layout>
       <div class="layout__scrim" data-mobile-nav-scrim aria-hidden="true"></div>
       <nav class="layout__sidebar" id="primary-navigation" data-sidebar tabindex="-1">
@@ -447,7 +448,6 @@
               {% endblock %}
             </div>
           </div>
-          {% set has_authenticated_user = current_user is defined and current_user and current_user.get('id') %}
           {% set header_actions_content %}
             {% block header_actions %}{% endblock %}
           {% endset %}
@@ -463,6 +463,31 @@
           {% endif %}
         </header>
         <section class="layout__content">
+          <div
+            class="update-banner"
+            data-update-banner
+            role="status"
+            aria-live="polite"
+            aria-hidden="true"
+            hidden
+          >
+            <div class="update-banner__body">
+              <div class="update-banner__copy">
+                <p class="update-banner__title">Update available</p>
+                <p class="update-banner__message" data-update-banner-message>
+                  A new version of the portal is ready. Refresh to apply the latest release.
+                </p>
+              </div>
+              <div class="update-banner__actions">
+                <button type="button" class="button" data-update-banner-refresh>
+                  Refresh now
+                </button>
+                <button type="button" class="button button--ghost" data-update-banner-dismiss>
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          </div>
           {% block content %}{% endblock %}
         </section>
       </main>


### PR DESCRIPTION
## Summary
- add a reusable update banner and JavaScript wiring so `pwa:update-available` events prompt users to refresh without relying on the old `window.confirm`
- keep the legacy confirm logic as a fallback, guarded so it does not duplicate the new UI
- fix the Force Refresh button visibility check and add styling/markup for the banner in the base layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691bc151fd7c83328042b4627c043027)