### PR TITLE
Show tray app version in tooltip and add app_version menu node

### DIFF
--- a/app/schemas/tray.py
+++ b/app/schemas/tray.py
@@ -44,6 +44,7 @@ class TrayMenuNode(BaseModel):
     The ``type`` discriminator selects how the client renders the node:
 
     * ``label`` — non-interactive caption.
+    * ``app_version`` — non-interactive caption showing the tray app version.
     * ``link`` — opens ``url`` in the default browser.
     * ``submenu`` — has ``children``.
     * ``display_text`` — opens a popup with ``text`` (sanitised HTML).

--- a/app/templates/admin/tray/configuration_form.html
+++ b/app/templates/admin/tray/configuration_form.html
@@ -84,7 +84,7 @@
             <p class="form-help">No Tactical RMM scripts were returned by the configured TRMM API.</p>
           {% endif %}
           <p class="form-help">
-            Configure each row with the fields you need. Types: <code>label</code>, <code>link</code>, <code>submenu</code>,
+            Configure each row with the fields you need. Types: <code>label</code>, <code>app_version</code>, <code>link</code>, <code>submenu</code>,
             <code>display_text</code>, <code>env_var</code>, <code>open_chat</code>, <code>submit_ticket</code>,
             <code>TRMM_Script</code>, <code>refresh_config</code>, <code>separator</code>, <code>quit</code>.
             Use <code>Level</code> to place nodes under the nearest preceding submenu. Add company visibility conditions to show a node only for selected company IDs or hide it from selected company IDs.
