### PR TITLE
Restrict Help and Reports menu visibility to explicit permissions

### DIFF
--- a/app/features/help/routes.py
+++ b/app/features/help/routes.py
@@ -25,7 +25,11 @@ def _main():
 @router.get("/help", response_class=HTMLResponse)
 async def help_index(request: Request):
     main_module = _main()
-    user, redirect = await main_module._require_authenticated_user(request)
+    user, redirect = await main_module._require_menu_page_access(
+        request,
+        "menu.help",
+        detail="Help access permission required",
+    )
     if redirect:
         return redirect
 
@@ -44,7 +48,11 @@ async def help_index(request: Request):
 @router.get("/help/{section_slug}/{article_slug}", response_class=HTMLResponse)
 async def help_article(request: Request, section_slug: str, article_slug: str):
     main_module = _main()
-    user, redirect = await main_module._require_authenticated_user(request)
+    user, redirect = await main_module._require_menu_page_access(
+        request,
+        "menu.help",
+        detail="Help access permission required",
+    )
     if redirect:
         return redirect
 

--- a/app/features/reports/handlers.py
+++ b/app/features/reports/handlers.py
@@ -29,7 +29,11 @@ async def _load_report_context(request: Request):
     from app.repositories import companies as company_repo
     from app.repositories import user_companies as user_company_repo
 
-    user, redirect = await _main()._require_authenticated_user(request)
+    user, redirect = await _main()._require_menu_page_access(
+        request,
+        "menu.reports",
+        detail="Reports access permission required",
+    )
     if redirect:
         return user, None, None, None, redirect
     company_id_raw = user.get("company_id")

