### PR TITLE
Add scheduled Unifi Talk recordings sync task

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3023,6 +3023,10 @@ async def _render_company_edit_page(
             {"value": "sync_to_xero_auto_send", "label": "Sync to Xero (Auto Send)"},
             {"value": "create_scheduled_ticket", "label": "Create scheduled ticket"},
             {"value": "sync_recordings", "label": "Sync call recordings"},
+            {
+                "value": "sync_unifi_talk_recordings",
+                "label": "Sync Unifi Talk recordings",
+            },
             {"value": "queue_transcriptions", "label": "Queue transcriptions"},
             {"value": "process_transcription", "label": "Process transcription"},
         ]
@@ -8378,6 +8382,10 @@ async def admin_automation(request: Request, show_inactive: bool = Query(default
         {"value": "sync_to_xero_auto_send", "label": "Sync to Xero (Auto Send)"},
         {"value": "create_scheduled_ticket", "label": "Create scheduled ticket"},
         {"value": "sync_recordings", "label": "Sync call recordings"},
+        {
+            "value": "sync_unifi_talk_recordings",
+            "label": "Sync Unifi Talk recordings",
+        },
         {"value": "queue_transcriptions", "label": "Queue transcriptions"},
         {"value": "process_transcription", "label": "Process transcription"},
     ]

--- a/tests/test_scheduler_unifi_talk_sync.py
+++ b/tests/test_scheduler_unifi_talk_sync.py
@@ -1,0 +1,62 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_scheduler_syncs_unifi_talk_recordings_success():
+    task = {"id": 5, "command": "sync_unifi_talk_recordings"}
+
+    from app.services.scheduler import SchedulerService
+
+    scheduler = SchedulerService()
+
+    with patch(
+        "app.services.scheduler.modules_service.trigger_module",
+        new_callable=AsyncMock,
+    ) as mock_trigger, patch(
+        "app.services.scheduler.scheduled_tasks_repo.record_task_run",
+        new_callable=AsyncMock,
+    ) as mock_record, patch(
+        "app.services.scheduler.db.acquire_lock",
+    ) as mock_lock:
+        mock_trigger.return_value = {
+            "status": "ok",
+            "downloaded": 3,
+            "skipped": 1,
+        }
+        mock_lock.return_value.__aenter__.return_value = True
+
+        await scheduler._run_task(task)
+
+        mock_trigger.assert_awaited_once_with("unifi-talk", {}, background=False)
+        assert mock_record.call_args.kwargs["status"] == "succeeded"
+        details = mock_record.call_args.kwargs["details"]
+        assert "downloaded" in (details or "")
+
+
+@pytest.mark.asyncio
+async def test_scheduler_syncs_unifi_talk_recordings_handles_errors():
+    task = {"id": 6, "command": "sync_unifi_talk_recordings"}
+
+    from app.services.scheduler import SchedulerService
+
+    scheduler = SchedulerService()
+
+    with patch(
+        "app.services.scheduler.modules_service.trigger_module",
+        new_callable=AsyncMock,
+    ) as mock_trigger, patch(
+        "app.services.scheduler.scheduled_tasks_repo.record_task_run",
+        new_callable=AsyncMock,
+    ) as mock_record, patch(
+        "app.services.scheduler.db.acquire_lock",
+    ) as mock_lock:
+        mock_trigger.return_value = {"status": "error", "error": "missing"}
+        mock_lock.return_value.__aenter__.return_value = True
+
+        await scheduler._run_task(task)
+
+        mock_trigger.assert_awaited_once_with("unifi-talk", {}, background=False)
+        assert mock_record.call_args.kwargs["status"] == "failed"
+        assert "missing" in (mock_record.call_args.kwargs["details"] or "")


### PR DESCRIPTION
## Summary
- add a scheduler command that triggers the `unifi-talk` module to download and sync recordings
- expose the new command in both company and global automation command pickers so it can be scheduled from the UI
- add regression tests to ensure scheduler status handling when the Unifi Talk sync succeeds or fails

## Testing
- pytest tests/test_scheduler_unifi_talk_sync.py tests/test_unifi_talk_integration.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691d07ec6db48332a2ea2afbed77f40d)