### PR TITLE
Hide ticket priority on public portal ticket detail view

### DIFF
--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -40,10 +40,6 @@
                     <dt>Status</dt>
                     <dd><span class="badge {{ ticket.status_badge }}">{{ ticket.status_label }}</span></dd>
                   </div>
-                  <div class="description-list__row">
-                    <dt>Priority</dt>
-                    <dd>{{ ticket.priority_label }}</dd>
-                  </div>
                   {% if ticket.company_name %}
                     <div class="description-list__row">
                       <dt>Company</dt>

--- a/tests/test_ticket_portal_pages.py
+++ b/tests/test_ticket_portal_pages.py
@@ -43,6 +43,13 @@ def test_portal_tickets_template_hides_priority_company_and_auto_applies_status(
     assert 'colspan="4"' in template
 
 
+def test_portal_ticket_detail_template_hides_priority():
+    template = Path("app/templates/tickets/detail.html").read_text()
+
+    assert "ticket.priority_label" not in template
+    assert "<dt>Priority</dt>" not in template
+
+
 @pytest.mark.anyio("asyncio")
 async def test_render_portal_tickets_page_formats_results(monkeypatch):
     request = _make_request()


### PR DESCRIPTION
### Motivation
- The public portal ticket detail page should not display ticket priority when viewed by customers, per the requested change to hide priority in `/tickets/{ticket_id}`.

### Description
- Removed the Priority row from the portal ticket detail template at `app/templates/tickets/detail.html` so the details card shows Status then Company/Requester/Assigned metadata.
- Added a regression assertion in `tests/test_ticket_portal_pages.py` (`test_portal_ticket_detail_template_hides_priority`) that verifies `ticket.priority_label` and the `<dt>Priority</dt>` label are not present in the portal template.
- This is a UI/template-only change; no API or backend logic was modified.

### Testing
- Ran `pytest tests/test_ticket_portal_pages.py` and the test file passed (all tests in the file succeeded).
- Verified the template change by asserting the priority markup is no longer present in `app/templates/tickets/detail.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b44aed2a4832da8aa7e0b25799732)