### PR TITLE
Allow non-admin users with `menu.admin.profile` permission to view My Profile

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5120,9 +5120,22 @@ async def admin_service_status_check_now(request: Request, service_id: int):
 # ---------------------------------------------------------------------------
 @app.get("/admin/profile", response_class=HTMLResponse)
 async def admin_profile_page(request: Request):
-    user, membership, redirect = await _require_administration_access(request)
+    user, redirect = await _require_authenticated_user(request)
     if redirect:
         return redirect
+
+    membership = getattr(request.state, "active_membership", None)
+    if membership is None:
+        active_company_id = getattr(request.state, "active_company_id", None)
+        if active_company_id is not None:
+            try:
+                membership = await user_company_repo.get_user_company(user["id"], int(active_company_id))
+            except Exception:  # pragma: no cover - defensive protection against membership lookup failures
+                membership = None
+            request.state.active_membership = membership
+
+    if not _membership_menu_can(user, membership, "menu.admin.profile"):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Profile access required")
 
     try:
         devices = await auth_repo.get_totp_authenticators(user["id"])

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -137,9 +137,10 @@
           {% set can_view_m365_shared_mailboxes = (can_view_m365_shared_mailboxes | default(false)) or is_super_admin or membership.get('can_view_m365_shared_mailboxes') or menu_access.get('menu.m365.shared_mailboxes') in ['read', 'write'] %}
           {% set can_access_chat = (can_access_chat | default(false)) or is_super_admin or membership.get('can_access_chat') or menu_access.get('menu.chat') in ['read', 'write'] %}
           {% set can_access_marketing = (can_access_marketing | default(false)) or is_super_admin or menu_access.get('menu.marketing') in ['read', 'write'] %}
+          {% set can_access_profile = is_super_admin or menu_access.get('menu.admin.profile') in ['read', 'write'] %}
           {% set has_company_section = can_access_tickets or can_manage_issues or can_access_marketing or can_access_shop or can_access_cart or can_access_orders or can_access_forms or can_manage_assets or can_manage_licenses or can_manage_subscriptions or can_manage_invoices or can_manage_staff or can_view_compliance or can_view_bcp or can_view_m365_best_practices or can_view_compliance_checks or can_view_m365_user_mailboxes or can_view_m365_shared_mailboxes %}
           {% set is_company_admin = membership.get('is_admin') %}
-          {% set has_admin_access = is_super_admin or is_company_admin %}
+          {% set has_admin_access = is_super_admin or is_company_admin or can_access_profile %}
           {% if can_access_dashboard %}
           <li class="menu__item">
             <a href="/" {% if current_path == '/' %}aria-current="page"{% endif %}>

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -201,6 +201,133 @@ def test_m365_menu_item_has_data_menu_key(monkeypatch):
         "in left menu customisation"
     )
 
