### PR TITLE
Restyle company access modal

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -4801,6 +4801,79 @@ dialog.modal:not([open]) {
   border-radius: var(--radius-xs);
 }
 
+.kb-admin__section-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.78);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 10000;
+}
+
+.kb-admin__section-modal-content {
+  width: min(520px, 92vw);
+  max-height: 80vh;
+  background: #0b1224;
+  color: #e2e8f0;
+  border: 1px solid #1f2937;
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.kb-admin__section-modal-title {
+  margin: 0;
+  color: #f8fafc;
+}
+
+.kb-admin__section-modal-help {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.kb-admin__section-modal-list {
+  flex: 1;
+  margin-top: 0.25rem;
+  margin-bottom: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid #1f2937;
+  border-radius: var(--radius-sm);
+  background: rgba(148, 163, 184, 0.06);
+  overflow-y: auto;
+  min-height: 280px;
+}
+
+.kb-admin__section-modal-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  transition: background-color 150ms ease;
+}
+
+.kb-admin__section-modal-option:hover,
+.kb-admin__section-modal-option:focus-within {
+  background-color: rgba(148, 163, 184, 0.15);
+}
+
+.kb-admin__section-modal-checkbox {
+  accent-color: #60a5fa;
+}
+
+.kb-admin__section-modal-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
 .kb-admin__section-companies-display {
   display: flex;
   flex-wrap: wrap;

--- a/app/static/js/knowledge_base_admin.js
+++ b/app/static/js/knowledge_base_admin.js
@@ -1002,34 +1002,32 @@
     
     // Create modal
     const modal = document.createElement('div');
-    modal.className = 'modal';
-    modal.style.cssText = 'position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 10000;';
-    
+    modal.className = 'modal kb-admin__section-modal';
+
     const modalContent = document.createElement('div');
-    modalContent.className = 'modal__content';
-    modalContent.style.cssText = 'background: white; padding: 2rem; border-radius: 8px; max-width: 500px; width: 90%; max-height: 80vh; overflow-y: auto;';
-    
+    modalContent.className = 'modal__content kb-admin__section-modal-content';
+
     const modalHeader = document.createElement('h3');
+    modalHeader.className = 'kb-admin__section-modal-title';
     modalHeader.textContent = 'Select Companies with Access to This Section';
-    modalHeader.style.cssText = 'margin-top: 0; margin-bottom: 1rem;';
-    
+
     const modalHelp = document.createElement('p');
+    modalHelp.className = 'kb-admin__section-modal-help';
     modalHelp.textContent = 'Leave empty to allow all companies to view this section. Select specific companies to restrict access.';
-    modalHelp.style.cssText = 'font-size: 0.9rem; color: #666; margin-bottom: 1rem;';
-    
+
     const companyList = document.createElement('div');
-    companyList.style.cssText = 'max-height: 300px; overflow-y: auto; border: 1px solid #ddd; padding: 0.5rem; margin-bottom: 1rem;';
+    companyList.className = 'kb-admin__section-modal-list';
     
     // Add checkboxes for each company
     companyOptions.forEach(company => {
       const label = document.createElement('label');
-      label.style.cssText = 'display: block; padding: 0.5rem; cursor: pointer;';
-      
+      label.className = 'kb-admin__section-modal-option';
+
       const checkbox = document.createElement('input');
       checkbox.type = 'checkbox';
       checkbox.value = company.id;
       checkbox.checked = currentCompanyIds.includes(company.id);
-      checkbox.style.cssText = 'margin-right: 0.5rem;';
+      checkbox.className = 'kb-admin__section-modal-checkbox';
       
       label.appendChild(checkbox);
       label.appendChild(document.createTextNode(company.name));
@@ -1037,7 +1035,7 @@
     });
     
     const buttonGroup = document.createElement('div');
-    buttonGroup.style.cssText = 'display: flex; gap: 0.5rem; justify-content: flex-end;';
+    buttonGroup.className = 'kb-admin__section-modal-actions';
     
     const cancelButton = document.createElement('button');
     cancelButton.type = 'button';


### PR DESCRIPTION
## Summary
- apply dark styling to the Company Access modal for knowledge base sections
- replace inline styles with reusable classes for the modal structure
- allow the company list to expand and scroll to fill the modal height

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69250e84732c83328b5c19900287c41a)