### PR TITLE
Scope issues and notifications to authorized access

### DIFF
--- a/app/api/routes/issues.py
+++ b/app/api/routes/issues.py
@@ -19,9 +19,26 @@ from app.schemas.issues import (
     IssueStatusUpdate,
     IssueUpdate,
 )
-from app.services import issues as issues_service
+from app.services import company_access, issues as issues_service
 
 router = APIRouter(prefix="/api/issues", tags=["Issues"])
+
+
+async def _accessible_company_ids(user: Mapping[str, Any]) -> set[int]:
+    memberships = await company_access.list_accessible_companies(user)
+    allowed_ids: set[int] = set()
+    for membership in memberships:
+        raw_id = membership.get("company_id") or membership.get("id")
+        try:
+            allowed_ids.add(int(raw_id))
+        except (TypeError, ValueError):
+            continue
+    return allowed_ids
+
+
+def _assert_company_allowed(company_id: int, allowed_company_ids: set[int]) -> None:
+    if company_id not in allowed_company_ids:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Company access required")
 
 
 def _build_issue_response(overview: issues_service.IssueOverview) -> IssueResponse:
@@ -88,7 +105,7 @@ async def list_issues(
     _: None = Depends(require_database),
     current_user: dict[str, Any] = Depends(require_issue_tracker_access),
 ) -> IssueListResponse:
-    del current_user  # Access control handled by dependency
+    allowed_company_ids = await _accessible_company_ids(current_user)
     resolved_company_id = company_id
     if resolved_company_id is None:
         raw_company_id = request.query_params.get("company_id")
