### PR TITLE
Add macOS tray icon build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ test_output.txt
 full_test_output.txt
 app/static/tray/*.msi
 app/static/tray/*.msi.etag
+tray/chat-shell/build/*.icns
+tray/chat-shell/build/*.iconset/

--- a/changes/cdef4343-a2b9-4bf8-8f52-dd047ff97622.json
+++ b/changes/cdef4343-a2b9-4bf8-8f52-dd047ff97622.json
@@ -1,0 +1,7 @@
+{
+  "guid": "cdef4343-a2b9-4bf8-8f52-dd047ff97622",
+  "occurred_at": "2026-06-09T00:00:00Z",
+  "change_type": "Feature",
+  "summary": "Add macOS tray chat-shell icon build process",
+  "content_hash": "90fe055210c3ab48a1241614cd7909d3a035056fcfa6193cdd5db50282abe028"
+}

--- a/tray/Makefile
+++ b/tray/Makefile
@@ -25,7 +25,7 @@ DIST     := dist
 
 .PHONY: all build-all build-windows build-darwin-amd64 build-darwin-arm64 \
         build-darwin-universal build-msi build-pkg package-all \
-        build-chat-shell-win build-chat-shell-mac \
+        build-macos-icons build-chat-shell-win build-chat-shell-mac \
         test lint clean
 
 all: build-all
@@ -90,6 +90,10 @@ build-darwin-universal: build-darwin-amd64 build-darwin-arm64
 # Like build-msi, these targets print an explanatory message and exit
 # successfully when run on the wrong host OS.
 # -----------------------------------------------------------------------
+build-macos-icons:
+	@echo "Building macOS icon asset..."
+	@bash scripts/build-macos-icons.sh
+
 build-chat-shell-win:
 	@case "$(HOST_OS)" in \
 	    MINGW*|MSYS*|CYGWIN*|Windows_NT) \

--- a/tray/README.md
+++ b/tray/README.md
@@ -19,6 +19,7 @@ tray/
 │   ├── main.js       Electron main process — session isolation + window management
 │   ├── preload.js    Security preload (context isolation)
 │   └── package.json  electron-builder config for Windows portable exe + macOS .app
+├── scripts/          Text-only build helpers, including macOS icon generation
 ├── installer/
 │   ├── windows/      WiX v7 MSI project + PowerShell RMM deployment script
 │   └── macos/        pkgbuild scripts + LaunchDaemon/LaunchAgent plists + bash RMM script
@@ -35,7 +36,7 @@ tray/
 - For MSI packaging: .NET SDK 8+ and WiX v7 (`dotnet tool install --global wix --version "7.*"`).
   WiX v7 requires accepting the FireGiant OSMF EULA — the Makefile passes
   `-acceptEula wix7` per https://docs.firegiant.com/wix/osmf/.
-- For macOS .pkg packaging: Xcode command-line tools with `pkgbuild` / `productbuild` (macOS only)
+- For macOS chat-shell icon and .pkg packaging: Xcode command-line tools with `iconutil`, `pkgbuild`, and `productbuild` (macOS only)
 - For chat shell: **Node.js 20+** and npm (required only on the native host runner for each platform)
 
 ### Cross-compile (CGO=0, no webview — for RMM deployment)
@@ -50,11 +51,28 @@ make build-darwin-arm64
 
 Binaries land in `dist/<platform>/`.
 
+### Build the macOS app icon
+
+The macOS chat-shell app icon is generated during the build from a text-only
+recipe so binary icon assets are not committed to the repository. Run this on
+macOS with Xcode Command Line Tools installed:
+
+```sh
+cd tray
+make build-macos-icons
+# or, from tray/chat-shell:
+npm run build:icons:mac
+```
+
+The target creates `tray/chat-shell/build/icon.icns`, which electron-builder
+uses for the packaged `myportal-tray-chat.app`. The generated `.icns` and
+`.iconset` intermediates are build outputs and should not be committed.
+
 ### Build the dedicated chat shell
 
 The chat shell is a minimal Electron app that opens the MyPortal support chat
 in an isolated window completely separate from the user's browser sessions.
-It **must be built on the target platform** (electron-builder constraint).
+It **must be built on the target platform** (electron-builder constraint). The macOS build runs the icon generation script before invoking electron-builder.
 
 ```sh
 # On a Windows host — produces dist/windows/myportal-tray-chat.exe

--- a/tray/chat-shell/package.json
+++ b/tray/chat-shell/package.json
@@ -8,7 +8,8 @@
     "start": "electron .",
     "build": "electron-builder",
     "build:win": "electron-builder --win --x64",
-    "build:mac": "electron-builder --mac --x64 --arm64"
+    "build:mac": "npm run build:icons:mac && electron-builder --mac --x64 --arm64",
+    "build:icons:mac": "bash ../scripts/build-macos-icons.sh"
   },
   "build": {
     "appId": "io.myportal.tray.chat",
@@ -42,7 +43,8 @@
         }
       ],
       "category": "public.app-category.utilities",
-      "darkModeSupport": true
+      "darkModeSupport": true,
+      "icon": "build/icon.icns"
     },
     "portable": {
       "artifactName": "myportal-tray-chat.exe"

--- a/tray/scripts/build-macos-icons.sh
+++ b/tray/scripts/build-macos-icons.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Generate the macOS .icns asset for the MyPortal tray/chat-shell bundle.
+#
+# The repository intentionally stores only this text build recipe; PNG/iconset
+# intermediates and the final .icns are generated during macOS builds so binary
+# icon files do not need to be committed.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRAY_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEFAULT_OUTPUT="${TRAY_DIR}/chat-shell/build/icon.icns"
+OUTPUT_PATH="${1:-${DEFAULT_OUTPUT}}"
+ICONSET_DIR="${OUTPUT_PATH%.icns}.iconset"
+
+case "${OUTPUT_PATH}" in
+  *.icns) ;;
+  *)
+    echo "Output path must end in .icns: ${OUTPUT_PATH}" >&2
+    exit 2
+    ;;
+esac
+
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+rm -rf "${ICONSET_DIR}"
+mkdir -p "${ICONSET_DIR}"
+
+python3 - "${ICONSET_DIR}" <<'PY'
+from __future__ import annotations
+
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+out = Path(sys.argv[1])
+
+# Standard macOS iconset members.  The @2x files intentionally duplicate the
+# pixel size of the next logical point size, matching Apple's iconutil input
+# contract (for example icon_16x16@2x.png is a 32x32 PNG).
+outputs = {
+    "icon_16x16.png": 16,
+    "icon_16x16@2x.png": 32,
+    "icon_32x32.png": 32,
+    "icon_32x32@2x.png": 64,
+    "icon_128x128.png": 128,
+    "icon_128x128@2x.png": 256,
+    "icon_256x256.png": 256,
+    "icon_256x256@2x.png": 512,
+    "icon_512x512.png": 512,
+    "icon_512x512@2x.png": 1024,
+}
+
+BG = (0x0F, 0x17, 0x2A, 0xFF)
+RING_START = (0x38, 0xBD, 0xF8, 0xFF)
+RING_END = (0x63, 0x66, 0xF1, 0xFF)
+INNER = BG
+
+def chunk(tag: bytes, data: bytes) -> bytes:
+    return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+def blend(a: tuple[int, int, int, int], b: tuple[int, int, int, int], t: float) -> tuple[int, int, int, int]:
+    return tuple(round(a[i] + (b[i] - a[i]) * t) for i in range(4))
+
+def png_rgba(size: int) -> bytes:
+    cx = cy = (size - 1) / 2.0
+    corner_radius = size * 0.25
+    ring_radius = size * 0.34375
+    inner_radius = size * 0.1875
+    rows = bytearray()
+    for y in range(size):
+        rows.append(0)
+        for x in range(size):
+            # Rounded-square signed distance field with light edge smoothing.
+            px = abs((x + 0.5) - size / 2) - (size / 2 - corner_radius)
+            py = abs((y + 0.5) - size / 2) - (size / 2 - corner_radius)
+            ox = max(px, 0.0)
+            oy = max(py, 0.0)
+            outside = (ox * ox + oy * oy) ** 0.5 + min(max(px, py), 0.0) - corner_radius
+            alpha = 255 if outside <= -1 else 0 if outside >= 1 else round((1 - outside) * 127.5)
+            if alpha <= 0:
+                rows.extend((0, 0, 0, 0))
+                continue
+
+            dx = x - cx
+            dy = y - cy
+            dist = (dx * dx + dy * dy) ** 0.5
+            if dist <= inner_radius:
+                colour = INNER
+            elif dist <= ring_radius:
+                t = min(1.0, max(0.0, (x + y) / (2 * (size - 1))))
+                colour = blend(RING_START, RING_END, t)
+            else:
+                colour = BG
+            rows.extend((colour[0], colour[1], colour[2], min(alpha, colour[3])))
+
+    ihdr = struct.pack(">IIBBBBB", size, size, 8, 6, 0, 0, 0)
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", zlib.compress(bytes(rows), 9)) + chunk(b"IEND", b"")
+
+for name, size in outputs.items():
+    (out / name).write_bytes(png_rgba(size))
+PY
+
+if ! command -v iconutil >/dev/null 2>&1; then
+  echo "iconutil is required to create ${OUTPUT_PATH}. Run this target on macOS with Xcode Command Line Tools installed." >&2
+  echo "Generated iconset remains at ${ICONSET_DIR} for inspection." >&2
+  exit 1
+fi
+
+iconutil -c icns "${ICONSET_DIR}" -o "${OUTPUT_PATH}"
+rm -rf "${ICONSET_DIR}"
+echo "Built macOS icon: ${OUTPUT_PATH}"


### PR DESCRIPTION
### Motivation
- The tray/chat-shell macOS build had no reproducible, text-only icon generation and required committing binary icon assets, so a platform-aware build step was needed to produce `.icns` at build time without adding binary files to the repo.
- The goal is to generate the macOS app icon from a deterministic recipe during macOS builds and integrate it into the existing Electron packaging flow.

### Description
- Added a text-only icon generator script at `tray/scripts/build-macos-icons.sh` that produces standard `.iconset` PNGs and calls `iconutil` to create `tray/chat-shell/build/icon.icns` on macOS. 
- Added a Makefile target `build-macos-icons` and included it in `.PHONY` so the tray Makefile can generate icons as a discrete step (`tray/Makefile`).
- Updated `tray/chat-shell/package.json` to run `npm run build:icons:mac` before `build:mac` and configured electron-builder to use `build/icon.icns` for mac packaging. 
- Documented the new icon build flow and prerequisites in `tray/README.md` and updated `.gitignore` to ignore generated `*.icns` and `.iconset` outputs. 
- Created a feature change-log entry `changes/cdef4343-a2b9-4bf8-8f52-dd047ff97622.json` describing the change.

### Testing
- Ran static/syntax checks: `bash -n tray/scripts/build-macos-icons.sh` and `python3 -m json.tool tray/chat-shell/package.json` which succeeded. 
- Executed the icon script locally (temporary output) to verify it creates the `.iconset` PNGs; the step that calls `iconutil` is macOS-only and therefore the final `.icns` is not created in this Linux environment (expected behavior). 
- Verified Node packaging changes by running `cd tray/chat-shell && npm install --package-lock-only --ignore-scripts` to ensure package.json remains valid (succeeded). 
- Ran Go unit tests with the nowebview build tag via `GOFLAGS='-tags=nowebview' go test -count=1 ./...` which passed, while `go test -count=1 ./...` without the tag failed due to a missing system dependency for `github.com/getlantern/systray` in this environment (expected on non-desktop CI hosts).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a277c33e548832da4ceb21169466e0c)