### PR TITLE
Add SMTP2Go admin controls for webhook verification

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -450,6 +450,7 @@ DEFAULT_MODULES: list[dict[str, Any]] = [
             "track_opens": True,
             "track_clicks": True,
             "webhook_secret": str(os.getenv("SMTP2GO_WEBHOOK_SECRET", "")),
+            "disable_webhook_signature_verification": False,
         },
     },
     {
@@ -611,6 +612,9 @@ def _coerce_settings(
                 "track_opens": _ensure_bool(merged.get("track_opens"), True),
                 "track_clicks": _ensure_bool(merged.get("track_clicks"), True),
                 "webhook_secret": str(merged.get("webhook_secret", "")).strip(),
+                "disable_webhook_signature_verification": _ensure_bool(
+                    merged.get("disable_webhook_signature_verification"), False
+                ),
             }
         )
     elif slug == "syncro":

--- a/app/templates/admin/modules.html
+++ b/app/templates/admin/modules.html
@@ -101,6 +101,60 @@
                   <label class="form-label" for="smtp-prefix">Subject prefix</label>
                   <input id="smtp-prefix" name="settings.subject_prefix" class="form-input" value="{{ settings.subject_prefix or '' }}" />
                 </div>
+              {% elif module.slug == 'smtp2go' %}
+                <div class="form-field">
+                  <label class="form-label" for="smtp2go-api-key">API key</label>
+                  <input
+                    id="smtp2go-api-key"
+                    name="settings.api_key"
+                    class="form-input"
+                    type="password"
+                    autocomplete="off"
+                    placeholder="Enter a new API key"
+                  />
+                  <p class="form-help">Keys are stored securely. Leave blank to keep the existing value.</p>
+                </div>
+                <fieldset class="form-field">
+                  <legend class="form-label">Tracking options</legend>
+                  <div class="form-field__group form-field__group--stacked">
+                    <label class="checkbox">
+                      <input type="checkbox" name="settings.enable_tracking" value="true" {% if settings.enable_tracking is not defined or settings.enable_tracking %}checked{% endif %} />
+                      <span>Enable SMTP2Go tracking for sent emails</span>
+                    </label>
+                    <label class="checkbox">
+                      <input type="checkbox" name="settings.track_opens" value="true" {% if settings.track_opens is not defined or settings.track_opens %}checked{% endif %} />
+                      <span>Track opens</span>
+                    </label>
+                    <label class="checkbox">
+                      <input type="checkbox" name="settings.track_clicks" value="true" {% if settings.track_clicks is not defined or settings.track_clicks %}checked{% endif %} />
+                      <span>Track clicks</span>
+                    </label>
+                  </div>
+                </fieldset>
+                <div class="form-field">
+                  <label class="form-label" for="smtp2go-webhook-url">Webhook URL</label>
+                  <input id="smtp2go-webhook-url" class="form-input" value="{{ request.url_for('smtp2go_webhook') }}" readonly />
+                  <p class="form-help">Configure this endpoint for SMTP2Go events (delivered, opened, clicked, bounced, spam).</p>
+                </div>
+                <div class="form-field">
+                  <label class="form-label" for="smtp2go-webhook-secret">Webhook secret</label>
+                  <input
+                    id="smtp2go-webhook-secret"
+                    name="settings.webhook_secret"
+                    class="form-input"
+                    type="password"
+                    autocomplete="off"
+                    placeholder="Enter a new webhook secret"
+                  />
+                  <p class="form-help">Secrets are stored securely. Leave blank to keep the existing value.</p>
+                </div>
+                <div class="form-field form-field--checkbox">
+                  <label class="toggle">
+                    <input type="checkbox" name="settings.disable_webhook_signature_verification" value="true" {% if settings.disable_webhook_signature_verification %}checked{% endif %} />
+                    <span>Disable webhook signature verification</span>
+                  </label>
+                  <p class="form-help">Process webhook events even when signature verification fails or cannot be configured.</p>
+                </div>
               {% elif module.slug == 'imap' %}
                 <p class="form-help">Manage mailbox credentials, folders, and schedules from the dedicated IMAP workspace.</p>
                 <div class="form-actions">

--- a/wiki/SMTP2Go-Integration.md
+++ b/wiki/SMTP2Go-Integration.md
@@ -162,6 +162,8 @@ Body: Single event object from SMTP2Go (JSON object)
 
 All webhook requests are verified using HMAC-SHA256 signatures. The webhook secret must be configured in both MyPortal and SMTP2Go for verification to work.
 
+If you need to ingest events from environments that cannot send signatures (for example, during testing with a mock forwarder), you can temporarily disable verification via the **Disable webhook signature verification** toggle in the SMTP2Go module settings. Only use this option in trusted environments because it bypasses signature checks.
+
 MyPortal supports multiple signature formats:
 
 1. **Timestamp-based format** (SMTP2Go's current format):


### PR DESCRIPTION
## Summary
- add SMTP2Go module form controls for API key, tracking settings, and webhook endpoint details in the admin UI
- expose a toggle to disable webhook signature verification alongside webhook secret configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924fc0b44e48332a47e923c042aa127)