### PR TITLE
Refine tray submit ticket form layout

### DIFF
--- a/tray/ui/ticket_windows.go
+++ b/tray/ui/ticket_windows.go
@@ -122,11 +122,40 @@ function New-Label($text, $x, $y) {
     $l = New-Object System.Windows.Forms.Label
     $l.Text = $text
     $l.Location = New-Object System.Drawing.Point($x, $y)
-    $l.Size = New-Object System.Drawing.Size(125, 24)
+    $l.Size = New-Object System.Drawing.Size(125, 44)
+    $l.MaximumSize = New-Object System.Drawing.Size(125, 0)
+    $l.AutoSize = $true
     $l.TextAlign = 'MiddleLeft'
     $l.ForeColor = $colorInk
     $l.Font = $fontLabel
     return $l
+}
+function Add-LayoutRow($label, $control, $minHeight) {
+    $labelH = 0
+    if ($label -ne $null) { $labelH = $label.PreferredHeight }
+    $controlH = 0
+    if ($control -ne $null) { $controlH = $control.Height }
+    $rowHeight = [Math]::Max($minHeight, [Math]::Max($labelH, $controlH) + 8)
+    [void]$script:LayoutRows.Add([pscustomobject]@{ Label = $label; Control = $control; Height = $rowHeight })
+}
+function Test-RowVisible($row) {
+    if ($row.Control -ne $null) { return $row.Control.Visible }
+    if ($row.Label -ne $null) { return $row.Label.Visible }
+    return $false
+}
+function Apply-FormLayout {
+    $currentY = $script:FormStartY
+    foreach ($row in $script:LayoutRows) {
+        if (Test-RowVisible $row) {
+            if ($row.Label -ne $null) { $row.Label.Location = New-Object System.Drawing.Point($labelX, ($currentY + 2)) }
+            if ($row.Control -ne $null) { $row.Control.Location = New-Object System.Drawing.Point($fieldX, $currentY) }
+            $currentY += $row.Height
+        }
+    }
+    $currentY += 12
+    if ($btnCancel -ne $null) { $btnCancel.Location = New-Object System.Drawing.Point($labelX, ($currentY + 18)) }
+    if ($btnSubmit -ne $null) { $btnSubmit.Location = New-Object System.Drawing.Point(($fieldX + $fieldW - 190), ($currentY + 18)) }
+    $form.ClientSize = New-Object System.Drawing.Size(780, [Math]::Min(($currentY + 92), [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea.Height - 80))
 }
 function New-TextBox($x, $y, $w, $h, $val, $placeholder) {
     $t = New-Object System.Windows.Forms.TextBox
@@ -246,30 +275,32 @@ $form.Controls.Add($lblIntro)
 $labelX = 70
 $fieldX = 205
 $fieldW = 505
-$y = 284
-$rowGap = 46
+$y = 276
+$script:FormStartY = $y
+$rowGap = 39
+$script:LayoutRows = New-Object System.Collections.ArrayList
 
 # ── Fixed fields ────────────────────────────────────────────────────
-$form.Controls.Add((New-Label "Name *" $labelX ($y+2)))
+$lblName = New-Label "Name *" $labelX ($y+2); $form.Controls.Add($lblName)
 $txtName = New-TextBox $fieldX $y $fieldW 30 $prefillName "e.g. John Smith"; $form.Controls.Add($txtName)
-$y += $rowGap
+Add-LayoutRow $lblName $txtName $rowGap
 
-$form.Controls.Add((New-Label "Email *" $labelX ($y+2)))
+$lblEmail = New-Label "Email *" $labelX ($y+2); $form.Controls.Add($lblEmail)
 $txtEmail = New-TextBox $fieldX $y $fieldW 30 $prefillEmail "e.g. john@smith.com"; $form.Controls.Add($txtEmail)
-$y += $rowGap
+Add-LayoutRow $lblEmail $txtEmail $rowGap
 
-$form.Controls.Add((New-Label "Phone" $labelX ($y+2)))
+$lblPhone = New-Label "Phone" $labelX ($y+2); $form.Controls.Add($lblPhone)
 $txtPhone = New-TextBox $fieldX $y $fieldW 30 $prefillPhone "The best number to reach you at"; $form.Controls.Add($txtPhone)
-$y += $rowGap
+Add-LayoutRow $lblPhone $txtPhone $rowGap
 
-$form.Controls.Add((New-Label "Subject *" $labelX ($y+2)))
+$lblSubject = New-Label "Subject *" $labelX ($y+2); $form.Controls.Add($lblSubject)
 $txtSubject = New-TextBox $fieldX $y $fieldW 30 "" "e.g. I'm having networking issues"; $form.Controls.Add($txtSubject)
-$y += $rowGap
+Add-LayoutRow $lblSubject $txtSubject $rowGap
 
-$form.Controls.Add((New-Label "Description" $labelX ($y+2)))
+$lblDesc = New-Label "Description" $labelX ($y+2); $form.Controls.Add($lblDesc)
 $txtDesc = New-Object System.Windows.Forms.TextBox
 $txtDesc.Location = New-Object System.Drawing.Point($fieldX, $y)
-$txtDesc.Size = New-Object System.Drawing.Size($fieldW, 112)
+$txtDesc.Size = New-Object System.Drawing.Size($fieldW, 100)
 $txtDesc.Multiline = $true
 $txtDesc.ScrollBars = 'Vertical'
 $txtDesc.Font = $fontBase
@@ -277,7 +308,7 @@ $txtDesc.ForeColor = $colorInk
 $txtDesc.BorderStyle = 'FixedSingle'
 Set-CueBanner $txtDesc "Please provide the details about the issue you are experiencing"
 $form.Controls.Add($txtDesc)
-$y += 132
+Add-LayoutRow $lblDesc $txtDesc 108
 
 # ── Dynamic questions ─────────────────────────────────────────────
 `)
@@ -304,7 +335,8 @@ $y += 132
 		switch q.FieldType {
 		case "select":
 			optList := psStringList(q.Options)
-			sb.WriteString(fmt.Sprintf("\n$form.Controls.Add((New-Label %q $labelX ($y+2)))\n", labelText))
+			sb.WriteString(fmt.Sprintf("\n%s = New-Label %q $labelX ($y+2)\n", lblVar, labelText))
+			sb.WriteString(fmt.Sprintf("$form.Controls.Add(%s)\n", lblVar))
 			sb.WriteString(fmt.Sprintf("%s = New-ComboBox $fieldX $y $fieldW @(%s)\n", varName, optList))
 			sb.WriteString(fmt.Sprintf("$form.Controls.Add(%s)\n", varName))
 		case "boolean":
@@ -313,19 +345,18 @@ $y += 132
 			// For booleans the label IS the checkbox; still emit a hidden label var.
 			sb.WriteString(fmt.Sprintf("%s = $null\n", lblVar))
 		default: // text
-			sb.WriteString(fmt.Sprintf("\n$form.Controls.Add((New-Label %q $labelX ($y+2)))\n", labelText))
+			sb.WriteString(fmt.Sprintf("\n%s = New-Label %q $labelX ($y+2)\n", lblVar, labelText))
+			sb.WriteString(fmt.Sprintf("$form.Controls.Add(%s)\n", lblVar))
 			placeholder := q.Placeholder
 			sb.WriteString(fmt.Sprintf("%s = New-TextBox $fieldX $y $fieldW 30 \"\" %q\n", varName, placeholder))
 			sb.WriteString(fmt.Sprintf("$form.Controls.Add(%s)\n", varName))
 		}
 
-		// Store the label control reference so we can hide it along with the control.
-		if q.FieldType != "boolean" {
-			sb.WriteString(fmt.Sprintf("%s = $form.Controls | Where-Object { $_.Text -eq %q } | Select-Object -Last 1\n",
-				lblVar, labelText))
+		if q.FieldType == "boolean" {
+			sb.WriteString(fmt.Sprintf("Add-LayoutRow $null %s $rowGap\n", varName))
+		} else {
+			sb.WriteString(fmt.Sprintf("Add-LayoutRow %s %s $rowGap\n", lblVar, varName))
 		}
-
-		sb.WriteString("$y += $rowGap\n")
 
 		metas = append(metas, qMeta{
 			varName:    varName,
@@ -339,9 +370,6 @@ $y += 132
 
 	// Resize form and place buttons after all controls.
 	sb.WriteString(`
-$y += 12
-$form.ClientSize = New-Object System.Drawing.Size(780, [Math]::Min(($y + 92), [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea.Height - 80))
-
 $btnCancel = New-Object System.Windows.Forms.Button
 $btnCancel.Text = "Cancel"
 $btnCancel.Location = New-Object System.Drawing.Point($labelX, ($y + 18))
@@ -352,12 +380,13 @@ $form.CancelButton = $btnCancel
 $form.Controls.Add($btnCancel)
 
 $btnSubmit = New-Object System.Windows.Forms.Button
-$btnSubmit.Text = "Send Request  ›"
+$btnSubmit.Text = "Send Request"
 $btnSubmit.Location = New-Object System.Drawing.Point(($fieldX + $fieldW - 190), ($y + 18))
 $btnSubmit.Size = New-Object System.Drawing.Size(190, 40)
 Set-ButtonStyle $btnSubmit $true
 $form.AcceptButton = $btnSubmit
 $form.Controls.Add($btnSubmit)
+Apply-FormLayout
 
 # WinForms event handlers do not reliably write pipeline output back to the
 # host process. Store the accepted payload in script scope and emit it only
@@ -410,7 +439,7 @@ $script:TicketDialogResult = $null
 					m.varName+".Visible", m.labelVar, m.labelVar))
 			}
 		}
