### PR TITLE
Fix BCP role permission checks

### DIFF
--- a/app/api/routes/bcp.py
+++ b/app/api/routes/bcp.py
@@ -61,11 +61,9 @@ async def _require_bcp_view(
         active_company_id = getattr(request.state, "active_company_id", None)
         return user, active_company_id
     
-    # Check continuity.access permission (new) or legacy bcp:view permission
-    has_permission = (
-        await membership_repo.user_has_permission(session.user_id, "continuity.access") or
-        await membership_repo.user_has_permission(session.user_id, "bcp:view")
-    )
+    # Check BCP view permission. The membership repository expands tri-state
+    # menu permissions and the continuity.access alias for backward compatibility.
+    has_permission = await membership_repo.user_has_permission(session.user_id, "bcp:view")
     if not has_permission:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="BCP view permission required")
     

--- a/app/repositories/company_memberships.py
+++ b/app/repositories/company_memberships.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional
 from app.core.database import db
 from app.repositories import users as user_repo
 from app.repositories import user_permissions as user_permissions_repo
+from app.security.menu_permissions import compact_menu_permissions, menu_permissions_to_legacy
 
 _VALID_STATUSES = {"invited", "active", "suspended"}
 
@@ -172,21 +173,23 @@ async def user_has_permission(user_id: int, permission: str) -> bool:
     user_record = await user_repo.get_user_by_id(user_id)
     if user_record and bool(user_record.get("is_super_admin")):
         return True
-    
-    # Check role-based permissions from memberships
+
+    # Check role-based permissions from memberships. Roles may be stored as the
+    # current tri-state menu permission map or as the older list of permission
+    # strings, so always expand to the legacy permission names before matching.
     memberships = await list_memberships_for_user(user_id, status="active")
     for membership in memberships:
         permissions = membership.get("permissions") or []
-        if permission in permissions:
+        if _permission_matches(permissions, permission):
             return True
-        
+
         # Also check user-specific permissions for this company
         company_id = membership.get("company_id")
         if company_id:
             user_permissions = await user_permissions_repo.list_user_permissions(user_id, company_id)
-            if permission in user_permissions:
+            if _permission_matches(user_permissions, permission):
                 return True
-    
+
     return False
 
 
@@ -222,7 +225,7 @@ async def list_users_with_permission(permission: str) -> List[dict[str, Any]]:
             permissions = permissions_raw or []
 
         is_super_admin = bool(row.get("is_super_admin", 0))
-        if permission not in permissions and not is_super_admin:
+        if not _permission_matches(permissions, permission) and not is_super_admin:
             continue
 
         try:
@@ -303,18 +306,36 @@ async def list_impersonatable_memberships() -> list[dict[str, Any]]:
     return [dict(row) for row in rows]
 
 
-def _normalise_membership(row: dict[str, Any]) -> dict[str, Any]:
-    permissions_raw = row.get("permissions")
-    permissions: list[str]
-    if isinstance(permissions_raw, str):
+def _decode_permissions(raw: Any) -> Any:
+    if isinstance(raw, str):
         try:
-            permissions = json.loads(permissions_raw)
+            return json.loads(raw)
         except json.JSONDecodeError:
-            permissions = []
-    else:
-        permissions = permissions_raw or []
+            return []
+    return raw or []
+
+
+def _legacy_permission_set(raw: Any) -> set[str]:
+    decoded = _decode_permissions(raw)
+    direct_permissions = (
+        {item for item in decoded if isinstance(item, str)}
+        if isinstance(decoded, list)
+        else set()
+    )
+    return direct_permissions | set(menu_permissions_to_legacy(decoded))
+
+
+def _permission_matches(raw: Any, permission: str) -> bool:
+    return permission in _legacy_permission_set(raw)
+
+
+def _normalise_membership(row: dict[str, Any]) -> dict[str, Any]:
+    permissions = _decode_permissions(row.get("permissions"))
+    menu_permissions = compact_menu_permissions(permissions)
     return {
         **row,
         "permissions": permissions,
+        "menu_permissions": menu_permissions,
+        "legacy_permissions": sorted(_legacy_permission_set(permissions)),
         "is_active": row.get("status") == "active",
     }

