### PR TITLE
Add tri-state menu permission system and migrate role handling to menu permissions

### DIFF
--- a/app/api/routes/roles.py
+++ b/app/api/routes/roles.py
@@ -5,7 +5,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from app.api.dependencies.auth import require_super_admin
 from app.api.dependencies.database import require_database
 from app.repositories import roles as role_repo
-from app.schemas.roles import RoleCreate, RoleResponse, RoleUpdate
+from app.schemas.roles import MenuPermissionResponse, RoleCreate, RoleResponse, RoleUpdate
+from app.security.menu_permissions import catalogue_for_api
 from app.services import audit as audit_service
 
 router = APIRouter(prefix="/roles", tags=["Roles"])
@@ -44,6 +45,15 @@ async def create_role(
         request=request,
     )
     return created
+
+
+@router.get("/permissions/available", response_model=list[MenuPermissionResponse])
+async def list_available_permissions(
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    """Get assignable tri-state menu permissions for role management."""
+    return catalogue_for_api()
 
 
 @router.get("/{role_id}", response_model=RoleResponse)
@@ -111,43 +121,3 @@ async def delete_role(
         request=request,
     )
     return None
-
-
-@router.get("/permissions/available", response_model=list[str])
-async def list_available_permissions(
-    _: None = Depends(require_database),
-    __: dict = Depends(require_super_admin),
-):
-    """Get list of all available permissions in the system."""
-    # These are all the permissions defined in the system
-    # Extracted from migrations and used throughout the codebase
-    return sorted([
-        "assets.manage",
-        "audit.view",
-        "billing.manage",
-        "cart.access",
-        "chat.access",
-        "company.admin",
-        "company.manage",
-        "compliance.access",
-        "compliance_checks.access",
-        "compliance_checks.manage",
-        "continuity.access",
-        "forms.access",
-        "helpdesk.technician",
-        "invoices.manage",
-        "issues.manage",
-        "licenses.manage",
-        "licenses.order",
-        "m365_best_practices.access",
-        "m365_shared_mailboxes.access",
-        "m365_user_mailboxes.access",
-        "marketing.access",
-        "membership.manage",
-        "office_groups.manage",
-        "orders.access",
-        "portal.access",
-        "shop.access",
-        "staff.manage",
-        "staff.request",
-    ])

--- a/app/features/subscriptions/portal_routes.py
+++ b/app/features/subscriptions/portal_routes.py
@@ -60,8 +60,9 @@ async def _load_subscription_context(request: Request):
     membership = await user_company_repo.get_user_company(user["id"], company_id)
     has_license = bool(membership and membership.get("can_manage_licenses"))
     has_cart = bool(membership and membership.get("can_access_cart"))
+    can_view_subscriptions = _main()._membership_menu_can(user, membership, "menu.subscriptions")
 
-    if not (is_super_admin or (has_license and has_cart)):
+    if not (is_super_admin or (has_license and has_cart) or can_view_subscriptions):
         return (
             user,
             membership,
@@ -105,6 +106,7 @@ async def subscriptions_page(request: Request):
     is_super_admin = bool(user.get("is_super_admin"))
     can_request_changes = bool(
         is_super_admin
+        or _main()._membership_menu_can(user, membership, "menu.subscriptions", write=True)
         or (
             membership
             and membership.get("can_manage_licenses")
@@ -128,6 +130,11 @@ async def request_subscription_change(request: Request, subscription_id: str):
     user, membership, _, company_id, redirect = await _load_subscription_context(request)
     if redirect:
         return redirect
+    if not (
+        _main()._membership_menu_can(user, membership, "menu.subscriptions", write=True)
+        or bool(membership and membership.get("can_manage_licenses") and membership.get("can_access_cart"))
+    ):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Subscription read/write permission required")
 
     subscription = await subscriptions_repo.get_subscription(subscription_id)
     if not subscription or int(subscription.get("customer_id", 0)) != company_id:

--- a/app/main.py
+++ b/app/main.py
@@ -141,6 +141,7 @@ from app.repositories import automations as automation_repo
 from app.repositories import integration_modules as integration_modules_repo
 from app.repositories import user_companies as user_company_repo
 from app.repositories import users as user_repo
+from app.security.menu_permissions import MENU_PERMISSIONS, catalogue_for_api, menu_has_access, normalize_menu_permissions
 from app.repositories import issues as issues_repo
 from app.repositories import asset_custom_fields as asset_custom_fields_repo
 from app.repositories import staff_custom_fields as staff_custom_fields_repo
@@ -1730,6 +1731,88 @@ async def _resolve_initial_company_id(user: dict[str, Any]) -> int | None:
     return await company_access.first_accessible_company_id(user)
 
 
+
+
+def _build_menu_access_map(
+    *,
+    is_super_admin: bool,
+    membership_data: dict[str, Any],
+    is_helpdesk_technician: bool = False,
+    has_issue_tracker_access: bool = False,
+    has_marketing_access: bool = False,
+) -> dict[str, str]:
+    if is_super_admin:
+        return {item.key: "write" for item in MENU_PERMISSIONS}
+
+    role_menu_permissions = normalize_menu_permissions(membership_data.get("menu_permissions"))
+    menu_access = {item.key: role_menu_permissions.get(item.key, "none") for item in MENU_PERMISSIONS}
+
+    def promote(key: str, level: str = "write") -> None:
+        rank = {"none": 0, "read": 1, "write": 2}
+        if rank[level] > rank[menu_access.get(key, "none")]:
+            menu_access[key] = level
+
+    # Baseline authenticated pages remain readable unless explicitly controlled by a role.
+    for key in ("menu.dashboard", "menu.service_status", "menu.knowledge_base", "menu.help", "menu.reports", "menu.admin.profile"):
+        promote(key, "read")
+
+    legacy_boolean_to_menu = {
+        "can_access_shop": "menu.shop",
+        "can_access_cart": "menu.shop",
+        "can_access_orders": "menu.orders",
+        "can_access_quotes": "menu.quotes",
+        "can_access_forms": "menu.forms",
+        "can_manage_assets": "menu.assets",
+        "can_manage_licenses": "menu.m365.licenses",
+        "can_manage_invoices": "menu.invoices",
+        "can_manage_staff": "menu.staff",
+        "can_view_compliance": "menu.compliance",
+        "can_view_bcp": "menu.continuity",
+        "can_view_m365_best_practices": "menu.m365.best_practices",
+        "can_view_compliance_checks": "menu.compliance_checks",
+        "can_manage_compliance_checks": "menu.compliance_checks.library",
+        "can_view_m365_user_mailboxes": "menu.m365.user_mailboxes",
+        "can_view_m365_shared_mailboxes": "menu.m365.shared_mailboxes",
+        "can_access_chat": "menu.chat",
+        "is_admin": "menu.admin.company",
+    }
+    for boolean_key, menu_key in legacy_boolean_to_menu.items():
+        if membership_data.get(boolean_key):
+            promote(menu_key, "write" if boolean_key.startswith("can_manage") or boolean_key == "is_admin" else "read")
+
+    if membership_data.get("can_manage_licenses"):
+        promote("menu.m365.configuration", "write")
+    if membership_data.get("can_manage_licenses") and membership_data.get("can_access_cart"):
+        promote("menu.subscriptions", "write")
+    if is_helpdesk_technician:
+        promote("menu.tickets", "write")
+        promote("menu.reporting", "write")
+    else:
+        promote("menu.tickets", "read")
+    if has_issue_tracker_access:
+        promote("menu.issues", "write")
+    if has_marketing_access:
+        promote("menu.marketing", "write")
+    if int(membership_data.get("staff_permission") or 0) > 0:
+        promote("menu.staff", "write")
+
+    return menu_access
+
+
+def _menu_can(menu_access: dict[str, Any] | None, key: str, *, write: bool = False) -> bool:
+    return menu_has_access(menu_access, key, write=write)
+
+
+def _membership_menu_can(user: dict[str, Any], membership: dict[str, Any] | None, key: str, *, write: bool = False) -> bool:
+    if user.get("is_super_admin"):
+        return True
+    menu_access = _build_menu_access_map(
+        is_super_admin=False,
+        membership_data=membership or {},
+    )
+    return _menu_can(menu_access, key, write=write)
+
+
 async def _build_base_context(
     request: Request,
     user: dict[str, Any],
@@ -1778,6 +1861,13 @@ async def _build_base_context(
     is_helpdesk_technician = await _is_helpdesk_technician(user, request)
     has_issue_tracker_access = await _has_issue_tracker_access(user, request)
     has_marketing_access = await _has_marketing_access(user, request)
+    menu_access = _build_menu_access_map(
+        is_super_admin=is_super_admin,
+        membership_data=membership_data,
+        is_helpdesk_technician=is_helpdesk_technician,
+        has_issue_tracker_access=has_issue_tracker_access,
+        has_marketing_access=has_marketing_access,
+    )
 
     def _has_permission(flag: str) -> bool:
         return bool(membership_data.get(flag))
@@ -1796,30 +1886,35 @@ async def _build_base_context(
                 can_edit_bcp = False
 
     permission_flags = {
-        "can_access_shop": is_super_admin or _has_permission("can_access_shop"),
+        "can_access_shop": _menu_can(menu_access, "menu.shop") or is_super_admin or _has_permission("can_access_shop"),
         "can_access_cart": is_super_admin or _has_permission("can_access_cart"),
-        "can_access_orders": is_super_admin or _has_permission("can_access_orders"),
-        "can_access_quotes": is_super_admin or _has_permission("can_access_quotes"),
-        "can_access_forms": is_super_admin or _has_permission("can_access_forms"),
-        "can_manage_assets": is_super_admin or _has_permission("can_manage_assets"),
-        "can_manage_licenses": is_super_admin or _has_permission("can_manage_licenses"),
-        "can_manage_invoices": is_super_admin or _has_permission("can_manage_invoices"),
+        "can_access_orders": _menu_can(menu_access, "menu.orders") or is_super_admin or _has_permission("can_access_orders"),
+        "can_access_quotes": _menu_can(menu_access, "menu.quotes") or is_super_admin or _has_permission("can_access_quotes"),
+        "can_access_forms": _menu_can(menu_access, "menu.forms") or is_super_admin or _has_permission("can_access_forms"),
+        "can_manage_assets": _menu_can(menu_access, "menu.assets", write=True) or is_super_admin or _has_permission("can_manage_assets"),
+        "can_manage_licenses": _menu_can(menu_access, "menu.m365.licenses", write=True) or is_super_admin or _has_permission("can_manage_licenses"),
+        "can_manage_invoices": _menu_can(menu_access, "menu.invoices", write=True) or is_super_admin or _has_permission("can_manage_invoices"),
         "can_manage_staff": (
             is_super_admin
             or _has_permission("can_manage_staff")
             or staff_permission_level > 0
         ),
-        "can_manage_issues": has_issue_tracker_access,
-        "can_view_compliance": is_super_admin or _has_permission("can_view_compliance"),
-        "can_view_bcp": can_view_bcp,
+        "can_manage_issues": _menu_can(menu_access, "menu.issues", write=True) or has_issue_tracker_access,
+        "can_view_compliance": _menu_can(menu_access, "menu.compliance") or is_super_admin or _has_permission("can_view_compliance"),
+        "can_view_bcp": _menu_can(menu_access, "menu.continuity") or can_view_bcp,
         "can_edit_bcp": can_edit_bcp,
-        "can_view_m365_best_practices": is_super_admin or _has_permission("can_view_m365_best_practices"),
-        "can_view_compliance_checks": is_super_admin or _has_permission("can_view_compliance_checks"),
-        "can_manage_compliance_checks": is_super_admin or _has_permission("can_manage_compliance_checks"),
-        "can_view_m365_user_mailboxes": is_super_admin or _has_permission("can_view_m365_user_mailboxes"),
-        "can_view_m365_shared_mailboxes": is_super_admin or _has_permission("can_view_m365_shared_mailboxes"),
-        "can_access_chat": is_super_admin or _has_permission("can_access_chat"),
-        "can_access_marketing": has_marketing_access,
+        "can_view_m365_best_practices": _menu_can(menu_access, "menu.m365.best_practices") or is_super_admin or _has_permission("can_view_m365_best_practices"),
+        "can_view_compliance_checks": _menu_can(menu_access, "menu.compliance_checks") or is_super_admin or _has_permission("can_view_compliance_checks"),
+        "can_manage_compliance_checks": _menu_can(menu_access, "menu.compliance_checks.library", write=True) or is_super_admin or _has_permission("can_manage_compliance_checks"),
+        "can_view_m365_user_mailboxes": _menu_can(menu_access, "menu.m365.user_mailboxes") or is_super_admin or _has_permission("can_view_m365_user_mailboxes"),
+        "can_view_m365_shared_mailboxes": _menu_can(menu_access, "menu.m365.shared_mailboxes") or is_super_admin or _has_permission("can_view_m365_shared_mailboxes"),
+        "can_access_chat": _menu_can(menu_access, "menu.chat") or is_super_admin or _has_permission("can_access_chat"),
+        "can_access_marketing": _menu_can(menu_access, "menu.marketing") or has_marketing_access,
+        "can_manage_subscriptions": _menu_can(menu_access, "menu.subscriptions", write=True),
+        "can_access_reports": _menu_can(menu_access, "menu.reports"),
+        "can_access_reporting": _menu_can(menu_access, "menu.reporting"),
+        "menu_access": menu_access,
+        "menu_permission_catalogue": catalogue_for_api(),
     }
 
     module_lookup = getattr(request.state, "module_lookup", None)
@@ -1913,7 +2008,7 @@ async def _build_base_context(
         "impersonator_user": impersonator_user,
         "impersonation_started_at": impersonation_started_at,
         "has_issue_tracker_access": has_issue_tracker_access,
-        "can_access_tickets": True,
+        "can_access_tickets": _menu_can(menu_access, "menu.tickets"),
         "plausible_config": plausible_config,
     }
     context.update(permission_flags)
@@ -2106,7 +2201,9 @@ async def _load_license_context(
     membership = await user_company_repo.get_user_company(user["id"], company_id)
     can_manage = bool(membership and membership.get("can_manage_licenses"))
     can_order = bool(membership and membership.get("can_order_licenses"))
-    if require_manage and not (is_super_admin or can_manage):
+    can_view_licenses = _membership_menu_can(user, membership, "menu.m365.licenses")
+    can_write_licenses = _membership_menu_can(user, membership, "menu.m365.licenses", write=True)
+    if require_manage and not (is_super_admin or can_manage or can_view_licenses):
         return (
             user,
             membership,
@@ -2114,7 +2211,7 @@ async def _load_license_context(
             company_id,
             RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER),
         )
-    if require_order and not (is_super_admin or can_order):
+    if require_order and not (is_super_admin or can_order or can_write_licenses):
         return (
             user,
             membership,
@@ -2936,6 +3033,8 @@ async def m365_page(request: Request):
     user, membership, company, company_id, redirect = await _load_license_context(request)
     if redirect:
         return redirect
+    if not _membership_menu_can(user, membership, "menu.m365.configuration"):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Office 365 configuration access required")
     credentials = await m365_service.get_credentials(company_id)
     credential_view = None
     if credentials:
@@ -3271,10 +3370,12 @@ async def _load_m365_mailbox_context(request: Request, *, mailbox_permission: st
     except (TypeError, ValueError) as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid company identifier") from exc
     membership = await user_company_repo.get_user_company(user["id"], company_id)
+    mailbox_menu_key = "menu.m365.user_mailboxes" if mailbox_permission == "can_view_m365_user_mailboxes" else "menu.m365.shared_mailboxes"
     can_access = bool(
         is_super_admin
         or (membership and membership.get("can_manage_licenses"))
         or (membership and membership.get(mailbox_permission))
+        or _membership_menu_can(user, membership, mailbox_menu_key)
     )
     if not can_access:
         return (
@@ -3362,8 +3463,12 @@ async def enable_m365_user_archive(request: Request):
     user, membership, company, company_id, redirect = await _load_license_context(request)
     if redirect:
         return JSONResponse({"error": "Authentication required"}, status_code=401)
-    if not user.get("is_super_admin"):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Super admin privileges required")
+    if not (
+        user.get("is_super_admin")
+        or _membership_menu_can(user, membership, "menu.m365.user_mailboxes", write=True)
+        or _membership_menu_can(user, membership, "menu.m365.shared_mailboxes", write=True)
+    ):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Mailbox read/write permission required")
 
     try:
         body = await request.json()
@@ -5137,6 +5242,7 @@ async def admin_roles(request: Request):
     extra = {
         "title": "Role management",
         "roles": roles_list,
+        "menu_permission_catalogue": catalogue_for_api(),
     }
     return await _render_template("admin/roles.html", request, current_user, extra=extra)
 

--- a/app/repositories/roles.py
+++ b/app/repositories/roles.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 from app.core.database import db
+from app.security.menu_permissions import compact_menu_permissions, menu_permissions_to_legacy
 
 
 async def list_roles() -> list[dict[str, Any]]:
@@ -26,7 +27,7 @@ async def get_role_by_name(name: str) -> Optional[dict[str, Any]]:
     return _normalise(row)
 
 
-async def create_role(*, name: str, description: str | None = None, permissions: list[str] | None = None, is_system: bool = False) -> dict[str, Any]:
+async def create_role(*, name: str, description: str | None = None, permissions: Any | None = None, is_system: bool = False) -> dict[str, Any]:
     now = datetime.utcnow()
     await db.execute(
         """
@@ -36,7 +37,7 @@ async def create_role(*, name: str, description: str | None = None, permissions:
         (
             name,
             description,
-            json.dumps(permissions or []),
+            json.dumps(compact_menu_permissions(permissions or {})),
             1 if is_system else 0,
             now,
             now,
@@ -58,7 +59,7 @@ async def update_role(role_id: int, **updates: Any) -> dict[str, Any]:
     params: list[Any] = []
     for column, value in updates.items():
         if column == "permissions" and value is not None:
-            value = json.dumps(value)
+            value = json.dumps(compact_menu_permissions(value))
         columns.append(f"{column} = %s")
         params.append(value)
     columns.append("updated_at = %s")
@@ -80,13 +81,16 @@ def _normalise(row: dict[str, Any]) -> dict[str, Any]:
     permissions_raw = row.get("permissions")
     if isinstance(permissions_raw, str):
         try:
-            permissions = json.loads(permissions_raw)
+            decoded_permissions = json.loads(permissions_raw)
         except json.JSONDecodeError:
-            permissions = []
+            decoded_permissions = {}
     else:
-        permissions = permissions_raw or []
+        decoded_permissions = permissions_raw or {}
+    permissions = compact_menu_permissions(decoded_permissions)
     return {
         **row,
         "permissions": permissions,
+        "menu_permissions": permissions,
+        "legacy_permissions": menu_permissions_to_legacy(permissions),
         "is_system": bool(row.get("is_system", 0)),
     }

--- a/app/repositories/user_companies.py
+++ b/app/repositories/user_companies.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional
 from app.core.database import db
 from app.repositories import company_memberships as membership_repo
 from app.repositories import roles as role_repo
+from app.security.menu_permissions import menu_has_access, menu_permissions_to_legacy, normalize_menu_permissions
 
 _BOOLEAN_FIELDS = {
     "can_manage_licenses",
@@ -89,19 +90,22 @@ def _enrich_with_role_permissions(data: dict[str, Any], role_permissions_raw: An
         return
     
     try:
-        role_permissions = json.loads(role_permissions_raw) if isinstance(role_permissions_raw, str) else role_permissions_raw or []
+        role_permissions = json.loads(role_permissions_raw) if isinstance(role_permissions_raw, str) else role_permissions_raw or {}
     except json.JSONDecodeError:
-        role_permissions = []
-    
-    # Update boolean fields based on role permissions
-    # Role permissions override legacy boolean fields
+        role_permissions = {}
+
+    menu_permissions = normalize_menu_permissions(role_permissions)
+    legacy_permissions = set(menu_permissions_to_legacy(menu_permissions))
+    data["menu_permissions"] = menu_permissions
+
+    # Update boolean fields based on role permissions. Role permissions override legacy fields.
     for role_perm, field_name in _PERMISSION_MAPPING.items():
-        if role_perm in role_permissions:
+        if role_perm in legacy_permissions:
             data[field_name] = True
         elif field_name in _PERMISSION_FIELDS:
-            # If the role doesn't have this permission, explicitly set to False
-            # This ensures role-based permissions override legacy settings
             data[field_name] = False
+
+    data["can_access_quotes"] = menu_has_access(menu_permissions, "menu.quotes")
 
 
 def _normalise(row: dict[str, Any]) -> dict[str, Any]:

--- a/app/schemas/roles.py
+++ b/app/schemas/roles.py
@@ -1,14 +1,44 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from app.security.menu_permissions import MENU_PERMISSION_MAP, compact_menu_permissions
+
+
+def _validate_permission_keys(value: Any) -> None:
+    if isinstance(value, dict):
+        source = value.get("menu") if isinstance(value.get("menu"), dict) else value
+        ignored = {"legacy", "permissions"}
+        unknown = [key for key in source if key not in MENU_PERMISSION_MAP and key not in ignored]
+        if unknown:
+            raise ValueError(f"Unknown menu permission key(s): {', '.join(sorted(map(str, unknown)))}")
 
 
 class RoleBase(BaseModel):
     name: str = Field(..., min_length=2, max_length=100)
     description: Optional[str] = None
-    permissions: list[str] = Field(default_factory=list)
+    permissions: dict[str, str] | list[str] = Field(
+        default_factory=dict,
+        description=(
+            "Tri-state menu permissions keyed by menu permission id. "
+            "Allowed levels are none, read, and write. Legacy string lists are accepted for compatibility."
+        ),
+        examples=[
+            {
+                "menu.m365.configuration": "none",
+                "menu.m365.user_mailboxes": "read",
+                "menu.subscriptions": "write",
+            }
+        ],
+    )
+
+    @field_validator("permissions")
+    @classmethod
+    def validate_permissions(cls, value: Any) -> dict[str, str]:
+        _validate_permission_keys(value)
+        return compact_menu_permissions(value)
 
 
 class RoleCreate(RoleBase):
@@ -18,12 +48,36 @@ class RoleCreate(RoleBase):
 class RoleUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=2, max_length=100)
     description: Optional[str] = None
-    permissions: Optional[list[str]] = None
+    permissions: Optional[dict[str, str] | list[str]] = Field(
+        default=None,
+        description="Tri-state menu permission updates. Use none, read, or write for each supplied menu key.",
+    )
+
+    @field_validator("permissions")
+    @classmethod
+    def validate_permissions(cls, value: Any) -> dict[str, str] | None:
+        if value is None:
+            return None
+        _validate_permission_keys(value)
+        return compact_menu_permissions(value)
+
+
+class MenuPermissionResponse(BaseModel):
+    key: str
+    label: str
+    group: str
+    description: str
+    legacy_permissions: list[str] = Field(default_factory=list)
+    legacy_boolean: Optional[str] = None
+    admin_only: bool = False
+    levels: list[str] = Field(default_factory=lambda: ["none", "read", "write"])
 
 
 class RoleResponse(RoleBase):
     id: int
     is_system: bool = False
+    menu_permissions: dict[str, str] = Field(default_factory=dict)
+    legacy_permissions: list[str] = Field(default_factory=list)
 
     class Config:
         from_attributes = True

--- a/app/security/menu_permissions.py
+++ b/app/security/menu_permissions.py
@@ -1,0 +1,163 @@
+"""Tri-state menu permission catalogue and compatibility helpers."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal
+
+AccessLevel = Literal["none", "read", "write"]
+ACCESS_LEVELS: tuple[AccessLevel, ...] = ("none", "read", "write")
+
+
+@dataclass(frozen=True)
+class MenuPermission:
+    key: str
+    label: str
+    group: str
+    description: str
+    legacy_permissions: tuple[str, ...] = ()
+    legacy_boolean: str | None = None
+    admin_only: bool = False
+
+
+MENU_PERMISSIONS: tuple[MenuPermission, ...] = (
+    MenuPermission("menu.dashboard", "Dashboard", "General", "View the company dashboard and overview."),
+    MenuPermission("menu.service_status", "Service status", "General", "View service status dashboards."),
+    MenuPermission("menu.notifications", "Notifications", "General", "View and manage notification settings.", admin_only=True),
+    MenuPermission("menu.knowledge_base", "Knowledge base", "General", "View knowledge base articles."),
+    MenuPermission("menu.help", "Help", "General", "View help and support documentation."),
+    MenuPermission("menu.chat", "Chat", "General", "Access the chat interface.", ("chat.access",), "can_access_chat"),
+    MenuPermission("menu.tickets", "Tickets", "Company", "View tickets; write access allows ticket actions.", ("helpdesk.technician",), None),
+    MenuPermission("menu.issues", "Issue tracker", "Company", "View or manage issue tracker items.", ("issues.manage",), "can_manage_issues"),
+    MenuPermission("menu.marketing", "Marketing", "Company", "View or manage marketing pages and contacts.", ("marketing.access",), None),
+    MenuPermission("menu.shop", "Shop", "Commerce", "Browse shop products; write access allows cart actions.", ("shop.access",), "can_access_shop"),
+    MenuPermission("menu.quotes", "Quotes", "Commerce", "View quotes; write access allows quote actions.", (), "can_access_quotes"),
+    MenuPermission("menu.orders", "Orders", "Commerce", "View orders; write access allows order actions.", ("orders.access",), "can_access_orders"),
+    MenuPermission("menu.forms", "Forms", "Company", "View forms; write access allows submissions.", ("forms.access",), "can_access_forms"),
+    MenuPermission("menu.assets", "Assets", "Company", "View assets; write access allows asset changes.", ("assets.manage",), "can_manage_assets"),
+    MenuPermission("menu.m365.configuration", "Office 365 Configuration", "Office 365", "View or manage Microsoft 365 tenant configuration.", ("licenses.manage",), "can_manage_licenses"),
+    MenuPermission("menu.m365.best_practices", "Office 365 Best Practices", "Office 365", "View or run Microsoft 365 best-practice checks.", ("m365_best_practices.access",), "can_view_m365_best_practices"),
+    MenuPermission("menu.m365.user_mailboxes", "User Mailboxes", "Office 365", "View user mailboxes; write access allows mailbox actions.", ("m365_user_mailboxes.access",), "can_view_m365_user_mailboxes"),
+    MenuPermission("menu.m365.shared_mailboxes", "Shared Mailboxes", "Office 365", "View shared mailboxes; write access allows mailbox actions.", ("m365_shared_mailboxes.access",), "can_view_m365_shared_mailboxes"),
+    MenuPermission("menu.m365.licenses", "Licenses", "Office 365", "View licenses; write access allows license changes.", ("licenses.manage", "licenses.order"), "can_manage_licenses"),
+    MenuPermission("menu.m365.diagnostics", "Office 365 Diagnostics", "Office 365", "View or repair Microsoft 365 diagnostics.", admin_only=True),
+    MenuPermission("menu.subscriptions", "Subscriptions", "Commerce", "View subscriptions; write access allows subscription change/order actions.", ("billing.manage", "licenses.manage", "cart.access"), None),
+    MenuPermission("menu.invoices", "Invoices", "Commerce", "View invoices; write access allows invoice management.", ("billing.manage", "invoices.manage"), "can_manage_invoices"),
+    MenuPermission("menu.staff", "Staff", "Company", "View staff; write access allows staff management.", ("staff.manage",), "can_manage_staff"),
+    MenuPermission("menu.compliance", "Compliance", "Compliance", "View or manage Essential 8 compliance.", ("compliance.access",), "can_view_compliance"),
+    MenuPermission("menu.reports", "Reports", "Reporting", "View generated company reports."),
+    MenuPermission("menu.reporting", "Reporting", "Reporting", "View or build reporting dashboards.", ("helpdesk.technician",), None),
+    MenuPermission("menu.compliance_checks", "Compliance Checks", "Compliance", "View assigned compliance checks.", ("compliance_checks.access",), "can_view_compliance_checks"),
+    MenuPermission("menu.compliance_checks.library", "Compliance Checks Library", "Compliance", "Manage compliance check library items.", ("compliance_checks.manage",), "can_manage_compliance_checks", admin_only=True),
+    MenuPermission("menu.continuity", "Continuity", "Compliance", "View or manage business continuity plans.", ("continuity.access", "bcp:view", "bcp:edit"), "can_view_bcp"),
+    MenuPermission("menu.admin.profile", "My Profile", "Administration", "View and update the user's administration profile."),
+    MenuPermission("menu.admin.impersonation", "Impersonation", "Administration", "Access impersonation administration.", admin_only=True),
+    MenuPermission("menu.admin.call_recordings", "Call Recordings", "Administration", "Access call recordings administration.", admin_only=True),
+    MenuPermission("menu.admin.scheduled_tasks", "Scheduled Tasks", "Administration", "Access scheduled task administration.", admin_only=True),
+    MenuPermission("menu.admin.backup_history", "Backup History", "Administration", "Access backup history.", admin_only=True),
+    MenuPermission("menu.admin.backup_summary", "Backup Summary", "Administration", "Access backup summary.", admin_only=True),
+    MenuPermission("menu.admin.message_templates", "Message Templates", "Administration", "Manage message templates.", admin_only=True),
+    MenuPermission("menu.admin.webhooks", "Webhooks", "Administration", "Monitor and manage webhooks.", admin_only=True),
+    MenuPermission("menu.admin.api_keys", "API Keys", "Administration", "Manage API keys.", admin_only=True),
+    MenuPermission("menu.admin.modules", "Modules", "Administration", "Manage integration modules.", admin_only=True),
+    MenuPermission("menu.admin.feature_packs", "Feature Packs", "Administration", "Manage feature packs.", admin_only=True),
+    MenuPermission("menu.admin.roles", "Roles", "Administration", "Manage roles and permissions.", admin_only=True),
+    MenuPermission("menu.admin.change_log", "Change Log", "Administration", "View application change logs.", admin_only=True),
+    MenuPermission("menu.admin.audit_trail", "Audit Trail", "Administration", "View audit logs.", ("audit.view",), None, True),
+    MenuPermission("menu.admin.company", "Company admin", "Administration", "Manage company administration settings.", ("company.admin", "company.manage", "membership.manage"), "is_admin"),
+)
+
+MENU_PERMISSION_MAP = {item.key: item for item in MENU_PERMISSIONS}
+LEGACY_TO_MENU: dict[str, list[tuple[str, AccessLevel]]] = {}
+for item in MENU_PERMISSIONS:
+    for legacy in item.legacy_permissions:
+        level: AccessLevel = "write" if any(part in legacy for part in ("manage", "order", "admin", "edit")) else "read"
+        LEGACY_TO_MENU.setdefault(legacy, []).append((item.key, level))
+
+
+def catalogue_for_api() -> list[dict[str, Any]]:
+    return [asdict(item) | {"levels": list(ACCESS_LEVELS)} for item in MENU_PERMISSIONS]
+
+
+def normalize_access_level(value: Any) -> AccessLevel:
+    value_str = str(value or "none").strip().lower().replace("-", "_")
+    aliases = {
+        "no_access": "none",
+        "no access": "none",
+        "readonly": "read",
+        "read_only": "read",
+        "read only": "read",
+        "read/write": "write",
+        "read_write": "write",
+        "read write": "write",
+        "rw": "write",
+    }
+    value_str = aliases.get(value_str, value_str)
+    if value_str not in ACCESS_LEVELS:
+        raise ValueError(f"Invalid menu permission level: {value}")
+    return value_str  # type: ignore[return-value]
+
+
+def merge_access(existing: AccessLevel, new: AccessLevel) -> AccessLevel:
+    rank = {"none": 0, "read": 1, "write": 2}
+    return new if rank[new] > rank[existing] else existing
+
+
+def normalize_menu_permissions(raw: Any) -> dict[str, AccessLevel]:
+    """Normalize dict or legacy list permissions into a full menu permission map."""
+    normalized: dict[str, AccessLevel] = {item.key: "none" for item in MENU_PERMISSIONS}
+    if not raw:
+        return normalized
+
+    if isinstance(raw, dict):
+        source = raw.get("menu") if isinstance(raw.get("menu"), dict) else raw
+        for key, value in source.items():
+            if key in MENU_PERMISSION_MAP:
+                normalized[key] = normalize_access_level(value)
+        # Also accept a legacy list nested under permissions for compatibility.
+        legacy = raw.get("legacy") or raw.get("permissions")
+        if isinstance(legacy, list):
+            legacy_map = normalize_menu_permissions(legacy)
+            for key, level in legacy_map.items():
+                normalized[key] = merge_access(normalized[key], level)
+        return normalized
+
+    if isinstance(raw, list):
+        for permission in raw:
+            if not isinstance(permission, str):
+                continue
+            if permission in MENU_PERMISSION_MAP:
+                normalized[permission] = merge_access(normalized[permission], "write")
+                continue
+            mapped_items = LEGACY_TO_MENU.get(permission, [])
+            for key, level in mapped_items:
+                normalized[key] = merge_access(normalized[key], level)
+        return normalized
+
+    return normalized
+
+
+def compact_menu_permissions(raw: Any) -> dict[str, AccessLevel]:
+    return {key: level for key, level in normalize_menu_permissions(raw).items() if level != "none"}
+
+
+def menu_permissions_to_legacy(menu_permissions: Any) -> list[str]:
+    normalized = normalize_menu_permissions(menu_permissions)
+    legacy: set[str] = set()
+    for item in MENU_PERMISSIONS:
+        level = normalized.get(item.key, "none")
+        if level == "none":
+            continue
+        if item.legacy_permissions:
+            if level == "write":
+                legacy.update(item.legacy_permissions)
+            else:
+                legacy.update(p for p in item.legacy_permissions if not any(part in p for part in ("manage", "order", "admin", "edit")))
+    return sorted(legacy)
+
+
+def menu_has_access(menu_access: dict[str, Any] | None, key: str, *, write: bool = False) -> bool:
+    if not menu_access:
+        return False
+    level = normalize_access_level(menu_access.get(key, "none"))
+    return level == "write" if write else level in {"read", "write"}

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10117,3 +10117,43 @@ a.stat-strip__stat:focus-visible {
     grid-template-columns: 1fr;
   }
 }
+
+.permissions-table-wrapper {
+  max-height: min(58vh, 42rem);
+  overflow: auto;
+}
+
+.permissions-table code {
+  display: inline-block;
+  margin-top: 0.35rem;
+  color: var(--color-text-muted, #64748b);
+  font-size: 0.8rem;
+}
+
+.permission-level {
+  display: grid;
+  gap: 0.4rem;
+  min-width: 16rem;
+}
+
+.permission-level label {
+  align-items: center;
+  border: 1px solid var(--color-border, #d8dee8);
+  border-radius: 999px;
+  cursor: pointer;
+  display: flex;
+  gap: 0.45rem;
+  padding: 0.35rem 0.65rem;
+}
+
+.permission-level label:has(input:checked) {
+  background: var(--color-primary-soft, #e8f1ff);
+  border-color: var(--color-primary, #2563eb);
+  color: var(--color-primary-strong, #1d4ed8);
+}
+
+@media (min-width: 52rem) {
+  .permission-level {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1438,18 +1438,73 @@
     const idField = form.querySelector('#role-id');
     const nameField = form.querySelector('#role-name');
     const descriptionField = form.querySelector('#role-description');
-    const permissionCheckboxes = form.querySelectorAll('[data-permission-checkbox]');
+    const permissionInputs = form.querySelectorAll('[data-permission-level]');
 
     function getSelectedPermissions() {
-      return Array.from(permissionCheckboxes)
-        .filter((checkbox) => checkbox.checked)
-        .map((checkbox) => checkbox.value);
+      const permissions = {};
+      permissionInputs.forEach((input) => {
+        if (!(input instanceof HTMLInputElement) || !input.checked) {
+          return;
+        }
+        const key = input.getAttribute('data-permission-key');
+        const level = input.value;
+        if (key && level && level !== 'none') {
+          permissions[key] = level;
+        }
+      });
+      return permissions;
+    }
+
+    function normalizePermissions(permissions) {
+      if (!permissions) {
+        return {};
+      }
+      if (Array.isArray(permissions)) {
+        const legacyMap = {
+          'chat.access': ['menu.chat', 'read'],
+          'helpdesk.technician': ['menu.tickets', 'write'],
+          'marketing.access': ['menu.marketing', 'write'],
+          'shop.access': ['menu.shop', 'read'],
+          'orders.access': ['menu.orders', 'read'],
+          'forms.access': ['menu.forms', 'read'],
+          'assets.manage': ['menu.assets', 'write'],
+          'licenses.manage': ['menu.m365.licenses', 'write'],
+          'licenses.order': ['menu.m365.licenses', 'write'],
+          'invoices.manage': ['menu.invoices', 'write'],
+          'staff.manage': ['menu.staff', 'write'],
+          'issues.manage': ['menu.issues', 'write'],
+          'compliance.access': ['menu.compliance', 'read'],
+          'continuity.access': ['menu.continuity', 'read'],
+          'compliance_checks.access': ['menu.compliance_checks', 'read'],
+          'compliance_checks.manage': ['menu.compliance_checks.library', 'write'],
+          'm365_best_practices.access': ['menu.m365.best_practices', 'read'],
+          'm365_user_mailboxes.access': ['menu.m365.user_mailboxes', 'read'],
+          'm365_shared_mailboxes.access': ['menu.m365.shared_mailboxes', 'read'],
+          'company.admin': ['menu.admin.company', 'write'],
+        };
+        return permissions.reduce((acc, permission) => {
+          const mapped = legacyMap[permission];
+          if (mapped) {
+            acc[mapped[0]] = mapped[1];
+          }
+          return acc;
+        }, {});
+      }
+      if (typeof permissions === 'object') {
+        return permissions.menu && typeof permissions.menu === 'object' ? permissions.menu : permissions;
+      }
+      return {};
     }
 
     function setSelectedPermissions(permissions) {
-      const permissionSet = new Set(Array.isArray(permissions) ? permissions : []);
-      permissionCheckboxes.forEach((checkbox) => {
-        checkbox.checked = permissionSet.has(checkbox.value);
+      const permissionMap = normalizePermissions(permissions);
+      permissionInputs.forEach((input) => {
+        if (!(input instanceof HTMLInputElement)) {
+          return;
+        }
+        const key = input.getAttribute('data-permission-key');
+        const expectedLevel = key ? permissionMap[key] || 'none' : 'none';
+        input.checked = input.value === expectedLevel;
       });
     }
 
@@ -1477,7 +1532,7 @@
         idField.value = '';
         nameField.value = '';
         descriptionField.value = '';
-        setSelectedPermissions([]);
+        setSelectedPermissions({});
         nameField.focus();
       });
     }
@@ -1492,10 +1547,10 @@
         nameField.value = row.dataset.roleName || '';
         descriptionField.value = row.dataset.roleDescription || '';
         try {
-          const permissions = JSON.parse(row.dataset.rolePermissions || '[]');
+          const permissions = JSON.parse(row.dataset.rolePermissions || '{}');
           setSelectedPermissions(permissions);
         } catch (error) {
-          setSelectedPermissions([]);
+          setSelectedPermissions({});
         }
         nameField.focus();
       });

--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -39,8 +39,8 @@
               <td data-label="Permissions" data-column-key="permissions">
                 {% if role.permissions %}
                   <span class="tag-list">
-                    {% for perm in role.permissions %}
-                      <span class="tag">{{ perm }}</span>
+                    {% for perm, level in role.permissions.items() %}
+                      <span class="tag">{{ perm }}: {{ 'Read/Write' if level == 'write' else 'Read Only' }}</span>
                     {% endfor %}
                   </span>
                 {% else %}
@@ -85,145 +85,47 @@
         <textarea class="form-input form-input--textarea" id="role-description" name="description" rows="3"></textarea>
       </div>
       <div class="form-field">
-        <label class="form-label">Permissions</label>
-        <div class="form-checkboxes form-checkboxes--grid" id="role-permissions-group" role="group" aria-describedby="role-permissions-help">
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="company.manage" data-permission-checkbox />
-            <span>Company Management</span>
-            <span class="form-help">Configure company profiles, contact details, and operational settings</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="membership.manage" data-permission-checkbox />
-            <span>Membership Management</span>
-            <span class="form-help">Invite, approve, suspend, or reassign company members</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="billing.manage" data-permission-checkbox />
-            <span>Billing Management</span>
-            <span class="form-help">Access subscription, invoicing, and payment methods</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="audit.view" data-permission-checkbox />
-            <span>Audit View</span>
-            <span class="form-help">Read-only visibility into security and activity audit trails</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="portal.access" data-permission-checkbox />
-            <span>Portal Access</span>
-            <span class="form-help">Sign in and use the general portal experience</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="helpdesk.technician" data-permission-checkbox />
-            <span>Helpdesk Technician</span>
-            <span class="form-help">Access the global ticketing workspace to triage, assign, and update tickets</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="marketing.access" data-permission-checkbox />
-            <span>Marketing Access</span>
-            <span class="form-help">Access marketing page administration and collected marketing contacts</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="licenses.manage" data-permission-checkbox />
-            <span>Manage Licenses</span>
-            <span class="form-help">Manage company licenses and subscriptions</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="licenses.order" data-permission-checkbox />
-            <span>Order Licenses</span>
-            <span class="form-help">Place orders for new licenses</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="staff.manage" data-permission-checkbox />
-            <span>Manage Staff</span>
-            <span class="form-help">Manage company staff members</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="shop.access" data-permission-checkbox />
-            <span>Shop Access</span>
-            <span class="form-help">Access the company shop</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="cart.access" data-permission-checkbox />
-            <span>Cart Access</span>
-            <span class="form-help">Access and manage shopping cart</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="orders.access" data-permission-checkbox />
-            <span>Orders Access</span>
-            <span class="form-help">View and manage company orders</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="forms.access" data-permission-checkbox />
-            <span>Forms Access</span>
-            <span class="form-help">Access and submit company forms</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="assets.manage" data-permission-checkbox />
-            <span>Manage Assets</span>
-            <span class="form-help">Manage company assets and inventory</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="invoices.manage" data-permission-checkbox />
-            <span>Manage Invoices</span>
-            <span class="form-help">View and manage company invoices</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="office_groups.manage" data-permission-checkbox />
-            <span>Manage Office Groups</span>
-            <span class="form-help">Manage company office groups and locations</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="issues.manage" data-permission-checkbox />
-            <span>Manage Issues</span>
-            <span class="form-help">Manage company issues and support tickets</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="company.admin" data-permission-checkbox />
-            <span>Company Administrator</span>
-            <span class="form-help">Full administrative access to company resources</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="compliance.access" data-permission-checkbox />
-            <span>Compliance Access</span>
-            <span class="form-help">Access to view and manage compliance requirements</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="continuity.access" data-permission-checkbox />
-            <span>Continuity Access</span>
-            <span class="form-help">Access to view and manage business continuity plans</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="compliance_checks.access" data-permission-checkbox />
-            <span>Compliance Checks Access</span>
-            <span class="form-help">View compliance check results and assigned checks (separate from Essential 8 Compliance)</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="compliance_checks.manage" data-permission-checkbox />
-            <span>Compliance Checks Manage</span>
-            <span class="form-help">Create, update, and delete compliance check items and assignments</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="m365_best_practices.access" data-permission-checkbox />
-            <span>Office 365 Best Practice</span>
-            <span class="form-help">View and run Microsoft 365 best practice checks and remediation</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="m365_user_mailboxes.access" data-permission-checkbox />
-            <span>Office 365 User Mailboxes</span>
-            <span class="form-help">View and manage user mailboxes in Microsoft 365</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="m365_shared_mailboxes.access" data-permission-checkbox />
-            <span>Office 365 Shared Mailboxes</span>
-            <span class="form-help">View and manage shared mailboxes in Microsoft 365</span>
-          </label>
-          <label class="form-checkbox">
-            <input type="checkbox" name="permission" value="chat.access" data-permission-checkbox />
-            <span>Chat Access</span>
-            <span class="form-help">Access the chat interface to view and participate in conversations</span>
-          </label>
+        <label class="form-label">Menu permissions</label>
+        <div class="table-wrapper permissions-table-wrapper">
+          <table class="table permissions-table" data-table data-table-id="role-menu-permissions">
+            <thead>
+              <tr>
+                <th scope="col" data-sort="string">Menu item</th>
+                <th scope="col" data-sort="string">Group</th>
+                <th scope="col">Access level</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for permission in menu_permission_catalogue %}
+                <tr>
+                  <td data-label="Menu item">
+                    <strong>{{ permission.label }}</strong>
+                    <span class="form-help">{{ permission.description }}</span>
+                    <code>{{ permission.key }}</code>
+                  </td>
+                  <td data-label="Group">{{ permission.group }}</td>
+                  <td data-label="Access level">
+                    <div class="permission-level" role="radiogroup" aria-label="{{ permission.label }} access level">
+                      <label>
+                        <input type="radio" name="permission_level_{{ loop.index }}" value="none" data-permission-level data-permission-key="{{ permission.key }}" checked />
+                        <span>No Access</span>
+                      </label>
+                      <label>
+                        <input type="radio" name="permission_level_{{ loop.index }}" value="read" data-permission-level data-permission-key="{{ permission.key }}" />
+                        <span>Read Only</span>
+                      </label>
+                      <label>
+                        <input type="radio" name="permission_level_{{ loop.index }}" value="write" data-permission-level data-permission-key="{{ permission.key }}" />
+                        <span>Read/Write</span>
+                      </label>
+                    </div>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
         </div>
-        <p class="form-help" id="role-permissions-help">Select the permissions to assign to this role.</p>
+        <p class="form-help" id="role-permissions-help">Choose No Access to hide a menu and block direct access, Read Only to view information without actions, or Read/Write to allow permitted actions.</p>
       </div>
       <div class="form-actions">
         <button type="submit" class="button">Save role</button>
@@ -262,74 +164,20 @@
         review the menu to confirm roles still match business needs, and document significant adjustments in your
         compliance records.
       </p>
-      <h3>Assignable permissions</h3>
+      <h3>Assignable menu permissions</h3>
       <p>
-        Roles can draw from the following permission catalogue. Combine only the capabilities required for each persona to
-        maintain least-privilege access.
+        Every left-menu item is available in the permission catalogue with three levels: <strong>No Access</strong>,
+        <strong>Read Only</strong>, and <strong>Read/Write</strong>. Use Read Only for mailbox visibility without
+        mailbox actions, and No Access to hide sensitive menus such as Office 365 configuration.
       </p>
       <dl class="definition-list">
+        {% for permission in menu_permission_catalogue %}
         <div class="definition-list__item">
-          <dt><code>company.manage</code></dt>
-          <dd>Grant authority to configure company profiles, contact details, and operational settings.</dd>
+          <dt><code>{{ permission.key }}</code></dt>
+          <dd>{{ permission.label }} — {{ permission.description }}</dd>
         </div>
-        <div class="definition-list__item">
-          <dt><code>membership.manage</code></dt>
-          <dd>Allow administrators to invite, approve, suspend, or reassign company members.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>billing.manage</code></dt>
-          <dd>Enable access to subscription, invoicing, and payment method management workflows.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>audit.view</code></dt>
-          <dd>Provide read-only visibility into security and activity audit trails.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>portal.access</code></dt>
-          <dd>Permit authenticated users to sign in and use the general portal experience.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>helpdesk.technician</code></dt>
-          <dd>Grant designated staff access to the global ticketing workspace so they can triage, assign, and update tickets without broader administrative privileges.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>marketing.access</code></dt>
-          <dd>Allow designated technicians to manage marketing landing pages and review submitted marketing contacts.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>compliance.access</code></dt>
-          <dd>Provide access to view and manage compliance requirements and essential 8 assessments.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>continuity.access</code></dt>
-          <dd>Provide access to view and manage business continuity plans and related documentation.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>compliance_checks.access</code></dt>
-          <dd>Allow members to view compliance check results and assigned checks. This is separate from the Essential 8 Compliance permission.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>compliance_checks.manage</code></dt>
-          <dd>Grant authority to create, update, and delete compliance check items and assignments.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>m365_best_practices.access</code></dt>
-          <dd>Allow members to view and run Microsoft 365 best practice checks and remediation actions.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>m365_user_mailboxes.access</code></dt>
-          <dd>Allow members to view and manage user mailboxes in the connected Microsoft 365 tenant.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>m365_shared_mailboxes.access</code></dt>
-          <dd>Allow members to view and manage shared mailboxes in the connected Microsoft 365 tenant.</dd>
-        </div>
-        <div class="definition-list__item">
-          <dt><code>chat.access</code></dt>
-          <dd>Permit members to access the chat interface and participate in conversations.</dd>
-        </div>
+        {% endfor %}
       </dl>
-      <p class="text-muted">New permissions will be documented here as they become available.</p>
       </div>
     </div>
   </details>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -103,30 +103,44 @@
           {% block sidebar_menu %}
           {% set current_path = request.url.path if request is defined else '' %}
           {% set membership = active_membership or {} %}
+          {% set menu_access = menu_access | default({}) %}
           {% set is_super_admin = is_super_admin | default(current_user.get('is_super_admin') if current_user else False) %}
           {% set staff_permission = staff_permission | default(membership.get('staff_permission', 0) or 0) %}
-          {% set can_access_tickets = (can_access_tickets | default(false)) or is_super_admin or (is_helpdesk_technician | default(false)) %}
-          {% set can_access_shop = (can_access_shop | default(false)) or is_super_admin or membership.get('can_access_shop') %}
+          {% set can_access_dashboard = is_super_admin or menu_access.get('menu.dashboard') in ['read', 'write'] %}
+          {% set can_access_service_status = is_super_admin or menu_access.get('menu.service_status') in ['read', 'write'] %}
+          {% set can_access_notifications = is_super_admin or menu_access.get('menu.notifications') in ['read', 'write'] %}
+          {% set can_access_knowledge_base = is_super_admin or menu_access.get('menu.knowledge_base') in ['read', 'write'] %}
+          {% set can_access_help = is_super_admin or menu_access.get('menu.help') in ['read', 'write'] %}
+          {% set can_access_reports = (can_access_reports | default(false)) or is_super_admin or menu_access.get('menu.reports') in ['read', 'write'] %}
+          {% set can_access_reporting = (can_access_reporting | default(false)) or is_super_admin or menu_access.get('menu.reporting') in ['read', 'write'] %}
+          {% set can_access_m365_configuration = is_super_admin or menu_access.get('menu.m365.configuration') in ['read', 'write'] %}
+          {% set can_access_m365_licenses = is_super_admin or menu_access.get('menu.m365.licenses') in ['read', 'write'] %}
+          {% set can_access_m365_diagnostics = is_super_admin or menu_access.get('menu.m365.diagnostics') in ['read', 'write'] %}
+          {% set can_access_compliance_checks_library = is_super_admin or menu_access.get('menu.compliance_checks.library') in ['read', 'write'] %}
+          {% set can_access_tickets = (can_access_tickets | default(false)) or is_super_admin or (is_helpdesk_technician | default(false)) or menu_access.get('menu.tickets') in ['read', 'write'] %}
+          {% set can_access_shop = (can_access_shop | default(false)) or is_super_admin or membership.get('can_access_shop') or menu_access.get('menu.shop') in ['read', 'write'] %}
           {% set can_access_cart = (can_access_cart | default(false)) or is_super_admin or membership.get('can_access_cart') %}
-          {% set can_access_orders = (can_access_orders | default(false)) or is_super_admin or membership.get('can_access_orders') %}
-          {% set can_access_forms = (can_access_forms | default(false)) or is_super_admin or membership.get('can_access_forms') %}
-          {% set can_manage_assets = (can_manage_assets | default(false)) or is_super_admin or membership.get('can_manage_assets') %}
-          {% set can_manage_licenses = (can_manage_licenses | default(false)) or is_super_admin or membership.get('can_manage_licenses') %}
-          {% set can_manage_subscriptions = (can_manage_subscriptions | default(false)) or is_super_admin or (membership.get('can_manage_licenses') and membership.get('can_access_cart')) %}
-          {% set can_manage_invoices = (can_manage_invoices | default(false)) or is_super_admin or membership.get('can_manage_invoices') %}
-          {% set can_manage_staff = (can_manage_staff | default(false)) or is_super_admin or membership.get('can_manage_staff') or (staff_permission > 0) %}
-          {% set can_manage_issues = has_issue_tracker_access | default(is_super_admin or (is_helpdesk_technician | default(false))) %}
-          {% set can_view_compliance = (can_view_compliance | default(false)) or is_super_admin or membership.get('can_view_compliance') %}
-          {% set can_view_m365_best_practices = (can_view_m365_best_practices | default(false)) or is_super_admin or membership.get('can_view_m365_best_practices') %}
-          {% set can_view_compliance_checks = (can_view_compliance_checks | default(false)) or is_super_admin or membership.get('can_view_compliance_checks') %}
-          {% set can_manage_compliance_checks = (can_manage_compliance_checks | default(false)) or is_super_admin or membership.get('can_manage_compliance_checks') %}
-          {% set can_view_m365_user_mailboxes = (can_view_m365_user_mailboxes | default(false)) or is_super_admin or membership.get('can_view_m365_user_mailboxes') %}
-          {% set can_view_m365_shared_mailboxes = (can_view_m365_shared_mailboxes | default(false)) or is_super_admin or membership.get('can_view_m365_shared_mailboxes') %}
-          {% set can_access_chat = (can_access_chat | default(false)) or is_super_admin or membership.get('can_access_chat') %}
-          {% set can_access_marketing = (can_access_marketing | default(false)) or is_super_admin %}
+          {% set can_access_quotes = (can_access_quotes | default(false)) or is_super_admin or membership.get('can_access_quotes') or menu_access.get('menu.quotes') in ['read', 'write'] %}
+          {% set can_access_orders = (can_access_orders | default(false)) or is_super_admin or membership.get('can_access_orders') or menu_access.get('menu.orders') in ['read', 'write'] %}
+          {% set can_access_forms = (can_access_forms | default(false)) or is_super_admin or membership.get('can_access_forms') or menu_access.get('menu.forms') in ['read', 'write'] %}
+          {% set can_manage_assets = (can_manage_assets | default(false)) or is_super_admin or membership.get('can_manage_assets') or menu_access.get('menu.assets') in ['read', 'write'] %}
+          {% set can_manage_licenses = (can_manage_licenses | default(false)) or is_super_admin or membership.get('can_manage_licenses') or can_access_m365_configuration or can_access_m365_licenses %}
+          {% set can_manage_subscriptions = (can_manage_subscriptions | default(false)) or is_super_admin or (membership.get('can_manage_licenses') and membership.get('can_access_cart')) or menu_access.get('menu.subscriptions') in ['read', 'write'] %}
+          {% set can_manage_invoices = (can_manage_invoices | default(false)) or is_super_admin or membership.get('can_manage_invoices') or menu_access.get('menu.invoices') in ['read', 'write'] %}
+          {% set can_manage_staff = (can_manage_staff | default(false)) or is_super_admin or membership.get('can_manage_staff') or (staff_permission > 0) or menu_access.get('menu.staff') in ['read', 'write'] %}
+          {% set can_manage_issues = has_issue_tracker_access | default(is_super_admin or (is_helpdesk_technician | default(false))) or menu_access.get('menu.issues') in ['read', 'write'] %}
+          {% set can_view_compliance = (can_view_compliance | default(false)) or is_super_admin or membership.get('can_view_compliance') or menu_access.get('menu.compliance') in ['read', 'write'] %}
+          {% set can_view_m365_best_practices = (can_view_m365_best_practices | default(false)) or is_super_admin or membership.get('can_view_m365_best_practices') or menu_access.get('menu.m365.best_practices') in ['read', 'write'] %}
+          {% set can_view_compliance_checks = (can_view_compliance_checks | default(false)) or is_super_admin or membership.get('can_view_compliance_checks') or menu_access.get('menu.compliance_checks') in ['read', 'write'] %}
+          {% set can_manage_compliance_checks = (can_manage_compliance_checks | default(false)) or is_super_admin or membership.get('can_manage_compliance_checks') or menu_access.get('menu.compliance_checks.library') in ['read', 'write'] %}
+          {% set can_view_m365_user_mailboxes = (can_view_m365_user_mailboxes | default(false)) or is_super_admin or membership.get('can_view_m365_user_mailboxes') or menu_access.get('menu.m365.user_mailboxes') in ['read', 'write'] %}
+          {% set can_view_m365_shared_mailboxes = (can_view_m365_shared_mailboxes | default(false)) or is_super_admin or membership.get('can_view_m365_shared_mailboxes') or menu_access.get('menu.m365.shared_mailboxes') in ['read', 'write'] %}
+          {% set can_access_chat = (can_access_chat | default(false)) or is_super_admin or membership.get('can_access_chat') or menu_access.get('menu.chat') in ['read', 'write'] %}
+          {% set can_access_marketing = (can_access_marketing | default(false)) or is_super_admin or menu_access.get('menu.marketing') in ['read', 'write'] %}
           {% set has_company_section = can_access_tickets or can_manage_issues or can_access_marketing or can_access_shop or can_access_cart or can_access_orders or can_access_forms or can_manage_assets or can_manage_licenses or can_manage_subscriptions or can_manage_invoices or can_manage_staff or can_view_compliance or can_view_bcp or can_view_m365_best_practices or can_view_compliance_checks or can_view_m365_user_mailboxes or can_view_m365_shared_mailboxes %}
           {% set is_company_admin = membership.get('is_admin') %}
           {% set has_admin_access = is_super_admin or is_company_admin %}
+          {% if can_access_dashboard %}
           <li class="menu__item">
             <a href="/" {% if current_path == '/' %}aria-current="page"{% endif %}>
               <span class="menu__icon" aria-hidden="true">
@@ -135,6 +149,8 @@
               <span class="menu__label">Dashboard</span>
             </a>
           </li>
+          {% endif %}
+          {% if can_access_service_status %}
           <li class="menu__item">
             <a href="/service-status" {% if current_path.startswith('/service-status') %}aria-current="page"{% endif %}>
               <span class="menu__icon" aria-hidden="true">
@@ -143,7 +159,8 @@
               <span class="menu__label">Service status</span>
             </a>
           </li>
-          {% if is_super_admin %}
+          {% endif %}
+          {% if can_access_notifications %}
           <li class="menu__item">
             <a href="/notifications" {% if current_path.startswith('/notifications') %}aria-current="page"{% endif %}>
               <span class="menu__icon" aria-hidden="true">
@@ -158,6 +175,7 @@
             </a>
           </li>
           {% endif %}
+          {% if can_access_knowledge_base %}
           <li class="menu__item">
             <a href="/knowledge-base" {% if current_path.startswith('/knowledge-base') %}aria-current="page"{% endif %}>
               <span class="menu__icon" aria-hidden="true">
@@ -166,6 +184,8 @@
               <span class="menu__label">Knowledge base</span>
             </a>
           </li>
+          {% endif %}
+          {% if can_access_help %}
           <li class="menu__item">
             <a href="/help" {% if current_path.startswith('/help') %}aria-current="page"{% endif %}>
               <span class="menu__icon" aria-hidden="true">
@@ -174,6 +194,7 @@
               <span class="menu__label">Help</span>
             </a>
           </li>
+          {% endif %}
 
           {% if matrix_chat_enabled | default(false) %}
           {% if is_super_admin or (is_helpdesk_technician | default(false)) or can_access_chat %}
@@ -288,24 +309,32 @@
                 </span>
               </button>
               <ul class="menu__submenu {% if m365_active %}menu__submenu--expanded{% endif %}">
+                {% if can_access_m365_configuration %}
                 <li class="menu__subitem">
                   <a href="/m365" {% if current_path == '/m365' %}aria-current="page"{% endif %}>Configuration</a>
                 </li>
+                {% endif %}
                 {% if can_view_m365_best_practices %}
                 <li class="menu__subitem">
                   <a href="/m365/best-practices" {% if current_path.startswith('/m365/best-practices') %}aria-current="page"{% endif %}>Best Practices</a>
                 </li>
                 {% endif %}
+                {% if can_view_m365_user_mailboxes %}
                 <li class="menu__subitem">
                   <a href="/m365/mailboxes/users" {% if current_path.startswith('/m365/mailboxes/users') %}aria-current="page"{% endif %}>User Mailboxes</a>
                 </li>
+                {% endif %}
+                {% if can_view_m365_shared_mailboxes %}
                 <li class="menu__subitem">
                   <a href="/m365/mailboxes/shared" {% if current_path.startswith('/m365/mailboxes/shared') %}aria-current="page"{% endif %}>Shared Mailboxes</a>
                 </li>
+                {% endif %}
+                {% if can_access_m365_licenses %}
                 <li class="menu__subitem">
                   <a href="/licenses" {% if current_path.startswith('/licenses') %}aria-current="page"{% endif %}>Licenses</a>
                 </li>
-                {% if is_super_admin %}
+                {% endif %}
+                {% if can_access_m365_diagnostics %}
                 <li class="menu__subitem">
                   <a href="/m365/diagnostics" {% if current_path.startswith('/m365/diagnostics') %}aria-current="page"{% endif %}>Diagnostics</a>
                 </li>
@@ -384,6 +413,7 @@
               </a>
             </li>
           {% endif %}
+          {% if can_access_reports %}
           <li class="menu__item">
             <a href="/reports/company-overview" {% if current_path.startswith('/reports') %}aria-current="page"{% endif %}>
               <span class="menu__icon" aria-hidden="true">
@@ -392,7 +422,8 @@
               <span class="menu__label">Reports</span>
             </a>
           </li>
-          {% if is_super_admin or (is_helpdesk_technician | default(false)) %}
+          {% endif %}
+          {% if can_access_reporting %}
           <li class="menu__item">
             <a href="/reporting" {% if current_path.startswith('/reporting') or current_path.startswith('/admin/reporting') %}aria-current="page"{% endif %}>
               <span class="menu__icon" aria-hidden="true">
@@ -417,7 +448,7 @@
                 <li class="menu__subitem">
                   <a href="/compliance-checks" {% if current_path == '/compliance-checks' %}aria-current="page"{% endif %}>My Checks</a>
                 </li>
-                {% if is_super_admin %}
+                {% if can_access_compliance_checks_library %}
                 <li class="menu__subitem">
                   <a href="/admin/compliance-checks/library" {% if current_path.startswith('/admin/compliance-checks') %}aria-current="page"{% endif %}>Library</a>
                 </li>

--- a/tests/test_menu_permissions.py
+++ b/tests/test_menu_permissions.py
@@ -1,0 +1,47 @@
+from app.security.menu_permissions import (
+    compact_menu_permissions,
+    menu_has_access,
+    menu_permissions_to_legacy,
+    normalize_menu_permissions,
+)
+
+
+def test_legacy_permissions_normalize_to_tri_state_menu_permissions():
+    permissions = normalize_menu_permissions([
+        "m365_user_mailboxes.access",
+        "licenses.manage",
+        "cart.access",
+    ])
+
+    assert permissions["menu.m365.user_mailboxes"] == "read"
+    assert permissions["menu.m365.licenses"] == "write"
+    assert permissions["menu.subscriptions"] == "write"
+
+
+def test_compact_menu_permissions_removes_no_access_entries():
+    compact = compact_menu_permissions(
+        {
+            "menu.m365.configuration": "No Access",
+            "menu.m365.user_mailboxes": "Read Only",
+            "menu.subscriptions": "Read/Write",
+        }
+    )
+
+    assert compact == {
+        "menu.m365.user_mailboxes": "read",
+        "menu.subscriptions": "write",
+    }
+
+
+def test_menu_has_access_enforces_read_vs_write():
+    menu_access = {"menu.m365.user_mailboxes": "read"}
+
+    assert menu_has_access(menu_access, "menu.m365.user_mailboxes") is True
+    assert menu_has_access(menu_access, "menu.m365.user_mailboxes", write=True) is False
+
+
+def test_menu_permissions_to_legacy_keeps_backward_compatibility():
+    legacy = menu_permissions_to_legacy({"menu.m365.user_mailboxes": "read", "menu.assets": "write"})
+
+    assert "m365_user_mailboxes.access" in legacy
+    assert "assets.manage" in legacy


### PR DESCRIPTION
### Motivation

- Replace the legacy flat permission list with a tri-state (none/read/write) menu permission model to support finer-grained UI and action controls.
- Provide a central catalogue of menu permissions for the API and admin UI so roles can be composed from menu items with clear semantics.
- Maintain backward compatibility by mapping legacy permissions and boolean flags to the new menu permission model.

### Description

- Introduces `app/security/menu_permissions.py` with the catalogue, normalization, compaction, legacy mapping, and helper functions (`MENU_PERMISSIONS`, `normalize_menu_permissions`, `compact_menu_permissions`, `menu_permissions_to_legacy`, `menu_has_access`, and `catalogue_for_api`).
- Updates roles API, schemas and repository to accept, store and normalise tri-state menu permissions, adds `MenuPermissionResponse`, exposes `GET /roles/permissions/available` to return the catalogue, and persists compacted menu permission JSON in `roles.permissions` while providing `menu_permissions` and `legacy_permissions` on role responses.
- Enhances membership handling in `user_companies` to enrich legacy boolean flags from role menu permissions and to set `menu_permissions` on memberships, and updates `roles` repository normalisation to emit both menu and legacy representations.
- Adds menu-access plumbing in `main.py` including `_build_menu_access_map`, `_membership_menu_can`, `_menu_can`, usage across page context and authorization checks, and updates templates, admin JS, and CSS to present and edit tri-state menu permissions in the roles UI.

### Testing

- Added unit tests in `tests/test_menu_permissions.py` covering legacy-to-menu normalization, compaction behavior, access checks, and legacy mapping, and ran `pytest tests/test_menu_permissions.py` which passed.
- Ran the project test suite with `pytest` after changes and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a1a14e094832da45df1a7307fb25d)