### PR TITLE
Allow Backup Summary access via menu permission and scope non-admin data

### DIFF
--- a/app/features/backups/handlers.py
+++ b/app/features/backups/handlers.py
@@ -114,21 +114,37 @@ async def admin_backup_jobs_page(request: Request):
 
 
 async def admin_backup_summary_page(request: Request):
+    from fastapi import HTTPException
+
     from app.repositories import companies as company_repo
     from app.services import backup_jobs as backup_jobs_service
 
-    user, redirect = await _main()._require_super_admin_page(request)
+    user, redirect = await _main()._require_menu_page_access(
+        request,
+        "menu.admin.backup_summary",
+        detail="Backup summary access required",
+    )
     if redirect:
         return redirect
 
     company_filter_raw = (request.query_params.get("company_id") or "").strip()
     status_filter = (request.query_params.get("status_filter") or "").strip().lower()
-    company_filter: int | None = None
+    requested_company_filter: int | None = None
     if company_filter_raw:
         try:
-            company_filter = int(company_filter_raw)
+            requested_company_filter = int(company_filter_raw)
         except ValueError:
-            company_filter = None
+            requested_company_filter = None
+
+    is_super_admin = bool((user or {}).get("is_super_admin"))
+    active_company_id = getattr(request.state, "active_company_id", None) or (user or {}).get("company_id")
+    if is_super_admin:
+        company_filter = requested_company_filter
+    else:
+        try:
+            company_filter = int(active_company_id)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Active company required")
 
     jobs = await backup_jobs_service.list_jobs_with_latest(
         company_id=company_filter, include_inactive=True
@@ -138,6 +154,16 @@ async def admin_backup_summary_page(request: Request):
 
     summary = backup_jobs_service.summarise_jobs(jobs)
     companies = await company_repo.list_companies()
+    if not is_super_admin:
+        scoped_companies = []
+        for company in companies:
+            try:
+                company_id = int(company.get("id"))
+            except (TypeError, ValueError):
+                continue
+            if company_id == company_filter:
+                scoped_companies.append(company)
+        companies = scoped_companies
     company_lookup = {
         int(company["id"]): company.get("name")
         for company in companies

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -137,9 +137,10 @@
           {% set can_view_m365_shared_mailboxes = (can_view_m365_shared_mailboxes | default(false)) or is_super_admin or membership.get('can_view_m365_shared_mailboxes') or menu_access.get('menu.m365.shared_mailboxes') in ['read', 'write'] %}
           {% set can_access_chat = (can_access_chat | default(false)) or is_super_admin or membership.get('can_access_chat') or menu_access.get('menu.chat') in ['read', 'write'] %}
           {% set can_access_marketing = (can_access_marketing | default(false)) or is_super_admin or menu_access.get('menu.marketing') in ['read', 'write'] %}
+          {% set can_access_admin_backup_summary = is_super_admin or menu_access.get('menu.admin.backup_summary') in ['read', 'write'] %}
           {% set has_company_section = can_access_tickets or can_manage_issues or can_access_marketing or can_access_shop or can_access_cart or can_access_orders or can_access_forms or can_manage_assets or can_manage_licenses or can_manage_subscriptions or can_manage_invoices or can_manage_staff or can_view_compliance or can_view_bcp or can_view_m365_best_practices or can_view_compliance_checks or can_view_m365_user_mailboxes or can_view_m365_shared_mailboxes %}
           {% set is_company_admin = membership.get('is_admin') %}
-          {% set has_admin_access = is_super_admin or is_company_admin %}
+          {% set has_admin_access = is_super_admin or is_company_admin or can_access_admin_backup_summary %}
           {% if can_access_dashboard %}
           <li class="menu__item">
             <a href="/" {% if current_path == '/' %}aria-current="page"{% endif %}>
@@ -476,6 +477,16 @@
                 <span class="menu__label">My Profile</span>
               </a>
             </li>
+            {% if can_access_admin_backup_summary %}
+              <li class="menu__item">
+                <a href="/admin/backup-summary" {% if current_path.startswith('/admin/backup-summary') %}aria-current="page"{% endif %}>
+                  <span class="menu__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false"><path d="M3 3h18v4H3zm0 6h18v4H3zm0 6h18v4H3z"/></svg>
+                  </span>
+                  <span class="menu__label">Backup Summary</span>
+                </a>
+              </li>
+            {% endif %}
             {% if is_super_admin %}
               <li class="menu__item">
                 <a href="/admin/impersonation" {% if current_path.startswith('/admin/impersonation') %}aria-current="page"{% endif %}>
@@ -507,14 +518,6 @@
                     <svg viewBox="0 0 24 24" focusable="false"><path d="M12 3a8 4 0 0 1 8 4v10a8 4 0 0 1-16 0V7a8 4 0 0 1 8-4zm-6 4c0 1.1 2.69 2 6 2s6-.9 6-2-2.69-2-6-2-6 .9-6 2zm0 3.5V13c0 1.1 2.69 2 6 2s6-.9 6-2v-2.5c-1.36.95-3.7 1.5-6 1.5s-4.64-.55-6-1.5zm0 4.5v2c0 1.1 2.69 2 6 2s6-.9 6-2v-2c-1.36.95-3.7 1.5-6 1.5s-4.64-.55-6-1.5z"/></svg>
                   </span>
                   <span class="menu__label">Backup History</span>
-                </a>
-              </li>
-              <li class="menu__item">
-                <a href="/admin/backup-summary" {% if current_path.startswith('/admin/backup-summary') %}aria-current="page"{% endif %}>
-                  <span class="menu__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false"><path d="M3 3h18v4H3zm0 6h18v4H3zm0 6h18v4H3z"/></svg>
-                  </span>
-                  <span class="menu__label">Backup Summary</span>
                 </a>
               </li>
               <li class="menu__item">

--- a/tests/test_backups_feature_pack.py
+++ b/tests/test_backups_feature_pack.py
@@ -97,3 +97,123 @@ def test_backups_pack_loads_and_reloads_cleanly():
         await registry.unload_all()
 
     asyncio.new_event_loop().run_until_complete(_run())
+
+
+def test_backup_summary_uses_menu_permission_and_scopes_non_super_admin(monkeypatch):
+    import asyncio
+
+    from starlette.requests import Request
+
+    from app.repositories import companies as company_repo
+    from app.services import backup_jobs as backup_jobs_service
+
+    calls: dict[str, object] = {}
+
+    async def fake_require_menu_page_access(request, key, *, write=False, detail=""):
+        calls["permission"] = (key, write, detail)
+        request.state.active_company_id = 10
+        return {"id": 7, "company_id": 10, "is_super_admin": False}, None
+
+    async def fake_list_jobs_with_latest(*, company_id=None, include_inactive=False):
+        calls["jobs_company_id"] = company_id
+        calls["jobs_include_inactive"] = include_inactive
+        return [{"id": 1, "company_id": company_id, "today_status": "success"}]
+
+    def fake_summarise_jobs(jobs):
+        calls["summarised_jobs"] = jobs
+        return {"total": len(jobs)}
+
+    async def fake_list_companies():
+        return [{"id": 10, "name": "Allowed"}, {"id": 20, "name": "Hidden"}]
+
+    async def fake_build_history_grid(*, company_id=None, days=14, include_inactive=False):
+        calls["history"] = (company_id, days, include_inactive)
+        return []
+
+    async def fake_render_template(template, request, user, *, extra=None):
+        calls["render"] = (template, user, extra)
+        return extra
+
+    monkeypatch.setattr(main_module, "_require_menu_page_access", fake_require_menu_page_access)
+    monkeypatch.setattr(main_module, "_render_template", fake_render_template)
+    monkeypatch.setattr(backup_jobs_service, "list_jobs_with_latest", fake_list_jobs_with_latest)
+    monkeypatch.setattr(backup_jobs_service, "summarise_jobs", fake_summarise_jobs)
+    monkeypatch.setattr(backup_jobs_service, "build_history_grid", fake_build_history_grid)
+    monkeypatch.setattr(company_repo, "list_companies", fake_list_companies)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/admin/backup-summary",
+        "query_string": b"company_id=20",
+        "headers": [],
+        "server": ("testserver", 80),
+        "scheme": "http",
+    }
+    request = Request(scope)
+
+    extra = asyncio.run(backup_handlers.admin_backup_summary_page(request))
+
+    assert calls["permission"] == (
+        "menu.admin.backup_summary",
+        False,
+        "Backup summary access required",
+    )
+    assert calls["jobs_company_id"] == 10
+    assert calls["jobs_include_inactive"] is True
+    assert calls["history"] == (10, 14, True)
+    assert extra["backup_company_filter"] == 10
+    assert extra["backup_companies"] == [{"id": 10, "name": "Allowed"}]
+    assert extra["backup_company_lookup"] == {10: "Allowed"}
+
+
+def test_backup_summary_keeps_super_admin_company_filter(monkeypatch):
+    import asyncio
+
+    from starlette.requests import Request
+
+    from app.repositories import companies as company_repo
+    from app.services import backup_jobs as backup_jobs_service
+
+    calls: dict[str, object] = {}
+
+    async def fake_require_menu_page_access(request, key, *, write=False, detail=""):
+        return {"id": 1, "is_super_admin": True}, None
+
+    async def fake_list_jobs_with_latest(*, company_id=None, include_inactive=False):
+        calls["jobs_company_id"] = company_id
+        return []
+
+    async def fake_list_companies():
+        return [{"id": 10, "name": "Allowed"}, {"id": 20, "name": "Other"}]
+
+    async def fake_build_history_grid(*, company_id=None, days=14, include_inactive=False):
+        calls["history_company_id"] = company_id
+        return []
+
+    async def fake_render_template(template, request, user, *, extra=None):
+        return extra
+
+    monkeypatch.setattr(main_module, "_require_menu_page_access", fake_require_menu_page_access)
+    monkeypatch.setattr(main_module, "_render_template", fake_render_template)
+    monkeypatch.setattr(backup_jobs_service, "list_jobs_with_latest", fake_list_jobs_with_latest)
+    monkeypatch.setattr(backup_jobs_service, "summarise_jobs", lambda jobs: {"total": len(jobs)})
+    monkeypatch.setattr(backup_jobs_service, "build_history_grid", fake_build_history_grid)
+    monkeypatch.setattr(company_repo, "list_companies", fake_list_companies)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/admin/backup-summary",
+        "query_string": b"company_id=20",
+        "headers": [],
+        "server": ("testserver", 80),
+        "scheme": "http",
+    }
+
+    extra = asyncio.run(backup_handlers.admin_backup_summary_page(Request(scope)))
+
+    assert calls["jobs_company_id"] == 20
+    assert calls["history_company_id"] == 20
+    assert extra["backup_company_filter"] == 20
+    assert extra["backup_companies"] == [{"id": 10, "name": "Allowed"}, {"id": 20, "name": "Other"}]

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -348,3 +348,32 @@ def test_super_admin_keeps_help_and_reports_menu_access():
 
     assert menu_access["menu.help"] == "write"
     assert menu_access["menu.reports"] == "write"
