### PR TITLE
Fix cart form actions to comply with CSP

### DIFF
--- a/app/templates/shop/cart.html
+++ b/app/templates/shop/cart.html
@@ -38,7 +38,7 @@
   {% endif %}
 
   {% if cart_items %}
-    <form action="{{ request.url_for('cart_update_items') }}" method="post" class="cart-items-form">
+    <form action="/cart/update" method="post" class="cart-items-form">
       {% include "partials/csrf.html" %}
       <div class="table-wrapper">
         <table class="table" id="cart-table" data-table>
@@ -111,14 +111,14 @@
         <button
           type="submit"
           class="button button--ghost"
-          formaction="{{ request.url_for('cart_remove_items') }}"
+          formaction="/cart/remove"
         >
           Remove selected
         </button>
       </div>
     </form>
 
-    <form action="{{ request.url_for('cart_place_order') }}" method="post" class="cart-checkout form-grid">
+    <form action="/cart/place-order" method="post" class="cart-checkout form-grid">
       {% include "partials/csrf.html" %}
       <div class="form-field">
         <label class="form-label" for="cart-po-number">PO number</label>
@@ -175,7 +175,7 @@
               {% if item.source_names %}
                 <p class="cart-recommendations__meta">Upgrade for {{ item.source_names | join(', ') }}</p>
               {% endif %}
-              <form action="{{ request.url_for('add_to_cart') }}" method="post" class="cart-recommendations__form">
+              <form action="/cart/add" method="post" class="cart-recommendations__form">
                 {% include "partials/csrf.html" %}
                 <input type="hidden" name="productId" value="{{ item.product_id }}" />
                 <input type="hidden" name="quantity" value="1" />
@@ -206,7 +206,7 @@
               {% if item.source_names %}
                 <p class="cart-recommendations__meta">Pairs with {{ item.source_names | join(', ') }}</p>
               {% endif %}
-              <form action="{{ request.url_for('add_to_cart') }}" method="post" class="cart-recommendations__form">
+              <form action="/cart/add" method="post" class="cart-recommendations__form">
                 {% include "partials/csrf.html" %}
                 <input type="hidden" name="productId" value="{{ item.product_id }}" />
                 <input type="hidden" name="quantity" value="1" />


### PR DESCRIPTION
### Motivation

- Cart form submissions were being blocked by the Content Security Policy because form targets were being emitted as absolute URLs and thus not considered `'self'` by the browser.
- Using absolute `request.url_for(...)` in the cart template caused requests like `http://portal.hawkinsit.au/cart/update` to violate `form-action 'self'`.
- The cart recommendations forms also used the same URL-building approach and needed to be aligned to avoid similar CSP violations.

### Description

- Updated `app/templates/shop/cart.html` to use relative form actions instead of `request.url_for(...)`, e.g. `action="/cart/update"` for the main cart form.
- Replaced `cart_remove_items`, `cart_place_order`, and `add_to_cart` template `url_for` usages with `"/cart/remove"`, `"/cart/place-order"`, and `"/cart/add"` respectively.
- The change is template-only and does not modify any backend routes or handlers.

### Testing

- Ran the targeted test module with `python -m pytest tests/test_cart_update.py` and all tests passed (`6 passed`).
- Automated test suite showed no regressions for the modified template behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c93ca76b08332a2704905cdd01df3)