### PR TITLE
Allow read-only users to access assets page

### DIFF
--- a/app/features/assets/routes.py
+++ b/app/features/assets/routes.py
@@ -63,8 +63,8 @@ async def _load_asset_context(request: Request):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid company identifier") from exc
 
     membership = await user_company_repo.get_user_company(user["id"], company_id)
-    can_manage_assets = bool(membership and membership.get("can_manage_assets"))
-    if not (is_super_admin or can_manage_assets):
+    can_view_assets = main_module._membership_menu_can(user, membership, "menu.assets")
+    if not (is_super_admin or can_view_assets):
         return (
             user,
             membership,

--- a/tests/test_assets_permissions.py
+++ b/tests/test_assets_permissions.py
@@ -1,0 +1,85 @@
+from starlette.requests import Request
+from starlette.responses import HTMLResponse
+import pytest
+
+from app.features.assets import routes as assets_routes
+import app.main as main_module
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _request() -> Request:
+    return Request({"type": "http", "method": "GET", "path": "/assets", "headers": []})
+
+
+@pytest.mark.anyio
+async def test_assets_page_allows_read_only_menu_permission(monkeypatch):
+    user = {"id": 7, "company_id": 42, "is_super_admin": False}
+    membership = {
+        "company_id": 42,
+        "can_manage_assets": False,
+        "menu_permissions": {"menu.assets": "read"},
+    }
+
+    async def fake_require_authenticated_user(request):
+        return user, None
+
+    async def fake_get_user_company(user_id, company_id):
+        return membership
+
+    async def fake_get_company_by_id(company_id):
+        return {"id": company_id, "name": "Acme"}
+
+    async def fake_list_company_assets(company_id):
+        return []
+
+    async def fake_list_field_definitions():
+        return []
+
+    async def fake_get_all_asset_field_values(asset_ids):
+        return {}
+
+    async def fake_render_template(template, request, current_user, *, extra=None):
+        assert template == "assets/index.html"
+        assert extra["company"] == {"id": 42, "name": "Acme"}
+        return HTMLResponse("assets page")
+
+    monkeypatch.setattr(main_module, "_require_authenticated_user", fake_require_authenticated_user)
+    monkeypatch.setattr(assets_routes.user_company_repo, "get_user_company", fake_get_user_company)
+    monkeypatch.setattr(assets_routes.company_repo, "get_company_by_id", fake_get_company_by_id)
+    monkeypatch.setattr(assets_routes.asset_repo, "list_company_assets", fake_list_company_assets)
+    monkeypatch.setattr(assets_routes.asset_custom_fields_repo, "list_field_definitions", fake_list_field_definitions)
+    monkeypatch.setattr(assets_routes.asset_custom_fields_repo, "get_all_asset_field_values", fake_get_all_asset_field_values)
+    monkeypatch.setattr(main_module, "_render_template", fake_render_template)
+
+    response = await assets_routes.assets_page(_request())
+
+    assert response.status_code == 200
+    assert response.body == b"assets page"
+
+
+@pytest.mark.anyio
+async def test_assets_page_redirects_when_menu_permission_is_none(monkeypatch):
+    user = {"id": 7, "company_id": 42, "is_super_admin": False}
+    membership = {
+        "company_id": 42,
+        "can_manage_assets": False,
+        "menu_permissions": {"menu.assets": "none"},
+    }
+
+    async def fake_require_authenticated_user(request):
+        return user, None
+
+    async def fake_get_user_company(user_id, company_id):
+        return membership
+
+    monkeypatch.setattr(main_module, "_require_authenticated_user", fake_require_authenticated_user)
+    monkeypatch.setattr(assets_routes.user_company_repo, "get_user_company", fake_get_user_company)
+
+    response = await assets_routes.assets_page(_request())
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/"


### PR DESCRIPTION
### Motivation
- The assets page required the legacy `can_manage_assets` flag which prevented users with read-level `menu.assets` menu permission from viewing `/assets`.

### Description
- Use the membership menu permission check for assets by calling `_membership_menu_can(user, membership, "menu.assets")` instead of requiring `can_manage_assets` in `app/features/assets/routes.py`.
- Add `tests/test_assets_permissions.py` to cover both a read-level `menu.assets` case that renders the page and a `none` case that redirects to `/`.
- Files changed: `app/features/assets/routes.py` and new test `tests/test_assets_permissions.py`.

### Testing
- Ran `pytest tests/test_assets_permissions.py tests/test_menu_permissions.py -q`; both test modules passed (7 tests passed in the run used here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a4e96bf5c83328c0e2e0c578ac8ac)