### PR TITLE
Admin roles: add Clone action and move create/edit into modal

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1435,10 +1435,15 @@
     if (!form) {
       return;
     }
+    const modal = document.getElementById('role-modal');
+    const modalTitle = document.getElementById('role-modal-title');
+    const modalSubtitle = document.getElementById('role-modal-subtitle');
+    const submitButton = form.querySelector('[data-role-submit]');
     const idField = form.querySelector('#role-id');
     const nameField = form.querySelector('#role-name');
     const descriptionField = form.querySelector('#role-description');
     const permissionInputs = form.querySelectorAll('[data-permission-level]');
+    let activeRoleTrigger = null;
 
     function getSelectedPermissions() {
       const permissions = {};
@@ -1508,6 +1513,56 @@
       });
     }
 
+    function updateModalText(mode, roleName) {
+      if (modalTitle) {
+        modalTitle.textContent = mode === 'edit' ? 'Edit role' : mode === 'clone' ? 'Clone role' : 'Create role';
+      }
+      if (modalSubtitle) {
+        if (mode === 'edit') {
+          modalSubtitle.textContent = `Update ${roleName || 'this role'} for every assigned member immediately.`;
+        } else if (mode === 'clone') {
+          modalSubtitle.textContent = `Review the copied permissions from ${roleName || 'the selected role'} before saving a new role.`;
+        } else {
+          modalSubtitle.textContent = 'Create a least-privilege permission set for company members.';
+        }
+      }
+      if (submitButton) {
+        submitButton.textContent = mode === 'edit' ? 'Save role' : mode === 'clone' ? 'Create clone' : 'Create role';
+      }
+    }
+
+    function openRoleModal(trigger, mode, row) {
+      activeRoleTrigger = trigger || null;
+      const roleName = row ? row.dataset.roleName || '' : '';
+      idField.value = mode === 'edit' && row ? row.dataset.roleId || '' : '';
+      nameField.value = mode === 'clone' && roleName ? `Copy of ${roleName}` : row ? row.dataset.roleName || '' : '';
+      descriptionField.value = row ? row.dataset.roleDescription || '' : '';
+      try {
+        const permissions = row ? JSON.parse(row.dataset.rolePermissions || '{}') : {};
+        setSelectedPermissions(permissions);
+      } catch (error) {
+        setSelectedPermissions({});
+      }
+      updateModalText(mode, roleName);
+      if (modal) {
+        modal.hidden = false;
+        modal.setAttribute('aria-hidden', 'false');
+      }
+      nameField.focus();
+      nameField.select();
+    }
+
+    function closeRoleModal() {
+      if (modal) {
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden', 'true');
+      }
+      if (activeRoleTrigger) {
+        activeRoleTrigger.focus();
+        activeRoleTrigger = null;
+      }
+    }
+
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
       const roleId = idField.value;
@@ -1533,9 +1588,16 @@
         nameField.value = '';
         descriptionField.value = '';
         setSelectedPermissions({});
+        updateModalText('create');
         nameField.focus();
       });
     }
+
+    document.querySelectorAll('[data-role-create]').forEach((button) => {
+      button.addEventListener('click', () => {
+        openRoleModal(button, 'create', null);
+      });
+    });
 
     document.querySelectorAll('[data-role-edit]').forEach((button) => {
       button.addEventListener('click', () => {
@@ -1543,18 +1605,33 @@
         if (!row) {
           return;
         }
-        idField.value = row.dataset.roleId || '';
-        nameField.value = row.dataset.roleName || '';
-        descriptionField.value = row.dataset.roleDescription || '';
-        try {
-          const permissions = JSON.parse(row.dataset.rolePermissions || '{}');
-          setSelectedPermissions(permissions);
-        } catch (error) {
-          setSelectedPermissions({});
-        }
-        nameField.focus();
+        openRoleModal(button, 'edit', row);
       });
     });
