### PR TITLE
Prefer bearer auth for tray ticket submissions; make device_uid optional and fix WinForms output

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -231,20 +231,42 @@ async def get_ticket_questions(
 )
 async def tray_submit_ticket(
     payload: TrayTicketSubmitRequest,
+    request: Request,
 ) -> TrayTicketSubmitResponse:
     """Create a support ticket submitted via the tray icon.
 
-    The ``device_uid`` identifies the device and is used to link the ticket
-    to the corresponding asset and company.  No bearer auth is required —
-    the device_uid is the device identifier.  Name, email, and phone are
-    provided by the user in the tray dialog; email is used to match an
-    existing portal user account when one exists.
+    The bearer auth token is the preferred device identity and is used to link
+    the ticket to the corresponding asset and company.  ``device_uid`` remains
+    accepted as a backwards-compatible fallback for older tray clients that do
+    not send bearer auth.  Name, email, and phone are provided by the user in
+    the tray dialog; email is used to match an existing portal user account
+    when one exists.
 
     Dynamic question answers are validated server-side against the current
     question definitions.  Required visible questions must have a non-empty
     value; select questions must use a declared option.
     """
-    device = await tray_repo.get_device_by_uid(payload.device_uid)
+    # Prefer the bearer auth token when available. Older tray clients also send
+    # device_uid in the JSON body, but relying exclusively on that body value
+    # makes submissions fragile when the UI has an auth token yet cannot read
+    # the service-written DeviceUID from registry/state. The token already
+    # identifies the enrolled device, so use it as the authoritative source and
+    # keep device_uid as a backwards-compatible fallback for existing clients.
+    device = None
+    auth_header = request.headers.get("Authorization", "")
+    token = ""
+    if auth_header.lower().startswith("bearer "):
+        token = auth_header.split(" ", 1)[1].strip()
+    if token:
+        device = await tray_repo.get_device_by_auth_hash(tray_service.hash_token(token))
+        if not device:
+            raise HTTPException(
+                status_code=401, detail="Tray device authentication failed"
+            )
+
+    if device is None and payload.device_uid:
+        device = await tray_repo.get_device_by_uid(payload.device_uid)
+
     if not device or device.get("status") == "revoked":
         raise HTTPException(status_code=404, detail="Device not found")
 
@@ -351,7 +373,7 @@ async def tray_submit_ticket(
 
     log_info(
         "Tray ticket submitted",
-        device_uid=payload.device_uid,
+        device_uid=device.get("uid") or payload.device_uid,
         ticket_id=ticket.get("id"),
         requester_id=requester_id,
     )

--- a/app/schemas/tray.py
+++ b/app/schemas/tray.py
@@ -210,7 +210,7 @@ class TrayChatTokenResponse(BaseModel):
 class TrayTicketSubmitRequest(BaseModel):
     """Fields submitted by a tray device when the user clicks Submit Ticket."""
 
-    device_uid: str = Field(min_length=1, max_length=64)
+    device_uid: Optional[str] = Field(default=None, min_length=1, max_length=64)
     name: str = Field(min_length=1, max_length=255)
     email: str = Field(min_length=1, max_length=255)
     phone: Optional[str] = Field(default=None, max_length=50)

--- a/tests/test_tray_submit_ticket_auth.py
+++ b/tests/test_tray_submit_ticket_auth.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_tray_submit_ticket_uses_bearer_token_without_device_uid(monkeypatch):
+    from app.api.routes import tray as tray_routes
+    from app.schemas.tray import TrayTicketSubmitRequest
+
+    captured_hashes: list[str] = []
+    created: dict[str, object] = {}
+
+    async def fake_get_device_by_auth_hash(token_hash: str):
+        captured_hashes.append(token_hash)
+        return {
+            "id": 123,
+            "uid": "device-from-token",
+            "status": "active",
+            "company_id": 456,
+            "asset_id": None,
+        }
+
+    async def fake_get_user_by_email(email: str):
+        return None
+
+    async def fake_get_questions_for_company(company_id: int | None):
+        created["questions_company_id"] = company_id
+        return []
+
+    async def fake_resolve_status_or_default(status: str | None):
+        return "open"
+
+    async def fake_create_ticket(**kwargs):
+        created.update(kwargs)
+        return {"id": 789, "ticket_number": "T-789"}
+
+    monkeypatch.setattr(
+        tray_routes.tray_repo,
+        "get_device_by_auth_hash",
+        fake_get_device_by_auth_hash,
+    )
+    monkeypatch.setattr(tray_routes.users_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        tray_routes.tq_service,
+        "get_questions_for_company",
+        fake_get_questions_for_company,
+    )
+    monkeypatch.setattr(
+        tray_routes.tickets_service,
+        "resolve_status_or_default",
+        fake_resolve_status_or_default,
+    )
+    monkeypatch.setattr(tray_routes.tickets_service, "create_ticket", fake_create_ticket)
+
+    request = SimpleNamespace(headers={"Authorization": "Bearer token-abc"})
+    payload = TrayTicketSubmitRequest(
+        name="Jane",
+        email="JANE@EXAMPLE.COM",
+        subject="Help",
+        description="Broken",
+    )
+
+    response = await tray_routes.tray_submit_ticket(payload, request)  # type: ignore[arg-type]
+
+    assert captured_hashes
+    assert response.ticket_id == 789
+    assert created["company_id"] == 456
+    assert created["requester_email"] == "jane@example.com"
+    assert created["questions_company_id"] == 456

--- a/tray/ui/ticket_windows.go
+++ b/tray/ui/ticket_windows.go
@@ -234,6 +234,12 @@ $btnCancel.DialogResult = [System.Windows.Forms.DialogResult]::Cancel
 $form.CancelButton = $btnCancel
 $form.Controls.Add($btnCancel)
 
+# WinForms event handlers do not reliably write pipeline output back to the
+# host process. Store the accepted payload in script scope and emit it only
+# after ShowDialog returns so the Go tray process can capture stdout and submit
+# the ticket to MyPortal.
+$script:TicketDialogResult = $null
+
 # ── Conditional visibility helper ─────────────────────────────────
 `)
 
@@ -373,19 +379,22 @@ $btnSubmit.add_Click({
 	}
 
 	sb.WriteString(`
-    @{
+    $script:TicketDialogResult = @{
         name        = $txtName.Text.Trim()
         email       = $txtEmail.Text.Trim()
         phone       = $txtPhone.Text.Trim()
         subject     = $txtSubject.Text.Trim()
         description = $txtDesc.Text.Trim()
         answers     = $answers
-    } | ConvertTo-Json -Compress -Depth 5 | Write-Output
+    }
     $form.DialogResult = [System.Windows.Forms.DialogResult]::OK
     $form.Close()
 })
 
