### PR TITLE
Fix Solidtime ticket project payload and improve API error diagnostics

### DIFF
--- a/app/services/solidtime.py
+++ b/app/services/solidtime.py
@@ -50,6 +50,9 @@ from app.services import rate_limit_store
 from app.services import webhook_monitor
 from app.services.redis import get_redis_client
 
+# Backwards-compatible alias used by the Solidtime unit tests and older code.
+module_repo = modules_service
+
 SOLIDTIME_MODULE_SLUG = "solidtime"
 DEFAULT_RATE_LIMIT_PER_MINUTE = 120
 REQUEST_TIMEOUT = httpx.Timeout(15.0, connect=5.0)
@@ -125,9 +128,15 @@ async def _load_module_settings() -> dict[str, Any] | None:
         if _MODULE_SETTINGS_CACHE is not None and now < _MODULE_SETTINGS_EXPIRY:
             return _MODULE_SETTINGS_CACHE
         try:
-            module = await modules_service.get_module(
-                SOLIDTIME_MODULE_SLUG, redact=False
-            )
+            try:
+                module = await modules_service.get_module(
+                    SOLIDTIME_MODULE_SLUG, redact=False
+                )
+            except TypeError:
+                # Some tests and older service implementations expose a
+                # single-argument get_module helper. Fall back without the
+                # redact flag while keeping production calls unredacted.
+                module = await modules_service.get_module(SOLIDTIME_MODULE_SLUG)
         except RuntimeError as exc:  # pragma: no cover - defensive
             log_error("Unable to load Solidtime module configuration", error=str(exc))
             module = None
@@ -449,9 +458,11 @@ async def _request(
                     event_id=event_id,
                     error=str(record_exc),
                 )
-        raise SolidtimeAPIError(
-            f"Solidtime API responded with {response.status_code}"
-        )
+        response_body = _truncate_body(response.text)
+        detail = f"Solidtime API responded with {response.status_code}"
+        if response_body:
+            detail = f"{detail}: {response_body}"
+        raise SolidtimeAPIError(detail)
     if response.status_code == httpx.codes.NO_CONTENT:
         if event_id is not None:
             try:
@@ -701,6 +712,23 @@ def _project_archived_for_status(status_value: Any) -> bool:
     return text in {"closed", "resolved"}
 
 
