### PR TITLE
Add branded HTML error pages

### DIFF
--- a/app/templates/errors/error.html
+++ b/app/templates/errors/error.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% block header_title %}
+  <div class="header__title-content header__title-content--stacked">
+    <span class="header__title-text">{{ error_title }}</span>
+    <span class="header__title-meta">Error {{ error_status_code }} · {{ error_status_message }}</span>
+  </div>
+{% endblock %}
+
+{% block content %}
+  <div data-error-page>
+    <section class="card card--panel">
+      <header class="card__header card__header--stacked">
+        <p class="card__subtitle">Something didn't go to plan</p>
+        <h1 class="card__title">{{ error_title }}</h1>
+      </header>
+      <div class="card__body card__body--stacked">
+        <p class="text-muted">{{ error_message }}</p>
+        <div class="button-group">
+          <a class="button" href="/">Back to dashboard</a>
+          <button type="button" class="button button--ghost" onclick="history.back()">
+            Go back
+          </button>
+        </div>
+        <p class="text-muted">Request: {{ error_path }}</p>
+        {% if error_detail %}
+          <details class="error-details">
+            <summary>Technical details</summary>
+            <pre>{{ error_detail }}</pre>
+          </details>
+        {% endif %}
+      </div>
+    </section>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add helper utilities and exception handlers so portal errors render with the standard layout instead of plain fallback pages
- include a reusable error template that keeps the sidebar navigation available to users while displaying friendly messaging

## Testing
- `pytest tests/test_transcription_logging.py` *(fails: async tests require pytest-asyncio plugin in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691d130e03c48332893b4c07da1882ad)