### PR TITLE
Capture SMTP2Go tracking IDs from API responses

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -105,13 +105,14 @@ async def send_email(
                 reply_to=reply_to,
                 tracking_id=tracking_id,
             )
-            
+
             # Record tracking metadata if ticket reply ID provided
-            smtp2go_message_id = result.get("email_id")
-            if tracking_id and ticket_reply_id and smtp2go_message_id:
+            smtp2go_message_id = result.get("smtp2go_message_id") or result.get("email_id")
+            response_tracking_id = result.get("tracking_id") or tracking_id
+            if response_tracking_id and ticket_reply_id and smtp2go_message_id:
                 await smtp2go.record_email_sent(
                     ticket_reply_id=ticket_reply_id,
-                    tracking_id=tracking_id,
+                    tracking_id=response_tracking_id,
                     smtp2go_message_id=smtp2go_message_id,
                 )
             

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -1572,11 +1572,12 @@ async def _invoke_smtp2go(
             tracking_id=tracking_id,
         )
 
-        smtp2go_message_id = result.get("email_id")
-        if enable_tracking and ticket_reply_id and smtp2go_message_id:
+        smtp2go_message_id = result.get("smtp2go_message_id") or result.get("email_id")
+        response_tracking_id = result.get("tracking_id") or tracking_id
+        if enable_tracking and ticket_reply_id and smtp2go_message_id and response_tracking_id:
             await smtp2go.record_email_sent(
                 ticket_reply_id=ticket_reply_id,
-                tracking_id=tracking_id or smtp2go.generate_tracking_id(),
+                tracking_id=response_tracking_id,
                 smtp2go_message_id=smtp2go_message_id,
             )
     except Exception as exc:  # pragma: no cover - defensive logging
@@ -1598,7 +1599,7 @@ async def _invoke_smtp2go(
             "recipients": recipients,
             "subject": subject,
             "smtp2go_message_id": smtp2go_message_id,
-            "tracking_id": tracking_id,
+            "tracking_id": response_tracking_id,
         }
     )
     updated_event = await _record_success(
@@ -1613,7 +1614,7 @@ async def _invoke_smtp2go(
             "recipients": recipients,
             "subject": subject,
             "smtp2go_message_id": smtp2go_message_id,
-            "tracking_id": tracking_id,
+            "tracking_id": response_tracking_id,
         },
     )
 


### PR DESCRIPTION
## Summary
- normalize SMTP2Go API responses to expose message and tracking identifiers
- persist SMTP2Go response tracking_id and smtp2go_message_id when logging ticket replies
- add regression coverage to confirm SMTP2Go response tracking metadata is stored

## Testing
- pytest tests/test_smtp2go.py::test_send_email_records_response_tracking


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6923fb35aedc83328666cce5773f8374)