### PR TITLE
Hide technician-only profile fields for standard users and adjust profile layout

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5014,6 +5014,10 @@ dialog.modal:not([open]) {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.profile-columns--standard {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
 @media (max-width: 1200px) {
   .profile-columns {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/app/templates/admin/profile.html
+++ b/app/templates/admin/profile.html
@@ -3,6 +3,7 @@
 {% block header_title %}Profile{% endblock %}
 
 {% block content %}
+{% set show_technician_profile_fields = is_super_admin or is_helpdesk_technician %}
 <div
   class="management management--single"
   data-layout
@@ -14,11 +15,12 @@
     <header class="management__header">
       <div>
         <h1 class="management__title">My profile</h1>
-        <p class="management__subtitle">Manage your account security, sidebar preferences, and email signature.</p>
+        <p class="management__subtitle">Manage your account security{% if show_technician_profile_fields %}, notification contact, booking links, chat details, email signature{% endif %}, and sidebar preferences.</p>
       </div>
     </header>
 
-    <div class="management__body management__body--columns profile-columns">
+    <div class="management__body management__body--columns profile-columns{% if not show_technician_profile_fields %} profile-columns--standard{% endif %}">
+      {% if show_technician_profile_fields %}
       <div class="management__column profile-columns__column">
         <section class="card card--panel">
           <header class="card__header card__header--stacked">
@@ -221,6 +223,7 @@
           </div>
         </section>
       </div>
+      {% endif %}
 
       <div class="management__column profile-columns__column">
         <section class="card card--panel">
@@ -360,6 +363,8 @@
 {% block scripts %}
   {{ super() }}
   <script src="{{ static_url('/static/js/tables.js') }}" defer></script>
+  {% if is_super_admin or is_helpdesk_technician %}
   <script src="{{ static_url('/static/js/rich_text_editor.js') }}" defer></script>
+  {% endif %}
   <script src="{{ static_url('/static/js/profile.js') }}" defer></script>
 {% endblock %}

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -307,6 +307,8 @@ def test_non_admin_with_profile_permission_can_open_profile_page(monkeypatch):
                 is_super_admin=False,
                 membership_data=membership,
             ),
+            "is_super_admin": False,
+            "is_helpdesk_technician": False,
             "matrix_chat_enabled": False,
             "plausible_config": {"enabled": False, "site_domain": "", "base_url": ""},
         }
@@ -328,6 +330,82 @@ def test_non_admin_with_profile_permission_can_open_profile_page(monkeypatch):
 
     assert response.status_code == 200
     assert "Manage your account security" in response.text
+    assert "Notification Contact" not in response.text
+    assert "Booking Link" not in response.text
+    assert "Matrix Username" not in response.text
+    assert "Email signature" not in response.text
+    assert "profile-columns--standard" in response.text
+
+
+def test_technician_with_profile_permission_keeps_profile_contact_tools(monkeypatch):
+    user = {
+        "id": 8,
+        "email": "tech@example.com",
+        "is_super_admin": False,
+        "mobile_phone": None,
+        "booking_link_url": None,
+        "matrix_user_id": None,
+        "email_signature": None,
+    }
+    membership = {
+        "company_id": 10,
+        "is_admin": False,
+        "menu_permissions": {"menu.admin.profile": "read"},
+    }
+
+    async def fake_require_user(request):
+        request.state.active_company_id = membership["company_id"]
+        request.state.active_membership = membership
+        return user, None
+
+    async def fake_get_totp_authenticators(user_id):
+        return []
+
+    async def fake_build_base_context(request, current_user, *, extra=None):
+        context = {
+            "request": request,
+            "app_name": "MyPortal",
+            "current_year": 2026,
+            "current_user": current_user,
+            "available_companies": [],
+            "active_company": None,
+            "active_company_id": membership["company_id"],
+            "active_membership": membership,
+            "csrf_token": "csrf-token",
+            "cart_summary": {"item_count": 0, "total_quantity": 0, "subtotal": 0},
+            "notification_unread_count": 0,
+            "menu_access": main_module._build_menu_access_map(
+                is_super_admin=False,
+                membership_data=membership,
+                is_helpdesk_technician=True,
+            ),
+            "is_super_admin": False,
+            "is_helpdesk_technician": True,
+            "matrix_chat_enabled": True,
+            "plausible_config": {"enabled": False, "site_domain": "", "base_url": ""},
+        }
+        if extra:
+            context.update(extra)
+        return context
+
+    monkeypatch.setattr(main_module, "_require_authenticated_user", fake_require_user)
+    monkeypatch.setattr(main_module.auth_repo, "get_totp_authenticators", fake_get_totp_authenticators)
+    monkeypatch.setattr(main_module, "_build_base_context", fake_build_base_context)
+    main_module.templates.env.globals["plausible_config"] = {
+        "enabled": False,
+        "site_domain": "",
+        "base_url": "",
+    }
+
+    with TestClient(app) as client:
+        response = client.get("/admin/profile")
+
+    assert response.status_code == 200
+    assert "Notification Contact" in response.text
+    assert "Booking Link" in response.text
+    assert "Matrix Username" in response.text
+    assert "Email signature" in response.text
+    assert "profile-columns--standard" not in response.text
 
 
 def test_bcp_menu_replaces_business_continuity(company_admin_context):


### PR DESCRIPTION
### Motivation
- Remove profile fields that are only relevant to technicians (Notification Contact, Booking Link, Matrix Username, Email Signature) from the `/admin/profile` page when the current user is a normal user to simplify the UI and reduce exposed surface.
- Reflow the page to use the freed space for the remaining boxes (Account security, Left menu customisation) so standard users have a clean two-column layout.
- Load heavy/HTML-editing assets only for users who can edit those fields to reduce unnecessary asset exposure.

### Description
- Template changes: wrap technician-only blocks in a guard and only render them when `is_super_admin or is_helpdesk_technician` (`app/templates/admin/profile.html`).
- Layout changes: add a `.profile-columns--standard` CSS class and apply it when technician fields are hidden to switch to a two-column grid for standard users (`app/static/css/app.css`).
- JS/asset adjustments: conditionally include the rich-text editor script only when technician fields are shown to avoid loading the editor for standard users (`app/templates/admin/profile.html`).
- Tests: added regression coverage to `tests/test_sidebar_menu.py` verifying that standard users do not see the removed sections and that helpdesk technicians still do.

### Testing
- Ran `pytest -q tests/test_sidebar_menu.py -q` and the tests passed successfully.
- Ran `git diff --check` to confirm there are no whitespace/format issues and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a62d79aac832da08db831963cf5e3)