### PR TITLE
Use rich text content for ticket replies

### DIFF
--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -359,15 +359,15 @@
                         data-placeholder="Write your reply..."
                       >{{ reply_body }}</div>
                     </div>
-                    <textarea
+                    <input
+                      type="hidden"
                       id="ticket-reply-body-hidden"
                       name="body"
-                      class="form-input rich-text-editor__fallback"
                       data-rich-text-value
                       data-rich-text-fallback
-                      rows="6"
+                      value="{{ reply_body | e }}"
                       required
-                    >{{ reply_body }}</textarea>
+                    />
                   </div>
                   <div class="form-field">
                     <label class="form-label" for="ticket-reply-attachments">Attachments (optional)</label>


### PR DESCRIPTION
## Summary
- replace the ticket reply fallback textarea with a hidden input
- rely on the rich text editor content for submitted user replies

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6928273ef8748332bd9045239bf2c04a)