+def _ticket_project_color(ticket: Mapping[str, Any]) -> str:
+    """Return a stable Solidtime-compatible hex color for a ticket project.
+
+    Solidtime requires a ``color`` value when projects are created or updated.
+    Deriving it from the ticket identity keeps retries idempotent and avoids
+    changing a project's colour on later sync attempts.
+    """
+    seed = str(
+        ticket.get("id")
+        or ticket.get("ticket_number")
+        or ticket.get("external_reference")
+        or _ticket_project_name(ticket)
+    )
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+    return f"#{digest[:6]}"
+
+
 def ticket_to_project_payload(
     ticket: Mapping[str, Any],
     *,
@@ -709,11 +737,13 @@ def ticket_to_project_payload(
     """Build a Solidtime project payload from a MyPortal ticket record."""
     body: dict[str, Any] = {
         "name": _ticket_project_name(ticket),
+        "color": _ticket_project_color(ticket),
         "is_billable": True,
         "is_archived": _project_archived_for_status(ticket.get("status")),
+        # Solidtime validates ``client_id`` as present+nullable on project
+        # create/update requests, so include the key even when unassigned.
+        "client_id": client_id or None,
     }
-    if client_id:
-        body["client_id"] = client_id
     description = ticket.get("description")
     if isinstance(description, str) and description.strip():
         # Keep the description short; ticket descriptions can be very large.

--- a/tests/test_solidtime.py
+++ b/tests/test_solidtime.py
@@ -46,6 +46,8 @@ def test_ticket_to_project_payload_uses_number_and_subject():
     body = ticket_to_project_payload(ticket, client_id="client-uuid")
     assert body["name"] == "#T-007 – Email not sending"
     assert body["client_id"] == "client-uuid"
+    assert body["color"].startswith("#")
+    assert len(body["color"]) == 7
     assert body["description"] == "please help"
     assert body["is_archived"] is False
     assert body["is_billable"] is True
@@ -61,13 +63,16 @@ def test_ticket_to_project_payload_archives_closed():
     body = ticket_to_project_payload(ticket)
     assert body["name"] == "#11 – All done"
     assert body["is_archived"] is True
-    assert "client_id" not in body
+    assert body["client_id"] is None
 
 
 def test_ticket_to_project_payload_falls_back_when_missing():
     body = ticket_to_project_payload({"id": 3, "subject": ""})
     # Empty subject falls back to "Ticket"
     assert body["name"] == "#3 – Ticket"
+    assert body["color"] == ticket_to_project_payload(
+        {"id": 3, "subject": "Renamed"}
+    )["color"]
 
 
 def test_reply_to_time_entry_payload_computes_start_from_minutes_and_created_at():
@@ -392,9 +397,10 @@ async def test_request_records_failure_when_api_returns_error(reset_solidtime_ca
 
     reset_solidtime_caches.setattr(solidtime.httpx, "AsyncClient", _DummyAsyncClient)
 
-    with pytest.raises(SolidtimeAPIError):
+    with pytest.raises(SolidtimeAPIError) as exc_info:
         await solidtime._request("GET", "/anything")
 
+    assert "server boom" in str(exc_info.value)
     assert failures, "failure should be recorded against the webhook monitor"
     assert failures[0]["response_status"] == 500
 
@@ -480,14 +486,14 @@ async def test_sync_ticket_to_project_creates_link(reset_solidtime_caches):
         solidtime.links_repo, "mark_project_link_error", fake_mark_project_error
     )
 
-    api_calls: list[tuple[str, str]] = []
+    api_calls: list[tuple[str, object]] = []
 
     async def fake_create_client(org_id, *, name):
         api_calls.append(("create_client", name))
         return {"id": "client-uuid"}
 
     async def fake_create_project(org_id, *, body):
-        api_calls.append(("create_project", body["name"]))
+        api_calls.append(("create_project", dict(body)))
         return {"id": "project-uuid", "name": body["name"]}
 
     async def fake_update_project(*args, **kwargs):
@@ -504,6 +510,10 @@ async def test_sync_ticket_to_project_creates_link(reset_solidtime_caches):
     # Client should be created first, then project.
     kinds = [call[0] for call in api_calls]
     assert kinds == ["create_client", "create_project"]
+    project_payload = api_calls[1][1]
+    assert isinstance(project_payload, dict)
+    assert project_payload["color"].startswith("#")
+    assert project_payload["client_id"] == "client-uuid"
     assert any(u.get("kind") == "client" for u in upserts)
     assert any(
         u.get("kind") == "project" and u.get("sync_status") == "synced"


### PR DESCRIPTION
### Motivation
- Solidtime ticket syncs could fail with HTTP 422 due to missing required project fields (Solidtime expects a `color` and a present `client_id` key). 
- Outbound API errors lacked useful response context which made debugging webhook failures harder. 
- Unit tests and older code referenced a single-argument `get_module` API, so the loader needed to remain compatible.

### Description
- Add a backwards-compatible `module_repo = modules_service` alias and fall back to calling `get_module(slug)` when `get_module(..., redact=False)` raises `TypeError` to support older test helpers. 
- Include truncated Solidtime response bodies in raised `SolidtimeAPIError` messages so error details are visible in diagnostics. 
- Add `_ticket_project_color` to derive a stable hex color from a ticket identity and include `color` in the project payload. 
- Always include `client_id` in the project payload as a present nullable key (`client_id: client_id or None`) to satisfy Solidtime validation. 
- Update Solidtime unit tests to assert the new `color` and `client_id` behavior and to check that API error detail contains the upstream response text.

### Testing
- Ran the Solidtime unit test suite with `pytest tests/test_solidtime.py -q`, and all tests passed (`40 passed`, existing deprecation warnings only). 
- Verified that the Solidtime error path now surfaces response text in exceptions via updated tests which assert the truncated response appears in the raised `SolidtimeAPIError`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a27bc7c4b40832db203e23bfe1d1ed0)