### PR TITLE
Central menu permission catalogue and granular Office 365 menu permissions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -154,6 +154,7 @@ from app.security.csrf import CSRFMiddleware
 from app.security.encryption import decrypt_secret, encrypt_secret
 from app.security.flash import flash_redirect, set_flash
 from app.security.ip_whitelist import IPWhitelistMiddleware
+from app.security.menu_permissions import ACCESS_LEVEL_LABELS, MENU_PERMISSIONS
 from app.security.rate_limiter import (
     EndpointRateLimiter,
     EndpointRateLimiterMiddleware,
@@ -1795,6 +1796,10 @@ async def _build_base_context(
                 log_error("Failed to check BCP edit permissions", error=str(exc))
                 can_edit_bcp = False
 
+    can_manage_licenses = is_super_admin or _has_permission("can_manage_licenses")
+    can_view_m365_best_practices = is_super_admin or _has_permission("can_view_m365_best_practices")
+    can_view_m365_user_mailboxes = is_super_admin or _has_permission("can_view_m365_user_mailboxes")
+    can_view_m365_shared_mailboxes = is_super_admin or _has_permission("can_view_m365_shared_mailboxes")
     permission_flags = {
         "can_access_shop": is_super_admin or _has_permission("can_access_shop"),
         "can_access_cart": is_super_admin or _has_permission("can_access_cart"),
@@ -1802,7 +1807,13 @@ async def _build_base_context(
         "can_access_quotes": is_super_admin or _has_permission("can_access_quotes"),
         "can_access_forms": is_super_admin or _has_permission("can_access_forms"),
         "can_manage_assets": is_super_admin or _has_permission("can_manage_assets"),
-        "can_manage_licenses": is_super_admin or _has_permission("can_manage_licenses"),
+        "can_manage_licenses": can_manage_licenses,
+        "can_view_m365_configuration": can_manage_licenses,
+        "can_view_m365_best_practices": can_view_m365_best_practices,
+        "can_view_m365_user_mailboxes": can_view_m365_user_mailboxes,
+        "can_view_m365_shared_mailboxes": can_view_m365_shared_mailboxes,
+        "can_view_m365_licenses": can_manage_licenses,
+        "can_view_m365_diagnostics": is_super_admin,
         "can_manage_invoices": is_super_admin or _has_permission("can_manage_invoices"),
         "can_manage_staff": (
             is_super_admin
@@ -1813,11 +1824,8 @@ async def _build_base_context(
         "can_view_compliance": is_super_admin or _has_permission("can_view_compliance"),
         "can_view_bcp": can_view_bcp,
         "can_edit_bcp": can_edit_bcp,
-        "can_view_m365_best_practices": is_super_admin or _has_permission("can_view_m365_best_practices"),
         "can_view_compliance_checks": is_super_admin or _has_permission("can_view_compliance_checks"),
         "can_manage_compliance_checks": is_super_admin or _has_permission("can_manage_compliance_checks"),
-        "can_view_m365_user_mailboxes": is_super_admin or _has_permission("can_view_m365_user_mailboxes"),
-        "can_view_m365_shared_mailboxes": is_super_admin or _has_permission("can_view_m365_shared_mailboxes"),
         "can_access_chat": is_super_admin or _has_permission("can_access_chat"),
         "can_access_marketing": has_marketing_access,
     }
@@ -1914,6 +1922,8 @@ async def _build_base_context(
         "impersonation_started_at": impersonation_started_at,
         "has_issue_tracker_access": has_issue_tracker_access,
         "can_access_tickets": True,
+        "menu_permission_catalogue": MENU_PERMISSIONS,
+        "menu_access_level_labels": ACCESS_LEVEL_LABELS,
         "plausible_config": plausible_config,
     }
     context.update(permission_flags)

--- a/app/security/menu_permissions.py
+++ b/app/security/menu_permissions.py
@@ -1,0 +1,147 @@
+"""Central catalogue of permissions represented by the left navigation menu.
+
+The sidebar should use these stable permission keys when deciding whether a menu
+entry is visible.  Route handlers can also reference the same catalogue when
+checking whether a user can read or write a feature.  The catalogue is purposely
+static and side-effect free so it can be imported safely by templates, tests,
+startup tasks, and API documentation code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Final, Iterable
+
+
+class MenuAccessLevel(str, Enum):
+    """Supported access levels for a left-menu permission."""
+
+    NONE = "none"
+    READ = "read"
+    WRITE = "write"
+
+
+ACCESS_LEVEL_LABELS: Final[MappingProxyType[str, str]] = MappingProxyType(
+    {
+        MenuAccessLevel.NONE.value: "No Access",
+        MenuAccessLevel.READ.value: "Read Only",
+        MenuAccessLevel.WRITE.value: "Read/Write",
+    }
+)
+
+DEFAULT_ACCESS_LEVELS: Final[tuple[MenuAccessLevel, ...]] = (
+    MenuAccessLevel.NONE,
+    MenuAccessLevel.READ,
+    MenuAccessLevel.WRITE,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MenuPermission:
+    """Permission metadata for one assignable left-menu item."""
+
+    key: str
+    label: str
+    route_prefixes: tuple[str, ...]
+    supported_access_levels: tuple[MenuAccessLevel, ...] = DEFAULT_ACCESS_LEVELS
+    legacy_flags: tuple[str, ...] = ()
+    super_admin_only: bool = False
+    always_visible: bool = False
+    group: str | None = None
+
+    def controls_route(self, path: str) -> bool:
+        """Return whether this permission controls *path* by route prefix."""
+
+        for prefix in self.route_prefixes:
+            if prefix == "/":
+                if path == "/":
+                    return True
+                continue
+            if path == prefix or path.startswith(prefix.rstrip("/") + "/"):
+                return True
+        return False
+
+
+MENU_PERMISSIONS: Final[tuple[MenuPermission, ...]] = (
+    # Always-visible top-level customer entries.
+    MenuPermission("menu.dashboard", "Dashboard", ("/",), always_visible=True),
+    MenuPermission("menu.service_status", "Service status", ("/service-status",), always_visible=True),
+    MenuPermission("menu.knowledge_base", "Knowledge base", ("/knowledge-base",), always_visible=True),
+    MenuPermission("menu.help", "Help", ("/help",), always_visible=True),
+    MenuPermission("menu.reports.company_overview", "Reports", ("/reports",), always_visible=True),
+    # Conditional top-level customer/company entries.
+    MenuPermission("menu.notifications", "Notifications", ("/notifications",), super_admin_only=True),
+    MenuPermission("menu.chat", "Chat", ("/chat",), legacy_flags=("can_access_chat",)),
+    MenuPermission("menu.tickets", "Tickets", ("/tickets", "/admin/tickets")),
+    MenuPermission("menu.issue_tracker", "Issue tracker", ("/admin/issues",)),
+    MenuPermission("menu.marketing", "Marketing", ("/admin/marketing",), super_admin_only=True),
+    MenuPermission("menu.shop", "Shop", ("/shop",), legacy_flags=("can_access_shop",)),
+    MenuPermission("menu.quotes", "Quotes", ("/quotes",), legacy_flags=("can_access_quotes",)),
+    MenuPermission("menu.orders", "Orders", ("/orders",), legacy_flags=("can_access_orders",)),
+    MenuPermission("menu.forms", "Forms", ("/myforms", "/forms"), legacy_flags=("can_access_forms",)),
+    MenuPermission("menu.assets", "Assets", ("/assets",), legacy_flags=("can_manage_assets",)),
+    # Office 365 grouped menu children.  These are intentionally separate so a
+    # user can, for example, read mailbox pages without seeing configuration.
+    MenuPermission("menu.m365.configuration", "Office 365 Configuration", ("/m365",), legacy_flags=("can_manage_licenses",), group="Office 365"),
+    MenuPermission("menu.m365.best_practices", "Best Practices", ("/m365/best-practices",), legacy_flags=("can_view_m365_best_practices",), group="Office 365"),
+    MenuPermission("menu.m365.user_mailboxes", "User Mailboxes", ("/m365/mailboxes/users",), legacy_flags=("can_view_m365_user_mailboxes",), group="Office 365"),
+    MenuPermission("menu.m365.shared_mailboxes", "Shared Mailboxes", ("/m365/mailboxes/shared",), legacy_flags=("can_view_m365_shared_mailboxes",), group="Office 365"),
+    MenuPermission("menu.m365.licenses", "Licenses", ("/licenses",), legacy_flags=("can_manage_licenses",), group="Office 365"),
+    MenuPermission("menu.m365.diagnostics", "Diagnostics", ("/m365/diagnostics",), super_admin_only=True, group="Office 365"),
+    MenuPermission("menu.subscriptions", "Subscriptions", ("/subscriptions",), legacy_flags=("can_manage_licenses", "can_access_cart")),
+    MenuPermission("menu.invoices", "Invoices", ("/invoices",), legacy_flags=("can_manage_invoices",)),
+    MenuPermission("menu.staff", "Staff", ("/staff",), legacy_flags=("can_manage_staff", "staff_permission")),
+    MenuPermission("menu.compliance", "Compliance", ("/compliance",), legacy_flags=("can_view_compliance",)),
+    MenuPermission("menu.reporting", "Reporting", ("/reporting", "/admin/reporting")),
+    # Compliance Checks grouped menu children.
+    MenuPermission("menu.compliance_checks.my_checks", "My Checks", ("/compliance-checks",), legacy_flags=("can_view_compliance_checks",), group="Compliance Checks"),
+    MenuPermission("menu.compliance_checks.library", "Library", ("/admin/compliance-checks/library",), legacy_flags=("can_manage_compliance_checks",), super_admin_only=True, group="Compliance Checks"),
+    MenuPermission("menu.bcp", "Continuity", ("/bcp",), legacy_flags=("can_view_bcp",)),
+    # Administration section entries.
+    MenuPermission("menu.admin.profile", "My Profile", ("/admin/profile",)),
+    MenuPermission("menu.admin.impersonation", "Impersonation", ("/admin/impersonation",), super_admin_only=True),
+    MenuPermission("menu.admin.call_recordings", "Call Recordings", ("/admin/call-recordings",), super_admin_only=True),
+    MenuPermission("menu.admin.scheduled_tasks", "Scheduled Tasks", ("/admin/scheduled-tasks",), super_admin_only=True),
+    MenuPermission("menu.admin.backup_history", "Backup History", ("/admin/backup-jobs",), super_admin_only=True),
+    MenuPermission("menu.admin.backup_summary", "Backup Summary", ("/admin/backup-summary",), super_admin_only=True),
+    MenuPermission("menu.admin.message_templates", "Message Templates", ("/admin/message-templates",), super_admin_only=True),
+    MenuPermission("menu.admin.webhooks", "Webhook Monitor", ("/admin/webhooks",), super_admin_only=True),
+    MenuPermission("menu.admin.companies", "Companies", ("/admin/companies",)),
+    MenuPermission("menu.admin.company_admin", "Company admin", ("/admin/companies",)),
+    MenuPermission("menu.admin.tray_settings", "Tray Settings", ("/admin/tray",), super_admin_only=True),
+    MenuPermission("menu.admin.api_keys", "API Keys", ("/admin/api-keys",), super_admin_only=True),
+    MenuPermission("menu.admin.modules", "Modules", ("/admin/modules",), super_admin_only=True),
+    MenuPermission("menu.admin.feature_packs", "Feature Packs", ("/admin/feature-packs",), super_admin_only=True),
+    MenuPermission("menu.admin.roles", "Roles", ("/admin/roles",), super_admin_only=True),
+    MenuPermission("menu.admin.change_log", "Change Log", ("/admin/change-log",), super_admin_only=True),
+    MenuPermission("menu.admin.audit_trail", "Audit Trail", ("/admin/audit-logs",), super_admin_only=True),
+)
+
+MENU_PERMISSION_BY_KEY: Final[MappingProxyType[str, MenuPermission]] = MappingProxyType(
+    {permission.key: permission for permission in MENU_PERMISSIONS}
+)
+
+
+def get_menu_permission(key: str) -> MenuPermission:
+    """Return the menu permission for *key* or raise ``KeyError``."""
+
+    return MENU_PERMISSION_BY_KEY[key]
+
+
+def iter_menu_permissions(*, group: str | None = None) -> Iterable[MenuPermission]:
+    """Iterate menu permissions, optionally limited to a grouped menu label."""
+
+    for permission in MENU_PERMISSIONS:
+        if group is None or permission.group == group:
+            yield permission
+
+
+def permission_for_route(path: str) -> MenuPermission | None:
+    """Return the most-specific permission controlling *path*, if any."""
+
+    matches = [permission for permission in MENU_PERMISSIONS if permission.controls_route(path)]
+    if not matches:
+        return None
+    return max(matches, key=lambda permission: max(len(prefix) for prefix in permission.route_prefixes))

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -112,6 +112,9 @@
           {% set can_access_forms = (can_access_forms | default(false)) or is_super_admin or membership.get('can_access_forms') %}
           {% set can_manage_assets = (can_manage_assets | default(false)) or is_super_admin or membership.get('can_manage_assets') %}
           {% set can_manage_licenses = (can_manage_licenses | default(false)) or is_super_admin or membership.get('can_manage_licenses') %}
+          {% set can_view_m365_configuration = (can_view_m365_configuration | default(false)) or can_manage_licenses %}
+          {% set can_view_m365_licenses = (can_view_m365_licenses | default(false)) or can_manage_licenses %}
+          {% set can_view_m365_diagnostics = (can_view_m365_diagnostics | default(false)) or is_super_admin %}
           {% set can_manage_subscriptions = (can_manage_subscriptions | default(false)) or is_super_admin or (membership.get('can_manage_licenses') and membership.get('can_access_cart')) %}
           {% set can_manage_invoices = (can_manage_invoices | default(false)) or is_super_admin or membership.get('can_manage_invoices') %}
           {% set can_manage_staff = (can_manage_staff | default(false)) or is_super_admin or membership.get('can_manage_staff') or (staff_permission > 0) %}
@@ -124,7 +127,8 @@
           {% set can_view_m365_shared_mailboxes = (can_view_m365_shared_mailboxes | default(false)) or is_super_admin or membership.get('can_view_m365_shared_mailboxes') %}
           {% set can_access_chat = (can_access_chat | default(false)) or is_super_admin or membership.get('can_access_chat') %}
           {% set can_access_marketing = (can_access_marketing | default(false)) or is_super_admin %}
-          {% set has_company_section = can_access_tickets or can_manage_issues or can_access_marketing or can_access_shop or can_access_cart or can_access_orders or can_access_forms or can_manage_assets or can_manage_licenses or can_manage_subscriptions or can_manage_invoices or can_manage_staff or can_view_compliance or can_view_bcp or can_view_m365_best_practices or can_view_compliance_checks or can_view_m365_user_mailboxes or can_view_m365_shared_mailboxes %}
+          {% set has_m365_menu = can_view_m365_configuration or can_view_m365_best_practices or can_view_m365_user_mailboxes or can_view_m365_shared_mailboxes or can_view_m365_licenses or can_view_m365_diagnostics %}
+          {% set has_company_section = can_access_tickets or can_manage_issues or can_access_marketing or can_access_shop or can_access_cart or can_access_orders or can_access_forms or can_manage_assets or can_manage_licenses or can_manage_subscriptions or can_manage_invoices or can_manage_staff or can_view_compliance or can_view_bcp or has_m365_menu or can_view_compliance_checks %}
           {% set is_company_admin = membership.get('is_admin') %}
           {% set has_admin_access = is_super_admin or is_company_admin %}
           <li class="menu__item">
@@ -275,7 +279,7 @@
               </a>
             </li>
           {% endif %}
-          {% if can_manage_licenses %}
+          {% if has_m365_menu %}
             {% set m365_active = current_path.startswith('/m365') or current_path.startswith('/licenses') %}
             <li class="menu__item menu__item--expandable {% if m365_active %}menu__item--expanded{% endif %}" data-menu-key="/m365">
               <button class="menu__toggle" type="button" data-menu-toggle aria-expanded="{% if m365_active %}true{% else %}false{% endif %}">
@@ -288,44 +292,11 @@
                 </span>
               </button>
               <ul class="menu__submenu {% if m365_active %}menu__submenu--expanded{% endif %}">
+                {% if can_view_m365_configuration %}
                 <li class="menu__subitem">
                   <a href="/m365" {% if current_path == '/m365' %}aria-current="page"{% endif %}>Configuration</a>
                 </li>
-                {% if can_view_m365_best_practices %}
-                <li class="menu__subitem">
-                  <a href="/m365/best-practices" {% if current_path.startswith('/m365/best-practices') %}aria-current="page"{% endif %}>Best Practices</a>
-                </li>
                 {% endif %}
-                <li class="menu__subitem">
-                  <a href="/m365/mailboxes/users" {% if current_path.startswith('/m365/mailboxes/users') %}aria-current="page"{% endif %}>User Mailboxes</a>
-                </li>
-                <li class="menu__subitem">
-                  <a href="/m365/mailboxes/shared" {% if current_path.startswith('/m365/mailboxes/shared') %}aria-current="page"{% endif %}>Shared Mailboxes</a>
-                </li>
-                <li class="menu__subitem">
-                  <a href="/licenses" {% if current_path.startswith('/licenses') %}aria-current="page"{% endif %}>Licenses</a>
-                </li>
-                {% if is_super_admin %}
-                <li class="menu__subitem">
-                  <a href="/m365/diagnostics" {% if current_path.startswith('/m365/diagnostics') %}aria-current="page"{% endif %}>Diagnostics</a>
-                </li>
-                {% endif %}
-              </ul>
-            </li>
-          {% endif %}
-          {% if not can_manage_licenses and (can_view_m365_best_practices or can_view_m365_user_mailboxes or can_view_m365_shared_mailboxes) %}
-            {% set m365_active = current_path.startswith('/m365/best-practices') or current_path.startswith('/m365/mailboxes') %}
-            <li class="menu__item menu__item--expandable {% if m365_active %}menu__item--expanded{% endif %}" data-menu-key="/m365">
-              <button class="menu__toggle" type="button" data-menu-toggle aria-expanded="{% if m365_active %}true{% else %}false{% endif %}">
-                <span class="menu__icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false"><path d="M21 3H3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2zm-9 13-5-5 1.41-1.41L12 13.17l7.59-7.59L21 7z"/></svg>
-                </span>
-                <span class="menu__label">Office 365</span>
-                <span class="menu__expand-icon" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" focusable="false"><path d="M7 10l5 5 5-5z"/></svg>
-                </span>
-              </button>
-              <ul class="menu__submenu {% if m365_active %}menu__submenu--expanded{% endif %}">
                 {% if can_view_m365_best_practices %}
                 <li class="menu__subitem">
                   <a href="/m365/best-practices" {% if current_path.startswith('/m365/best-practices') %}aria-current="page"{% endif %}>Best Practices</a>
@@ -339,6 +310,16 @@
                 {% if can_view_m365_shared_mailboxes %}
                 <li class="menu__subitem">
                   <a href="/m365/mailboxes/shared" {% if current_path.startswith('/m365/mailboxes/shared') %}aria-current="page"{% endif %}>Shared Mailboxes</a>
+                </li>
+                {% endif %}
+                {% if can_view_m365_licenses %}
+                <li class="menu__subitem">
+                  <a href="/licenses" {% if current_path.startswith('/licenses') %}aria-current="page"{% endif %}>Licenses</a>
+                </li>
+                {% endif %}
+                {% if can_view_m365_diagnostics %}
+                <li class="menu__subitem">
+                  <a href="/m365/diagnostics" {% if current_path.startswith('/m365/diagnostics') %}aria-current="page"{% endif %}>Diagnostics</a>
                 </li>
                 {% endif %}
               </ul>

--- a/tests/test_menu_permissions.py
+++ b/tests/test_menu_permissions.py
@@ -1,0 +1,57 @@
+from app.security.menu_permissions import (
+    ACCESS_LEVEL_LABELS,
+    DEFAULT_ACCESS_LEVELS,
+    MENU_PERMISSION_BY_KEY,
+    MENU_PERMISSIONS,
+    MenuAccessLevel,
+    permission_for_route,
+)
+
+
+def test_menu_permission_keys_are_unique_and_have_required_metadata():
+    keys = [permission.key for permission in MENU_PERMISSIONS]
+
+    assert len(keys) == len(set(keys))
+    for permission in MENU_PERMISSIONS:
+        assert permission.key.startswith("menu.")
+        assert permission.label
+        assert permission.route_prefixes
+        assert permission.supported_access_levels == DEFAULT_ACCESS_LEVELS
+        assert {level.value for level in permission.supported_access_levels} == {"none", "read", "write"}
+
+
+def test_access_level_labels_are_stable():
+    assert ACCESS_LEVEL_LABELS[MenuAccessLevel.NONE.value] == "No Access"
+    assert ACCESS_LEVEL_LABELS[MenuAccessLevel.READ.value] == "Read Only"
+    assert ACCESS_LEVEL_LABELS[MenuAccessLevel.WRITE.value] == "Read/Write"
+
+
+def test_office_365_menu_is_split_into_child_permissions():
+    expected = {
+        "menu.m365.configuration",
+        "menu.m365.best_practices",
+        "menu.m365.user_mailboxes",
+        "menu.m365.shared_mailboxes",
+        "menu.m365.licenses",
+        "menu.m365.diagnostics",
+    }
+
+    assert expected.issubset(MENU_PERMISSION_BY_KEY)
+    assert {MENU_PERMISSION_BY_KEY[key].group for key in expected} == {"Office 365"}
+    assert MENU_PERMISSION_BY_KEY["menu.m365.configuration"].route_prefixes == ("/m365",)
+    assert MENU_PERMISSION_BY_KEY["menu.m365.user_mailboxes"].route_prefixes == ("/m365/mailboxes/users",)
+    assert MENU_PERMISSION_BY_KEY["menu.m365.shared_mailboxes"].route_prefixes == ("/m365/mailboxes/shared",)
+
+
+def test_permission_for_route_prefers_most_specific_prefix():
+    assert permission_for_route("/m365/mailboxes/users").key == "menu.m365.user_mailboxes"
+    assert permission_for_route("/m365/mailboxes/shared/details").key == "menu.m365.shared_mailboxes"
+    assert permission_for_route("/m365/best-practices/settings").key == "menu.m365.best_practices"
+    assert permission_for_route("/licenses").key == "menu.m365.licenses"
+    assert permission_for_route("/compliance-checks").key == "menu.compliance_checks.my_checks"
+    assert permission_for_route("/admin/compliance-checks/library").key == "menu.compliance_checks.library"
+
+
+def test_permission_for_route_does_not_treat_dashboard_as_catch_all():
+    assert permission_for_route("/").key == "menu.dashboard"
+    assert permission_for_route("/not-a-real-menu") is None


### PR DESCRIPTION
### Motivation
- Centralise and stabilise left-sidebar permission metadata to avoid ad-hoc boolean flags and super-admin checks scattered in templates and handlers.
- Provide a single source of truth for menu permissions with stable keys and explicit route mappings so UI and route handlers can make consistent visibility and access decisions.
- Enable finer-grained Office 365 visibility so mailbox pages can be shown while hiding configuration, addressing the previous all-or-nothing `can_manage_licenses` gate.

### Description
- Added a new permission catalogue module `app/security/menu_permissions.py` containing `MenuPermission`, `MenuAccessLevel`, `MENU_PERMISSIONS`, `MENU_PERMISSION_BY_KEY`, `permission_for_route`, and iteration helpers. 
- Split the Office 365 group into separate child permissions (`menu.m365.configuration`, `menu.m365.best_practices`, `menu.m365.user_mailboxes`, `menu.m365.shared_mailboxes`, `menu.m365.licenses`, `menu.m365.diagnostics`) and captured legacy flag metadata for compatibility. 
- Updated `app/main.py` to import the catalogue and expose `MENU_PERMISSIONS` and `ACCESS_LEVEL_LABELS` into the base template context and to compute per-child visibility flags rather than a single `can_manage_licenses` gate. 
- Updated `app/templates/base.html` to render the Office 365 grouped menu when any child permission is visible and to gate each submenu item by its corresponding visibility flag. 
- Added regression tests in `tests/test_menu_permissions.py` to validate catalogue metadata, access level labels, Office 365 child keys, most-specific route lookup, and that `/` (Dashboard) is not treated as a catch-all.

### Testing
- Ran `python -m pytest tests/test_menu_permissions.py` and all tests passed (`5 passed`) with unrelated deprecation warnings from existing schemas. 
- Compiled the new/modified modules with `python -m py_compile app/security/menu_permissions.py app/main.py` which succeeded without syntax errors. 
- Verified template rendering by loading `app/templates/base.html` with Jinja2 using `Environment(loader=FileSystemLoader('app/templates')).get_template('base.html')`, which compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a1e3a2374832db97a6a546dbecf17)