### PR TITLE
Restrict company admin access when menu permission is denied

### DIFF
--- a/app/features/companies/handlers.py
+++ b/app/features/companies/handlers.py
@@ -83,12 +83,7 @@ async def _get_company_management_scope(
             company_id = int(raw_company_id)
         except (TypeError, ValueError):
             continue
-        staff_permission = _normalize_staff_access_scope(record.get("staff_permission"))
-        if (
-            bool(record.get("is_admin"))
-            or bool(record.get("can_manage_staff"))
-            or staff_permission > 0
-        ):
+        if _main()._membership_menu_can(user, record, "menu.admin.company"):
             membership_lookup[company_id] = record
 
     if not membership_lookup:

--- a/app/main.py
+++ b/app/main.py
@@ -1979,6 +1979,7 @@ async def _build_base_context(
         "can_manage_subscriptions": _menu_can(menu_access, "menu.subscriptions", write=True),
         "can_access_reports": _menu_can(menu_access, "menu.reports"),
         "can_access_reporting": _menu_can(menu_access, "menu.reporting"),
+        "can_access_admin_company": _menu_can(menu_access, "menu.admin.company"),
         "menu_access": menu_access,
         "menu_permission_catalogue": catalogue_for_api(),
     }
@@ -2065,7 +2066,7 @@ async def _build_base_context(
         "staff_permission": staff_permission_level,
         "is_super_admin": is_super_admin,
         "is_helpdesk_technician": is_helpdesk_technician,
-        "is_company_admin": is_super_admin or bool(membership_data.get("is_admin")),
+        "is_company_admin": is_super_admin or _menu_can(menu_access, "menu.admin.company"),
         "integration_modules": module_lookup,
         "syncro_module_enabled": bool((module_lookup or {}).get("syncro", {}).get("enabled")),
         "enable_auto_refresh": bool(settings.enable_auto_refresh),

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -142,9 +142,10 @@
           {% set can_access_marketing = (can_access_marketing | default(false)) or is_super_admin or menu_access.get('menu.marketing') in ['read', 'write'] %}
           {% set can_access_admin_profile = is_super_admin or menu_access.get('menu.admin.profile') in ['read', 'write'] %}
           {% set can_access_admin_backup_summary = is_super_admin or menu_access.get('menu.admin.backup_summary') in ['read', 'write'] %}
+          {% set can_access_admin_company = (can_access_admin_company | default(false)) or is_super_admin or menu_access.get('menu.admin.company') in ['read', 'write'] %}
           {% set has_company_section = can_access_tickets or can_manage_issues or can_access_marketing or can_access_shop or can_access_cart or can_access_orders or can_access_forms or can_manage_assets or can_manage_licenses or can_manage_subscriptions or can_manage_invoices or can_manage_staff or can_view_compliance or can_view_bcp or can_view_m365_best_practices or can_view_compliance_checks or can_view_m365_user_mailboxes or can_view_m365_shared_mailboxes %}
-          {% set is_company_admin = membership.get('is_admin') %}
-          {% set has_admin_access = is_super_admin or is_company_admin or can_access_admin_profile or can_access_admin_backup_summary %}
+          {% set is_company_admin = can_access_admin_company %}
+          {% set has_admin_access = is_super_admin or can_access_admin_company or can_access_admin_profile or can_access_admin_backup_summary %}
           {% if can_access_dashboard %}
           <li class="menu__item">
             <a href="/" {% if current_path == '/' %}aria-current="page"{% endif %}>
@@ -604,7 +605,7 @@
                   <span class="menu__label">Audit Trail</span>
                 </a>
               </li>
-            {% else %}
+            {% elif can_access_admin_company %}
               <li class="menu__item">
                 <a href="/admin/companies" {% if current_path.startswith('/admin/companies') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">

--- a/tests/test_company_admin_menu_access.py
+++ b/tests/test_company_admin_menu_access.py
@@ -1,0 +1,98 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app import main
+from app.features.companies import handlers as company_handlers
+from app.security.session import SessionData
+
+
+async def _dummy_receive() -> dict[str, object]:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _make_request(path: str = "/admin/companies") -> Request:
+    scope = {"type": "http", "method": "GET", "path": path, "headers": []}
+    return Request(scope, _dummy_receive)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_base_context_hides_company_admin_when_menu_permission_is_no_access(monkeypatch):
+    request = _make_request()
+    session = SessionData(
+        id=1,
+        user_id=5,
+        session_token="token",
+        csrf_token="csrf",
+        created_at=datetime.utcnow(),
+        expires_at=datetime.utcnow() + timedelta(hours=1),
+        last_seen_at=datetime.utcnow(),
+        ip_address="127.0.0.1",
+        user_agent="pytest",
+        active_company_id=7,
+    )
+
+    async def fake_load_session(req):
+        req.state.session = session
+        req.state.active_company_id = session.active_company_id
+        return session
+
+    membership = {
+        "company_id": 7,
+        "is_admin": True,
+        "staff_permission": 0,
+        "menu_permissions": {"menu.admin.company": "none"},
+    }
+
+    monkeypatch.setattr(main.session_manager, "load_session", fake_load_session)
+    monkeypatch.setattr(
+        main.company_access,
+        "list_accessible_companies",
+        AsyncMock(return_value=[{"company_id": 7, "company_name": "Example"}]),
+    )
+    monkeypatch.setattr(main.user_company_repo, "get_user_company", AsyncMock(return_value=membership))
+    monkeypatch.setattr(
+        main.cart_repo,
+        "summarise_cart",
+        AsyncMock(return_value={"item_count": 0, "total_quantity": 0, "subtotal": Decimal("0")}),
+    )
+    monkeypatch.setattr(main.notifications_repo, "count_notifications", AsyncMock(return_value=0))
+
+    user = {"id": 5, "email": "user@example.com", "is_super_admin": False}
+    context = await main._build_base_context(request, user)
+
+    assert context["menu_access"]["menu.admin.company"] == "none"
+    assert context["can_access_admin_company"] is False
+    assert context["is_company_admin"] is False
+
+
+@pytest.mark.anyio("asyncio")
+async def test_company_management_scope_denies_explicit_no_access_company_admin(monkeypatch):
+    request = _make_request()
+    user = {"id": 5, "email": "user@example.com", "is_super_admin": False}
+    membership = {
+        "company_id": 7,
+        "is_admin": True,
+        "staff_permission": 0,
+        "menu_permissions": {"menu.admin.company": "none"},
+    }
+
+    from app.repositories import companies as company_repo
+    from app.repositories import user_companies as user_company_repo
+
+    monkeypatch.setattr(user_company_repo, "list_companies_for_user", AsyncMock(return_value=[membership]))
+    monkeypatch.setattr(company_repo, "get_company_by_id", AsyncMock(return_value={"id": 7, "name": "Example"}))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await company_handlers._get_company_management_scope(request, user)
+
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
### Motivation
- Ensure the left-hand "Company admin" menu and the `/admin/companies` management surface are hidden/forbidden for users who have an explicit `menu.admin.company` = `none` menu permission, even when legacy membership flags like `is_admin` are set.
- Prevent showing a blank/accessible admin page to users who were explicitly denied access by their role/menu permissions.

### Description
- Gate company-management scope in `_get_company_management_scope` on the effective `menu.admin.company` permission by using `_membership_menu_can(user, record, "menu.admin.company")` instead of relying on legacy `is_admin`, `can_manage_staff`, or `staff_permission` checks. (`app/features/companies/handlers.py`)
- Add `can_access_admin_company` into the shared base context and change `is_company_admin` to reflect the effective `menu.admin.company` menu permission (`app/main.py`).
- Update the sidebar template to only render the "Company admin" menu item when the effective `menu.admin.company` permission allows access (`app/templates/base.html`).
- Add regression tests that prove an explicit `menu.admin.company: none` setting hides the Company admin context and causes `_get_company_management_scope` to deny access (`tests/test_company_admin_menu_access.py`).

### Testing
- Compiled the updated modules with `python -m compileall -q app/main.py app/features/companies/handlers.py` and the compilation succeeded. 
- Ran the new regression tests with `pytest -q tests/test_company_admin_menu_access.py` and they passed (`2 passed`).
- Ran a broader test run including legacy feature-pack tests which surfaced unrelated preexisting failures in other test modules; those failures are not caused by the changes in this PR and are noted separately for follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a634cc620832db6c1606dbe9ea58f)