### PR TITLE
Update tray automation notification wording and use branded tray icon/name

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -282,7 +282,7 @@ async def run_trmm_script(
         )
         or None,
         event_id=event_id,
-        message="Tactical RMM script has been scheduled and will run shortly.",
+        message="The requested automation has been scheduled and will run in the background shortly.",
     )
 
 

--- a/tray/ui/trmm_script.go
+++ b/tray/ui/trmm_script.go
@@ -68,9 +68,5 @@ func trmmScriptSuccessMessage(label string, serverMessage string) string {
 	if serverMessage != "" {
 		return serverMessage
 	}
-	label = strings.TrimSpace(label)
-	if label == "" {
-		return "Your requested script has been scheduled and will run shortly."
-	}
-	return fmt.Sprintf("The script %q has been scheduled and will run shortly.", label)
+	return "The requested automation has been scheduled and will run in the background shortly."
 }

--- a/tray/ui/trmm_script_test.go
+++ b/tray/ui/trmm_script_test.go
@@ -2,9 +2,9 @@ package main
 
 import "testing"
 
-func TestTRMMScriptSuccessMessageIncludesScheduledScriptNotice(t *testing.T) {
+func TestTRMMScriptSuccessMessageUsesAutomationScheduledNotice(t *testing.T) {
 	msg := trmmScriptSuccessMessage("Nightly Maintenance", "")
-	want := `The script "Nightly Maintenance" has been scheduled and will run shortly.`
+	want := "The requested automation has been scheduled and will run in the background shortly."
 	if msg != want {
 		t.Fatalf("unexpected success message:\n got: %q\nwant: %q", msg, want)
 	}
@@ -20,7 +20,7 @@ func TestTRMMScriptSuccessMessageUsesServerMessage(t *testing.T) {
 
 func TestTRMMScriptSuccessMessageTrimsBlankLabel(t *testing.T) {
 	msg := trmmScriptSuccessMessage("  \t", "")
-	want := "Your requested script has been scheduled and will run shortly."
+	want := "The requested automation has been scheduled and will run in the background shortly."
 	if msg != want {
 		t.Fatalf("unexpected success message for blank label:\n got: %q\nwant: %q", msg, want)
 	}

--- a/tray/ui/version_label.go
+++ b/tray/ui/version_label.go
@@ -20,14 +20,18 @@ func trayTooltipVersion(version string) string {
 	return "v" + version
 }
 
-// trayTooltip returns the system-tray hover text with the running app version.
-func trayTooltip(cfg *api.ConfigResponse) string {
-	displayName := defaultTrayTooltip
+func trayDisplayName(cfg *api.ConfigResponse) string {
 	if cfg != nil {
 		if brandedName := strings.TrimSpace(cfg.BrandingDisplayName); brandedName != "" {
-			displayName = brandedName
+			return brandedName
 		}
 	}
+	return defaultTrayTooltip
+}
+
+// trayTooltip returns the system-tray hover text with the running app version.
+func trayTooltip(cfg *api.ConfigResponse) string {
+	displayName := trayDisplayName(cfg)
 	version := trayTooltipVersion(updater.AgentVersion)
 	if version == "" {
 		return displayName

--- a/tray/ui/windows_notification.go
+++ b/tray/ui/windows_notification.go
@@ -11,6 +11,7 @@ import (
 )
 
 func windowsToastEncodedCommand(title, body string) string {
+	appName := windowsToastAppName()
 	iconURL := windowsToastIconURL()
 	template := "ToastText02"
 	imageScript := ""
@@ -24,11 +25,12 @@ $xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([
 ` + imageScript + `$textNodes = $xml.GetElementsByTagName('text')
 [void]$textNodes.Item(0).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(title) + `'))
 [void]$textNodes.Item(1).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(body) + `'))
-[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('MyPortal').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + powershellSingleQuotedString(appName) + `').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
 	return encodePowerShellCommand(script)
 }
 
 func windowsPersistentChatToastEncodedCommand(title, body, chatURL string) string {
+	appName := windowsToastAppName()
 	iconURL := windowsToastIconURL()
 	template := "ToastText02"
 	imageScript := ""
@@ -73,7 +75,7 @@ $dismiss.SetAttribute('arguments', 'dismiss')
 $notification = [Windows.UI.Notifications.ToastNotification]::new($xml)
 $notification.Tag = 'myportal-chat'
 $notification.Group = 'myportal'
-[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('MyPortal').Show($notification)`
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + powershellSingleQuotedString(appName) + `').Show($notification)`
 	return encodePowerShellCommand(script)
 }
 
@@ -81,6 +83,10 @@ func showChatSessionNotification(title, body, chatURL string) {
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsPersistentChatToastEncodedCommand(title, body, chatURL))
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
 	_ = cmd.Start()
+}
+
+func windowsToastAppName() string {
+	return trayDisplayName(gConfig)
 }
 
 func windowsToastIconURL() string {

--- a/tray/ui/windows_notification_test.go
+++ b/tray/ui/windows_notification_test.go
@@ -7,10 +7,21 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf16"
+
+	"github.com/bradhawkins85/myportal-tray/internal/api"
 )
 
 func TestWindowsToastEncodedCommandAppendsTextNodes(t *testing.T) {
-	cmd := windowsToastEncodedCommand("Script scheduled", `The script "Nightly Maintenance" has been scheduled.`)
+	prevConfig := gConfig
+	prevPortalURL := gPortalURL
+	gConfig = &api.ConfigResponse{BrandingDisplayName: "Acme Support"}
+	gPortalURL = "https://portal.example.test"
+	t.Cleanup(func() {
+		gConfig = prevConfig
+		gPortalURL = prevPortalURL
+	})
+
+	cmd := windowsToastEncodedCommand("Script scheduled", `The requested automation has been scheduled and will run in the background shortly.`)
 	raw, err := base64.StdEncoding.DecodeString(cmd)
 	if err != nil {
 		t.Fatalf("decode encoded command: %v", err)
@@ -22,8 +33,10 @@ func TestWindowsToastEncodedCommandAppendsTextNodes(t *testing.T) {
 	script := string(utf16.Decode(units))
 	for _, want := range []string{
 		"$textNodes = $xml.GetElementsByTagName('text')",
+		"$xml.GetElementsByTagName('image')[0].SetAttribute('src', 'https://portal.example.test/tray/icon.ico')",
 		"AppendChild($xml.CreateTextNode('Script scheduled'))",
-		`AppendChild($xml.CreateTextNode('The script "Nightly Maintenance" has been scheduled.'))`,
+		"AppendChild($xml.CreateTextNode('The requested automation has been scheduled and will run in the background shortly.'))",
+		"CreateToastNotifier('Acme Support').Show",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("encoded script missing %q:\n%s", want, script)


### PR DESCRIPTION
### Motivation
- Make tray notifications and API responses use a more generic, user-facing phrasing: "The requested automation has been scheduled and will run in the background shortly" and ensure tray notifications reflect portal branding (icon + tooltip display name). 

### Description
- Replaced the RMM scheduling message returned by the tray API with the requested automation wording in `app/api/routes/tray.py` (response `message`).
- Updated the tray client fallback notification text in `tray/ui/trmm_script.go` to the requested automation wording while preserving any server-supplied message.
- Added a reusable `trayDisplayName(cfg *api.ConfigResponse)` helper and used it so the tray tooltip and other consumers can use the configured branding tooltip display name in `tray/ui/version_label.go`.
- Made Windows toast payloads include the branded tray icon URL and use the branded tooltip display name as the toast app name instead of the hard-coded `MyPortal` notifier, and updated the PowerShell script generation accordingly in `tray/ui/windows_notification.go`.
- Updated unit tests to reflect the new wording and branding behavior in `tray/ui/trmm_script_test.go` and `tray/ui/windows_notification_test.go`.

### Testing
- Ran `go test ./...`; most packages ran but the top-level `go test` in this Linux environment reports a build failure for the systray integration due to a missing system dev package (`ayatana-appindicator3-0.1`), not related to the changes here (environment limitation).
- Ran `go test ./ui -tags nowebview` which passed for the tray UI package.
- Ran `pytest tests/test_notifications_page.py` which passed (2 tests).
- Updated tray-specific unit tests (`tray/ui/trmm_script_test.go`, `tray/ui/windows_notification_test.go`) to validate the new notification text and branded icon/app-name usage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a0efe4cfc832d946cbe58b5209e2d)