### PR TITLE
Restyle conversation timeline and time badges

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2424,6 +2424,56 @@ button.header-title-menu__link {
   font-size: 0.9rem;
 }
 
+.timeline__meta-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.timeline__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-weight: 650;
+  font-size: 0.9rem;
+  background: rgba(148, 163, 184, 0.12);
+  color: rgba(226, 232, 240, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.timeline__chip svg,
+.timeline__chip-icon {
+  width: 0.9rem;
+  height: 0.9rem;
+}
+
+.timeline__chip--time {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: #e0f2fe;
+}
+
+.timeline__chip--billable {
+  background: rgba(74, 222, 128, 0.18);
+  border-color: rgba(74, 222, 128, 0.32);
+  color: #dcfce7;
+}
+
+.timeline__chip--nonbillable {
+  background: rgba(251, 113, 133, 0.14);
+  border-color: rgba(251, 113, 133, 0.32);
+  color: #ffe4e6;
+}
+
+.timeline__chip--labour {
+  background: rgba(129, 140, 248, 0.16);
+  border-color: rgba(129, 140, 248, 0.32);
+  color: #e0e7ff;
+}
+
 .timeline__body {
   color: rgba(226, 232, 240, 0.85);
   font-size: 0.95rem;
@@ -6284,6 +6334,15 @@ dialog.dialog::backdrop {
 .timeline__marker--active {
   background: #38bdf8;
   box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.25);
+}
+
+.timeline--conversation {
+  position: static;
+  padding-left: 0;
+}
+
+.timeline--conversation::before {
+  display: none;
 }
 
 .version-card,

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -76,6 +76,51 @@
     return summary;
   }
 
+  function renderTimeSummary(container, minutes, isBillable, labourName, fallbackText = '') {
+    if (!(container instanceof HTMLElement)) {
+      return;
+    }
+
+    const summaryText = fallbackText || formatTimeSummary(minutes, isBillable, labourName);
+    const hasSummary = typeof summaryText === 'string' && summaryText.trim() !== '';
+
+    container.hidden = !hasSummary;
+    container.replaceChildren();
+
+    if (!hasSummary) {
+      return;
+    }
+
+    const chips = [];
+    const hasMinutes = typeof minutes === 'number' && !Number.isNaN(minutes) && minutes >= 0;
+    if (hasMinutes) {
+      const timeChip = document.createElement('span');
+      timeChip.className = 'timeline__chip timeline__chip--time';
+      const unit = minutes === 1 ? 'minute' : 'minutes';
+      timeChip.textContent = `⏱️ ${minutes} ${unit}`;
+      chips.push(timeChip);
+    }
+
+    const billableChip = document.createElement('span');
+    billableChip.className = `timeline__chip ${isBillable ? 'timeline__chip--billable' : 'timeline__chip--nonbillable'}`;
+    billableChip.textContent = isBillable ? 'Billable' : 'Non-billable';
+    chips.push(billableChip);
+
+    if (typeof labourName === 'string' && labourName.trim() !== '') {
+      const labourChip = document.createElement('span');
+      labourChip.className = 'timeline__chip timeline__chip--labour';
+      labourChip.textContent = labourName.trim();
+      chips.push(labourChip);
+    }
+
+    if (chips.length === 0) {
+      container.textContent = summaryText;
+      return;
+    }
+
+    chips.forEach((chip) => container.appendChild(chip));
+  }
+
   function getCookie(name) {
     const pattern = `(?:^|; )${name.replace(/([.$?*|{}()\[\]\\\/\+^])/g, '\\$1')}=([^;]*)`;
     const matches = document.cookie.match(new RegExp(pattern));
@@ -788,13 +833,7 @@
       const summaryElement = replyArticle.querySelector('[data-reply-time-summary]');
       if (summaryElement) {
         const text = summary || formatTimeSummary(minutes, billable, labourTypeName);
-        if (text) {
-          summaryElement.textContent = text;
-          summaryElement.hidden = false;
-        } else {
-          summaryElement.textContent = '';
-          summaryElement.hidden = true;
-        }
+        renderTimeSummary(summaryElement, minutes, billable, labourTypeName, text);
       }
     }
 
@@ -1329,13 +1368,7 @@
       const summaryElement = recordingArticle.querySelector('[data-recording-time-summary]');
       if (summaryElement) {
         const text = summary || formatTimeSummary(minutes, billable, labourTypeName);
-        if (text) {
-          summaryElement.textContent = text;
-          summaryElement.hidden = false;
-        } else {
-          summaryElement.textContent = '';
-          summaryElement.hidden = true;
-        }
+        renderTimeSummary(summaryElement, minutes, billable, labourTypeName, text);
       }
     }
 

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -866,7 +866,7 @@
             </header>
             <div class="card__body">
               {% if ticket_replies or ticket_call_recordings %}
-                <div class="timeline" data-ticket-timeline data-ticket-id="{{ ticket.id }}">
+                <div class="timeline timeline--conversation" data-ticket-timeline data-ticket-id="{{ ticket.id }}">
                   {% for reply in ticket_replies %}
                     <article
                       class="timeline__event"
@@ -909,11 +909,22 @@
                             {% endif %}
                           </span>
                           <span
