### PR TITLE
Add tray tooltip branding display name

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -183,6 +183,7 @@ async def get_device_config(
         menu=config.get("menu") or [],
         display_text=config.get("display_text"),
         branding_icon_url=config.get("branding_icon_url"),
+        branding_display_name=config.get("branding_display_name"),
         env_allowlist=config.get("env_allowlist") or [],
         chat_enabled=chat_enabled,
         chat_client_mode=config.get("chat_client_mode") or None,

--- a/app/main.py
+++ b/app/main.py
@@ -5903,9 +5903,12 @@ async def admin_tray_branding_page(
     if redirect:
         return redirect
     current_path = await site_settings_repo.get_tray_icon_path()
+    tooltip_name = await site_settings_repo.get_tray_icon_tooltip_name()
     extra = {
         "title": "Tray icon",
         "current_path": current_path,
+        "tooltip_name": tooltip_name or "",
+        "default_tooltip_name": "MyPortal Helpdesk",
     }
     return await _render_template(
         "admin/tray/branding.html", request, current_user, extra=extra
@@ -5916,6 +5919,7 @@ async def admin_tray_branding_page(
 async def admin_tray_branding_upload(
     request: Request,
     icon: UploadFile = File(None),
+    tooltip_name: str | None = Form(None),
 ):
     current_user, redirect = await _require_super_admin_page(request)
     if redirect:
@@ -5923,8 +5927,27 @@ async def admin_tray_branding_upload(
 
     from app.services import tray_icon as tray_icon_service
 
+    normalized_tooltip_name = re.sub(r"\s+", " ", str(tooltip_name or "").strip())
+    if len(normalized_tooltip_name) > 100:
+        return flash_redirect(
+            "/admin/tray/branding",
+            "Display name must be 100 characters or fewer",
+            "error",
+        )
     if icon is None or not icon.filename:
-        return flash_redirect("/admin/tray/branding", "No file selected", "error")
+        if tooltip_name is not None:
+            await site_settings_repo.set_tray_icon_tooltip_name(
+                normalized_tooltip_name or None
+            )
+        await audit_service.log_action(
+            action="admin.tray.branding.update",
+            user_id=current_user.get("id"),
+            entity_type="site_settings",
+            entity_id=1,
+            metadata={"tooltip_name": normalized_tooltip_name or None},
+            request=request,
+        )
+        return flash_redirect("/admin/tray/branding", "Tray branding updated", "success")
 
     data = await icon.read(_TRAY_ICON_MAX_BYTES + 1)
     if len(data) > _TRAY_ICON_MAX_BYTES:
@@ -5942,15 +5965,23 @@ async def admin_tray_branding_upload(
 
     relative_path = str(target.relative_to(uploads_root)).replace("\\", "/")
     await site_settings_repo.set_tray_icon_path(relative_path)
+    if tooltip_name is not None:
+        await site_settings_repo.set_tray_icon_tooltip_name(
+            normalized_tooltip_name or None
+        )
     await audit_service.log_action(
         action="admin.tray.icon.upload",
         user_id=current_user.get("id"),
         entity_type="site_settings",
         entity_id=1,
-        metadata={"path": relative_path, "bytes": len(data)},
+        metadata={
+            "path": relative_path,
+            "bytes": len(data),
+            "tooltip_name": normalized_tooltip_name or None,
+        },
         request=request,
     )
-    return flash_redirect("/admin/tray/branding", "Tray icon updated", "success")
+    return flash_redirect("/admin/tray/branding", "Tray branding updated", "success")
 
 
 @app.post("/admin/tray/branding/delete", response_class=HTMLResponse)

--- a/app/repositories/site_settings.py
+++ b/app/repositories/site_settings.py
@@ -51,6 +51,22 @@ async def get_tray_icon_path() -> str | None:
     return str(value) if value else None
 
 
+async def get_tray_icon_tooltip_name() -> str | None:
+    """Return the custom tray icon tooltip display name, or ``None`` if unset."""
+    row = await db.fetch_one(
+        "SELECT tray_icon_tooltip_name FROM site_settings WHERE id = 1",
+        (),
+    )
+    if row is None:
+        return None
+    value = (
+        row.get("tray_icon_tooltip_name")
+        if isinstance(row, Mapping)
+        else row["tray_icon_tooltip_name"]
+    )
+    return str(value) if value else None
+
+
 async def set_tray_icon_path(path: str | None) -> None:
     """Persist (or clear) the custom tray icon path in site_settings.
 
@@ -72,9 +88,29 @@ async def set_tray_icon_path(path: str | None) -> None:
         )
 
 
+async def set_tray_icon_tooltip_name(name: str | None) -> None:
+    """Persist (or clear) the custom tray icon tooltip display name."""
+    existing = await db.fetch_one(
+        "SELECT id FROM site_settings WHERE id = 1",
+        (),
+    )
+    if existing is None:
+        await db.execute(
+            "INSERT INTO site_settings (id, tray_icon_tooltip_name) VALUES (1, %s)",
+            (name,),
+        )
+    else:
+        await db.execute(
+            "UPDATE site_settings SET tray_icon_tooltip_name = %s WHERE id = 1",
+            (name,),
+        )
+
+
 __all__ = [
     "get_pdf_cover_image",
     "set_pdf_cover_image",
     "get_tray_icon_path",
+    "get_tray_icon_tooltip_name",
     "set_tray_icon_path",
+    "set_tray_icon_tooltip_name",
 ]

--- a/app/schemas/tray.py
+++ b/app/schemas/tray.py
@@ -78,6 +78,7 @@ class TrayConfigResponse(BaseModel):
     menu: list[TrayMenuNode]
     display_text: Optional[str] = None
     branding_icon_url: Optional[str] = None
+    branding_display_name: Optional[str] = Field(default=None, max_length=100)
     env_allowlist: list[str] = Field(default_factory=list)
     chat_enabled: bool = False
     # Controls how the tray client opens chat windows.

--- a/app/services/tray.py
+++ b/app/services/tray.py
@@ -25,6 +25,7 @@ from app.core.config import get_settings
 from app.core.logging import log_info, log_warning
 from app.repositories import assets as assets_repo
 from app.repositories import companies as companies_repo
+from app.repositories import site_settings as site_settings_repo
 from app.repositories import tray as tray_repo
 
 _settings = get_settings()
@@ -226,6 +227,7 @@ async def resolve_config_for_device(device: dict[str, Any]) -> dict[str, Any]:
     payload: list[dict[str, Any]]
     display_text: str | None = None
     branding_icon_url: str | None = None
+    branding_display_name = await site_settings_repo.get_tray_icon_tooltip_name()
     env_allowlist: list[str] = []
     version = 0
 
@@ -254,6 +256,7 @@ async def resolve_config_for_device(device: dict[str, Any]) -> dict[str, Any]:
         "menu": payload,
         "display_text": display_text,
         "branding_icon_url": branding_icon_url,
+        "branding_display_name": branding_display_name,
         "env_allowlist": env_allowlist,
     }
 

--- a/app/templates/admin/tray/branding.html
+++ b/app/templates/admin/tray/branding.html
@@ -17,8 +17,9 @@
     <header class="card__header">
       <p class="card__lede">
         The MyPortal tray app shows this icon in the system tray on every enrolled device.
-        By default it uses an icon derived from the website favicon. Upload a custom
-        Windows <code>.ico</code> file below to override it across all devices.
+        Use this page to customize both the tray icon image and the display name shown
+        when users hover over the icon. By default it uses an icon derived from the
+        website favicon and the tooltip name <strong>{{ default_tooltip_name }}</strong>.
       </p>
     </header>
     <div class="card__body">
@@ -29,6 +30,14 @@
         <p class="status status--danger">{{ error_message }}</p>
       {% endif %}
 
+      <p>
+        <strong>Current tooltip display name:</strong>
+        {% if tooltip_name %}
+          {{ tooltip_name }}
+        {% else %}
+          {{ default_tooltip_name }} (default)
+        {% endif %}
+      </p>
       <p>
         <strong>Current icon:</strong>
         {% if current_path %}
@@ -47,12 +56,22 @@
             enctype="multipart/form-data" class="form">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
         <div class="form-field">
+          <label for="tray-tooltip-name">Tooltip display name</label>
+          <input class="form-input" id="tray-tooltip-name" type="text"
+                 name="tooltip_name" value="{{ tooltip_name }}" maxlength="100"
+                 placeholder="{{ default_tooltip_name }}" />
+          <p class="form-help">
+            Leave blank to use the default display name. The tray app adds its version after this name.
+          </p>
+        </div>
+        <div class="form-field">
           <label for="tray-icon-file">Upload new icon (.ico, max 1&nbsp;MB)</label>
           <input id="tray-icon-file" type="file" name="icon"
-                 accept=".ico,image/x-icon,image/vnd.microsoft.icon" required />
+                 accept=".ico,image/x-icon,image/vnd.microsoft.icon" />
+          <p class="form-help">Leave empty to update only the tooltip display name.</p>
         </div>
         <div class="form-actions">
-          <button type="submit" class="button button--primary">Upload icon</button>
+          <button type="submit" class="button button--primary">Save branding</button>
         </div>
       </form>
 

--- a/migrations/262_tray_icon_tooltip_name.sql
+++ b/migrations/262_tray_icon_tooltip_name.sql
@@ -1,0 +1,2 @@
+-- Optional branded display name shown when users hover over the tray icon.
+ALTER TABLE site_settings ADD COLUMN IF NOT EXISTS tray_icon_tooltip_name VARCHAR(100) NULL DEFAULT NULL;

--- a/tray/internal/api/client.go
+++ b/tray/internal/api/client.go
@@ -111,12 +111,13 @@ type MenuNode struct {
 
 // ConfigResponse mirrors the server's TrayConfigResponse schema.
 type ConfigResponse struct {
-	Version         int        `json:"version"`
-	Menu            []MenuNode `json:"menu"`
-	DisplayText     string     `json:"display_text,omitempty"`
-	BrandingIconURL string     `json:"branding_icon_url,omitempty"`
-	EnvAllowlist    []string   `json:"env_allowlist"`
-	ChatEnabled     bool       `json:"chat_enabled"`
+	Version             int        `json:"version"`
+	Menu                []MenuNode `json:"menu"`
+	DisplayText         string     `json:"display_text,omitempty"`
+	BrandingIconURL     string     `json:"branding_icon_url,omitempty"`
+	BrandingDisplayName string     `json:"branding_display_name,omitempty"`
+	EnvAllowlist        []string   `json:"env_allowlist"`
+	ChatEnabled         bool       `json:"chat_enabled"`
 	// ChatClientMode controls how the tray opens chat windows.
 	// "" or "app" (default): try dedicated chat shell, then browser app-mode, then
 	// fall back to the default browser.

--- a/tray/ui/main.go
+++ b/tray/ui/main.go
@@ -131,7 +131,7 @@ func defaultConfig() *api.ConfigResponse {
 
 func onTrayReady() {
 	systray.SetTitle("MyPortal")
-	systray.SetTooltip(trayTooltip())
+	systray.SetTooltip(trayTooltip(gConfig))
 	// Use a simple built-in icon; real icon bytes loaded from branding URL in Phase 6.
 	buildMenu(gConfig)
 }
@@ -351,6 +351,7 @@ func handleIPCMessages(conn net.Conn) {
 			// Re-read cached config. Menu rebuild on config_changed is deferred
 			// until a systray library version that exposes ResetMenu is adopted.
 			gConfig = loadCachedConfig()
+			systray.SetTooltip(trayTooltip(gConfig))
 
 		case "show_notification":
 			var n struct {

--- a/tray/ui/tray_nowebview_windows.go
+++ b/tray/ui/tray_nowebview_windows.go
@@ -44,7 +44,7 @@ func runUI() {
 
 func onTrayReady() {
 	systray.SetTitle("MyPortal")
-	systray.SetTooltip(trayTooltip())
+	systray.SetTooltip(trayTooltip(gConfig))
 	// Set the default icon immediately so the tray appears without delay,
 	// then fetch the branded icon from the portal in the background.
 	systray.SetIcon(defaultIconICO())
@@ -93,6 +93,8 @@ func fetchAndSetIcon() {
 // A 60-second cooldown prevents restart storms if multiple config_changed
 // events arrive in quick succession.
 func handleConfigChanged(cfg *api.ConfigResponse) {
+	systray.SetTooltip(trayTooltip(cfg))
+
 	// Always refresh the icon — this can be updated without a restart.
 	go fetchAndSetIcon()
 

--- a/tray/ui/version_label.go
+++ b/tray/ui/version_label.go
@@ -10,12 +10,18 @@ import (
 const defaultTrayTooltip = "MyPortal Helpdesk"
 
 // trayTooltip returns the system-tray hover text with the running app version.
-func trayTooltip() string {
+func trayTooltip(cfg *api.ConfigResponse) string {
+	displayName := defaultTrayTooltip
+	if cfg != nil {
+		if brandedName := strings.TrimSpace(cfg.BrandingDisplayName); brandedName != "" {
+			displayName = brandedName
+		}
+	}
 	version := strings.TrimSpace(updater.AgentVersion)
 	if version == "" {
-		return defaultTrayTooltip
+		return displayName
 	}
-	return defaultTrayTooltip + " v" + version
+	return displayName + " v" + version
 }
 
 // versionMenuLabel returns the visible label for an app_version menu node.

--- a/tray/ui/version_label_test.go
+++ b/tray/ui/version_label_test.go
@@ -13,9 +13,20 @@ func TestTrayTooltipIncludesAgentVersion(t *testing.T) {
 	updater.AgentVersion = "9.8.7"
 	t.Cleanup(func() { updater.AgentVersion = old })
 
-	got := trayTooltip()
+	got := trayTooltip(nil)
 	if !strings.Contains(got, "9.8.7") {
 		t.Fatalf("trayTooltip() = %q, want it to include agent version", got)
+	}
+}
+
+func TestTrayTooltipUsesBrandingDisplayName(t *testing.T) {
+	old := updater.AgentVersion
+	updater.AgentVersion = "9.8.7"
+	t.Cleanup(func() { updater.AgentVersion = old })
+
+	got := trayTooltip(&api.ConfigResponse{BrandingDisplayName: "Acme Support"})
+	if !strings.Contains(got, "Acme Support") {
+		t.Fatalf("trayTooltip() = %q, want it to include branded display name", got)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Allow administrators to set a branded display name shown in the system-tray tooltip so users see a company-specific label when hovering the tray icon.
- Make the display name configurable independently of the tray `.ico` upload and deliver it to tray clients with the existing config refresh flow.

### Description
- Add a new optional site setting column via `migrations/262_tray_icon_tooltip_name.sql` and repository helpers `get_tray_icon_tooltip_name` / `set_tray_icon_tooltip_name` in `app/repositories/site_settings.py` to persist the tooltip name.
- Extend the admin UI at `/admin/tray/branding` to accept a `tooltip_name` text field (100-char max), validate and persist it, and audit tooltip-only and icon+tooltip updates in `app/main.py` and `app/templates/admin/tray/branding.html`.
- Include `branding_display_name` in the resolved tray config returned by `app/services/tray.py` and exposed on the API (`TrayConfigResponse`) in `app/schemas/tray.py` and `app/api/routes/tray.py` so clients receive the branded name.
- Update the tray client code to deserialize `branding_display_name` (`tray/internal/api/client.go`) and use it as the tooltip prefix in `tray/ui/version_label.go`, refreshing the tooltip when `config_changed` arrives (`tray/ui/main.go`, `tray/ui/tray_nowebview_windows.go`), and add a Go unit test for this behavior (`tray/ui/version_label_test.go`).

### Testing
- Ran Python byte-compile: `python -m compileall app/schemas/tray.py app/repositories/site_settings.py app/services/tray.py app/api/routes/tray.py app/main.py` (success).
- Ran targeted Python tests: `pytest tests/test_tray_devices_page.py tests/test_tray_install_tokens_page.py tests/test_tray_submit_ticket_auth.py`, which completed with `8 passed`.
- Ran Go unit tests for UI nowebview build: `cd tray && go test -tags nowebview ./ui ./internal/api`, which succeeded, and `cd tray && go test ./...` failed in this environment due to missing system package `ayatana-appindicator3-0.1` required by the systray CGO build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28d1330ba88332bb23a89ce61bf48d)