### PR TITLE
Improve dashboard card layout flexibility and edit-mode controls

### DIFF
--- a/app/services/dashboard_cards.py
+++ b/app/services/dashboard_cards.py
@@ -48,9 +48,9 @@ LAYOUT_PREFERENCE_KEY = "dashboard:layout:v1"
 # Layout primitives
 # ---------------------------------------------------------------------------
 
-GRID_COLUMNS = 12
-MIN_CARD_WIDTH = 2
-MAX_CARD_WIDTH = 12
+GRID_COLUMNS = 24
+MIN_CARD_WIDTH = 1
+MAX_CARD_WIDTH = 24
 MIN_CARD_HEIGHT = 1
 MAX_CARD_HEIGHT = 8
 MAX_LAYOUT_CARDS = 32
@@ -58,12 +58,12 @@ MAX_GRID_ROWS = 60
 
 # Named sizes mapped to (width, height) in grid cells.
 SIZE_PRESETS: dict[str, tuple[int, int]] = {
-    "small": (3, 2),
-    "medium": (4, 2),
-    "wide": (6, 2),
-    "large": (6, 3),
-    "tall": (4, 4),
-    "full": (12, 3),
+    "small": (6, 2),
+    "medium": (8, 2),
+    "wide": (12, 2),
+    "large": (12, 3),
+    "tall": (8, 4),
+    "full": (24, 3),
 }
 
 
@@ -801,7 +801,7 @@ def sanitise_layout(
 def default_layout(allowed_ids) -> list[dict[str, Any]]:
     """Return a sensible default layout for the supplied allowed cards.
 
-    Cards are placed left-to-right in a 12-column grid, in registration order
+    Cards are placed left-to-right in a 24-column grid, in registration order
     among the allowed set, with each card given its preferred size.
     """
     layout: list[dict[str, Any]] = []

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -9493,8 +9493,9 @@ a.stat-strip__stat:focus-visible {
 
 .dashboard--customisable .dashboard__grid {
   display: grid;
-  grid-template-columns: repeat(var(--dashboard-columns, 12), minmax(0, 1fr));
-  grid-auto-rows: minmax(80px, auto);
+  grid-template-columns: repeat(var(--dashboard-columns, 24), minmax(0, 1fr));
+  --dashboard-row-height: 2rem;
+  grid-auto-rows: var(--dashboard-row-height);
   align-content: start;
   gap: clamp(0.5rem, 1vw, 1rem);
   width: 100%;
@@ -9503,16 +9504,15 @@ a.stat-strip__stat:focus-visible {
 
 @media (max-width: 960px) {
   .dashboard--customisable .dashboard__grid {
-    grid-template-columns: repeat(6, minmax(0, 1fr));
-  }
-  .dashboard--customisable .dashboard-card {
-    grid-column: 1 / -1 !important;
+    grid-template-columns: repeat(var(--dashboard-columns, 24), minmax(0, 1fr));
+    --dashboard-row-height: 1.8rem;
   }
 }
 
 @media (max-width: 600px) {
   .dashboard--customisable .dashboard__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(var(--dashboard-columns, 24), minmax(0, 1fr));
+    --dashboard-row-height: 1.6rem;
   }
 }
 

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -21,7 +21,8 @@
   const layoutEndpoint = root.dataset.layoutEndpoint || '/api/dashboard/layout';
   const cardEndpoint = root.dataset.cardEndpoint || '/api/dashboard/cards';
   const resetEndpoint = root.dataset.resetEndpoint || '/api/dashboard/layout/reset';
-  const gridColumns = parseInt(root.dataset.gridColumns || '12', 10) || 12;
+  const gridColumns = parseInt(root.dataset.gridColumns || '24', 10) || 24;
+  const maxGridRows = 60;
 
   const optionsDetails = root.querySelector('[data-dashboard-options]');
   const editToggle = root.querySelector('[data-dashboard-edit]');
@@ -99,16 +100,52 @@
     return value;
   }
 
+  function getCardRect(card) {
+    return {
+      x: parseInt(card.dataset.cardX || '0', 10) || 0,
+      y: parseInt(card.dataset.cardY || '0', 10) || 0,
+      w: parseInt(card.dataset.cardW || '4', 10) || 4,
+      h: parseInt(card.dataset.cardH || '2', 10) || 2,
+    };
+  }
+
+  function rectanglesOverlap(a, b) {
+    return a.x < (b.x + b.w) && (a.x + a.w) > b.x && a.y < (b.y + b.h) && (a.y + a.h) > b.y;
+  }
+
+  function resolveCollisions(activeCard) {
+    const cards = Array.from(grid.querySelectorAll('[data-dashboard-card]'));
+    const activeRect = getCardRect(activeCard);
+    let changed = true;
+    let pass = 0;
+    while (changed && pass < 80) {
+      changed = false;
+      pass += 1;
+      cards.forEach((card) => {
+        if (card === activeCard) return;
+        const rect = getCardRect(card);
+        if (!rectanglesOverlap(activeRect, rect)) return;
+        const nextY = clamp(activeRect.y + activeRect.h, 0, maxGridRows);
+        if (nextY !== rect.y) {
+          card.dataset.cardY = String(nextY);
+          applyPosition(card);
+          changed = true;
+        }
+      });
+    }
+  }
+
   function setCardPosition(card, position) {
-    const w = clamp(position.w, 2, gridColumns);
+    const w = clamp(position.w, 1, gridColumns);
     const x = clamp(position.x, 0, gridColumns - w);
-    const y = clamp(position.y, 0, 60);
-    const h = clamp(position.h, 1, 8);
+    const y = clamp(position.y, 0, maxGridRows);
+    const h = clamp(position.h, 1, 12);
     card.dataset.cardX = String(x);
     card.dataset.cardY = String(y);
     card.dataset.cardW = String(w);
     card.dataset.cardH = String(h);
     applyPosition(card);
+    resolveCollisions(card);
     schedulePersist();
   }
 
@@ -152,6 +189,7 @@
       card.setAttribute('tabindex', editMode ? '0' : '-1');
       card.querySelectorAll('[data-dashboard-card-handle], [data-dashboard-card-remove], [data-dashboard-card-resize]').forEach((control) => {
         control.setAttribute('tabindex', editMode ? '0' : '-1');
+        control.hidden = !editMode;
       });
     });
   }
