### PR TITLE
Skip Xero item creation when lookup returns non-404 (e.g. 401)

### DIFF
--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -309,6 +309,8 @@ async def _ensure_xero_items_exist(
                 status_code=lookup_response.status_code,
                 response_text=lookup_response.text[:500],
             )
+            failed_codes.append(item_code)
+            continue
 
         payload = {
             "Items": [


### PR DESCRIPTION
### Motivation
- Prevent quote sync from repeatedly failing when Xero item `GET /Items/{code}` returns a non-404 error (for example `401 Unauthorized`) by treating non-404 lookup responses as a failed lookup and skipping create attempts for that code. 

### Description
- In `app/services/xero.py` inside `_ensure_xero_items_exist`, when `lookup_response.status_code != 404` the code now appends the `item_code` to `failed_codes` and `continue`s to the next code, avoiding an invalid `POST` create attempt for codes the lookup failed on. 

### Testing
- Ran `pytest -q tests/test_quotes_api.py -k sync_to_xero` which exited with code 5 because no tests matched that filter in this environment, so no unit tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a054ce90cd083329b0fb577edbd1ed8)