--- a/app/main.py
+++ b/app/main.py
@@ -1753,7 +1753,7 @@ def _build_menu_access_map(
             menu_access[key] = level
 
     # Baseline authenticated pages remain readable unless explicitly controlled by a role.
-    for key in ("menu.dashboard", "menu.service_status", "menu.knowledge_base", "menu.help", "menu.reports", "menu.admin.profile"):
+    for key in ("menu.dashboard", "menu.service_status", "menu.knowledge_base", "menu.admin.profile"):
         promote(key, "read")
 
     legacy_boolean_to_menu = {
@@ -1802,6 +1802,44 @@ def _build_menu_access_map(
 def _menu_can(menu_access: dict[str, Any] | None, key: str, *, write: bool = False) -> bool:
     return menu_has_access(menu_access, key, write=write)
 
+
+async def _has_menu_page_access(request: Request, user: Mapping[str, Any], key: str, *, write: bool = False) -> bool:
+    """Return whether the authenticated user has explicit access to a menu-owned page.
+
+    Super administrators keep unrestricted access. Other users must have the
+    requested menu permission on their active company membership; baseline
+    authenticated menu items are intentionally not elevated here.
+    """
+    if user.get("is_super_admin"):
+        return True
+
+    membership = getattr(request.state, "active_membership", None)
+    active_company_id = getattr(request.state, "active_company_id", None) or user.get("company_id")
+    if membership is None and active_company_id is not None:
+        try:
+            membership = await user_company_repo.get_user_company(int(user["id"]), int(active_company_id))
+        except (TypeError, ValueError):
+            membership = None
+        if membership is not None:
+            request.state.active_membership = membership
+
+    menu_access = normalize_menu_permissions((membership or {}).get("menu_permissions"))
+    return _menu_can(menu_access, key, write=write)
+
+
+async def _require_menu_page_access(
+    request: Request,
+    key: str,
+    *,
+    write: bool = False,
+    detail: str = "Page access permission required",
+) -> tuple[dict[str, Any] | None, RedirectResponse | None]:
+    user, redirect = await _require_authenticated_user(request)
+    if redirect:
+        return None, redirect
+    if not await _has_menu_page_access(request, user, key, write=write):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+    return user, None
 
 def _membership_menu_can(user: dict[str, Any], membership: dict[str, Any] | None, key: str, *, write: bool = False) -> bool:
     if user.get("is_super_admin"):

--- a/tests/test_help_pages.py
+++ b/tests/test_help_pages.py
@@ -104,6 +104,10 @@ def patched_dependencies(monkeypatch):
     async def fake_require_user(request):
         return {"id": 1, "email": "user@example.com"}, None
 
+    async def fake_require_menu_page_access(request, key, *, write=False, detail="Page access permission required"):
+        assert key == "menu.help"
+        return {"id": 1, "email": "user@example.com"}, None
+
     async def fake_build_base_context(request, user, *, extra=None):
         context = {
             "request": request,
@@ -124,6 +128,7 @@ def patched_dependencies(monkeypatch):
         return context
 
     monkeypatch.setattr(main_module, "_require_authenticated_user", fake_require_user)
+    monkeypatch.setattr(main_module, "_require_menu_page_access", fake_require_menu_page_access)
     monkeypatch.setattr(main_module, "_build_base_context", fake_build_base_context)
     main_module.templates.env.globals["plausible_config"] = {
         "enabled": False,

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -167,6 +167,10 @@ def test_m365_menu_item_has_data_menu_key(monkeypatch):
             "csrf_token": "csrf-token",
             "cart_summary": {"item_count": 0, "total_quantity": 0, "subtotal": 0},
             "notification_unread_count": 0,
+            "menu_access": main_module._build_menu_access_map(
+                is_super_admin=False,
+                membership_data=membership,
+            ),
             "can_access_tickets": False,
             "can_view_bcp": False,
             "can_view_compliance": False,
@@ -307,3 +311,40 @@ def test_public_knowledge_base_shows_login_menu(public_knowledge_base_context):
     # Should show the Knowledge base link
     assert 'href="/knowledge-base"' in html
     assert "Knowledge base" in html
+
+
+def test_help_and_reports_are_not_baseline_authenticated_menu_items():
+    menu_access = main_module._build_menu_access_map(
+        is_super_admin=False,
+        membership_data={},
+    )
+
+    assert menu_access["menu.dashboard"] == "read"
+    assert menu_access["menu.knowledge_base"] == "read"
+    assert menu_access["menu.help"] == "none"
+    assert menu_access["menu.reports"] == "none"
+
+
+def test_help_and_reports_menu_items_require_explicit_permission():
+    menu_access = main_module._build_menu_access_map(
+        is_super_admin=False,
+        membership_data={
+            "menu_permissions": {
+                "menu.help": "read",
+                "menu.reports": "read",
+            }
+        },
+    )
+
+    assert menu_access["menu.help"] == "read"
+    assert menu_access["menu.reports"] == "read"
+
+
+def test_super_admin_keeps_help_and_reports_menu_access():
+    menu_access = main_module._build_menu_access_map(
+        is_super_admin=True,
+        membership_data={},
+    )
+
+    assert menu_access["menu.help"] == "write"
+    assert menu_access["menu.reports"] == "write"


### PR DESCRIPTION
### Motivation
- Prevent Help and Reports pages from being visible to authenticated users unless their membership explicitly grants those menu permissions, while retaining full access for super administrators.
- Centralise page-level menu permission checks to improve consistency and reduce duplicated permission logic.

### Description
- Removed `menu.help` and `menu.reports` from the baseline readable set in `_build_menu_access_map`, so they default to `none` unless explicitly granted. (`app/main.py`)
- Added `_has_menu_page_access` and `_require_menu_page_access` helpers to evaluate menu permissions against the active membership `menu_permissions` and enforce page access (super admins bypass checks). (`app/main.py`)
- Applied ` _require_menu_page_access` to the Help routes (`/help`, `/help/{section}/{article}`) so Help pages require the `menu.help` permission. (`app/features/help/routes.py`)
- Applied ` _require_menu_page_access` to the Reports feature context loader so company reports require the `menu.reports` permission. (`app/features/reports/handlers.py`)
- Updated tests to assert the new behaviour and added coverage for explicit grants and super-admin access. (`tests/test_sidebar_menu.py`, `tests/test_help_pages.py`)

### Testing
- Compiled updated modules with `python -m py_compile app/main.py app/features/help/routes.py app/features/reports/handlers.py` and confirmed no syntax errors. (success)
- Ran focused test suites with `pytest tests/test_menu_permissions.py tests/test_sidebar_menu.py tests/test_help_pages.py tests/test_reports_feature_pack.py -q` and all tests passed (`17 passed`). (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a43b8e584832da0d146b8d6bc0ebb)