### PR TITLE
Fix portal tickets 'Own' scope by requiring admin-technician for platform access

### DIFF
--- a/app/features/tickets/portal_routes.py
+++ b/app/features/tickets/portal_routes.py
@@ -241,10 +241,37 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
             status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found"
         )
 
-    has_helpdesk_access = await main_module._is_helpdesk_technician(user, request)
+    has_helpdesk_access = await main_module._has_admin_technician_access(user, request)
     is_super_admin = bool(user.get("is_super_admin"))
     is_requester = ticket.get("requester_id") == user_id
+
+    has_company_ticket_access = False
     if not (has_helpdesk_access or is_super_admin or is_requester):
+        has_all_ticket_access = await main_module._has_menu_page_access(
+            request, user, "menu.tickets", write=True
+        )
+        if has_all_ticket_access:
+            available_companies = await main_module.company_access.list_accessible_companies(user)
+            active_company_id = getattr(request.state, "active_company_id", None)
+            allowed_company_ids: set[int] = set()
+            if active_company_id is not None:
+                try:
+                    allowed_company_ids.add(int(active_company_id))
+                except (TypeError, ValueError):
+                    pass
+            if not allowed_company_ids:
+                for entry in available_companies:
+                    try:
+                        allowed_company_ids.add(int(entry.get("company_id")))
+                    except (AttributeError, TypeError, ValueError):
+                        continue
+            try:
+                ticket_company_id = int(ticket.get("company_id"))
+            except (TypeError, ValueError):
+                ticket_company_id = 0
+            has_company_ticket_access = ticket_company_id in allowed_company_ids
+
+    if not (has_helpdesk_access or is_super_admin or is_requester or has_company_ticket_access):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found"
         )

