### PR TITLE
Fix assets settings route ordering to prevent 'settings' being parsed as asset_id

### DIFF
--- a/app/features/assets/__init__.py
+++ b/app/features/assets/__init__.py
@@ -3,8 +3,8 @@
 Owns the assets pages and delete endpoint:
 
 * ``GET /assets``
-* ``GET /assets/{asset_id}``
 * ``GET /assets/settings``
+* ``GET /assets/{asset_id}``
 * ``DELETE /assets/{asset_id}``
 
 Handlers are migrated from ``app/main.py`` so they can be hot-reloaded
@@ -20,7 +20,7 @@ from .routes import router as assets_router
 
 PACK = FeaturePack(
     slug="assets",
-    version="1.0.2",
+    version="1.0.3",
     routers=(assets_router,),
 )
 

--- a/app/features/assets/routes.py
+++ b/app/features/assets/routes.py
@@ -251,20 +251,6 @@ async def assets_page(request: Request):
     return await main_module._render_template("assets/index.html", request, user, extra=extra)
 
 
-@router.get("/assets/{asset_id}", response_class=RedirectResponse)
-async def asset_detail_page(request: Request, asset_id: int):
-    user, _membership, _, company_id, redirect = await _load_asset_context(request)
-    if redirect:
-        return redirect
-
-    record = await asset_repo.get_asset_by_id(asset_id)
-    record_company_id = record.get("company_id") if record else None
-    if record_company_id is None or int(record_company_id) != company_id:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found")
-
-    return RedirectResponse(url=f"/assets#asset-{asset_id}", status_code=status.HTTP_303_SEE_OTHER)
-
-
 @router.get("/assets/settings", response_class=HTMLResponse)
 async def assets_settings_page(request: Request):
     main_module = _main()
@@ -283,6 +269,20 @@ async def assets_settings_page(request: Request):
         "is_super_admin": True,
     }
     return await main_module._render_template("assets/settings.html", request, user, extra=extra)
+
+
+@router.get("/assets/{asset_id}", response_class=RedirectResponse)
+async def asset_detail_page(request: Request, asset_id: int):
+    user, _membership, _, company_id, redirect = await _load_asset_context(request)
+    if redirect:
+        return redirect
+
+    record = await asset_repo.get_asset_by_id(asset_id)
+    record_company_id = record.get("company_id") if record else None
+    if record_company_id is None or int(record_company_id) != company_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found")
+
+    return RedirectResponse(url=f"/assets#asset-{asset_id}", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @router.delete("/assets/{asset_id}", response_class=JSONResponse)

--- a/tests/test_assets_route_order.py
+++ b/tests/test_assets_route_order.py
@@ -1,0 +1,12 @@
+"""Regression tests for assets feature route ordering."""
+
+from fastapi.routing import APIRoute
+
+from app.features.assets.routes import router
+
+
+def test_assets_settings_route_precedes_asset_id_route():
+    """Ensure /assets/settings is not captured by /assets/{asset_id}."""
+    paths = [route.path for route in router.routes if isinstance(route, APIRoute)]
+
+    assert paths.index("/assets/settings") < paths.index("/assets/{asset_id}")


### PR DESCRIPTION
### Motivation
- Requests to `/assets/settings` were being matched by the dynamic route `/assets/{asset_id}`, causing FastAPI to attempt to parse `"settings"` as an integer and returning a 422/parse error. 
- The change ensures the static settings endpoint is matched first so the settings page loads correctly.

### Description
- Reordered handlers in `app/features/assets/routes.py` so the static `@router.get("/assets/settings")` route is declared before the dynamic `@router.get("/assets/{asset_id}")` route. 
- Bumped the assets feature pack version in `app/features/assets/__init__.py` to `1.0.3` and adjusted the pack docstring listing to reflect the new route order. 
- Added a regression test `tests/test_assets_route_order.py` that asserts `/assets/settings` is registered before `/assets/{asset_id}`.

### Testing
- Ran `pytest tests/test_assets_route_order.py` and the test passed (`1 passed`).
- Ran `python -m compileall app/features/assets tests/test_assets_route_order.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b3fd4b8f8832d8702381b1633237b)