### PR TITLE
Handle missing Plausible settings during email tracking

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -87,7 +87,16 @@ async def send_email(
                 )
             else:
                 # Check if Plausible module is enabled and configured
-                module_settings = await modules_service.get_module_settings('plausible')
+                try:
+                    module_settings = await modules_service.get_module_settings('plausible')
+                except Exception as settings_exc:  # pragma: no cover - defensive logging
+                    logger.warning(
+                        "Plausible settings unavailable; using tracking defaults",
+                        reply_id=ticket_reply_id,
+                        error=str(settings_exc),
+                    )
+                    module_settings = None
+
                 track_opens = module_settings.get('track_opens', True) if module_settings else True
                 track_clicks = module_settings.get('track_clicks', True) if module_settings else True
                 


### PR DESCRIPTION
## Summary
- guard Plausible module settings retrieval to avoid failing email tracking when settings cannot be loaded
- default to tracking configuration when Plausible settings are unavailable and log a warning

## Testing
- pytest tests/test_email_tracking.py::test_generate_tracking_id -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691fe2635ff08332ae880eb3a98489ef)