### PR TITLE
Create tickets for staff edit requests by non-super-admin staff editors

### DIFF
--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import secrets
+from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from html import escape
 from typing import Any, cast
@@ -48,8 +49,211 @@ staff_onboarding_workflow_service = main_module.staff_onboarding_workflow_servic
 staff_repo = main_module.staff_repo
 staff_requests_repo = main_module.staff_requests_repo
 staff_workflow_repo = main_module.staff_workflow_repo
+tickets_service = main_module.tickets_service
 user_company_repo = main_module.user_company_repo
 user_repo = main_module.user_repo
+
+
+_STAFF_EDIT_REQUEST_FIELDS: tuple[tuple[str, str, str, str], ...] = (
+    ("first_name", "firstName", "Identity", "First name"),
+    ("last_name", "lastName", "Identity", "Last name"),
+    ("email", "email", "Identity", "Email"),
+    ("mobile_phone", "mobilePhone", "Identity", "Mobile phone"),
+    ("enabled", "enabled", "Identity", "Enabled"),
+    ("department", "department", "Employment / Organisation", "Department"),
+    ("job_title", "jobTitle", "Employment / Organisation", "Job title"),
+    ("org_company", "company", "Employment / Organisation", "Company"),
+    ("manager_name", "managerName", "Employment / Organisation", "Manager"),
+    ("street", "street", "Address", "Street"),
+    ("city", "city", "Address", "City"),
+    ("state", "state", "Address", "State"),
+    ("postcode", "postcode", "Address", "Postcode"),
+    ("country", "country", "Address", "Country"),
+)
+
+_STAFF_WORKFLOW_LIFECYCLE_FIELDS: tuple[tuple[str, str, str], ...] = (
+    ("account_action", "accountAction", "Account action"),
+    ("date_onboarded", "dateOnboarded", "Onboard date"),
+    ("date_offboarded", "dateOffboarded", "Offboard schedule"),
+    ("onboarding_status", "onboardingStatus", "Onboarding status"),
+    ("onboarding_complete", "onboardingComplete", "Onboarding complete"),
+    ("onboarding_completed_at", "onboardingCompletedAt", "Onboarding completed at"),
+    ("approval_status", "approvalStatus", "Approval status"),
+)
+
+
+def _payload_has_key(payload: Mapping[str, Any], snake_key: str, camel_key: str) -> bool:
+    return snake_key in payload or camel_key in payload
+
+
+def _payload_value(payload: Mapping[str, Any], snake_key: str, camel_key: str) -> Any:
+    if camel_key in payload:
+        return payload[camel_key]
+    return payload.get(snake_key)
+
+
+def _normalise_change_value(value: Any) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value).strip()
+
+
+def _normalise_lifecycle_value(field_name: str, value: Any) -> Any:
+    if field_name == "date_onboarded":
+        if isinstance(value, datetime):
+            return value.date().isoformat()
+        raw = str(value or "").strip()
+        return raw[:10] if raw else ""
+    if field_name == "date_offboarded":
+        if isinstance(value, datetime):
+            return value.replace(second=0, microsecond=0).isoformat()[:16]
+        raw = str(value or "").strip()
+        return raw.replace(" ", "T")[:16] if raw else ""
+    return _normalise_change_value(value)
+
+
+def _format_change_value(value: Any) -> str:
+    normalised = _normalise_change_value(value)
+    if normalised is True:
+        return "Yes"
+    if normalised is False:
+        return "No"
+    return str(normalised) if normalised != "" else "(blank)"
+
+
+def _staff_display_name(staff_member: Mapping[str, Any]) -> str:
+    name = " ".join(
+        part for part in (
+            str(staff_member.get("first_name") or "").strip(),
+            str(staff_member.get("last_name") or "").strip(),
+        ) if part
+    )
+    return name or str(staff_member.get("email") or f"Staff #{staff_member.get('id')}").strip()
+
+
+def _user_display_name(user: Mapping[str, Any]) -> str:
+    name = " ".join(
+        part for part in (
+            str(user.get("first_name") or "").strip(),
+            str(user.get("last_name") or "").strip(),
+        ) if part
+    )
+    return name or str(user.get("email") or f"User #{user.get('id')}").strip()
+
+
+def _staff_edit_request_changes(existing: Mapping[str, Any], payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    changes: list[dict[str, Any]] = []
+    for field_name, payload_key, section, label in _STAFF_EDIT_REQUEST_FIELDS:
+        if not _payload_has_key(payload, field_name, payload_key):
+            continue
+        requested = _payload_value(payload, field_name, payload_key)
+        current = existing.get(field_name)
+        if _normalise_change_value(current) == _normalise_change_value(requested):
+            continue
+        changes.append({"section": section, "label": label, "current": current, "requested": requested})
+
+    raw_custom_fields = _payload_value(payload, "custom_fields", "customFields")
+    if isinstance(raw_custom_fields, Mapping):
+        existing_custom = existing.get("custom_fields") if isinstance(existing.get("custom_fields"), Mapping) else {}
+        for name, requested in sorted(raw_custom_fields.items(), key=lambda item: str(item[0]).lower()):
+            current = existing_custom.get(name) if isinstance(existing_custom, Mapping) else None
+            if _normalise_change_value(current) == _normalise_change_value(requested):
+                continue
+            changes.append({
+                "section": "Custom fields",
+                "label": str(name),
+                "current": current,
+                "requested": requested,
+            })
+    return changes
+
+
+def _changed_workflow_lifecycle_fields(existing: Mapping[str, Any], payload: Mapping[str, Any]) -> list[str]:
+    changed: list[str] = []
+    for field_name, payload_key, label in _STAFF_WORKFLOW_LIFECYCLE_FIELDS:
+        if not _payload_has_key(payload, field_name, payload_key):
+            continue
+        requested = _payload_value(payload, field_name, payload_key)
+        if _normalise_lifecycle_value(field_name, existing.get(field_name)) != _normalise_lifecycle_value(field_name, requested):
+            changed.append(label)
+    return changed
+
+
+def _render_staff_edit_ticket_description(
+    *,
+    existing: Mapping[str, Any],
+    requester: Mapping[str, Any],
+    company: Mapping[str, Any] | None,
+    changes: list[dict[str, Any]],
+) -> str:
+    staff_name = _staff_display_name(existing)
+    requester_name = _user_display_name(requester)
+    requester_email = str(requester.get("email") or "").strip() or "(no email)"
+    staff_email = str(existing.get("email") or "").strip() or "(no email)"
+    company_name = str((company or {}).get("name") or existing.get("company_name") or "").strip() or "(unknown company)"
+    lines = [
+        "A staff details change request was submitted from the Staff page.",
+        "",
+        "Staff member being edited:",
+        f"- Name: {staff_name}",
+        f"- Staff ID: {existing.get('id')}",
+        f"- Email: {staff_email}",
+        f"- Company: {company_name} (ID: {existing.get('company_id')})",
+        "",
+        "Requested by:",
+        f"- Name: {requester_name}",
+        f"- User ID: {requester.get('id')}",
+        f"- Email: {requester_email}",
+        "",
+        "Requested changes:",
+    ]
+    for change in changes:
+        lines.append(
+            f"- [{change['section']}] {change['label']}: "
+            f"{_format_change_value(change.get('current'))} -> {_format_change_value(change.get('requested'))}"
+        )
+    return "\n".join(lines)
+
+
+async def _create_staff_edit_request_ticket(
+    *,
+    existing: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    user: Mapping[str, Any],
+    company: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    changes = _staff_edit_request_changes(existing, payload)
+    if not changes:
+        return None
+    staff_name = _staff_display_name(existing)
+    description = _render_staff_edit_ticket_description(
+        existing=existing,
+        requester=user,
+        company=company,
+        changes=changes,
+    )
+    requester_id = int(user["id"]) if user.get("id") is not None else None
+    return await tickets_service.create_ticket(
+        subject=f"Staff change request: {staff_name}",
+        description=description,
+        requester_id=requester_id,
+        company_id=int(existing.get("company_id") or user.get("company_id") or 0) or None,
+        assigned_user_id=None,
+        priority="normal",
+        status="open",
+        category="Staff Change Request",
+        module_slug="staff",
+        external_reference=f"staff-change-request:{existing.get('id')}",
+        trigger_automations=True,
+        initial_reply_author_id=requester_id,
+        requester_email=str(user.get("email") or "").strip() or None,
+    )
 
 
 async def _get_current_user_staff_department(user: dict[str, Any], company_id: int) -> str | None:
@@ -2174,7 +2378,7 @@ async def update_staff_member(staff_id: int, request: Request):
         staff_permission,
         company_id,
         redirect,
-    ) = await _load_staff_context(request)
+    ) = await _load_staff_context(request, require_admin=True)
     if redirect:
         return redirect
 
