### PR TITLE
Use company dropdowns for tray visibility

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5582,12 +5582,27 @@ async def _get_tray_trmm_scripts_for_form() -> tuple[list[dict], str | None]:
         return [], str(exc)
 
 
+async def _get_tray_companies_for_form() -> list[dict]:
+    from app.repositories import companies as company_repo
+
+    companies = await company_repo.list_companies(include_archived=True)
+    return [
+        {
+            "id": int(company["id"]),
+            "name": str(company.get("name") or f"Company #{company['id']}"),
+        }
+        for company in companies
+        if company.get("id") is not None
+    ]
+
+
 @app.get("/admin/tray/configurations/new", response_class=HTMLResponse)
 async def admin_tray_new_configuration_page(request: Request):
     current_user, redirect = await _require_super_admin_page(request)
     if redirect:
         return redirect
     trmm_scripts, trmm_scripts_error = await _get_tray_trmm_scripts_for_form()
+    companies = await _get_tray_companies_for_form()
     extra = {
         "title": "New tray configuration",
         "heading": "New tray menu configuration",
@@ -5604,6 +5619,7 @@ async def admin_tray_new_configuration_page(request: Request):
         },
         "trmm_scripts": trmm_scripts,
         "trmm_scripts_error": trmm_scripts_error,
+        "companies": companies,
     }
     return await _render_template(
         "admin/tray/configuration_form.html", request, current_user, extra=extra
@@ -5621,6 +5637,7 @@ async def admin_tray_edit_configuration_page(config_id: int, request: Request):
     if not record:
         return RedirectResponse(url="/admin/tray/configurations", status_code=303)
     trmm_scripts, trmm_scripts_error = await _get_tray_trmm_scripts_for_form()
+    companies = await _get_tray_companies_for_form()
     extra = {
         "title": "Edit tray configuration",
         "heading": f"Edit configuration: {record.get('name')}",
@@ -5637,6 +5654,7 @@ async def admin_tray_edit_configuration_page(config_id: int, request: Request):
         },
         "trmm_scripts": trmm_scripts,
         "trmm_scripts_error": trmm_scripts_error,
+        "companies": companies,
     }
     return await _render_template(
         "admin/tray/configuration_form.html", request, current_user, extra=extra

--- a/app/templates/admin/tray/configuration_form.html
+++ b/app/templates/admin/tray/configuration_form.html
@@ -124,9 +124,9 @@
       const URL_MAX = 500;
       const NAME_MAX = 128;
       const COLOR_MAX = 32;
-      const COMPANY_IDS_MAX = 500;
       const DEFAULT_MENU_LABEL = 'Menu';
       const TRMM_SCRIPTS = {{ (trmm_scripts or [])|tojson }};
+      const TRAY_COMPANIES = {{ (companies or [])|tojson }};
 
       const NODE_TYPES = [
         'label',
@@ -169,11 +169,37 @@
           });
       }
 
