### PR TITLE
Fix tray chat reply alignment

### DIFF
--- a/app/templates/tray/chat_popup.html
+++ b/app/templates/tray/chat_popup.html
@@ -165,7 +165,7 @@
     <div id="chat-empty">No messages yet. Say hello!</div>
     {% endif %}
     {% for msg in messages %}
-    <div class="chat-message{% if not msg.sender_user_id %} chat-message--self{% endif %}"
+    <div class="chat-message{% if msg.sender_matrix_id == ('@tray-device-' ~ device_id ~ ':tray') %} chat-message--self{% endif %}"
          data-msg-id="{{ msg.id | default('') }}"
          data-event-id="{{ msg.matrix_event_id | default('') }}">
       <div class="chat-message__meta">
@@ -203,6 +203,7 @@
   const CSRF_TOKEN = {{ csrf_token | tojson }};
   const DEVICE_ID = {{ device_id | int }};
   const IS_CLOSED = {{ 'true' if (room and room.status == 'closed') else 'false' }};
+  const DEVICE_MATRIX_ID = '@tray-device-' + DEVICE_ID + ':tray';
 
   const messagesEl = document.getElementById('chat-messages');
   const inputEl    = document.getElementById('chat-input');
@@ -227,6 +228,10 @@
     errorEl.textContent = msg;
     errorEl.style.display = 'block';
     setTimeout(() => { errorEl.style.display = 'none'; }, 5000);
+  }
+
+  function isMessageFromThisTray(msg) {
+    return String(msg?.sender_matrix_id || '') === DEVICE_MATRIX_ID;
   }
 
   function appendMessage(msg, isSelf, isNew) {
@@ -318,8 +323,10 @@
           if (mid && renderedMsgIds.has(mid)) continue;
           if (key) rendered.add(key);
           if (mid) renderedMsgIds.add(mid);
-          // Messages without a sender_user_id are from the tray device (self).
-          const isSelf = !msg.sender_user_id;
+          // Only messages sent by this tray device are self messages; Matrix
+          // technician/mobile replies may not map to a portal user and must
+          // still render as received messages.
+          const isSelf = isMessageFromThisTray(msg);
           appendMessage(msg, isSelf, !isSelf);
         }
       } catch (_) {}

--- a/tests/test_tray_chat_popup.py
+++ b/tests/test_tray_chat_popup.py
@@ -303,3 +303,47 @@ def test_popup_session_rejects_tampered_cookie(monkeypatch):
     result = _parse_popup_session_cookie("this-is-not-valid-encrypted-data")
     assert result is None
 
+
+
+def test_tray_chat_popup_only_marks_current_tray_messages_as_self():
+    """Technician Matrix replies with no portal user ID render as received."""
+    from pathlib import Path
+
+    from jinja2 import Template
+
+    template = Template(Path("app/templates/tray/chat_popup.html").read_text(), autoescape=True)
+    html = template.render(
+        room={"id": 12, "subject": "Support", "status": "open"},
+        messages=[
+            {
+                "id": 1,
+                "matrix_event_id": "$client",
+                "sender_matrix_id": "@tray-device-7:tray",
+                "sender_user_id": None,
+                "sender_display_name": "Client PC",
+                "body": "Client message",
+                "sent_at": "2026-06-10T00:00:00",
+            },
+            {
+                "id": 2,
+                "matrix_event_id": "$tech",
+                "sender_matrix_id": "@technician:matrix.example",
+                "sender_user_id": None,
+                "sender_display_name": "Technician",
+                "body": "Technician reply",
+                "sent_at": "2026-06-10T00:01:00",
+            },
+        ],
+        csrf_token="csrf",
+        room_id=12,
+        device_id=7,
+        hostname="Client PC",
+    )
+
+    assert 'data-event-id="$client"' in html
+    client_block = html.split('data-event-id="$client"', 1)[0].rsplit('<div class="chat-message', 1)[1]
+    assert "chat-message--self" in client_block
+    tech_block = html.split('data-event-id="$tech"', 1)[0].rsplit('<div class="chat-message', 1)[1]
+    assert "chat-message--self" not in tech_block
+    assert "function isMessageFromThisTray" in html
+    assert "const isSelf = isMessageFromThisTray(msg);" in html


### PR DESCRIPTION
### Motivation
- Technician replies delivered via Matrix (or mobile) that lack a linked portal user were being treated as "self" messages in the tray popup, causing them to appear on the right side of the popup instead of as incoming messages. 
- Make the tray popup reliably distinguish messages that genuinely originate from the current tray device versus other Matrix senders.

### Description
- Change the server-rendered template logic in `app/templates/tray/chat_popup.html` to mark a message as `chat-message--self` only when the message's `sender_matrix_id` exactly matches the current tray device Matrix ID (`@tray-device-{device_id}:tray`).
- Add a client-side helper `isMessageFromThisTray(msg)` and update the polling handler to use it when deciding whether newly polled messages should be displayed as self/outgoing or incoming/received. 
- Add a regression test `test_tray_chat_popup_only_marks_current_tray_messages_as_self` in `tests/test_tray_chat_popup.py` that renders the popup with a tray-device message and an unlinked technician Matrix reply and asserts only the tray-device message is styled as self.

### Testing
- Ran `pytest -q tests/test_tray_chat_popup.py`, which includes the new regression test, and all tests in that file passed.
- The change is limited to the tray popup template and its unit test; no runtime server changes were required beyond the template update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28afed6104832dac4b16db00ae4984)