### PR TITLE
Fix tray chat replies syncing to linked tickets

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -55,6 +55,7 @@ from app.schemas.tray import (
     TrayTicketSubmitResponse,
 )
 from app.services import audit as audit_service
+from app.services import chat_ticket_sync
 from app.services import matrix as matrix_service
 from app.services import tickets as tickets_service
 from app.services import tray as tray_service
@@ -1454,6 +1455,7 @@ async def popup_chat_send_message(
         except Exception as exc:
             log_error("popup_chat_send_message: Matrix send failed", error=str(exc))
 
+    sent_at = datetime.now(timezone.utc).replace(tzinfo=None)
     msg = await chat_repo.add_message(
         room_id=room_id,
         matrix_event_id=matrix_event_id,
@@ -1461,15 +1463,36 @@ async def popup_chat_send_message(
         body=message_body,
         sender_user_id=None,
         sender_display_name=hostname,
+        sent_at=sent_at,
     )
+    await chat_repo.update_room(room_id, last_message_at=sent_at, updated_at=sent_at)
+
+    try:
+        await chat_ticket_sync.sync_chat_message_to_ticket(
+            room=room,
+            message=msg,
+            author_id=None,
+        )
+    except Exception as exc:
+        log_error(
+            "popup_chat_send_message: failed to sync chat message to linked ticket",
+            room_id=room_id,
+            error=str(exc),
+        )
 
     # Notify portal users of new message.
     try:
         from app.services.realtime import refresh_notifier
 
-        await refresh_notifier.notify(
-            f"chat:room:{room_id}",
-            data={"message": {k: (v.isoformat() if isinstance(v, datetime) else v) for k, v in msg.items()}},
+        await refresh_notifier.broadcast_refresh(
+            topics=[f"chat:room:{room_id}"],
+            data={
+                "message": {
+                    k: (v.isoformat() if isinstance(v, datetime) else v)
+                    for k, v in msg.items()
+                },
+                "room_id": room_id,
+            },
         )
     except Exception:
         pass

--- a/tests/test_tray_popup_chat_ticket_sync.py
+++ b/tests/test_tray_popup_chat_ticket_sync.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from app.api.routes import tray as tray_routes
+
+
+class _PopupRequest:
+    headers = {"X-Tray-CSRF": "csrf-token"}
+
+    async def json(self) -> dict[str, str]:
+        return {"body": "I still need help"}
+
+
+@pytest.mark.anyio("asyncio")
+async def test_popup_chat_send_message_syncs_linked_ticket(monkeypatch):
+    """Tray popup/client replies should mirror to the room's linked ticket."""
+
+    room = {
+        "id": 42,
+        "status": "open",
+        "matrix_room_id": "",
+        "linked_ticket_id": 1001,
+    }
+    created_message = {
+        "id": 501,
+        "room_id": 42,
+        "matrix_event_id": None,
+        "sender_matrix_id": "@tray-device-7:tray",
+        "sender_user_id": None,
+        "sender_display_name": "CLIENT-PC",
+        "body": "I still need help",
+        "sent_at": datetime(2026, 6, 10, 12, 0, 0),
+    }
+    synced: dict[str, object] = {}
+    room_updates: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        tray_routes,
+        "_parse_popup_session",
+        lambda request: {
+            "device_id": 7,
+            "room_id": 42,
+            "company_id": 3,
+            "csrf": "csrf-token",
+        },
+    )
+
+    async def fake_get_room(room_id: int) -> dict[str, object]:
+        assert room_id == 42
+        return room
+
+    async def fake_get_device_by_id(device_id: int) -> dict[str, object]:
+        assert device_id == 7
+        return {"hostname": "CLIENT-PC"}
+
+    async def fake_add_message(**kwargs):
+        assert kwargs["room_id"] == 42
+        assert kwargs["body"] == "I still need help"
+        assert kwargs["sender_user_id"] is None
+        assert kwargs["sender_display_name"] == "CLIENT-PC"
+        assert kwargs["sent_at"] is not None
+        return {**created_message, "sent_at": kwargs["sent_at"]}
+
+    async def fake_update_room(room_id: int, **fields):
+        room_updates.append({"room_id": room_id, **fields})
+
+    async def fake_sync_chat_message_to_ticket(**kwargs):
+        synced.update(kwargs)
+
+    monkeypatch.setattr(tray_routes.chat_repo, "get_room", fake_get_room)
+    monkeypatch.setattr(tray_routes.tray_repo, "get_device_by_id", fake_get_device_by_id)
+    monkeypatch.setattr(tray_routes.chat_repo, "add_message", fake_add_message)
+    monkeypatch.setattr(tray_routes.chat_repo, "update_room", fake_update_room)
+    monkeypatch.setattr(
+        tray_routes.chat_ticket_sync,
+        "sync_chat_message_to_ticket",
+        fake_sync_chat_message_to_ticket,
+    )
+    response = await tray_routes.popup_chat_send_message(_PopupRequest(), 42)
+
+    assert response.status_code == 201
+    assert synced["room"] == room
+    assert synced["message"]["id"] == 501
+    assert synced["message"]["body"] == "I still need help"
+    assert synced["author_id"] is None
+    assert room_updates
+    assert room_updates[0]["room_id"] == 42
+    assert room_updates[0]["last_message_at"] == room_updates[0]["updated_at"]


### PR DESCRIPTION
### Motivation
- Tray popup/client chat replies were not mirrored into a room's linked support ticket, causing missing conversation history on tickets. 
- The popup handler used an outdated realtime notify call that didn't match the available `refresh_notifier` API, preventing UI refreshes after messages.

### Description
- Import and call the existing chat-ticket sync service by adding `from app.services import chat_ticket_sync` and invoking `sync_chat_message_to_ticket` after persisting popup messages. 
- Ensure messages preserve original timestamps by creating a `sent_at` value and passing it to `chat_repo.add_message`, then update the chat room's `last_message_at`/`updated_at`. 
- Wrap the sync call in a `try/except` and log failures to avoid breaking the request path on errors. 
- Replace the removed `refresh_notifier.notify` usage with the supported `refresh_notifier.broadcast_refresh` and include the `topics` and `room_id` in the broadcast payload. 
- Add a regression test `tests/test_tray_popup_chat_ticket_sync.py` that verifies popup chat messages are saved, room timestamps are updated, and the chat->ticket sync is invoked.

### Testing
- Ran `python -m py_compile app/api/routes/tray.py tests/test_tray_popup_chat_ticket_sync.py` which succeeded. 
- Ran `pytest -q tests/test_tray_popup_chat_ticket_sync.py` which passed. 
- Ran `pytest -q tests/test_tray_popup_chat_ticket_sync.py tests/test_ticket_reply_update_api.py` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28b34ff6cc832db9f90b87a166899f)