### PR TITLE
Add TRMM_Script tray action (menu designer, device API, and client execution)

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -31,6 +31,7 @@ from app.api.dependencies.auth import (
 )
 from app.core.config import get_settings
 from app.core.logging import log_error, log_info
+from app.repositories import assets as assets_repo
 from app.repositories import chat as chat_repo
 from app.repositories import companies as companies_repo
 from app.repositories import tray as tray_repo
@@ -53,9 +54,12 @@ from app.schemas.tray import (
     TrayTicketQuestionUpdate,
     TrayTicketSubmitRequest,
     TrayTicketSubmitResponse,
+    TrayTRMMScriptRunRequest,
+    TrayTRMMScriptRunResponse,
 )
 from app.services import audit as audit_service
 from app.services import matrix as matrix_service
+from app.services import tacticalrmm as tacticalrmm_service
 from app.services import tickets as tickets_service
 from app.services import tray as tray_service
 from app.services import tray_ticket_questions as tq_service
@@ -181,6 +185,102 @@ async def get_device_config(
         env_allowlist=config.get("env_allowlist") or [],
         chat_enabled=chat_enabled,
         chat_client_mode=config.get("chat_client_mode") or None,
+    )
+
+
+def _find_trmm_script_node(
+    nodes: list[dict[str, Any]], script_id: int
+) -> dict[str, Any] | None:
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        node_type = str(node.get("type") or "").strip().lower()
+        try:
+            node_script_id = int(node.get("script_id") or 0)
+        except (TypeError, ValueError):
+            node_script_id = 0
+        if node_type == "trmm_script" and node_script_id == int(script_id):
+            return node
+        children = node.get("children")
+        if isinstance(children, list):
+            found = _find_trmm_script_node(children, script_id)
+            if found:
+                return found
+    return None
+
+
+@router.post(
+    "/trmm-script",
+    response_model=TrayTRMMScriptRunResponse,
+    summary="Run a configured Tactical RMM script for this tray device",
+)
+async def run_trmm_script(
+    payload: TrayTRMMScriptRunRequest,
+    device: dict = Depends(get_current_tray_device),
+) -> TrayTRMMScriptRunResponse:
+    """Run a menu-approved Tactical RMM script against the linked asset.
+
+    The script ID must exist in this device's resolved tray menu. This prevents
+    a compromised tray client from asking MyPortal to execute arbitrary scripts
+    that an administrator did not expose in the menu designer.
+    """
+
+    config = await tray_service.resolve_config_for_device(device)
+    script_node = _find_trmm_script_node(
+        config.get("menu") or [], int(payload.script_id)
+    )
+    if not script_node:
+        raise HTTPException(
+            status_code=403, detail="TRMM script is not enabled for this tray device"
+        )
+
+    asset_id = device.get("asset_id")
+    if not asset_id:
+        raise HTTPException(
+            status_code=409, detail="Tray device is not linked to an asset"
+        )
+    asset = await assets_repo.get_asset_by_id(int(asset_id))
+    if not asset:
+        raise HTTPException(status_code=409, detail="Linked asset was not found")
+    trmm_agent_id = str(asset.get("tactical_asset_id") or "").strip()
+    if not trmm_agent_id:
+        raise HTTPException(
+            status_code=409, detail="Linked asset does not have a Tactical RMM agent ID"
+        )
+
+    try:
+        result = await tacticalrmm_service.run_script_on_agent(
+            trmm_agent_id, int(payload.script_id)
+        )
+    except tacticalrmm_service.TacticalRMMConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except tacticalrmm_service.TacticalRMMAPIError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    response = result.get("response") if isinstance(result, dict) else None
+    event_id = None
+    if isinstance(response, dict) and response.get("event_id") is not None:
+        try:
+            event_id = int(response["event_id"])
+        except (TypeError, ValueError):
+            event_id = None
+    log_info(
+        "Tray requested Tactical RMM script",
+        device_id=device.get("id"),
+        asset_id=asset_id,
+        trmm_agent_id=trmm_agent_id,
+        script_id=payload.script_id,
+        event_id=event_id,
+    )
+    return TrayTRMMScriptRunResponse(
+        status="queued",
+        script_id=int(payload.script_id),
+        script_name=str(
+            script_node.get("script_name") or script_node.get("label") or ""
+        )
+        or None,
+        event_id=event_id,
+        message="Tactical RMM script request submitted.",
     )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -5573,11 +5573,21 @@ async def admin_tray_configurations_page(request: Request):
     )
 
 