-      function normaliseCompanyIDsForInput(value) {
-        if (Array.isArray(value)) {
-          return parseCompanyIDs(value.join(',')).join(', ');
-        }
-        return parseCompanyIDs(value).join(', ');
+      function getCompanyName(companyID) {
+        const company = TRAY_COMPANIES.find((candidate) => Number(candidate.id) === Number(companyID));
+        return company ? String(company.name || `Company #${companyID}`) : `Unknown company #${companyID}`;
+      }
+
+      function createCompanySelectOptions(selectedCompanyIDs = []) {
+        const selectedValue = Array.isArray(selectedCompanyIDs) ? selectedCompanyIDs.join(',') : selectedCompanyIDs;
+        const selectedSet = new Set(parseCompanyIDs(selectedValue));
+        const knownIDs = new Set(TRAY_COMPANIES.map((company) => Number(company.id)));
+        const options = TRAY_COMPANIES.map((company) => {
+          const id = Number(company.id);
+          const label = escapeHtml(String(company.name || `Company #${id}`));
+          const selected = selectedSet.has(id) ? ' selected' : '';
+          return `<option value="${id}"${selected}>${label}</option>`;
+        });
+
+        selectedSet.forEach((id) => {
+          if (knownIDs.has(id)) return;
+          options.push(`<option value="${id}" selected>${escapeHtml(getCompanyName(id))}</option>`);
+        });
+
+        return options.join('');
+      }
+
+      function getSelectedCompanyIDs(selectEl) {
+        return parseCompanyIDs(Array.from(selectEl.selectedOptions).map((option) => option.value).join(','));
+      }
+
+      function setSelectedCompanyIDs(selectEl, companyIDs) {
+        const selectedIDs = parseCompanyIDs(Array.isArray(companyIDs) ? companyIDs.join(',') : companyIDs);
+        selectEl.innerHTML = createCompanySelectOptions(selectedIDs);
       }
 
       function showError(message) {
@@ -281,14 +307,14 @@
             </div>
             <div class="form-row">
               <div class="form-field">
-                <label class="form-label" for="${rowId}-visible-companies">Show only for company IDs</label>
-                <input class="form-input" id="${rowId}-visible-companies" data-node-visible-company-ids maxlength="${COMPANY_IDS_MAX}" placeholder="e.g. 12, 34" />
-                <p class="form-help">Leave blank to show for every company unless hidden below.</p>
+                <label class="form-label" for="${rowId}-visible-companies">Show only for companies</label>
+                <select class="form-input" id="${rowId}-visible-companies" data-node-visible-company-ids multiple size="6"></select>
+                <p class="form-help">Leave empty to show for every company unless hidden below. Hold Ctrl (Windows) or Cmd (Mac) to select multiple companies.</p>
               </div>
               <div class="form-field">
-                <label class="form-label" for="${rowId}-hidden-companies">Hide for company IDs</label>
-                <input class="form-input" id="${rowId}-hidden-companies" data-node-hidden-company-ids maxlength="${COMPANY_IDS_MAX}" placeholder="e.g. 56, 78" />
-                <p class="form-help">Use this to suppress menu items that do not apply to specific companies.</p>
+                <label class="form-label" for="${rowId}-hidden-companies">Hide for companies</label>
+                <select class="form-input" id="${rowId}-hidden-companies" data-node-hidden-company-ids multiple size="6"></select>
+                <p class="form-help">Select companies where this menu item should be suppressed.</p>
               </div>
             </div>
             <div class="form-row">
@@ -316,8 +342,8 @@
         row.querySelector('[data-node-name]').value = node.name || '';
         row.querySelector('[data-node-text]').value = node.text || '';
         row.querySelector('[data-node-script-id]').value = node.script_id || '';
-        row.querySelector('[data-node-visible-company-ids]').value = normaliseCompanyIDsForInput(node.visible_company_ids);
-        row.querySelector('[data-node-hidden-company-ids]').value = normaliseCompanyIDsForInput(node.hidden_company_ids);
+        setSelectedCompanyIDs(row.querySelector('[data-node-visible-company-ids]'), node.visible_company_ids);
+        setSelectedCompanyIDs(row.querySelector('[data-node-hidden-company-ids]'), node.hidden_company_ids);
 
         const colorEl = row.querySelector('[data-node-color]');
         const colorPreview = row.querySelector('[data-node-color-preview]');
@@ -459,8 +485,8 @@
             text: row.querySelector('[data-node-text]').value.trim(),
             color: (colorEl && colorEl.dataset.active === '1') ? colorEl.value.trim() : '',
             script_id: Number(row.querySelector('[data-node-script-id]').value) || 0,
-            visible_company_ids: parseCompanyIDs(row.querySelector('[data-node-visible-company-ids]').value),
-            hidden_company_ids: parseCompanyIDs(row.querySelector('[data-node-hidden-company-ids]').value)
+            visible_company_ids: getSelectedCompanyIDs(row.querySelector('[data-node-visible-company-ids]')),
+            hidden_company_ids: getSelectedCompanyIDs(row.querySelector('[data-node-hidden-company-ids]'))
           };
         });
       }

--- a/docs/wiki/getting-started/Tray App.md
+++ b/docs/wiki/getting-started/Tray App.md
@@ -155,9 +155,8 @@ Example TRMM script node visible only for company IDs `12` and `34`:
 ```
 
 The **Admin → Tray → Configurations** menu-node editor exposes these as
-comma-separated **Show only for company IDs** and **Hide for company IDs**
-fields on every row. Empty submenus are removed after their children are
-filtered out.
+**Show only for companies** and **Hide for companies** dropdown fields on
+every row. Empty submenus are removed after their children are filtered out.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Improve admin UX by letting super-admins pick companies by name when configuring tray menu visibility instead of typing company IDs.
- Ensure existing tray payload schema continues to work while making the form friendlier and less error-prone.

### Description
- Add `_get_tray_companies_for_form()` to load company ID/name options (including archived companies) for the New/Edit tray configuration pages in `app/main.py`.
- Replace comma-separated `visible_company_ids` / `hidden_company_ids` text inputs with multi-select `<select>` dropdowns in `app/templates/admin/tray/configuration_form.html` and add JS helpers to populate, select, and read options while preserving serialization back to `visible_company_ids` / `hidden_company_ids` in the JSON payload.
- Update client-side helper functions (`createCompanySelectOptions`, `setSelectedCompanyIDs`, `getSelectedCompanyIDs`, etc.) to handle known and unknown IDs gracefully and to keep the payload schema unchanged.
- Update documentation `docs/wiki/getting-started/Tray App.md` to reference the new “Show only for companies” / “Hide for companies” dropdown fields.

### Testing
- Confirmed Python file compiles with `python -m py_compile app/main.py` and validated template markers via a small script that checks for expected strings; the checks succeeded.
- Ran the focused unit test `tests/test_tray_app.py::test_resolve_config_filters_menu_nodes_by_company` which passed locally after the change.
- Ran several broader test subsets; template-related tests passed but larger test runs hit unrelated test-environment/database initialization errors (SQLite/TestClient startup and `plugin_registry` table missing), causing some test failures/errors that are not caused by these UI changes.
- Performed `git diff --check` and static checks locally with no whitespace/trailing issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28cf2f009883329ed4b2c0dbef7ba0)