### PR TITLE
Restrict admin ticket pages to technician admins

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1142,6 +1142,42 @@ async def _is_helpdesk_technician(user: Mapping[str, Any], request: Request | No
     return bool(result)
 
 
+async def _has_admin_technician_access(user: Mapping[str, Any], request: Request | None = None) -> bool:
+    """Return whether the user may access technician-only admin ticket pages.
+
+    ``menu.tickets`` write access allows a company user to see all tickets for
+    their company in the portal. It intentionally maps to the legacy
+    ``helpdesk.technician`` permission for older ticket workflows, so it must
+    not be used as the gate for ``/admin/tickets``. The admin ticket workspace
+    is reserved for super administrators and roles with the explicit
+    ``menu.admin.technician``/``company.switch_all`` technician switch access.
+    """
+    if user.get("is_super_admin"):
+        if request is not None:
+            request.state.has_admin_technician_access = True
+        return True
+    if request is not None:
+        cached = getattr(request.state, "has_admin_technician_access", None)
+        if cached is not None:
+            return bool(cached)
+    user_id = user.get("id")
+    try:
+        user_id_int = int(user_id)
+    except (TypeError, ValueError):
+        result = False
+    else:
+        try:
+            result = await membership_repo.user_has_permission(
+                user_id_int, "company.switch_all"
+            )
+        except Exception as exc:  # pragma: no cover - defensive fallback for tests without DB
+            log_error("Failed to determine admin technician access", error=str(exc))
+            result = False
+    if request is not None:
+        request.state.has_admin_technician_access = bool(result)
+    return bool(result)
+
+
 async def _has_issue_tracker_access(user: Mapping[str, Any], request: Request | None = None) -> bool:
     if user.get("is_super_admin"):
         if request is not None:
@@ -1210,10 +1246,10 @@ async def _require_helpdesk_page(request: Request) -> tuple[dict[str, Any] | Non
     user, redirect = await _require_authenticated_user(request)
     if redirect:
         return None, redirect
-    if not await _is_helpdesk_technician(user, request):
+    if not await _has_admin_technician_access(user, request):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Helpdesk technician privileges required",
+            detail="Access denied",
         )
     return user, None
 
@@ -1943,6 +1979,7 @@ async def _build_base_context(
     is_super_admin = bool(user.get("is_super_admin"))
     staff_permission_level = int(membership_data.get("staff_permission") or 0)
     is_helpdesk_technician = await _is_helpdesk_technician(user, request)
+    has_admin_technician_access = await _has_admin_technician_access(user, request)
     has_issue_tracker_access = await _has_issue_tracker_access(user, request)
     has_marketing_access = await _has_marketing_access(user, request)
     menu_access = _build_menu_access_map(
@@ -2086,6 +2123,7 @@ async def _build_base_context(
         "staff_permission": staff_permission_level,
         "is_super_admin": is_super_admin,
         "is_helpdesk_technician": is_helpdesk_technician,
+        "has_admin_technician_access": has_admin_technician_access,
         "is_company_admin": is_super_admin or _menu_can(menu_access, "menu.admin.company"),
         "integration_modules": module_lookup,
         "syncro_module_enabled": bool((module_lookup or {}).get("syncro", {}).get("enabled")),

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -215,7 +215,7 @@
           {% endif %}
           {% endif %}
           {% if can_access_tickets %}
-            {% set show_admin_tickets = (is_super_admin | default(false)) or (is_helpdesk_technician | default(false)) %}
+            {% set show_admin_tickets = (is_super_admin | default(false)) or (has_admin_technician_access | default(false)) %}
             {% if show_admin_tickets %}
               {% set ticket_href = '/admin/tickets' %}
               {% set ticket_active = current_path.startswith('/admin/tickets') and not current_path.startswith('/admin/tickets/syncro-import') %}

--- a/tests/test_admin_tickets_phone_search.py
+++ b/tests/test_admin_tickets_phone_search.py
@@ -129,6 +129,7 @@ def test_admin_tickets_page_with_phone_search(monkeypatch, active_session, helpd
         return user.get("id") == helpdesk_user["id"]
     
     monkeypatch.setattr(main_module, "_is_helpdesk_technician", fake_is_helpdesk_technician)
+    monkeypatch.setattr(main_module, "_has_admin_technician_access", fake_is_helpdesk_technician)
     
     # Mock ticket search by phone using the shared sample ticket
     sample_tickets = [sample_ticket]
@@ -204,6 +205,7 @@ def test_admin_tickets_page_with_empty_phone_search(monkeypatch, active_session,
         return user.get("id") == helpdesk_user["id"]
     
     monkeypatch.setattr(main_module, "_is_helpdesk_technician", fake_is_helpdesk_technician)
+    monkeypatch.setattr(main_module, "_has_admin_technician_access", fake_is_helpdesk_technician)
     
     # Mock ticket search by phone - returns empty list
     async def fake_list_tickets_by_phone(phone_number: str, limit: int = 100):
@@ -275,6 +277,7 @@ def test_admin_tickets_page_without_phone_search(monkeypatch, active_session, he
         return user.get("id") == helpdesk_user["id"]
     
     monkeypatch.setattr(main_module, "_is_helpdesk_technician", fake_is_helpdesk_technician)
+    monkeypatch.setattr(main_module, "_has_admin_technician_access", fake_is_helpdesk_technician)
     
     # Mock dashboard service using the shared sample ticket
     from app.services import tickets as tickets_service

--- a/tests/test_sidebar_menu.py
+++ b/tests/test_sidebar_menu.py
@@ -674,3 +674,73 @@ def test_tickets_role_ui_labels_are_no_access_own_all():
     assert "{{ 'Own' if is_ticket_permission else 'Read Only' }}" in template
     assert "{{ 'All' if is_ticket_permission else ('Yes' if is_boolean_permission else 'Read/Write') }}" in template
     assert "All opens <code>/tickets</code> for company tickets" in template
+
+
+@pytest.mark.anyio
+async def test_admin_ticket_access_requires_technician_admin_permission(monkeypatch):
+    async def fake_user_has_permission(user_id: int, permission: str) -> bool:
+        return permission == "helpdesk.technician"
+
+    monkeypatch.setattr(
+        main_module.membership_repo,
+        "user_has_permission",
+        fake_user_has_permission,
+    )
+
+    user = {"id": 42, "is_super_admin": False}
+
+    assert await main_module._is_helpdesk_technician(user) is True
+    assert await main_module._has_admin_technician_access(user) is False
+
+
+def test_all_tickets_without_technician_admin_permission_links_to_portal_tickets():
+    from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+    env = Environment(
+        loader=FileSystemLoader("app/templates"),
+        autoescape=select_autoescape(["html"]),
+    )
+    env.globals["static_url"] = lambda path: path
+    template = env.get_template("base.html")
+    html = template.render(
+        request=type("Request", (), {"url": type("Url", (), {"path": "/tickets"})()})(),
+        current_user={"id": 2, "is_super_admin": False},
+        active_membership={},
+        menu_access={
+            "menu.dashboard": "read",
+            "menu.tickets": "write",
+        },
+        is_helpdesk_technician=True,
+        has_admin_technician_access=False,
+        available_companies=[],
+        cart_summary={"item_count": 0, "total_quantity": 0, "subtotal": 0},
+        notification_unread_count=0,
+        plausible_config={"enabled": False},
+        csrf_token="csrf-token",
+    )
+
+    assert 'href="/tickets"' in html
+    assert 'href="/admin/tickets"' not in html
+
+
+@pytest.mark.anyio
+async def test_require_helpdesk_page_denies_all_tickets_without_admin_technician(monkeypatch):
+    from fastapi import HTTPException
+    from starlette.requests import Request
+
+    async def fake_require_authenticated_user(request):
+        return {"id": 42, "is_super_admin": False}, None
+
+    async def fake_has_admin_technician_access(user, request=None):
+        return False
+
+    monkeypatch.setattr(main_module, "_require_authenticated_user", fake_require_authenticated_user)
+    monkeypatch.setattr(main_module, "_has_admin_technician_access", fake_has_admin_technician_access)
+
+    request = Request({"type": "http", "method": "GET", "path": "/admin/tickets", "headers": []})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await main_module._require_helpdesk_page(request)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Access denied"


### PR DESCRIPTION
### Motivation
- Prevent non-technician users (who only have `menu.tickets` All access) from seeing the technician admin workspace at `/admin/tickets` and ensure they stay on the portal `/tickets` view.
- Preserve legacy helpdesk/technician role checks used for routing while introducing a stricter gate for the admin ticket workspace to follow least-privilege principles.

### Description
- Added a new helper `_has_admin_technician_access` in `app/main.py` that checks explicit admin-technician switch access (`company.switch_all` / `menu.admin.technician`) and caches the result on the request state.
- Replaced the previous `_is_helpdesk_technician` gate for the admin tickets page with `_has_admin_technician_access` and updated the error detail to "Access denied".
- Exposed `has_admin_technician_access` in the base template context and updated `app/templates/base.html` so the sidebar Tickets link resolves to `/tickets` for users without the admin-technician permission and to `/admin/tickets` only for super admins or users with the admin-technician switch.
- Updated tests to cover the new permission distinction and adjusted `tests/test_admin_tickets_phone_search.py` and `tests/test_sidebar_menu.py` to mock the new helper and assert access/links behave correctly.

### Testing
- Ran `pytest tests/test_sidebar_menu.py tests/test_menu_permissions.py` and they passed after the change (`tests related to sidebar and menu permissions` passed).
- Ran `pytest tests/test_admin_tickets_phone_search.py`, observed initial failures until the tests were updated to mock the new `_has_admin_technician_access`, and then re-ran the tests successfully.
- Final targeted test run of the modified areas (`tests/test_sidebar_menu.py tests/test_menu_permissions.py tests/test_admin_tickets_phone_search.py`) completed with all tests passing (25 passed, warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b4a4c8490832db8f7ec6f89c5ae74)