### PR TITLE
Fix tray ticket form display on Windows

### DIFF
--- a/changes/57c2cc62-0b23-42c4-a00e-0968d5ba2551.json
+++ b/changes/57c2cc62-0b23-42c4-a00e-0968d5ba2551.json
@@ -1,0 +1,7 @@
+{
+  "guid": "57c2cc62-0b23-42c4-a00e-0968d5ba2551",
+  "occurred_at": "2026-06-09T02:17:54Z",
+  "change_type": "Fix",
+  "summary": "Fix tray submit ticket action displaying the Windows ticket form",
+  "content_hash": "87fd0a2989aa573dd9c4df475caf0fe151ee8a021fbc4253c328e3c934409577"
+}

--- a/tray/ui/ticket_nowebview_windows.go
+++ b/tray/ui/ticket_nowebview_windows.go
@@ -20,12 +20,12 @@ import (
 
 // ticketFormResult holds the core and dynamic fields collected by the dialog.
 type ticketFormResult struct {
-	Name        string                   `json:"name"`
-	Email       string                   `json:"email"`
-	Phone       string                   `json:"phone"`
-	Subject     string                   `json:"subject"`
-	Description string                   `json:"description"`
-	Answers     []ticketDynamicAnswer    `json:"answers"`
+	Name        string                `json:"name"`
+	Email       string                `json:"email"`
+	Phone       string                `json:"phone"`
+	Subject     string                `json:"subject"`
+	Description string                `json:"description"`
+	Answers     []ticketDynamicAnswer `json:"answers"`
 }
 
 // ticketDynamicAnswer represents one answer to a dynamic question.
@@ -401,11 +401,7 @@ func openNewTicketDialog(cfg *api.ConfigResponse) {
 
 	prefillName, prefillEmail, prefillPhone := loadTicketPrefill()
 
-	cmd := exec.Command(
-		"powershell", "-NonInteractive", "-WindowStyle", "Hidden", "-ExecutionPolicy", "Bypass",
-		"-File", scriptPath,
-	)
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
+	cmd := newTicketDialogCommand(scriptPath)
 	cmd.Env = append(os.Environ(),
 		"MP_PREFILL_NAME="+prefillName,
 		"MP_PREFILL_EMAIL="+prefillEmail,
@@ -448,6 +444,19 @@ func openNewTicketDialog(cfg *api.ConfigResponse) {
 	}
 
 	showOSNotification("Submit Ticket", "Your ticket has been submitted. We will be in touch soon.")
+}
+
+func newTicketDialogCommand(scriptPath string) *exec.Cmd {
+	cmd := exec.Command(
+		"powershell", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+		"-File", scriptPath,
+	)
+	// CREATE_NO_WINDOW suppresses the transient PowerShell console while still
+	// allowing the WinForms ticket dialog to become visible. Do not pass
+	// -WindowStyle Hidden or STARTF_USESHOWWINDOW/HideWindow here: those startup
+	// hints can hide the form itself, making the tray action appear to do nothing.
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
+	return cmd
 }
 
 // fetchTicketQuestions calls GET /api/tray/ticket-questions using the device
@@ -539,4 +548,3 @@ func submitTicketToPortal(result ticketFormResult) error {
 	logger.Info("Tray ticket submitted (HTTP %d)", resp.StatusCode)
 	return nil
 }
-

--- a/tray/ui/ticket_nowebview_windows_test.go
+++ b/tray/ui/ticket_nowebview_windows_test.go
@@ -160,3 +160,18 @@ func TestBuildTicketScriptAnswersJSON(t *testing.T) {
 		t.Error("expected question id 5 in JSON output")
 	}
 }
+
+func TestNewTicketDialogCommandAllowsWinFormsWindow(t *testing.T) {
+	cmd := newTicketDialogCommand(`C:\Temp\mp-ticket.ps1`)
+	for _, arg := range cmd.Args {
+		if arg == "-WindowStyle" || arg == "Hidden" {
+			t.Fatalf("ticket dialog command must not hide the PowerShell process: %v", cmd.Args)
+		}
+	}
+	if cmd.SysProcAttr == nil {
+		t.Fatal("expected Windows process attributes")
+	}
+	if cmd.SysProcAttr.HideWindow {
+		t.Fatal("HideWindow hides the WinForms ticket dialog")
+	}
+}


### PR DESCRIPTION
### Motivation
- The tray "Submit Ticket" action could appear to do nothing because the PowerShell process was launched with startup flags that hid the WinForms dialog, so the ticket form was not visible to users.

### Description
- Replace inline PowerShell command creation with `newTicketDialogCommand(scriptPath)` that launches `powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File` and uses only `CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */` to suppress the transient console while allowing the WinForms dialog to become visible.
- Remove `-WindowStyle Hidden` and `SysProcAttr.HideWindow` usage and add a clarifying comment explaining why those flags must not be used for the ticket form.
- Add a regression test `TestNewTicketDialogCommandAllowsWinFormsWindow` in `tray/ui/ticket_nowebview_windows_test.go` that asserts the new command does not include `-WindowStyle`/`Hidden` and that `SysProcAttr.HideWindow` is not set.
- Add a change-log JSON entry at `changes/57c2cc62-0b23-42c4-a00e-0968d5ba2551.json` documenting this Fix.

### Testing
- Ran `go test -tags nowebview ./ui` and it passed.
- Compiled Windows test binary with `GOOS=windows GOARCH=amd64 go test -tags nowebview -c -o /tmp/myportal-ui-nowebview-windows.test.exe ./ui` which succeeded.
- Ran `go test -tags nowebview ./...` across packages and the relevant UI package tests passed.
- Ran `go test ./...` across all packages which failed in this Linux environment due to a missing system development package (`ayatana-appindicator3-0.1`) required by `systray`, which is an environment limitation rather than a regression in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2776fa1b8c832d97c94a3ce38fe27b)