### PR TITLE
Add graceful fallback for portal ticket reply editor

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -499,6 +499,18 @@ html {
   pointer-events: none;
 }
 
+.rich-text-editor [data-rich-text-content] {
+  display: none;
+}
+
+.rich-text-editor--enhanced [data-rich-text-content] {
+  display: block;
+}
+
+.rich-text-editor--enhanced [data-rich-text-fallback] {
+  display: none;
+}
+
 .rich-text-editor__surface {
   min-height: 10.5rem;
   padding: var(--space-gap-base);
@@ -509,6 +521,17 @@ html {
   overflow-y: auto;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.rich-text-editor__fallback {
+  min-height: 10.5rem;
+  font: inherit;
+  color: #e2e8f0;
+  background: rgba(15, 23, 42, 0.3);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 0.85rem 1rem;
+  resize: vertical;
 }
 
 .rich-text-editor__surface a {

--- a/app/static/js/rich_text_editor.js
+++ b/app/static/js/rich_text_editor.js
@@ -98,11 +98,14 @@
       return;
     }
 
+    editor.classList.add('rich-text-editor--enhanced');
+
     if (hidden.value) {
       surface.innerHTML = hidden.value;
     } else {
       surface.innerHTML = '';
     }
+
     updateSurfaceState(surface, hidden);
 
     const form = editor.closest('form');

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -362,9 +362,10 @@
                     <textarea
                       id="ticket-reply-body-hidden"
                       name="body"
-                      class="visually-hidden"
-                      aria-hidden="true"
+                      class="form-input rich-text-editor__fallback"
                       data-rich-text-value
+                      data-rich-text-fallback
+                      rows="6"
                       required
                     >{{ reply_body }}</textarea>
                   </div>


### PR DESCRIPTION
## Summary
- add a visible textarea fallback for ticket replies so messages submit even if the rich text script fails to load
- style the fallback textarea and gate rich text UI behind JS enhancement
- initialize the editor by marking it enhanced so only one input is shown

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6927de6afa78833283ed35d9eba7bbc5)