### PR TITLE
Trim quoted email content from ticket replies

### DIFF
--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -29,3 +29,24 @@ def test_sanitize_rich_text_marks_plain_text_as_content():
     assert result.html == "Hello world"
     assert result.text_content == "Hello world"
     assert result.has_rich_content is True
+
+
+def test_sanitize_rich_text_strips_quoted_email_headers_and_styles():
+    content = """
+        <p>Latest reply</p>
+        <style>P { margin-top: 0; margin-bottom: 0; }</style>
+        <p>From: Example Sender &lt;sender@example.com&gt;</p>
+        <p>Sent: Monday, 1 January 2025 10:00</p>
+        <p>To: Support Team &lt;support@example.com&gt;</p>
+        <p>Subject: RE: Ticket update</p>
+        <p>Earlier thread content that should be trimmed</p>
+    """
+
+    result = sanitize_rich_text(content)
+
+    assert "Latest reply" in result.html
+    assert "Earlier thread content" not in result.html
+    assert "From:" not in result.html
+    assert "Sent:" not in result.html
+    assert "Subject:" not in result.html
+    assert "margin-top" not in result.html

--- a/tests/test_xss_prevention.py
+++ b/tests/test_xss_prevention.py
@@ -62,10 +62,11 @@ def test_sanitize_rich_text_removes_style_tags():
     """Test that style tags are removed."""
     malicious_input = '<style>body { display: none; }</style><p>Content</p>'
     result = sanitize_rich_text(malicious_input)
-    
+
     # Style tags should be removed (not executed)
     assert "<style>" not in result.html
     assert "</style>" not in result.html
+    assert "display: none" not in result.html
     # Content should remain
     assert "<p>Content</p>" in result.html
 


### PR DESCRIPTION
## Summary
- strip style blocks and quoted email headers before sanitizing rich-text replies to keep ticket updates focused on the latest response
- add regression coverage to ensure CSS rules and quoted email metadata are removed during sanitization

## Testing
- pytest tests/test_xss_prevention.py tests/test_sanitization.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691f144a576883329ebe2cf889ca6ca5)