### PR TITLE
Potential fix for code scanning alert no. 1935: Information exposure through an exception

### DIFF
--- a/app/services/service_status.py
+++ b/app/services/service_status.py
@@ -590,8 +590,8 @@ async def run_ai_lookup_for_service(service_id: int) -> dict[str, Any]:
     # Validate URL to prevent SSRF
     try:
         _validate_lookup_url(lookup_url)
-    except ValueError as exc:
-        return {"service_id": service_id, "error": f"Invalid lookup URL: {exc}", "changed": False}
+    except ValueError:
+        return {"service_id": service_id, "error": "Invalid lookup URL", "changed": False}
 
     # Fetch the URL content
     try:
@@ -603,8 +603,8 @@ async def run_ai_lookup_for_service(service_id: int) -> dict[str, Any]:
             response = await client.get(lookup_url)
         response.raise_for_status()
         url_content = _sanitize_url_content(response.text)
-    except Exception as exc:
-        return {"service_id": service_id, "error": f"URL fetch failed: {exc}", "changed": False}
+    except Exception:
+        return {"service_id": service_id, "error": "URL fetch failed", "changed": False}
 
     # Build the full prompt
     full_prompt = (
@@ -627,9 +627,9 @@ async def run_ai_lookup_for_service(service_id: int) -> dict[str, Any]:
         module_result = await modules_service.trigger_module(
             "ollama", ollama_payload, background=False
         )
-    except ValueError as exc:
+    except ValueError:
         # trigger_module raises ValueError when the module is not configured at all
-        return {"service_id": service_id, "error": f"Ollama module not configured: {exc}", "changed": False}
+        return {"service_id": service_id, "error": "Ollama module not configured", "changed": False}
 
     module_status = str(module_result.get("status") or "")
     if module_status == "skipped":


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/1935](https://github.com/bradhawkins85/MyPortal/security/code-scanning/1935)

General fix: stop returning exception-derived strings to clients. Keep detailed error context in server logs, and return stable, generic client-facing messages.

Best minimal fix (without changing intended behavior): update `run_ai_lookup_for_service` to replace exception-interpolated error strings with generic messages for the three flagged branches:
- invalid URL validation failure (`except ValueError as exc` around `_validate_lookup_url`)
- URL fetch failure (`except Exception as exc`)
- module-not-configured failure (`except ValueError as exc` around `trigger_module`)

This single service-layer fix addresses all variants because the route returns/uses the service result’s `"error"` field. By sanitizing that field at the source, both `raise build_client_http_error(..., result["error"], ...)` and `return result` no longer expose internal exception details.

Files/regions to edit:
- `app/services/service_status.py`: in `run_ai_lookup_for_service`, replace three `return {"error": f"... {exc}" ...}` with generic constant text (no `exc` interpolation). No new imports/dependencies needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
