### PR TITLE
Improve module background task error logging

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -1042,7 +1042,9 @@ async def trigger_module(
         try:
             result = await handler(settings, payload or {}, event_future=event_future)
         except Exception as exc:
-            logger.error("Module background task encountered an error", module=slug, error=str(exc))
+            logger.exception(
+                "Module background task encountered an error", module=slug, error=str(exc)
+            )
             if event_future and not event_future.done():
                 event_future.set_result(None)
             result = {"status": "error", "error": str(exc), "module": slug}


### PR DESCRIPTION
## Summary
- use exception logging for background module task failures
- ensure SMTP2Go errors surface with stack traces when invoked asynchronously

## Testing
- python -m pytest tests/test_smtp2go.py *(fails: missing dependency aiosqlite in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692009e0d8c48332abae2ded4c81c137)