### PR TITLE
Add company-conditional visibility for Tray menu nodes

### DIFF
--- a/app/schemas/tray.py
+++ b/app/schemas/tray.py
@@ -64,6 +64,8 @@ class TrayMenuNode(BaseModel):
     color: Optional[str] = Field(default=None, max_length=32)
     script_id: Optional[int] = Field(default=None, ge=1)
     script_name: Optional[str] = Field(default=None, max_length=200)
+    visible_company_ids: Optional[list[int]] = None
+    hidden_company_ids: Optional[list[int]] = None
     children: Optional[list["TrayMenuNode"]] = None
 
 

--- a/app/services/tray.py
+++ b/app/services/tray.py
@@ -136,6 +136,66 @@ _DEFAULT_MENU: list[dict[str, Any]] = [
 ]
 
 
+def _normalise_company_id_list(value: Any) -> list[int]:
+    """Return positive company IDs from a menu-node condition field."""
+
+    if value is None or value == "":
+        return []
+    raw_items: Iterable[Any]
+    if isinstance(value, (list, tuple, set)):
+        raw_items = value
+    else:
+        raw_items = str(value).split(",")
+
+    ids: list[int] = []
+    seen: set[int] = set()
+    for item in raw_items:
+        try:
+            company_id = int(str(item).strip())
+        except (TypeError, ValueError):
+            continue
+        if company_id <= 0 or company_id in seen:
+            continue
+        ids.append(company_id)
+        seen.add(company_id)
+    return ids
+
+
+def _node_is_visible_for_company(node: dict[str, Any], company_id: int | None) -> bool:
+    """Return whether a menu node passes company visibility conditions."""
+
+    include_ids = _normalise_company_id_list(node.get("visible_company_ids"))
+    exclude_ids = _normalise_company_id_list(node.get("hidden_company_ids"))
+    if include_ids and company_id not in include_ids:
+        return False
+    if company_id is not None and company_id in exclude_ids:
+        return False
+    return True
+
+
+def _filter_menu_nodes_for_company(
+    nodes: list[dict[str, Any]],
+    company_id: int | None,
+) -> list[dict[str, Any]]:
+    """Recursively remove menu nodes hidden for the device's assigned company."""
+
+    filtered: list[dict[str, Any]] = []
+    for raw_node in nodes:
+        if not isinstance(raw_node, dict):
+            continue
+        if not _node_is_visible_for_company(raw_node, company_id):
+            continue
+        node = dict(raw_node)
+        children = node.get("children")
+        if isinstance(children, list):
+            node["children"] = _filter_menu_nodes_for_company(children, company_id)
+            node_type = str(node.get("type") or "").strip().lower()
+            if node_type == "submenu" and not node["children"]:
+                continue
+        filtered.append(node)
+    return filtered
+
+
 async def resolve_config_for_device(device: dict[str, Any]) -> dict[str, Any]:
     """Return the menu config payload + branding to send to ``device``.
 
@@ -172,8 +232,11 @@ async def resolve_config_for_device(device: dict[str, Any]) -> dict[str, Any]:
     if chosen:
         try:
             payload = json.loads(chosen.get("payload_json") or "[]") or _DEFAULT_MENU
+            if not isinstance(payload, list):
+                payload = _DEFAULT_MENU
         except (ValueError, TypeError):
             payload = _DEFAULT_MENU
+        payload = _filter_menu_nodes_for_company(payload, company_id)
         display_text = chosen.get("display_text")
         branding_icon_url = chosen.get("branding_icon_url")
         raw_allow = chosen.get("env_allowlist") or ""

--- a/app/templates/admin/tray/configuration_form.html
+++ b/app/templates/admin/tray/configuration_form.html
@@ -87,7 +87,7 @@
             Configure each row with the fields you need. Types: <code>label</code>, <code>link</code>, <code>submenu</code>,
             <code>display_text</code>, <code>env_var</code>, <code>open_chat</code>, <code>submit_ticket</code>,
             <code>TRMM_Script</code>, <code>refresh_config</code>, <code>separator</code>, <code>quit</code>.
-            Use <code>Level</code> to place nodes under the nearest preceding submenu.
+            Use <code>Level</code> to place nodes under the nearest preceding submenu. Add company visibility conditions to show a node only for selected company IDs or hide it from selected company IDs.
           </p>
           <p class="form-help">
             See <a href="/docs/tray_app">docs/tray_app</a> for the schema.
@@ -124,6 +124,7 @@
       const URL_MAX = 500;
       const NAME_MAX = 128;
       const COLOR_MAX = 32;
+      const COMPANY_IDS_MAX = 500;
       const DEFAULT_MENU_LABEL = 'Menu';
       const TRMM_SCRIPTS = {{ (trmm_scripts or [])|tojson }};
 
@@ -154,6 +155,25 @@
       function getSelectedScript(row) {
         const scriptID = Number(row.querySelector('[data-node-script-id]').value) || 0;
         return TRMM_SCRIPTS.find((script) => Number(script.id) === scriptID) || null;
+      }
+
+      function parseCompanyIDs(value) {
+        const seen = new Set();
+        return String(value || '')
+          .split(',')
+          .map((part) => Number.parseInt(part.trim(), 10))
+          .filter((id) => {
+            if (!Number.isInteger(id) || id <= 0 || seen.has(id)) return false;
+            seen.add(id);
+            return true;
+          });
+      }
+
+      function normaliseCompanyIDsForInput(value) {
+        if (Array.isArray(value)) {
+          return parseCompanyIDs(value.join(',')).join(', ');
+        }
+        return parseCompanyIDs(value).join(', ');
       }
 
       function showError(message) {
@@ -260,6 +280,18 @@
               </div>
             </div>
             <div class="form-row">
+              <div class="form-field">
+                <label class="form-label" for="${rowId}-visible-companies">Show only for company IDs</label>
+                <input class="form-input" id="${rowId}-visible-companies" data-node-visible-company-ids maxlength="${COMPANY_IDS_MAX}" placeholder="e.g. 12, 34" />
+                <p class="form-help">Leave blank to show for every company unless hidden below.</p>
+              </div>
+              <div class="form-field">
+                <label class="form-label" for="${rowId}-hidden-companies">Hide for company IDs</label>
+                <input class="form-input" id="${rowId}-hidden-companies" data-node-hidden-company-ids maxlength="${COMPANY_IDS_MAX}" placeholder="e.g. 56, 78" />
+                <p class="form-help">Use this to suppress menu items that do not apply to specific companies.</p>
+              </div>
+            </div>
+            <div class="form-row">
               <div class="form-field" data-wrap-color style="max-width:12rem;">
                 <label class="form-label" for="${rowId}-color">Text color</label>
                 <div style="display:flex; align-items:center; gap:0.5rem;">
@@ -284,6 +316,8 @@
         row.querySelector('[data-node-name]').value = node.name || '';
         row.querySelector('[data-node-text]').value = node.text || '';
         row.querySelector('[data-node-script-id]').value = node.script_id || '';
+        row.querySelector('[data-node-visible-company-ids]').value = normaliseCompanyIDsForInput(node.visible_company_ids);
+        row.querySelector('[data-node-hidden-company-ids]').value = normaliseCompanyIDsForInput(node.hidden_company_ids);
 
         const colorEl = row.querySelector('[data-node-color]');
         const colorPreview = row.querySelector('[data-node-color-preview]');
@@ -385,7 +419,9 @@
             text: typeof candidate.text === 'string' ? candidate.text : '',
             color: typeof candidate.color === 'string' ? candidate.color : '',
             script_id: Number(candidate.script_id) || 0,
-            script_name: typeof candidate.script_name === 'string' ? candidate.script_name : ''
+            script_name: typeof candidate.script_name === 'string' ? candidate.script_name : '',
+            visible_company_ids: parseCompanyIDs(candidate.visible_company_ids),
+            hidden_company_ids: parseCompanyIDs(candidate.hidden_company_ids)
           };
           rows.push({ node: rest, level });
           const children = Array.isArray(candidate.children) ? candidate.children : [];
@@ -422,7 +458,9 @@
             name: row.querySelector('[data-node-name]').value.trim(),
             text: row.querySelector('[data-node-text]').value.trim(),
             color: (colorEl && colorEl.dataset.active === '1') ? colorEl.value.trim() : '',
-            script_id: Number(row.querySelector('[data-node-script-id]').value) || 0
+            script_id: Number(row.querySelector('[data-node-script-id]').value) || 0,
+            visible_company_ids: parseCompanyIDs(row.querySelector('[data-node-visible-company-ids]').value),
+            hidden_company_ids: parseCompanyIDs(row.querySelector('[data-node-hidden-company-ids]').value)
           };
         });
       }
@@ -438,6 +476,8 @@
           if (row.name) node.name = row.name;
           if (row.text) node.text = row.text;
           if (row.color) node.color = row.color;
+          if (row.visible_company_ids.length) node.visible_company_ids = row.visible_company_ids;
+          if (row.hidden_company_ids.length) node.hidden_company_ids = row.hidden_company_ids;
           if (row.type === 'TRMM_Script') {
             if (row.script_id) node.script_id = row.script_id;
             const script = TRMM_SCRIPTS.find((candidate) => Number(candidate.id) === Number(row.script_id));

--- a/docs/wiki/getting-started/Tray App.md
+++ b/docs/wiki/getting-started/Tray App.md
@@ -130,9 +130,38 @@ Each entry in `payload_json` is a JSON object:
 A built-in default menu is returned when no configuration matches a
 device — see `app/services/tray.py::_default_menu()`.
 
+### 4.1 Company-conditional menu nodes
+
+Any menu node can include company visibility conditions. The server evaluates
+these conditions against the company assigned to the tray device before sending
+the menu payload to the agent. This lets admins expose a TRMM script, link,
+submenu, or any other node only to the companies where it applies.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `visible_company_ids` | array of integers | Optional allowlist. When present, the node is shown only when the device's `company_id` is in this list. |
+| `hidden_company_ids` | array of integers | Optional denylist. When present, the node is hidden when the device's `company_id` is in this list. |
+
+Example TRMM script node visible only for company IDs `12` and `34`:
+
+```json
+{
+  "type": "TRMM_Script",
+  "label": "Run onboarding script",
+  "script_id": 123,
+  "script_name": "Onboarding",
+  "visible_company_ids": [12, 34]
+}
+```
+
+The **Admin → Tray → Configurations** menu-node editor exposes these as
+comma-separated **Show only for company IDs** and **Hide for company IDs**
+fields on every row. Empty submenus are removed after their children are
+filtered out.
+
 ---
 
-### 4.1 Displaying an environment variable in the tray menu
+### 4.2 Displaying an environment variable in the tray menu
 
 Follow these steps to add a menu item that shows the value of a Windows or macOS environment variable when a user clicks it.
 

--- a/tests/test_tray_app.py
+++ b/tests/test_tray_app.py
@@ -549,6 +549,67 @@ def test_resolve_config_precedence(tray_db, run):
     assert cfg_company["menu"][0]["label"] == "company-99"
 
 
+def test_resolve_config_filters_menu_nodes_by_company(tray_db, run):
+    import json
+    from app.repositories import tray as repo
+    from app.services import tray as svc
+
+    run(
+        repo.create_menu_config(
+            name="company-conditional-nodes",
+            scope="global",
+            scope_ref_id=None,
+            payload_json=json.dumps(
+                [
+                    {"type": "label", "label": "everyone"},
+                    {
+                        "type": "TRMM_Script",
+                        "label": "company 42 script",
+                        "script_id": 10,
+                        "visible_company_ids": [42],
+                    },
+                    {
+                        "type": "link",
+                        "label": "hidden from 12345",
+                        "url": "https://example.com",
+                        "hidden_company_ids": [12345],
+                    },
+                    {
+                        "type": "submenu",
+                        "label": "empty after filtering",
+                        "children": [
+                            {
+                                "type": "link",
+                                "label": "only company 7",
+                                "url": "https://example.com/7",
+                                "visible_company_ids": [7],
+                            }
+                        ],
+                    },
+                ]
+            ),
+            display_text=None,
+            env_allowlist=None,
+            branding_icon_url=None,
+            enabled=True,
+            created_by_user_id=None,
+        )
+    )
+
+    cfg_42 = run(svc.resolve_config_for_device({"company_id": 42, "asset_id": None}))
+    labels_42 = [node.get("label") for node in cfg_42["menu"]]
+    assert labels_42 == ["everyone", "company 42 script", "hidden from 12345"]
+
+    cfg_12345 = run(svc.resolve_config_for_device({"company_id": 12345, "asset_id": None}))
+    labels_12345 = [node.get("label") for node in cfg_12345["menu"]]
+    assert labels_12345 == ["everyone"]
+
+    cfg_7 = run(svc.resolve_config_for_device({"company_id": 7, "asset_id": None}))
+    labels_7 = [node.get("label") for node in cfg_7["menu"]]
+    assert labels_7 == ["everyone", "hidden from 12345", "empty after filtering"]
+    assert cfg_7["menu"][-1]["children"][0]["label"] == "only company 7"
+
+
 # ---------------------------------------------------------------------------
 # HTTP endpoints (TestClient) — exercises auth middleware too
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Allow admins to show or hide individual tray menu nodes per company so items like TRMM scripts or links can be exposed only to relevant tenants.
- Ensure the server filters the resolved menu payload by the company assigned to the tray device before sending it to agents.

### Description
- Added server-side visibility helpers in `app/services/tray.py`: `_normalise_company_id_list`, `_node_is_visible_for_company`, and `_filter_menu_nodes_for_company`, and applied filtering in `resolve_config_for_device` so menu payloads are pruned per-device `company_id` (empty submenus are removed).
- Extended the tray menu node schema in `app/schemas/tray.py` to include `visible_company_ids` and `hidden_company_ids` fields on `TrayMenuNode` so the API validates and documents the new properties.
- Updated the admin editor UI `app/templates/admin/tray/configuration_form.html` to expose two new per-row fields: **Show only for company IDs** and **Hide for company IDs**, with JavaScript parsing/serialization so values round-trip into the JSON `payload_json`.
- Updated documentation `docs/wiki/getting-started/Tray App.md` with a new section describing company-conditional menu nodes and examples.

### Testing
- Ran the targeted unit test `tests/test_tray_app.py::test_resolve_config_filters_menu_nodes_by_company`, which passed against the modified service code.
- Ran the tray tests file (`tests/test_tray_app.py`) and observed the new test passing in isolation; a full test run of that file produced unrelated startup errors (SQLite/fixture plugin_registry table and app startup tasks) that are environmental and not caused by the menu-filtering logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28c274ced88332aa39e349c1f51aec)