@@ -2185,6 +2389,10 @@ async def update_staff_member(staff_id: int, request: Request):
     is_super_admin = bool(user.get("is_super_admin"))
     if not is_super_admin and existing.get("company_id") != company_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+    if not is_super_admin and staff_permission == 1:
+        user_department = await _get_current_user_staff_department(user, int(company_id or 0))
+        if not _departments_match(user_department, str(existing.get("department") or "").strip() or None):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
 
     payload = await request.json()
     if not isinstance(payload, dict):
@@ -2195,6 +2403,42 @@ async def update_staff_member(staff_id: int, request: Request):
             if key in payload:
                 return payload[key]
         return None
+
+    if not is_super_admin:
+        blocked_fields = _changed_workflow_lifecycle_fields(existing, payload)
+        if blocked_fields:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "Workflow & lifecycle fields cannot be changed from staff edit requests: "
+                    + ", ".join(blocked_fields)
+                ),
+            )
+        ticket = await _create_staff_edit_request_ticket(
+            existing=existing,
+            payload=payload,
+            user=user,
+            company=company,
+        )
+        await audit_service.log_action(
+            user_id=int(user["id"]) if user.get("id") is not None else None,
+            action="staff.change_request.ticket_created" if ticket else "staff.change_request.no_changes",
+            entity_type="staff",
+            entity_id=staff_id,
+            metadata={
+                "company_id": int(existing.get("company_id") or company_id or 0),
+                "ticket_id": ticket.get("id") if isinstance(ticket, Mapping) else None,
+            },
+        )
+        return JSONResponse({
+            "success": True,
+            "ticket": ticket,
+            "message": (
+                "A ticket has been created for a technician to review the requested staff changes."
+                if ticket
+                else "No staff changes were requested."
+            ),
+        })
 
     if is_super_admin:
         first_name = (get_value("firstName", "first_name") or existing.get("first_name") or "").strip()