@@ -167,14 +205,9 @@
   }
 
   function getGridRowHeight() {
-    // Use the first card's height-per-row as a reference; fall back to 80px.
-    const card = grid.querySelector('[data-dashboard-card]');
-    if (card) {
-      const h = Math.max(parseInt(card.dataset.cardH || '2', 10), 1);
-      const rect = card.getBoundingClientRect();
-      if (rect.height > 0) return rect.height / h;
-    }
-    return 80;
+    const configured = parseFloat(getComputedStyle(grid).getPropertyValue('--dashboard-row-height'));
+    if (configured > 0) return configured;
+    return 36;
   }
 
   function getCellFromPointer(clientX, clientY) {
@@ -267,31 +300,10 @@
   function onDrop(event) {
     if (!editMode || !draggedCard) return;
     event.preventDefault();
-    const target = event.target.closest('[data-dashboard-card]');
     const w = parseInt(draggedCard.dataset.cardW, 10);
     const h = parseInt(draggedCard.dataset.cardH, 10);
-
-    if (target && target !== draggedCard) {
-      // Swap grid positions of the two cards.
-      const srcPos = {
-        x: parseInt(draggedCard.dataset.cardX, 10),
-        y: parseInt(draggedCard.dataset.cardY, 10),
-        w: parseInt(draggedCard.dataset.cardW, 10),
-        h: parseInt(draggedCard.dataset.cardH, 10),
-      };
-      const dstPos = {
-        x: parseInt(target.dataset.cardX, 10),
-        y: parseInt(target.dataset.cardY, 10),
-        w: parseInt(target.dataset.cardW, 10),
-        h: parseInt(target.dataset.cardH, 10),
-      };
-      setCardPosition(draggedCard, dstPos);
-      setCardPosition(target, srcPos);
-    } else if (!target) {
-      // Dropped on empty grid space — move card to that position.
-      const cell = getCellFromPointer(event.clientX, event.clientY);
-      setCardPosition(draggedCard, { x: cell.x, y: cell.y, w: w, h: h });
-    }
+    const cell = getCellFromPointer(event.clientX, event.clientY);
+    setCardPosition(draggedCard, { x: cell.x, y: cell.y, w: w, h: h });
     onDragEnd();
   }
 
@@ -485,12 +497,12 @@
           '<span class="dashboard-card__category"></span>' +
         '</div>' +
         '<div class="dashboard-card__controls" data-dashboard-card-controls>' +
-          '<button type="button" class="dashboard-card__handle" data-dashboard-card-handle aria-label="Move card" tabindex="-1">⠿</button>' +
-          '<button type="button" class="dashboard-card__remove" data-dashboard-card-remove aria-label="Remove card" tabindex="-1">×</button>' +
+          '<button type="button" class="dashboard-card__handle" data-dashboard-card-handle aria-label="Move card" hidden tabindex="-1">⠿</button>' +
+          '<button type="button" class="dashboard-card__remove" data-dashboard-card-remove aria-label="Remove card" hidden tabindex="-1">×</button>' +
         '</div>' +
       '</header>' +
       '<div class="dashboard-card__body"><p class="dashboard-card__empty">Loaded — refresh the page to render.</p></div>' +
-      '<button type="button" class="dashboard-card__resize" data-dashboard-card-resize aria-label="Resize card" tabindex="-1">⇲</button>'
+      '<button type="button" class="dashboard-card__resize" data-dashboard-card-resize aria-label="Resize card" hidden tabindex="-1">⇲</button>'
     );
     card.querySelector('.dashboard-card__title').textContent = resolvedDescriptor.title || cardId;
     card.querySelector('.dashboard-card__category').textContent = resolvedDescriptor.category || '';

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -88,6 +88,7 @@
               class="dashboard-card__handle"
               data-dashboard-card-handle
               aria-label="Move {{ descriptor.title }}"
