### PR TITLE
Respect explicit `menu.staff: none` and require staff menu access for /staff

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -141,7 +141,7 @@ from app.repositories import automations as automation_repo
 from app.repositories import integration_modules as integration_modules_repo
 from app.repositories import user_companies as user_company_repo
 from app.repositories import users as user_repo
-from app.security.menu_permissions import MENU_PERMISSIONS, catalogue_for_api, menu_has_access, normalize_menu_permissions
+from app.security.menu_permissions import MENU_PERMISSIONS, catalogue_for_api, menu_has_access, normalize_access_level, normalize_menu_permissions
 from app.repositories import issues as issues_repo
 from app.repositories import asset_custom_fields as asset_custom_fields_repo
 from app.repositories import staff_custom_fields as staff_custom_fields_repo
@@ -1733,6 +1733,15 @@ async def _resolve_initial_company_id(user: dict[str, Any]) -> int | None:
 
 
 
+def _menu_permission_is_explicit_no_access(raw: Any, key: str) -> bool:
+    """Return whether a menu permission payload explicitly denies a menu key."""
+    if isinstance(raw, dict):
+        source = raw.get("menu") if isinstance(raw.get("menu"), dict) else raw
+        if key in source:
+            return normalize_access_level(source.get(key)) == "none"
+    return False
+
+
 def _build_menu_access_map(
     *,
     is_super_admin: bool,
@@ -1744,10 +1753,20 @@ def _build_menu_access_map(
     if is_super_admin:
         return {item.key: "write" for item in MENU_PERMISSIONS}
 
-    role_menu_permissions = normalize_menu_permissions(membership_data.get("menu_permissions"))
+    raw_menu_permissions = membership_data.get("menu_permissions")
+    role_menu_permissions = normalize_menu_permissions(raw_menu_permissions)
     menu_access = {item.key: role_menu_permissions.get(item.key, "none") for item in MENU_PERMISSIONS}
+    explicitly_denied_menu_keys = {
+        item.key
+        for item in MENU_PERMISSIONS
+        if _menu_permission_is_explicit_no_access(raw_menu_permissions, item.key)
+    }
+    for key in explicitly_denied_menu_keys:
+        menu_access[key] = "none"
 
     def promote(key: str, level: str = "write") -> None:
+        if key in explicitly_denied_menu_keys:
+            return
         rank = {"none": 0, "read": 1, "write": 2}
         if rank[level] > rank[menu_access.get(key, "none")]:
             menu_access[key] = level
@@ -1934,8 +1953,10 @@ async def _build_base_context(
         "can_manage_invoices": _menu_can(menu_access, "menu.invoices", write=True) or is_super_admin or _has_permission("can_manage_invoices"),
         "can_manage_staff": (
             is_super_admin
-            or _has_permission("can_manage_staff")
-            or staff_permission_level > 0
+            or (
+                _menu_can(menu_access, "menu.staff")
+                and (_has_permission("can_manage_staff") or staff_permission_level > 0)
+            )
         ),
         "can_manage_issues": _menu_can(menu_access, "menu.issues", write=True) or has_issue_tracker_access,
         "can_view_compliance": _menu_can(menu_access, "menu.compliance") or is_super_admin or _has_permission("can_view_compliance"),

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -127,7 +127,8 @@
           {% set can_manage_licenses = (can_manage_licenses | default(false)) or is_super_admin or membership.get('can_manage_licenses') or can_access_m365_configuration or can_access_m365_licenses %}
           {% set can_manage_subscriptions = (can_manage_subscriptions | default(false)) or is_super_admin or (membership.get('can_manage_licenses') and membership.get('can_access_cart')) or menu_access.get('menu.subscriptions') in ['read', 'write'] %}
           {% set can_manage_invoices = (can_manage_invoices | default(false)) or is_super_admin or membership.get('can_manage_invoices') or menu_access.get('menu.invoices') in ['read', 'write'] %}
-          {% set can_manage_staff = (can_manage_staff | default(false)) or is_super_admin or ((staff_permission > 0) and menu_access.get('menu.staff') in ['read', 'write']) %}
+          {% set has_staff_menu_access = menu_access.get('menu.staff') in ['read', 'write'] %}
+          {% set can_manage_staff = is_super_admin or (has_staff_menu_access and ((can_manage_staff | default(false)) or (staff_permission > 0))) %}
           {% set can_manage_issues = has_issue_tracker_access | default(is_super_admin or (is_helpdesk_technician | default(false))) or menu_access.get('menu.issues') in ['read', 'write'] %}
           {% set can_view_compliance = (can_view_compliance | default(false)) or is_super_admin or membership.get('can_view_compliance') or menu_access.get('menu.compliance') in ['read', 'write'] %}
           {% set can_view_m365_best_practices = (can_view_m365_best_practices | default(false)) or is_super_admin or membership.get('can_view_m365_best_practices') or menu_access.get('menu.m365.best_practices') in ['read', 'write'] %}

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -484,6 +484,7 @@ def test_backup_summary_menu_permission_shows_admin_menu_without_super_admin():
         loader=FileSystemLoader("app/templates"),
         autoescape=select_autoescape(["html"]),
     )
+    env.globals["static_url"] = lambda path: path
     template = env.get_template("base.html")
     html = template.render(
         request=type("Request", (), {"url": type("Url", (), {"path": "/admin/backup-summary"})()})(),
@@ -504,3 +505,60 @@ def test_backup_summary_menu_permission_shows_admin_menu_without_super_admin():
     assert "Backup Summary" in html
     assert 'href="/admin/backup-jobs"' not in html
     assert 'href="/admin/impersonation"' not in html
+
+
+def test_staff_menu_no_access_overrides_staff_assignment_levels():
+    for staff_permission in (0, 1, 3):
+        menu_access = main_module._build_menu_access_map(
+            is_super_admin=False,
+            membership_data={
+                "menu_permissions": {"menu.staff": "none"},
+                "staff_permission": staff_permission,
+                "can_manage_staff": True,
+            },
+        )
+
+        assert menu_access["menu.staff"] == "none"
+
+    nested_menu_access = main_module._build_menu_access_map(
+        is_super_admin=False,
+        membership_data={
+            "menu_permissions": {
+                "menu": {"menu.staff": "No Access"},
+                "permissions": ["staff.manage"],
+            },
+            "staff_permission": 3,
+            "can_manage_staff": True,
+        },
+    )
+
+    assert nested_menu_access["menu.staff"] == "none"
+
+
+def test_staff_link_hidden_when_staff_menu_no_access_even_with_staff_assignment():
+    from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+    env = Environment(
+        loader=FileSystemLoader("app/templates"),
+        autoescape=select_autoescape(["html"]),
+    )
+    env.globals["static_url"] = lambda path: path
+    template = env.get_template("base.html")
+    html = template.render(
+        request=type("Request", (), {"url": type("Url", (), {"path": "/"})()})(),
+        current_user={"id": 2, "is_super_admin": False},
+        active_membership={"staff_permission": 3, "can_manage_staff": True},
+        staff_permission=3,
+        can_manage_staff=True,
+        menu_access={
+            "menu.dashboard": "read",
+            "menu.staff": "none",
+        },
+        available_companies=[],
+        cart_summary={"item_count": 0, "total_quantity": 0, "subtotal": 0},
+        notification_unread_count=0,
+        plausible_config={"enabled": False},
+        csrf_token="csrf-token",
+    )
+
+    assert 'href="/staff"' not in html


### PR DESCRIPTION
### Motivation
- Prevent an explicit `menu.staff` No Access value from being silently overridden by legacy flags or staff assignment scopes so the Staff menu can be hidden when intended. 
- Ensure the `/staff` sidebar link and staff management UI only appear when the membership actually grants menu access and not just legacy boolean flags or assignment scope.

### Description
- Added `_menu_permission_is_explicit_no_access(raw, key)` and wired it into `_build_menu_access_map` so explicit `menu.staff: none` (or `"No Access"`) forces `menu_access['menu.staff'] == 'none'` and blocks promotion. 
- Prevented promotion of a menu key when it is explicitly denied by the incoming `menu_permissions` payload by marking such keys as denied before any promotion logic runs. 
- Updated the base context `permission_flags` so `can_manage_staff` for non-super-admins now requires the Staff menu to be accessible before legacy flags or `staff_permission` scopes can enable it. 
- Updated `app/templates/base.html` sidebar logic to only render the `/staff` link when `menu.staff` is `read` or `write` (added `has_staff_menu_access`), and added regression tests to `tests/test_sidebar_menu.py` covering explicit No Access scenarios.

### Testing
- Ran the targeted regression tests `tests/test_sidebar_menu.py::test_staff_menu_no_access_overrides_staff_assignment_levels` and `tests/test_sidebar_menu.py::test_staff_link_hidden_when_staff_menu_no_access_even_with_staff_assignment`, and both passed. 
- Compiled the modified module with `python -m py_compile app/main.py`, which succeeded. 
- Ran a broader test subset with `pytest -q tests/test_sidebar_menu.py tests/test_staff_permissions_ui.py` and observed unrelated existing test failures in `test_company_admin_sees_authorised_menu_items`, `test_profile_menu_permission_shows_my_profile_for_non_admin`, and `test_staff_page_technician_can_approve_without_staff_manage` that predate this change; the two new No Access tests still pass in isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a58e3ce188332afc3d340c1d0166b)