### PR TITLE
Handle nested SMTP2Go response envelopes

### DIFF
--- a/app/services/smtp2go.py
+++ b/app/services/smtp2go.py
@@ -401,6 +401,15 @@ async def send_email_via_api(
         if not isinstance(data, dict):
             data = result if isinstance(result, dict) else {}
 
+        # Some responses further nest identifiers under a "response" object
+        # inside the "data" envelope. Flatten these so message/tracking IDs are
+        # available for storage.
+        nested_response = data.get("response") if isinstance(data, dict) else None
+        if isinstance(nested_response, dict):
+            # Preserve any top-level keys already present on data
+            merged_data = {**nested_response, **data}
+            data = merged_data
+
         # Normalise message ID field for downstream tracking logic
         message_id = (
             data.get("smtp2go_message_id")


### PR DESCRIPTION
## Summary
- flatten nested SMTP2Go responses so message and tracking identifiers are captured for storage
- add coverage to ensure nested response envelopes expose email_id and tracking_id values

## Testing
- pytest -q tests/test_smtp2go.py -k flattens_response_envelope


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692404d0b6f08332ad9c7e8929aa60c1)