### PR TITLE
Ensure SMTP2Go webhooks are always persisted

### DIFF
--- a/app/api/routes/smtp2go_webhooks.py
+++ b/app/api/routes/smtp2go_webhooks.py
@@ -289,6 +289,15 @@ async def smtp2go_webhook(
                     tracking_id=result.get('tracking_id'),
                 )
             else:
+                fallback_result = await smtp2go.record_raw_webhook_event(event_type, event_item)
+                if fallback_result:
+                    processed_count += 1
+                    logger.info(
+                        "SMTP2Go webhook event recorded via fallback handler",
+                        event_type=event_type,
+                        email_id=email_id,
+                        tracking_id=fallback_result.get('tracking_id'),
+                    )
                 logger.warning(
                     "Failed to process SMTP2Go webhook event",
                     event_type=event_type,


### PR DESCRIPTION
## Summary
- add flexible tracking identifier extraction for SMTP2Go webhook payloads
- introduce fallback recording to persist webhook events even when standard processing fails
- extend webhook endpoint tests to cover fallback handling and Message-Id tracking

## Testing
- pytest tests/test_smtp2go_webhook_storage.py tests/test_smtp2go_webhook_endpoint.py (fails: async plugin missing in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69250a00eb9c8332b9b2d0a0e784e1e4)