### PR TITLE
Scheduled automations: per-ticket age-based scans and comparison filters

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -409,6 +409,39 @@ async def list_tickets(
     return [_normalise_ticket(row) for row in rows]
 
 
+async def list_tickets_for_automation_scan(*, limit: int = 1000) -> list[TicketRecord]:
+    """Return recent ticket records with reply timestamps for scheduled automations.
+
+    Scheduled automations apply their filter JSON in Python so the same nested
+    filter language used for event automations can be reused for time-based
+    ticket scans.  The query intentionally caps the batch size to avoid a
+    runaway automation reading an unbounded ticket table in one scheduler tick.
+    """
+
+    safe_limit = max(1, min(int(limit or 1000), 5000))
+    rows = await db.fetch_all(
+        """
+        SELECT
+            t.*,
+            (
+                SELECT MAX(tr.created_at)
+                FROM ticket_replies tr
+                WHERE tr.ticket_id = t.id
+            ) AS latest_reply_at
+        FROM tickets t
+        ORDER BY t.updated_at ASC, t.id ASC
+        LIMIT %s
+        """,
+        (safe_limit,),
+    )
+    records: list[TicketRecord] = []
+    for row in rows:
+        record = _normalise_ticket(row)
+        record["latest_reply_at"] = _make_aware(row.get("latest_reply_at"))
+        records.append(record)
+    return records
+
+
 def _prepare_status_filters(status: str | Sequence[str] | None) -> list[str]:
     if status in (None, ""):
         return []

--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Awaitable, Mapping, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 import re
@@ -13,6 +14,7 @@ from loguru import logger
 
 from app.core.database import db
 from app.repositories import automations as automation_repo
+from app.repositories import tickets as tickets_repo
 from app.services import modules as modules_service
 from app.services import value_templates
 
@@ -131,6 +133,65 @@ def _value_matches(actual: Any, expected: Any) -> bool:
     return actual == expected
 
 
+def _coerce_comparable(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.timestamp()
+    if isinstance(value, date):
+        return datetime.combine(value, time.min, tzinfo=timezone.utc).timestamp()
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return text
+        try:
+            return float(text)
+        except ValueError:
+            return text.casefold()
+    return value
+
+
+def _compare_values(actual: Any, expected: Any, operator: str) -> bool:
+    actual_value = _coerce_comparable(actual)
+    expected_value = _coerce_comparable(expected)
+    try:
+        if operator == "not_equals":
+            return not _value_matches(actual, expected)
+        if operator == "greater_than":
+            return actual_value > expected_value
+        if operator == "greater_than_or_equal":
+            return actual_value >= expected_value
+        if operator == "less_than":
+            return actual_value < expected_value
+        if operator == "less_than_or_equal":
+            return actual_value <= expected_value
+    except TypeError:
+        return False
+    return _value_matches(actual, expected)
+
+
+def _operator_filters_match(
+    filters: Mapping[str, Any],
+    context: Mapping[str, Any] | None,
+    *,
+    operator: str,
+) -> bool:
+    if not filters:
+        return False
+    for key, expected in filters.items():
+        lookup_key = str(key)
+        actual = _resolve_context_value(context, lookup_key)
+        if actual is None and "." not in lookup_key and isinstance(context, Mapping):
+            ticket_ctx = context.get("ticket")
+            if isinstance(ticket_ctx, Mapping):
+                fallback = _resolve_context_value(ticket_ctx, lookup_key)
+                if fallback is not None:
+                    actual = fallback
+        if not _compare_values(actual, expected, operator):
+            return False
+    return True
+
+
 def _filters_match(filters: Mapping[str, Any] | None, context: Mapping[str, Any] | None) -> bool:
     if not filters:
         return True
@@ -157,6 +218,22 @@ def _filters_match(filters: Mapping[str, Any] | None, context: Mapping[str, Any]
 
     if "not" in filters:
         return not _filters_match(filters.get("not"), context)
+
+    operator_keys = {
+        "not_equals": "not_equals",
+        "gt": "greater_than",
+        "greater_than": "greater_than",
+        "gte": "greater_than_or_equal",
+        "greater_than_or_equal": "greater_than_or_equal",
+        "lt": "less_than",
+        "less_than": "less_than",
+        "lte": "less_than_or_equal",
+        "less_than_or_equal": "less_than_or_equal",
+    }
+    for filter_key, operator in operator_keys.items():
+        comparison_filters = filters.get(filter_key)
+        if isinstance(comparison_filters, Mapping):
+            return _operator_filters_match(comparison_filters, context, operator=operator)
 
     matchers: Mapping[str, Any] | None
     if "match" in filters and isinstance(filters["match"], Mapping):
@@ -189,6 +266,60 @@ def _filters_match(filters: Mapping[str, Any] | None, context: Mapping[str, Any]
             if not _value_matches(actual, expected):
                 return False
     return True
+
+
+def _serialise_datetime(value: Any) -> str | None:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat()
+    return None
+
+
+def _age_metrics(value: Any, *, now: datetime) -> dict[str, Any]:
+    if not isinstance(value, datetime):
+        return {"seconds": None, "minutes": None, "hours": None, "days": None}
+    timestamp = value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    seconds = max(0.0, (now - timestamp).total_seconds())
+    return {
+        "seconds": seconds,
+        "minutes": seconds / 60,
+        "hours": seconds / 3600,
+        "days": seconds / 86400,
+    }
+
+
+def _attach_ticket_age_context(ticket: Mapping[str, Any], *, now: datetime) -> dict[str, Any]:
+    enriched = dict(ticket)
+    created_at = enriched.get("created_at")
+    updated_at = enriched.get("updated_at")
+    latest_reply_at = enriched.get("latest_reply_at")
+    last_activity_at = latest_reply_at or updated_at or created_at
+
+    enriched["age"] = _age_metrics(created_at, now=now)
+    enriched["updated_age"] = _age_metrics(updated_at, now=now)
+    enriched["last_reply_at"] = latest_reply_at
+    enriched["last_activity_at"] = last_activity_at
+    enriched["last_reply_age"] = _age_metrics(latest_reply_at or created_at, now=now)
+    enriched["last_activity_age"] = _age_metrics(last_activity_at, now=now)
+
+    # Flat aliases keep the builder simple and make advanced JSON easy to read.
+    for prefix in ("age", "updated_age", "last_reply_age", "last_activity_age"):
+        metrics = enriched.get(prefix)
+        if isinstance(metrics, Mapping):
+            for unit, metric_value in metrics.items():
+                enriched[f"{prefix}_{unit}"] = metric_value
+    enriched["last_reply_at_iso"] = _serialise_datetime(latest_reply_at)
+    enriched["last_activity_at_iso"] = _serialise_datetime(last_activity_at)
+    return enriched
+
+
+def _is_ticket_scoped_scheduled_automation(automation: Mapping[str, Any]) -> bool:
+    if str(automation.get("kind") or "").strip().lower() != "scheduled":
+        return False
+    filters = automation.get("trigger_filters")
+    if not isinstance(filters, Mapping):
+        return False
+    haystack = json.dumps({"filters": filters}, default=str)
+    return "ticket" in haystack
 
 
 def calculate_next_run(
@@ -285,6 +416,146 @@ async def refresh_all_schedules() -> None:
         await automation_repo.set_next_run(int(automation["id"]), next_run)
 
 
+async def _invoke_automation_actions_for_context(
+    automation: Mapping[str, Any],
+    *,
+    context: Mapping[str, Any] | None,
+) -> tuple[Any, str | None]:
+    """Invoke configured module action(s) without recording an automation run."""
+
+    payload = automation.get("action_payload")
+    actions = _normalise_actions(payload.get("actions")) if isinstance(payload, Mapping) else []
+    if actions:
+        results: list[dict[str, Any]] = []
+        first_error: str | None = None
+        for action in actions:
+            module_slug = action["module"]
+            payload_source = action.get("payload")
+            module_payload = dict(payload_source) if isinstance(payload_source, Mapping) else {}
+            module_payload = await value_templates.render_value_async(module_payload, context)
+            if context:
+                module_payload.setdefault("context", context)
+            try:
+                action_result = await modules_service.trigger_module(
+                    module_slug,
+                    module_payload,
+                    background=False,
+                )
+            except Exception as exc:  # pragma: no cover - network/runtime guard
+                exc_message = str(exc)
+                if not first_error:
+                    first_error = exc_message
+                results.append({"module": module_slug, "status": "failed", "error": exc_message})
+                continue
+
+            action_status_raw = action_result.get("status") if isinstance(action_result, Mapping) else None
+            action_error = None
+            action_reason = None
+            if isinstance(action_result, Mapping):
+                action_status_raw = action_result.get("status") or action_result.get("event_status")
+                action_error = action_result.get("error") or action_result.get("last_error") or None
+                action_reason = action_result.get("reason")
+            action_status = str(action_status_raw or "").strip().lower() or "unknown"
+            result_entry: dict[str, Any] = {
+                "module": module_slug,
+                "status": action_status,
+                "result": action_result,
+            }
+            if action_error:
+                result_entry["error"] = action_error
+            if action_reason:
+                result_entry["reason"] = action_reason
+            results.append(result_entry)
+            if action_status in {"failed", "error"} or (action_status == "unknown" and action_error):
+                if not first_error:
+                    first_error = str(action_error or "Module action failed")
+        return results, first_error
+
+    if not isinstance(payload, Mapping):
+        payload = {}
+    module_slug = automation.get("action_module")
+    if module_slug:
+        module_payload = await value_templates.render_value_async(dict(payload), context)
+        if context:
+            module_payload.setdefault("context", context)
+        result = await modules_service.trigger_module(str(module_slug), module_payload, background=False)
+        if isinstance(result, Mapping):
+            result_status = str(result.get("status") or result.get("event_status") or "").strip().lower()
+            result_error = result.get("error") or result.get("last_error") or None
+            if result_status in {"failed", "error"} or result_error:
+                return result, str(result_error or "Module action failed")
+        return result, None
+    return {"status": "skipped", "reason": "No action module configured"}, None
+
+
+async def _execute_scheduled_ticket_automation(automation: Mapping[str, Any]) -> dict[str, Any]:
+    """Run a scheduled automation once for each ticket matching its filters."""
+
+    now = datetime.now(timezone.utc)
+    raw_filters = automation.get("trigger_filters")
+    filters = raw_filters if isinstance(raw_filters, Mapping) else None
+    scanned = await tickets_repo.list_tickets_for_automation_scan(limit=1000)
+    matched = 0
+    succeeded = 0
+    failed = 0
+    skipped = 0
+    results: list[dict[str, Any]] = []
+
+    # Local import avoids a circular import during application startup because
+    # the ticket service emits automation events.
+    from app.services import tickets as tickets_service
+
+    for ticket in scanned:
+        ticket_context = _attach_ticket_age_context(ticket, now=now)
+        try:
+            enriched_ticket = await tickets_service._enrich_ticket_context(ticket_context)
+        except Exception:  # pragma: no cover - defensive fallback
+            enriched_ticket = ticket_context
+        context = {
+            "ticket": _attach_ticket_age_context(enriched_ticket, now=now),
+            "ticket_update": {
+                "actor_type": "automation",
+                "actor_label": "Automation",
+                "actor_user": None,
+            },
+            "schedule": {
+                "automation_id": automation.get("id"),
+                "automation_name": automation.get("name"),
+                "checked_at": now.isoformat(),
+            },
+        }
+        if not _filters_match(filters, context):
+            continue
+        matched += 1
+        action_result, action_error = await _invoke_automation_actions_for_context(
+            automation,
+            context=context,
+        )
+        ticket_result: dict[str, Any] = {
+            "ticket_id": ticket.get("id"),
+            "status": "failed" if action_error else "succeeded",
+            "result": action_result,
+        }
+        if action_error:
+            failed += 1
+            ticket_result["error"] = action_error
+        else:
+            succeeded += 1
+        results.append(ticket_result)
+
+    if matched == 0:
+        skipped = len(scanned)
+    return {
+        "mode": "scheduled_ticket_scan",
+        "scanned": len(scanned),
+        "matched": matched,
+        "succeeded": succeeded,
+        "failed": failed,
+        "skipped": skipped,
+        "results": results,
+    }
+
+
 async def _execute_automation(
     automation: Mapping[str, Any],
     *,
@@ -316,7 +587,13 @@ async def _execute_automation(
         payload = automation.get("action_payload")
         actions = _normalise_actions(payload.get("actions")) if isinstance(payload, Mapping) else []
         try:
-            if actions:
+            if context is None and _is_ticket_scoped_scheduled_automation(automation):
+                result_payload = await _execute_scheduled_ticket_automation(automation)
+                failed_count = int(result_payload.get("failed", 0)) if isinstance(result_payload, Mapping) else 0
+                if failed_count > 0:
+                    status = "failed"
+                    error_message = f"{failed_count} scheduled ticket action(s) failed"
+            elif actions:
                 results: list[dict[str, Any]] = []
                 for action in actions:
                     module_slug = action["module"]

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -30,6 +30,30 @@
       }),
     },
     {
+      label: 'Ticket is older than 30 days',
+      value: toJsonTemplate({
+        greater_than: {
+          'ticket.age_days': 30,
+        },
+      }),
+    },
+    {
+      label: 'Ticket has not been updated for 7 days',
+      value: toJsonTemplate({
+        greater_than: {
+          'ticket.updated_age_days': 7,
+        },
+      }),
+    },
+    {
+      label: 'Ticket has not had a reply for 24 hours',
+      value: toJsonTemplate({
+        greater_than: {
+          'ticket.last_reply_age_hours': 24,
+        },
+      }),
+    },
+    {
       label: 'Match any ticket status open or pending',
       value: toJsonTemplate({
         any: [
@@ -1458,8 +1482,23 @@
       if (!node || typeof node !== 'object') {
         return null;
       }
-      if (node.match && typeof node.match === 'object' && !Array.isArray(node.match)) {
-        const entries = Object.entries(node.match);
+      const operatorNodes = {
+        match: 'equals',
+        not_equals: 'not_equals',
+        greater_than: 'greater_than',
+        gt: 'greater_than',
+        greater_than_or_equal: 'greater_than_or_equal',
+        gte: 'greater_than_or_equal',
+        less_than: 'less_than',
+        lt: 'less_than',
+        less_than_or_equal: 'less_than_or_equal',
+        lte: 'less_than_or_equal',
+      };
+      const operatorKey = Object.keys(operatorNodes).find((key) => (
+        node[key] && typeof node[key] === 'object' && !Array.isArray(node[key])
+      ));
+      if (operatorKey) {
+        const entries = Object.entries(node[operatorKey]);
         if (entries.length < 1) {
           return null;
         }
@@ -1467,6 +1506,7 @@
         return makeRowState({
           conditionType: 'match',
           fieldPath: String(fieldPath),
+          operator: operatorNodes[operatorKey],
           valueType: inferType(value),
           value: value === null ? '' : String(value),
         });
@@ -1519,7 +1559,14 @@
         return null;
       }
       const typedValue = parseTypedValue(row.valueType, row.value);
-      const matchNode = { match: { [fieldPath]: typedValue } };
+      const operatorKey = {
+        not_equals: 'not_equals',
+        greater_than: 'greater_than',
+        greater_than_or_equal: 'greater_than_or_equal',
+        less_than: 'less_than',
+        less_than_or_equal: 'less_than_or_equal',
+      }[row.operator] || 'match';
+      const matchNode = { [operatorKey]: { [fieldPath]: typedValue } };
       if (row.conditionType === 'all') {
         return { all: [matchNode] };
       }
@@ -1598,10 +1645,19 @@
 
         const operatorSelect = document.createElement('select');
         operatorSelect.className = 'form-input';
-        const equalsOption = document.createElement('option');
-        equalsOption.value = 'equals';
-        equalsOption.textContent = 'equals';
-        operatorSelect.appendChild(equalsOption);
+        [
+          ['equals', 'equals'],
+          ['not_equals', 'not equals'],
+          ['greater_than', 'greater than'],
+          ['greater_than_or_equal', 'greater than or equal'],
+          ['less_than', 'less than'],
+          ['less_than_or_equal', 'less than or equal'],
+        ].forEach(([value, label]) => {
+          const option = document.createElement('option');
+          option.value = value;
+          option.textContent = label;
+          operatorSelect.appendChild(option);
+        });
         operatorSelect.value = row.operator || 'equals';
         operatorSelect.addEventListener('change', () => handleRowChange(index, 'operator', operatorSelect.value));
 

--- a/app/templates/admin/automations_create_scheduled.html
+++ b/app/templates/admin/automations_create_scheduled.html
@@ -48,7 +48,7 @@
         <section class="card card--panel">
           <header class="card__header card__header--stacked">
             <h2 class="card__title">Workflow definition</h2>
-            <p class="card__subtitle">All fields support JSON validation and UTC storage to keep automations deterministic.</p>
+            <p class="card__subtitle">Scheduled automations run on cadence, scan tickets with the filters below, and execute actions for every matching ticket.</p>
           </header>
           <div class="card__body">
             <form action="{{ action_url }}" method="post" class="form management__form">
@@ -106,30 +106,9 @@
                 />
                 <p class="form-help">Select the date and time when this automation should run. The automation will run once and will not repeat.</p>
               </div>
-              <div class="form-field">
-                <label class="form-label" for="automation-trigger-select">Trigger event</label>
-                <select id="automation-trigger-select" class="form-input" data-trigger-select>
-                  <option value="">Select a trigger</option>
-                  {% for trigger in automation_trigger_options %}
-                    <option value="{{ trigger.value }}" {% if trigger_select == trigger.value %}selected{% endif %}>{{ trigger.label }}</option>
-                  {% endfor %}
-                  <option value="__custom__" {% if trigger_select == '__custom__' %}selected{% endif %}>Custom event…</option>
-                </select>
-                <input
-                  id="automation-trigger-custom"
-                  class="form-input"
-                  type="text"
-                  name="triggerEventCustom"
-                  placeholder="custom.event"
-                  data-trigger-custom
-                  {% if trigger_select != '__custom__' %}hidden{% endif %}
-                  value="{{ trigger_custom }}"
-                />
-                <input type="hidden" id="automation-trigger" name="triggerEvent" value="{{ values.get('triggerEvent', '') }}" />
-                <p class="form-help">Choose the event that starts this automation. Select “Custom event…” to enter your own value.</p>
-              </div>
+              <input type="hidden" id="automation-trigger" name="triggerEvent" value="" />
               <div class="form-field" data-filter-builder data-filter-raw="{{ values.get('triggerFiltersRaw', '') | e }}">
-                <label class="form-label" for="automation-filters-advanced">Trigger filters</label>
+                <label class="form-label" for="automation-filters-advanced">Ticket selection filters</label>
                 <input type="hidden" id="automation-filters-data" name="triggerFilters" value="{{ values.get('triggerFiltersRaw', '') }}" />
                 <input type="hidden" id="automation-filters-mode" name="triggerFiltersMode" value="builder" />
                 <div class="automation-filters" data-filter-builder-list></div>
@@ -147,11 +126,11 @@
                   >{{ values.get('triggerFiltersRaw', '') }}</textarea>
                 </div>
                 <p class="form-help" data-filter-builder-error hidden></p>
-                <p class="form-help">Build common trigger filters with structured conditions. Use Advanced JSON for complex nested logic.</p>
+                <p class="form-help">Use ticket fields such as <code>ticket.status</code>, <code>ticket.age_days</code>, <code>ticket.updated_age_hours</code>, and <code>ticket.last_reply_age_hours</code>. Use Advanced JSON for complex nested logic.</p>
               </div>
               <div class="form-field" data-automation-actions>
-                <label class="form-label">Trigger actions</label>
-                <p class="form-help">Define one or more module executions. Payloads are persisted as JSON objects and executed sequentially.</p>
+                <label class="form-label">Scheduled actions</label>
+                <p class="form-help">Define one or more module executions. Actions run once per matching ticket and can use templates such as <code>{{ '{{ ticket.id }}' }}</code>.</p>
                 <div
                   class="automation-actions"
                   id="automation-actions-list"

--- a/changes/56477aa7-e4c1-4eb5-ad70-53221c3ed93a.json
+++ b/changes/56477aa7-e4c1-4eb5-ad70-53221c3ed93a.json
@@ -1,0 +1,7 @@
+{
+  "guid": "56477aa7-e4c1-4eb5-ad70-53221c3ed93a",
+  "occurred_at": "2026-06-09T02:40:07.303169+00:00",
+  "change_type": "Feature",
+  "summary": "Add ticket-age and last-reply scanning support to scheduled automations.",
+  "content_hash": "fbf8d635240ea1cbf58a8794bc77ee2234b99b4ca7f8fecc00271af62d97e89a"
+}

--- a/tests/test_automations_service.py
+++ b/tests/test_automations_service.py
@@ -737,3 +737,114 @@ async def test_execute_automation_continues_after_first_action_failure(monkeypat
     assert len(captured_run["result_payload"]) == 2
     assert captured_run["result_payload"][0]["status"] == "failed"
     assert captured_run["result_payload"][1]["status"] == "succeeded"
+
+
+def test_filters_match_supports_ticket_age_comparisons():
+    context = {
+        "ticket": {
+            "status": "open",
+            "age_days": 31,
+            "updated_age_hours": 49,
+            "last_reply_age_hours": 12,
+        }
+    }
+
+    assert automations_service._filters_match(
+        {
+            "all": [
+                {"match": {"ticket.status": "open"}},
+                {"greater_than": {"ticket.age_days": 30}},
+                {"greater_than_or_equal": {"ticket.updated_age_hours": 48}},
+            ]
+        },
+        context,
+    )
+    assert not automations_service._filters_match(
+        {"greater_than": {"ticket.last_reply_age_hours": 24}},
+        context,
+    )
+
+
+@pytest.mark.anyio
+async def test_execute_scheduled_ticket_automation_runs_actions_for_matching_tickets(monkeypatch):
+    scanned_tickets = [
+        {
+            "id": 1,
+            "status": "open",
+            "subject": "Old ticket",
+            "created_at": datetime.now(timezone.utc) - timedelta(days=45),
+            "updated_at": datetime.now(timezone.utc) - timedelta(days=40),
+            "latest_reply_at": datetime.now(timezone.utc) - timedelta(days=35),
+        },
+        {
+            "id": 2,
+            "status": "open",
+            "subject": "New ticket",
+            "created_at": datetime.now(timezone.utc) - timedelta(days=5),
+            "updated_at": datetime.now(timezone.utc) - timedelta(days=1),
+            "latest_reply_at": datetime.now(timezone.utc) - timedelta(hours=4),
+        },
+    ]
+    captured: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_list_tickets_for_automation_scan(*, limit: int = 1000):
+        assert limit == 1000
+        return scanned_tickets
+
+    async def fake_enrich(ticket):
+        return dict(ticket)
+
+    async def fake_trigger_module(module_slug, payload, *, background=False):
+        captured.append((module_slug, payload))
+        return {"status": "succeeded"}
+
+    from app.services import tickets as tickets_service
+
+    monkeypatch.setattr(
+        automations_service.tickets_repo,
+        "list_tickets_for_automation_scan",
+        fake_list_tickets_for_automation_scan,
+    )
+    monkeypatch.setattr(
+        tickets_service,
+        "_enrich_ticket_context",
+        fake_enrich,
+    )
+    monkeypatch.setattr(
+        automations_service.modules_service,
+        "trigger_module",
+        fake_trigger_module,
+    )
+
+    automation = {
+        "id": 11,
+        "name": "Close stale tickets",
+        "kind": "scheduled",
+        "trigger_filters": {
+            "all": [
+                {"match": {"ticket.status": "open"}},
+                {"greater_than": {"ticket.age_days": 30}},
+                {"greater_than": {"ticket.last_reply_age_days": 30}},
+            ]
+        },
+        "action_payload": {
+            "actions": [
+                {
+                    "module": "update-ticket",
+                    "payload": {"ticket_id": "{{ ticket.id }}", "status": "closed"},
+                }
+            ]
+        },
+    }
+
+    result = await automations_service._execute_scheduled_ticket_automation(automation)
+
+    assert result["scanned"] == 2
+    assert result["matched"] == 1
+    assert result["succeeded"] == 1
+    assert result["failed"] == 0
+    assert len(captured) == 1
+    assert captured[0][0] == "update-ticket"
+    assert captured[0][1]["ticket_id"] == 1
+    assert captured[0][1]["status"] == "closed"
+    assert captured[0][1]["context"]["ticket"]["id"] == 1


### PR DESCRIPTION
### Motivation
- Enable scheduled automations to select tickets by age/last-reply/last-update and run actions per matching ticket without requiring an event trigger.
- Provide comparison operators for filter rules so administrators can express conditions like “older than 30 days” or “no reply for 24 hours”.
- Update the UI and filter builder so scheduled automations are clearly defined as per-ticket scans (not event triggers).

### Description
- Added ticket scan API `list_tickets_for_automation_scan` in `app/repositories/tickets.py` that returns tickets with `latest_reply_at` capped by a safe `limit` to avoid unbounded queries.
- Extended automation service `app/services/automations.py` with:
  - comparison operator support (`greater_than`, `greater_than_or_equal`, `less_than`, `less_than_or_equal`, `not_equals`), plus helper functions `_coerce_comparable`, `_compare_values`, and `_operator_filters_match` to evaluate them against automation contexts.
  - ticket age/last-reply/last-activity metrics via `_attach_ticket_age_context` and `_age_metrics`, exposing flat aliases (e.g. `ticket.age_days`, `ticket.last_reply_age_hours`) for filter use.
  - scheduled ticket runner `_execute_scheduled_ticket_automation` that scans tickets, enriches ticket context, applies filters, and invokes action modules once per matching ticket using `_invoke_automation_actions_for_context`.
  - integration so scheduled automations that include ticket-scoped filters will run the per-ticket scan when executed without an event context.
- Updated the automation filter builder and snippets in `app/static/js/automation.js` to include age/last-reply examples and to support operator nodes in the builder representation.
- Updated the scheduled automation form `app/templates/admin/automations_create_scheduled.html` to remove trigger-event selection for scheduled automations and clarify the ticket selection filters and scheduled actions messaging.
- Added regression tests in `tests/test_automations_service.py` covering comparison filter semantics and the scheduled ticket scan/action flow.
- Added a change-log entry `changes/56477aa7-e4c1-4eb5-ad70-53221c3ed93a.json` documenting the feature addition.

### Testing
- Ran unit tests: `pytest tests/test_automations_service.py tests/test_automation_form_parsing.py` and all tests passed (22 passed in the selected suites).
- Verified module compilation with `python -m compileall app/services/automations.py app/repositories/tickets.py` and no syntax errors were reported.
- New and updated tests assert filter matching for age comparisons and that scheduled automations invoke configured actions for matching tickets; these tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a277bf1e57c832dafe97aa8f8303afe)