### PR TITLE
Potential fix for code scanning alert no. 1602: Empty except

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -471,8 +471,8 @@ async def create_ticket(
         await tickets_repo.add_watcher(ticket["id"], requester_id)
     try:
         await tickets_service.refresh_ticket_ai_summary(ticket["id"])
-    except RuntimeError:
-        pass
+    except RuntimeError as exc:
+        log_error(f"Failed to refresh AI summary for ticket {ticket['id']}: {exc}", exc_info=True)
     await tickets_service.refresh_ticket_ai_tags(ticket["id"])
     # For API key requests, pass a minimal user dict for building ticket detail
     detail_user = current_user or {"id": requester_id, "is_super_admin": False}


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/1602](https://github.com/bradhawkins85/MyPortal/security/code-scanning/1602)

The best way to fix the problem is to log the exception when it occurs, instead of silently passing. This can be done by adding a call to the existing logging utility. In this file, there is already an import (`from app.core.logging import log_error`), so we should use this function to capture the exception, including its traceback and any useful contextual information (e.g., the `ticket["id"]`). The edit should be localized to the except block at lines 474–475, replacing the `pass` with a call such as `log_error(...)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
