### PR TITLE
Fix tray submenu nesting

### DIFF
--- a/tray/ui/main.go
+++ b/tray/ui/main.go
@@ -149,7 +149,7 @@ func buildMenu(cfg *api.ConfigResponse) {
 	}
 
 	for _, node := range cfg.Menu {
-		addNode(node, cfg)
+		addNode(node, cfg, nil)
 	}
 }
 
@@ -163,19 +163,35 @@ func requestConfigRefresh() {
 	}
 }
 
-func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
+func addTrayMenuItem(parent *systray.MenuItem, label string, tooltip string) *systray.MenuItem {
+	if parent != nil {
+		return parent.AddSubMenuItem(label, tooltip)
+	}
+	return systray.AddMenuItem(label, tooltip)
+}
+
+func addTraySeparator(parent *systray.MenuItem) {
+	if parent == nil {
+		systray.AddSeparator()
+		return
+	}
+	item := parent.AddSubMenuItem("────────", "")
+	item.Disable()
+}
+
+func addNode(node api.MenuNode, cfg *api.ConfigResponse, parent *systray.MenuItem) {
 	switch node.Type {
 	case "separator":
-		systray.AddSeparator()
+		addTraySeparator(parent)
 
 	case "label":
-		item := systray.AddMenuItem(node.Label, "")
+		item := addTrayMenuItem(parent, node.Label, "")
 		if node.Color == "" {
 			item.Disable()
 		}
 
 	case "link":
-		item := systray.AddMenuItem(node.Label, node.URL)
+		item := addTrayMenuItem(parent, node.Label, node.URL)
 		go func(url string) {
 			for range item.ClickedCh {
 				openBrowser(url)
@@ -190,7 +206,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Chat with helpdesk"
 		}
-		item := systray.AddMenuItem(label, "Open chat window")
+		item := addTrayMenuItem(parent, label, "Open chat window")
 		go func() {
 			for range item.ClickedCh {
 				openChatWindow("", cfg)
@@ -202,7 +218,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Info"
 		}
-		item := systray.AddMenuItem(label, "")
+		item := addTrayMenuItem(parent, label, "")
 		go func(text string) {
 			for range item.ClickedCh {
 				showTextWindow("Information", text)
@@ -211,7 +227,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 
 	case "env_var":
 		label := resolveEnvVarMenuLabel(node)
-		item := systray.AddMenuItem(label, "Click to copy value")
+		item := addTrayMenuItem(parent, label, "Click to copy value")
 		go func(varName string) {
 			for range item.ClickedCh {
 				val := os.Getenv(varName)
@@ -223,14 +239,16 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		}(normalizeEnvVarName(node.Name))
 
 	case "submenu":
-		// systray doesn't natively support submenus in all implementations;
-		// render children at the same level with an indented label for Phase 3.
-		if node.Label != "" {
-			item := systray.AddMenuItem("▸ "+node.Label, "")
-			item.Disable()
+		label := node.Label
+		if label == "" {
+			label = "Menu"
 		}
+		item := addTrayMenuItem(parent, label, "")
 		for _, child := range node.Children {
-			addNode(*child, cfg)
+			if child == nil {
+				continue
+			}
+			addNode(*child, cfg, item)
 		}
 
 	case "submit_ticket":
@@ -238,7 +256,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Submit Ticket"
 		}
-		item := systray.AddMenuItem(label, "Submit a support ticket")
+		item := addTrayMenuItem(parent, label, "Submit a support ticket")
 		go func() {
 			for range item.ClickedCh {
 				go openNewTicketWindow(cfg)
@@ -253,7 +271,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Run Tactical RMM Script"
 		}
-		item := systray.AddMenuItem(label, "Run a Tactical RMM script on this computer")
+		item := addTrayMenuItem(parent, label, "Run a Tactical RMM script on this computer")
 		go func(menuNode api.MenuNode) {
 			for range item.ClickedCh {
 				go runTRMMScriptFromMenu(menuNode)
@@ -265,7 +283,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Refresh"
 		}
-		item := systray.AddMenuItem(label, "Refresh tray menu from server")
+		item := addTrayMenuItem(parent, label, "Refresh tray menu from server")
 		go func() {
 			for range item.ClickedCh {
 				requestConfigRefresh()
@@ -277,7 +295,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Quit"
 		}
-		item := systray.AddMenuItem(label, "Exit MyPortal tray")
+		item := addTrayMenuItem(parent, label, "Exit MyPortal tray")
 		go func() {
 			for range item.ClickedCh {
 				systray.Quit()

--- a/tray/ui/tray_nowebview_windows.go
+++ b/tray/ui/tray_nowebview_windows.go
@@ -150,23 +150,39 @@ func buildMenu(cfg *api.ConfigResponse) {
 	logger.Debug("buildMenu: rendering version=%d, %d top-level node(s), chat_enabled=%t",
 		cfg.Version, len(cfg.Menu), cfg.ChatEnabled)
 	for _, node := range cfg.Menu {
-		addNode(node, cfg)
+		addNode(node, cfg, nil)
 	}
 }
 
-func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
+func addTrayMenuItem(parent *systray.MenuItem, label string, tooltip string) *systray.MenuItem {
+	if parent != nil {
+		return parent.AddSubMenuItem(label, tooltip)
+	}
+	return systray.AddMenuItem(label, tooltip)
+}
+
+func addTraySeparator(parent *systray.MenuItem) {
+	if parent == nil {
+		systray.AddSeparator()
+		return
+	}
+	item := parent.AddSubMenuItem("────────", "")
+	item.Disable()
+}
+
+func addNode(node api.MenuNode, cfg *api.ConfigResponse, parent *systray.MenuItem) {
 	switch node.Type {
 	case "separator":
-		systray.AddSeparator()
+		addTraySeparator(parent)
 
 	case "label":
-		item := systray.AddMenuItem(node.Label, "")
+		item := addTrayMenuItem(parent, node.Label, "")
 		if node.Color == "" {
 			item.Disable()
 		}
 
 	case "link":
-		item := systray.AddMenuItem(node.Label, node.URL)
+		item := addTrayMenuItem(parent, node.Label, node.URL)
 		go func(url string) {
 			for range item.ClickedCh {
 				openBrowser(url)
@@ -181,7 +197,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Chat with helpdesk"
 		}
-		item := systray.AddMenuItem(label, "Open chat window")
+		item := addTrayMenuItem(parent, label, "Open chat window")
 		go func() {
 			for range item.ClickedCh {
 				openChatWindow("", cfg)
@@ -193,7 +209,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Info"
 		}
-		item := systray.AddMenuItem(label, "")
+		item := addTrayMenuItem(parent, label, "")
 		go func(text string) {
 			for range item.ClickedCh {
 				showTextWindow("Information", text)
@@ -202,7 +218,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 
 	case "env_var":
 		label := resolveEnvVarMenuLabel(node)
-		item := systray.AddMenuItem(label, "Click to copy value")
+		item := addTrayMenuItem(parent, label, "Click to copy value")
 		go func(varName string) {
 			for range item.ClickedCh {
 				val := os.Getenv(varName)
@@ -214,12 +230,16 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		}(normalizeEnvVarName(node.Name))
 
 	case "submenu":
-		if node.Label != "" {
-			item := systray.AddMenuItem("▸ "+node.Label, "")
-			item.Disable()
+		label := node.Label
+		if label == "" {
+			label = "Menu"
 		}
+		item := addTrayMenuItem(parent, label, "")
 		for _, child := range node.Children {
-			addNode(*child, cfg)
+			if child == nil {
+				continue
+			}
+			addNode(*child, cfg, item)
 		}
 
 	case "submit_ticket":
@@ -227,7 +247,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Submit Ticket"
 		}
-		item := systray.AddMenuItem(label, "Submit a support ticket")
+		item := addTrayMenuItem(parent, label, "Submit a support ticket")
 		go func() {
 			for range item.ClickedCh {
 				go openNewTicketDialog(cfg)
@@ -242,7 +262,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Run Tactical RMM Script"
 		}
-		item := systray.AddMenuItem(label, "Run a Tactical RMM script on this computer")
+		item := addTrayMenuItem(parent, label, "Run a Tactical RMM script on this computer")
 		go func(menuNode api.MenuNode) {
 			for range item.ClickedCh {
 				go runTRMMScriptFromMenu(menuNode)
@@ -254,7 +274,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Refresh"
 		}
-		item := systray.AddMenuItem(label, "Refresh tray menu from server")
+		item := addTrayMenuItem(parent, label, "Refresh tray menu from server")
 		go func() {
 			for range item.ClickedCh {
 				requestConfigRefresh()
@@ -266,7 +286,7 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse) {
 		if label == "" {
 			label = "Quit"
 		}
-		item := systray.AddMenuItem(label, "Exit MyPortal tray")
+		item := addTrayMenuItem(parent, label, "Exit MyPortal tray")
 		go func() {
 			for range item.ClickedCh {
 				systray.Quit()


### PR DESCRIPTION
### Motivation
- Submenu payloads were rendering child entries as top-level items instead of nested menu items, causing the tray submenu UI to appear flat and misordered.
- The intent is to use systray's native submenu APIs when available so submenus expand into child items rather than placing children below the submenu label.

### Description
- Change `addNode` to accept a `parent *systray.MenuItem` and recurse with the appropriate parent so children are attached as real sub-items instead of top-level entries.
- Add helper functions `addTrayMenuItem(parent, label, tooltip)` and `addTraySeparator(parent)` to centralize logic for top-level vs nested menu items and separators and to call `AddSubMenuItem` when `parent != nil`.
- Replace direct `systray.AddMenuItem` / `systray.AddSeparator` calls with the new helpers in both `tray/ui/main.go` and `tray/ui/tray_nowebview_windows.go` so both webview and Windows nowebview builds behave consistently.
- Add nil-child safety when iterating `node.Children` so corrupt or missing children are skipped.

### Testing
- Ran `cd tray && go test ./ui -tags nowebview` and the tests passed (ok). 
- Built a Windows test binary with `cd tray && go test -c ./ui -tags nowebview -o /tmp/myportal-tray-ui.test.exe` which produced the test binary successfully. 
- `cd tray && go test ./ui` (native Linux build) failed in this container due to a missing `ayatana-appindicator3-0.1` pkg-config dependency required by `systray`, so full native UI tests could not run here. 
- Attempt to build the webview-enabled UI test binary failed due to webview build constraints in this environment, which is expected in a non-GUI CI/container without the webview native deps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28bd3aae00832db9083721a1b0ea78)