+async def _get_tray_trmm_scripts_for_form() -> tuple[list[dict], str | None]:
+    from app.services import tacticalrmm as tacticalrmm_service
+
+    try:
+        return await tacticalrmm_service.fetch_scripts(), None
+    except Exception as exc:  # pragma: no cover - external integration availability
+        return [], str(exc)
+
+
 @app.get("/admin/tray/configurations/new", response_class=HTMLResponse)
 async def admin_tray_new_configuration_page(request: Request):
     current_user, redirect = await _require_super_admin_page(request)
     if redirect:
         return redirect
+    trmm_scripts, trmm_scripts_error = await _get_tray_trmm_scripts_for_form()
     extra = {
         "title": "New tray configuration",
         "heading": "New tray menu configuration",
@@ -5592,6 +5602,8 @@ async def admin_tray_new_configuration_page(request: Request):
             "branding_icon_url": "",
             "payload_json": "[]",
         },
+        "trmm_scripts": trmm_scripts,
+        "trmm_scripts_error": trmm_scripts_error,
     }
     return await _render_template(
         "admin/tray/configuration_form.html", request, current_user, extra=extra
@@ -5608,6 +5620,7 @@ async def admin_tray_edit_configuration_page(config_id: int, request: Request):
     record = await tray_repo.get_menu_config(config_id)
     if not record:
         return RedirectResponse(url="/admin/tray/configurations", status_code=303)
+    trmm_scripts, trmm_scripts_error = await _get_tray_trmm_scripts_for_form()
     extra = {
         "title": "Edit tray configuration",
         "heading": f"Edit configuration: {record.get('name')}",
@@ -5622,6 +5635,8 @@ async def admin_tray_edit_configuration_page(config_id: int, request: Request):
             "branding_icon_url": record.get("branding_icon_url") or "",
             "payload_json": record.get("payload_json") or "[]",
         },
+        "trmm_scripts": trmm_scripts,
+        "trmm_scripts_error": trmm_scripts_error,
     }
     return await _render_template(
         "admin/tray/configuration_form.html", request, current_user, extra=extra

--- a/app/schemas/tray.py
+++ b/app/schemas/tray.py
@@ -50,6 +50,7 @@ class TrayMenuNode(BaseModel):
     * ``env_var`` — reads an env var named ``name`` and shows / copies it.
     * ``open_chat`` — opens the chat window.
     * ``submit_ticket`` — opens the submit-a-ticket dialog.
+    * ``TRMM_Script`` — asks MyPortal to run a selected Tactical RMM script on the linked asset.
     * ``refresh_config`` — asks the tray service to pull the latest menu config.
     * ``separator`` — visual divider.
     * ``quit`` — exits the tray application.
@@ -61,6 +62,8 @@ class TrayMenuNode(BaseModel):
     name: Optional[str] = Field(default=None, max_length=128)
     text: Optional[str] = Field(default=None)
     color: Optional[str] = Field(default=None, max_length=32)
+    script_id: Optional[int] = Field(default=None, ge=1)
+    script_name: Optional[str] = Field(default=None, max_length=200)
     children: Optional[list["TrayMenuNode"]] = None
 
 
@@ -118,6 +121,18 @@ class TrayInstallTokenResponse(BaseModel):
     revoked_at: Optional[datetime] = None
     last_used_at: Optional[datetime] = None
     use_count: int = 0
+
+
+class TrayTRMMScriptRunRequest(BaseModel):
+    script_id: int = Field(ge=1)
+
+
+class TrayTRMMScriptRunResponse(BaseModel):
+    status: str
+    script_id: int
+    script_name: Optional[str] = None
+    event_id: Optional[int] = None
+    message: Optional[str] = None
 
 
 class TrayChatStartRequest(BaseModel):

--- a/app/services/tacticalrmm.py
+++ b/app/services/tacticalrmm.py
@@ -66,8 +66,12 @@ async def _load_settings() -> dict[str, Any]:
         return cached
 
 
-async def _call_endpoint(endpoint: str) -> Any:
-    payload = {"endpoint": endpoint, "method": "GET"}
+async def _call_endpoint(
+    endpoint: str, *, method: str = "GET", body: Any = None
+) -> Any:
+    payload = {"endpoint": endpoint, "method": method.upper()}
+    if body is not None:
+        payload["body"] = body
     try:
         result = await modules_service.trigger_module("tacticalrmm", payload, background=False)
     except ValueError as exc:
@@ -457,6 +461,125 @@ def extract_trmm_custom_fields(agent: Mapping[str, Any]) -> dict[str, dict[str, 
                 value = field.get("value")
         result[name] = {"type": field_type, "value": value}
     return result
+
+
+def _extract_items(response: Any, *keys: str) -> list[Mapping[str, Any]]:
+    if isinstance(response, list):
+        return [item for item in response if isinstance(item, Mapping)]
+    if isinstance(response, Mapping):
+        for key in keys or ("results", "items", "data"):
+            value = response.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, Mapping)]
+        if response.get("id") is not None:
+            return [response]
+    return []
+
+
+def _script_label(script: Mapping[str, Any]) -> str:
+    for key in ("name", "filename", "script_name", "title"):
+        label = _clean_text(script.get(key))
+        if label:
+            return label
+    script_id = script.get("id") or script.get("pk")
+    return f"Script #{script_id}" if script_id is not None else "Unnamed script"
+
+
+def _script_id(script: Mapping[str, Any]) -> int | None:
+    for key in ("id", "pk", "script", "script_id"):
+        raw = script.get(key)
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return None
+
+
+async def fetch_scripts() -> list[dict[str, Any]]:
+    """Return scripts from Tactical RMM's script library for tray menu design."""
+
+    await _load_settings()
+    try:
+        response = await _call_endpoint("scripts/")
+    except (TacticalRMMAPIError, TacticalRMMConfigurationError) as exc:
+        log_error("Failed to fetch Tactical RMM scripts", error=str(exc))
+        raise
+
+    scripts: list[dict[str, Any]] = []
+    for item in _extract_items(response, "results", "scripts", "items", "data"):
+        sid = _script_id(item)
+        if sid is None:
+            continue
+        scripts.append({
+            "id": sid,
+            "name": _script_label(item),
+            "description": _clean_text(item.get("description")),
+            "category": _clean_text(item.get("category")),
+            "script_type": (
+                _clean_text(item.get("shell"))
+                or _clean_text(item.get("script_type"))
+                or _clean_text(item.get("type"))
+            ),
+            "raw": dict(item),
+        })
+    scripts.sort(
+        key=lambda s: (str(s.get("name") or "").lower(), int(s.get("id") or 0))
+    )
+    return scripts
+
+
+def _script_default_body(
+    script_id: int, script: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
+    script = script or {}
+    timeout_raw = script.get("timeout") or script.get("default_timeout") or 90
+    try:
+        timeout = int(timeout_raw)
+    except (TypeError, ValueError):
+        timeout = 90
+    timeout = max(1, min(timeout, 86400))
+    return {
+        "output": script.get("output") or "forget",
+        "emails": script.get("emails") if isinstance(script.get("emails"), list) else [],
+        "emailMode": script.get("emailMode") or script.get("email_mode") or "default",
+        "custom_field": script.get("custom_field"),
+        "save_all_output": bool(script.get("save_all_output", False)),
+        "script": script_id,
+        "args": script.get("args") if isinstance(script.get("args"), list) else [],
+        "env_vars": script.get("env_vars") if isinstance(script.get("env_vars"), list) else [],
+        "run_as_user": bool(script.get("run_as_user", False)),
+        "timeout": timeout,
+    }
+
+
+async def run_script_on_agent(agent_id: str, script_id: int) -> dict[str, Any]:
+    """Ask Tactical RMM to run ``script_id`` on ``agent_id`` using default options."""
+
+    clean_agent_id = _clean_text(agent_id)
+    if not clean_agent_id:
+        raise TacticalRMMConfigurationError(
+            "Tactical RMM agent ID is not available for this device"
+        )
+    if int(script_id) <= 0:
+        raise TacticalRMMConfigurationError("Tactical RMM script ID is required")
+
+    script_record: Mapping[str, Any] | None = None
+    try:
+        detail = await _call_endpoint(f"scripts/{int(script_id)}/")
+        if isinstance(detail, Mapping):
+            script_record = detail
+    except TacticalRMMAPIError:
+        script_record = None
+
+    body = _script_default_body(int(script_id), script_record)
+    response = await _call_endpoint(
+        f"agents/{clean_agent_id}/runscript/",
+        method="POST",
+        body=body,
+    )
+    return {"response": response, "request": body}
 
 
 async def fetch_agent_installed_software(agent_id: str) -> list[str]:

--- a/app/templates/admin/tray/configuration_form.html
+++ b/app/templates/admin/tray/configuration_form.html
@@ -76,10 +76,17 @@
             </div>
           </div>
           <p class="form-help" id="menu-node-error" hidden></p>
+          {% if trmm_scripts_error %}
+            <p class="form-help">Tactical RMM scripts could not be loaded: {{ trmm_scripts_error }}</p>
+          {% elif trmm_scripts %}
+            <p class="form-help">Tactical RMM scripts are loaded from the configured TRMM API and can be selected with the <code>TRMM_Script</code> node type.</p>
+          {% else %}
+            <p class="form-help">No Tactical RMM scripts were returned by the configured TRMM API.</p>
+          {% endif %}
           <p class="form-help">
             Configure each row with the fields you need. Types: <code>label</code>, <code>link</code>, <code>submenu</code>,
             <code>display_text</code>, <code>env_var</code>, <code>open_chat</code>, <code>submit_ticket</code>,
-            <code>refresh_config</code>, <code>separator</code>, <code>quit</code>.
+            <code>TRMM_Script</code>, <code>refresh_config</code>, <code>separator</code>, <code>quit</code>.
             Use <code>Level</code> to place nodes under the nearest preceding submenu.
           </p>
           <p class="form-help">
@@ -118,6 +125,7 @@
       const NAME_MAX = 128;
       const COLOR_MAX = 32;
       const DEFAULT_MENU_LABEL = 'Menu';
+      const TRMM_SCRIPTS = {{ (trmm_scripts or [])|tojson }};
 
       const NODE_TYPES = [
         'label',
@@ -127,10 +135,26 @@
         'env_var',
         'open_chat',
         'submit_ticket',
+        'TRMM_Script',
         'refresh_config',
         'separator',
         'quit'
       ];
+
+      function escapeHtml(value) {
+        return String(value || '').replace(/[&<>"']/g, (char) => ({
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#39;'
+        }[char]));
+      }
+
+      function getSelectedScript(row) {
+        const scriptID = Number(row.querySelector('[data-node-script-id]').value) || 0;
+        return TRMM_SCRIPTS.find((script) => Number(script.id) === scriptID) || null;
+      }
 
       function showError(message) {
         if (!errorEl) return;
@@ -160,6 +184,7 @@
         row.querySelector('[data-wrap-url]').hidden = type !== 'link';
         row.querySelector('[data-wrap-name]').hidden = type !== 'env_var';
         row.querySelector('[data-wrap-text]').hidden = type !== 'display_text';
+        row.querySelector('[data-wrap-script]').hidden = type !== 'TRMM_Script';
         row.querySelector('[data-wrap-color]').hidden = type === 'separator';
       }
 
@@ -169,6 +194,10 @@
         if (type === 'env_var') {
           const name = row.querySelector('[data-node-name]').value.trim();
           return name || '(no name)';
+        }
+        if (type === 'TRMM_Script') {
+          const script = getSelectedScript(row);
+          return script ? script.name : '(no TRMM script selected)';
         }
         const label = row.querySelector('[data-node-label]').value.trim();
         return label || '(no label)';
@@ -222,6 +251,13 @@
                 <label class="form-label" for="${rowId}-text">Display text (HTML)</label>
                 <textarea class="form-input" id="${rowId}-text" data-node-text rows="2"></textarea>
               </div>
+              <div class="form-field" data-wrap-script>
+                <label class="form-label" for="${rowId}-script">Tactical RMM script</label>
+                <select class="form-input" id="${rowId}-script" data-node-script-id>
+                  <option value="">Select a TRMM script…</option>
+                  ${TRMM_SCRIPTS.map((script) => `<option value="${script.id}">${escapeHtml(script.name || ('Script #' + script.id))}</option>`).join('')}
+                </select>
+              </div>
             </div>
             <div class="form-row">
               <div class="form-field" data-wrap-color style="max-width:12rem;">
@@ -247,6 +283,7 @@
         row.querySelector('[data-node-url]').value = node.url || '';
         row.querySelector('[data-node-name]').value = node.name || '';
         row.querySelector('[data-node-text]').value = node.text || '';
+        row.querySelector('[data-node-script-id]').value = node.script_id || '';
 
         const colorEl = row.querySelector('[data-node-color]');
         const colorPreview = row.querySelector('[data-node-color-preview]');
@@ -346,7 +383,9 @@
             url: typeof candidate.url === 'string' ? candidate.url : '',
             name: typeof candidate.name === 'string' ? candidate.name : '',
             text: typeof candidate.text === 'string' ? candidate.text : '',
-            color: typeof candidate.color === 'string' ? candidate.color : ''
+            color: typeof candidate.color === 'string' ? candidate.color : '',
+            script_id: Number(candidate.script_id) || 0,
+            script_name: typeof candidate.script_name === 'string' ? candidate.script_name : ''
           };
           rows.push({ node: rest, level });
           const children = Array.isArray(candidate.children) ? candidate.children : [];
