### PR TITLE
Allow public knowledge base access for guests

### DIFF
--- a/app/security/csrf.py
+++ b/app/security/csrf.py
@@ -17,6 +17,7 @@ DEFAULT_EXEMPT_PREFIXES = (
     "/auth/register",
     "/auth/password/forgot",
     "/auth/password/reset",
+    "/api/knowledge-base/search",
 )
 
 

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -12,25 +12,18 @@
   </a>
 </li>
 <li class="menu__item">
-  <a href="/docs" target="_blank" rel="noopener noreferrer">
+  <a href="/knowledge-base">
     <span class="menu__icon" aria-hidden="true">
-      <svg viewBox="0 0 24 24" focusable="false"><path d="M6 3h9l5 5v13a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1zm8 6V4.5L18.5 9H14z"/></svg>
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M6 3a3 3 0 0 1 3-3h9a2 2 0 0 1 2 2v19.5a.5.5 0 0 1-.74.44L15 20l-4.26 1.94A.5.5 0 0 1 10 21.5V5a1 1 0 0 0-1-1H6v15.5a.5.5 0 0 1-.74.44L3 19.94V4a1 1 0 0 1 1-1z"/></svg>
     </span>
-    <span class="menu__label">API Docs</span>
+    <span class="menu__label">Knowledge base</span>
   </a>
 </li>
 {% endblock %}
 
 {% block header_actions %}
 <a class="button-link" href="/register">Create account</a>
-<a
-  class="button-link"
-  href="/docs"
-  target="_blank"
-  rel="noopener noreferrer"
-  aria-label="Open API documentation"
-  >Swagger UI</a
->
+<a class="button-link" href="/knowledge-base">Browse knowledge base</a>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- allow the knowledge base search endpoint to bypass CSRF so public users can search
- update the login page menu and header to link to the knowledge base instead of API docs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69282a2a162c833287e11b256dded638)