### PR TITLE
docs: add feature-pack migration PR backlog

### DIFF
--- a/docs/feature_pack_pr_backlog.md
+++ b/docs/feature_pack_pr_backlog.md
@@ -1,0 +1,70 @@
+# Feature-pack migration PR backlog
+
+This backlog breaks the migration work into **one pull request per feature pack** as requested.
+
+## App function PRs
+
+- [ ] Notifications
+- [ ] Knowledge Base
+- [ ] Chat
+- [ ] Reports
+- [ ] Backup History
+- [ ] Backup Summary
+- [ ] Issue Tracker
+- [ ] Shop
+- [ ] Quotes
+- [ ] Invoices
+- [ ] Cart
+- [ ] Orders
+- [ ] Subscriptions
+- [ ] Assets
+- [ ] Staff
+- [ ] Compliance
+- [ ] Continuity
+- [ ] Call
+- [ ] Recordings
+- [ ] Message
+- [ ] Templates
+- [ ] Webhook
+- [ ] Companies
+- [ ] API Keys
+- [ ] Reporting
+
+## Integration module PRs (`/admin/modules`)
+
+Each entry below should be treated as its own feature-pack migration PR.
+
+- [ ] plausible
+- [ ] syncro
+- [ ] ollama
+- [ ] smtp
+- [ ] smtp2go
+- [ ] imap
+- [ ] m365-mail
+- [ ] tacticalrmm
+- [ ] ntfy
+- [ ] apprise
+- [ ] uptimekuma
+- [ ] chatgpt-mcp
+- [ ] ollama-mcp
+- [ ] xero
+- [ ] sms-gateway
+- [ ] m365-admin
+- [ ] create-ticket
+- [ ] create-task
+- [ ] call-recordings
+- [ ] unifi-talk
+- [ ] update-ticket
+- [ ] update-ticket-description
+- [ ] reprocess-ai
+- [ ] add-ticket-reply
+- [ ] password-pusher
+- [ ] hudu
+- [ ] huntress
+- [ ] trello
+- [ ] solidtime
+
+## Naming convention for branch/PR
+
+- Branch: `feature-pack/<slug>`
+- PR title: `feat(feature-pack): migrate <slug> into feature pack`


### PR DESCRIPTION
### Motivation
- Capture the requested migration plan as a concrete, trackable backlog by splitting work into one PR per feature pack and by treating each `/admin/modules` item as an individual migration.

### Description
- Add `docs/feature_pack_pr_backlog.md` containing a checklist of app function feature-packs, a checklist of integration modules from `/admin/modules`, and a recommended branch/PR naming convention (`feature-pack/<slug>` and `feat(feature-pack): migrate <slug> into feature pack`).

### Testing
- Ran `git status --short --branch` to verify repository state and `nl -ba docs/feature_pack_pr_backlog.md | sed -n '1,140p'` to inspect the new file contents, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0d717e54788332807c8f6dc1d8777c)