### PR TITLE
Fix bulk select to ignore hidden tickets

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -636,19 +636,39 @@
     const getRowCheckboxes = () =>
       Array.from(table.querySelectorAll('input[type="checkbox"][data-bulk-delete-checkbox]'));
 
+    const isRowVisible = (row) => {
+      if (!row) {
+        return false;
+      }
+      if (row.dataset.filterHidden === 'true' || row.dataset.pageHidden === 'true') {
+        return false;
+      }
+      if (
+        row.classList.contains('ticket-filtered-hidden') ||
+        row.classList.contains('ticket-group-hidden') ||
+        row.classList.contains('table-search-hidden')
+      ) {
+        return false;
+      }
+      if (row.hidden || row.style.display === 'none') {
+        return false;
+      }
+      return true;
+    };
+
     const getVisibleCheckboxes = () =>
       getRowCheckboxes().filter((checkbox) => {
         const row = checkbox.closest('tr');
         if (!row || checkbox.disabled) {
           return false;
         }
-        return row.dataset.filterHidden !== 'true';
+        return isRowVisible(row);
       });
 
     const uncheckHiddenCheckboxes = () => {
       getRowCheckboxes().forEach((checkbox) => {
         const row = checkbox.closest('tr');
-        if (row && row.dataset.filterHidden === 'true') {
+        if (row && !isRowVisible(row)) {
           checkbox.checked = false;
         }
       });


### PR DESCRIPTION
### Motivation
- The bulk-select header checkbox was counting and acting on all ticket rows even when some were hidden by filters, grouping, search, or pagination, causing inaccurate counts like "8 selected" when only 3 were visible.
- The intent is to limit bulk actions to rows that are actually visible to the user so bulk-delete and the header select behave intuitively.

### Description
- Added an `isRowVisible` helper in `app/static/js/admin.js` that checks `dataset.filterHidden`, `dataset.pageHidden`, visibility classes (`ticket-filtered-hidden`, `ticket-group-hidden`, `table-search-hidden`), and inline `display`/`hidden` state to determine true visibility.
- Updated `getVisibleCheckboxes` to only return checkboxes whose row passes `isRowVisible` and updated `uncheckHiddenCheckboxes` to uncheck any checkboxes for rows that are not visible.
- Kept the existing update/submit logic intact so the header checkbox, count label, and bulk-submit button reflect only visible selections.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697828d7d0c08332ac42f5d2f0aff0fe)