@@ -100,6 +117,8 @@ async def list_issues(
             except ValueError as exc:
                 raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid company filter") from exc
     resolved_company_id = await _resolve_company_filter(resolved_company_id, company_name)
+    if resolved_company_id is not None and resolved_company_id not in allowed_company_ids:
+        return IssueListResponse(items=[], total=0)
     try:
         status_value = issues_service.normalise_status(status_filter) if status_filter else None
     except ValueError as exc:
@@ -115,6 +134,7 @@ async def list_issues(
         search=search_value,
         status=status_value,
         company_id=resolved_company_id,
+        company_ids=allowed_company_ids,
     )
     items = [_build_issue_response(overview) for overview in overviews]
     return IssueListResponse(items=items, total=len(items))
@@ -133,6 +153,16 @@ async def create_issue(
     current_user: dict[str, Any] = Depends(require_issue_tracker_access),
 ) -> IssueResponse:
     user_id = _extract_user_id(current_user)
+    allowed_company_ids = await _accessible_company_ids(current_user)
+    resolved_assignments: list[tuple[int, str]] = []
+    for assignment in payload.companies:
+        company = await company_repo.get_company_by_name(assignment.company_name)
+        if not company:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+        company_id = int(company["id"])
+        _assert_company_allowed(company_id, allowed_company_ids)
+        resolved_assignments.append((company_id, assignment.status))
+
     try:
         await issues_service.ensure_issue_name_available(payload.name)
     except ValueError as exc:
@@ -178,19 +208,16 @@ async def create_issue(
     if issue_id is None:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Issue identifier missing")
 
-    for assignment in payload.companies:
-        company = await company_repo.get_company_by_name(assignment.company_name)
-        if not company:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
-        status_value = issues_service.normalise_status(assignment.status)
+    for company_id, assignment_status in resolved_assignments:
+        status_value = issues_service.normalise_status(assignment_status)
         await issues_repo.assign_issue_to_company(
             issue_id=issue_id,
-            company_id=int(company["id"]),
+            company_id=company_id,
             status=status_value,
             updated_by=user_id,
         )
 
-    overview = await issues_service.get_issue_overview(issue_id)
+    overview = await issues_service.get_issue_overview(issue_id, company_ids=allowed_company_ids)
     if not overview:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Issue lookup failed")
 
@@ -215,6 +242,11 @@ async def update_issue_status(
     current_user: dict[str, Any] = Depends(require_issue_tracker_access),
 ) -> IssueStatusResponse:
     user_id = _extract_user_id(current_user)
+    allowed_company_ids = await _accessible_company_ids(current_user)
+    company = await company_repo.get_company_by_name(payload.company_name)
+    if not company:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    _assert_company_allowed(int(company["id"]), allowed_company_ids)
     try:
         assignment = await issues_service.upsert_issue_status_by_name(
             issue_name=payload.issue_name,
@@ -279,6 +311,17 @@ async def update_issue(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Issue not found")
     issue_id = int(issue["issue_id"])
     user_id = _extract_user_id(current_user)
+    allowed_company_ids = await _accessible_company_ids(current_user)
+    scoped_overview = await issues_service.get_issue_overview(issue_id, company_ids=allowed_company_ids)
+    has_existing_access = bool(scoped_overview and scoped_overview.assignments)
+    resolved_assignments: list[tuple[int, str]] = []
+    for assignment in payload.add_companies:
+        company = await company_repo.get_company_by_name(assignment.company_name)
+        if not company:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Company '{assignment.company_name}' not found")
+        company_id = int(company["id"])
+        _assert_company_allowed(company_id, allowed_company_ids)
+        resolved_assignments.append((company_id, assignment.status))
 
     updates: dict[str, Any] = {}
     if payload.description is not None:
@@ -304,23 +347,23 @@ async def update_issue(
     if payload.new_slug is not None:
         updates["slug"] = payload.new_slug
 
+    if not has_existing_access and (updates or not resolved_assignments):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Issue not found")
+
     if updates:
         updates["updated_by"] = user_id
         await issues_repo.update_issue(issue_id, **updates)
 
-    for assignment in payload.add_companies:
-        company = await company_repo.get_company_by_name(assignment.company_name)
-        if not company:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Company '{assignment.company_name}' not found")
-        status_value = issues_service.normalise_status(assignment.status)
+    for company_id, assignment_status in resolved_assignments:
+        status_value = issues_service.normalise_status(assignment_status)
         await issues_repo.assign_issue_to_company(
             issue_id=issue_id,
-            company_id=int(company["id"]),
+            company_id=company_id,
             status=status_value,
             updated_by=user_id,
         )
 
-    overview = await issues_service.get_issue_overview(issue_id)
+    overview = await issues_service.get_issue_overview(issue_id, company_ids=allowed_company_ids)
     if not overview:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Issue lookup failed")
 

--- a/app/features/issue_tracker/handlers.py
+++ b/app/features/issue_tracker/handlers.py
@@ -17,6 +17,43 @@ def _main():
     return main_module
 
 
+
+def _coerce_company_id(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+async def _accessible_company_options(user: dict[str, Any]) -> tuple[list[dict[str, Any]], set[int]]:
+    from app.services import company_access
+
+    memberships = await company_access.list_accessible_companies(user)
+    options: list[dict[str, Any]] = []
+    allowed_ids: set[int] = set()
+    for record in memberships:
+        company_id = _coerce_company_id(record.get("company_id") or record.get("id"))
+        if company_id is None:
+            continue
+        name = str(record.get("company_name") or record.get("name") or "").strip()
+        allowed_ids.add(company_id)
+        options.append({"id": company_id, "name": name or f"Company #{company_id}"})
+    options.sort(key=lambda item: item["name"].lower())
+    return options, allowed_ids
+
+
+def _filter_company_ids(company_ids: list[int], allowed_company_ids: set[int]) -> list[int]:
+    return [company_id for company_id in dict.fromkeys(company_ids) if company_id in allowed_company_ids]
+
+
+async def _assignment_is_accessible(assignment_id: int, allowed_company_ids: set[int]) -> bool:
+    from app.repositories import issues as issues_repo
+
+    assignment = await issues_repo.get_assignment_by_id(assignment_id)
+    company_id = _coerce_company_id((assignment or {}).get("company_id"))
+    return company_id is not None and company_id in allowed_company_ids
+
+
 def _format_issue_overview_for_template(overview: Any) -> dict[str, Any]:
     from app.services import issues as issues_service
 
@@ -51,7 +88,6 @@ async def admin_issue_tracker(
     company_id: int | None = Query(default=None, alias="companyId"),
     issue_id: int | None = Query(default=None, alias="issueId"),
 ):
-    from app.repositories import companies as company_repo
     from app.services import issues as issues_service
 
     current_user, redirect = await _main()._require_issue_tracker_access(request)
@@ -73,38 +109,26 @@ async def admin_issue_tracker(
         except ValueError:
             status_filter = None
 
+    company_options, allowed_company_ids = await _accessible_company_options(current_user)
+    if company_filter is not None and company_filter not in allowed_company_ids:
+        company_filter = None
+
     overviews = await issues_service.build_issue_overview(
         search=search_term,
         status=status_filter,
         company_id=company_filter,
+        company_ids=allowed_company_ids,
     )
     issues_payload = [_format_issue_overview_for_template(item) for item in overviews]
 
     editing_issue: dict[str, Any] | None = None
     edit_error: str | None = None
     if issue_id:
-        lookup = await issues_service.get_issue_overview(issue_id)
+        lookup = await issues_service.get_issue_overview(issue_id, company_ids=allowed_company_ids)
         if lookup:
             editing_issue = _format_issue_overview_for_template(lookup)
         else:
             edit_error = "Selected issue could not be found."
-
-    companies = await company_repo.list_companies()
-    company_options: list[dict[str, Any]] = []
-    for record in companies:
-        raw_id = record.get("id")
-        name = (record.get("name") or "").strip()
-        try:
-            option_id = int(raw_id)
-        except (TypeError, ValueError):
-            continue
-        company_options.append(
-            {
-                "id": option_id,
-                "name": name or f"Company #{option_id}",
-            }
-        )
-    company_options.sort(key=lambda item: item["name"].lower())
 
     if editing_issue:
         assigned_company_ids = {
@@ -140,7 +164,6 @@ async def admin_issue_tracker(
 
 async def admin_create_issue(request: Request):
     from app.core.logging import log_info
-    from app.repositories import companies as company_repo
     from app.repositories import issues as issues_repo
     from app.services import issues as issues_service
 
@@ -188,15 +211,12 @@ async def admin_create_issue(request: Request):
     company_ids_raw = form.getlist("company_ids")
     selected_companies: list[int] = []
     for raw in company_ids_raw:
-        try:
-            selected_companies.append(int(raw))
-        except (TypeError, ValueError):
-            continue
+        company_id_value = _coerce_company_id(raw)
+        if company_id_value is not None:
+            selected_companies.append(company_id_value)
+    _, allowed_company_ids = await _accessible_company_options(current_user)
 
-    for company_id_value in selected_companies:
-        company = await company_repo.get_company_by_id(company_id_value)
-        if not company:
-            continue
+    for company_id_value in _filter_company_ids(selected_companies, allowed_company_ids):
         await issues_repo.assign_issue_to_company(
             issue_id=issue_id_int,
             company_id=company_id_value,
@@ -215,7 +235,6 @@ async def admin_create_issue(request: Request):
 
 async def admin_update_issue(issue_id: int, request: Request):
     from app.core.logging import log_info
-    from app.repositories import companies as company_repo
     from app.repositories import issues as issues_repo
     from app.services import issues as issues_service
 
@@ -223,8 +242,9 @@ async def admin_update_issue(issue_id: int, request: Request):
     if redirect:
         return redirect
 
-    issue = await issues_repo.get_issue_by_id(issue_id)
-    if not issue:
+    _, allowed_company_ids = await _accessible_company_options(current_user)
+    issue = await issues_repo.get_issue_by_id(issue_id, company_ids=allowed_company_ids)
+    if not issue or not issue.get("assignments"):
         return flash_redirect("/admin/issues", 'Issue not found.', "error")
 
     form = await request.form()
@@ -262,15 +282,11 @@ async def admin_update_issue(issue_id: int, request: Request):
     new_company_ids_raw = form.getlist("newCompanyIds")
     selected_companies: list[int] = []
     for raw in new_company_ids_raw:
-        try:
-            selected_companies.append(int(raw))
-        except (TypeError, ValueError):
-            continue
+        company_id_value = _coerce_company_id(raw)
+        if company_id_value is not None:
+            selected_companies.append(company_id_value)
 
-    for company_id_value in selected_companies:
-        company = await company_repo.get_company_by_id(company_id_value)
-        if not company:
-            continue
+    for company_id_value in _filter_company_ids(selected_companies, allowed_company_ids):
         await issues_repo.assign_issue_to_company(
             issue_id=issue_id,
             company_id=company_id_value,
@@ -308,6 +324,10 @@ async def admin_update_issue_assignment_status(
         normalised_status = issues_service.normalise_status(status_value)
     except ValueError:
         return flash_redirect(f"/admin/issues?issueId={issue_id}", 'Invalid status selection.', "error")
+
+    _, allowed_company_ids = await _accessible_company_options(current_user)
+    if not await _assignment_is_accessible(assignment_id, allowed_company_ids):
+        return flash_redirect(f"/admin/issues?issueId={issue_id}", 'Assignment not found.', "error")
 
     try:
         await issues_repo.update_assignment_status(
@@ -350,6 +370,10 @@ async def admin_delete_issue_assignment(
 
     form = await request.form()
     return_url = str(form.get("returnUrl", "")).strip() or None
+
+    _, allowed_company_ids = await _accessible_company_options(current_user)
+    if not await _assignment_is_accessible(assignment_id, allowed_company_ids):
+        return flash_redirect(f"/admin/issues?issueId={issue_id}", 'Assignment not found.', "error")
 
     await issues_repo.delete_assignment(assignment_id)
     log_info(

--- a/app/repositories/issues.py
+++ b/app/repositories/issues.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any, Iterable, Mapping
 
@@ -8,6 +9,18 @@ from app.core.database import db
 
 IssueRecord = dict[str, Any]
 AssignmentRecord = dict[str, Any]
+
+
+def _normalise_company_ids(company_ids: Sequence[int] | None) -> list[int] | None:
+    if company_ids is None:
+        return None
+    values: list[int] = []
+    for value in company_ids:
+        try:
+            values.append(int(value))
+        except (TypeError, ValueError):
+            continue
+    return list(dict.fromkeys(values))
 
 
 def _ensure_aware(value: Any) -> datetime | None:
@@ -79,6 +92,7 @@ async def list_issues_with_assignments(
     search: str | None = None,
     status: str | None = None,
     company_id: int | None = None,
+    company_ids: Sequence[int] | None = None,
 ) -> list[IssueRecord]:
     where: list[str] = []
     params: list[Any] = []
@@ -95,6 +109,14 @@ async def list_issues_with_assignments(
     if company_id is not None:
         where.append("ics.company_id = %s")
         params.append(company_id)
+    elif company_ids is not None:
+        allowed_company_ids = _normalise_company_ids(company_ids) or []
+        if allowed_company_ids:
+            placeholders = ", ".join(["%s"] * len(allowed_company_ids))
+            where.append(f"ics.company_id IN ({placeholders})")
+            params.extend(allowed_company_ids)
+        else:
+            where.append("1 = 0")
 
     where_clause = f"WHERE {' AND '.join(where)}" if where else ""
 
@@ -179,7 +201,11 @@ async def list_issues_with_assignments(
     return result
 
 
-async def get_issue_by_id(issue_id: int) -> IssueRecord | None:
+async def get_issue_by_id(
+    issue_id: int,
+    *,
+    company_ids: Sequence[int] | None = None,
+) -> IssueRecord | None:
     row = await db.fetch_one(
         "SELECT id AS issue_id, name, slug, description, created_by, updated_by, created_at_utc, updated_at_utc FROM issue_definitions WHERE id = %s",
         (issue_id,),
@@ -187,8 +213,18 @@ async def get_issue_by_id(issue_id: int) -> IssueRecord | None:
     issue = _normalise_issue(row)
     if not issue:
         return None
+    assignment_where = ["issue_id = %s"]
+    assignment_params: list[Any] = [issue_id]
+    if company_ids is not None:
+        allowed_company_ids = _normalise_company_ids(company_ids) or []
+        if allowed_company_ids:
+            placeholders = ", ".join(["%s"] * len(allowed_company_ids))
+            assignment_where.append(f"company_id IN ({placeholders})")
+            assignment_params.extend(allowed_company_ids)
+        else:
+            assignment_where.append("1 = 0")
     assignment_rows = await db.fetch_all(
-        """
+        f"""
         SELECT
             id AS assignment_id,
             issue_id,
@@ -199,10 +235,10 @@ async def get_issue_by_id(issue_id: int) -> IssueRecord | None:
             created_at_utc,
             updated_at_utc
         FROM issue_company_statuses
-        WHERE issue_id = %s
+        WHERE {' AND '.join(assignment_where)}
         ORDER BY updated_at_utc DESC
         """,
-        (issue_id,),
+        tuple(assignment_params),
     )
     issue["assignments"] = [assignment for assignment in (_normalise_assignment(row) for row in assignment_rows) if assignment]
     return issue
@@ -390,6 +426,18 @@ async def assign_issue_to_company(
         "created_at_utc": None,
         "updated_at_utc": None,
     }
+
+
+async def get_assignment_by_id(assignment_id: int) -> AssignmentRecord | None:
+    row = await db.fetch_one(
+        """
+        SELECT id AS assignment_id, issue_id, company_id, status, notes, updated_by, created_at_utc, updated_at_utc
+        FROM issue_company_statuses
+        WHERE id = %s
+        """,
+        (assignment_id,),
+    )
+    return _normalise_assignment(row)
 
 
 async def update_assignment_status(

--- a/app/repositories/notifications.py
+++ b/app/repositories/notifications.py
@@ -59,7 +59,7 @@ def _build_filters(
     params: list[Any] = []
 
     if user_id is not None:
-        clauses.append("(user_id = %s OR user_id IS NULL)")
+        clauses.append("user_id = %s")
         params.append(user_id)
 
     if read_state == "unread":
@@ -279,7 +279,7 @@ async def list_event_types(*, user_id: int | None = None) -> list[str]:
     clauses = ["1=1"]
     params: list[Any] = []
     if user_id is not None:
-        clauses.append("(user_id = %s OR user_id IS NULL)")
+        clauses.append("user_id = %s")
         params.append(user_id)
     sql = f"SELECT DISTINCT event_type FROM notifications WHERE {' AND '.join(clauses)} ORDER BY event_type"
     rows = await db.fetch_all(sql, tuple(params))

--- a/app/services/issues.py
+++ b/app/services/issues.py
@@ -143,13 +143,16 @@ async def build_issue_overview(
     search: str | None = None,
     status: str | None = None,
     company_id: int | None = None,
+    company_ids: Iterable[int] | None = None,
 ) -> list[IssueOverview]:
     status_filter = normalise_status(status) if status else None
     search_term = search.strip() if search else ""
+    scoped_company_ids = list(company_ids) if company_ids is not None else None
     rows = await issues_repo.list_issues_with_assignments(
         search=search_term.lower() if search_term else None,
         status=status_filter,
         company_id=company_id,
+        company_ids=scoped_company_ids,
     )
     overview: list[IssueOverview] = []
     for row in rows:
@@ -184,8 +187,13 @@ async def resolve_company_by_name(name: str) -> dict[str, Any]:
     return company
 
 
-async def get_issue_overview(issue_id: int) -> IssueOverview | None:
-    record = await issues_repo.get_issue_by_id(issue_id)
+async def get_issue_overview(
+    issue_id: int,
+    *,
+    company_ids: Iterable[int] | None = None,
+) -> IssueOverview | None:
+    scoped_company_ids = list(company_ids) if company_ids is not None else None
+    record = await issues_repo.get_issue_by_id(issue_id, company_ids=scoped_company_ids)
     if not record:
         return None
     return _build_overview(record)

--- a/tests/test_user_scope_filters.py
+++ b/tests/test_user_scope_filters.py
@@ -1,0 +1,83 @@
+import pytest
+
+from app.repositories import issues as issues_repo
+from app.repositories import notifications as notifications_repo
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_issue_list_filters_to_allowed_company_ids(monkeypatch):
+    calls = []
+
+    async def fake_fetch_all(sql, params=()):
+        calls.append((sql, params))
+        return []
+
+    monkeypatch.setattr(issues_repo.db, "fetch_all", fake_fetch_all)
+
+    await issues_repo.list_issues_with_assignments(company_ids=[7, 11, 7])
+
+    assert calls
+    sql, params = calls[0]
+    assert "ics.company_id IN (%s, %s)" in sql
+    assert params == (7, 11)
+
+
+@pytest.mark.anyio
+async def test_issue_list_empty_allowed_companies_returns_no_rows(monkeypatch):
+    calls = []
+
+    async def fake_fetch_all(sql, params=()):
+        calls.append((sql, params))
+        return []
+
+    monkeypatch.setattr(issues_repo.db, "fetch_all", fake_fetch_all)
+
+    await issues_repo.list_issues_with_assignments(company_ids=[])
+
+    assert calls
+    sql, params = calls[0]
+    assert "1 = 0" in sql
+    assert params == ()
+
+
+@pytest.mark.anyio
+async def test_notifications_filter_to_exact_user_only(monkeypatch):
+    calls = []
+
+    async def fake_fetch_all(sql, params=()):
+        calls.append((sql, params))
+        return []
+
+    monkeypatch.setattr(notifications_repo.db, "fetch_all", fake_fetch_all)
+
+    await notifications_repo.list_notifications(user_id=42, limit=5, offset=0)
+
+    assert calls
+    sql, params = calls[0]
+    assert "user_id = %s" in sql
+    assert "user_id IS NULL" not in sql
+    assert params[-3:] == (42, 5, 0)
+
+
+@pytest.mark.anyio
+async def test_notification_event_types_filter_to_exact_user_only(monkeypatch):
+    calls = []
+
+    async def fake_fetch_all(sql, params=()):
+        calls.append((sql, params))
+        return []
+
+    monkeypatch.setattr(notifications_repo.db, "fetch_all", fake_fetch_all)
+
+    await notifications_repo.list_event_types(user_id=42)
+
+    assert calls
+    sql, params = calls[0]
+    assert "user_id = %s" in sql
+    assert "user_id IS NULL" not in sql
+    assert params == (42,)


### PR DESCRIPTION
### Motivation
- Ensure issue tracker views and APIs only surface assignments for companies the signed-in user is allowed to access so users cannot see or act on other companies' data.
- Prevent the dashboard and admin pages from showing global/unscoped notifications or assignments that are not explicitly targeted to the current user or their companies.
- Harden create/update/status/delete flows to validate that operations only affect companies the user is authorized to manage.

### Description
- Add company scoping to issue queries and lookups by extending `app/repositories/issues.py` with `company_ids` support, `_normalise_company_ids`, and `get_assignment_by_id` to allow assignment-level access checks. 
- Propagate company scoping through the service layer by adding `company_ids` parameters to `app/services/issues.py` and using them in `build_issue_overview` and `get_issue_overview`.
- Restrict admin handlers in `app/features/issue_tracker/handlers.py` to build company options from `company_access.list_accessible_companies`, filter incoming company IDs, and prevent status/delete actions on assignments outside the allowed companies via helper checks (`_accessible_company_options`, `_assignment_is_accessible`, `_filter_company_ids`).
- Enforce company-scoped access in the JSON API by adding `_accessible_company_ids` and `_assert_company_allowed` helpers and wiring `company_ids` into list/create/update/status endpoints in `app/api/routes/issues.py` so API operations validate and restrict assignments to permitted companies.
- Narrow notification queries to the exact logged-in user by changing the notifications filters in `app/repositories/notifications.py` to use `user_id = %s` (remove the previous `(user_id = %s OR user_id IS NULL)`), so feeds and event-type lists no longer include global/unassigned messages for non-super users.
- Add regression tests `tests/test_user_scope_filters.py` covering SQL generation for scoped issue queries and user-only notification filters.

### Testing
- Ran unit tests `pytest -q tests/test_user_scope_filters.py tests/test_issue_slug_variables.py` and observed success with `18 passed` and no failures.
- Compiled modified modules with `python -m py_compile app/api/routes/issues.py app/features/issue_tracker/handlers.py app/repositories/issues.py app/services/issues.py app/repositories/notifications.py` which completed without errors.
- Ran static checks `git diff --check` (whitespace/merge checks) which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a4f30e3c08332a9fece8bc2804bf6)