+def test_profile_menu_permission_shows_my_profile_for_non_admin(monkeypatch):
+    user = {"id": 7, "email": "user@example.com", "is_super_admin": False}
+    membership = {
+        "company_id": 10,
+        "is_admin": False,
+        "menu_permissions": {"menu.admin.profile": "read"},
+    }
+
+    async def fake_require_user(request):
+        request.state.active_company_id = membership["company_id"]
+        request.state.active_membership = membership
+        return user, None
+
+    async def fake_overview(request, current_user):
+        return {"unread_notifications": 0}
+
+    async def fake_run_system_update(*, force_restart: bool = False):
+        return None
+
+    async def fake_build_base_context(request, current_user, *, extra=None):
+        context = {
+            "request": request,
+            "app_name": "MyPortal",
+            "current_year": 2026,
+            "current_user": current_user,
+            "available_companies": [],
+            "active_company": None,
+            "active_company_id": membership["company_id"],
+            "active_membership": membership,
+            "csrf_token": "csrf-token",
+            "cart_summary": {"item_count": 0, "total_quantity": 0, "subtotal": 0},
+            "notification_unread_count": 0,
+            "menu_access": main_module._build_menu_access_map(
+                is_super_admin=False,
+                membership_data=membership,
+            ),
+            "can_access_tickets": False,
+            "can_view_bcp": False,
+            "can_view_compliance": False,
+            "plausible_config": {"enabled": False, "site_domain": "", "base_url": ""},
+        }
+        if extra:
+            context.update(extra)
+        return context
+
+    monkeypatch.setattr(main_module, "_require_authenticated_user", fake_require_user)
+    monkeypatch.setattr(main_module, "_build_consolidated_overview", fake_overview)
+    monkeypatch.setattr(main_module, "_build_base_context", fake_build_base_context)
+    monkeypatch.setattr(scheduler_service, "run_system_update", fake_run_system_update)
+    main_module.templates.env.globals["plausible_config"] = {
+        "enabled": False,
+        "site_domain": "",
+        "base_url": "",
+    }
+
+    with TestClient(app) as client:
+        response = client.get("/")
+
+    assert response.status_code == 200
+    html = response.text
+    assert 'href="/admin/profile"' in html
+    assert "My Profile" in html
+
+
+def test_non_admin_with_profile_permission_can_open_profile_page(monkeypatch):
+    user = {
+        "id": 7,
+        "email": "user@example.com",
+        "is_super_admin": False,
+        "mobile_phone": None,
+        "booking_link_url": None,
+        "matrix_user_id": None,
+        "email_signature": None,
+    }
+    membership = {
+        "company_id": 10,
+        "is_admin": False,
+        "menu_permissions": {"menu.admin.profile": "read"},
+    }
+
+    async def fake_require_user(request):
+        request.state.active_company_id = membership["company_id"]
+        request.state.active_membership = membership
+        return user, None
+
+    async def fake_get_totp_authenticators(user_id):
+        return []
+
+    async def fake_build_base_context(request, current_user, *, extra=None):
+        context = {
+            "request": request,
+            "app_name": "MyPortal",
+            "current_year": 2026,
+            "current_user": current_user,
+            "available_companies": [],
+            "active_company": None,
+            "active_company_id": membership["company_id"],
+            "active_membership": membership,
+            "csrf_token": "csrf-token",
+            "cart_summary": {"item_count": 0, "total_quantity": 0, "subtotal": 0},
+            "notification_unread_count": 0,
+            "menu_access": main_module._build_menu_access_map(
+                is_super_admin=False,
+                membership_data=membership,
+            ),
+            "matrix_chat_enabled": False,
+            "plausible_config": {"enabled": False, "site_domain": "", "base_url": ""},
+        }
+        if extra:
+            context.update(extra)
+        return context
+
+    monkeypatch.setattr(main_module, "_require_authenticated_user", fake_require_user)
+    monkeypatch.setattr(main_module.auth_repo, "get_totp_authenticators", fake_get_totp_authenticators)
+    monkeypatch.setattr(main_module, "_build_base_context", fake_build_base_context)
+    main_module.templates.env.globals["plausible_config"] = {
+        "enabled": False,
+        "site_domain": "",
+        "base_url": "",
+    }
+
+    with TestClient(app) as client:
+        response = client.get("/admin/profile")
+
+    assert response.status_code == 200
+    assert "Manage your account security" in response.text
+
 
 def test_bcp_menu_replaces_business_continuity(company_admin_context):
     """Ensure the BCP navigation link is present and the legacy menu is removed."""


### PR DESCRIPTION
### Motivation
- My Profile was previously restricted to company admins, preventing users granted the `menu.admin.profile` menu permission from seeing the menu entry or opening the page.
- The change ensures the UI and page access align with the menu permission system so delegated/profile-only users can manage their own profile.

### Description
- Updated the `/admin/profile` handler in `app/main.py` to authenticate the user, resolve the active membership, and check `menu.admin.profile` via `_membership_menu_can` instead of requiring company admin status, returning `403` if the user lacks the menu permission. (changes in `app/main.py`).
- Updated the sidebar template `app/templates/base.html` to expose `can_access_profile` (based on `menu.admin.profile`) and include it in the `has_admin_access` calculation so the Administration header and the "My Profile" menu item become visible for users with the profile permission. (changes in `app/templates/base.html`).
- Added regression tests in `tests/test_sidebar_menu.py` that cover: a non-admin user with `menu.admin.profile` seeing the My Profile menu entry, and such a user successfully opening `/admin/profile`. (tests added to `tests/test_sidebar_menu.py`).

### Testing
- Compiled files with `python -m py_compile app/main.py tests/test_sidebar_menu.py` and verified no syntax errors. (success)
- Ran unit tests: `pytest tests/test_sidebar_menu.py tests/test_menu_permissions.py tests/test_sidebar_preferences_repo.py -q` and all tests passed (14 passed, with warnings). (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a488908bc832daae55243ec81779e)