### PR TITLE
Allow selecting ticket requesters from enabled staff (including unregistered staff)

### DIFF
--- a/app/api/routes/companies.py
+++ b/app/api/routes/companies.py
@@ -18,7 +18,7 @@ from app.schemas.company_recurring_invoice_items import (
     RecurringInvoiceItemResponse,
     RecurringInvoiceItemUpdate,
 )
-from app.schemas.users import UserResponse
+from app.schemas.users import StaffRequesterOption, UserResponse
 from app.services import audit as audit_service
 from app.services import company_id_lookup
 
@@ -198,7 +198,7 @@ async def unarchive_company(
     return updated
 
 
-@router.get("/{company_id}/staff-users", response_model=list[UserResponse])
+@router.get("/{company_id}/staff-users", response_model=list[StaffRequesterOption])
 async def list_company_staff_users(
     company_id: int,
     _: None = Depends(require_database),
@@ -213,7 +213,7 @@ async def list_company_staff_users(
     if not company:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
     users = await staff_repo.list_enabled_staff_users(company_id)
-    return [UserResponse.model_validate(user) for user in users]
+    return [StaffRequesterOption.model_validate(user) for user in users]
 
 
 

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -51,6 +51,24 @@ def _main():
     return main_module
 
 
+
+
+def _parse_requester_value(raw: Any) -> tuple[str | None, int | None]:
+    value = str(raw or "").strip()
+    if not value:
+        return None, None
+    if ":" in value:
+        prefix, identifier = value.split(":", 1)
+        prefix = prefix.strip().lower()
+    else:
+        prefix, identifier = "user", value
+    if prefix not in {"user", "staff"}:
+        raise ValueError("Unsupported requester selector value.")
+    numeric_id = int(identifier)
+    if numeric_id <= 0:
+        raise ValueError("Requester ID must be positive.")
+    return prefix, numeric_id
+
 def _safe_local_redirect_target(raw: str | None, *, fallback: str) -> str:
     candidate = (raw or "").strip()
     if not candidate:
@@ -118,28 +136,54 @@ async def admin_create_ticket(request: Request):
         assigned_user_id = int(assigned_raw) if assigned_raw else None
     except (TypeError, ValueError):
         assigned_user_id = None
-    try:
-        requester_id = int(requester_raw) if requester_raw else current_user.get("id")
-    except (TypeError, ValueError):
-        requester_id = current_user.get("id")
-
-    if requester_id and company_id and requester_id != current_user.get("id"):
+    requester_id: int | None = None
+    requester_staff_id: int | None = None
+    if requester_raw:
         try:
-            staff_member = await staff_repo.get_staff_by_id(requester_id)
-            if not staff_member or staff_member.get("company_id") != company_id:
-                return await main_module._render_tickets_dashboard(
-                    request,
-                    current_user,
-                    error_message="The selected requester does not belong to the selected company.",
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                )
-        except Exception:
+            requester_kind, requester_identifier = _parse_requester_value(requester_raw)
+        except (TypeError, ValueError):
             return await main_module._render_tickets_dashboard(
                 request,
                 current_user,
                 error_message="Invalid requester selection.",
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
+        if requester_kind == "staff":
+            requester_staff_id = requester_identifier
+        elif requester_kind == "user":
+            requester_id = requester_identifier
+    else:
+        requester_id = current_user.get("id")
+
+    if requester_staff_id and company_id is None:
+        return await main_module._render_tickets_dashboard(
+            request,
+            current_user,
+            error_message="Link the ticket to a company before selecting a requester.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if requester_staff_id and company_id:
+        staff_member = await staff_repo.get_enabled_staff_requester(company_id, requester_staff_id)
+        if not staff_member:
+            return await main_module._render_tickets_dashboard(
+                request,
+                current_user,
+                error_message="The selected requester is not an enabled staff member for the selected company.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        requester_id = staff_member.get("user_id")
+    elif requester_id and company_id and requester_id != current_user.get("id"):
+        allowed_requesters = await staff_repo.list_enabled_staff_users(company_id)
+        matched = next((option for option in allowed_requesters if option.get("user_id") == requester_id), None)
+        if not matched:
+            return await main_module._render_tickets_dashboard(
+                request,
+                current_user,
+                error_message="The selected requester is not an enabled staff member for the selected company.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        requester_staff_id = matched.get("staff_id")
 
     if not subject:
         return await main_module._render_tickets_dashboard(
@@ -157,6 +201,7 @@ async def admin_create_ticket(request: Request):
             subject=subject,
             description=description,
             requester_id=requester_id,
+            requester_staff_id=requester_staff_id,
             company_id=company_id,
             assigned_user_id=assigned_user_id,
             priority=priority,
@@ -537,9 +582,12 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
         )
 
     requester_id: int | None = None
+    requester_staff_id: int | None = None
+    requester_kind: str | None = None
+    requester_identifier: int | None = None
     if requester_raw:
         try:
-            requester_id = int(requester_raw)
+            requester_kind, requester_identifier = _parse_requester_value(requester_raw)
         except (TypeError, ValueError):
             return await main_module._render_ticket_detail(
                 request,
@@ -548,15 +596,19 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
                 error_message="Select a valid requester.",
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
-        requester = await user_repo.get_user_by_id(requester_id)
-        if not requester:
-            return await main_module._render_ticket_detail(
-                request,
-                current_user,
-                ticket_id=ticket_id,
-                error_message="Select a valid requester.",
-                status_code=status.HTTP_400_BAD_REQUEST,
-            )
+        if requester_kind == "user":
+            requester_id = requester_identifier
+            requester = await user_repo.get_user_by_id(requester_id)
+            if not requester:
+                return await main_module._render_ticket_detail(
+                    request,
+                    current_user,
+                    ticket_id=ticket_id,
+                    error_message="Select a valid requester.",
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                )
+        elif requester_kind == "staff":
+            requester_staff_id = requester_identifier
 
     assigned_user_id: int | None = None
     if assigned_raw:
@@ -609,7 +661,7 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
     if company_raw is None:
         final_company_id = existing_company_id
 
-    if requester_id is not None:
+    if requester_id is not None or requester_staff_id is not None:
         if final_company_id is None:
             return await main_module._render_ticket_detail(
                 request,
@@ -619,12 +671,12 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
         allowed_requesters = await staff_repo.list_enabled_staff_users(final_company_id)
-        allowed_ids = {
-            int(option.get("id"))
-            for option in allowed_requesters
-            if option.get("id") is not None
-        }
-        if requester_id not in allowed_ids:
+        matched: dict[str, Any] | None = None
+        if requester_kind == "staff":
+            matched = next((option for option in allowed_requesters if option.get("staff_id") == requester_staff_id), None)
+        else:
+            matched = next((option for option in allowed_requesters if option.get("user_id") == requester_id), None)
+        if not matched:
             return await main_module._render_ticket_detail(
                 request,
                 current_user,
@@ -632,10 +684,13 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
                 error_message="Select a requester from the linked company's enabled staff list.",
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
+        requester_id = matched.get("user_id")
+        requester_staff_id = matched.get("staff_id")
 
     update_fields: dict[str, Any] = {
         "priority": priority_value,
         "requester_id": requester_id,
+        "requester_staff_id": requester_staff_id,
         "assigned_user_id": assigned_user_id,
         "company_id": company_id,
         "category": category_value,

--- a/app/main.py
+++ b/app/main.py
@@ -7424,6 +7424,13 @@ async def _render_portal_ticket_detail(
         return email or "System"
 
     requester_record = user_lookup.get(ticket.get("requester_id"))
+    requester_staff_record = None
+    requester_staff_id = ticket.get("requester_staff_id")
+    if requester_staff_id is not None:
+        try:
+            requester_staff_record = await staff_repo.get_staff_by_id(int(requester_staff_id))
+        except (TypeError, ValueError):
+            requester_staff_record = None
     assigned_record = user_lookup.get(ticket.get("assigned_user_id"))
 
     timeline_entries: list[dict[str, Any]] = []
@@ -7629,7 +7636,11 @@ async def _render_portal_ticket_detail(
             "company": company_record,
             "company_name": company_name,
             "requester": requester_record,
-            "requester_label": _format_user_label(requester_record) if requester_record else None,
+            "requester_label": (
+                _format_user_label(requester_staff_record)
+                if requester_staff_record
+                else (_format_user_label(requester_record) if requester_record else None)
+            ),
             "assigned_user": assigned_record,
             "assigned_label": _format_user_label(assigned_record) if assigned_record else None,
             "created_iso": created_iso,

--- a/app/repositories/staff.py
+++ b/app/repositories/staff.py
@@ -230,20 +230,65 @@ async def list_staff(
 
 
 async def list_enabled_staff_users(company_id: int) -> List[dict[str, Any]]:
+    """Return enabled staff requester options for a company.
+
+    The ticket requester selector is staff-driven, not portal-user-driven.
+    Registered MyPortal users are still linked when their email matches the
+    staff record so existing requester permissions and notifications continue
+    to work, while unregistered staff can be selected by their staff ID.
+    """
     rows = await db.fetch_all(
         """
-        SELECT DISTINCT u.*
+        SELECT
+            s.id AS staff_id,
+            u.id AS user_id,
+            COALESCE(NULLIF(u.email, ''), s.email) AS email,
+            COALESCE(NULLIF(u.first_name, ''), s.first_name) AS first_name,
+            COALESCE(NULLIF(u.last_name, ''), s.last_name) AS last_name,
+            s.company_id AS company_id,
+            u.created_at AS created_at,
+            u.updated_at AS updated_at,
+            COALESCE(u.is_super_admin, 0) AS is_super_admin
         FROM staff AS s
-        INNER JOIN users AS u
+        LEFT JOIN users AS u
             ON LOWER(u.email) = LOWER(s.email)
+           AND u.company_id = s.company_id
         WHERE s.company_id = %s
           AND s.enabled = 1
-          AND u.company_id = s.company_id
-        ORDER BY LOWER(u.email), u.id
+        ORDER BY LOWER(COALESCE(NULLIF(u.email, ''), s.email)), s.id
         """,
         (company_id,),
     )
-    return [dict(row) for row in rows]
+    results: list[dict[str, Any]] = []
+    for row in rows:
+        record = dict(row)
+        staff_id = record.get("staff_id")
+        user_id = record.get("user_id")
+        try:
+            staff_id_int = int(staff_id) if staff_id is not None else None
+        except (TypeError, ValueError):
+            staff_id_int = None
+        try:
+            user_id_int = int(user_id) if user_id is not None else None
+        except (TypeError, ValueError):
+            user_id_int = None
+        record["staff_id"] = staff_id_int
+        record["user_id"] = user_id_int
+        record["id"] = user_id_int if user_id_int is not None else staff_id_int
+        record["requester_value"] = (
+            f"user:{user_id_int}" if user_id_int is not None else f"staff:{staff_id_int}"
+        )
+        record["is_registered_user"] = user_id_int is not None
+        results.append(record)
+    return results
+
+
+async def get_enabled_staff_requester(company_id: int, staff_id: int) -> dict[str, Any] | None:
+    options = await list_enabled_staff_users(company_id)
+    for option in options:
+        if option.get("staff_id") == staff_id:
+            return option
+    return None
 
 
 async def list_staff_with_users(company_id: int) -> list[dict[str, Any]]:

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -174,7 +174,7 @@ def _make_aware(value: Any) -> datetime | None:
 
 def _normalise_ticket(row: dict[str, Any]) -> TicketRecord:
     record = dict(row)
-    for key in ("id", "company_id", "requester_id", "assigned_user_id", "merged_into_ticket_id", "split_from_ticket_id"):
+    for key in ("id", "company_id", "requester_id", "requester_staff_id", "assigned_user_id", "merged_into_ticket_id", "split_from_ticket_id"):
         if key in record and record[key] is not None:
             record[key] = int(record[key])
     for key in ("created_at", "updated_at", "closed_at", "ai_summary_updated_at"):
@@ -221,6 +221,7 @@ async def create_ticket(
     description: str | None,
     requester_id: int | None,
     company_id: int | None,
+    requester_staff_id: int | None = None,
     assigned_user_id: int | None,
     priority: str,
     status: str,
@@ -235,6 +236,7 @@ async def create_ticket(
         subject=subject,
         company_id=company_id,
         requester_id=requester_id,
+        requester_staff_id=requester_staff_id,
         assigned_user_id=assigned_user_id,
         status=status,
         priority=priority,
@@ -246,13 +248,14 @@ async def create_ticket(
         ticket_id = await db.execute_returning_lastrowid(
             """
             INSERT INTO tickets
-                (id, company_id, requester_id, assigned_user_id, subject, description, status, priority, category, module_slug, external_reference, ticket_number)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                (id, company_id, requester_id, requester_staff_id, assigned_user_id, subject, description, status, priority, category, module_slug, external_reference, ticket_number)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 id,
                 company_id,
                 requester_id,
+                requester_staff_id,
                 assigned_user_id,
                 subject,
                 description,
@@ -282,12 +285,13 @@ async def create_ticket(
         ticket_id = await db.execute_returning_lastrowid(
             """
             INSERT INTO tickets
-                (company_id, requester_id, assigned_user_id, subject, description, status, priority, category, module_slug, external_reference, ticket_number)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                (company_id, requester_id, requester_staff_id, assigned_user_id, subject, description, status, priority, category, module_slug, external_reference, ticket_number)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 company_id,
                 requester_id,
+                requester_staff_id,
                 assigned_user_id,
                 subject,
                 description,
@@ -308,6 +312,7 @@ async def create_ticket(
         "id": ticket_id,
         "company_id": company_id,
         "requester_id": requester_id,
+        "requester_staff_id": requester_staff_id,
         "assigned_user_id": assigned_user_id,
         "subject": subject,
         "description": description,
@@ -591,11 +596,12 @@ async def list_tickets_in_companies(
     query = f"""
         SELECT
             t.*,
-            requester.first_name AS requester_first_name,
-            requester.last_name AS requester_last_name,
-            requester.email AS requester_email
+            COALESCE(requester.first_name, staff_requester.first_name) AS requester_first_name,
+            COALESCE(requester.last_name, staff_requester.last_name) AS requester_last_name,
+            COALESCE(requester.email, staff_requester.email) AS requester_email
         FROM tickets AS t
         LEFT JOIN users AS requester ON requester.id = t.requester_id
+        LEFT JOIN staff AS staff_requester ON staff_requester.id = t.requester_staff_id
         WHERE {' AND '.join(where_clauses)}
         ORDER BY t.updated_at DESC, t.id DESC
         LIMIT %s OFFSET %s

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -41,3 +41,17 @@ class UserResponse(UserBase):
 
     class Config:
         from_attributes = True
+
+
+class StaffRequesterOption(UserBase):
+    id: int
+    staff_id: int
+    user_id: Optional[int] = None
+    requester_value: str
+    is_registered_user: bool = False
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    is_super_admin: bool = False
+
+    class Config:
+        from_attributes = True

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -17,6 +17,7 @@ from app.repositories import tickets as tickets_repo
 from app.repositories import companies as company_repo
 from app.repositories import company_memberships as membership_repo
 from app.repositories import ticket_statuses as ticket_status_repo
+from app.repositories import staff as staff_repo
 from app.repositories.tickets import TicketRecord
 from app.services import automations as automations_service
 from app.repositories import users as user_repo
@@ -456,9 +457,26 @@ async def _enrich_ticket_context(ticket: Mapping[str, Any]) -> TicketRecord:
         enriched["requester_email"] = requester_snapshot.get("email")
         enriched["requester_display_name"] = requester_snapshot.get("display_name")
     else:
-        enriched.setdefault("requester", None)
-        enriched["requester_email"] = None
-        enriched["requester_display_name"] = None
+        staff_snapshot = None
+        requester_staff_id = enriched.get("requester_staff_id")
+        try:
+            staff_record = (
+                await staff_repo.get_staff_by_id(int(requester_staff_id))
+                if requester_staff_id is not None
+                else None
+            )
+        except (TypeError, ValueError):
+            staff_record = None
+        if isinstance(staff_record, Mapping):
+            staff_snapshot = _build_user_snapshot(staff_record)
+        if staff_snapshot:
+            enriched["requester"] = staff_snapshot
+            enriched["requester_email"] = staff_snapshot.get("email")
+            enriched["requester_display_name"] = staff_snapshot.get("display_name")
+        else:
+            enriched.setdefault("requester", None)
+            enriched["requester_email"] = None
+            enriched["requester_display_name"] = None
 
     ticket_id = enriched.get("id")
     watchers: list[Mapping[str, Any]] = []
@@ -1166,6 +1184,7 @@ async def create_ticket(
     description: str | None,
     requester_id: int | None,
     company_id: int | None,
+    requester_staff_id: int | None = None,
     assigned_user_id: int | None,
     priority: str,
     status: str,
@@ -1193,6 +1212,7 @@ async def create_ticket(
         subject=subject,
         description=truncated_description,
         requester_id=requester_id,
+        requester_staff_id=requester_staff_id,
         company_id=company_id,
         assigned_user_id=assigned_user_id,
         priority=priority,
@@ -1762,6 +1782,45 @@ async def load_dashboard_state(
         status_counts[slug] += 1
 
     available_statuses = sorted({*definition_slugs, *status_counts.keys()})
+
+    requester_staff_ids: set[int] = set()
+    for ticket in tickets:
+        identifier = ticket.get("requester_staff_id")
+        try:
+            if identifier is not None:
+                requester_staff_ids.add(int(identifier))
+        except (TypeError, ValueError):
+            continue
+    staff_lookup: dict[int, dict[str, Any]] = {}
+    if requester_staff_ids:
+        staff_results = await asyncio.gather(
+            *(staff_repo.get_staff_by_id(staff_id) for staff_id in requester_staff_ids),
+            return_exceptions=True,
+        )
+        for record in staff_results:
+            if not isinstance(record, Mapping) or record.get("id") is None:
+                continue
+            try:
+                staff_lookup[int(record["id"])] = dict(record)
+            except (TypeError, ValueError):
+                continue
+    for ticket in tickets:
+        requester_staff_id = ticket.get("requester_staff_id")
+        try:
+            staff_record = staff_lookup.get(int(requester_staff_id)) if requester_staff_id is not None else None
+        except (TypeError, ValueError):
+            staff_record = None
+        if staff_record:
+            name = " ".join(
+                part
+                for part in (
+                    str(staff_record.get("first_name") or "").strip(),
+                    str(staff_record.get("last_name") or "").strip(),
+                )
+                if part
+            )
+            ticket["requester_label"] = name or str(staff_record.get("email") or "").strip() or None
+            ticket["requester_email"] = str(staff_record.get("email") or "").strip() or None
 
     modules: list[Mapping[str, Any]] = []
     companies: list[Mapping[str, Any]] = []

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -3105,8 +3105,9 @@
 
         users.forEach((user) => {
           const option = document.createElement('option');
-          option.value = user.id;
-          option.textContent = `${user.first_name} ${user.last_name} (${user.email})`;
+          option.value = user.requester_value || (user.user_id ? `user:${user.user_id}` : `staff:${user.staff_id || user.id}`);
+          const fullName = `${user.first_name || ''} ${user.last_name || ''}`.trim();
+          option.textContent = fullName ? `${fullName} (${user.email})` : user.email;
           requesterSelect.appendChild(option);
         });
       } catch (error) {

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -818,8 +818,9 @@
             return;
           }
           const option = document.createElement('option');
-          option.value = String(user.id);
-          option.textContent = user.email;
+          option.value = user.requester_value || (user.user_id ? `user:${user.user_id}` : `staff:${user.staff_id || user.id}`);
+          const fullName = `${user.first_name || ''} ${user.last_name || ''}`.trim();
+          option.textContent = fullName ? `${fullName} (${user.email})` : user.email;
           requesterSelect.appendChild(option);
         });
         requesterSelect.disabled = false;

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -146,8 +146,9 @@
                 >
                   <option value="">Not set</option>
                   {% for requester in ticket_requester_options %}
-                    <option value="{{ requester.id }}" {% if requester.id == ticket.requester_id %}selected{% endif %}>
-                      {{ requester.email }}
+                    {% set requester_value = requester.requester_value or ('user:' ~ requester.id) %}
+                    <option value="{{ requester_value }}" {% if requester.staff_id == ticket.requester_staff_id or (requester.user_id and requester.user_id == ticket.requester_id) %}selected{% endif %}>
+                      {{ ([requester.first_name, requester.last_name] | select | join(' ')) | trim or requester.email }}{% if requester.email %} ({{ requester.email }}){% endif %}
                     </option>
                   {% endfor %}
                 </select>

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -464,7 +464,7 @@
                     <td data-label="Category" data-column="category" class="tickets-table__cell tickets-table__cell--category">{{ ticket.category or '—' }}</td>
                     {% set requester = user_lookup.get(ticket.requester_id) %}
                     {% set requester_name = ([requester.first_name, requester.last_name] | select | join(' ')) | trim if requester else '' %}
-                    {% set requester_label = requester_name or (requester.email if requester else '—') %}
+                    {% set requester_label = ticket.requester_label or requester_name or (requester.email if requester else '—') %}
                     <td data-label="Requester" data-column="requester" class="tickets-table__cell tickets-table__cell--requester">{{ requester_label }}</td>
                     <td data-label="Module" data-column="module" class="tickets-table__cell tickets-table__cell--module">{{ ticket.module_slug or '—' }}</td>
                     <td data-label="External Ref" data-column="external-ref" class="tickets-table__cell tickets-table__cell--external-ref">{{ ticket.external_reference or '—' }}</td>

--- a/migrations/266_ticket_requester_staff.sql
+++ b/migrations/266_ticket_requester_staff.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tickets
+  ADD COLUMN IF NOT EXISTS requester_staff_id INT NULL AFTER requester_id;
+
+CREATE INDEX IF NOT EXISTS idx_tickets_requester_staff_id
+  ON tickets (requester_staff_id);

--- a/tests/test_staff_repository.py
+++ b/tests/test_staff_repository.py
@@ -30,8 +30,8 @@ def anyio_backend():
 @pytest.mark.anyio
 async def test_list_enabled_staff_users_returns_rows(monkeypatch):
     dummy_rows = [
-        {"id": 11, "email": "bravo@example.com"},
-        {"id": 5, "email": "alpha@example.com"},
+        {"staff_id": 11, "user_id": 101, "email": "bravo@example.com"},
+        {"staff_id": 5, "user_id": None, "email": "alpha@example.com"},
     ]
     dummy_db = _DummyStaffDB(dummy_rows)
     monkeypatch.setattr(staff, "db", dummy_db)
@@ -40,7 +40,12 @@ async def test_list_enabled_staff_users_returns_rows(monkeypatch):
 
     assert dummy_db.last_params == (3,)
     assert "FROM staff AS s" in (dummy_db.last_sql or "")
-    assert result == dummy_rows
+    assert result[0]["id"] == 101
+    assert result[0]["requester_value"] == "user:101"
+    assert result[0]["is_registered_user"] is True
+    assert result[1]["id"] == 5
+    assert result[1]["requester_value"] == "staff:5"
+    assert result[1]["is_registered_user"] is False
     assert result is not dummy_rows
 
 

--- a/tests/test_ticket_requester_api.py
+++ b/tests/test_ticket_requester_api.py
@@ -11,8 +11,8 @@ def anyio_backend() -> str:
 
 
 @pytest.mark.anyio
-async def test_list_company_staff_users_returns_user_ids(monkeypatch):
-    """Verify that the staff-users endpoint returns user records with user IDs."""
+async def test_list_company_staff_users_returns_all_enabled_staff(monkeypatch):
+    """Verify that the staff-users endpoint returns registered and unregistered staff."""
     from app.api.routes import companies
     from app.repositories import companies as company_repo
     from app.repositories import staff as staff_repo
@@ -28,7 +28,11 @@ async def test_list_company_staff_users_returns_user_ids(monkeypatch):
         if company_id == 1:
             return [
                 {
-                    "id": 100,  # This is a USER ID from users table
+                    "id": 100,  # Registered users keep the user ID for compatibility
+                    "staff_id": 10,
+                    "user_id": 100,
+                    "requester_value": "user:100",
+                    "is_registered_user": True,
                     "email": "john@example.com",
                     "first_name": "John",
                     "last_name": "Doe",
@@ -38,7 +42,11 @@ async def test_list_company_staff_users_returns_user_ids(monkeypatch):
                     "is_super_admin": False,
                 },
                 {
-                    "id": 101,  # This is a USER ID from users table
+                    "id": 11,  # Unregistered staff use the staff ID as their option ID
+                    "staff_id": 11,
+                    "user_id": None,
+                    "requester_value": "staff:11",
+                    "is_registered_user": False,
                     "email": "jane@example.com",
                     "first_name": "Jane",
                     "last_name": "Smith",
@@ -60,11 +68,17 @@ async def test_list_company_staff_users_returns_user_ids(monkeypatch):
         __={"id": 1, "is_super_admin": True},  # Mock current user
     )
 
-    # Verify we get UserResponse objects with the correct user IDs
+    # Verify we get requester options for both registered and unregistered staff.
     assert len(result) == 2
     assert result[0].id == 100
+    assert result[0].staff_id == 10
+    assert result[0].user_id == 100
+    assert result[0].requester_value == "user:100"
     assert result[0].email == "john@example.com"
-    assert result[1].id == 101
+    assert result[1].id == 11
+    assert result[1].staff_id == 11
+    assert result[1].user_id is None
+    assert result[1].requester_value == "staff:11"
     assert result[1].email == "jane@example.com"
 
 


### PR DESCRIPTION
### Motivation
- Technicians could only pick requesters that had MyPortal user accounts, which prevented selecting enabled staff who are not registered users.
- The ticket requester selector must be staff-driven so technicians can choose any enabled staff member while preserving links to registered users for notifications and permissions.

### Description
- Replace the user-driven staff query with `list_enabled_staff_users` that returns enabled `staff` rows joined to `users` when present and exposes `staff_id`, `user_id`, `requester_value` and `is_registered_user` for each option (implemented in `app/repositories/staff.py`).
- Add `StaffRequesterOption` schema and switch the `/api/companies/{company_id}/staff-users` endpoint to return the new schema so the frontend receives staff-aware requester options (`app/schemas/users.py`, `app/api/routes/companies.py`).
- Persist staff requesters on tickets with a new `requester_staff_id` column and migration, and update repositories/services to accept and store `requester_staff_id` alongside `requester_id` (`migrations/266_ticket_requester_staff.sql`, `app/repositories/tickets.py`, `app/services/tickets.py`).
- Update admin routes and validation to parse prefixed requester selector values like `user:123` or `staff:45`, to validate staff membership for the linked company, and to store both `requester_id` and `requester_staff_id` (`app/features/tickets/admin_routes.py`).
- Update server-side ticket enrichment and dashboard rendering to display staff names/emails when the requester is an unregistered staff record, and update templates/JS to submit and display prefixed `requester_value` options (`app/main.py`, `app/templates/admin/*.html`, `app/static/js/*.js`).
- Add helper `get_enabled_staff_requester` and adjust tests to cover registered and unregistered staff requester options (`app/repositories/staff.py`, `tests/*`).

### Testing
- Built/checked Python files with `python3 -m compileall` for modified modules and it completed without syntax errors.
- Ran unit tests for the new behavior with `pytest tests/test_staff_repository.py tests/test_ticket_requester_api.py -q` and they passed.
- Ran a broader ticket-related test run (`pytest tests/test_admin_ticket_detail.py tests/test_tickets_service_create.py -q`) which surfaced one pre-existing attachment flash-message assertion (`test_admin_reply_reports_failed_attachments`) that failed and appears unrelated to the requester selection changes; the requester-related tests in that run passed.
- Ensured no `git diff --check` issues and included a migration file to add `requester_staff_id` to `tickets`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b51fb2eb8832da48bde48d8895e0e)