### PR TITLE
Reuse existing tray chat sessions

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -731,29 +731,37 @@ async def start_device_chat(
 
     subject = (payload.subject or "Tray support chat").strip()[:500]
 
-    # Reuse Matrix room creation + chat_rooms persistence so the message
-    # appears in the standard /chat experience.
-    try:
-        matrix_resp = await matrix_service.create_room(
-            name=subject,
-            topic=f"Tray-initiated support chat: {subject}",
+    # Reconnect technicians to the device's current open chat first. User-
+    # initiated tray chats are linked to the device, so this prevents creating
+    # duplicate Matrix rooms while an active support conversation already
+    # exists.
+    room = await chat_repo.get_open_room_by_device_id(int(device["id"]))
+    matrix_room_id = str((room or {}).get("matrix_room_id") or "")
+
+    if not room:
+        # Reuse Matrix room creation + chat_rooms persistence so the message
+        # appears in the standard /chat experience.
+        try:
+            matrix_resp = await matrix_service.create_room(
+                name=subject,
+                topic=f"Tray-initiated support chat: {subject}",
+            )
+            matrix_room_id = matrix_resp.get("room_id", "")
+        except Exception as exc:
+            log_error("Failed to create Matrix room for tray chat", error=str(exc))
+            raise HTTPException(status_code=502, detail="Failed to create chat room") from exc
+
+        room = await chat_repo.create_room(
+            subject=subject,
+            matrix_room_id=matrix_room_id,
+            room_alias=matrix_resp.get("room_alias"),
+            created_by_user_id=int(current_user["id"]),
+            company_id=int(device.get("company_id") or 0),
+            linked_ticket_id=None,
         )
-        matrix_room_id = matrix_resp.get("room_id", "")
-    except Exception as exc:
-        log_error("Failed to create Matrix room for tray chat", error=str(exc))
-        raise HTTPException(status_code=502, detail="Failed to create chat room") from exc
 
-    room = await chat_repo.create_room(
-        subject=subject,
-        matrix_room_id=matrix_room_id,
-        room_alias=matrix_resp.get("room_alias"),
-        created_by_user_id=int(current_user["id"]),
-        company_id=int(device.get("company_id") or 0),
-        linked_ticket_id=None,
-    )
-
-    # Link the room back to its device so the UI can highlight it.
-    await _attach_room_to_device(int(room["id"]), int(device["id"]))
+        # Link the room back to its device so the UI can highlight it.
+        await _attach_room_to_device(int(room["id"]), int(device["id"]))
 
     initial_message = (payload.message or "").strip()[:4000]
     initiator_name = current_user.get("display_name") or current_user.get("email")

--- a/app/features/chat/routes.py
+++ b/app/features/chat/routes.py
@@ -255,6 +255,9 @@ async def tray_chat_popup(
             chat_room = None
 
     if not chat_room:
+        chat_room = await chat_repo.get_open_room_by_device_id(device_id)
+
+    if not chat_room:
         # User-initiated chat: create a fresh room.
         hostname = (device.get("hostname") or "Tray Device")[:200]
         subject = f"Chat from {hostname}"

--- a/tests/test_tray_devices_page.py
+++ b/tests/test_tray_devices_page.py
@@ -92,3 +92,160 @@ async def test_tray_bulk_delete_revoked_devices_calls_repo(monkeypatch):
     assert response.status_code == 303
     assert response.headers["location"] == "/admin/tray/devices"
     delete_mock.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_start_device_chat_reuses_existing_open_tray_room(monkeypatch):
+    import app.api.routes.tray as tray_routes
+    import app.repositories.chat as chat_repo
+    import app.repositories.companies as companies_repo
+    import app.repositories.tray as tray_repo
+    from app.schemas.tray import TrayChatStartRequest
+    from app.services import audit as audit_service
+    from app.services import matrix as matrix_service
+    from app.services import tray as tray_service
+
+    monkeypatch.setattr(
+        tray_routes,
+        "_settings",
+        type(
+            "Settings",
+            (),
+            {"matrix_enabled": True, "matrix_bot_user_id": "@bot:example"},
+        )(),
+    )
+    monkeypatch.setattr(
+        tray_repo,
+        "get_device_by_uid",
+        AsyncMock(
+            return_value={
+                "id": 7,
+                "device_uid": "dev-7",
+                "status": "active",
+                "company_id": 3,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        companies_repo, "get_company_by_id", AsyncMock(return_value={"id": 3})
+    )
+    monkeypatch.setattr(
+        tray_service, "technician_can_initiate", lambda user, company: True
+    )
+
+    existing_room = {
+        "id": 42,
+        "matrix_room_id": "!existing:example",
+        "status": "open",
+        "company_id": 3,
+        "tray_device_id": 7,
+    }
+    monkeypatch.setattr(
+        chat_repo, "get_open_room_by_device_id", AsyncMock(return_value=existing_room)
+    )
+    create_matrix_mock = AsyncMock(return_value={"room_id": "!new:example"})
+    create_room_mock = AsyncMock()
+    attach_mock = AsyncMock()
+    monkeypatch.setattr(matrix_service, "create_room", create_matrix_mock)
+    monkeypatch.setattr(chat_repo, "create_room", create_room_mock)
+    monkeypatch.setattr(tray_routes, "_attach_room_to_device", attach_mock)
+    monkeypatch.setattr(tray_service, "send_to_device", AsyncMock(return_value=True))
+    monkeypatch.setattr(tray_repo, "log_command", AsyncMock())
+    monkeypatch.setattr(audit_service, "log_action", AsyncMock())
+
+    response = await tray_routes.start_device_chat(
+        "dev-7",
+        TrayChatStartRequest(subject="Help me"),
+        {"id": 99, "email": "tech@example.test", "display_name": "Tech"},
+    )
+
+    assert response.room_id == 42
+    assert response.matrix_room_id == "!existing:example"
+    assert response.delivered is True
+    create_matrix_mock.assert_not_called()
+    create_room_mock.assert_not_called()
+    attach_mock.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_tray_chat_popup_reuses_existing_open_room_from_unbound_token(monkeypatch):
+    import app.features.chat.routes as chat_routes
+    import app.repositories.chat as chat_repo
+    import app.repositories.companies as companies_repo
+    import app.repositories.tray as tray_repo
+    from app.services import matrix as matrix_service
+
+    monkeypatch.setattr(
+        chat_routes,
+        "get_settings",
+        lambda: type(
+            "Settings", (), {"matrix_enabled": True, "environment": "development"}
+        )(),
+    )
+    monkeypatch.setattr(
+        chat_routes.tray_service, "hash_token", lambda token: f"hash:{token}"
+    )
+    monkeypatch.setattr(
+        tray_repo,
+        "get_chat_token_by_hash",
+        AsyncMock(
+            return_value={
+                "id": 11,
+                "device_id": 7,
+                "room_id": None,
+                "expires_at": None,
+                "used_at": None,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        tray_repo,
+        "get_device_by_id",
+        AsyncMock(
+            return_value={
+                "id": 7,
+                "device_uid": "dev-7",
+                "status": "active",
+                "company_id": 3,
+                "hostname": "PC-7",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        companies_repo,
+        "get_company_by_id",
+        AsyncMock(return_value={"id": 3, "tray_chat_enabled": True}),
+    )
+    monkeypatch.setattr(tray_repo, "mark_chat_token_used", AsyncMock())
+
+    existing_room = {
+        "id": 42,
+        "matrix_room_id": "!existing:example",
+        "status": "open",
+        "company_id": 3,
+        "tray_device_id": 7,
+        "subject": "Chat from PC-7",
+    }
+    monkeypatch.setattr(chat_repo, "get_room", AsyncMock())
+    monkeypatch.setattr(
+        chat_repo, "get_open_room_by_device_id", AsyncMock(return_value=existing_room)
+    )
+    create_matrix_mock = AsyncMock(return_value={"room_id": "!new:example"})
+    create_room_mock = AsyncMock()
+    monkeypatch.setattr(matrix_service, "create_room", create_matrix_mock)
+    monkeypatch.setattr(chat_repo, "create_room", create_room_mock)
+    monkeypatch.setattr(chat_repo, "get_messages", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        chat_routes, "_make_popup_session", lambda **kwargs: "cookie-value"
+    )
+    monkeypatch.setattr(
+        chat_routes, "_render_popup", lambda **kwargs: f"room={kwargs['room_id']}"
+    )
+
+    request = _make_request("/tray/chat", method="GET")
+    response = await chat_routes.tray_chat_popup(request, None, token="abc", room=None)
+
+    assert response.status_code == 200
+    assert response.body == b"room=42"
+    create_matrix_mock.assert_not_called()
+    create_room_mock.assert_not_called()


### PR DESCRIPTION
### Motivation

- Prevent creating duplicate chat rooms when a technician starts a chat from the tray device so an ongoing conversation is preserved.
- Ensure device-initiated popup sessions reconnect to any existing open device-linked chat so users continue prior conversations instead of getting a new thread.
- Reduce noise and confusion in the Matrix/chat history by reusing existing `chat_rooms` linked to tray devices.

### Description

- Update technician-start flow in `app/api/routes/tray.py` (`start_device_chat`) to call `chat_repo.get_open_room_by_device_id` and reuse the returned room when present, creating a new Matrix room only when none exists.
- Update popup flow in `app/features/chat/routes.py` (`tray_chat_popup`) to check `chat_repo.get_open_room_by_device_id(device_id)` for unbound tokens and reuse an open room before creating a fresh user-initiated room.
- Ensure room-to-device linking is preserved when a new room is created and avoid re-linking when reusing an existing room.
- Add regression tests in `tests/test_tray_devices_page.py` for `test_start_device_chat_reuses_existing_open_tray_room` and `test_tray_chat_popup_reuses_existing_open_room_from_unbound_token` to cover both technician-started and popup cases.

### Testing

- Ran `pytest -q tests/test_tray_devices_page.py` and the test suite passed (`5 passed`).
- Performed a bytecode/parse check via `python -m compileall -q app/api/routes/tray.py app/features/chat/routes.py tests/test_tray_devices_page.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2900bed1dc832d9f1fbb00f724176b)