### PR TITLE
Fix ticket split merge migration syntax

### DIFF
--- a/migrations/145_ticket_split_merge.sql
+++ b/migrations/145_ticket_split_merge.sql
@@ -13,9 +13,9 @@ ADD INDEX IF NOT EXISTS idx_tickets_split_from (split_from_ticket_id);
 
 -- Add foreign key constraints
 ALTER TABLE tickets
-ADD CONSTRAINT IF NOT EXISTS fk_tickets_merged_into
+ADD CONSTRAINT fk_tickets_merged_into
     FOREIGN KEY (merged_into_ticket_id) REFERENCES tickets(id) ON DELETE SET NULL;
 
 ALTER TABLE tickets
-ADD CONSTRAINT IF NOT EXISTS fk_tickets_split_from
+ADD CONSTRAINT fk_tickets_split_from
     FOREIGN KEY (split_from_ticket_id) REFERENCES tickets(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- remove unsupported `IF NOT EXISTS` from foreign key additions in migration 145 to restore valid SQL

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6923e88d49308332b05b2240684113f0)