-                            class="timeline__meta text-muted"
+                            class="timeline__meta timeline__meta-group"
                             data-reply-time-summary
                             {% if not reply.time_summary %}hidden{% endif %}
+                            aria-label="Time spent details"
                           >
-                            {{ reply.time_summary or '' }}
+                            {% if reply.minutes_spent is not none %}
+                              <span class="timeline__chip timeline__chip--time">
+                                ⏱️ {{ reply.minutes_spent }} minute{{ 's' if reply.minutes_spent != 1 else '' }}
+                              </span>
+                            {% endif %}
+                            <span class="timeline__chip {{ 'timeline__chip--billable' if reply.is_billable else 'timeline__chip--nonbillable' }}">
+                              {{ 'Billable' if reply.is_billable else 'Non-billable' }}
+                            </span>
+                            {% if reply.labour_type_name %}
+                              <span class="timeline__chip timeline__chip--labour">{{ reply.labour_type_name }}</span>
+                            {% endif %}
                           </span>
                         </div>
                         <div class="timeline__header-controls">
@@ -979,11 +990,22 @@
                             <strong>📞 Call Recording:</strong> {{ recording.caller_name or 'Unknown' }} → {{ recording.callee_name or 'Unknown' }}
                           </span>
                           <span
-                            class="timeline__meta text-muted"
+                            class="timeline__meta timeline__meta-group"
                             data-recording-time-summary
                             {% if not recording.time_summary %}hidden{% endif %}
+                            aria-label="Time spent details"
                           >
-                            {{ recording.time_summary or '' }}
+                            {% if recording.minutes_spent is not none %}
+                              <span class="timeline__chip timeline__chip--time">
+                                ⏱️ {{ recording.minutes_spent }} minute{{ 's' if recording.minutes_spent != 1 else '' }}
+                              </span>
+                            {% endif %}
+                            <span class="timeline__chip {{ 'timeline__chip--billable' if recording.is_billable else 'timeline__chip--nonbillable' }}">
+                              {{ 'Billable' if recording.is_billable else 'Non-billable' }}
+                            </span>
+                            {% if recording.labour_type_name %}
+                              <span class="timeline__chip timeline__chip--labour">{{ recording.labour_type_name }}</span>
+                            {% endif %}
                           </span>
                         </div>
                         <div class="timeline__header-controls">

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -398,7 +398,7 @@
             </header>
             <div class="card__body">
               {% if ticket_replies %}
-                <div class="timeline" data-ticket-timeline data-ticket-id="{{ ticket.id }}">
+                <div class="timeline timeline--conversation" data-ticket-timeline data-ticket-id="{{ ticket.id }}">
                   {% for reply in ticket_replies %}
                     {% if reply.type == 'call_recording' %}
                     <article class="timeline__event timeline__event--call-recording" data-recording-id="{{ reply.id }}">
@@ -415,7 +415,19 @@
                             <strong>📞 Call Recording:</strong> {{ reply.caller_name }} → {{ reply.callee_name }}
                           </span>
                           {% if reply.time_summary %}
-                            <span class="timeline__meta text-muted">{{ reply.time_summary }}</span>
+                            <span class="timeline__meta timeline__meta-group" aria-label="Time spent details">
+                              {% if reply.minutes_spent is not none %}
+                                <span class="timeline__chip timeline__chip--time">
+                                  ⏱️ {{ reply.minutes_spent }} minute{{ 's' if reply.minutes_spent != 1 else '' }}
+                                </span>
+                              {% endif %}
+                              <span class="timeline__chip {{ 'timeline__chip--billable' if reply.is_billable else 'timeline__chip--nonbillable' }}">
+                                {{ 'Billable' if reply.is_billable else 'Non-billable' }}
+                              </span>
+                              {% if reply.labour_type_name %}
+                                <span class="timeline__chip timeline__chip--labour">{{ reply.labour_type_name }}</span>
+                              {% endif %}
+                            </span>
                           {% endif %}
                         </div>
                       </header>
@@ -472,7 +484,19 @@
                             {% endif %}
                           </span>
                           {% if reply.time_summary %}
-                            <span class="timeline__meta text-muted">{{ reply.time_summary }}</span>
+                            <span class="timeline__meta timeline__meta-group" aria-label="Time spent details">
+                              {% if reply.minutes_spent is not none %}
+                                <span class="timeline__chip timeline__chip--time">
+                                  ⏱️ {{ reply.minutes_spent }} minute{{ 's' if reply.minutes_spent != 1 else '' }}
+                                </span>
+                              {% endif %}
+                              <span class="timeline__chip {{ 'timeline__chip--billable' if reply.is_billable else 'timeline__chip--nonbillable' }}">
+                                {{ 'Billable' if reply.is_billable else 'Non-billable' }}
+                              </span>
+                              {% if reply.labour_type_name %}
+                                <span class="timeline__chip timeline__chip--labour">{{ reply.labour_type_name }}</span>
+                              {% endif %}
+                            </span>
                           {% endif %}
                         </div>
                       </header>


### PR DESCRIPTION
## Summary
- remove the vertical guide line from conversation history timelines
- add color-coded chips for time spent, billable status, and labour type in conversation headers
- update ticket detail scripts to render the new chips when time entries are edited

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69250b6566f08332bbbe509fe03e2f89)