### PR TITLE
Add "Submit Ticket" for Essential 8 requirements (prevents duplicate open tickets)

### DIFF
--- a/app/features/compliance/routes.py
+++ b/app/features/compliance/routes.py
@@ -13,12 +13,17 @@ from app.core.config import get_settings
 from app.repositories import companies as company_repo
 from app.repositories import compliance_checks as cc_repo
 from app.repositories import essential8 as essential8_repo
+from app.repositories import tickets as tickets_repo
 from app.repositories import user_companies as user_company_repo
+from app.security.flash import flash_redirect
+from app.services import tickets as tickets_service
 
 
 router = APIRouter(tags=["Compliance"])
 settings = get_settings()
 _STATUSES_REQUIRING_HELP = {"not_started", "in_progress", "non_compliant"}
+_ESSENTIAL8_TICKET_CATEGORY = "essential8"
+_ESSENTIAL8_TICKET_MODULE = "compliance"
 
 
 def _slugify_essential8_element(name: str) -> str:
@@ -38,6 +43,59 @@ def _build_essential8_help_url(base_url: str, element_slug: str) -> str:
     query_items.append(("element", element_slug))
     return urlunsplit(
         (split.scheme, split.netloc, split.path, urlencode(query_items), split.fragment)
+    )
+
+
+def _build_essential8_ticket_reference(company_id: int, requirement_id: int) -> str:
+    return f"essential8:req:{requirement_id}:company:{company_id}"
+
+
+def _format_requirement_label(requirement: dict) -> str:
+    maturity_level = str(requirement.get("maturity_level") or "").upper() or "ML"
+    requirement_order = requirement.get("requirement_order")
+    if requirement_order not in (None, ""):
+        return f"{maturity_level} requirement {requirement_order}"
+    return f"{maturity_level} requirement"
+
+
+def _build_essential8_ticket_subject(control: dict, requirement: dict) -> str:
+    control_name = str(control.get("name") or "Essential 8 control").strip()
+    label = _format_requirement_label(requirement)
+    return f"Essential 8 implementation request: {control_name} - {label}"[:255]
+
+
+def _build_essential8_ticket_description(
+    *,
+    control: dict,
+    requirement: dict,
+    company: dict | None,
+    user: dict,
+) -> str:
+    company_name = str((company or {}).get("name") or "Unknown company").strip()
+    requester_name = str(
+        user.get("display_name")
+        or user.get("full_name")
+        or user.get("name")
+        or user.get("username")
+        or user.get("email")
+        or "Portal user"
+    ).strip()
+    requester_email = str(user.get("email") or "Not provided").strip()
+    return "\n".join(
+        [
+            "A portal user requested technician assistance to implement an Essential 8 requirement.",
+            "",
+            f"Company: {company_name}",
+            f"Requester: {requester_name}",
+            f"Requester email: {requester_email}",
+            "",
+            f"Control: {control.get('name') or 'Essential 8 control'}",
+            f"Control description: {control.get('description') or 'No description provided.'}",
+            f"Requirement: {_format_requirement_label(requirement)}",
+            f"Requirement details: {requirement.get('description') or 'No requirement details provided.'}",
+            "",
+            "Requested action: Please contact the requester to plan and implement this Essential 8 item.",
+        ]
     )
 
 
@@ -111,7 +169,7 @@ async def _load_compliance_context(request: Request):
 @router.get("/compliance", response_class=HTMLResponse)
 async def compliance_page(request: Request):
     main_module = _main()
-    user, membership, company, company_id, redirect = await _load_compliance_context(request)
+    user, _membership, company, company_id, redirect = await _load_compliance_context(request)
     if redirect:
         return redirect
 
@@ -149,7 +207,7 @@ async def compliance_page(request: Request):
 @router.get("/compliance/control/{control_id}", response_class=HTMLResponse)
 async def compliance_control_requirements_page(request: Request, control_id: int):
     main_module = _main()
-    user, membership, company, company_id, redirect = await _load_compliance_context(request)
+    user, _membership, company, company_id, redirect = await _load_compliance_context(request)
     if redirect:
         return redirect
 
@@ -201,6 +259,57 @@ async def compliance_control_requirements_page(request: Request, control_id: int
         user,
         extra=extra,
     )
