### PR TITLE
Scope /tickets 'All' access to company and show Requestor in portal list

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1210,11 +1210,10 @@ async def _require_helpdesk_page(request: Request) -> tuple[dict[str, Any] | Non
     user, redirect = await _require_authenticated_user(request)
     if redirect:
         return None, redirect
-    has_access = await _has_menu_page_access(request, user, "menu.tickets", write=True)
-    if not has_access:
+    if not await _is_helpdesk_technician(user, request):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="All tickets permission required",
+            detail="Helpdesk technician privileges required",
         )
     return user, None
 
@@ -1853,6 +1852,9 @@ async def _has_menu_page_access(request: Request, user: Mapping[str, Any], key: 
         try:
             membership = await user_company_repo.get_user_company(int(user["id"]), int(active_company_id))
         except (TypeError, ValueError):
+            membership = None
+        except Exception as exc:  # pragma: no cover - defensive fallback for tests without DB
+            log_error("Failed to load active membership for menu access", error=str(exc))
             membership = None
         if membership is not None:
             request.state.active_membership = membership
@@ -7039,20 +7041,48 @@ async def _render_portal_tickets_page(
     search_value = (search_term or "").strip()
     effective_search = search_value or None
 
+    has_all_ticket_access = await _has_menu_page_access(request, user, "menu.tickets", write=True)
+    has_platform_ticket_access = await _is_helpdesk_technician(user, request)
+
     try:
-        tickets = await tickets_repo.list_tickets_for_user(
-            user_id,
-            company_ids=active_company_ids or None,
-            status=selected_status_slugs,
-            search=effective_search,
-            limit=200,
-        )
-        total_count = await tickets_repo.count_tickets_for_user(
-            user_id,
-            company_ids=active_company_ids or None,
-            status=selected_status_slugs,
-            search=effective_search,
-        )
+        if has_platform_ticket_access:
+            tickets = await tickets_repo.list_tickets_in_companies(
+                company_ids=None,
+                status=selected_status_slugs,
+                search=effective_search,
+                limit=200,
+            )
+            total_count = await tickets_repo.count_tickets_in_companies(
+                company_ids=None,
+                status=selected_status_slugs,
+                search=effective_search,
+            )
+        elif has_all_ticket_access:
+            tickets = await tickets_repo.list_tickets_in_companies(
+                company_ids=active_company_ids,
+                status=selected_status_slugs,
+                search=effective_search,
+                limit=200,
+            )
+            total_count = await tickets_repo.count_tickets_in_companies(
+                company_ids=active_company_ids,
+                status=selected_status_slugs,
+                search=effective_search,
+            )
+        else:
+            tickets = await tickets_repo.list_tickets_for_user(
+                user_id,
+                company_ids=active_company_ids or None,
+                status=selected_status_slugs,
+                search=effective_search,
+                limit=200,
+            )
+            total_count = await tickets_repo.count_tickets_for_user(
+                user_id,
+                company_ids=active_company_ids or None,
+                status=selected_status_slugs,
+                search=effective_search,
+            )
     except Exception as exc:  # pragma: no cover - defensive fallback
         log_error("Failed to load portal tickets", error=str(exc))
         tickets = []
@@ -7092,6 +7122,15 @@ async def _render_portal_tickets_page(
             if hasattr(created_at, "astimezone")
             else ""
         )
+        requester_name = " ".join(
+            part
+            for part in (
+                str(record.get("requester_first_name") or "").strip(),
+                str(record.get("requester_last_name") or "").strip(),
+            )
+            if part
+        )
+        requester_label = requester_name or str(record.get("requester_email") or "").strip() or None
         formatted_tickets.append(
             {
                 "id": record.get("id"),
@@ -7102,6 +7141,7 @@ async def _render_portal_tickets_page(
                 "priority_label": priority_label,
                 "company_name": company_name,
                 "company_id": record.get("company_id"),
+                "requester_label": requester_label,
                 "updated_iso": updated_iso,
                 "created_iso": created_iso,
             }
@@ -7214,7 +7254,31 @@ async def _render_portal_ticket_detail(
             log_error("Failed to determine ticket watcher state", error=str(exc))
             is_watcher = False
 
+    has_company_ticket_access = False
     if not (has_helpdesk_access or is_super_admin or is_requester or is_watcher):
+        has_all_ticket_access = await _has_menu_page_access(request, user, "menu.tickets", write=True)
+        if has_all_ticket_access:
+            available_companies = await company_access.list_accessible_companies(user)
+            active_company_id = getattr(request.state, "active_company_id", None)
+            allowed_company_ids: set[int] = set()
+            if active_company_id is not None:
+                try:
+                    allowed_company_ids.add(int(active_company_id))
+                except (TypeError, ValueError):
+                    pass
+            if not allowed_company_ids:
+                for entry in available_companies:
+                    try:
+                        allowed_company_ids.add(int(entry.get("company_id")))
+                    except (TypeError, ValueError):
+                        continue
+            try:
+                ticket_company_id = int(ticket.get("company_id"))
+            except (TypeError, ValueError):
+                ticket_company_id = 0
+            has_company_ticket_access = ticket_company_id in allowed_company_ids
+
+    if not (has_helpdesk_access or is_super_admin or is_requester or is_watcher or has_company_ticket_access):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
 
     sanitized_description = sanitize_rich_text(str(ticket.get("description") or ""))

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -559,6 +559,99 @@ async def list_tickets_for_user(
     return [_normalise_ticket(row) for row in rows]
 
 
+async def list_tickets_in_companies(
+    *,
+    company_ids: Sequence[int] | None,
+    search: str | None = None,
+    status: str | Sequence[str] | None = None,
+    limit: int = 25,
+    offset: int = 0,
+) -> list[TicketRecord]:
+    """Return recent tickets for the supplied companies, or all tickets when company_ids is None."""
+
+    status_filters = _prepare_status_filters(status)
+    company_filters = [int(cid) for cid in (company_ids or []) if int(cid) > 0]
+    if company_ids is not None and not company_filters:
+        return []
+
+    search_clause, search_params = _build_ticket_search_clause(
+        search=search,
+        column_prefix="t.",
+        include_external_reference=True,
+    )
+
+    where_clauses = [f"({search_clause})"]
+    if status_filters:
+        status_placeholders = ", ".join(["%s"] * len(status_filters))
+        where_clauses.append(f"t.status IN ({status_placeholders})")
+    if company_filters:
+        company_placeholders = ", ".join(["%s"] * len(company_filters))
+        where_clauses.append(f"t.company_id IN ({company_placeholders})")
+
+    query = f"""
+        SELECT
+            t.*,
+            requester.first_name AS requester_first_name,
+            requester.last_name AS requester_last_name,
+            requester.email AS requester_email
+        FROM tickets AS t
+        LEFT JOIN users AS requester ON requester.id = t.requester_id
+        WHERE {' AND '.join(where_clauses)}
+        ORDER BY t.updated_at DESC, t.id DESC
+        LIMIT %s OFFSET %s
+    """
+    params: list[Any] = [
+        *search_params,
+        *status_filters,
+        *company_filters,
+        int(max(1, limit)),
+        int(max(0, offset)),
+    ]
+    rows = await db.fetch_all(query, tuple(params))
+    return [_normalise_ticket(row) for row in rows]
+
+
+async def count_tickets_in_companies(
+    *,
+    company_ids: Sequence[int] | None,
+    search: str | None = None,
+    status: str | Sequence[str] | None = None,
+) -> int:
+    """Return the number of tickets for the supplied companies, or all tickets when company_ids is None."""
+
+    status_filters = _prepare_status_filters(status)
+    company_filters = [int(cid) for cid in (company_ids or []) if int(cid) > 0]
+    if company_ids is not None and not company_filters:
+        return 0
+
+    search_clause, search_params = _build_ticket_search_clause(
+        search=search,
+        column_prefix="t.",
+        include_external_reference=True,
+    )
+
+    where_clauses = [f"({search_clause})"]
+    if status_filters:
+        status_placeholders = ", ".join(["%s"] * len(status_filters))
+        where_clauses.append(f"t.status IN ({status_placeholders})")
+    if company_filters:
+        company_placeholders = ", ".join(["%s"] * len(company_filters))
+        where_clauses.append(f"t.company_id IN ({company_placeholders})")
+
+    query = f"""
+        SELECT COUNT(*) AS count
+        FROM tickets AS t
+        WHERE {' AND '.join(where_clauses)}
+    """
+    params: list[Any] = [
+        *search_params,
+        *status_filters,
+        *company_filters,
+    ]
+    row = await db.fetch_one(query, tuple(params))
+    return int(row["count"]) if row else 0
+
+
 async def count_tickets_for_user(
     user_id: int,
     *,

--- a/app/security/menu_permissions.py
+++ b/app/security/menu_permissions.py
@@ -28,7 +28,7 @@ MENU_PERMISSIONS: tuple[MenuPermission, ...] = (
     MenuPermission("menu.knowledge_base", "Knowledge base", "General", "View knowledge base articles."),
     MenuPermission("menu.help", "Help", "General", "View help and support documentation."),
     MenuPermission("menu.chat", "Chat", "General", "Access the chat interface.", ("chat.access",), "can_access_chat"),
-    MenuPermission("menu.tickets", "Tickets", "Company", "No Access blocks tickets, Own opens /tickets for the user, and All opens /admin/tickets for technicians.", ("helpdesk.technician",), None),
+    MenuPermission("menu.tickets", "Tickets", "Company", "No Access blocks tickets, Own opens /tickets for the user, All opens /tickets for company tickets, and technicians can use /admin/tickets across customers.", ("helpdesk.technician",), None),
     MenuPermission("menu.issues", "Issue tracker", "Company", "View or manage issue tracker items.", ("issues.manage",), "can_manage_issues"),
     MenuPermission("menu.marketing", "Marketing", "Company", "View or manage marketing pages and contacts.", ("marketing.access",), None),
     MenuPermission("menu.shop", "Shop", "Commerce", "Browse shop products; write access allows cart actions.", ("shop.access",), "can_access_shop"),

--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -182,7 +182,7 @@
       <p>
         Most left-menu items are available in the permission catalogue with three levels: <strong>No Access</strong>,
         <strong>Read Only</strong>, and <strong>Read/Write</strong>. The Technician administration permission is a two-state <strong>No</strong>/<strong>Yes</strong> control. Tickets use the same stored levels with labels
-        <strong>No Access</strong>, <strong>Own</strong>, and <strong>All</strong>: Own opens <code>/tickets</code> for the user's tickets, while All opens <code>/admin/tickets</code> for technicians. Use Read Only for mailbox visibility without
+        <strong>No Access</strong>, <strong>Own</strong>, and <strong>All</strong>: Own opens <code>/tickets</code> for the user's tickets, while All opens <code>/tickets</code> for company tickets; technicians continue to use <code>/admin/tickets</code> for all customers. Use Read Only for mailbox visibility without
         mailbox actions, and No Access to hide sensitive menus such as Office 365 configuration.
       </p>
       <dl class="definition-list">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -215,7 +215,7 @@
           {% endif %}
           {% endif %}
           {% if can_access_tickets %}
-            {% set show_admin_tickets = (can_access_all_tickets | default(false)) or (is_super_admin | default(false)) %}
+            {% set show_admin_tickets = (is_super_admin | default(false)) or (is_helpdesk_technician | default(false)) %}
             {% if show_admin_tickets %}
               {% set ticket_href = '/admin/tickets' %}
               {% set ticket_active = current_path.startswith('/admin/tickets') and not current_path.startswith('/admin/tickets/syncro-import') %}

--- a/app/templates/tickets/index.html
+++ b/app/templates/tickets/index.html
@@ -65,6 +65,7 @@
             <th scope="col" data-column-key="id" data-sort="int">Ticket</th>
             <th scope="col" data-column-key="subject" data-sort="string">Subject</th>
             <th scope="col" data-column-key="status" data-sort="string">Status</th>
+            <th scope="col" data-column-key="requester" data-sort="string">Requestor</th>
             <th scope="col" data-column-key="updated" data-sort="date">Updated</th>
           </tr>
         </thead>
@@ -79,6 +80,7 @@
                 <td data-column-key="status" data-label="Status">
                   <span class="badge {{ ticket.status_badge }}">{{ ticket.status_label }}</span>
                 </td>
+                <td data-column-key="requester" data-label="Requestor">{{ ticket.requester_label or '—' }}</td>
                 <td data-column-key="updated" data-label="Updated" data-value="{{ ticket.updated_iso or '' }}">
                   {% if ticket.updated_iso %}
                     <span data-utc="{{ ticket.updated_iso }}"></span>
@@ -90,7 +92,7 @@
             {% endfor %}
           {% else %}
             <tr>
-              <td colspan="4" class="table__empty">No tickets available.</td>
+              <td colspan="5" class="table__empty">No tickets available.</td>
             </tr>
           {% endif %}
         </tbody>

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -672,4 +672,5 @@ def test_tickets_role_ui_labels_are_no_access_own_all():
 
     assert "permission.key == 'menu.tickets'" in template
     assert "{{ 'Own' if is_ticket_permission else 'Read Only' }}" in template
-    assert "{{ 'All' if is_ticket_permission else 'Read/Write' }}" in template
+    assert "{{ 'All' if is_ticket_permission else ('Yes' if is_boolean_permission else 'Read/Write') }}" in template
+    assert "All opens <code>/tickets</code> for company tickets" in template

--- a/tests/test_ticket_portal_pages.py
+++ b/tests/test_ticket_portal_pages.py
@@ -40,7 +40,9 @@ def test_portal_tickets_template_hides_priority_company_and_auto_applies_status(
     assert 'data-column-key="company"' not in template
     assert 'data-label="Priority"' not in template
     assert 'data-label="Company"' not in template
-    assert 'colspan="4"' in template
+    assert 'data-column-key="requester"' in template
+    assert 'data-label="Requestor"' in template
+    assert 'colspan="5"' in template
 
 
 @pytest.mark.anyio("asyncio")
@@ -115,6 +117,7 @@ async def test_render_portal_tickets_page_formats_results(monkeypatch):
             "priority_label": "High",
             "company_name": "Example",
             "company_id": 22,
+            "requester_label": None,
             "updated_iso": "2025-01-10T09:30:00+00:00",
             "created_iso": "2025-01-09T16:45:00+00:00",
         }
@@ -124,6 +127,60 @@ async def test_render_portal_tickets_page_formats_results(monkeypatch):
     ]
     option_labels = {option["value"]: option["label"] for option in extra["status_options"]}
     assert option_labels == {"open": "Open", "closed": "Closed"}
+
+
+@pytest.mark.anyio("asyncio")
+async def test_render_portal_tickets_page_company_all_scope_includes_requestor(monkeypatch):
+    request = _make_request()
+    request.state.active_company_id = 22
+    request.state.active_membership = {"menu_permissions": {"menu.tickets": "write"}}
+    user = {"id": 5, "company_id": 22, "is_super_admin": False}
+
+    statuses = [TicketStatusDefinition(tech_status="open", tech_label="Open", public_status="Open")]
+    listed_tickets = [
+        {
+            "id": 42,
+            "subject": "Shared company ticket",
+            "status": "open",
+            "priority": "normal",
+            "company_id": 22,
+            "requester_first_name": "Riley",
+            "requester_last_name": "Stone",
+            "requester_email": "riley@example.com",
+            "updated_at": datetime(2025, 1, 11, 9, 30, tzinfo=timezone.utc),
+            "created_at": datetime(2025, 1, 10, 16, 45, tzinfo=timezone.utc),
+        }
+    ]
+
+    monkeypatch.setattr(
+        main.company_access,
+        "list_accessible_companies",
+        AsyncMock(return_value=[{"company_id": 22, "company_name": "Example"}]),
+    )
+    monkeypatch.setattr(main, "_is_helpdesk_technician", AsyncMock(return_value=False))
+    company_list_mock = AsyncMock(return_value=listed_tickets)
+    company_count_mock = AsyncMock(return_value=1)
+    user_list_mock = AsyncMock(return_value=[])
+    monkeypatch.setattr(main.tickets_repo, "list_tickets_in_companies", company_list_mock)
+    monkeypatch.setattr(main.tickets_repo, "count_tickets_in_companies", company_count_mock)
+    monkeypatch.setattr(main.tickets_repo, "list_tickets_for_user", user_list_mock)
+    monkeypatch.setattr(main.tickets_service, "list_status_definitions", AsyncMock(return_value=statuses))
+
+    captured: dict[str, Any] = {}
+
+    async def fake_render_template(template_name, request_obj, user_obj, *, extra):
+        captured["extra"] = extra
+        return HTMLResponse("OK")
+
+    monkeypatch.setattr(main, "_render_template", fake_render_template)
+
+    await main._render_portal_tickets_page(request, user)
+
+    company_list_mock.assert_awaited_once()
+    company_count_mock.assert_awaited_once()
+    user_list_mock.assert_not_awaited()
+    assert company_list_mock.await_args.kwargs["company_ids"] == [22]
+    assert captured["extra"]["tickets"][0]["requester_label"] == "Riley Stone"
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation
- Ensure users who are not helpdesk technicians but have `menu.tickets` set to All see All tickets only for their active/accessible company rather than platform-wide tickets.
- Preserve full platform-wide visibility for actual helpdesk technicians and keep their admin workspace at `/admin/tickets`.
- Surface the ticket requestor on the public portal list so non-technician users with company-scoped All can see who requested tickets.

### Description
- Added company-scoped ticket listing helpers `list_tickets_in_companies` and `count_tickets_in_companies` in `app/repositories/tickets.py` to support queries scoped to one or multiple companies and include requester name/email in results.
- Updated portal ticket loading in `app/main.py` to select between (a) platform-wide tickets for technicians, (b) company-scoped tickets for non-technicians granted `menu.tickets=All`, and (c) the existing per-user scope; also added logic to permit viewing individual tickets when the user has company-scoped access.
- Changed `_require_helpdesk_page` to require actual helpdesk technician privileges for admin helpdesk pages, and updated base template routing so only technicians are routed to `/admin/tickets` while non-technician All users remain on `/tickets`.
- Added `Requestor` column to the portal tickets template `app/templates/tickets/index.html` and populated `requester_label` from the new repository join; updated role help text in `app/templates/admin/roles.html` and `app/security/menu_permissions.py` to reflect company-scoped behaviour.
- Adjusted tests to reflect new behaviour and added a regression test verifying company-scoped All users see the requestor in the portal list (`tests/test_ticket_portal_pages.py`) and updated role UI test expectation (`tests/test_sidebar_menu.py`).

### Testing
- Ran portal and role tests: `pytest tests/test_ticket_portal_pages.py tests/test_sidebar_menu.py -q` which passed locally.
- Executed focused test runs and iterated fixes until the portal/dashboard ticket tests and role UI tests passed (`23 passed` for the executed test set with warnings only).
- Performed a byte-compile check with `python -m compileall app/main.py app/repositories/tickets.py app/security/menu_permissions.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b45598198832daa85e48123e40be4)