### PR TITLE
Fix M365 mailbox archive-size parsing for CSV header variants

### DIFF
--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -2990,6 +2990,12 @@ async def _fetch_mailbox_usage_report(access_token: str) -> list[dict[str, Any]]
 
         normalised_item = {_normalise_key(k): v for k, v in item.items()}
 
+        def _first_normalised_value(*keys: str) -> Any:
+            for key in keys:
+                if key in normalised_item:
+                    return normalised_item.get(key)
+            return None
+
         upn = (
             str(
                 item.get("userPrincipalName")
@@ -3014,9 +3020,11 @@ async def _fetch_mailbox_usage_report(access_token: str) -> list[dict[str, Any]]
             item.get("archiveMailboxStorageUsedInBytes")
             if "archiveMailboxStorageUsedInBytes" in item
             else (
-                normalised_item.get("archive mailbox storage used (byte)")
-                if "archive mailbox storage used (byte)" in normalised_item
-                else normalised_item.get("archive storage used (byte)")
+                _first_normalised_value(
+                    "archive mailbox storage used (byte)",
+                    "archive storage used (byte)",
+                    "archive mailbox size (byte)",
+                )
             )
         )
         is_deleted_raw = (
@@ -3035,7 +3043,11 @@ async def _fetch_mailbox_usage_report(access_token: str) -> list[dict[str, Any]]
             str(
                 item.get("hasArchive")
                 if "hasArchive" in item
-                else normalised_item.get("has archive") or "false"
+                else _first_normalised_value(
+                    "has archive",
+                    "has archive mailbox",
+                )
+                or "false"
             )
             .strip()
             .lower()
@@ -3050,7 +3062,11 @@ async def _fetch_mailbox_usage_report(access_token: str) -> list[dict[str, Any]]
             str(
                 item.get("archiveStatus")
                 if "archiveStatus" in item
-                else normalised_item.get("archive status") or ""
+                else _first_normalised_value(
+                    "archive status",
+                    "in-place archive status",
+                )
+                or ""
             )
             .strip()
             .lower()

--- a/tests/test_m365_mailboxes.py
+++ b/tests/test_m365_mailboxes.py
@@ -925,6 +925,60 @@ async def test_fetch_mailbox_usage_report_csv_has_archive_column():
 
 
 @pytest.mark.anyio("asyncio")
+async def test_fetch_mailbox_usage_report_csv_has_archive_mailbox_column():
+    """CSV fallback reads archive column/header variants used across tenants."""
+
+    class _FakeResponse:
+        def __init__(
+            self,
+            status_code: int,
+            text: str = "",
+            headers: dict[str, str] | None = None,
+        ):
+            self.status_code = status_code
+            self.text = text
+            self.content = text.encode("utf-8")
+            self.headers = headers or {}
+
+    class _FakeAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.calls = 0
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url: str, headers: dict[str, str] | None = None):
+            self.calls += 1
+            if self.calls == 1:
+                return _FakeResponse(
+                    302, headers={"Location": "https://download.example/report.csv"}
+                )
+            csv_text = (
+                "User Principal Name,Display Name,Is Deleted,Storage Used (Byte),"
+                "Archive Mailbox Size (Byte),Has Archive Mailbox,In-Place Archive Status\n"
+                "user@example.com,User One,false,1024,0,true,Inactive\n"
+            )
+            return _FakeResponse(200, text=csv_text)
+
+    with patch("app.services.m365.httpx.AsyncClient", _FakeAsyncClient):
+        rows = await m365_service._fetch_mailbox_usage_report("tok")
+
+    assert rows == [
+        {
+            "userPrincipalName": "user@example.com",
+            "displayName": "User One",
+            "storageUsedInBytes": 1024,
+            "archiveMailboxStorageUsedInBytes": 0,
+            "hasArchive": True,
+            "isDeleted": False,
+        }
+    ]
+
+
+@pytest.mark.anyio("asyncio")
 async def test_sync_mailboxes_has_archive_from_report_flag():
     """has_archive is set True when the report's hasArchive flag is True even
     if archive_storage_used_bytes is zero (e.g. newly provisioned archive)."""


### PR DESCRIPTION
### Motivation
- The mailbox usage CSV from Microsoft Graph can include differently-named archive-related columns in some tenants, which caused `hasArchive` to be inferred as false and archive sizes to be hidden on `/m365/mailboxes/users`.
- The change aims to robustly normalise the CSV report so archive-enabled mailboxes (including zero-byte archives) display correctly.

### Description
- Added a helper `_first_normalised_value` in `app/services/m365.py` to read the first available normalised CSV column key when multiple header variants may exist.
- Broadened archive byte lookups to accept `Archive Mailbox Size (Byte)` and other legacy/variant keys when `archiveMailboxStorageUsedInBytes` is absent.
- Broadened archive-enabled lookups to accept `Has Archive Mailbox` and archive-status fallbacks like `In-Place Archive Status` when `hasArchive` is absent.
- Added a regression test `test_fetch_mailbox_usage_report_csv_has_archive_mailbox_column` in `tests/test_m365_mailboxes.py` to cover the alternate headers and ensure `hasArchive=True` and archive bytes are preserved.

### Testing
- Ran `pytest -q tests/test_m365_mailboxes.py -k "has_archive_column or has_archive_mailbox_column or archive_status_active"` and the selected tests passed successfully (3 passed, 34 deselected).
- The new test asserts that a CSV with `Archive Mailbox Size (Byte)` and `Has Archive Mailbox` returns a normalized row with `hasArchive: True` and `archiveMailboxStorageUsedInBytes` preserved as `0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef0254b1e48332bb06e5c8742254d7)