-		sb.WriteString("}\nUpdate-Visibility\n")
+		sb.WriteString("  Apply-FormLayout\n}\nUpdate-Visibility\n")
 
 		// Wire change events for controls whose answers may affect others.
 		triggeredIDs := map[int]bool{}

--- a/tray/ui/ticket_windows_test.go
+++ b/tray/ui/ticket_windows_test.go
@@ -150,6 +150,43 @@ func TestBuildTicketScriptConditionalEmitsUpdateVisibility(t *testing.T) {
 
 // TestBuildTicketScriptAnswersJSON verifies the JSON output block references
 // dynamic question answer variables.
+
+func TestBuildTicketScriptUsesCompactedDynamicLayout(t *testing.T) {
+	questions := []api.TicketQuestion{
+		{
+			ID:        10,
+			FieldType: "select",
+			Label:     "Issue category",
+			Options:   []string{"Hardware", "Software"},
+		},
+		{
+			ID:        11,
+			FieldType: "text",
+			Label:     "Application affected",
+			Conditions: []api.TicketQuestionCondition{
+				{ParentQuestionID: 10, Operator: "equals", ExpectedValue: "Software"},
+			},
+		},
+	}
+	script := buildTicketScript(questions)
+
+	mustContain := []string{
+		"Add-LayoutRow $dynLbl_10 $dynCtrl_10 $rowGap",
+		"Add-LayoutRow $dynLbl_11 $dynCtrl_11 $rowGap",
+		"Apply-FormLayout",
+		"$rowGap = 39",
+		"$btnSubmit.Text = \"Send Request\"",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(script, want) {
+			t.Fatalf("expected script to contain %q", want)
+		}
+	}
+	if strings.Contains(script, "Send Request  ›") {
+		t.Fatal("submit button should not include the decorative arrow glyph")
+	}
+}
+
 func TestBuildTicketScriptAnswersJSON(t *testing.T) {
 	questions := []api.TicketQuestion{
 		{ID: 5, FieldType: "text", Label: "Room number"},


### PR DESCRIPTION
### Motivation

- Make the Windows "Submit Ticket" (tray) dialog labels wrap and not be truncated so long titles like the "This Issue Impacts"/"Issue Category" label are readable.
- Remove wasted vertical gaps when dynamic/conditional fields are hidden so the dialog compacts vertically instead of leaving blank space.
- Clean up the primary action label by removing the decorative arrow glyph and slightly tighten the overall vertical spacing.

### Description

- Added a layout manager for rows (`Add-LayoutRow`, `Apply-FormLayout`, `Test-RowVisible`) and changed `New-Label` to autosize so labels can wrap and row heights are computed from control/preferred heights in `tray/ui/ticket_windows.go`.
- Register fixed and dynamic rows with the layout manager and call `Apply-FormLayout` after visibility changes so hidden conditional rows do not consume vertical space.
- Reduced the initial vertical offset and `rowGap`, and shortened the description text area height to condense the form vertically.
- Updated dynamic question generation to create explicit label variables and register each dynamic row (including boolean rows that omit a left-hand label) so visibility toggles reflow correctly.
- Removed the decorative arrow glyph from the submit button text (`"Send Request  ›"` -> `"Send Request"`).
- Added a unit test `TestBuildTicketScriptUsesCompactedDynamicLayout` to verify row registration, tighter spacing, reflow application, and the cleaned button label in `tray/ui/ticket_windows_test.go`.

### Testing

- Ran `cd tray && go test -tags nowebview ./ui` which passed successfully for the UI package with the `nowebview` tag.
- Compiled a Windows test binary with `cd tray && GOOS=windows go test -tags nowebview -c ./ui -o /tmp/myportal-ui.test.exe` which produced a Windows executable successfully on this host.
- Attempted to run `cd tray && GOOS=windows go test -tags nowebview ./ui`, which compiled but could not be executed on this Linux host due to `exec format error` (expected when running a Windows binary on Linux).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a0ae48f78832d8bacfb9976fe5740)