@@ -382,7 +421,8 @@
             url: row.querySelector('[data-node-url]').value.trim(),
             name: row.querySelector('[data-node-name]').value.trim(),
             text: row.querySelector('[data-node-text]').value.trim(),
-            color: (colorEl && colorEl.dataset.active === '1') ? colorEl.value.trim() : ''
+            color: (colorEl && colorEl.dataset.active === '1') ? colorEl.value.trim() : '',
+            script_id: Number(row.querySelector('[data-node-script-id]').value) || 0
           };
         });
       }
@@ -398,6 +438,11 @@
           if (row.name) node.name = row.name;
           if (row.text) node.text = row.text;
           if (row.color) node.color = row.color;
+          if (row.type === 'TRMM_Script') {
+            if (row.script_id) node.script_id = row.script_id;
+            const script = TRMM_SCRIPTS.find((candidate) => Number(candidate.id) === Number(row.script_id));
+            if (script && script.name) node.script_name = String(script.name).slice(0, LABEL_MAX);
+          }
           let parent = null;
           for (let level = row.level - 1; level >= 0; level -= 1) {
             const candidate = lastAtLevel[level];

--- a/tests/test_tacticalrmm_scripts.py
+++ b/tests/test_tacticalrmm_scripts.py
@@ -1,0 +1,69 @@
+import asyncio
+
+from app.services import tacticalrmm
+
+
+def test_fetch_scripts_normalises_script_library(monkeypatch):
+    async def fake_load_settings():
+        return {
+            "base_url": "https://trmm.example",
+            "api_key": "secret",
+            "verify_ssl": True,
+        }
+
+    async def fake_call_endpoint(endpoint, *, method="GET", body=None):
+        assert endpoint == "scripts/"
+        assert method == "GET"
+        assert body is None
+        return {
+            "results": [
+                {
+                    "id": 2,
+                    "name": "Beta",
+                    "description": "Second",
+                    "shell": "powershell",
+                },
+                {"id": "1", "filename": "Alpha.ps1", "category": "Ops"},
+                {"name": "Missing ID"},
+            ]
+        }
+
+    monkeypatch.setattr(tacticalrmm, "_load_settings", fake_load_settings)
+    monkeypatch.setattr(tacticalrmm, "_call_endpoint", fake_call_endpoint)
+
+    scripts = asyncio.run(tacticalrmm.fetch_scripts())
+
+    assert [script["id"] for script in scripts] == [1, 2]
+    assert scripts[0]["name"] == "Alpha.ps1"
+    assert scripts[1]["script_type"] == "powershell"
+
+
+def test_run_script_on_agent_posts_default_body(monkeypatch):
+    calls = []
+
+    async def fake_call_endpoint(endpoint, *, method="GET", body=None):
+        calls.append((endpoint, method, body))
+        if endpoint == "scripts/89/":
+            return {
+                "id": 89,
+                "name": "Collect Logs",
+                "timeout": 120,
+                "run_as_user": True,
+            }
+        return {"event_id": 123, "status": "completed"}
+
+    monkeypatch.setattr(tacticalrmm, "_call_endpoint", fake_call_endpoint)
+
+    result = asyncio.run(tacticalrmm.run_script_on_agent("agent-abc", 89))
+
+    assert result["response"]["event_id"] == 123
+    endpoint, method, body = calls[-1]
+    assert endpoint == "agents/agent-abc/runscript/"
+    assert method == "POST"
+    assert body["script"] == 89
+    assert body["output"] == "forget"
+    assert body["emailMode"] == "default"
+    assert body["args"] == []
+    assert body["env_vars"] == []
+    assert body["timeout"] == 120
+    assert body["run_as_user"] is True

--- a/tray/internal/api/client.go
+++ b/tray/internal/api/client.go
@@ -55,14 +55,14 @@ func (c *Client) DeviceUID() string {
 
 // EnrolRequest mirrors the server's TrayEnrolRequest schema.
 type EnrolRequest struct {
-	InstallToken  string  `json:"install_token"`
-	DeviceUID     string  `json:"device_uid,omitempty"`
-	OS            string  `json:"os"`
-	OSVersion     string  `json:"os_version,omitempty"`
-	Hostname      string  `json:"hostname,omitempty"`
-	SerialNumber  string  `json:"serial_number,omitempty"`
-	AgentVersion  string  `json:"agent_version,omitempty"`
-	ConsoleUser   string  `json:"console_user,omitempty"`
+	InstallToken string `json:"install_token"`
+	DeviceUID    string `json:"device_uid,omitempty"`
+	OS           string `json:"os"`
+	OSVersion    string `json:"os_version,omitempty"`
+	Hostname     string `json:"hostname,omitempty"`
+	SerialNumber string `json:"serial_number,omitempty"`
+	AgentVersion string `json:"agent_version,omitempty"`
+	ConsoleUser  string `json:"console_user,omitempty"`
 }
 
 // EnrolResponse mirrors the server's TrayEnrolResponse schema.
@@ -98,30 +98,32 @@ func (c *Client) Enrol(ctx context.Context, req EnrolRequest) (*EnrolResponse, e
 
 // MenuNode mirrors the server's TrayMenuNode schema.
 type MenuNode struct {
-	Type     string      `json:"type"`
-	Label    string      `json:"label,omitempty"`
-	URL      string      `json:"url,omitempty"`
-	Name     string      `json:"name,omitempty"`
-	Text     string      `json:"text,omitempty"`
-	Color    string      `json:"color,omitempty"`
-	Children []*MenuNode `json:"children,omitempty"`
+	Type       string      `json:"type"`
+	Label      string      `json:"label,omitempty"`
+	URL        string      `json:"url,omitempty"`
+	Name       string      `json:"name,omitempty"`
+	Text       string      `json:"text,omitempty"`
+	Color      string      `json:"color,omitempty"`
+	ScriptID   int         `json:"script_id,omitempty"`
+	ScriptName string      `json:"script_name,omitempty"`
+	Children   []*MenuNode `json:"children,omitempty"`
 }
 
 // ConfigResponse mirrors the server's TrayConfigResponse schema.
 type ConfigResponse struct {
-	Version          int        `json:"version"`
-	Menu             []MenuNode `json:"menu"`
-	DisplayText      string     `json:"display_text,omitempty"`
-	BrandingIconURL  string     `json:"branding_icon_url,omitempty"`
-	EnvAllowlist     []string   `json:"env_allowlist"`
-	ChatEnabled      bool       `json:"chat_enabled"`
+	Version         int        `json:"version"`
+	Menu            []MenuNode `json:"menu"`
+	DisplayText     string     `json:"display_text,omitempty"`
+	BrandingIconURL string     `json:"branding_icon_url,omitempty"`
+	EnvAllowlist    []string   `json:"env_allowlist"`
+	ChatEnabled     bool       `json:"chat_enabled"`
 	// ChatClientMode controls how the tray opens chat windows.
 	// "" or "app" (default): try dedicated chat shell, then browser app-mode, then
 	// fall back to the default browser.
 	// "browser": always open in the default system browser (legacy behaviour).
 	// "shell": require the dedicated chat shell; log a warning if absent rather
 	// than falling back to the browser.
-	ChatClientMode   string     `json:"chat_client_mode,omitempty"`
+	ChatClientMode string `json:"chat_client_mode,omitempty"`
 }
 
 // GetConfig fetches the resolved menu configuration for this device.
@@ -275,6 +277,26 @@ func (c *Client) RequestChatToken(ctx context.Context, roomID int) (*ChatTokenRe
 		return nil, err
 	}
 	return &out, nil
+}
+
+// RunTRMMScript asks MyPortal to run a configured Tactical RMM script on this device.
+func (c *Client) RunTRMMScript(ctx context.Context, scriptID int) error {
+	if scriptID <= 0 {
+		return fmt.Errorf("trmm-script: script id is required")
+	}
+	body, err := json.Marshal(map[string]int{"script_id": scriptID})
+	if err != nil {
+		return err
+	}
+	resp, err := c.post(ctx, "/api/tray/trmm-script", body, true)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("trmm-script: HTTP %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // UploadDiagnostics zips logDir and uploads it to the server.

--- a/tray/ui/main.go
+++ b/tray/ui/main.go
@@ -245,6 +245,21 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 			}
 		}()
 
+	case "TRMM_Script", "trmm_script":
+		label := node.Label
+		if label == "" {
+			label = node.ScriptName
+		}
+		if label == "" {
+			label = "Run Tactical RMM Script"
+		}
+		item := systray.AddMenuItem(label, "Run a Tactical RMM script on this computer")
+		go func(menuNode api.MenuNode) {
+			for range item.ClickedCh {
+				go runTRMMScriptFromMenu(menuNode)
+			}
+		}(node)
+
 	case "refresh_config":
 		label := node.Label
 		if label == "" {

--- a/tray/ui/tray_nowebview_windows.go
+++ b/tray/ui/tray_nowebview_windows.go
@@ -234,6 +234,21 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 			}
 		}()
 
+	case "TRMM_Script", "trmm_script":
+		label := node.Label
+		if label == "" {
+			label = node.ScriptName
+		}
+		if label == "" {
+			label = "Run Tactical RMM Script"
+		}
+		item := systray.AddMenuItem(label, "Run a Tactical RMM script on this computer")
+		go func(menuNode api.MenuNode) {
+			for range item.ClickedCh {
+				go runTRMMScriptFromMenu(menuNode)
+			}
+		}(node)
+
 	case "refresh_config":
 		label := node.Label
 		if label == "" {

--- a/tray/ui/trmm_script.go
+++ b/tray/ui/trmm_script.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/bradhawkins85/myportal-tray/internal/api"
+	"github.com/bradhawkins85/myportal-tray/internal/logger"
+)
+
+func runTRMMScriptFromMenu(node api.MenuNode) {
+	if node.ScriptID <= 0 {
+		logger.Warn("TRMM script menu item %q has no script_id", node.Label)
+		showTextWindow("Tactical RMM", "This menu item is missing a Tactical RMM script selection.")
+		return
+	}
+	if strings.TrimSpace(gPortalURL) == "" || strings.TrimSpace(gAuthToken) == "" {
+		logger.Warn("TRMM script request skipped: portal URL or auth token is missing")
+		showTextWindow("Tactical RMM", "MyPortal is not connected yet. Please try again in a moment.")
+		return
+	}
+	url := strings.TrimRight(gPortalURL, "/") + "/api/tray/trmm-script"
+	body := []byte(fmt.Sprintf(`{"script_id":%d}`, node.ScriptID))
+	req, err := newHTTPRequest(http.MethodPost, url, body)
+	if err != nil {
+		logger.Warn("TRMM script request build failed: %v", err)
+		showTextWindow("Tactical RMM", "Could not build the Tactical RMM script request.")
+		return
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		logger.Warn("TRMM script request failed: %v", err)
+		showTextWindow("Tactical RMM", "Could not contact MyPortal to start the script.")
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		logger.Warn("TRMM script request HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+		showTextWindow("Tactical RMM", "MyPortal could not start the Tactical RMM script. Please contact support.")
+		return
+	}
+	label := node.ScriptName
+	if label == "" {
+		label = node.Label
+	}
+	if label == "" {
+		label = fmt.Sprintf("Script #%d", node.ScriptID)
+	}
+	showTextWindow("Tactical RMM", "Requested Tactical RMM to run "+label+" on this computer.")
+}


### PR DESCRIPTION
### Motivation
- Provide administrators a tray menu node that lets them expose TacticalRMM scripts in the tray menu and let a device request MyPortal to execute a selected TRMM script on that device using TacticalRMM default settings. 
- Ensure the server authorises runs by verifying the script is present in the resolved menu for the device and that the device is linked to an asset with a Tactical RMM agent id.

### Description
- Schema: added `script_id` and `script_name` to `TrayMenuNode` and new `TrayTRMMScriptRunRequest` / `TrayTRMMScriptRunResponse` models in `app/schemas/tray.py`.
- TRMM service: implemented `fetch_scripts()` to normalise the TRMM script library and `run_script_on_agent()` (with `_script_default_body`) to post to `agents/{agent_id}/runscript/` using `modules_service.trigger_module` via `_call_endpoint` in `app/services/tacticalrmm.py`.
- API: added device-authenticated endpoint `POST /api/tray/trmm-script` that verifies the script exists in the device-resolved menu, resolves the linked asset and its `tactical_asset_id`, and invokes the TRMM runscript helper (`app/api/routes/tray.py`).
- Admin UI: updated tray menu designer template and page to load available TRMM scripts (`app/main.py`, `app/templates/admin/tray/configuration_form.html`) and added a `TRMM_Script` node type with a script dropdown and client-side JSON builder changes.
- Tray clients: extended tray API client, menu node model and UI handlers so both webview and nowebview builds render `TRMM_Script` items and call `/api/tray/trmm-script` (Go changes in `tray/internal/api/client.go`, `tray/ui/*`, new `tray/ui/trmm_script.go`).
- Tests: added unit tests normalising scripts and verifying run payload construction in `tests/test_tacticalrmm_scripts.py`.

### Testing
- `python -m py_compile app/schemas/tray.py app/services/tacticalrmm.py app/api/routes/tray.py app/main.py` — succeeded.
- `pytest -q tests/test_tacticalrmm_scripts.py` — succeeded (2 tests passed).
- Tray UI Go tests: `cd tray && go test -tags nowebview ./ui` — succeeded; `cd tray && go test ./...` may fail in some environments where the `ayatana-appindicator3-0.1` pkg-config dependency for `systray` is missing (observed in CI-like Linux environments), otherwise tray Go packages build/test OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28b221e7f0832da34402fc90ab82fe)