### PR TITLE
Ensure plausible config available to public templates

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1390,6 +1390,7 @@ async def _build_public_context(
         "can_manage_invoices": False,
         "can_manage_staff": False,
         "can_view_compliance": False,
+        "plausible_config": {"enabled": False},
         "cart_summary": {"item_count": 0, "total_quantity": 0, "subtotal": Decimal("0")},
         "notification_unread_count": 0,
         "enable_auto_refresh": bool(settings.enable_auto_refresh),


### PR DESCRIPTION
## Summary
- provide a default Plausible configuration in the public context to keep templates from failing when no user is present

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691fa8f842c88332a693010529da6538)