### PR TITLE
Potential fix for code scanning alert no. 1924: Incomplete multi-character sanitization

### DIFF
--- a/app/static/js/shop_admin.js
+++ b/app/static/js/shop_admin.js
@@ -580,31 +580,35 @@
     let descriptionSunEditor = null;
 
     function sanitizeDescriptionHtml(value) {
-      let current = String(value || '');
-      let previous;
-        previous = current;
-      do {
-        previous = current;
+      const html = String(value || '');
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(html, 'text/html');
 
-        const withoutBlockedTags = previous.replace(
-          /<\s*\/?\s*(script|iframe|object|embed|link|meta|base|form)\b[^>]*>/gi,
+      doc.querySelectorAll('script, iframe, object, embed, link, meta, base, form').forEach((element) => {
+        element.remove();
+      });
 
-        );
+      doc.querySelectorAll('*').forEach((element) => {
+        Array.from(element.attributes).forEach((attribute) => {
+          const name = attribute.name.toLowerCase();
+          const rawValue = String(attribute.value || '');
+          const normalizedValue = rawValue.trim().toLowerCase();
 
-        current = withoutBlockedTags
-          .replace(/\son[a-z]+\s*=\s*(["']).*?\1/gi, '')
-          .replace(/\son[a-z]+\s*=\s*[^\s>]+/gi, '')
-          .replace(
-            /\s(href|src)\s*=\s*(["'])\s*(javascript:|data:|vbscript:).*?\2/gi,
-            ''
-          )
-          .replace(
-            /\s(href|src)\s*=\s*(javascript:|data:|vbscript:)[^\s>]*/gi,
-            ''
-          );
-      } while (current !== previous);
+          if (name.startsWith('on')) {
+            element.removeAttribute(attribute.name);
+            return;
+          }
 
-      return current;
+          if (
+            (name === 'href' || name === 'src') &&
+            /^(javascript:|data:|vbscript:)/i.test(normalizedValue)
+          ) {
+            element.removeAttribute(attribute.name);
+          }
+        });
+      });
+
+      return doc.body.innerHTML;
     }
 
     function getOrCreateDescriptionEditor() {


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/1924](https://github.com/bradhawkins85/MyPortal/security/code-scanning/1924)

Best fix: replace regex-based HTML sanitization with DOM-based sanitization in `sanitizeDescriptionHtml` (in `app/static/js/shop_admin.js`, around lines 582–608). This avoids incomplete multi-character regex behavior entirely and preserves existing functionality goals (remove blocked tags, `on*` handlers, and dangerous `href/src` protocols).

Implement by:
- Parsing input with `DOMParser` as HTML.
- Removing blocked elements: `script, iframe, object, embed, link, meta, base, form`.
- Iterating all remaining elements and removing:
  - Any attribute whose name starts with `on` (case-insensitive).
  - `href`/`src` attributes whose trimmed value starts with `javascript:`, `data:`, or `vbscript:` (case-insensitive).
- Returning `doc.body.innerHTML`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