-$form.ShowDialog() | Out-Null
+$dialogResult = $form.ShowDialog()
+if ($dialogResult -eq [System.Windows.Forms.DialogResult]::OK -and $script:TicketDialogResult -ne $null) {
+    $script:TicketDialogResult | ConvertTo-Json -Compress -Depth 5 | Write-Output
+}
 `)
 
 	return sb.String()
@@ -572,7 +581,7 @@ func submitTicketToPortal(result ticketFormResult) error {
 		Value      string `json:"value"`
 	}
 	type submitRequest struct {
-		DeviceUID   string         `json:"device_uid"`
+		DeviceUID   string         `json:"device_uid,omitempty"`
 		Name        string         `json:"name"`
 		Email       string         `json:"email"`
 		Phone       string         `json:"phone,omitempty"`
@@ -591,8 +600,8 @@ func submitTicketToPortal(result ticketFormResult) error {
 		refreshDeviceUID()
 		deviceUID = strings.TrimSpace(gDeviceUID)
 	}
-	if deviceUID == "" {
-		return fmt.Errorf("device UID is not available yet")
+	if deviceUID == "" && strings.TrimSpace(gAuthToken) == "" {
+		return fmt.Errorf("device UID or auth token is not available yet")
 	}
 
 	body, err := json.Marshal(submitRequest{

--- a/tray/ui/ticket_windows_test.go
+++ b/tray/ui/ticket_windows_test.go
@@ -165,6 +165,31 @@ func TestBuildTicketScriptAnswersJSON(t *testing.T) {
 	}
 }
 
+func TestBuildTicketScriptEmitsResultAfterDialogCloses(t *testing.T) {
+	script := buildTicketScript(nil)
+
+	mustContain := []string{
+		"$script:TicketDialogResult = $null",
+		"$script:TicketDialogResult = @{",
+		"$dialogResult = $form.ShowDialog()",
+		"$script:TicketDialogResult | ConvertTo-Json -Compress -Depth 5 | Write-Output",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(script, want) {
+			t.Fatalf("expected script to contain %q", want)
+		}
+	}
+
+	clickHandlerStart := strings.Index(script, "$btnSubmit.add_Click({")
+	showDialogStart := strings.Index(script, "$dialogResult = $form.ShowDialog()")
+	if clickHandlerStart < 0 || showDialogStart < 0 {
+		t.Fatal("expected submit handler and ShowDialog block in script")
+	}
+	if strings.Contains(script[clickHandlerStart:showDialogStart], "ConvertTo-Json") {
+		t.Fatal("submit click handler should store the payload, not write pipeline output before ShowDialog returns")
+	}
+}
+
 func TestNewTicketDialogCommandAllowsWinFormsWindow(t *testing.T) {
 	cmd := newTicketDialogCommand(`C:\Temp\mp-ticket.ps1`)
 	for _, arg := range cmd.Args {
@@ -248,17 +273,56 @@ func TestSubmitTicketToPortalPostsJSONWithAuth(t *testing.T) {
 	}
 }
 
-func TestSubmitTicketToPortalRequiresDeviceUID(t *testing.T) {
-	oldPortalURL, oldDeviceUID := gPortalURL, gDeviceUID
+func TestSubmitTicketToPortalCanUseAuthTokenWithoutDeviceUID(t *testing.T) {
+	oldPortalURL, oldDeviceUID, oldAuthToken, oldClient := gPortalURL, gDeviceUID, gAuthToken, ticketHTTPClient
 	defer func() {
 		gPortalURL = oldPortalURL
 		gDeviceUID = oldDeviceUID
+		gAuthToken = oldAuthToken
+		ticketHTTPClient = oldClient
+	}()
+
+	gDeviceUID = ""
+	gAuthToken = "token-abc"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer token-abc" {
+			t.Fatalf("unexpected Authorization header: %q", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if _, ok := body["device_uid"]; ok {
+			t.Fatalf("device_uid should be omitted when unavailable: %#v", body["device_uid"])
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ticket_id":42}`))
+	}))
+	defer server.Close()
+
+	gPortalURL = server.URL
+	ticketHTTPClient = server.Client()
+	ticketHTTPClient.Timeout = 5 * time.Second
+
+	if err := submitTicketToPortal(ticketFormResult{Name: "Jane", Email: "jane@example.com", Subject: "Help"}); err != nil {
+		t.Fatalf("submit ticket with auth token only: %v", err)
+	}
+}
+
+func TestSubmitTicketToPortalRequiresDeviceUIDOrAuthToken(t *testing.T) {
+	oldPortalURL, oldDeviceUID, oldAuthToken := gPortalURL, gDeviceUID, gAuthToken
+	defer func() {
+		gPortalURL = oldPortalURL
+		gDeviceUID = oldDeviceUID
+		gAuthToken = oldAuthToken
 	}()
 	gPortalURL = "https://portal.example.test"
 	gDeviceUID = ""
+	gAuthToken = ""
 
 	err := submitTicketToPortal(ticketFormResult{Name: "Jane", Email: "jane@example.com", Subject: "Help"})
-	if err == nil || !strings.Contains(err.Error(), "device UID") {
-		t.Fatalf("expected device UID error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "device UID or auth token") {
+		t.Fatalf("expected device UID/auth token error, got %v", err)
 	}
 }


### PR DESCRIPTION
### Motivation

- Prefer bearer token authentication as the authoritative device identity for tray ticket submissions while keeping `device_uid` as a backwards-compatible fallback for older clients.
- Ensure the PowerShell WinForms ticket dialog reliably emits the JSON payload to stdout after the dialog closes so the Go tray process can capture it.
- Update the tray client to omit `device_uid` when unavailable and allow submissions using an auth token only.

### Description

- Update `tray_submit_ticket` to accept a `Request`, extract a `Bearer` token from the `Authorization` header, resolve the device via `tray_repo.get_device_by_auth_hash(tray_service.hash_token(token))`, fall back to `payload.device_uid` when no token is present, and return `401` when a token is provided but invalid; logging now reports `device.get("uid") or payload.device_uid`.
- Change schema `TrayTicketSubmitRequest.device_uid` to `Optional[str]` in `app/schemas/tray.py`.
- Add `tests/test_tray_submit_ticket_auth.py` to verify the server prefers bearer auth and still populates ticket creation fields correctly when no `device_uid` is provided in the payload.
- Modify PowerShell ticket dialog generation in `tray/ui/ticket_windows.go` to store the accepted payload in `$script:TicketDialogResult` and only write JSON to stdout after `ShowDialog()` returns, and update the Go client to use `omitempty` for `device_uid`, require either a device UID or an auth token before submitting, and include `Authorization: Bearer ...` when `gAuthToken` is set.
- Add and adjust Go unit tests in `tray/ui/ticket_windows_test.go` to assert the new emission behavior and auth-token-only submission path, and update error messages accordingly.

### Testing

- Ran the new Python async test `pytest tests/test_tray_submit_ticket_auth.py` which passed and confirmed bearer token resolution and ticket creation behavior.
- Ran the Go unit tests including `TestBuildTicketScriptEmitsResultAfterDialogCloses`, `TestSubmitTicketToPortalCanUseAuthTokenWithoutDeviceUID`, and the rest of `ticket_windows_test.go` with `go test ./tray/...`, which passed.
- Verified existing tray submission tests that exercise JSON marshaling and submission headers still pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a27a3b304fc832dbf43a672f538756e)