### PR TITLE
Make menu.admin.technician a Yes/No permission (treat existing Read as Yes)

### DIFF
--- a/app/schemas/roles.py
+++ b/app/schemas/roles.py
@@ -23,7 +23,7 @@ class RoleBase(BaseModel):
         default_factory=dict,
         description=(
             "Tri-state menu permissions keyed by menu permission id. "
-            "Allowed levels are none, read, and write. Legacy string lists are accepted for compatibility."
+            "Allowed levels are none, read, and write; menu.admin.technician accepts none/write and treats existing read values as write. Legacy string lists are accepted for compatibility."
         ),
         examples=[
             {
@@ -50,7 +50,7 @@ class RoleUpdate(BaseModel):
     description: Optional[str] = None
     permissions: Optional[dict[str, str] | list[str]] = Field(
         default=None,
-        description="Tri-state menu permission updates. Use none, read, or write for each supplied menu key.",
+        description="Menu permission updates. Use none, read, or write for each supplied menu key; menu.admin.technician accepts none/write and treats read as write.",
     )
 
     @field_validator("permissions")

--- a/app/security/menu_permissions.py
+++ b/app/security/menu_permissions.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 
 AccessLevel = Literal["none", "read", "write"]
 ACCESS_LEVELS: tuple[AccessLevel, ...] = ("none", "read", "write")
+BOOLEAN_MENU_PERMISSIONS: frozenset[str] = frozenset({"menu.admin.technician"})
 
 
 @dataclass(frozen=True)
@@ -85,7 +86,16 @@ for item in MENU_PERMISSIONS:
 
 
 def catalogue_for_api() -> list[dict[str, Any]]:
-    return [asdict(item) | {"levels": list(ACCESS_LEVELS)} for item in MENU_PERMISSIONS]
+    return [
+        asdict(item) | {"levels": list(_access_levels_for_permission(item.key))}
+        for item in MENU_PERMISSIONS
+    ]
+
+
+def _access_levels_for_permission(key: str) -> tuple[AccessLevel, ...]:
+    if key in BOOLEAN_MENU_PERMISSIONS:
+        return ("none", "write")
+    return ACCESS_LEVELS
 
 
 def normalize_access_level(value: Any) -> AccessLevel:
@@ -107,6 +117,13 @@ def normalize_access_level(value: Any) -> AccessLevel:
     return value_str  # type: ignore[return-value]
 
 
+def normalize_menu_permission_level(key: str, value: Any) -> AccessLevel:
+    level = normalize_access_level(value)
+    if key in BOOLEAN_MENU_PERMISSIONS and level == "read":
+        return "write"
+    return level
+
+
 def merge_access(existing: AccessLevel, new: AccessLevel) -> AccessLevel:
     rank = {"none": 0, "read": 1, "write": 2}
     return new if rank[new] > rank[existing] else existing
@@ -122,13 +139,13 @@ def normalize_menu_permissions(raw: Any) -> dict[str, AccessLevel]:
         source = raw.get("menu") if isinstance(raw.get("menu"), dict) else raw
         for key, value in source.items():
             if key in MENU_PERMISSION_MAP:
-                normalized[key] = normalize_access_level(value)
+                normalized[key] = normalize_menu_permission_level(key, value)
         # Also accept a legacy list nested under permissions for compatibility.
         legacy = raw.get("legacy") or raw.get("permissions")
         if isinstance(legacy, list):
             legacy_map = normalize_menu_permissions(legacy)
             for key, level in legacy_map.items():
-                normalized[key] = merge_access(normalized[key], level)
+                normalized[key] = merge_access(normalized[key], normalize_menu_permission_level(key, level))
         return normalized
 
     if isinstance(raw, list):
@@ -136,11 +153,11 @@ def normalize_menu_permissions(raw: Any) -> dict[str, AccessLevel]:
             if not isinstance(permission, str):
                 continue
             if permission in MENU_PERMISSION_MAP:
-                normalized[permission] = merge_access(normalized[permission], "write")
+                normalized[permission] = merge_access(normalized[permission], normalize_menu_permission_level(permission, "write"))
                 continue
             mapped_items = LEGACY_TO_MENU.get(permission, [])
             for key, level in mapped_items:
-                normalized[key] = merge_access(normalized[key], level)
+                normalized[key] = merge_access(normalized[key], normalize_menu_permission_level(key, level))
         return normalized
 
     return normalized
@@ -168,5 +185,5 @@ def menu_permissions_to_legacy(menu_permissions: Any) -> list[str]:
 def menu_has_access(menu_access: dict[str, Any] | None, key: str, *, write: bool = False) -> bool:
     if not menu_access:
         return False
-    level = normalize_access_level(menu_access.get(key, "none"))
+    level = normalize_menu_permission_level(key, menu_access.get(key, "none"))
     return level == "write" if write else level in {"read", "write"}

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1486,6 +1486,7 @@
           'm365_user_mailboxes.access': ['menu.m365.user_mailboxes', 'read'],
           'm365_shared_mailboxes.access': ['menu.m365.shared_mailboxes', 'read'],
           'company.admin': ['menu.admin.company', 'write'],
+          'company.switch_all': ['menu.admin.technician', 'write'],
         };
         return permissions.reduce((acc, permission) => {
           const mapped = legacyMap[permission];
@@ -1496,7 +1497,11 @@
         }, {});
       }
       if (typeof permissions === 'object') {
-        return permissions.menu && typeof permissions.menu === 'object' ? permissions.menu : permissions;
+        const menuPermissions = permissions.menu && typeof permissions.menu === 'object' ? permissions.menu : permissions;
+        if (menuPermissions['menu.admin.technician'] === 'read') {
+          return { ...menuPermissions, 'menu.admin.technician': 'write' };
+        }
+        return menuPermissions;
       }
       return {};
     }

