### PR TITLE
Include active role-based memberships in user company listings (fallback for switcher)

### DIFF
--- a/app/repositories/user_companies.py
+++ b/app/repositories/user_companies.py
@@ -182,6 +182,45 @@ async def _suspend_company_membership(company_id: int, user_id: int) -> None:
             await membership_repo.update_membership(int(membership_id), status="suspended")
 
 
+def _membership_row_to_user_company(row: dict[str, Any]) -> dict[str, Any]:
+    """Build a legacy user_company-shaped record from an active role membership."""
+
+    data: dict[str, Any] = {
+        "user_id": row.get("user_id"),
+        "company_id": row.get("company_id"),
+        "company_name": row.get("company_name"),
+        "syncro_company_id": row.get("syncro_company_id"),
+        "staff_permission": _STAFF_PERMISSION_NONE,
+    }
+    for field in _BOOLEAN_FIELDS:
+        data.setdefault(field, False)
+
+    normalised = _normalise(data)
+    _enrich_with_role_permissions(normalised, row.get("role_permissions"))
+    return normalised
+
+
+async def _get_active_membership_company(user_id: int, company_id: int) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one(
+        """
+        SELECT
+            m.user_id,
+            m.company_id,
+            c.name AS company_name,
+            c.syncro_company_id,
+            r.permissions AS role_permissions
+        FROM company_memberships AS m
+        INNER JOIN companies AS c ON c.id = m.company_id
+        INNER JOIN roles AS r ON r.id = m.role_id
+        WHERE m.user_id = %s AND m.company_id = %s AND m.status = 'active'
+        """,
+        (user_id, company_id),
+    )
+    if not row:
+        return None
+    return _membership_row_to_user_company(row)
+
+
 async def get_user_company(user_id: int, company_id: int) -> Optional[dict[str, Any]]:
     row = await db.fetch_one(
         """
@@ -197,7 +236,7 @@ async def get_user_company(user_id: int, company_id: int) -> Optional[dict[str, 
         (user_id, company_id),
     )
     if not row:
-        return None
+        return await _get_active_membership_company(user_id, company_id)
     
     normalised = _normalise(row)
     _enrich_with_role_permissions(normalised, row.get("role_permissions"))
@@ -223,13 +262,48 @@ async def list_companies_for_user(user_id: int) -> List[dict[str, Any]]:
         (user_id,),
     )
     companies: List[dict[str, Any]] = []
+    seen_company_ids: set[int] = set()
     for row in rows:
         normalised = _normalise(row)
         normalised["company_name"] = row.get("company_name")
         if "syncro_company_id" in row:
             normalised["syncro_company_id"] = row.get("syncro_company_id")
         _enrich_with_role_permissions(normalised, row.get("role_permissions"))
+        company_id = normalised.get("company_id")
+        if company_id is not None:
+            seen_company_ids.add(int(company_id))
         companies.append(normalised)
+
+    membership_rows = await db.fetch_all(
+        """
+        SELECT
+            m.user_id,
+            m.company_id,
+            c.name AS company_name,
+            c.syncro_company_id,
+            r.permissions AS role_permissions
+        FROM company_memberships AS m
+        INNER JOIN companies AS c ON c.id = m.company_id
+        INNER JOIN roles AS r ON r.id = m.role_id
+        WHERE m.user_id = %s AND m.status = 'active'
+        ORDER BY c.name
+        """,
+        (user_id,),
+    )
+    for row in membership_rows:
+        membership_company = _membership_row_to_user_company(row)
+        company_id = membership_company.get("company_id")
+        if company_id is None or int(company_id) in seen_company_ids:
+            continue
+        seen_company_ids.add(int(company_id))
+        companies.append(membership_company)
+
+    companies.sort(
+        key=lambda company: (
+            (company.get("company_name") or "").lower(),
+            int(company.get("company_id") or 0),
+        )
+    )
     return companies
 
 

--- a/tests/test_company_switcher_visibility.py
+++ b/tests/test_company_switcher_visibility.py
@@ -83,6 +83,9 @@ def single_company_context(monkeypatch):
             "csrf_token": "csrf-token",
             "cart_summary": {"item_count": 0, "total_quantity": 0, "subtotal": 0},
             "notification_unread_count": 0,
+            "plausible_config": {"enabled": False},
+            "enable_auto_refresh": False,
+            "is_impersonating": False,
         }
         if extra:
             context.update(extra)
@@ -129,6 +132,9 @@ def multiple_companies_context(monkeypatch):
             "csrf_token": "csrf-token",
             "cart_summary": {"item_count": 0, "total_quantity": 0, "subtotal": 0},
             "notification_unread_count": 0,
+            "plausible_config": {"enabled": False},
+            "enable_auto_refresh": False,
+            "is_impersonating": False,
         }
         if extra:
             context.update(extra)
@@ -165,6 +171,9 @@ def no_companies_context(monkeypatch):
             "csrf_token": "csrf-token",
             "cart_summary": {"item_count": 0, "total_quantity": 0, "subtotal": 0},
             "notification_unread_count": 0,
+            "plausible_config": {"enabled": False},
+            "enable_auto_refresh": False,
+            "is_impersonating": False,
         }
         if extra:
             context.update(extra)
@@ -184,6 +193,7 @@ def test_company_switcher_hidden_with_single_company(single_company_context):
     from pathlib import Path
     template_path = Path(__file__).resolve().parent.parent / "app" / "templates"
     main_module.templates = Jinja2Templates(directory=str(template_path))
+    main_module.templates.env.globals["static_url"] = main_module._static_url
     
     with TestClient(app) as client:
         response = client.get("/")

--- a/tests/test_user_companies_membership_access.py
+++ b/tests/test_user_companies_membership_access.py
@@ -1,0 +1,77 @@
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.repositories import user_companies
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_list_companies_for_user_includes_active_membership_only_assignments(monkeypatch):
+    legacy_rows = [
+        {
+            "user_id": 7,
+            "company_id": 10,
+            "company_name": "Legacy Co",
+            "syncro_company_id": None,
+            "can_access_shop": 1,
+            "can_access_cart": 0,
+            "staff_permission": 0,
+            "role_permissions": json.dumps({"menu": {"menu.shop": "read"}}),
+        }
+    ]
+    membership_rows = [
+        {
+            "user_id": 7,
+            "company_id": 20,
+            "company_name": "Membership Co",
+            "syncro_company_id": "syncro-20",
+            "role_permissions": json.dumps({"menu": {"menu.quotes": "read"}}),
+        },
+        {
+            "user_id": 7,
+            "company_id": 10,
+            "company_name": "Legacy Co Duplicate",
+            "syncro_company_id": None,
+            "role_permissions": json.dumps({"menu": {"menu.forms": "read"}}),
+        },
+    ]
+
+    fetch_all = AsyncMock(side_effect=[legacy_rows, membership_rows])
+    monkeypatch.setattr(user_companies.db, "fetch_all", fetch_all)
+
+    result = await user_companies.list_companies_for_user(7)
+
+    assert [company["company_id"] for company in result] == [10, 20]
+    membership_company = next(company for company in result if company["company_id"] == 20)
+    assert membership_company["company_name"] == "Membership Co"
+    assert membership_company["syncro_company_id"] == "syncro-20"
+    assert membership_company["can_access_quotes"] is True
+
+
+@pytest.mark.anyio("asyncio")
+async def test_get_user_company_falls_back_to_active_membership(monkeypatch):
+    membership_row = {
+        "user_id": 7,
+        "company_id": 20,
+        "company_name": "Membership Co",
+        "syncro_company_id": None,
+        "role_permissions": json.dumps({"menu": {"menu.forms": "read"}}),
+    }
+
+    fetch_one = AsyncMock(side_effect=[None, membership_row])
+    monkeypatch.setattr(user_companies.db, "fetch_one", fetch_one)
+
+    result = await user_companies.get_user_company(7, 20)
+
+    assert result is not None
+    assert result["user_id"] == 7
+    assert result["company_id"] == 20
+    assert result["company_name"] == "Membership Co"
+    assert result["can_access_forms"] is True
+    assert result["is_admin"] is False


### PR DESCRIPTION
### Motivation
- Users assigned to companies via the newer role-based `company_memberships` table should appear in the same places as legacy `user_companies` entries (so the company switcher and permission checks work for them). This change ensures users who only have an active membership (and no explicit user_companies row) can still switch and see their companies.

### Description
- Added helpers in `app/repositories/user_companies.py`: `_membership_row_to_user_company` and `_get_active_membership_company` to map an active `company_memberships` row into a legacy `user_company`-shaped record.  
- Updated `get_user_company` to fallback to the active membership mapping when no `user_companies` row exists.  
- Updated `list_companies_for_user` to include active `company_memberships` in the returned list, deduplicate by company id, and sort consistently.  
- Kept existing normalization and enrichment logic (`_normalise`, `_enrich_with_role_permissions`) so role-based permissions are transformed into the legacy boolean flags and `menu_permissions` as before.  
- Added tests covering the new behaviour in `tests/test_user_companies_membership_access.py`.

### Testing
- New unit tests `tests/test_user_companies_membership_access.py` were executed and passed (2 tests, both green).  
- Ran the existing targeted test suite for company access and switcher tests (`tests/test_company_access_service.py`, `tests/test_company_switcher_visibility.py`, `tests/test_switch_company_payload.py`); the new repository unit tests passed, but a UI/template-related test (`test_company_switcher_hidden_with_single_company`) failed in the test run due to a missing Jinja helper (`static_url`) when the test recreates the Jinja environment — this appears to be an unrelated test environment/template initialization issue rather than a user-company lookup regression.  
- Manual lint/compile check (`python -m py_compile`) performed on modified module (`app/repositories/user_companies.py`) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a6067b724832d8e0f2ad6cc46cc34)