### PR TITLE
Ensure ticket updates always expose ticket number for templates

### DIFF
--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -398,10 +398,16 @@ def _build_user_snapshot(user: Mapping[str, Any] | None) -> Mapping[str, Any] | 
 async def _enrich_ticket_context(ticket: Mapping[str, Any]) -> TicketRecord:
     enriched: TicketRecord = dict(ticket)
 
+    # Normalise ticket number fields so templates always have access
+    ticket_number = enriched.get("ticket_number") or enriched.get("number")
+    if not ticket_number and enriched.get("id") is not None:
+        # Fall back to the database ID when an explicit ticket number is missing
+        ticket_number = str(enriched.get("id"))
+
     # Add 'number' alias for 'ticket_number' to support {{ticket.number}} template variable
     # Ensure it's always present for consistent template access
-    if "number" not in enriched:
-        enriched["number"] = enriched.get("ticket_number")
+    enriched["ticket_number"] = ticket_number
+    enriched["number"] = ticket_number
     
     # Add 'labels' alias for 'ai_tags' to support {{ticket.labels}} template variable
     if "labels" not in enriched:


### PR DESCRIPTION
## Summary
- normalize ticket context to always include a ticket number alias
- fall back to the ticket ID when an explicit number is missing so email templates render correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ef9559f5c8332b1c20a022554fb25)