+
+    document.querySelectorAll('[data-role-clone]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const row = button.closest('tr');
+        if (!row) {
+          return;
+        }
+        openRoleModal(button, 'clone', row);
+      });
+    });
+
+    if (modal) {
+      modal.addEventListener('click', (event) => {
+        if (event.target === modal || event.target.closest('[data-modal-close]')) {
+          event.preventDefault();
+          closeRoleModal();
+        }
+      });
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !modal.hidden) {
+          closeRoleModal();
+        }
+      });
+    }
 
     document.querySelectorAll('[data-role-delete]').forEach((button) => {
       button.addEventListener('click', async () => {

--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -1,10 +1,17 @@
 {% extends "base.html" %}
+{% from "macros/header.html" import page_header_actions %}
 
 {% block header_title %}Roles{% endblock %}
 
+{% block header_actions %}
+  {{ page_header_actions([
+    {"label": "Add role", "variant": "primary", "attrs": {"data-role-create": "", "aria-haspopup": "dialog", "aria-controls": "role-modal"}}
+  ]) }}
+{% endblock %}
+
 {% block content %}
 <div class="admin-grid">
-  <section class="card card--panel">
+  <section class="card card--panel admin-grid__full">
     <header class="card__header">
       <input
         type="search"
@@ -50,7 +57,8 @@
               <td data-label="System" data-column-key="system">{{ 'Yes' if role.is_system else 'No' }}</td>
               <td class="table__actions" data-column-key="actions">
                 <div class="table__action-buttons">
-                  <button type="button" class="button button--ghost" data-role-edit>Edit</button>
+                  <button type="button" class="button button--ghost" data-role-edit aria-haspopup="dialog" aria-controls="role-modal">Edit</button>
+                  <button type="button" class="button button--ghost" data-role-clone aria-haspopup="dialog" aria-controls="role-modal">Clone</button>
                   {% if not role.is_system %}
                     <button type="button" class="button button--danger" data-role-delete>Delete</button>
                   {% endif %}
@@ -67,13 +75,13 @@
     </div>
   </section>
 
-  <section class="card card--panel">
-    <header class="card__header">
-      <div>
-        <h2 class="card__title">Create or update a role</h2>
-        <p class="card__subtitle">Editing a role updates permissions for every assigned member immediately.</p>
-      </div>
-    </header>
+  <div class="modal" id="role-modal" role="dialog" aria-modal="true" aria-labelledby="role-modal-title" aria-describedby="role-modal-subtitle" aria-hidden="true" hidden>
+    <div class="modal__content" role="document">
+      <button type="button" class="modal__close" data-modal-close aria-label="Close role form"></button>
+      <header class="modal__header">
+        <h2 class="modal__title" id="role-modal-title">Create role</h2>
+        <p class="modal__subtitle" id="role-modal-subtitle">Create a least-privilege permission set for company members.</p>
+      </header>
     <form id="role-form" class="form" autocomplete="off">
       <input type="hidden" name="role_id" id="role-id" />
       <div class="form-field">
@@ -128,14 +136,16 @@
         <p class="form-help" id="role-permissions-help">Choose No Access to hide a menu and block direct access, Read Only to view information without actions, or Read/Write to allow permitted actions.</p>
       </div>
       <div class="form-actions">
-        <button type="submit" class="button">Save role</button>
         <button type="button" class="button button--ghost" data-role-reset>Clear form</button>
+        <button type="button" class="button button--ghost" data-modal-close>Cancel</button>
+        <button type="submit" class="button" data-role-submit>Save role</button>
       </div>
       <p class="form-hint">System roles cannot be deleted and their names are fixed to retain portal integrity.</p>
     </form>
-  </section>
+    </div>
+  </div>
 
-  <details class="card card--panel card-collapsible" data-roles-admin-menu>
+  <details class="card card--panel card-collapsible admin-grid__full" data-roles-admin-menu>
     <summary class="card__header card__header--collapsible">
       <div>
         <h2 class="card__title">Roles administration menu</h2>
@@ -152,9 +162,9 @@
         access policies.
       </p>
       <p>
-        When you open the menu from the navigation sidebar, two panels are always available: the catalogue of existing
-        roles and the management form for updates. Use the search filter to quickly locate a role, select <strong>Edit</strong>
-        to populate the form, and provide a comma-separated list of permission keys when creating or refining roles. All
+        When you open the menu from the navigation sidebar, the role catalogue is available with modal workflows for creating, editing, and cloning roles. Use the search filter
+        to quickly locate a role, select <strong>Edit</strong> to update it, or select <strong>Clone</strong> to start
+        from an existing permission set. Choose explicit menu permission levels when creating or refining roles. All
         changes take effect immediately across the portal to keep member privileges aligned with the latest security
         requirements.
       </p>


### PR DESCRIPTION
### Motivation
- Consolidate role management UI into a focused modal workflow to remove the lower-page form and make create/edit/clone actions consistent and accessible.
- Provide a quick way to duplicate an existing role so administrators can create new roles based on an existing permission set.

### Description
- Move the role create/edit form into a popup modal and add an `Add role` page-header action to open it, updating layout to use a full-width table (changed `app/templates/admin/roles.html`).
- Add a `Clone` button next to `Edit` for each row and wire both `Edit` and `Clone` to open the role modal with appropriate prefilled data; cloned names default to `Copy of <role>` (changes in `app/templates/admin/roles.html`).
- Update the role form JavaScript to manage modal state, labels and subtitles for `create`/`edit`/`clone` modes, focus restoration on close, backdrop/Escape/cancel close handlers, and to continue using `POST /roles` for creates (including clones) and `PATCH /roles/{id}` for edits (changed `app/static/js/admin.js`).
- Improve accessibility and ARIA attributes on modal controls, and update the help text to describe modal-based create/edit/clone workflows (template updates).

### Testing
- Ran a Jinja syntax parse for `app/templates/admin/roles.html` which completed successfully.
- Performed a JavaScript syntax check with `node --check app/static/js/admin.js` which succeeded.
- Ran `python -m pytest tests/test_layout_macros.py` which passed (`8 passed`).
- Screenshot capture could not be performed because no browser/image-capture executable (`chromium`, `google-chrome`, `firefox`, or `wkhtmltoimage`) was available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a5bbceb6c832d95bf5c41b1d2d68b)