### PR TITLE
Redact SMTP2Go secrets from module responses

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -869,7 +869,8 @@ def _redact_module_settings(module: dict[str, Any]) -> dict[str, Any]:
         "xero": ("client_secret", "refresh_token", "access_token"),
         "sms-gateway": ("authorization",),
         "unifi-talk": ("password",),
-        "plausible": ("api_key",),
+        "plausible": ("api_key", "pepper"),
+        "smtp2go": ("api_key", "webhook_secret"),
     }
     targets = fields_to_redact.get(slug)
     if not targets:


### PR DESCRIPTION
## Summary
- add smtp2go API key and webhook secret to the module redaction list
- redact the Plausible pepper alongside existing API keys to avoid leaking tracking secrets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6927954781408332b14ad287376084fd)