### PR TITLE
Fix tray TRMM script notification message and Windows toast rendering

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -282,7 +282,7 @@ async def run_trmm_script(
         )
         or None,
         event_id=event_id,
-        message="Tactical RMM script request submitted.",
+        message="Tactical RMM script has been scheduled and will run shortly.",
     )
 
 

--- a/tray/ui/trmm_script.go
+++ b/tray/ui/trmm_script.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -42,20 +43,34 @@ func runTRMMScriptFromMenu(node api.MenuNode) {
 		showTextWindow("Tactical RMM", "MyPortal could not start the Tactical RMM script. Please contact support.")
 		return
 	}
-	label := node.ScriptName
+	var result struct {
+		ScriptName string `json:"script_name"`
+		Message    string `json:"message"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4096)).Decode(&result); err != nil && err != io.EOF {
+		logger.Debug("TRMM script response decode failed: %v", err)
+	}
+	label := result.ScriptName
+	if label == "" {
+		label = node.ScriptName
+	}
 	if label == "" {
 		label = node.Label
 	}
 	if label == "" {
 		label = fmt.Sprintf("Script #%d", node.ScriptID)
 	}
-	showOSNotification("Script requested", trmmScriptSuccessMessage(label))
+	showOSNotification("Script scheduled", trmmScriptSuccessMessage(label, result.Message))
 }
 
-func trmmScriptSuccessMessage(label string) string {
+func trmmScriptSuccessMessage(label string, serverMessage string) string {
+	serverMessage = strings.TrimSpace(serverMessage)
+	if serverMessage != "" {
+		return serverMessage
+	}
 	label = strings.TrimSpace(label)
 	if label == "" {
-		return "Your requested script has been executed and will run shortly."
+		return "Your requested script has been scheduled and will run shortly."
 	}
-	return fmt.Sprintf("The script %q you requested has been executed and will run shortly.", label)
+	return fmt.Sprintf("The script %q has been scheduled and will run shortly.", label)
 }

--- a/tray/ui/trmm_script_test.go
+++ b/tray/ui/trmm_script_test.go
@@ -2,17 +2,25 @@ package main
 
 import "testing"
 
-func TestTRMMScriptSuccessMessageIncludesRequestedScriptNotice(t *testing.T) {
-	msg := trmmScriptSuccessMessage("Nightly Maintenance")
-	want := `The script "Nightly Maintenance" you requested has been executed and will run shortly.`
+func TestTRMMScriptSuccessMessageIncludesScheduledScriptNotice(t *testing.T) {
+	msg := trmmScriptSuccessMessage("Nightly Maintenance", "")
+	want := `The script "Nightly Maintenance" has been scheduled and will run shortly.`
 	if msg != want {
 		t.Fatalf("unexpected success message:\n got: %q\nwant: %q", msg, want)
 	}
 }
 
+func TestTRMMScriptSuccessMessageUsesServerMessage(t *testing.T) {
+	msg := trmmScriptSuccessMessage("Nightly Maintenance", "Tactical RMM script request submitted.")
+	want := "Tactical RMM script request submitted."
+	if msg != want {
+		t.Fatalf("unexpected server success message:\n got: %q\nwant: %q", msg, want)
+	}
+}
+
 func TestTRMMScriptSuccessMessageTrimsBlankLabel(t *testing.T) {
-	msg := trmmScriptSuccessMessage("  \t")
-	want := "Your requested script has been executed and will run shortly."
+	msg := trmmScriptSuccessMessage("  \t", "")
+	want := "Your requested script has been scheduled and will run shortly."
 	if msg != want {
 		t.Fatalf("unexpected success message for blank label:\n got: %q\nwant: %q", msg, want)
 	}

--- a/tray/ui/windows_notification.go
+++ b/tray/ui/windows_notification.go
@@ -21,8 +21,9 @@ func windowsToastEncodedCommand(title, body string) string {
 	}
 	script := `[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
 $xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::` + template + `)
-` + imageScript + `$xml.GetElementsByTagName('text')[0].InnerText = '` + powershellSingleQuotedString(title) + `'
-$xml.GetElementsByTagName('text')[1].InnerText = '` + powershellSingleQuotedString(body) + `'
+` + imageScript + `$textNodes = $xml.GetElementsByTagName('text')
+[void]$textNodes.Item(0).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(title) + `'))
+[void]$textNodes.Item(1).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(body) + `'))
 [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('MyPortal').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
 	return encodePowerShellCommand(script)
 }
@@ -40,8 +41,9 @@ func windowsPersistentChatToastEncodedCommand(title, body, chatURL string) strin
 $xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::` + template + `)
 ` + imageScript + `$toast = $xml.GetElementsByTagName('toast')[0]
 $toast.SetAttribute('scenario', 'reminder')
