### PR TITLE
Fix knowledge base company access persistence

### DIFF
--- a/app/services/knowledge_base.py
+++ b/app/services/knowledge_base.py
@@ -112,6 +112,7 @@ def _prepare_sections(
             content = _sanitise_html(content)
             heading = section.get("heading")
             heading_text = str(heading).strip() if isinstance(heading, str) else ""
+            allowed_company_ids = _normalise_ids(section.get("allowed_company_ids", []))
             if heading_text:
                 heading_text = heading_text[:255]
             else:
@@ -121,6 +122,7 @@ def _prepare_sections(
                     "heading": heading_text or None,
                     "content": content,
                     "position": index,
+                    "allowed_company_ids": allowed_company_ids,
                 }
             )
     if not prepared and fallback_content:

--- a/app/static/js/knowledge_base_admin.js
+++ b/app/static/js/knowledge_base_admin.js
@@ -931,7 +931,13 @@
       content: composeSectionsHtml(sections),
       permission_scope: scope,
       is_published: Boolean(publishedField.checked),
-      sections: sections.map((section) => ({ heading: section.heading, content: section.content })),
+      sections: sections.map((section) => ({
+        heading: section.heading,
+        content: section.content,
+        allowed_company_ids: Array.isArray(section.allowed_company_ids)
+          ? section.allowed_company_ids
+          : [],
+      })),
     };
     if (scope === 'user') {
       payload.allowed_user_ids = getSelectedValues(userSelect);


### PR DESCRIPTION
## Summary
- ensure knowledge base editor submits per-section company access selections when saving articles
- preserve company access restrictions when preparing sections on the backend to keep associations intact

## Testing
- pytest tests/test_knowledge_base_section_permissions.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69251085e89c83328c094c55d0712d19)