### PR TITLE
Hide sidebar for public knowledge base pages

### DIFF
--- a/app/templates/knowledge_base/article.html
+++ b/app/templates/knowledge_base/article.html
@@ -14,6 +14,12 @@
   <span class="header__title-text">{{ kb_article.title }}</span>
 {% endblock %}
 
+{% block sidebar_menu %}
+  {% if has_authenticated_user %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
 {% block header_actions %}
   <form id="knowledge-base-search-form" class="header-search" data-knowledge-base-search>
     <label for="knowledge-base-search" class="visually-hidden">Search knowledge base</label>

--- a/app/templates/knowledge_base/index.html
+++ b/app/templates/knowledge_base/index.html
@@ -14,6 +14,12 @@
   <span class="header__title-text">Knowledge base</span>
 {% endblock %}
 
+{% block sidebar_menu %}
+  {% if has_authenticated_user %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
 {% block header_actions %}
   <form id="knowledge-base-search-form" class="header-search" data-knowledge-base-search>
     <label for="knowledge-base-search" class="visually-hidden">Search knowledge base</label>


### PR DESCRIPTION
## Summary
- hide the default sidebar navigation on knowledge base pages when users are not signed in
- keep the full navigation for authenticated users by deferring to the base menu

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69282de7bc388332ba1b176f732e7caa)