+              hidden
               tabindex="-1"
             >
               <span aria-hidden="true">⠿</span>
@@ -97,6 +98,7 @@
               class="dashboard-card__remove"
               data-dashboard-card-remove
               aria-label="Remove {{ descriptor.title }}"
+              hidden
               tabindex="-1"
             >
               <span aria-hidden="true">×</span>
@@ -115,6 +117,7 @@
           class="dashboard-card__resize"
           data-dashboard-card-resize
           aria-label="Resize {{ descriptor.title }}"
+          hidden
           tabindex="-1"
         >
           <span aria-hidden="true">⇲</span>


### PR DESCRIPTION
### Motivation
- Make dashboard cards more flexible to resize and position so content like "Asset Distribution" and "Companies" can be resized/moved freely instead of being constrained by fixed column widths and swap-only drops. 
- Hide move/delete/resize affordances unless the user enables edit mode to reduce visual clutter and accidental interactions. 
- Provide a denser grid and better collision handling so the underlying grid fills available space and cards can be placed anywhere reliably.

### Description
- Increased the grid resolution and bounds by changing `GRID_COLUMNS` from `12` to `24` and allowing `MIN_CARD_WIDTH` of `1` and `MAX_CARD_WIDTH` of `24`, and updated `SIZE_PRESETS` to match the denser layout in `app/services/dashboard_cards.py`.
- Updated CSS to use a 24-column responsive grid and fixed row units via a `--dashboard-row-height` custom property so the grid fills available space and row height is consistent (`app/static/css/app.css`).
- Reworked client-side placement and resizing in `app/static/js/dashboard.js`: changed default `gridColumns`, added `maxGridRows`, introduced `getCardRect`, `rectanglesOverlap` and `resolveCollisions` to push overlapping cards downwards, allowed finer width/height clamps, and changed drag/drop to place cards at the pointer location instead of swapping automatically.
- Made edit controls hidden by default by adding `hidden` to handle/remove/resize buttons in server-rendered template (`app/templates/dashboard.html`) and ensuring dynamically added cards include `hidden` on those buttons while `setEditMode` toggles `control.hidden = !editMode` so controls only appear in edit mode.

### Testing
- Ran `python -m compileall app` to validate Python modules compiled successfully, and the command completed without errors. 
- No automated browser/visual tests were run in this environment, so visual validation of layout/drag-resize behavior should be performed in a browser during QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e82a6d603c8332b71f644568276e94)