### PR TITLE
Fix cart total double-counting and force cart page no-cache

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5345,9 +5345,6 @@ async def view_cart(
                 image_url=image_url,
             )
 
-        line_total = current_price * quantity
-        total += line_total
-
         cart_items_payload.append(
             {
                 "product_id": resolved_product_id,
@@ -5509,7 +5506,11 @@ async def view_cart(
         "cart_recommendations": recommendations,
         "low_stock_threshold": SHOP_LOW_STOCK_THRESHOLD,
     }
-    return await _render_template("shop/cart.html", request, user, extra=extra)
+    response = await _render_template("shop/cart.html", request, user, extra=extra)
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    return response
 
 
 def _normalise_status_badge(label: str) -> str:


### PR DESCRIPTION
### Motivation
- Correct an overflow in the cart total calculation where each line total was accidentally accumulated twice, causing the displayed cart total to be double the actual amount.
- Ensure the cart page always shows up-to-date values after quantity updates, removals, or placing an order by preventing caching of the cart response.

### Description
- Adjusted the cart item processing so each `line_total` is added to the `total` exactly once when building the cart view in `app/main.py`.
- Added HTTP response headers `Cache-Control`, `Pragma`, and `Expires` to the cart page response returned from `_render_template` to force no-caching of the page.
- Change is localized to `view_cart` behavior in `app/main.py` (cart rendering and totals logic).

### Testing
- No automated tests were executed for this change.
- The change was committed locally in `app/main.py` and verified by code inspection to remove the duplicate accumulation and add the cache-control headers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695c983f437483329ecb386ff4d0c0b3)