### PR TITLE
Show background notice for TRMM tray script actions

### DIFF
--- a/tray/ui/platform_nowebview_windows.go
+++ b/tray/ui/platform_nowebview_windows.go
@@ -160,5 +160,7 @@ func openChatAppWindow(chatURL string) {
 }
 
 func showOSNotification(title, body string) {
-	fmt.Printf("[notification] %s: %s\n", title, body)
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsToastEncodedCommand(title, body))
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
+	_ = cmd.Start()
 }

--- a/tray/ui/platform_windows.go
+++ b/tray/ui/platform_windows.go
@@ -48,13 +48,7 @@ func openNewTicketWindow(cfg *api.ConfigResponse) {
 }
 
 func showOSNotification(title, body string) {
-	// Use PowerShell toast for Windows 10+.
-	script := `[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
-$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
-$xml.GetElementsByTagName('text')[0].InnerText = '` + title + `'
-$xml.GetElementsByTagName('text')[1].InnerText = '` + body + `'
-[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('MyPortal').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
-	cmd := exec.Command("powershell", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", script)
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsToastEncodedCommand(title, body))
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
 	_ = cmd.Start()
 }

--- a/tray/ui/trmm_script.go
+++ b/tray/ui/trmm_script.go
@@ -49,5 +49,13 @@ func runTRMMScriptFromMenu(node api.MenuNode) {
 	if label == "" {
 		label = fmt.Sprintf("Script #%d", node.ScriptID)
 	}
-	showTextWindow("Tactical RMM", "Requested Tactical RMM to run "+label+" on this computer.")
+	showOSNotification("Tactical RMM", trmmScriptSuccessMessage(label))
+}
+
+func trmmScriptSuccessMessage(label string) string {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return "The Tactical RMM script has been executed and will run in the background shortly."
+	}
+	return fmt.Sprintf("The Tactical RMM script %q has been executed and will run in the background shortly.", label)
 }

--- a/tray/ui/trmm_script_test.go
+++ b/tray/ui/trmm_script_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func TestTRMMScriptSuccessMessageIncludesBackgroundNotice(t *testing.T) {
+	msg := trmmScriptSuccessMessage("Nightly Maintenance")
+	want := `The Tactical RMM script "Nightly Maintenance" has been executed and will run in the background shortly.`
+	if msg != want {
+		t.Fatalf("unexpected success message:\n got: %q\nwant: %q", msg, want)
+	}
+}
+
+func TestTRMMScriptSuccessMessageTrimsBlankLabel(t *testing.T) {
+	msg := trmmScriptSuccessMessage("  \t")
+	want := "The Tactical RMM script has been executed and will run in the background shortly."
+	if msg != want {
+		t.Fatalf("unexpected success message for blank label:\n got: %q\nwant: %q", msg, want)
+	}
+}

--- a/tray/ui/windows_notification.go
+++ b/tray/ui/windows_notification.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"unicode/utf16"
+)
+
+func windowsToastEncodedCommand(title, body string) string {
+	script := `[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+$xml.GetElementsByTagName('text')[0].InnerText = '` + powershellSingleQuotedString(title) + `'
+$xml.GetElementsByTagName('text')[1].InnerText = '` + powershellSingleQuotedString(body) + `'
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('MyPortal').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
+	return encodePowerShellCommand(script)
+}
+
+func powershellSingleQuotedString(value string) string {
+	return strings.ReplaceAll(value, `'`, `''`)
+}
+
+func encodePowerShellCommand(script string) string {
+	encoded := utf16.Encode([]rune(script))
+	buf := make([]byte, 0, len(encoded)*2)
+	for _, r := range encoded {
+		buf = append(buf, byte(r), byte(r>>8))
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}


### PR DESCRIPTION
### Motivation
- Ensure TRMM_Script tray actions provide the user with a visible notification that the script was accepted and will run in the background shortly. 
- Use native Windows toasts for clearer notifications on Windows builds (both webview and nowebview) and avoid embedding raw unescaped script text. 
- Add a small, testable helper to produce the success message consistently across UI code paths.

### Description
- Update TRMM handler to show an OS notification on success and add `trmmScriptSuccessMessage` to produce the user-facing message in `tray/ui/trmm_script.go` instead of printing to stdout. 
- Add `tray/ui/windows_notification.go` with `windowsToastEncodedCommand`, `powershellSingleQuotedString` and `encodePowerShellCommand` to safely build an encoded PowerShell toast command for Windows. 
- Switch Windows notification callers to use the new encoded-command approach in `tray/ui/platform_windows.go` and `tray/ui/platform_nowebview_windows.go` so toasts work in both webview and nowebview builds. 
- Add unit tests `tray/ui/trmm_script_test.go` covering the success message formatting and blank-label trimming.

### Testing
- Ran `cd tray && go test -tags nowebview ./ui` and all UI tests passed. 
- Ran `cd tray && go test -tags nowebview ./...` to exercise the tray module test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28ba594e00832d963371dfdb3397a3)