+
+
+def test_backup_summary_menu_permission_shows_admin_menu_without_super_admin():
+    from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+    env = Environment(
+        loader=FileSystemLoader("app/templates"),
+        autoescape=select_autoescape(["html"]),
+    )
+    template = env.get_template("base.html")
+    html = template.render(
+        request=type("Request", (), {"url": type("Url", (), {"path": "/admin/backup-summary"})()})(),
+        current_user={"id": 2, "is_super_admin": False},
+        active_membership={},
+        menu_access={"menu.admin.backup_summary": "read"},
+        csrf_token=None,
+        available_companies=[],
+        app_name="MyPortal",
+        current_year=2026,
+        cart_summary={"item_count": 0, "total_quantity": 0},
+        plausible_config={"enabled": False},
+        static_url=lambda path: path,
+    )
+
+    assert "Administration" in html
+    assert 'href="/admin/backup-summary"' in html
+    assert "Backup Summary" in html
+    assert 'href="/admin/backup-jobs"' not in html
+    assert 'href="/admin/impersonation"' not in html


### PR DESCRIPTION
### Motivation
- Enable users granted the `menu.admin.backup_summary` menu permission to view the Backup Summary page instead of requiring super-admin privileges.
- Prevent cross-company exposure by ensuring non-super-admins only see backup data for their active company.
- Show the Backup Summary sidebar link to authorized users without exposing other super-admin-only admin links.

### Description
- Changed `admin_backup_summary_page` to use `_require_menu_page_access(request, "menu.admin.backup_summary", ...)` and handle redirects and 403s; added `HTTPException` usage. (`app/features/backups/handlers.py`)
- Resolved `company_filter` from the active membership for non-super-admins while allowing super-admins to keep an explicit `company_id` query filter, and scoped the `companies` list accordingly. (`app/features/backups/handlers.py`)
- Updated sidebar template to compute `can_access_admin_backup_summary` and show the Backup Summary menu item when the permission is present, without granting other admin-only links. (`app/templates/base.html`)
- Added regression tests covering permission-based handler access, non-super-admin company scoping, super-admin behavior, and sidebar visibility. (`tests/test_backups_feature_pack.py`, `tests/test_sidebar_menu.py`)

### Testing
- Ran the focused test suite with `pytest tests/test_backups_feature_pack.py tests/test_sidebar_menu.py` and observed all tests passed (`14 passed`).
- Compiled the modified module with `python -m py_compile app/features/backups/handlers.py` which succeeded.
- Template rendering was validated in tests by injecting a `static_url` helper in the test context to avoid Jinja undefined errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a48a138dc832d9f035fd009a1625a)