### PR TITLE
Make ticket split/merge migration idempotent

### DIFF
--- a/migrations/145_ticket_split_merge.sql
+++ b/migrations/145_ticket_split_merge.sql
@@ -1,21 +1,117 @@
--- Add support for ticket split and merge functionality
--- Migration 145: Add merged_into_ticket_id and split_from_ticket_id columns
+-- This migration is idempotent to avoid duplicate column/index warnings on reruns
 
--- Add merged_into_ticket_id column to track when a ticket has been merged into another
-ALTER TABLE tickets
-ADD COLUMN IF NOT EXISTS merged_into_ticket_id INT NULL AFTER external_reference,
-ADD INDEX IF NOT EXISTS idx_tickets_merged_into (merged_into_ticket_id);
+-- Add merged_into_ticket_id column if it does not exist
+SET @merged_col_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tickets'
+      AND COLUMN_NAME = 'merged_into_ticket_id'
+);
 
--- Add split_from_ticket_id column to track when a ticket was split from another
-ALTER TABLE tickets
-ADD COLUMN IF NOT EXISTS split_from_ticket_id INT NULL AFTER merged_into_ticket_id,
-ADD INDEX IF NOT EXISTS idx_tickets_split_from (split_from_ticket_id);
+SET @sql = IF(
+    @merged_col_exists = 0,
+    'ALTER TABLE tickets ADD COLUMN merged_into_ticket_id INT NULL AFTER external_reference',
+    'SELECT "Column merged_into_ticket_id already exists" AS message'
+);
 
--- Add foreign key constraints
-ALTER TABLE tickets
-ADD CONSTRAINT fk_tickets_merged_into
-    FOREIGN KEY (merged_into_ticket_id) REFERENCES tickets(id) ON DELETE SET NULL;
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
 
-ALTER TABLE tickets
-ADD CONSTRAINT fk_tickets_split_from
-    FOREIGN KEY (split_from_ticket_id) REFERENCES tickets(id) ON DELETE SET NULL;
+-- Add index for merged_into_ticket_id if it does not exist
+SET @merged_idx_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tickets'
+      AND INDEX_NAME = 'idx_tickets_merged_into'
+);
+
+SET @sql = IF(
+    @merged_idx_exists = 0,
+    'CREATE INDEX idx_tickets_merged_into ON tickets(merged_into_ticket_id)',
+    'SELECT "Index idx_tickets_merged_into already exists" AS message'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Add split_from_ticket_id column if it does not exist
+SET @split_col_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tickets'
+      AND COLUMN_NAME = 'split_from_ticket_id'
+);
+
+SET @sql = IF(
+    @split_col_exists = 0,
+    'ALTER TABLE tickets ADD COLUMN split_from_ticket_id INT NULL AFTER merged_into_ticket_id',
+    'SELECT "Column split_from_ticket_id already exists" AS message'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Add index for split_from_ticket_id if it does not exist
+SET @split_idx_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tickets'
+      AND INDEX_NAME = 'idx_tickets_split_from'
+);
+
+SET @sql = IF(
+    @split_idx_exists = 0,
+    'CREATE INDEX idx_tickets_split_from ON tickets(split_from_ticket_id)',
+    'SELECT "Index idx_tickets_split_from already exists" AS message'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Add foreign key for merged_into_ticket_id if it does not exist
+SET @merged_fk_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tickets'
+      AND CONSTRAINT_NAME = 'fk_tickets_merged_into'
+      AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+);
+
+SET @sql = IF(
+    @merged_fk_exists = 0,
+    'ALTER TABLE tickets ADD CONSTRAINT fk_tickets_merged_into FOREIGN KEY (merged_into_ticket_id) REFERENCES tickets(id) ON DELETE SET NULL',
+    'SELECT "Foreign key fk_tickets_merged_into already exists" AS message'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Add foreign key for split_from_ticket_id if it does not exist
+SET @split_fk_exists = (
+    SELECT COUNT(*)
+    FROM information_schema.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tickets'
+      AND CONSTRAINT_NAME = 'fk_tickets_split_from'
+      AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+);
+
+SET @sql = IF(
+    @split_fk_exists = 0,
+    'ALTER TABLE tickets ADD CONSTRAINT fk_tickets_split_from FOREIGN KEY (split_from_ticket_id) REFERENCES tickets(id) ON DELETE SET NULL',
+    'SELECT "Foreign key fk_tickets_split_from already exists" AS message'
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## Summary
- add information_schema checks before altering the tickets table in migration 145
- ensure indexes and foreign keys for split/merge columns are created only when missing to prevent startup warnings

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6923ead0de788332b2959715e32611f6)