--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -47,7 +47,7 @@
                 {% if role.permissions %}
                   <span class="tag-list">
                     {% for perm, level in role.permissions.items() %}
-                      <span class="tag">{{ perm }}: {{ 'Read/Write' if level == 'write' else 'Read Only' }}</span>
+                      <span class="tag">{{ perm }}: {{ 'Yes' if perm == 'menu.admin.technician' else ('Read/Write' if level == 'write' else 'Read Only') }}</span>
                     {% endfor %}
                   </span>
                 {% else %}
@@ -114,18 +114,21 @@
                   <td data-label="Group">{{ permission.group }}</td>
                   <td data-label="Access level">
                     {% set is_ticket_permission = permission.key == 'menu.tickets' %}
+                    {% set is_boolean_permission = permission.key == 'menu.admin.technician' %}
                     <div class="permission-level" role="radiogroup" aria-label="{{ permission.label }} access level">
                       <label>
                         <input type="radio" name="permission_level_{{ loop.index }}" value="none" data-permission-level data-permission-key="{{ permission.key }}" checked />
-                        <span>No Access</span>
+                        <span>{{ 'No' if is_boolean_permission else 'No Access' }}</span>
                       </label>
-                      <label>
-                        <input type="radio" name="permission_level_{{ loop.index }}" value="read" data-permission-level data-permission-key="{{ permission.key }}" />
-                        <span>{{ 'Own' if is_ticket_permission else 'Read Only' }}</span>
-                      </label>
+                      {% if not is_boolean_permission %}
+                        <label>
+                          <input type="radio" name="permission_level_{{ loop.index }}" value="read" data-permission-level data-permission-key="{{ permission.key }}" />
+                          <span>{{ 'Own' if is_ticket_permission else 'Read Only' }}</span>
+                        </label>
+                      {% endif %}
                       <label>
                         <input type="radio" name="permission_level_{{ loop.index }}" value="write" data-permission-level data-permission-key="{{ permission.key }}" />
-                        <span>{{ 'All' if is_ticket_permission else 'Read/Write' }}</span>
+                        <span>{{ 'All' if is_ticket_permission else ('Yes' if is_boolean_permission else 'Read/Write') }}</span>
                       </label>
                     </div>
                   </td>
@@ -134,7 +137,7 @@
             </tbody>
           </table>
         </div>
-        <p class="form-help" id="role-permissions-help">Choose No Access to hide a menu and block direct access, Read Only/Own to view permitted information, or Read/Write/All to allow permitted actions.</p>
+        <p class="form-help" id="role-permissions-help">Choose No Access to hide a menu and block direct access, Read Only/Own to view permitted information, or Read/Write/All to allow permitted actions. The Technician permission is a Yes/No setting.</p>
       </div>
       <div class="form-actions">
         <button type="button" class="button button--ghost" data-role-reset>Clear form</button>
@@ -177,8 +180,8 @@
       </p>
       <h3>Assignable menu permissions</h3>
       <p>