@@ -130,6 +130,7 @@
 
       const NODE_TYPES = [
         'label',
+        'app_version',
         'link',
         'submenu',
         'display_text',
@@ -211,6 +212,10 @@
       function getSummaryText(row) {
         const type = row.querySelector('[data-node-type]').value;
         if (type === 'separator') return '— separator —';
+        if (type === 'app_version') {
+          const label = row.querySelector('[data-node-label]').value.trim();
+          return label ? `${label} (app version)` : 'Version (app version)';
+        }
         if (type === 'env_var') {
           const name = row.querySelector('[data-node-name]').value.trim();
           return name || '(no name)';

--- a/tray/ui/main.go
+++ b/tray/ui/main.go
@@ -131,7 +131,7 @@ func defaultConfig() *api.ConfigResponse {
 
 func onTrayReady() {
 	systray.SetTitle("MyPortal")
-	systray.SetTooltip("MyPortal Helpdesk")
+	systray.SetTooltip(trayTooltip())
 	// Use a simple built-in icon; real icon bytes loaded from branding URL in Phase 6.
 	buildMenu(gConfig)
 }
@@ -189,6 +189,10 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse, parent *systray.MenuIte
 		if node.Color == "" {
 			item.Disable()
 		}
+
+	case "app_version":
+		item := addTrayMenuItem(parent, versionMenuLabel(node), "")
+		item.Disable()
 
 	case "link":
 		item := addTrayMenuItem(parent, node.Label, node.URL)

--- a/tray/ui/tray_nowebview_windows.go
+++ b/tray/ui/tray_nowebview_windows.go
@@ -44,7 +44,7 @@ func runUI() {
 
 func onTrayReady() {
 	systray.SetTitle("MyPortal")
-	systray.SetTooltip("MyPortal Helpdesk")
+	systray.SetTooltip(trayTooltip())
 	// Set the default icon immediately so the tray appears without delay,
 	// then fetch the branded icon from the portal in the background.
 	systray.SetIcon(defaultIconICO())
@@ -180,6 +180,10 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse, parent *systray.MenuIte
 		if node.Color == "" {
 			item.Disable()
 		}
+
+	case "app_version":
+		item := addTrayMenuItem(parent, versionMenuLabel(node), "")
+		item.Disable()
 
 	case "link":
 		item := addTrayMenuItem(parent, node.Label, node.URL)

--- a/tray/ui/version_label.go
+++ b/tray/ui/version_label.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/bradhawkins85/myportal-tray/internal/api"
+	"github.com/bradhawkins85/myportal-tray/internal/updater"
+)
+
+const defaultTrayTooltip = "MyPortal Helpdesk"
+
+// trayTooltip returns the system-tray hover text with the running app version.
+func trayTooltip() string {
+	version := strings.TrimSpace(updater.AgentVersion)
+	if version == "" {
+		return defaultTrayTooltip
+	}
+	return defaultTrayTooltip + " v" + version
+}
+
+// versionMenuLabel returns the visible label for an app_version menu node.
+func versionMenuLabel(node api.MenuNode) string {
+	prefix := strings.TrimSpace(node.Label)
+	if prefix == "" {
+		prefix = "Version"
+	}
+	version := strings.TrimSpace(updater.AgentVersion)
+	if version == "" {
+		version = "unknown"
+	}
+	return prefix + " " + version
+}

--- a/tray/ui/version_label_test.go
+++ b/tray/ui/version_label_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bradhawkins85/myportal-tray/internal/api"
+	"github.com/bradhawkins85/myportal-tray/internal/updater"
+)
+
+func TestTrayTooltipIncludesAgentVersion(t *testing.T) {
+	old := updater.AgentVersion
+	updater.AgentVersion = "9.8.7"
+	t.Cleanup(func() { updater.AgentVersion = old })
+
+	got := trayTooltip()
+	if !strings.Contains(got, "9.8.7") {
+		t.Fatalf("trayTooltip() = %q, want it to include agent version", got)
+	}
+}
+
+func TestVersionMenuLabelUsesDefaultPrefix(t *testing.T) {
+	old := updater.AgentVersion
+	updater.AgentVersion = "1.2.3"
+	t.Cleanup(func() { updater.AgentVersion = old })
+
+	got := versionMenuLabel(api.MenuNode{Type: "app_version"})
+	if got != "Version 1.2.3" {
+		t.Fatalf("versionMenuLabel() = %q, want %q", got, "Version 1.2.3")
+	}
+}
+
+func TestVersionMenuLabelUsesCustomPrefix(t *testing.T) {
+	old := updater.AgentVersion
+	updater.AgentVersion = "1.2.3"
+	t.Cleanup(func() { updater.AgentVersion = old })
+
+	got := versionMenuLabel(api.MenuNode{Type: "app_version", Label: "Tray app"})
+	if got != "Tray app 1.2.3" {
+		t.Fatalf("versionMenuLabel() = %q, want %q", got, "Tray app 1.2.3")
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide administrators an easy way to expose the running tray app version to end users via the tray menu and the tray icon tooltip for troubleshooting and visibility.

### Description
- Add a new `app_version` menu node type to the tray menu schema and admin UI so configs can include an informational version entry (`app/schemas/tray.py`, `app/templates/admin/tray/configuration_form.html`).
- Add `trayTooltip()` and `versionMenuLabel()` helpers in `tray/ui/version_label.go` to render the running `updater.AgentVersion` in the tray hover text and format the version menu label; use them from the tray UI (`tray/ui/main.go`, `tray/ui/tray_nowebview_windows.go`).
- Render `app_version` nodes as disabled informational menu items (label optionally editable in the admin UI) and update the configuration form builder JS to show `app_version` in the type list and row summary (`app/templates/admin/tray/configuration_form.html`).
- Add unit tests covering tooltip and version label formatting (`tray/ui/version_label_test.go`).

### Testing
- Ran `go test -tags nowebview ./...` in the `tray` module; tests passed (UI tests built with `nowebview` tag).
- Ran `python3 -m py_compile app/schemas/tray.py app/main.py app/api/routes/tray.py app/services/tray.py`; Python files compiled without errors.
- Ran `go test ./...` (full build); this failed in the Linux CI image due to a missing system pkg-config dependency required by `github.com/getlantern/systray` (`ayatana-appindicator3-0.1`), not related to the code changes in this PR.
- `gofmt` was applied to new Go files and unit tests were executed locally under the `nowebview` tag and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28cd912f888332a43653b71714f875)