--- a/app/static/js/staff.js
+++ b/app/static/js/staff.js
@@ -1113,8 +1113,6 @@
           lastName: editFields.last_name ? editFields.last_name.value : '',
           email: editFields.email ? editFields.email.value : '',
           mobilePhone: editFields.mobile_phone ? editFields.mobile_phone.value : '',
-          dateOnboarded: editFields.date_onboarded ? editFields.date_onboarded.value : '',
-          dateOffboarded: editFields.date_offboarded ? editFields.date_offboarded.value : '',
           enabled: editFields.enabled ? editFields.enabled.checked : false,
           street: editFields.street ? editFields.street.value : '',
           city: editFields.city ? editFields.city.value : '',
@@ -1125,9 +1123,13 @@
           jobTitle: editFields.job_title ? editFields.job_title.value : '',
           company: editFields.org_company ? editFields.org_company.value : '',
           managerName: editFields.manager_name ? editFields.manager_name.value : '',
-          accountAction: editFields.account_action ? editFields.account_action.value : '',
           customFields: {},
         };
+        if (flags && flags.isSuperAdmin) {
+          payload.dateOnboarded = editFields.date_onboarded ? editFields.date_onboarded.value : '';
+          payload.dateOffboarded = editFields.date_offboarded ? editFields.date_offboarded.value : '';
+          payload.accountAction = editFields.account_action ? editFields.account_action.value : '';
+        }
         editCustomFieldInputs.forEach((entry, name) => {
           if (!entry || !entry.input) {
             return;
@@ -1151,10 +1153,13 @@
         });
         try {
           setInlineError(editFormError, '');
-          await requestJson(`/staff/${staffId}`, {
+          const result = await requestJson(`/staff/${staffId}`, {
             method: 'PUT',
             body: JSON.stringify(payload),
           });
+          if (result && result.message && !(flags && flags.isSuperAdmin)) {
+            window.alert(result.message);
+          }
           window.location.reload();
         } catch (error) {
           setInlineError(editFormError, `Unable to update staff member: ${error.message}`);

--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -615,6 +615,9 @@
     <div class="staff-modal__header">
       <h2 class="modal__title">Edit staff member</h2>
       <p class="staff-modal__staff-name" id="edit-modal-staff-name"></p>
+      {% if can_edit_staff and not is_super_admin %}
+        <p class="form-help">Saving Identity, Employment / Organisation, Address, or Custom Fields changes creates a helpdesk ticket for a technician to apply. Workflow &amp; lifecycle fields are read-only.</p>
+      {% endif %}
     </div>
     <form id="staff-edit-form" class="form-grid staff-modal-grid">
       <input type="hidden" id="edit-staff-id" />
@@ -623,23 +626,23 @@
         <div class="form-grid staff-modal-grid">
           <div class="form-field">
             <label class="form-label" for="edit-first-name">First name</label>
-            <input class="form-input" id="edit-first-name" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-first-name" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-last-name">Last name</label>
-            <input class="form-input" id="edit-last-name" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-last-name" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-email">Email</label>
-            <input class="form-input" id="edit-email" type="email" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-email" type="email" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-mobile">Mobile phone</label>
-            <input class="form-input" id="edit-mobile" type="tel" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-mobile" type="tel" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field form-field--checkbox form-field--full">
             <label class="checkbox">
-              <input type="checkbox" id="edit-enabled" {% if not is_super_admin %}disabled{% endif %} />
+              <input type="checkbox" id="edit-enabled" {% if not can_edit_staff %}disabled{% endif %} />
               <span>Enabled</span>
             </label>
           </div>
@@ -650,19 +653,19 @@
         <div class="form-grid staff-modal-grid">
           <div class="form-field">
             <label class="form-label" for="edit-department">Department</label>
-            <input class="form-input" id="edit-department" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-department" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-job-title">Job title</label>
-            <input class="form-input" id="edit-job-title" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-job-title" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-company">Company</label>
-            <input class="form-input" id="edit-company" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-company" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-manager-name">Manager</label>
-            <input class="form-input" id="edit-manager-name" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-manager-name" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
         </div>
       </fieldset>
@@ -689,7 +692,7 @@
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-date-offboarded">Offboard schedule</label>
-            <input class="form-input" id="edit-date-offboarded" type="datetime-local" {% if not is_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-date-offboarded" type="datetime-local" {% if not is_super_admin %}readonly{% endif %} />
             <p class="form-help">Set when offboarding should be executed; leave blank until a confirmed exit date.</p>
           </div>
           <div class="form-field">
@@ -703,23 +706,23 @@
         <div class="form-grid staff-modal-grid">
           <div class="form-field">
             <label class="form-label" for="edit-street">Street</label>
-            <input class="form-input" id="edit-street" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-street" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-city">City</label>
-            <input class="form-input" id="edit-city" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-city" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-state">State</label>
-            <input class="form-input" id="edit-state" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-state" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-postcode">Postcode</label>
-            <input class="form-input" id="edit-postcode" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-postcode" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-country">Country</label>
-            <input class="form-input" id="edit-country" {% if not is_super_admin %}readonly{% endif %} />
+            <input class="form-input" id="edit-country" {% if not can_edit_staff %}readonly{% endif %} />
           </div>
         </div>
       </fieldset>

--- a/tests/test_staff_edit_change_request_ticket.py
+++ b/tests/test_staff_edit_change_request_ticket.py
@@ -1,0 +1,128 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.features.staff import handlers
+
+
+class JsonRequest(SimpleNamespace):
+    async def json(self):
+        return self.payload
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_staff_rw_edit_creates_ticket_instead_of_updating_staff(monkeypatch):
+    existing = {
+        "id": 55,
+        "company_id": 9,
+        "first_name": "Alex",
+        "last_name": "Smith",
+        "email": "alex@example.com",
+        "mobile_phone": "0400000000",
+        "enabled": True,
+        "department": "Support",
+        "job_title": "Analyst",
+        "org_company": "Example Co",
+        "manager_name": "Morgan",
+        "street": "1 Old St",
+        "city": "Sydney",
+        "state": "NSW",
+        "postcode": "2000",
+        "country": "AU",
+        "account_action": "Onboarded",
+        "date_onboarded": None,
+        "date_offboarded": None,
+        "custom_fields": {"Desk": "A1"},
+    }
+    created_ticket = {"id": 901, "subject": "Staff change request: Alex Smith"}
+
+    async def fake_load_context(request, **kwargs):
+        assert kwargs == {"require_admin": True}
+        return (
+            {"id": 7, "company_id": 9, "email": "requester@example.com", "first_name": "Pat", "last_name": "Lee"},
+            {"menu_permissions": {"menu.staff": "write"}, "staff_permission": 3},
+            {"id": 9, "name": "Example Co"},
+            3,
+            9,
+            None,
+        )
+
+    monkeypatch.setattr(handlers, "_load_staff_context", fake_load_context)
+    monkeypatch.setattr(handlers.staff_repo, "get_staff_by_id", AsyncMock(return_value=existing))
+    update_mock = AsyncMock()
+    monkeypatch.setattr(handlers.staff_repo, "update_staff", update_mock)
+    create_ticket_mock = AsyncMock(return_value=created_ticket)
+    monkeypatch.setattr(handlers.tickets_service, "create_ticket", create_ticket_mock)
+    monkeypatch.setattr(handlers.audit_service, "log_action", AsyncMock())
+
+    response = await handlers.update_staff_member(
+        55,
+        JsonRequest(
+            payload={
+                "firstName": "Alexandra",
+                "department": "Projects",
+                "street": "2 New St",
+                "customFields": {"Desk": "B2"},
+            }
+        ),
+    )
+
+    assert response.status_code == 200
+    assert update_mock.await_count == 0
+    create_kwargs = create_ticket_mock.await_args.kwargs
+    assert create_kwargs["requester_id"] == 7
+    assert create_kwargs["company_id"] == 9
+    assert create_kwargs["module_slug"] == "staff"
+    assert "Staff member being edited" in create_kwargs["description"]
+    assert "Requested by" in create_kwargs["description"]
+    assert "[Identity] First name: Alex -> Alexandra" in create_kwargs["description"]
+    assert "[Employment / Organisation] Department: Support -> Projects" in create_kwargs["description"]
+    assert "[Address] Street: 1 Old St -> 2 New St" in create_kwargs["description"]
+    assert "[Custom fields] Desk: A1 -> B2" in create_kwargs["description"]
+
+
+@pytest.mark.anyio
+async def test_staff_rw_edit_rejects_changed_workflow_lifecycle_fields(monkeypatch):
+    existing = {
+        "id": 55,
+        "company_id": 9,
+        "first_name": "Alex",
+        "last_name": "Smith",
+        "email": "alex@example.com",
+        "department": "Support",
+        "account_action": "Onboarded",
+        "date_onboarded": "2026-01-01T00:00:00",
+        "date_offboarded": None,
+        "custom_fields": {},
+    }
+
+    async def fake_load_context(request, **kwargs):
+        return (
+            {"id": 7, "company_id": 9, "email": "requester@example.com"},
+            {"menu_permissions": {"menu.staff": "write"}, "staff_permission": 3},
+            {"id": 9, "name": "Example Co"},
+            3,
+            9,
+            None,
+        )
+
+    monkeypatch.setattr(handlers, "_load_staff_context", fake_load_context)
+    monkeypatch.setattr(handlers.staff_repo, "get_staff_by_id", AsyncMock(return_value=existing))
+    monkeypatch.setattr(handlers.tickets_service, "create_ticket", AsyncMock())
+
+    with pytest.raises(HTTPException) as exc:
+        await handlers.update_staff_member(
+            55,
+            JsonRequest(payload={"accountAction": "Offboard Requested", "firstName": "Alexandra"}),
+        )
+
+    assert exc.value.status_code == 400
+    assert "Workflow & lifecycle fields cannot be changed" in exc.value.detail
+    assert handlers.tickets_service.create_ticket.await_count == 0


### PR DESCRIPTION
### Motivation
- Allow users with `menu.staff` write access to request edits to Identity, Employment/Organisation, Address, and Custom Fields without granting them permission to directly mutate provisioning/workflow state.  
- Ensure Workflow & lifecycle fields remain protected and cannot be changed by staff-menu editors to avoid unintended automation or provisioning side-effects.  

### Description
- Added change-detection and formatting helpers in `app/features/staff/handlers.py` to collect requested Identity / Employment / Address / Custom Field changes, render a human-readable change list and requester details, and create a helpdesk ticket using `tickets_service.create_ticket`.  
- Updated `update_staff_member` in `app/features/staff/handlers.py` so non-super-admin staff editors now have their edits routed to a created ticket (including requester, edited staff, and required changes), and server-side validation rejects any attempted changes to Workflow & lifecycle fields.  
- Enforced department-scoped editors (staff_permission == 1) to only edit members in their own department when using the staff UI.  
- Updated the UI in `app/templates/staff/index.html` to show guidance and enforce readonly/disabled state for Workflow & lifecycle fields for non-super-admin editors, and updated `app/static/js/staff.js` to omit workflow/lifecycle fields from non-super-admin payloads and surface the ticket-creation message to the user.  
- Added regression tests in `tests/test_staff_edit_change_request_ticket.py` covering ticket creation for permitted edits and rejection when Workflow & lifecycle fields are changed.  

### Testing
- Ran `pytest -q tests/test_staff_edit_change_request_ticket.py` and the new tests passed.  
- Ran `pytest -q tests/test_staff_workflow_permissions.py tests/test_staff_request_permissions.py tests/test_staff_access.py` and these suites passed.  
- Ran `python -m py_compile app/features/staff/handlers.py` to validate syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a5bb53f50832d840798330bfba2e3)