### PR TITLE
Improve tray script notification wording and include tray icon in Windows toasts

### DIFF
--- a/tray/ui/trmm_script.go
+++ b/tray/ui/trmm_script.go
@@ -49,13 +49,13 @@ func runTRMMScriptFromMenu(node api.MenuNode) {
 	if label == "" {
 		label = fmt.Sprintf("Script #%d", node.ScriptID)
 	}
-	showOSNotification("Tactical RMM", trmmScriptSuccessMessage(label))
+	showOSNotification("Script requested", trmmScriptSuccessMessage(label))
 }
 
 func trmmScriptSuccessMessage(label string) string {
 	label = strings.TrimSpace(label)
 	if label == "" {
-		return "The Tactical RMM script has been executed and will run in the background shortly."
+		return "Your requested script has been executed and will run shortly."
 	}
-	return fmt.Sprintf("The Tactical RMM script %q has been executed and will run in the background shortly.", label)
+	return fmt.Sprintf("The script %q you requested has been executed and will run shortly.", label)
 }

--- a/tray/ui/trmm_script_test.go
+++ b/tray/ui/trmm_script_test.go
@@ -2,9 +2,9 @@ package main
 
 import "testing"
 
-func TestTRMMScriptSuccessMessageIncludesBackgroundNotice(t *testing.T) {
+func TestTRMMScriptSuccessMessageIncludesRequestedScriptNotice(t *testing.T) {
 	msg := trmmScriptSuccessMessage("Nightly Maintenance")
-	want := `The Tactical RMM script "Nightly Maintenance" has been executed and will run in the background shortly.`
+	want := `The script "Nightly Maintenance" you requested has been executed and will run shortly.`
 	if msg != want {
 		t.Fatalf("unexpected success message:\n got: %q\nwant: %q", msg, want)
 	}
@@ -12,7 +12,7 @@ func TestTRMMScriptSuccessMessageIncludesBackgroundNotice(t *testing.T) {
 
 func TestTRMMScriptSuccessMessageTrimsBlankLabel(t *testing.T) {
 	msg := trmmScriptSuccessMessage("  \t")
-	want := "The Tactical RMM script has been executed and will run in the background shortly."
+	want := "Your requested script has been executed and will run shortly."
 	if msg != want {
 		t.Fatalf("unexpected success message for blank label:\n got: %q\nwant: %q", msg, want)
 	}

--- a/tray/ui/windows_notification.go
+++ b/tray/ui/windows_notification.go
@@ -9,12 +9,28 @@ import (
 )
 
 func windowsToastEncodedCommand(title, body string) string {
+	iconURL := windowsToastIconURL()
+	template := "ToastText02"
+	imageScript := ""
+	if iconURL != "" {
+		template = "ToastImageAndText02"
+		imageScript = `$xml.GetElementsByTagName('image')[0].SetAttribute('src', '` + powershellSingleQuotedString(iconURL) + `')
+`
+	}
 	script := `[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
-$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
-$xml.GetElementsByTagName('text')[0].InnerText = '` + powershellSingleQuotedString(title) + `'
+$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::` + template + `)
+` + imageScript + `$xml.GetElementsByTagName('text')[0].InnerText = '` + powershellSingleQuotedString(title) + `'
 $xml.GetElementsByTagName('text')[1].InnerText = '` + powershellSingleQuotedString(body) + `'
 [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('MyPortal').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
 	return encodePowerShellCommand(script)
+}
+
+func windowsToastIconURL() string {
+	portalURL := strings.TrimSpace(gPortalURL)
+	if portalURL == "" {
+		return ""
+	}
+	return strings.TrimRight(portalURL, "/") + "/tray/icon.ico"
 }
 
 func powershellSingleQuotedString(value string) string {


### PR DESCRIPTION
### Motivation
- Make the tray notification for requested scripts more informative by including the requested script name when available and using clearer wording that the script will run shortly.  
- Show the portal-branded tray icon in Windows toast notifications when available so the notification displays both icon and message.

### Description
- Change the TRMM success notification title and message in `tray/ui/trmm_script.go` to use a friendlier title `"Script requested"` and wording that includes the script name when present via `trmmScriptSuccessMessage`.  
- Update `tray/ui/trmm_script_test.go` to assert the new success messages and blank-label fallback.  
- Update Windows toast generation in `tray/ui/windows_notification.go` to pick an image-capable template (`ToastImageAndText02`) when the portal `tray/icon.ico` URL is available and inject the icon `src` into the toast XML via a generated PowerShell payload, plus add `windowsToastIconURL` helper.

### Testing
- Ran `go test -tags nowebview ./...` and the package tests passed.  
- Built a Windows test binary with `GOOS=windows GOARCH=amd64 go test -c -tags nowebview -o /tmp/myportal-ui.test.exe ./ui` which succeeded.  
- Running `go test ./...` in this Linux environment fails due to a missing system dependency (`ayatana-appindicator3-0.1`) required by `systray`, which is an environment issue rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28cf5bdce483328b77d2af41dd39e4)