-        Every left-menu item is available in the permission catalogue with three levels: <strong>No Access</strong>,
-        <strong>Read Only</strong>, and <strong>Read/Write</strong>. Tickets use the same stored levels with labels
+        Most left-menu items are available in the permission catalogue with three levels: <strong>No Access</strong>,
+        <strong>Read Only</strong>, and <strong>Read/Write</strong>. The Technician administration permission is a two-state <strong>No</strong>/<strong>Yes</strong> control. Tickets use the same stored levels with labels
         <strong>No Access</strong>, <strong>Own</strong>, and <strong>All</strong>: Own opens <code>/tickets</code> for the user's tickets, while All opens <code>/admin/tickets</code> for technicians. Use Read Only for mailbox visibility without
         mailbox actions, and No Access to hide sensitive menus such as Office 365 configuration.
       </p>

--- a/migrations/265_technician_permission_yes_no.sql
+++ b/migrations/265_technician_permission_yes_no.sql
@@ -1,0 +1,14 @@
+-- Normalize existing Technician menu permission records to the new Yes/No model.
+-- No Access remains unset/none, while prior Read Only values become Yes (write).
+UPDATE roles
+SET permissions = REPLACE(
+  REPLACE(
+    REPLACE(
+      REPLACE(permissions, '"menu.admin.technician":"read"', '"menu.admin.technician":"write"'),
+      '"menu.admin.technician": "read"', '"menu.admin.technician": "write"'
+    ),
+    '"menu.admin.technician":"Read Only"', '"menu.admin.technician":"write"'
+  ),
+  '"menu.admin.technician": "Read Only"', '"menu.admin.technician": "write"'
+)
+WHERE permissions LIKE '%"menu.admin.technician"%';

--- a/tests/test_menu_permissions.py
+++ b/tests/test_menu_permissions.py
@@ -55,3 +55,21 @@ def test_bcp_continuity_menu_permission_expands_to_legacy_permissions():
     assert "bcp:view" in legacy_read
     assert "bcp:edit" not in legacy_read
     assert "bcp:edit" in legacy_write
+
+
+def test_technician_permission_is_yes_no_for_catalogue_and_normalization():
+    permissions = normalize_menu_permissions({"menu.admin.technician": "Read Only"})
+
+    assert permissions["menu.admin.technician"] == "write"
+    assert compact_menu_permissions({"menu.admin.technician": "read"}) == {"menu.admin.technician": "write"}
+    assert menu_has_access({"menu.admin.technician": "read"}, "menu.admin.technician", write=True) is True
+
+
+def test_technician_permission_catalogue_exposes_yes_no_levels():
+    from app.security.menu_permissions import catalogue_for_api
+
+    technician_permission = next(
+        permission for permission in catalogue_for_api() if permission["key"] == "menu.admin.technician"
+    )
+
+    assert technician_permission["levels"] == ["none", "write"]


### PR DESCRIPTION
### Motivation
- The Technician administration menu item should be a binary Yes/No control rather than a tri-state menu (No Access / Read Only / Read/Write).
- Existing records that used the legacy `read` label for Technician should be interpreted as Yes to preserve behavior and avoid losing technician privileges.

### Description
- Restrict the Technician menu permission catalogue to only `none`/`write` levels and expose those levels via `catalogue_for_api()`; other menu items remain tri-state. (`app/security/menu_permissions.py`)
- Normalize input and access checks so `menu.admin.technician = read` is interpreted as `write` (Yes) for compatibility. (`app/security/menu_permissions.py`)
- Update the Roles admin UI to show the Technician permission as No/Yes in both the role list and the role edit modal while keeping other permissions unchanged. (`app/templates/admin/roles.html`) 
- Adjust client-side role form normalization to map legacy `company.switch_all` and to treat incoming `menu.admin.technician: read` as Yes. (`app/static/js/admin.js`)
- Clarify schema docs to state that `menu.admin.technician` accepts none/write and that read is treated as write. (`app/schemas/roles.py`)
- Add a migration SQL (`migrations/265_technician_permission_yes_no.sql`) that converts stored `menu.admin.technician: read` values to `write` so existing DB records become Yes while leaving none as No. (`migrations/265_technician_permission_yes_no.sql`)
- Add regression tests to verify catalogue levels and normalization behavior for the Technician permission. (`tests/test_menu_permissions.py`)

### Testing
- Ran the permission unit tests: `python -m pytest tests/test_menu_permissions.py -q` and all tests passed (7 passed). 
- Verified Python modules compile: `python -m compileall app/security/menu_permissions.py app/schemas/roles.py` succeeded. 
- Executed the new migration against an in-memory SQLite roles table to confirm `"menu.admin.technician":"read"` is converted to `"menu.admin.technician":"write"` and the update behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a66d2726c832da467708cffa41e30)