### PR TITLE
Portal tickets: remove Priority & Company columns and auto-apply Status filter

### DIFF
--- a/app/templates/tickets/index.html
+++ b/app/templates/tickets/index.html
@@ -27,22 +27,21 @@
   <section class="card card--panel">
     <header class="card__header">
       <div class="card__controls tickets-toolbar">
-        <form method="get" class="tickets-toolbar__form" autocomplete="off">
+        <form method="get" class="tickets-toolbar__form" autocomplete="off" data-ticket-status-filter-form>
           <div class="tickets-toolbar__field">
             <label class="form-label" for="tickets-status-filter">Status</label>
-            <select id="tickets-status-filter" name="status" class="form-input">
+            <select id="tickets-status-filter" name="status" class="form-input" data-ticket-status-filter>
               <option value="">All statuses</option>
               {% for option in status_options %}
                 <option value="{{ option.value }}" {% if status_filter and status_filter == option.value %}selected{% endif %}>{{ option.label }}</option>
               {% endfor %}
             </select>
           </div>
-          <div class="tickets-toolbar__actions">
-            <button type="submit" class="button">Apply filters</button>
-            {% if filters_active %}
+          {% if filters_active %}
+            <div class="tickets-toolbar__actions">
               <a class="button button--ghost" href="{{ request.url.path }}">Clear</a>
-            {% endif %}
-          </div>
+            </div>
+          {% endif %}
         </form>
         <input
           type="search"
@@ -66,8 +65,6 @@
             <th scope="col" data-column-key="id" data-sort="int">Ticket</th>
             <th scope="col" data-column-key="subject" data-sort="string">Subject</th>
             <th scope="col" data-column-key="status" data-sort="string">Status</th>
-            <th scope="col" data-column-key="priority" data-sort="string">Priority</th>
-            <th scope="col" data-column-key="company" data-sort="string">Company</th>
             <th scope="col" data-column-key="updated" data-sort="date">Updated</th>
           </tr>
         </thead>
@@ -82,8 +79,6 @@
                 <td data-column-key="status" data-label="Status">
                   <span class="badge {{ ticket.status_badge }}">{{ ticket.status_label }}</span>
                 </td>
-                <td data-column-key="priority" data-label="Priority">{{ ticket.priority_label }}</td>
-                <td data-column-key="company" data-label="Company">{{ ticket.company_name or '—' }}</td>
                 <td data-column-key="updated" data-label="Updated" data-value="{{ ticket.updated_iso or '' }}">
                   {% if ticket.updated_iso %}
                     <span data-utc="{{ ticket.updated_iso }}"></span>
@@ -95,7 +90,7 @@
             {% endfor %}
           {% else %}
             <tr>
-              <td colspan="6" class="table__empty">No tickets available.</td>
+              <td colspan="4" class="table__empty">No tickets available.</td>
             </tr>
           {% endif %}
         </tbody>
@@ -383,6 +378,20 @@
           modalId: 'create-ticket-modal', 
           triggerSelector: '[data-create-ticket-modal-open]' 
         });
+
+        const statusFilter = document.querySelector('[data-ticket-status-filter]');
+        const statusFilterForm = document.querySelector('[data-ticket-status-filter-form]');
+        if (statusFilter instanceof HTMLSelectElement && statusFilterForm instanceof HTMLFormElement) {
+          statusFilter.addEventListener('change', () => {
+            const targetUrl = new URL(statusFilterForm.action || window.location.href, window.location.href);
+            if (statusFilter.value) {
+              targetUrl.searchParams.set(statusFilter.name, statusFilter.value);
+            } else {
+              targetUrl.searchParams.delete(statusFilter.name);
+            }
+            window.location.assign(targetUrl.toString());
+          });
+        }
       });
     })();
   </script>

--- a/tests/test_ticket_portal_pages.py
+++ b/tests/test_ticket_portal_pages.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -27,6 +28,19 @@ def _make_request(path: str = "/tickets", query_string: str = "") -> Request:
 @pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
+
+
+def test_portal_tickets_template_hides_priority_company_and_auto_applies_status():
+    template = Path("app/templates/tickets/index.html").read_text()
+
+    assert "Apply filters" not in template
+    assert 'data-ticket-status-filter' in template
+    assert "statusFilter.addEventListener('change'" in template
+    assert 'data-column-key="priority"' not in template
+    assert 'data-column-key="company"' not in template
+    assert 'data-label="Priority"' not in template
+    assert 'data-label="Company"' not in template
+    assert 'colspan="4"' in template
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation
- Simplify the public `/tickets` list view by removing Priority and Company columns to match the requested UI change.
- Improve UX by removing the manual “Apply filters” button and automatically applying the Status filter when the user changes the dropdown.

### Description
- Updated the portal tickets template `app/templates/tickets/index.html` to remove the Priority and Company table columns and their cells, reduce the empty-state `colspan` to match the new column count, and hide the previous submit button for filters while keeping the Clear action visible when filters are active.
- Added `data-` attributes to the status select and form (`data-ticket-status-filter` and `data-ticket-status-filter-form`) and client-side JS that listens for `change` on the Status dropdown and navigates the browser with the appropriate `status` query parameter so the filter is applied immediately.
- Added a regression test `test_portal_tickets_template_hides_priority_company_and_auto_applies_status` to `tests/test_ticket_portal_pages.py` which checks the template no longer renders the removed elements and that the auto-apply handler is present.

### Testing
- Ran `pytest tests/test_ticket_portal_pages.py -q` and the suite passed (`7 passed`).
- Verified the new template renders without the Priority/Company columns and includes the `data-ticket-status-filter` attribute and the auto-apply JS handler.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b41853028832dac9dba6159129756)