### PR TITLE
Exempt SMTP2Go webhooks from CSRF

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -515,7 +515,12 @@ app.add_middleware(
     exempt_paths=("/static",),
 )
 
-app.add_middleware(CSRFMiddleware)
+app.add_middleware(
+    CSRFMiddleware,
+    exempt_paths=(
+        "/api/webhooks/smtp2go",
+    ),
+)
 
 # Add Plausible tracking middleware for authenticated pageviews
 # This middleware sends custom events to Plausible Analytics when users access pages


### PR DESCRIPTION
## Summary
- exempt SMTP2Go webhook routes from CSRF middleware validation
- add regression test to ensure CSRF-exempt webhook posts succeed and adjust dummy session to include user id

## Testing
- python -m pytest tests/test_csrf_middleware.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691ffc8072c483329299cc32339a19e3)