### PR TITLE
Assets: add Export CSV option (write-permission gated)

### DIFF
--- a/app/features/assets/routes.py
+++ b/app/features/assets/routes.py
@@ -80,9 +80,11 @@ async def _load_asset_context(request: Request):
 @router.get("/assets", response_class=HTMLResponse)
 async def assets_page(request: Request):
     main_module = _main()
-    user, _membership, company, company_id, redirect = await _load_asset_context(request)
+    user, membership, company, company_id, redirect = await _load_asset_context(request)
     if redirect:
         return redirect
+
+    can_export_assets = main_module._membership_menu_can(user, membership, "menu.assets", write=True)
 
     rows = await asset_repo.list_company_assets(company_id)
     field_definitions = await asset_custom_fields_repo.list_field_definitions()
@@ -246,6 +248,7 @@ async def assets_page(request: Request):
         "company": company,
         "stats": stats,
         "has_assets": bool(prepared),
+        "can_export_assets": can_export_assets,
         "is_super_admin": bool(user.get("is_super_admin")),
     }
     return await main_module._render_template("assets/index.html", request, user, extra=extra)

--- a/app/static/js/assets.js
+++ b/app/static/js/assets.js
@@ -48,6 +48,100 @@
     totalElement.textContent = String(count);
   }
 
