### PR TITLE
Persist can_access_quotes for active and pending company assignments

### DIFF
--- a/app/repositories/pending_staff_access.py
+++ b/app/repositories/pending_staff_access.py
@@ -15,6 +15,7 @@ _BOOLEAN_FIELDS = {
     "can_access_shop",
     "can_access_cart",
     "can_access_orders",
+    "can_access_quotes",
     "can_access_forms",
     "is_admin",
 }
@@ -53,6 +54,7 @@ async def upsert_assignment(
     can_access_shop: bool = False,
     can_access_cart: bool = False,
     can_access_orders: bool = False,
+    can_access_quotes: bool = False,
     can_access_forms: bool = False,
     is_admin: bool = False,
     role_id: int | None = None,
@@ -76,11 +78,12 @@ async def upsert_assignment(
             can_access_shop,
             can_access_cart,
             can_access_orders,
+            can_access_quotes,
             can_access_forms,
             is_admin,
             role_id
         ) VALUES (
-            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+            %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
         )
         ON DUPLICATE KEY UPDATE
             staff_permission = VALUES(staff_permission),
@@ -94,6 +97,7 @@ async def upsert_assignment(
             can_access_shop = VALUES(can_access_shop),
             can_access_cart = VALUES(can_access_cart),
             can_access_orders = VALUES(can_access_orders),
+            can_access_quotes = VALUES(can_access_quotes),
             can_access_forms = VALUES(can_access_forms),
             is_admin = VALUES(is_admin),
             role_id = VALUES(role_id)
@@ -112,6 +116,7 @@ async def upsert_assignment(
             1 if can_access_shop else 0,
             1 if can_access_cart else 0,
             1 if can_access_orders else 0,
+            1 if can_access_quotes else 0,
             1 if can_access_forms else 0,
             1 if is_admin else 0,
             role_id,

--- a/app/repositories/user_companies.py
+++ b/app/repositories/user_companies.py
@@ -20,6 +20,7 @@ _BOOLEAN_FIELDS = {
     "can_access_shop",
     "can_access_cart",
     "can_access_orders",
+    "can_access_quotes",
     "can_access_forms",
     "can_view_compliance",
     "can_view_bcp",
@@ -42,6 +43,7 @@ _PERMISSION_FIELDS = {
     "can_access_shop",
     "can_access_cart",
     "can_access_orders",
+    "can_access_quotes",
     "can_access_forms",
     "can_view_compliance",
     "can_view_bcp",
@@ -229,6 +231,7 @@ async def assign_user_to_company(
     can_access_shop: bool = False,
     can_access_cart: bool = False,
     can_access_orders: bool = False,
+    can_access_quotes: bool = False,
     can_access_forms: bool = False,
     is_admin: bool = False,
 ) -> None:
@@ -252,9 +255,10 @@ async def assign_user_to_company(
             can_access_shop,
             can_access_cart,
             can_access_orders,
+            can_access_quotes,
             can_access_forms,
             is_admin
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON DUPLICATE KEY UPDATE
             can_manage_licenses = VALUES(can_manage_licenses),
             can_manage_staff = VALUES(can_manage_staff),
@@ -267,6 +271,7 @@ async def assign_user_to_company(
             can_access_shop = VALUES(can_access_shop),
             can_access_cart = VALUES(can_access_cart),
             can_access_orders = VALUES(can_access_orders),
+            can_access_quotes = VALUES(can_access_quotes),
             can_access_forms = VALUES(can_access_forms),
             is_admin = VALUES(is_admin)
         """,
@@ -284,6 +289,7 @@ async def assign_user_to_company(
             1 if can_access_shop else 0,
             1 if can_access_cart else 0,
             1 if can_access_orders else 0,
+            1 if can_access_quotes else 0,
             1 if can_access_forms else 0,
             1 if is_admin else 0,
         ),

--- a/app/services/staff_access.py
+++ b/app/services/staff_access.py
@@ -53,6 +53,7 @@ async def apply_pending_access_for_user(user: dict[str, Any]) -> None:
             can_access_shop=assignment.get("can_access_shop", False),
             can_access_cart=assignment.get("can_access_cart", False),
             can_access_orders=assignment.get("can_access_orders", False),
+            can_access_quotes=assignment.get("can_access_quotes", False),
             can_access_forms=assignment.get("can_access_forms", False),
             is_admin=assignment.get("is_admin", False),
         )

--- a/migrations/263_pending_staff_quotes_access.sql
+++ b/migrations/263_pending_staff_quotes_access.sql
@@ -1,0 +1,12 @@
+-- Add quote access permission to pending staff assignments so queued access
+-- can preserve the same company permissions as active user assignments.
+
+ALTER TABLE pending_staff_access
+  ADD COLUMN IF NOT EXISTS can_access_quotes TINYINT(1);
+
+UPDATE pending_staff_access
+SET can_access_quotes = IFNULL(can_access_quotes, 0)
+WHERE can_access_quotes IS NULL;
+
+ALTER TABLE pending_staff_access
+  MODIFY can_access_quotes TINYINT(1) NOT NULL DEFAULT 0;

--- a/tests/test_company_memberships.py
+++ b/tests/test_company_memberships.py
@@ -174,6 +174,7 @@ async def test_admin_assign_user_to_company_preserves_existing_permissions(monke
         "can_access_shop": True,
         "can_access_cart": True,
         "can_access_orders": False,
+        "can_access_quotes": True,
         "can_access_forms": True,
         "can_manage_assets": True,
         "can_manage_licenses": False,
@@ -213,6 +214,7 @@ async def test_admin_assign_user_to_company_preserves_existing_permissions(monke
         "can_access_shop": True,
         "can_access_cart": True,
         "can_access_orders": False,
+        "can_access_quotes": True,
         "can_access_forms": True,
         "can_manage_assets": True,
         "can_manage_licenses": False,
@@ -290,6 +292,7 @@ async def test_admin_assign_user_to_company_queues_pending_access(monkeypatch):
             "staffPermission": "2",
             "can_manage_staff": "1",
             "can_access_shop": "1",
+            "can_access_quotes": "1",
             "roleId": "3",
         }
     )
@@ -354,6 +357,7 @@ async def test_admin_assign_user_to_company_queues_pending_access(monkeypatch):
         "can_access_shop": True,
         "can_access_cart": False,
         "can_access_orders": False,
+        "can_access_quotes": True,
         "can_access_forms": False,
         "is_admin": False,
         "role_id": 3,

--- a/tests/test_quote_company_permissions.py
+++ b/tests/test_quote_company_permissions.py
@@ -1,0 +1,55 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.repositories import pending_staff_access, user_companies
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_assign_user_to_company_persists_quote_access(monkeypatch):
+    execute_mock = AsyncMock()
+    monkeypatch.setattr(user_companies.db, "execute", execute_mock)
+    monkeypatch.setattr(
+        user_companies,
+        "_ensure_company_membership",
+        AsyncMock(),
+    )
+
+    await user_companies.assign_user_to_company(
+        user_id=7,
+        company_id=4,
+        can_access_quotes=True,
+    )
+
+    sql, params = execute_mock.await_args.args
+    assert "can_access_quotes" in sql
+    assert "can_access_quotes = VALUES(can_access_quotes)" in sql
+    assert params[13] == 1
+
+
+@pytest.mark.anyio("asyncio")
+async def test_pending_staff_access_persists_quote_access(monkeypatch):
+    execute_mock = AsyncMock()
+    monkeypatch.setattr(pending_staff_access.db, "execute", execute_mock)
+    monkeypatch.setattr(
+        pending_staff_access,
+        "get_assignment",
+        AsyncMock(return_value={"can_access_quotes": True}),
+    )
+
+    result = await pending_staff_access.upsert_assignment(
+        staff_id=202,
+        company_id=4,
+        can_access_quotes=True,
+    )
+
+    sql, params = execute_mock.await_args.args
+    assert "can_access_quotes" in sql
+    assert "can_access_quotes = VALUES(can_access_quotes)" in sql
+    assert params[13] == 1
+    assert result == {"can_access_quotes": True}

--- a/tests/test_staff_access.py
+++ b/tests/test_staff_access.py
@@ -33,6 +33,7 @@ async def test_apply_pending_access_for_user_assigns_permissions(monkeypatch):
             "can_access_shop": True,
             "can_access_cart": False,
             "can_access_orders": False,
+            "can_access_quotes": True,
             "can_access_forms": True,
             "is_admin": True,
             "role_id": 7,
@@ -49,6 +50,7 @@ async def test_apply_pending_access_for_user_assigns_permissions(monkeypatch):
             "can_access_shop": False,
             "can_access_cart": True,
             "can_access_orders": True,
+            "can_access_quotes": False,
             "can_access_forms": False,
             "is_admin": False,
             "role_id": None,
@@ -125,6 +127,7 @@ async def test_apply_pending_access_for_user_assigns_permissions(monkeypatch):
         "can_access_shop": True,
         "can_access_cart": False,
         "can_access_orders": False,
+        "can_access_quotes": True,
         "can_access_forms": True,
         "is_admin": True,
     }
@@ -143,6 +146,7 @@ async def test_apply_pending_access_for_user_assigns_permissions(monkeypatch):
         "can_access_shop": False,
         "can_access_cart": True,
         "can_access_orders": True,
+        "can_access_quotes": False,
         "can_access_forms": False,
         "is_admin": False,
     }


### PR DESCRIPTION
### Motivation
- Ensure the new Quotes access flag is accepted and persisted for both active company assignments and queued (pending) staff assignments so quote access behaves consistently across role migration boundaries.
- Preserve pending quote access when queued assignments are applied at user sign-up so permissions do not get lost during onboarding.
- Align database schema and tests with the new permission column to prevent runtime `unexpected keyword argument` errors when `can_access_quotes` is provided.

### Description
- Added `can_access_quotes` to `_BOOLEAN_FIELDS` and `_PERMISSION_FIELDS` and extended `assign_user_to_company` to accept and upsert `can_access_quotes` in `app/repositories/user_companies.py`.
- Added `can_access_quotes` parameter, SQL column handling, and normalization in `app/repositories/pending_staff_access.py` so pending assignments can store quote access.
- Propagated `can_access_quotes` when applying pending assignments in `app/services/staff_access.py` so queued quote access is carried to created users.
- Added a migration `migrations/263_pending_staff_quotes_access.sql` to create/initialize the `pending_staff_access.can_access_quotes` column.
- Added `tests/test_quote_company_permissions.py` and updated `tests/test_company_memberships.py` and `tests/test_staff_access.py` expectations to cover `can_access_quotes` behavior.

### Testing
- ✅ Ran `python -m pytest tests/test_quote_company_permissions.py tests/test_staff_access.py`, both tests passed.
- ✅ Compiled modified modules with `python -m compileall app/repositories/user_companies.py app/repositories/pending_staff_access.py app/services/staff_access.py tests/test_quote_company_permissions.py` with no syntax errors.
- ❌ Running `python -m pytest tests/test_company_memberships.py tests/test_staff_access.py` surfaced unrelated failures due to missing/non-exported `app.main` attributes referenced by existing tests, which predated these changes and are not caused by the `can_access_quotes` updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a43174cd0832db3a7957d372e606d)