### PR TITLE
Allow public access to knowledge base images

### DIFF
--- a/tests/test_kb_image_upload.py
+++ b/tests/test_kb_image_upload.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 import io
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 import pytest
 from fastapi import UploadFile
 from starlette.datastructures import Headers
+from fastapi.testclient import TestClient
 
 from app.services import file_storage
+from app import main as app_main
 
 
 @pytest.mark.asyncio
@@ -102,13 +105,55 @@ async def test_store_knowledge_base_image_too_large():
     import tempfile
     with tempfile.TemporaryDirectory() as tmpdir:
         uploads_root = Path(tmpdir)
-        
+
         # Store the image should raise an error
         with pytest.raises(HTTPException) as exc_info:
             await file_storage.store_knowledge_base_image(
                 upload=upload,
                 uploads_root=uploads_root,
             )
-        
+
         assert exc_info.value.status_code == 413
         assert "exceeds the 5 MB limit" in exc_info.value.detail
+
+
+def test_public_access_for_knowledge_base_images(tmp_path, monkeypatch):
+    """Knowledge base images should load without authentication."""
+
+    uploads_root = tmp_path / "knowledge-base"
+    uploads_root.mkdir(parents=True)
+    image_path = uploads_root / "example.png"
+    image_bytes = b"kb image"
+    image_path.write_bytes(image_bytes)
+
+    auth_called = False
+    sanitized_inputs: list[str] = []
+
+    async def fake_require_authenticated_user(request):
+        nonlocal auth_called
+        auth_called = True
+        return {}, None
+
+    original_sanitizer = app_main._sanitize_upload_path
+
+    def capture_sanitized_path(path: str):
+        sanitized_inputs.append(path)
+        return original_sanitizer(path)
+
+    monkeypatch.setattr(app_main, "_private_uploads_path", tmp_path)
+    monkeypatch.setattr(app_main, "_require_authenticated_user", fake_require_authenticated_user)
+    monkeypatch.setattr(app_main, "_sanitize_upload_path", capture_sanitized_path)
+
+    @asynccontextmanager
+    async def noop_lifespan(app):
+        yield
+
+    monkeypatch.setattr(app_main.app.router, "lifespan_context", noop_lifespan)
+
+    with TestClient(app_main.app) as client:
+        response = client.get("/uploads/knowledge-base/example.png")
+
+    assert response.status_code == 200
+    assert response.content == image_bytes
+    assert auth_called is False
+    assert sanitized_inputs == ["knowledge-base/example.png"]


### PR DESCRIPTION
## Summary
- sanitize upload paths before resolving uploads and reuse the helper for serving files
- allow knowledge base image requests to bypass authentication while keeping other uploads protected
- add a regression test confirming public knowledge base images remain accessible

## Testing
- pytest tests/test_kb_image_upload.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69282f2c72f48332a4f1d89943f144d0)