+
+
+@router.post("/compliance/requirements/{requirement_id}/ticket", response_class=HTMLResponse)
+async def compliance_submit_requirement_ticket(request: Request, requirement_id: int):
+    user, _membership, company, company_id, redirect = await _load_compliance_context(request)
+    if redirect:
+        return redirect
+
+    requirement = await essential8_repo.get_essential8_requirement(requirement_id)
+    if not requirement:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Requirement not found")
+    control_id = int(requirement["control_id"])
+    control = await essential8_repo.get_essential8_control(control_id)
+    if not control:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Control not found")
+
+    external_reference = _build_essential8_ticket_reference(company_id, requirement_id)
+    existing_ticket = await tickets_repo.find_open_ticket_by_external_reference(external_reference)
+    if existing_ticket:
+        ticket_id = existing_ticket.get("id")
+        message = "An open ticket already exists for that Essential 8 requirement."
+        if ticket_id:
+            message = f"An open ticket already exists for that Essential 8 requirement (ticket #{ticket_id})."
+        return flash_redirect(f"/compliance/control/{control_id}", message, "info")
+
+    ticket_status = await tickets_service.resolve_status_or_default(None)
+    ticket = await tickets_service.create_ticket(
+        subject=_build_essential8_ticket_subject(control, requirement),
+        description=_build_essential8_ticket_description(
+            control=control,
+            requirement=requirement,
+            company=company,
+            user=user,
+        ),
+        requester_id=int(user["id"]),
+        company_id=company_id,
+        assigned_user_id=None,
+        priority="normal",
+        status=ticket_status,
+        category=_ESSENTIAL8_TICKET_CATEGORY,
+        module_slug=_ESSENTIAL8_TICKET_MODULE,
+        external_reference=external_reference,
+        trigger_automations=True,
+        initial_reply_author_id=int(user["id"]),
+        requester_email=str(user.get("email") or "") or None,
+    )
+    ticket_id = ticket.get("id")
+    message = "Ticket submitted. A technician will contact you about this Essential 8 requirement."
+    if ticket_id:
+        message = f"Ticket #{ticket_id} submitted. A technician will contact you about this Essential 8 requirement."
+    return flash_redirect(f"/compliance/control/{control_id}", message, "success")
 
 
 async def _load_compliance_checks_context(request: Request):

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -8634,7 +8634,13 @@ a.service-card__ai-icon:hover {
 
 .compliance-form__actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.75rem;
+}
+
+.requirement-item__ticket-form {
+  display: inline-flex;
+  margin: 0;
 }
 
 .requirement-item__help-btn {

--- a/app/templates/compliance/control_requirements.html
+++ b/app/templates/compliance/control_requirements.html
@@ -151,8 +151,12 @@
                   <a href="{{ req.compliance_help_url }}" class="button button--ghost button--small">
                     Get compliance help
                   </a>
+                  <button type="submit" form="e8-ticket-form-{{ req.id }}" class="button button--primary button--small">Submit ticket</button>
                   {% endif %}
                 </div>
+              </form>
+              <form id="e8-ticket-form-{{ req.id }}" method="post" action="/compliance/requirements/{{ req.id }}/ticket" class="requirement-item__ticket-form">
+                {% if csrf_token %}<input type="hidden" name="_csrf" value="{{ csrf_token }}" />{% endif %}
               </form>
             </div>
           </details>
@@ -223,8 +227,12 @@
                   <a href="{{ req.compliance_help_url }}" class="button button--ghost button--small">
                     Get compliance help
                   </a>
+                  <button type="submit" form="e8-ticket-form-{{ req.id }}" class="button button--primary button--small">Submit ticket</button>
                   {% endif %}
                 </div>
+              </form>
+              <form id="e8-ticket-form-{{ req.id }}" method="post" action="/compliance/requirements/{{ req.id }}/ticket" class="requirement-item__ticket-form">
+                {% if csrf_token %}<input type="hidden" name="_csrf" value="{{ csrf_token }}" />{% endif %}
               </form>
             </div>
           </details>
@@ -295,8 +303,12 @@
                   <a href="{{ req.compliance_help_url }}" class="button button--ghost button--small">
                     Get compliance help
                   </a>
+                  <button type="submit" form="e8-ticket-form-{{ req.id }}" class="button button--primary button--small">Submit ticket</button>
                   {% endif %}
                 </div>
+              </form>
+              <form id="e8-ticket-form-{{ req.id }}" method="post" action="/compliance/requirements/{{ req.id }}/ticket" class="requirement-item__ticket-form">
+                {% if csrf_token %}<input type="hidden" name="_csrf" value="{{ csrf_token }}" />{% endif %}
               </form>
             </div>
           </details>

--- a/changes/3e9785a8-3ed8-42c2-b26f-dc04364d4a1e.json
+++ b/changes/3e9785a8-3ed8-42c2-b26f-dc04364d4a1e.json
@@ -1,0 +1,7 @@
+{
+  "guid": "3e9785a8-3ed8-42c2-b26f-dc04364d4a1e",
+  "occurred_at": "2026-06-09T02:12:58.630323Z",
+  "change_type": "Feature",
+  "summary": "Feature: Added Essential 8 requirement ticket submission with duplicate open-ticket prevention.",
+  "content_hash": "6432cfd13e1c7b18104e896c8264532f4c78ce3a4fbfddc7f8603a2509867576"
+}

--- a/tests/test_compliance_marketing_urls.py
+++ b/tests/test_compliance_marketing_urls.py
@@ -305,3 +305,101 @@ async def test_marketing_update_help_links_replaces_mappings(monkeypatch):
 
     assert response.status_code == 303
     assert captured["mappings"] == {101: 7, 102: None}
+
+@pytest.mark.anyio("asyncio")
+async def test_submit_requirement_ticket_creates_e8_ticket(monkeypatch):
+    request = _make_request("/compliance/requirements/101/ticket")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        compliance_routes,
+        "_load_compliance_context",
+        AsyncMock(
+            return_value=(
+                {"id": 5, "is_super_admin": False, "email": "user@example.test", "name": "User One"},
+                {},
+                {"id": 2, "name": "Acme"},
+                2,
+                None,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        compliance_routes.essential8_repo,
+        "get_essential8_requirement",
+        AsyncMock(
+            return_value={
+                "id": 101,
+                "control_id": 1,
+                "maturity_level": "ml1",
+                "requirement_order": 3,
+                "description": "Block unapproved apps.",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        compliance_routes.essential8_repo,
+        "get_essential8_control",
+        AsyncMock(return_value={"id": 1, "name": "Application Control", "description": "Only approved apps run."}),
+    )
+    monkeypatch.setattr(
+        compliance_routes.tickets_repo,
+        "find_open_ticket_by_external_reference",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(compliance_routes.tickets_service, "resolve_status_or_default", AsyncMock(return_value="open"))
+
+    async def fake_create_ticket(**kwargs):
+        captured["ticket"] = kwargs
+        return {"id": 77, **kwargs}
+
+    monkeypatch.setattr(compliance_routes.tickets_service, "create_ticket", fake_create_ticket)
+
+    response = await compliance_routes.compliance_submit_requirement_ticket(request, requirement_id=101)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/compliance/control/1"
+    ticket = captured["ticket"]
+    assert ticket["requester_id"] == 5
+    assert ticket["company_id"] == 2
+    assert ticket["category"] == "essential8"
+    assert ticket["module_slug"] == "compliance"
+    assert ticket["external_reference"] == "essential8:req:101:company:2"
+    assert "Application Control" in ticket["subject"]
+    assert "ML1 requirement 3" in ticket["subject"]
+    assert "Block unapproved apps." in ticket["description"]
+    assert "Only approved apps run." in ticket["description"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_submit_requirement_ticket_reuses_existing_open_ticket(monkeypatch):
+    request = _make_request("/compliance/requirements/101/ticket")
+    create_ticket = AsyncMock()
+
+    monkeypatch.setattr(
+        compliance_routes,
+        "_load_compliance_context",
+        AsyncMock(return_value=({"id": 5, "is_super_admin": False}, {}, {"id": 2, "name": "Acme"}, 2, None)),
+    )
+    monkeypatch.setattr(
+        compliance_routes.essential8_repo,
+        "get_essential8_requirement",
+        AsyncMock(return_value={"id": 101, "control_id": 1, "maturity_level": "ml2", "requirement_order": 1, "description": "Req"}),
+    )
+    monkeypatch.setattr(
+        compliance_routes.essential8_repo,
+        "get_essential8_control",
+        AsyncMock(return_value={"id": 1, "name": "Application Control", "description": "Desc"}),
+    )
+    monkeypatch.setattr(
+        compliance_routes.tickets_repo,
+        "find_open_ticket_by_external_reference",
+        AsyncMock(return_value={"id": 88}),
+    )
+    monkeypatch.setattr(compliance_routes.tickets_service, "create_ticket", create_ticket)
+
+    response = await compliance_routes.compliance_submit_requirement_ticket(request, requirement_id=101)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/compliance/control/1"
+    create_ticket.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Provide a quick way for portal users to request a technician to implement a specific Essential 8 requirement from the compliance UI and avoid creating duplicate open tickets for the same request.

### Description
- Added a new POST route `POST /compliance/requirements/{requirement_id}/ticket` that builds a ticket subject and body containing control and requirement details and creates a ticket via `tickets_service.create_ticket`.
- Prevent duplicate open tickets by using a stable `external_reference` format (`essential8:req:{requirement_id}:company:{company_id}`) and checking `tickets_repo.find_open_ticket_by_external_reference` before creating a new ticket.
- UI updates in `app/templates/compliance/control_requirements.html` to add a CSRF-protected `Submit ticket` button for ML1/ML2/ML3 requirement rows and render a hidden form per requirement; adjusted layout styles in `app/static/css/app.css` to ensure buttons wrap correctly.
- Added helper functions in `app/features/compliance/routes.py` to format subject/description and to generate the external reference; wired in `flash_redirect` for user feedback.
- Added regression tests in `tests/test_compliance_marketing_urls.py` covering ticket creation and duplicate-ticket prevention, and created a change-log JSON entry under `changes/`.

### Testing
- Ran Python compile check: `python -m py_compile app/features/compliance/routes.py` (succeeds).
- Ran linting: `python -m ruff check app/features/compliance/routes.py tests/test_compliance_marketing_urls.py` (no issues).
- Ran targeted tests: `pytest -q tests/test_compliance_marketing_urls.py` which passed (11 passed, with repository-wide warnings unrelated to the change).
- Verified template and CSS adjustments render the new button and that tests assert the ticket payload and duplicate-check behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2775b67a84832d9d038d043ef86962)