### PR TITLE
Notify tray users when technicians start chats

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -754,6 +754,42 @@ async def start_device_chat(
     # Link the room back to its device so the UI can highlight it.
     await _attach_room_to_device(int(room["id"]), int(device["id"]))
 
+    initial_message = (payload.message or "").strip()[:4000]
+    initiator_name = current_user.get("display_name") or current_user.get("email")
+    if initial_message:
+        matrix_event_id: str | None = None
+        try:
+            matrix_event = await matrix_service.send_message(
+                room_id=matrix_room_id,
+                body=initial_message,
+                sender_display_name=initiator_name,
+            )
+            matrix_event_id = matrix_event.get("event_id")
+        except Exception as exc:
+            log_error(
+                "Failed to send initial tray chat message",
+                room_id=room["id"],
+                error=str(exc),
+            )
+
+        sent_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        await chat_repo.add_message(
+            room_id=int(room["id"]),
+            matrix_event_id=matrix_event_id,
+            sender_matrix_id=(
+                current_user.get("matrix_user_id") or _settings.matrix_bot_user_id or ""
+            ),
+            body=initial_message,
+            sender_user_id=int(current_user["id"]),
+            sender_display_name=initiator_name,
+            sent_at=sent_at,
+        )
+        await chat_repo.update_room(
+            int(room["id"]),
+            last_message_at=sent_at,
+            updated_at=sent_at,
+        )
+
     delivered = await tray_service.send_to_device(
         device_uid,
         {
@@ -761,8 +797,8 @@ async def start_device_chat(
             "room_id": int(room["id"]),
             "matrix_room_id": matrix_room_id,
             "subject": subject,
-            "initiated_by": current_user.get("display_name")
-            or current_user.get("email"),
+            "initiated_by": initiator_name,
+            "message": initial_message,
         },
     )
     await tray_repo.log_command(

--- a/tray/ui/chat_notification.go
+++ b/tray/ui/chat_notification.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bradhawkins85/myportal-tray/internal/logger"
+)
+
+type chatOpenPayload struct {
+	RoomID       int    `json:"room_id"`
+	MatrixRoomID string `json:"matrix_room_id"`
+	Subject      string `json:"subject"`
+	InitiatedBy  string `json:"initiated_by"`
+	Message      string `json:"message"`
+}
+
+var (
+	notificationActionOnce    sync.Once
+	notificationActionBaseURL string
+	notificationActionMu      sync.Mutex
+	notificationActions       = map[string]notificationAction{}
+)
+
+type notificationAction struct {
+	RoomID    int
+	ExpiresAt time.Time
+}
+
+func handleChatOpen(payload chatOpenPayload) {
+	actionURL := registerChatOpenAction(payload.RoomID)
+	if actionURL == "" {
+		logger.Warn("handleChatOpen: could not register chat notification action for room_id=%d", payload.RoomID)
+	}
+
+	title, body := chatNotificationText(payload)
+	showChatSessionNotification(title, body, actionURL)
+}
+
+func chatNotificationText(payload chatOpenPayload) (string, string) {
+	initiator := strings.TrimSpace(payload.InitiatedBy)
+	if initiator == "" {
+		initiator = "A technician"
+	}
+
+	subject := strings.TrimSpace(payload.Subject)
+	message := summarizeChatMessage(payload.Message)
+
+	title := "New MyPortal chat"
+	body := initiator + " started a support chat"
+	if subject != "" {
+		body += ": " + subject
+	}
+	if message != "" {
+		body += "\n" + message
+	}
+	return title, body
+}
+
+func summarizeChatMessage(message string) string {
+	message = strings.Join(strings.Fields(strings.TrimSpace(message)), " ")
+	const maxRunes = 180
+	runes := []rune(message)
+	if len(runes) <= maxRunes {
+		return message
+	}
+	return string(runes[:maxRunes-1]) + "…"
+}
+
+func registerChatOpenAction(roomID int) string {
+	startNotificationActionServer()
+	if notificationActionBaseURL == "" {
+		return buildChatURL(roomID)
+	}
+
+	id, err := randomActionID()
+	if err != nil {
+		logger.Warn("registerChatOpenAction: random action id failed: %v", err)
+		return buildChatURL(roomID)
+	}
+	notificationActionMu.Lock()
+	pruneExpiredNotificationActionsLocked(time.Now())
+	notificationActions[id] = notificationAction{
+		RoomID:    roomID,
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	notificationActionMu.Unlock()
+	return notificationActionBaseURL + "/open-chat?id=" + id
+}
+
+func startNotificationActionServer() {
+	notificationActionOnce.Do(func() {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			logger.Warn("notification action listener failed: %v", err)
+			return
+		}
+		notificationActionBaseURL = "http://" + listener.Addr().String()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/open-chat", handleNotificationOpenChat)
+		server := &http.Server{
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+		go func() {
+			if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+				logger.Warn("notification action server stopped: %v", err)
+			}
+		}()
+	})
+}
+
+func handleNotificationOpenChat(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	now := time.Now()
+
+	notificationActionMu.Lock()
+	action, ok := notificationActions[id]
+	if ok && now.After(action.ExpiresAt) {
+		delete(notificationActions, id)
+		ok = false
+	}
+	notificationActionMu.Unlock()
+
+	if !ok {
+		http.Error(w, "This chat notification has expired. Open MyPortal Chat from the tray icon.", http.StatusGone)
+		return
+	}
+
+	chatURL := requestChatTokenForRoom(action.RoomID)
+	if chatURL == "" {
+		chatURL = buildChatURL(action.RoomID)
+	}
+	if chatURL == "" {
+		http.Error(w, "Unable to open chat. Please try again from the MyPortal tray icon.", http.StatusBadGateway)
+		return
+	}
+
+	go openChatWindow(chatURL, gConfig)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_, _ = fmt.Fprint(w, "<html><body><p>Opening MyPortal Chat…</p><script>window.close();</script></body></html>")
+}
+
+func pruneExpiredNotificationActionsLocked(now time.Time) {
+	for id, action := range notificationActions {
+		if now.After(action.ExpiresAt) {
+			delete(notificationActions, id)
+		}
+	}
+}
+
+func randomActionID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/tray/ui/chat_notification_other.go
+++ b/tray/ui/chat_notification_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package main
+
+func showChatSessionNotification(title, body, chatURL string) {
+	showOSNotification(title, body)
+}

--- a/tray/ui/chat_notification_test.go
+++ b/tray/ui/chat_notification_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestChatNotificationTextIncludesInitiatorSubjectAndMessageSummary(t *testing.T) {
+	longMessage := strings.Repeat("hello ", 50)
+	title, body := chatNotificationText(chatOpenPayload{
+		Subject:     "Printer issue",
+		InitiatedBy: "Alex Tech",
+		Message:     longMessage,
+	})
+
+	if title != "New MyPortal chat" {
+		t.Fatalf("title = %q", title)
+	}
+	for _, want := range []string{"Alex Tech", "Printer issue", "hello"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body = %q, want it to contain %q", body, want)
+		}
+	}
+	if len([]rune(body)) > 260 {
+		t.Fatalf("body = %q, expected concise notification summary", body)
+	}
+	if !strings.Contains(body, "…") {
+		t.Fatalf("body = %q, expected truncated message ellipsis", body)
+	}
+}
+
+func TestChatNotificationTextFallsBackToTechnician(t *testing.T) {
+	_, body := chatNotificationText(chatOpenPayload{})
+	if !strings.Contains(body, "A technician started a support chat") {
+		t.Fatalf("body = %q, want fallback initiator", body)
+	}
+}

--- a/tray/ui/main.go
+++ b/tray/ui/main.go
@@ -332,17 +332,9 @@ func handleIPCMessages(conn net.Conn) {
 		}
 		switch msg.Type {
 		case "chat_open":
-			var payload struct {
-				RoomID       int    `json:"room_id"`
-				MatrixRoomID string `json:"matrix_room_id"`
-				Subject      string `json:"subject"`
-			}
+			var payload chatOpenPayload
 			_ = json.Unmarshal(msg.Payload, &payload)
-			chatURL := requestChatTokenForRoom(payload.RoomID)
-			if chatURL == "" {
-				chatURL = buildChatURL(payload.RoomID)
-			}
-			openChatWindow(chatURL, gConfig)
+			handleChatOpen(payload)
 
 		case "config_changed":
 			refreshPortalURL()

--- a/tray/ui/main_nowebview.go
+++ b/tray/ui/main_nowebview.go
@@ -191,16 +191,9 @@ func handleIPCMessages(conn net.Conn) {
 		logger.Debug("handleIPCMessages: received type=%q", msg.Type)
 		switch msg.Type {
 		case "chat_open":
-			var payload struct {
-				RoomID int `json:"room_id"`
-			}
+			var payload chatOpenPayload
 			_ = json.Unmarshal(msg.Payload, &payload)
-			chatURL := requestChatTokenForRoom(payload.RoomID)
-			if chatURL == "" {
-				logger.Warn("handleIPCMessages: chat_open: could not obtain chat token — portal may be unreachable")
-				break
-			}
-			openChatWindow(chatURL, gConfig)
+			handleChatOpen(payload)
 		case "config_changed":
 			refreshPortalURL()
 			refreshDeviceUID()

--- a/tray/ui/windows_notification.go
+++ b/tray/ui/windows_notification.go
@@ -4,7 +4,9 @@ package main
 
 import (
 	"encoding/base64"
+	"os/exec"
 	"strings"
+	"syscall"
 	"unicode/utf16"
 )
 
@@ -23,6 +25,60 @@ $xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([
 $xml.GetElementsByTagName('text')[1].InnerText = '` + powershellSingleQuotedString(body) + `'
 [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('MyPortal').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
 	return encodePowerShellCommand(script)
+}
+
+func windowsPersistentChatToastEncodedCommand(title, body, chatURL string) string {
+	iconURL := windowsToastIconURL()
+	template := "ToastText02"
+	imageScript := ""
+	if iconURL != "" {
+		template = "ToastImageAndText02"
+		imageScript = `$xml.GetElementsByTagName('image')[0].SetAttribute('src', '` + powershellSingleQuotedString(iconURL) + `')
+`
+	}
+	script := `[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::` + template + `)
+` + imageScript + `$toast = $xml.GetElementsByTagName('toast')[0]
+$toast.SetAttribute('scenario', 'reminder')
+$xml.GetElementsByTagName('text')[0].InnerText = '` + powershellSingleQuotedString(title) + `'
+$xml.GetElementsByTagName('text')[1].InnerText = '` + powershellSingleQuotedString(body) + `'
+$actions = $xml.CreateElement('actions')
+$open = $xml.CreateElement('action')
+$open.SetAttribute('content', 'Open chat')
+$open.SetAttribute('activationType', 'protocol')
+$open.SetAttribute('arguments', '` + powershellSingleQuotedString(chatURL) + `')
+[void]$actions.AppendChild($open)
+$input = $xml.CreateElement('input')
+$input.SetAttribute('id', 'snoozeTime')
+$input.SetAttribute('type', 'selection')
+$input.SetAttribute('defaultInput', '15')
+$selection = $xml.CreateElement('selection')
+$selection.SetAttribute('id', '15')
+$selection.SetAttribute('content', '15 minutes')
+[void]$input.AppendChild($selection)
+[void]$actions.AppendChild($input)
+$snooze = $xml.CreateElement('action')
+$snooze.SetAttribute('content', 'Snooze')
+$snooze.SetAttribute('activationType', 'system')
+$snooze.SetAttribute('arguments', 'snooze')
+[void]$actions.AppendChild($snooze)
+$dismiss = $xml.CreateElement('action')
+$dismiss.SetAttribute('content', 'Dismiss')
+$dismiss.SetAttribute('activationType', 'system')
+$dismiss.SetAttribute('arguments', 'dismiss')
+[void]$actions.AppendChild($dismiss)
+[void]$toast.AppendChild($actions)
+$notification = [Windows.UI.Notifications.ToastNotification]::new($xml)
+$notification.Tag = 'myportal-chat'
+$notification.Group = 'myportal'
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('MyPortal').Show($notification)`
+	return encodePowerShellCommand(script)
+}
+
+func showChatSessionNotification(title, body, chatURL string) {
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsPersistentChatToastEncodedCommand(title, body, chatURL))
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
+	_ = cmd.Start()
 }
 
 func windowsToastIconURL() string {


### PR DESCRIPTION
### Motivation
- Technician-initiated chats previously opened silently and users without the chat UI open were never notified; the tray should surface a persistent notification with a concise summary and actions so end-users are aware and can open/snooze/dismiss the chat.

### Description
- Persist the technician-provided initial message and mirror it into Matrix and the local chat DB from `start_device_chat` so the room has a last-message and the payload can include a summary (`app/api/routes/tray.py`).
- Replace automatic immediate chat-window opening on `chat_open` with a notification flow and wire `handleChatOpen` into the UI IPC handlers so the tray shows a notification instead of forcibly launching a window (`tray/ui/main.go`, `tray/ui/main_nowebview.go`).
- Add a background local action server and `tray/ui/chat_notification.go` that registers short-lived action URLs so notification clicks request a fresh chat token and then open the chat, avoiding expired one-time tokens after snoozing.
- Add a Windows-specific persistent toast with portal icon and actionable buttons `Open chat`, `Snooze`, and `Dismiss` (`tray/ui/windows_notification.go`), plus a non-Windows fallback (`tray/ui/chat_notification_other.go`), and unit tests for notification summary text (`tray/ui/chat_notification_test.go`).

### Testing
- Ran `go test -tags nowebview ./...` and the test suite passed for the tray packages under the nowebview tag. (OK)
- Built Windows UI test binary with `GOOS=windows GOARCH=amd64 go test -c -tags nowebview ./ui` and the build succeeded. (OK)
- Checked Python server module syntax with `python -m py_compile app/api/routes/tray.py` and it compiled cleanly. (OK)
- Ran `go test ./...` (full environment) and observed a known environment limitation: the `systray` package requires `ayatana-appindicator3-0.1` via `pkg-config` on some Linux runners which causes unrelated build warnings/failure in this environment; this is an env dependency, not a code regression. (⚠️)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28d13711d083329d1c44b253feb5d0)