+
+  function csvEscape(value) {
+    const text = String(value ?? '').replace(/\r?\n|\r/g, ' ').trim();
+    const safeText = /^[=+\-@\t\r]/.test(text) ? `'${text}` : text;
+    return `"${safeText.replace(/"/g, '""')}"`;
+  }
+
+  function getVisibleTableColumns(table) {
+    if (!table || !table.tHead || !table.tHead.rows.length) {
+      return [];
+    }
+    return Array.from(table.tHead.rows[0].cells)
+      .filter((header) => header.dataset.column && header.style.display !== 'none')
+      .map((header) => ({
+        key: header.dataset.column,
+        label: (header.textContent || '').trim(),
+      }));
+  }
+
+  function getDisplayedRows(table) {
+    if (!table || !table.tBodies.length) {
+      return [];
+    }
+    return Array.from(table.tBodies[0].rows).filter((row) => row.style.display !== 'none');
+  }
+
+  function escapeColumnSelector(value) {
+    if (window.CSS && typeof window.CSS.escape === 'function') {
+      return window.CSS.escape(value);
+    }
+    return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  }
+
+  function getCellExportText(cell) {
+    if (!cell) {
+      return '';
+    }
+    const mutedPlaceholder = cell.querySelector('.text-muted');
+    if (mutedPlaceholder && (cell.textContent || '').trim() === (mutedPlaceholder.textContent || '').trim()) {
+      return '';
+    }
+    return (cell.innerText || cell.textContent || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function buildAssetsCsv(table) {
+    const columns = getVisibleTableColumns(table);
+    const rows = getDisplayedRows(table);
+    if (!columns.length) {
+      return '';
+    }
+    const lines = [columns.map((column) => csvEscape(column.label)).join(',')];
+    rows.forEach((row) => {
+      const values = columns.map((column) => {
+        const cell = row.querySelector(`td[data-column="${escapeColumnSelector(column.key)}"]`);
+        return csvEscape(getCellExportText(cell));
+      });
+      lines.push(values.join(','));
+    });
+    return lines.join('\r\n');
+  }
+
+  function downloadCsv(csv, filename) {
+    const blob = new Blob([`\ufeff${csv}`], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  function initialiseCsvExport(table) {
+    const button = document.querySelector('[data-export-csv="assets-table"]');
+    if (!button || !table) {
+      return;
+    }
+    button.addEventListener('click', () => {
+      const csv = buildAssetsCsv(table);
+      if (!csv) {
+        if (window.__portalToast && typeof window.__portalToast.show === 'function') {
+          window.__portalToast.show('No asset columns are available to export.', { variant: 'error' });
+        } else {
+          window.alert('No asset columns are available to export.');
+        }
+        return;
+      }
+      const timestamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-');
+      downloadCsv(csv, `assets-${timestamp}.csv`);
+    });
+  }
+
   function initialiseColumnControls(table) {
     const container = document.querySelector('[data-asset-columns]');
     if (!container || !table) {
@@ -363,6 +457,7 @@
     const searchInput = document.getElementById('asset-search');
 
     initialiseColumnControls(table);
+    initialiseCsvExport(table);
     initialiseDeletion(table);
     initialiseCustomFieldsEditing();
     updateVisibleCount(table);

--- a/app/templates/assets/index.html
+++ b/app/templates/assets/index.html
@@ -32,6 +32,15 @@
           aria-label="Search assets"
           data-table-filter="assets-table"
         />
+        {% if can_export_assets %}
+          <button
+            type="button"
+            class="button button--ghost asset-export-button"
+            data-export-csv="assets-table"
+          >
+            Export CSV
+          </button>
+        {% endif %}
         <div class="asset-columns" data-asset-columns>
           <button type="button" class="button button--ghost asset-columns__toggle" data-columns-toggle>
             <span>Columns</span>

--- a/tests/test_asset_csv_export.py
+++ b/tests/test_asset_csv_export.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import app.main as main_module
+from app.features.assets import routes as assets_routes
+
+
+@pytest.mark.parametrize(
+    ("menu_level", "expected"),
+    [
+        ("read", False),
+        ("write", True),
+    ],
+)
+def test_assets_page_export_option_requires_write_menu_permission(monkeypatch, menu_level, expected):
+    captured: dict[str, object] = {}
+    user = {"id": 7, "company_id": 11, "is_super_admin": False}
+    membership = {"menu_permissions": {"menu.assets": menu_level}}
+
+    async def fake_require_authenticated_user(request):
+        return user, None
+
+    async def fake_get_user_company(user_id, company_id):
+        assert user_id == 7
+        assert company_id == 11
+        return membership
+
+    async def fake_get_company_by_id(company_id):
+        assert company_id == 11
+        return {"id": company_id, "name": "Example Co"}
+
+    async def fake_list_company_assets(company_id):
+        assert company_id == 11
+        return []
+
+    async def fake_list_field_definitions():
+        return []
+
+    async def fake_render_template(template_name, request, user_arg, *, extra):
+        captured["template_name"] = template_name
+        captured["extra"] = extra
+        return SimpleNamespace(template_name=template_name, extra=extra)
+
+    monkeypatch.setattr(main_module, "_require_authenticated_user", fake_require_authenticated_user)
+    monkeypatch.setattr(main_module, "_render_template", fake_render_template)
+    monkeypatch.setattr(assets_routes.user_company_repo, "get_user_company", fake_get_user_company)
+    monkeypatch.setattr(assets_routes.company_repo, "get_company_by_id", fake_get_company_by_id)
+    monkeypatch.setattr(assets_routes.asset_repo, "list_company_assets", fake_list_company_assets)
+    monkeypatch.setattr(assets_routes.asset_custom_fields_repo, "list_field_definitions", fake_list_field_definitions)
+
+    import asyncio
+
+    response = asyncio.run(assets_routes.assets_page(SimpleNamespace()))
+
+    assert response.extra["can_export_assets"] is expected
+    assert captured["template_name"] == "assets/index.html"


### PR DESCRIPTION
### Motivation
- Provide users with a convenient way to export the currently-displayed assets and visible columns to CSV from the Assets page. 
- Only allow the export action for users who have write-level asset permissions to avoid exposing export functionality to read-only users.

### Description
- Gate export visibility in `assets_page` by computing `can_export_assets = _membership_menu_can(user, membership, "menu.assets", write=True)` and pass it to the template. 
- Add an `Export CSV` button to `app/templates/assets/index.html` that is shown only when `can_export_assets` is true. 
- Implement client-side CSV generation in `app/static/js/assets.js` that exports only visible columns and displayed rows, with proper CSV escaping, spreadsheet-formula hardening (prefixing potentially dangerous leading characters), UTF-8 BOM, and timestamped filenames, and register the button via `initialiseCsvExport`. 
- Add a regression test `tests/test_asset_csv_export.py` that verifies the `can_export_assets` flag is present for write-level menu permission and absent for read-level permission.

### Testing
- Ran JavaScript syntax check with `node --check app/static/js/assets.js` which passed. 
- Verified Python modules compile with `python -m py_compile app/features/assets/routes.py tests/test_asset_csv_export.py` which passed. 
- Ran unit tests `pytest -q tests/test_assets_by_type.py tests/test_asset_csv_export.py` and they passed (`6 passed`, with environment warnings), confirming permission gating and no regressions in the related asset tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b4208b50c832da08afd1b43912cdf)