### PR TITLE
Harden M365 license sync parsing for contract term and auto-renew

### DIFF
--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -2028,6 +2028,40 @@ _TERM_DURATION_LABELS: dict[str, str] = {
 }
 
 
+def _coerce_optional_bool(value: Any) -> bool | None:
+    """Convert Graph boolean-like values into a real bool while preserving None."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalised = value.strip().lower()
+        if normalised in {"true", "1", "yes", "y"}:
+            return True
+        if normalised in {"false", "0", "no", "n"}:
+            return False
+    return None
+
+
+def _normalise_contract_term(term_duration: Any) -> str | None:
+    """Map common Graph contract-term values into display labels."""
+    if term_duration is None:
+        return None
+    value = str(term_duration).strip()
+    if not value:
+        return None
+    upper = value.upper()
+    if upper in _TERM_DURATION_LABELS:
+        return _TERM_DURATION_LABELS[upper]
+    if upper in {"MONTHLY", "MONTH"}:
+        return "Monthly"
+    if upper in {"ANNUAL", "YEARLY", "YEAR"}:
+        return "Annual"
+    return value
+
+
 def _parse_subscription_date(value: str | None) -> date | None:
     """Parse an ISO 8601 datetime string returned by the Graph API into a date."""
     if not value:
@@ -2179,14 +2213,16 @@ async def sync_company_licenses(company_id: int) -> None:
         if sub_info:
             api_expiry_date = _parse_subscription_date(sub_info.get("nextLifecycleDateTime"))
             raw_auto_renew = sub_info.get("autoRenew")
-            if raw_auto_renew is not None:
-                api_auto_renew = bool(raw_auto_renew)
+            if raw_auto_renew is None:
+                # Some tenants expose this flag as autoRenewEnabled instead.
+                raw_auto_renew = sub_info.get("autoRenewEnabled")
+            api_auto_renew = _coerce_optional_bool(raw_auto_renew)
             term_info = sub_info.get("subscriptionTermInfo") or {}
             term_duration = term_info.get("termDuration") if isinstance(term_info, dict) else None
-            if term_duration:
-                api_contract_term = _TERM_DURATION_LABELS.get(
-                    str(term_duration).upper(), str(term_duration)
-                )
+            if term_duration is None:
+                # Fallbacks seen in older/variant payloads.
+                term_duration = sub_info.get("termDuration") or sub_info.get("commitmentTerm")
+            api_contract_term = _normalise_contract_term(term_duration)
 
         existing = await license_repo.get_license_by_company_and_sku(
             company_id, part_number

--- a/tests/test_m365_sync_subscription_details.py
+++ b/tests/test_m365_sync_subscription_details.py
@@ -17,7 +17,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.services import m365 as m365_service
-from app.services.m365 import _parse_subscription_date, _TERM_DURATION_LABELS
+from app.services.m365 import (
+    _coerce_optional_bool,
+    _normalise_contract_term,
+    _parse_subscription_date,
+    _TERM_DURATION_LABELS,
+)
 
 
 @pytest.fixture
@@ -50,6 +55,18 @@ def test_parse_subscription_date_empty_string() -> None:
 
 def test_parse_subscription_date_invalid() -> None:
     assert _parse_subscription_date("not-a-date") is None
+
+
+def test_coerce_optional_bool_handles_strings() -> None:
+    assert _coerce_optional_bool("true") is True
+    assert _coerce_optional_bool("FALSE") is False
+    assert _coerce_optional_bool("unknown") is None
+
+
+def test_normalise_contract_term_handles_aliases() -> None:
+    assert _normalise_contract_term("P1Y") == "Annual"
+    assert _normalise_contract_term("monthly") == "Monthly"
+    assert _normalise_contract_term(None) is None
 
 
 # ---------------------------------------------------------------------------
@@ -382,6 +399,53 @@ async def test_sync_sku_id_case_insensitive_match():
             m365_service.license_repo,
             "get_license_by_company_and_sku",
             AsyncMock(return_value=_make_license(1, "SKU_X")),
+        ),
+        patch.object(m365_service.license_repo, "update_license", side_effect=capture_update),
+        patch.object(m365_service.license_repo, "record_usage_if_changed", AsyncMock(return_value=False)),
+        patch.object(m365_service, "_sync_staff_assignments", AsyncMock()),
+        patch.object(m365_service.license_repo, "list_company_licenses", AsyncMock(return_value=[])),
+        patch.object(m365_service, "log_info", lambda *a, **kw: None),
+    ):
+        await m365_service.sync_company_licenses(1)
+
+    assert update_calls, "update_license should have been called"
+    assert update_calls[0]["auto_renew"] is False
+    assert update_calls[0]["contract_term"] == "Annual"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_sync_uses_auto_renew_enabled_and_commitment_term_fallbacks():
+    """Variant Graph payload keys should still populate auto-renew and contract term."""
+    m365_skus = [_make_sku("SKU_VAR", "sku-id-var")]
+    subscriptions = [
+        {
+            "skuId": "sku-id-var",
+            "nextLifecycleDateTime": "2028-05-01T00:00:00Z",
+            "autoRenewEnabled": "false",
+            "commitmentTerm": "annual",
+        }
+    ]
+    update_calls: list[dict[str, Any]] = []
+
+    async def fake_graph_get(token, url):
+        if "subscribedSkus" in url:
+            return {"value": m365_skus}
+        return {"value": []}
+
+    async def capture_update(license_id, **kwargs):
+        update_calls.append(kwargs)
+        return _make_license(license_id, kwargs["platform"])
+
+    with (
+        patch.object(m365_service, "acquire_access_token", AsyncMock(return_value="tok")),
+        patch.object(m365_service, "_graph_get", side_effect=fake_graph_get),
+        patch.object(m365_service, "_graph_get_all", AsyncMock(return_value=subscriptions)),
+        patch.object(m365_service.apps_repo, "get_app_by_vendor_sku", AsyncMock(return_value=None)),
+        patch.object(m365_service.sku_friendly_repo, "get_friendly_name", AsyncMock(return_value=None)),
+        patch.object(
+            m365_service.license_repo,
+            "get_license_by_company_and_sku",
+            AsyncMock(return_value=_make_license(1, "SKU_VAR")),
         ),
         patch.object(m365_service.license_repo, "update_license", side_effect=capture_update),
         patch.object(m365_service.license_repo, "record_usage_if_changed", AsyncMock(return_value=False)),


### PR DESCRIPTION
### Motivation
- Microsoft Graph can return variant field names and formats for subscription metadata which caused `contract_term` and `auto_renew` to sometimes not be synchronised from M365 into the portal. 
- Make license synchronisation resilient to alternate keys/values (e.g. `autoRenewEnabled`, `commitmentTerm`, string booleans) so UI and reports reflect the tenant state.

### Description
- Added helper ` _coerce_optional_bool ` to safely coerce Graph boolean-like values (including strings and numeric types) while preserving `None` semantics in `app/services/m365.py`.
- Added helper ` _normalise_contract_term ` to map common subscription term formats and aliases into display labels (e.g. `P1Y` -> `Annual`, `monthly` -> `Monthly`) in `app/services/m365.py`.
- Updated `sync_company_licenses` to use fallbacks and the new normalisers for subscription metadata: it now looks for `autoRenew` or `autoRenewEnabled`, and falls back from `subscriptionTermInfo.termDuration` to `termDuration` or `commitmentTerm`, then normalises the value before persisting.
- Extended tests in `tests/test_m365_sync_subscription_details.py` to cover the new helpers and a variant Graph payload path that uses `autoRenewEnabled` and `commitmentTerm` to ensure the fields continue to sync.

### Testing
- Ran `pytest -q tests/test_m365_sync_subscription_details.py` and all tests passed (`15 passed`).
- The modified test file now includes unit tests for ` _coerce_optional_bool ` and ` _normalise_contract_term ` and a new integration-style case exercising variant Graph keys which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ef026c112c8332bf0ce636229afacd)