--- a/app/main.py
+++ b/app/main.py
@@ -7080,7 +7080,7 @@ async def _render_portal_tickets_page(
     effective_search = search_value or None
 
     has_all_ticket_access = await _has_menu_page_access(request, user, "menu.tickets", write=True)
-    has_platform_ticket_access = await _is_helpdesk_technician(user, request)
+    has_platform_ticket_access = await _has_admin_technician_access(user, request)
 
     try:
         if has_platform_ticket_access:
@@ -7274,7 +7274,7 @@ async def _render_portal_ticket_detail(
     if not ticket:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
 
-    has_helpdesk_access = await _is_helpdesk_technician(user, request)
+    has_helpdesk_access = await _has_admin_technician_access(user, request)
     is_super_admin = bool(user.get("is_super_admin"))
 
     user_id = user.get("id")

--- a/tests/test_ticket_portal_pages.py
+++ b/tests/test_ticket_portal_pages.py
@@ -137,6 +137,62 @@ async def test_render_portal_tickets_page_formats_results(monkeypatch):
 
 
 @pytest.mark.anyio("asyncio")
+async def test_render_portal_tickets_page_own_scope_ignores_legacy_helpdesk_mapping(monkeypatch):
+    request = _make_request()
+    request.state.active_company_id = 22
+    request.state.active_membership = {"menu_permissions": {"menu.tickets": "read"}}
+    user = {"id": 5, "company_id": 22, "is_super_admin": False}
+
+    statuses = [TicketStatusDefinition(tech_status="open", tech_label="Open", public_status="Open")]
+    listed_tickets = [
+        {
+            "id": 41,
+            "subject": "Own ticket",
+            "status": "open",
+            "priority": "normal",
+            "company_id": 22,
+            "updated_at": datetime(2025, 1, 10, 9, 30, tzinfo=timezone.utc),
+            "created_at": datetime(2025, 1, 9, 16, 45, tzinfo=timezone.utc),
+        }
+    ]
+
+    monkeypatch.setattr(
+        main.company_access,
+        "list_accessible_companies",
+        AsyncMock(return_value=[{"company_id": 22, "company_name": "Example"}]),
+    )
+    monkeypatch.setattr(main, "_is_helpdesk_technician", AsyncMock(return_value=True))
+    monkeypatch.setattr(main, "_has_admin_technician_access", AsyncMock(return_value=False))
+    company_list_mock = AsyncMock(return_value=[])
+    company_count_mock = AsyncMock(return_value=0)
+    user_list_mock = AsyncMock(return_value=listed_tickets)
+    user_count_mock = AsyncMock(return_value=1)
+    monkeypatch.setattr(main.tickets_repo, "list_tickets_in_companies", company_list_mock)
+    monkeypatch.setattr(main.tickets_repo, "count_tickets_in_companies", company_count_mock)
+    monkeypatch.setattr(main.tickets_repo, "list_tickets_for_user", user_list_mock)
+    monkeypatch.setattr(main.tickets_repo, "count_tickets_for_user", user_count_mock)
+    monkeypatch.setattr(main.tickets_service, "list_status_definitions", AsyncMock(return_value=statuses))
+
+    captured: dict[str, Any] = {}
+
+    async def fake_render_template(template_name, request_obj, user_obj, *, extra):
+        captured["extra"] = extra
+        return HTMLResponse("OK")
+
+    monkeypatch.setattr(main, "_render_template", fake_render_template)
+
+    await main._render_portal_tickets_page(request, user)
+
+    user_list_mock.assert_awaited_once()
+    user_count_mock.assert_awaited_once()
+    company_list_mock.assert_not_awaited()
+    company_count_mock.assert_not_awaited()
+    assert user_list_mock.await_args.args == (5,)
+    assert user_list_mock.await_args.kwargs["company_ids"] == [22]
+    assert captured["extra"]["tickets"][0]["subject"] == "Own ticket"
+
+
+@pytest.mark.anyio("asyncio")
 async def test_render_portal_tickets_page_company_all_scope_includes_requestor(monkeypatch):
     request = _make_request()
     request.state.active_company_id = 22
@@ -530,7 +586,8 @@ async def test_render_portal_ticket_detail_denies_unrelated_user(monkeypatch):
     monkeypatch.setattr(main.tickets_repo, "get_ticket", AsyncMock(return_value=ticket))
     monkeypatch.setattr(main.tickets_repo, "list_replies", list_replies_mock)
     monkeypatch.setattr(main.tickets_repo, "is_ticket_watcher", AsyncMock(return_value=False))
-    monkeypatch.setattr(main, "_is_helpdesk_technician", AsyncMock(return_value=False))
+    monkeypatch.setattr(main, "_is_helpdesk_technician", AsyncMock(return_value=True))
+    monkeypatch.setattr(main, "_has_admin_technician_access", AsyncMock(return_value=False))
 
     with pytest.raises(main.HTTPException) as exc_info:
         await main._render_portal_ticket_detail(request, user, ticket_id=41)


### PR DESCRIPTION
### Motivation
- Prevent users with `menu.tickets = Own` from being treated as full helpdesk technicians via legacy permission mappings so they only see their own tickets in the portal.
- Keep `menu.tickets = All` behaviour to allow company-scoped ticket access while ensuring internal/helpdesk-level views and replies remain restricted to explicit admin/technician roles.

### Description
- Replace uses of the broad helpdesk mapping with explicit admin-technician checks by switching `_is_helpdesk_technician` to `_has_admin_technician_access` in portal listing and portal ticket detail rendering (`app/main.py`).
- Tighten reply authorization in the portal reply route (`app/features/tickets/portal_routes.py`) to allow replies for super-admins, helpdesk-admins, requesters, watchers, or tickets within the user’s accessible companies; otherwise deny access.
- Add company-scoping logic when `menu.tickets` grants `write` so company-`All` users can access tickets only for companies they can access.
- Add regression test `test_render_portal_tickets_page_own_scope_ignores_legacy_helpdesk_mapping` and adjust `test_render_portal_ticket_detail_denies_unrelated_user` to validate the new behaviour (`tests/test_ticket_portal_pages.py`).

### Testing
- Ran `pytest -q tests/test_ticket_portal_pages.py tests/test_sidebar_menu.py::test_admin_ticket_access_requires_technician_admin_permission` and the targeted test suite passed (`11 passed`, warnings reported).
- Ran the portal-specific tests including the new regression (`tests/test_ticket_portal_pages.py`) and the related assertions passed (new tests exercise Own vs All scoping and unrelated-ticket denial).
- Ran `git diff --check` to ensure no whitespace/formatting issues and no problems were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b4f326cec832da7316fde952b147b)