-$xml.GetElementsByTagName('text')[0].InnerText = '` + powershellSingleQuotedString(title) + `'
-$xml.GetElementsByTagName('text')[1].InnerText = '` + powershellSingleQuotedString(body) + `'
+$textNodes = $xml.GetElementsByTagName('text')
+[void]$textNodes.Item(0).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(title) + `'))
+[void]$textNodes.Item(1).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(body) + `'))
 $actions = $xml.CreateElement('actions')
 $open = $xml.CreateElement('action')
 $open.SetAttribute('content', 'Open chat')

--- a/tray/ui/windows_notification_test.go
+++ b/tray/ui/windows_notification_test.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
+
+func TestWindowsToastEncodedCommandAppendsTextNodes(t *testing.T) {
+	cmd := windowsToastEncodedCommand("Script scheduled", `The script "Nightly Maintenance" has been scheduled.`)
+	raw, err := base64.StdEncoding.DecodeString(cmd)
+	if err != nil {
+		t.Fatalf("decode encoded command: %v", err)
+	}
+	units := make([]uint16, 0, len(raw)/2)
+	for i := 0; i+1 < len(raw); i += 2 {
+		units = append(units, uint16(raw[i])|uint16(raw[i+1])<<8)
+	}
+	script := string(utf16.Decode(units))
+	for _, want := range []string{
+		"$textNodes = $xml.GetElementsByTagName('text')",
+		"AppendChild($xml.CreateTextNode('Script scheduled'))",
+		`AppendChild($xml.CreateTextNode('The script "Nightly Maintenance" has been scheduled.'))`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("encoded script missing %q:\n%s", want, script)
+		}
+	}
+	if strings.Contains(script, ".InnerText =") {
+		t.Fatalf("encoded script should not use InnerText assignment:\n%s", script)
+	}
+}


### PR DESCRIPTION
### Motivation
- Ensure tray toast notifications show the actual scheduled-script message (and any server-provided message) instead of an unrelated/placeholder text or image content. 
- Avoid Windows notification placeholders by populating toast XML with text nodes rather than assigning to `InnerText`. 
- Provide regression coverage so the behaviour remains stable across future changes.

### Description
- Parse the portal response in the tray client `runTRMMScriptFromMenu` to prefer `script_name`/`message` returned by the server and use those when composing the OS notification; update the toast title to "Script scheduled". (`tray/ui/trmm_script.go`).
- Update the tray API success message to explicitly say the Tactical RMM script "has been scheduled and will run shortly." (`app/api/routes/tray.py`).
- Change Windows toast generation to append text nodes (`AppendChild($xml.CreateTextNode(...))`) instead of setting `.InnerText`, preventing Windows showing the generic placeholder text. (`tray/ui/windows_notification.go`).
- Add unit tests that verify the scheduled-script message logic and the Windows toast encoded command content. (`tray/ui/trmm_script_test.go`, `tray/ui/windows_notification_test.go`).

### Testing
- Ran `CGO_ENABLED=0 go test -tags nowebview ./ui ./internal/api` which succeeded, exercising tray UI and internal API unit tests. 
- Compiled the modified Python route with `python3 -m compileall app/api/routes/tray.py` which succeeded. 
- Verified Windows-targeted build/test steps with `GOOS=windows CGO_ENABLED=0 go test -c -tags nowebview ./ui` which produced a Windows test binary successfully in this environment. 
- `go test ./ui ./internal/api` failed in this Linux environment because the system is missing `ayatana-appindicator3-0.1` pkg-config development files required by `systray`, which is an environment/dependency issue and unrelated to the change logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29041d2610832d934a5df4dffc644c)