### PR TITLE
Fix Windows tray startup config replay race

### DIFF
--- a/tray/ui/main.go
+++ b/tray/ui/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync/atomic"
 	"time"
 
 	"github.com/getlantern/systray"
@@ -50,6 +51,11 @@ var (
 	gPortalURL string
 	gDeviceUID string
 	gAuthToken string
+
+	// trayReady is set once systray has created its hidden window and notify
+	// icon. The service can replay config_changed immediately after IPC connect,
+	// which may happen before systray.Run finishes native initialization.
+	trayReady atomic.Bool
 )
 
 func main() {
@@ -130,6 +136,7 @@ func defaultConfig() *api.ConfigResponse {
 }
 
 func onTrayReady() {
+	trayReady.Store(true)
 	systray.SetTitle("MyPortal")
 	systray.SetTooltip(trayTooltip(gConfig))
 	// Use a simple built-in icon; real icon bytes loaded from branding URL in Phase 6.
@@ -137,6 +144,7 @@ func onTrayReady() {
 }
 
 func onTrayExit() {
+	trayReady.Store(false)
 	if gIPCConn != nil {
 		gIPCConn.Close()
 	}
@@ -343,7 +351,11 @@ func handleIPCMessages(conn net.Conn) {
 			// Re-read cached config. Menu rebuild on config_changed is deferred
 			// until a systray library version that exposes ResetMenu is adopted.
 			gConfig = loadCachedConfig()
-			systray.SetTooltip(trayTooltip(gConfig))
+			if trayReady.Load() {
+				systray.SetTooltip(trayTooltip(gConfig))
+			} else {
+				logger.Debug("config_changed: received before tray ready; deferring tooltip update")
+			}
 
 		case "show_notification":
 			var n struct {

--- a/tray/ui/tray_nowebview_windows.go
+++ b/tray/ui/tray_nowebview_windows.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/getlantern/systray"
@@ -26,6 +27,13 @@ import (
 // lastRestartAt is used to prevent rapid restart loops when config_changed
 // events arrive in quick succession.
 var lastRestartAt time.Time
+
+// trayReady is set after systray has created its hidden window and notify icon.
+// IPC can connect very quickly during startup, and the service replays a
+// config_changed message on connect. Calling systray.SetTooltip/SetIcon before
+// onTrayReady runs dereferences systray's internal notify-icon state and exits
+// the GUI-subsystem process before any error can be shown.
+var trayReady atomic.Bool
 
 // hasHandledInitialConfigChanged prevents restart loops from the service's
 // IPC onConnect bootstrap replay of config_changed.
@@ -43,6 +51,7 @@ func runUI() {
 }
 
 func onTrayReady() {
+	trayReady.Store(true)
 	systray.SetTitle("MyPortal")
 	systray.SetTooltip(trayTooltip(gConfig))
 	// Set the default icon immediately so the tray appears without delay,
@@ -93,6 +102,17 @@ func fetchAndSetIcon() {
 // A 60-second cooldown prevents restart storms if multiple config_changed
 // events arrive in quick succession.
 func handleConfigChanged(cfg *api.ConfigResponse) {
+	if !trayReady.Load() {
+		// The initial config replay can arrive before systray.Run has completed
+		// native initialization. gConfig has already been refreshed by the IPC
+		// handler, so onTrayReady will render the latest cache shortly.
+		if !hasHandledInitialConfigChanged {
+			hasHandledInitialConfigChanged = true
+		}
+		logger.Debug("config_changed: received before tray ready; deferring systray updates")
+		return
+	}
+
 	systray.SetTooltip(trayTooltip(cfg))
 
 	// Always refresh the icon — this can be updated without a restart.
@@ -136,6 +156,7 @@ func handleConfigChanged(cfg *api.ConfigResponse) {
 }
 
 func onTrayExit() {
+	trayReady.Store(false)
 	if gIPCConn != nil {
 		gIPCConn.Close()
 	}


### PR DESCRIPTION
### Motivation
- Prevent the UI agent from exiting silently when the service replays `config_changed` over IPC before the native systray window/icon is ready.
- Calls into the `systray` package during this early replay could dereference internal state and terminate the GUI-subsystem before the tray appears in Task Manager.

### Description
- Add a readiness flag `trayReady` (an `atomic.Bool`) to both the webview and nowebview Windows UI builds (`tray/ui/main.go` and `tray/ui/tray_nowebview_windows.go`) to track native systray initialization. 
- Set `trayReady` in `onTrayReady()` and clear it in `onTrayExit()` so systray operations are gated until the tray is initialized. 
- Defer tooltip/icon/restart work when a `config_changed` IPC replay arrives before `trayReady` is true, while still refreshing cached config on-disk. 
- Import `sync/atomic` where required and add lightweight logging to indicate deferred updates.

### Testing
- Ran `go test -count=1 -tags=nowebview ./...` which passed. 
- Built the Windows artifacts with `make build-windows`, which produced the no-CGO Windows UI `myportal-tray-ui.exe` successfully. 
- Ran `go test -count=1 ./...` in the Linux environment which failed due to a missing native dependency (`ayatana-appindicator3-0.1`) needed by the platform systray build, not due to the changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28d62952008332b34541c60ceabadb)