### PR TITLE
Fix tray chat reply toasts in nowebview client

### DIFF
--- a/tray/ui/chat_notification.go
+++ b/tray/ui/chat_notification.go
@@ -33,6 +33,8 @@ type chatMessagePayload struct {
 }
 
 var (
+	showChatSessionNotificationFunc = showChatSessionNotification
+
 	notificationActionOnce    sync.Once
 	notificationActionBaseURL string
 	notificationActionMu      sync.Mutex
@@ -51,7 +53,7 @@ func handleChatOpen(payload chatOpenPayload) {
 	}
 
 	title, body := chatNotificationText(payload)
-	showChatSessionNotification(title, body, actionURL)
+	showChatSessionNotificationFunc(title, body, actionURL)
 }
 
 func handleChatMessage(payload chatMessagePayload) {
@@ -61,7 +63,7 @@ func handleChatMessage(payload chatMessagePayload) {
 	}
 
 	title, body := chatMessageNotificationText(payload)
-	showChatSessionNotification(title, body, actionURL)
+	showChatSessionNotificationFunc(title, body, actionURL)
 }
 
 func chatMessageNotificationText(payload chatMessagePayload) (string, string) {

--- a/tray/ui/main_nowebview.go
+++ b/tray/ui/main_nowebview.go
@@ -189,27 +189,35 @@ func handleIPCMessages(conn net.Conn) {
 			return
 		}
 		logger.Debug("handleIPCMessages: received type=%q", msg.Type)
-		switch msg.Type {
-		case "chat_open":
-			var payload chatOpenPayload
-			_ = json.Unmarshal(msg.Payload, &payload)
-			handleChatOpen(payload)
-		case "config_changed":
-			refreshPortalURL()
-			refreshDeviceUID()
-			refreshAuthToken()
-			gConfig = loadCachedConfig()
-			if onConfigChanged != nil {
-				onConfigChanged(gConfig)
-			}
-		case "show_notification":
-			var n struct {
-				Title string `json:"title"`
-				Body  string `json:"body"`
-			}
-			_ = json.Unmarshal(msg.Payload, &n)
-			showOSNotification(n.Title, n.Body)
+		handleIPCMessage(*msg)
+	}
+}
+
+func handleIPCMessage(msg ipc.Message) {
+	switch msg.Type {
+	case "chat_open":
+		var payload chatOpenPayload
+		_ = json.Unmarshal(msg.Payload, &payload)
+		handleChatOpen(payload)
+	case "chat_message":
+		var payload chatMessagePayload
+		_ = json.Unmarshal(msg.Payload, &payload)
+		handleChatMessage(payload)
+	case "config_changed":
+		refreshPortalURL()
+		refreshDeviceUID()
+		refreshAuthToken()
+		gConfig = loadCachedConfig()
+		if onConfigChanged != nil {
+			onConfigChanged(gConfig)
 		}
+	case "show_notification":
+		var n struct {
+			Title string `json:"title"`
+			Body  string `json:"body"`
+		}
+		_ = json.Unmarshal(msg.Payload, &n)
+		showOSNotification(n.Title, n.Body)
 	}
 }
 

--- a/tray/ui/main_nowebview_test.go
+++ b/tray/ui/main_nowebview_test.go
@@ -1,0 +1,48 @@
+//go:build nowebview
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/bradhawkins85/myportal-tray/internal/ipc"
+)
+
+func TestHandleIPCMessageDispatchesChatMessageNotification(t *testing.T) {
+	previous := showChatSessionNotificationFunc
+	var gotTitle string
+	var gotBody string
+	var gotURL string
+	showChatSessionNotificationFunc = func(title, body, chatURL string) {
+		gotTitle = title
+		gotBody = body
+		gotURL = chatURL
+	}
+	t.Cleanup(func() { showChatSessionNotificationFunc = previous })
+
+	payload, err := json.Marshal(chatMessagePayload{
+		RoomID:  42,
+		Subject: "Printer offline",
+		Sender:  "Alex Tech",
+		Message: "Please try printing again.",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	handleIPCMessage(ipc.Message{Type: "chat_message", Payload: payload})
+
+	if gotTitle != "New MyPortal chat message" {
+		t.Fatalf("title = %q", gotTitle)
+	}
+	for _, want := range []string{"Alex Tech", "Printer offline", "Please try printing again."} {
+		if !strings.Contains(gotBody, want) {
+			t.Fatalf("body = %q, want it to contain %q", gotBody, want)
+		}
+	}
+	if gotURL == "" {
+		t.Fatalf("chat notification action URL should not be empty")
+	}
+}


### PR DESCRIPTION
### Motivation
- Technician replies were not producing OS toast notifications when the user's chat window was closed because the nowebview tray UI did not dispatch `chat_message` IPC payloads to the same handler used for `chat_open` notifications.

### Description
- Route IPC messages through a unified handler by adding `handleIPCMessage` and calling it from `handleIPCMessages` so `chat_message` payloads are processed (change in `tray/ui/main_nowebview.go`).
- Introduce a testable notification hook `showChatSessionNotificationFunc` and route chat toasts through it so notification behavior can be overridden in tests (change in `tray/ui/chat_notification.go`).
- Preserve existing `show_notification` and `config_changed` handling while ensuring `chat_open` and `chat_message` both create the same chat toast with an action URL.
- Add a regression test `tray/ui/main_nowebview_test.go` that asserts a `chat_message` IPC payload yields the expected title/body and a non-empty chat action URL.

### Testing
- Ran `go test -tags nowebview -count=1 ./...` and the nowebview-targeted tests passed, including the new `handleIPCMessage` regression test. 
- Ran `go test -count=1 ./...` (full native build) which failed in this container due to missing system pkg-config libraries (`ayatana-appindicator3-0.1`) required by the native systray build, unrelated to these changes.
- Verified the tray UI behavior locally in headless/nowebview test runs and confirmed `chat_message` notifications are dispatched to the same toast path as `chat_open`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a162cb728832d9f74d89a56d7af05)