### PR TITLE
Restrict staff workflows to super admins

### DIFF
--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -1491,7 +1491,12 @@ async def staff_onboarding_workflow_page(request: Request):
         staff_permission,
         _company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
 
@@ -1515,7 +1520,12 @@ async def staff_onboarding_workflow_policy(request: Request):
         _staff_permission,
         company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if company_id is None:
@@ -1539,7 +1549,12 @@ async def upsert_staff_onboarding_workflow_policy(request: Request):
         _staff_permission,
         company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if company_id is None:
@@ -1574,7 +1589,12 @@ async def staff_offboarding_workflow_page(request: Request):
         staff_permission,
         _company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
 
@@ -1598,7 +1618,12 @@ async def staff_offboarding_workflow_policy(request: Request):
         _staff_permission,
         company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if company_id is None:
@@ -1629,7 +1654,12 @@ async def upsert_staff_offboarding_workflow_policy(request: Request):
         _staff_permission,
         company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if company_id is None:
@@ -1678,7 +1708,12 @@ async def list_staff_workflow_policies(direction: str, request: Request):
         _staff_permission,
         company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if company_id is None:
@@ -1706,7 +1741,12 @@ async def create_staff_workflow_policy(direction: str, request: Request):
         _staff_permission,
         company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if company_id is None:
@@ -1746,7 +1786,12 @@ async def update_staff_workflow_policy(direction: str, policy_id: int, request: 
         _staff_permission,
         company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if company_id is None:
@@ -1789,7 +1834,12 @@ async def delete_staff_workflow_policy(direction: str, policy_id: int, request: 
         _staff_permission,
         company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if company_id is None:
@@ -1818,7 +1868,12 @@ async def staff_workflow_history_page(request: Request):
         staff_permission,
         _company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
 
@@ -1844,7 +1899,12 @@ async def staff_workflow_history_recent(request: Request):
         _staff_permission,
         company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if not bool(user.get("is_super_admin")):
@@ -1933,7 +1993,12 @@ async def retry_workflow_execution(execution_id: int, request: Request):
         _staff_permission,
         _company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if not bool(user.get("is_super_admin")):
@@ -1957,7 +2022,12 @@ async def resume_workflow_execution(execution_id: int, request: Request):
         _staff_permission,
         _company_id,
         redirect,
-    ) = await _load_staff_context(request, require_admin=True, require_all_staff_access=True)
+    ) = await _load_staff_context(
+        request,
+        require_admin=True,
+        require_all_staff_access=True,
+        require_super_admin=True,
+    )
     if redirect:
         return redirect
     if not bool(user.get("is_super_admin")):

--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -18,7 +18,7 @@
               Add Staff Member
             </button>
           </li>
-          {% if is_super_admin or staff_permission == 3 %}
+          {% if is_super_admin %}
             <li class="header-title-menu__item" role="none">
               <a href="/staff/workflows/onboarding" class="header-title-menu__link" role="menuitem">Onboarding workflow</a>
             </li>

--- a/tests/test_staff_workflow_permissions.py
+++ b/tests/test_staff_workflow_permissions.py
@@ -1,0 +1,88 @@
+import asyncio
+from types import SimpleNamespace
+
+from app.features.staff import handlers
+from app.features.staff import helpers
+
+
+def async_return(value):
+    async def _inner(*args, **kwargs):
+        return value
+
+    return _inner
+
+
+def test_staff_workflow_handlers_request_super_admin_context(monkeypatch):
+    captured_calls = []
+    redirect = SimpleNamespace(status_code=303)
+
+    async def fake_load_staff_context(request, **kwargs):
+        captured_calls.append(kwargs)
+        return (
+            {"id": 10, "company_id": 1, "is_super_admin": False},
+            {"menu_permissions": {"menu.staff": "write"}, "staff_permission": 3},
+            None,
+            3,
+            1,
+            redirect,
+        )
+
+    monkeypatch.setattr(handlers, "_load_staff_context", fake_load_staff_context)
+    request = SimpleNamespace(query_params={})
+
+    calls = [
+        handlers.staff_onboarding_workflow_page(request),
+        handlers.staff_onboarding_workflow_policy(request),
+        handlers.upsert_staff_onboarding_workflow_policy(request),
+        handlers.staff_offboarding_workflow_page(request),
+        handlers.staff_offboarding_workflow_policy(request),
+        handlers.upsert_staff_offboarding_workflow_policy(request),
+        handlers.list_staff_workflow_policies("onboarding", request),
+        handlers.create_staff_workflow_policy("onboarding", request),
+        handlers.update_staff_workflow_policy("onboarding", 1, request),
+        handlers.delete_staff_workflow_policy("onboarding", 1, request),
+        handlers.staff_workflow_history_page(request),
+        handlers.staff_workflow_history_recent(request),
+        handlers.retry_workflow_execution(1, request),
+        handlers.resume_workflow_execution(1, request),
+    ]
+
+    for call in calls:
+        result = asyncio.run(call)
+        assert result is redirect
+
+    assert captured_calls
+    assert all(call.get("require_super_admin") is True for call in captured_calls)
+
+
+def test_load_staff_context_rejects_staff_menu_assignee_for_super_admin_context(monkeypatch):
+    class FakeMain:
+        user_company_repo = SimpleNamespace(
+            get_user_company=async_return(
+                {"menu_permissions": {"menu.staff": "write"}, "staff_permission": 3}
+            )
+        )
+
+        @staticmethod
+        async def _require_authenticated_user(request):
+            return {"id": 10, "company_id": 1, "is_super_admin": False}, None
+
+    monkeypatch.setattr(helpers, "_main", lambda: FakeMain)
+
+    user, membership, company, staff_permission, company_id, redirect = asyncio.run(
+        helpers._load_staff_context(SimpleNamespace(), require_super_admin=True)
+    )
+
+    assert user["id"] == 10
+    assert membership is None
+    assert company is None
+    assert staff_permission == 0
+    assert company_id is None
+    assert redirect.status_code == 303
+
+
+def test_staff_page_workflow_links_are_super_admin_only():
+    template = open("app/templates/staff/index.html", encoding="utf-8").read()
+
+    assert "{% if is_super_admin %}" in template
+    assert "is_super_admin or staff_permission == 3" not in template


### PR DESCRIPTION
### Motivation
- Prevent company-assigned users who only have `menu.staff` (or equivalent staff assignment) from accessing sensitive Staff Onboarding/Offboarding workflow pages and APIs.
- Ensure only super administrators can view, create, modify, or run workflow executions to reduce accidental or unauthorized provisioning actions.

### Description
- Updated workflow handlers in `app/features/staff/handlers.py` to require a super-admin context by calling `_load_staff_context(..., require_super_admin=True)` for onboarding/offboarding pages, policy endpoints, policy CRUD, workflow history, and retry/resume actions.
- Hid the Onboarding/Offboarding workflow links on the Staff page by changing the template check in `app/templates/staff/index.html` to only show those links when `is_super_admin` is true.
- Added `tests/test_staff_workflow_permissions.py` with regression tests that assert workflow handlers are invoked with `require_super_admin=True`, that `_load_staff_context` rejects staff-menu assignees for super-admin-only contexts, and that the Staff page template no longer includes the old `is_super_admin or staff_permission == 3` condition.

### Testing
- Ran the focused test suite: `pytest -q tests/test_staff_feature_pack.py tests/test_staff_workflow_permissions.py` and observed all tests passed (`8 passed`) with expected deprecation warnings.
- Also executed the new test file alone with `pytest -q tests/test_staff_workflow_permissions.py` (smoke/regression) and it passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a589e9ec08332a60163b5816c63a3)