### PR TITLE
Allow Cal.com embed resources

### DIFF
--- a/app/security/security_headers.py
+++ b/app/security/security_headers.py
@@ -50,8 +50,17 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         if any(path.startswith(prefix) for prefix in self.exempt_paths):
             return response
 
+        # Allowed sources for Cal.com embeds (scripts, frames, and API calls)
+        cal_embed_sources = ["https://cal.com", "https://app.cal.com"]
+
         # Build script-src directive with dynamic sources
-        script_sources = ["'self'", "'unsafe-inline'", "'unsafe-eval'", "https://unpkg.com"]
+        script_sources = [
+            "'self'",
+            "'unsafe-inline'",
+            "'unsafe-eval'",
+            "https://unpkg.com",
+            *cal_embed_sources,
+        ]
 
         # Add extra script sources (e.g., Plausible analytics)
         if self._get_extra_script_sources:
@@ -66,7 +75,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
                 pass
 
         # Build connect-src directive
-        connect_sources = ["'self'"]
+        connect_sources = ["'self'", *cal_embed_sources]
+
+        frame_sources = ["'self'", *cal_embed_sources]
 
         # Add extra connect sources (e.g., analytics APIs)
         if self._get_extra_connect_sources:
@@ -91,6 +102,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "img-src 'self' data: blob:",
             "font-src 'self' data:",
             f"connect-src {' '.join(connect_sources)}",
+            f"frame-src {' '.join(frame_sources)}",
             "frame-ancestors 'none'",
             "base-uri 'self'",
             "form-action 'self'",

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -114,12 +114,16 @@ def test_csp_header_configuration(test_app):
     
     # Check key CSP directives
     assert "default-src 'self'" in csp
-    assert "connect-src 'self'" in csp
+    assert "connect-src 'self' https://cal.com https://app.cal.com" in csp
     assert "frame-ancestors 'none'" in csp
+    assert "frame-src 'self' https://cal.com https://app.cal.com" in csp
     assert "base-uri 'self'" in csp
     assert "form-action 'self'" in csp
     # Check that unpkg.com is allowed for loading htmx in script-src directive
-    assert "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com" in csp
+    assert (
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com https://cal.com https://app.cal.com"
+        in csp
+    )
 
 
 def test_x_frame_options_deny(test_app):
@@ -204,7 +208,10 @@ def test_csp_with_plausible_analytics(test_app_with_plausible):
     # Check that Plausible domain is included in script-src
     assert "https://plausible.example.com" in csp
     # Plausible should also be allowed for connect-src
-    assert "connect-src 'self' https://plausible.example.com" in csp
+    assert (
+        "connect-src 'self' https://cal.com https://app.cal.com https://plausible.example.com"
+        in csp
+    )
     # Check that default sources are still present
     assert "'self'" in csp
     assert "'unsafe-inline'" in csp


### PR DESCRIPTION
## Summary
- allow Cal.com scripts, frames, and API calls through the Content-Security-Policy
- include frame-src directive to permit Cal.com embeds while keeping frame-ancestors protections
- update security header tests to reflect the new CSP allowances

## Testing
- pytest tests/test_security_headers.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691fe471e7d08332b932f6d84835f7df)