### PR TITLE
Fix tray tooltip version prefix

### DIFF
--- a/tray/ui/version_label.go
+++ b/tray/ui/version_label.go
@@ -9,6 +9,17 @@ import (
 
 const defaultTrayTooltip = "MyPortal Helpdesk"
 
+func trayTooltipVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(version), "v") {
+		return version
+	}
+	return "v" + version
+}
+
 // trayTooltip returns the system-tray hover text with the running app version.
 func trayTooltip(cfg *api.ConfigResponse) string {
 	displayName := defaultTrayTooltip
@@ -17,11 +28,11 @@ func trayTooltip(cfg *api.ConfigResponse) string {
 			displayName = brandedName
 		}
 	}
-	version := strings.TrimSpace(updater.AgentVersion)
+	version := trayTooltipVersion(updater.AgentVersion)
 	if version == "" {
 		return displayName
 	}
-	return displayName + " v" + version
+	return displayName + " " + version
 }
 
 // versionMenuLabel returns the visible label for an app_version menu node.

--- a/tray/ui/version_label_test.go
+++ b/tray/ui/version_label_test.go
@@ -19,6 +19,20 @@ func TestTrayTooltipIncludesAgentVersion(t *testing.T) {
 	}
 }
 
+func TestTrayTooltipDoesNotDuplicateVersionPrefix(t *testing.T) {
+	old := updater.AgentVersion
+	updater.AgentVersion = "v0.0.1.2"
+	t.Cleanup(func() { updater.AgentVersion = old })
+
+	got := trayTooltip(nil)
+	if strings.Contains(got, "vv0.0.1.2") {
+		t.Fatalf("trayTooltip() = %q, should not duplicate version prefix", got)
+	}
+	if !strings.Contains(got, "v0.0.1.2") {
+		t.Fatalf("trayTooltip() = %q, want it to include prefixed agent version", got)
+	}
+}
+
 func TestTrayTooltipUsesBrandingDisplayName(t *testing.T) {
 	old := updater.AgentVersion
 	updater.AgentVersion = "9.8.7"


### PR DESCRIPTION
### Motivation
- The tray tooltip prepended an extra `v` when `updater.AgentVersion` already included a leading `v`, producing `vv0.0.1.2` instead of `v0.0.1.2`.
- Add a regression test to prevent future reintroduction of the duplicated prefix.

### Description
- Add `trayTooltipVersion(version string)` to normalize `updater.AgentVersion`, preserving an existing leading `v` and adding one when missing.
- Update `trayTooltip` to call `trayTooltipVersion` and change formatting to concatenate the display name and the normalized version with a single space.
- Add `TestTrayTooltipDoesNotDuplicateVersionPrefix` to `tray/ui/version_label_test.go` to cover prefixed build names like `v0.0.1.2`.

### Testing
- Ran `go test ./...` which executed many packages but overall failed because the `ui` package could not build on this Linux environment due to desktop/systray dependencies (missing `ayatana-appindicator3-0.1`).
- Ran `CGO_ENABLED=0 go test ./ui` which failed because the systray package lacks a Linux no-CGO implementation in this environment.
- Attempted Windows-targeted runs: `GOOS=windows GOARCH=amd64 go test -tags nowebview ./ui` failed to execute on Linux (cross-built test binary cannot run here), but `GOOS=windows GOARCH=amd64 go test -tags nowebview -c ./ui -o /tmp/myportal-ui.test.exe` succeeded to compile the Windows test binary.
- The new unit test compiles as part of the `ui` package build for appropriate targets and the change is covered by the added test; CI on a matching desktop target should run the full suite successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2903fb6c8c832da7d562291c2ce0ee)