--- a/tests/test_bcp_permissions.py
+++ b/tests/test_bcp_permissions.py
@@ -1,6 +1,6 @@
 """Tests for BCP permission checks and company isolation."""
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 from fastapi import HTTPException, Request
 
 pytestmark = pytest.mark.anyio
@@ -118,6 +118,27 @@ class TestBCPViewPermission:
                     
                     assert exc_info.value.status_code == 403
                     assert "BCP view permission required" in exc_info.value.detail
+
+
+class TestBCPPermissionCompatibility:
+    """Test BCP permission compatibility with tri-state role storage."""
+
+    def test_menu_continuity_read_grants_bcp_view(self):
+        from app.repositories.company_memberships import _permission_matches
+
+        assert _permission_matches({"menu.continuity": "read"}, "bcp:view") is True
+        assert _permission_matches({"menu.continuity": "read"}, "bcp:edit") is False
+
+    def test_menu_continuity_write_grants_bcp_edit(self):
+        from app.repositories.company_memberships import _permission_matches
+
+        assert _permission_matches({"menu.continuity": "write"}, "bcp:view") is True
+        assert _permission_matches({"menu.continuity": "write"}, "bcp:edit") is True
+
+    def test_continuity_alias_grants_bcp_view(self):
+        from app.repositories.company_memberships import _permission_matches
+
+        assert _permission_matches(["continuity.access"], "bcp:view") is True
 
 
 class TestBCPEditPermission:

--- a/tests/test_menu_permissions.py
+++ b/tests/test_menu_permissions.py
@@ -45,3 +45,13 @@ def test_menu_permissions_to_legacy_keeps_backward_compatibility():
 
     assert "m365_user_mailboxes.access" in legacy
     assert "assets.manage" in legacy
+
+
+def test_bcp_continuity_menu_permission_expands_to_legacy_permissions():
+    legacy_read = menu_permissions_to_legacy({"menu.continuity": "read"})
+    legacy_write = menu_permissions_to_legacy({"menu.continuity": "write"})
+
+    assert "continuity.access" in legacy_read
+    assert "bcp:view" in legacy_read
+    assert "bcp:edit" not in legacy_read
+    assert "bcp:edit" in legacy_write


### PR DESCRIPTION
### Motivation
- Users with BCP permissions were intermittently denied access because role permissions can be stored either as legacy permission lists or as the newer tri-state `menu.*` map, and checks were not normalising both forms.
- The BCP route code was checking multiple aliases (`continuity.access` + `bcp:view`) which duplicated logic and hid compatibility concerns that belong in the membership layer.

### Description
- Route change: `_require_bcp_view` now checks the canonical `bcp:view` permission and relies on the membership repository to expand legacy aliases and tri-state menu maps (change in `app/api/routes/bcp.py`).
- Repository changes: `app/repositories/company_memberships.py` now decodes permission payloads and exposes helpers `
_decode_permissions`, `
_legacy_permission_set`, and `
_permission_matches` to expand tri-state `menu.*` maps into legacy permission names and to match permissions consistently.
- Permission logic: `user_has_permission` and `list_users_with_permission` were updated to use `
_permission_matches` so role-based and user-level permissions stored in either format are respected, and `_normalise_membership` now emits `menu_permissions` and `legacy_permissions` for consumers.
- Tests: added regression tests to `tests/test_bcp_permissions.py` and `tests/test_menu_permissions.py` to verify `menu.continuity` read/write behavior and the `continuity.access` alias mapping to `bcp:view`/`bcp:edit`.

### Testing
- Linting: ran `python -m ruff check app/repositories/company_memberships.py tests/test_bcp_permissions.py tests/test_menu_permissions.py` which passed for the changed files.
- Sanity/compilation: ran `python -m compileall -q app/repositories/company_memberships.py app/api/routes/bcp.py` which completed successfully.
- Unit tests: ran `python -m pytest -q tests/test_bcp_permissions.py tests/test_menu_permissions.py` and all tests passed (`19 passed`), with warnings noted but unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a4805165c832db64c1b5ecbaf7f25)