### PR TITLE
Restrict Matrix chat invites to staff

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -427,6 +427,12 @@ async def invite_external(
         raise HTTPException(status_code=404, detail="Room not found")
 
     user_id = current_user["id"]
+    is_staff = current_user.get("is_super_admin") or current_user.get(
+        "is_helpdesk_technician"
+    )
+    if not is_staff:
+        raise HTTPException(status_code=403, detail="Staff only")
+
     invite_domain = _settings.matrix_invite_domain or _settings.matrix_server_name or ""
     if not invite_domain:
         raise HTTPException(status_code=500, detail="MATRIX_INVITE_DOMAIN is not configured")

--- a/app/templates/chat/room.html
+++ b/app/templates/chat/room.html
@@ -19,7 +19,7 @@
           {% if room.assigned_tech_user_id %}Reassign to me{% else %}Assign to me{% endif %}
         </button>
       {% endif %}
-      {% if matrix_is_self_hosted and (is_creator or is_staff) %}
+      {% if matrix_is_self_hosted and is_staff %}
         <button class="button button--sm" id="btn-invite-external" data-room-id="{{ room.id }}" aria-haspopup="dialog" aria-controls="invite-modal">
           Invite to Matrix
         </button>
@@ -105,7 +105,7 @@
   {% endif %}
 </div>
 
-{% if matrix_is_self_hosted and (is_creator or is_staff) %}
+{% if matrix_is_self_hosted and is_staff %}
 <!-- Invite to Matrix modal -->
 <div id="invite-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="invite-modal-title" hidden>
   <div class="modal__backdrop" data-modal-close></div>

--- a/tests/test_matrix_chat.py
+++ b/tests/test_matrix_chat.py
@@ -308,6 +308,18 @@ def test_external_invite_gated_by_self_hosted():
     )
 
 
+def test_external_invite_staff_only_in_route_and_chat_template():
+    """External Matrix invites must not be exposed or accepted for customer users."""
+    route_source = pathlib.Path("app/api/routes/chat.py").read_text()
+    template_source = pathlib.Path("app/templates/chat/room.html").read_text()
+
+    assert 'current_user.get("is_super_admin")' in route_source
+    assert '"is_helpdesk_technician"' in route_source
+    assert 'raise HTTPException(status_code=403, detail="Staff only")' in route_source
+    assert 'matrix_is_self_hosted and is_staff' in template_source
+    assert 'matrix_is_self_hosted and (is_creator or is_staff)' not in template_source
+
+
 def test_join_and_assign_use_tech_matrix_user_id():
     """join_room and assign_room must use the technician's matrix_user_id as admin."""
     source = pathlib.Path("app/api/routes/chat.py").read_text()


### PR DESCRIPTION
### Motivation
- Prevent non-staff (customer) users from seeing or triggering external Matrix provisioning/invites from the chat UI to reduce exposure and accidental provisioning.

### Description
- Update chat room template to show the "Invite to Matrix" button and modal only when `matrix_is_self_hosted` and `is_staff` in `app/templates/chat/room.html`.
- Add a server-side guard in the external invite endpoint to require staff privileges, returning `HTTP 403` for non-staff in `app/api/routes/chat.py` by checking `current_user` for `is_super_admin` or `is_helpdesk_technician`.
- Add a regression test `test_external_invite_staff_only_in_route_and_chat_template` to `tests/test_matrix_chat.py` that asserts both the route and template are staff-restricted.

### Testing
- Ran `pytest tests/test_matrix_chat.py` and all tests passed (`16 passed`).
- Verified there are no whitespace/diff errors with `git diff --check` (no issues found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a6272e9b8832db2a7e36218a2a091)