### PR TITLE
Enforce staff read-only UI permissions

### DIFF
--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -70,12 +70,25 @@ async def staff_page(
 
     is_super_admin = bool(user.get("is_super_admin"))
     is_admin = is_super_admin or bool(membership and membership.get("is_admin"))
-    membership_permissions = set((membership or {}).get("combined_permissions") or (membership or {}).get("permissions") or [])
-    can_approve_onboarding = bool(
+    is_helpdesk_technician = await main_module._is_helpdesk_technician(user, request)
+    membership_data = membership or {}
+    raw_staff_menu_access = main_module.normalize_menu_permissions(
+        membership_data.get("menu_permissions")
+    ).get("menu.staff", "none")
+    has_readonly_staff_menu_access = raw_staff_menu_access == "read"
+    has_write_staff_menu_access = raw_staff_menu_access == "write"
+    can_edit_staff = bool(
         is_super_admin
-        or "staff.manage" in membership_permissions
-        or bool(membership and membership.get("can_manage_staff"))
+        or has_write_staff_menu_access
+        or (
+            not has_readonly_staff_menu_access
+            and (
+                bool(membership_data.get("can_manage_staff"))
+                or int(membership_data.get("staff_permission") or 0) > 0
+            )
+        )
     )
+    can_approve_onboarding = bool(is_super_admin or is_helpdesk_technician)
 
     enabled_value = enabled.strip()
     enabled_filter: bool | None
@@ -303,7 +316,9 @@ async def staff_page(
         "title": "Staff",
         "is_super_admin": is_super_admin,
         "is_admin": is_admin,
+        "is_helpdesk_technician": is_helpdesk_technician,
         "staff_permission": staff_permission,
+        "can_edit_staff": can_edit_staff,
         "can_approve_onboarding": can_approve_onboarding,
         "departments": departments,
         "staff_members": cast(list[dict[str, Any]], _serialise_for_json(staff_members)),

--- a/app/features/staff/helpers.py
+++ b/app/features/staff/helpers.py
@@ -43,12 +43,32 @@ async def _load_staff_context(
             detail="Invalid company identifier",
         ) from exc
     membership = await main_module.user_company_repo.get_user_company(user["id"], company_id)
-    staff_permission = int(membership.get("staff_permission", 0)) if membership else 0
-    if not is_super_admin and staff_permission <= 0:
+    membership_data = membership or {}
+    staff_permission = int(membership_data.get("staff_permission", 0)) if membership else 0
+    raw_staff_menu_access = main_module.normalize_menu_permissions(
+        membership_data.get("menu_permissions")
+    ).get("menu.staff", "none")
+    has_readonly_staff_menu_access = raw_staff_menu_access == "read"
+    has_write_staff_menu_access = raw_staff_menu_access == "write"
+    legacy_staff_menu_access = main_module._membership_menu_can(
+        user, membership, "menu.staff", write=require_admin or require_super_admin
+    )
+    has_staff_menu_access = (
+        has_write_staff_menu_access
+        if require_admin or require_super_admin
+        else raw_staff_menu_access in {"read", "write"} or legacy_staff_menu_access
+    )
+    if has_readonly_staff_menu_access and (require_admin or require_super_admin):
+        has_staff_menu_access = False
+    if not is_super_admin and staff_permission <= 0 and not has_staff_menu_access:
         return user, membership, None, staff_permission, company_id, RedirectResponse(
             url="/", status_code=status.HTTP_303_SEE_OTHER
         )
-    if require_admin and not (is_super_admin or (membership and membership.get("is_admin"))):
+    if require_admin and not (
+        is_super_admin
+        or has_staff_menu_access
+        or (not has_readonly_staff_menu_access and membership and membership.get("is_admin"))
+    ):
         return user, membership, None, staff_permission, company_id, RedirectResponse(
             url="/", status_code=status.HTTP_303_SEE_OTHER
         )

--- a/app/static/js/staff.js
+++ b/app/static/js/staff.js
@@ -455,6 +455,7 @@
     const editActionError = getField('edit-action-error');
     const editFormError = getField('edit-form-error');
     const editDeleteConfirm = getField('edit-delete-confirm');
+    const editDangerZone = getField('edit-danger-zone');
 
     const editFields = {
       first_name: getField('edit-first-name'),
@@ -799,8 +800,9 @@
       const isExStaff = Boolean(member.date_offboarded) || accountAction === 'offboarded';
       const canInvite = Boolean(flags && flags.isAdmin && member.enabled && !isExStaff && member.email);
       const canRequestOffboarding = Boolean(flags && flags.isAdmin && member.enabled && !isExStaff && accountAction !== 'offboard requested');
-      const canApprove = Boolean(flags && flags.canApproveOnboarding && ['pending', 'requested'].includes(approvalStatus));
-      const canDeny = Boolean(flags && flags.canApproveOnboarding && ['pending', 'requested'].includes(approvalStatus));
+      const canPrivilegedStaffActions = Boolean(flags && (flags.isSuperAdmin || flags.isHelpdeskTechnician));
+      const canApprove = Boolean(canPrivilegedStaffActions && flags.canApproveOnboarding && ['pending', 'requested'].includes(approvalStatus));
+      const canDeny = Boolean(canPrivilegedStaffActions && flags.canApproveOnboarding && ['pending', 'requested'].includes(approvalStatus));
 
       setActionVisibility(editActionButtons.invite, { visible: canInvite, disabled: false });
       setActionVisibility(editActionButtons.offboardingRequest, { visible: canRequestOffboarding, disabled: false });
@@ -814,6 +816,10 @@
       setActionVisibility(editActionButtons.m365ResetPassword, { visible: canM365Actions, disabled: false });
       setActionVisibility(editActionButtons.m365EnableSignIn, { visible: canM365Actions, disabled: false });
       setActionVisibility(editActionButtons.m365DisableSignIn, { visible: canM365Actions, disabled: false });
+      const canSeeDangerZone = Boolean(flags && (flags.isSuperAdmin || flags.isHelpdeskTechnician));
+      if (editDangerZone) {
+        editDangerZone.hidden = !canSeeDangerZone;
+      }
       setActionVisibility(editActionButtons.delete, { visible: Boolean(flags && flags.isSuperAdmin), disabled: false });
 
       if (editActionButtons.workflowForceComplete) {

--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block header_title %}
-  {% if is_admin %}
+  {% if can_edit_staff %}
     <div class="header-title-menu">
       <span class="header-title-menu__label">Staff workspace</span>
       <details class="header-title-menu__dropdown" data-header-menu>
@@ -184,7 +184,9 @@
               <th scope="col" data-sort="string" data-column="custom-{{ field.name }}">{{ field.display_name or field.name }}</th>
             {% endfor %}
             <th scope="col" data-sort="string" data-column="enabled" data-mobile-priority="supporting">Enabled</th>
-            <th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>
+            {% if can_edit_staff %}
+              <th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>
+            {% endif %}
           </tr>
         </thead>
         <tbody>
@@ -277,32 +279,38 @@
                 </td>
               {% endfor %}
               <td data-label="Enabled" data-column="enabled">
-                <form action="/staff/enabled" method="post" class="inline-form">
-                  {% include "partials/csrf.html" %}
-                  <input type="hidden" name="staffId" value="{{ member.id }}" />
-                  <label class="visually-hidden" for="staff-enabled-{{ member.id }}">Toggle enabled state for {{ member.first_name }} {{ member.last_name }}</label>
-                  <input
-                    id="staff-enabled-{{ member.id }}"
-                    type="checkbox"
-                    name="enabled"
-                    value="1"
-                    {% if member.enabled %}checked{% endif %}
-                    data-submit-on-change
-                  />
-                </form>
+                {% if can_edit_staff %}
+                  <form action="/staff/enabled" method="post" class="inline-form">
+                    {% include "partials/csrf.html" %}
+                    <input type="hidden" name="staffId" value="{{ member.id }}" />
+                    <label class="visually-hidden" for="staff-enabled-{{ member.id }}">Toggle enabled state for {{ member.first_name }} {{ member.last_name }}</label>
+                    <input
+                      id="staff-enabled-{{ member.id }}"
+                      type="checkbox"
+                      name="enabled"
+                      value="1"
+                      {% if member.enabled %}checked{% endif %}
+                      data-submit-on-change
+                    />
+                  </form>
+                {% else %}
+                  {{ 'Yes' if member.enabled else 'No' }}
+                {% endif %}
               </td>
-              <td class="table__actions">
-                <div class="table__action-buttons">
-                  <button type="button" class="button button--ghost" data-staff-edit="{{ member.id }}">Edit</button>
-                  {% if is_super_admin %}
-                    <button type="button" class="button button--ghost" data-staff-verify="{{ member.id }}" {% if not member.mobile_phone %}disabled{% endif %}>Send code</button>
-                  {% endif %}
-                </div>
-              </td>
+              {% if can_edit_staff %}
+                <td class="table__actions">
+                  <div class="table__action-buttons">
+                    <button type="button" class="button button--ghost" data-staff-edit="{{ member.id }}">Edit</button>
+                    {% if is_super_admin %}
+                      <button type="button" class="button button--ghost" data-staff-verify="{{ member.id }}" {% if not member.mobile_phone %}disabled{% endif %}>Send code</button>
+                    {% endif %}
+                  </div>
+                </td>
+              {% endif %}
             </tr>
           {% else %}
             <tr>
-              <td colspan="{{ 10 + (staff_custom_field_definitions|length) }}" class="table__empty">No staff records found.</td>
+              <td colspan="{{ (10 if can_edit_staff else 9) + (staff_custom_field_definitions|length) }}" class="table__empty">No staff records found.</td>
             </tr>
           {% endfor %}
         </tbody>
@@ -331,7 +339,7 @@
   </section>
 </div>
 
-{% if is_admin %}
+{% if can_edit_staff %}
   <div class="modal" id="staff-add-modal" role="dialog" aria-modal="true" hidden>
     <div class="modal__content" role="document">
       <button type="button" class="modal__close" data-modal-close>
@@ -717,6 +725,7 @@
         <legend>Custom fields</legend>
         <div class="staff-modal__group-stack" id="edit-custom-fields-grid"></div>
       </fieldset>
+      {% if can_edit_staff %}
       <fieldset class="fieldset staff-modal__section" id="edit-actions-section">
         <legend>Secondary actions</legend>
         <p class="form-help form-field--full">Use these controls for invite, approvals, or workflow interventions. Add context notes for audit history.</p>
@@ -744,7 +753,8 @@
           <button type="button" class="button button--ghost" id="edit-action-m365-enable-sign-in" data-edit-action="m365-enable-sign-in" hidden>Enable O365 Sign-in</button>
           <button type="button" class="button button--ghost" id="edit-action-m365-disable-sign-in" data-edit-action="m365-disable-sign-in" hidden>Disable O365 Sign-in</button>
         </div>
-        <div class="staff-danger-panel">
+        {% if is_super_admin or is_helpdesk_technician %}
+        <div class="staff-danger-panel" id="edit-danger-zone">
           <h3 class="staff-danger-panel__title">Danger zone</h3>
           <p class="form-help">Delete permanently removes the staff record and cannot be undone.</p>
           <label class="checkbox" for="edit-delete-confirm">
@@ -755,7 +765,9 @@
           <button type="button" class="button button--danger" id="edit-action-delete" data-edit-action="delete">Delete</button>
           </div>
         </div>
+        {% endif %}
       </fieldset>
+      {% endif %}
       <p class="form-help form-help--error form-field--full" id="edit-form-error" hidden role="alert" aria-live="polite"></p>
       <div class="form-actions staff-modal__footer">
         <button type="submit" class="button">Save changes</button>
@@ -772,6 +784,8 @@
   'isSuperAdmin': is_super_admin,
   'isAdmin': is_admin,
   'canApproveOnboarding': can_approve_onboarding,
+  'canEditStaff': can_edit_staff,
+  'isHelpdeskTechnician': is_helpdesk_technician,
   'offboardingEmailForwardingEnabled': offboarding_email_forwarding_enabled,
   'hasM365': has_m365
 } | tojson }}</script>

--- a/tests/test_staff_permissions_ui.py
+++ b/tests/test_staff_permissions_ui.py
@@ -1,0 +1,81 @@
+import asyncio
+from types import SimpleNamespace
+
+from app.features.staff import handlers
+
+
+def async_return(value):
+    async def _inner(*args, **kwargs):
+        return value
+
+    return _inner
+
+
+def test_staff_page_menu_read_only_disables_staff_editing(monkeypatch):
+    captured = {}
+
+    async def fake_load_staff_context(request):
+        return (
+            {"id": 10, "company_id": 1, "is_super_admin": False},
+            {"menu_permissions": {"menu.staff": "read"}, "staff_permission": 3, "can_manage_staff": True},
+            {"id": 1, "email_domains": []},
+            3,
+            1,
+            None,
+        )
+
+    async def fake_render_template(template_name, request, user, *, extra):
+        captured.update(extra)
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(handlers, "_load_staff_context", fake_load_staff_context)
+    monkeypatch.setattr(handlers.main_module, "_is_helpdesk_technician", async_return(False))
+    monkeypatch.setattr(handlers.staff_field_config_service, "load_effective_company_staff_fields", async_return([]))
+    monkeypatch.setattr(handlers.staff_custom_fields_repo, "list_field_definitions", async_return([]))
+    monkeypatch.setattr(handlers.staff_repo, "list_staff", async_return([]))
+    monkeypatch.setattr(handlers.company_repo, "get_company_by_id", async_return({"email_domains": []}))
+    monkeypatch.setattr(handlers.staff_repo, "list_active_staff_for_offboarding", async_return([]))
+    monkeypatch.setattr(handlers.m365_service, "get_credentials", async_return(None))
+    monkeypatch.setattr(handlers.staff_workflow_repo, "list_executions_for_staff_ids", async_return({}))
+    monkeypatch.setattr(handlers, "_render_template", fake_render_template)
+
+    asyncio.run(handlers.staff_page(SimpleNamespace()))
+
+    assert captured["can_edit_staff"] is False
+    assert captured["can_approve_onboarding"] is False
+
+
+def test_staff_page_technician_can_approve_without_staff_manage(monkeypatch):
+    captured = {}
+
+    async def fake_load_staff_context(request):
+        return (
+            {"id": 11, "company_id": 1, "is_super_admin": False},
+            {"menu_permissions": {"menu.staff": "write"}, "staff_permission": 0},
+            {"id": 1, "email_domains": []},
+            0,
+            1,
+            None,
+        )
+
+    async def fake_render_template(template_name, request, user, *, extra):
+        captured.update(extra)
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(handlers, "_load_staff_context", fake_load_staff_context)
+    monkeypatch.setattr(handlers.main_module, "_is_helpdesk_technician", async_return(True))
+    monkeypatch.setattr(handlers.staff_field_config_service, "load_effective_company_staff_fields", async_return([]))
+    monkeypatch.setattr(handlers.staff_custom_fields_repo, "list_field_definitions", async_return([]))
+    monkeypatch.setattr(handlers.staff_repo, "list_staff", async_return([]))
+    monkeypatch.setattr(handlers.company_repo, "get_company_by_id", async_return({"email_domains": []}))
+    monkeypatch.setattr(handlers.staff_repo, "list_active_staff_for_offboarding", async_return([]))
+    monkeypatch.setattr(handlers.m365_service, "get_credentials", async_return(None))
+    monkeypatch.setattr(handlers.staff_requests_repo, "list_requests", async_return([{"id": 1}]))
+    monkeypatch.setattr(handlers.staff_workflow_repo, "list_executions_for_staff_ids", async_return({}))
+    monkeypatch.setattr(handlers, "_render_template", fake_render_template)
+
+    asyncio.run(handlers.staff_page(SimpleNamespace()))
+
+    assert captured["can_edit_staff"] is True
+    assert captured["can_approve_onboarding"] is True
+    assert captured["staff_pending_requests"] == [{"id": 1}]


### PR DESCRIPTION
### Motivation
- Allow `menu.staff = read` members to view the /staff page but not perform edits or actions, and ensure only appropriate roles see sensitive controls. 
- Restrict Approve/Deny and the Danger Zone so only super admins and helpdesk technicians can access destructive or privileged actions.

### Description
- Compute an explicit `can_edit_staff` flag in `staff_page` using normalized `menu.staff` levels and existing `staff_permission`/`can_manage_staff` fallbacks, and expose `is_helpdesk_technician` for UI decisions (changes in `app/features/staff/handlers.py`).
- Update `_load_staff_context` to allow read-only `menu.staff` access to reach the page while ensuring write/admin checks still require write-level access (changes in `app/features/staff/helpers.py`).
- Template changes in `app/templates/staff/index.html` hide the action column, Add/Edit controls, and edit-modal actions when `can_edit_staff` is false; render the Enabled column as plain text when a user cannot edit; gate the Danger Zone to only super admins or helpdesk technicians.
- Frontend logic in `app/static/js/staff.js` now requires privileged staff (super admin or helpdesk technician) to show Approve/Deny and to unhide the Danger Zone client-side.
- Add unit tests `tests/test_staff_permissions_ui.py` to validate read-only menu behavior and helpdesk technician approval visibility.

### Testing
- Verified Python syntax and template compilation with `python -m py_compile app/features/staff/handlers.py app/features/staff/helpers.py` and Jinja template load of `staff/index.html`, both succeeded.
- Checked frontend JS with `node --check app/static/js/staff.js`, which succeeded.
- Ran the relevant test suites: `pytest -q tests/test_staff_feature_pack.py tests/test_staff_permissions_ui.py`, and all tests passed (7 passed total, including the two new regression tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a492414988332aaedeeea39da478e)