### PR TITLE
Use flat Hudu /api/v1/asset_passwords endpoint and include company_id in payload

### DIFF
--- a/app/services/hudu.py
+++ b/app/services/hudu.py
@@ -189,9 +189,10 @@ async def create_asset_password(
     base_url = settings["base_url"]
     api_key = settings["api_key"]
 
-    endpoint = f"{base_url}/api/v1/companies/{company_id}/asset_passwords"
+    endpoint = f"{base_url}/api/v1/asset_passwords"
     pw_payload: dict[str, Any] = {
         "name": name,
+        "company_id": company_id,
         "password": password,
     }
     if username:

--- a/tests/test_hudu_service.py
+++ b/tests/test_hudu_service.py
@@ -12,13 +12,13 @@ def anyio_backend() -> str:
 
 
 @pytest.mark.anyio
-async def test_create_asset_password_uses_company_scoped_endpoint_and_sends_auth(monkeypatch):
-    """create_asset_password must POST to the company-scoped URL and include the x-api-key header.
+async def test_create_asset_password_uses_flat_endpoint_with_company_id_and_sends_auth(monkeypatch):
+    """create_asset_password must POST to Hudu's asset_passwords endpoint with company_id in the body.
 
-    The flat /api/v1/asset_passwords endpoint does not carry the company ID
-    in the URL, which causes Hudu to return 401 because it cannot verify that
-    the API key is authorised for the requested company.  The correct endpoint
-    is /api/v1/companies/{company_id}/asset_passwords.
+    Hudu exposes password creation at /api/v1/asset_passwords. Posting to a
+    nested /api/v1/companies/{company_id}/asset_passwords URL returns 404 on
+    Hudu Cloud instances, so the company association must be sent as the
+    asset_password.company_id field.
     """
     captured: dict[str, object] = {}
 
@@ -60,15 +60,15 @@ async def test_create_asset_password_uses_company_scoped_endpoint_and_sends_auth
         username="alice@example.com",
     )
 
-    # Endpoint must be company-scoped (not the flat /api/v1/asset_passwords)
-    assert captured["url"] == "https://hudu.example.com/api/v1/companies/99/asset_passwords"
+    # Endpoint must be the flat Hudu asset_passwords endpoint (not company-scoped)
+    assert captured["url"] == "https://hudu.example.com/api/v1/asset_passwords"
 
     # Authentication header must be present with the configured API key
     assert captured["headers"].get("x-api-key") == "test-api-key-abc"
 
-    # company_id must NOT be in the body (it lives in the URL)
+    # Hudu expects company_id in the asset_password body
     pw_body = captured["json"]["asset_password"]
-    assert "company_id" not in pw_body
+    assert pw_body["company_id"] == "99"
 
     # Core fields must be present
     assert pw_body["name"] == "Test Password"


### PR DESCRIPTION
### Motivation
- Onboarding password pushes to Hudu were returning `404 Not Found` because the integration posted to a company-scoped URL that Hudu Cloud does not support. 
- Hudu Cloud expects password creation at the flat `/api/v1/asset_passwords` endpoint with the company association supplied in the request body.

### Description
- Change `app/services/hudu.py:create_asset_password` to POST to `{base_url}/api/v1/asset_passwords` instead of the nested company URL. 
- Add `company_id` to the `asset_password` payload so the request body contains the company association. 
- Update `tests/test_hudu_service.py` to assert the flat endpoint, presence of the `x-api-key` header, and that `asset_password.company_id` is sent in the JSON payload.

### Testing
- Ran `pytest tests/test_hudu_service.py -q` and the test passed (`1 passed`).
- Ran `git diff --check` to ensure no whitespace or diff issues and it produced no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a4d3de2248332a9fe95877cbf7597)