### PR TITLE
Hide Approve/Deny and restrict Danger Zone in staff edit modal

### DIFF
--- a/app/static/js/staff.js
+++ b/app/static/js/staff.js
@@ -816,7 +816,7 @@
       setActionVisibility(editActionButtons.m365ResetPassword, { visible: canM365Actions, disabled: false });
       setActionVisibility(editActionButtons.m365EnableSignIn, { visible: canM365Actions, disabled: false });
       setActionVisibility(editActionButtons.m365DisableSignIn, { visible: canM365Actions, disabled: false });
-      const canSeeDangerZone = Boolean(flags && (flags.isSuperAdmin || flags.isHelpdeskTechnician));
+      const canSeeDangerZone = Boolean(flags && flags.isSuperAdmin);
       if (editDangerZone) {
         editDangerZone.hidden = !canSeeDangerZone;
       }

--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -748,8 +748,8 @@
         <div class="form-actions form-actions--inline staff-actions">
           <button type="button" class="button button--ghost" id="edit-action-invite" data-edit-action="invite">Invite</button>
           <button type="button" class="button button--ghost" id="edit-action-offboarding-request" data-edit-action="offboarding-request">Request Offboarding</button>
-          <button type="button" class="button button--ghost" id="edit-action-approve" data-edit-action="approve">Approve</button>
-          <button type="button" class="button button--ghost" id="edit-action-deny" data-edit-action="deny">Deny</button>
+          <button type="button" class="button button--ghost" id="edit-action-approve" data-edit-action="approve" hidden>Approve</button>
+          <button type="button" class="button button--ghost" id="edit-action-deny" data-edit-action="deny" hidden>Deny</button>
           <button type="button" class="button button--ghost" id="edit-action-workflow-rerun" data-edit-action="workflow-rerun">Workflow rerun</button>
           <button type="button" class="button button--ghost" id="edit-action-workflow-retry" data-edit-action="workflow-retry">Workflow retry</button>
           <button type="button" class="button button--ghost" id="edit-action-workflow-resume" data-edit-action="workflow-resume">Workflow resume</button>
@@ -758,7 +758,7 @@
           <button type="button" class="button button--ghost" id="edit-action-m365-enable-sign-in" data-edit-action="m365-enable-sign-in" hidden>Enable O365 Sign-in</button>
           <button type="button" class="button button--ghost" id="edit-action-m365-disable-sign-in" data-edit-action="m365-disable-sign-in" hidden>Disable O365 Sign-in</button>
         </div>
-        {% if is_super_admin or is_helpdesk_technician %}
+        {% if is_super_admin %}
         <div class="staff-danger-panel" id="edit-danger-zone">
           <h3 class="staff-danger-panel__title">Danger zone</h3>
           <p class="form-help">Delete permanently removes the staff record and cannot be undone.</p>


### PR DESCRIPTION
### Motivation
- Prevent users with `menu.staff` Read/Write (non-technician) from seeing privileged controls in the edit staff modal (Approve, Deny, Danger Zone) unless explicitly allowed by permission checks.
- Ensure server-rendered template and client-side visibility checks are aligned so only super admins (or explicit client-side logic) can see dangerous actions.

### Description
- Hide the modal Approve and Deny buttons by default by adding `hidden` to the elements in `app/templates/staff/index.html` so they only appear when client-side permission logic reveals them.
- Restrict server-side rendering of the Danger Zone to super admins only by changing the template condition from `{% if is_super_admin or is_helpdesk_technician %}` to `{% if is_super_admin %}` in `app/templates/staff/index.html`.
- Update the client-side visibility check in `app/static/js/staff.js` to require `flags.isSuperAdmin` for the danger panel (remove `isHelpdeskTechnician` from the check) and keep existing per-action reveal logic for Approve/Deny.

### Testing
- Ran `pytest tests/test_staff_permissions_ui.py tests/test_staff_workflow_permissions.py` and the suite completed successfully with all tests passing (`8 passed`).
- Existing unit tests covering staff page permissions and workflow context were executed to validate the UI flag exposure and super-admin-only workflow guards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b5947a12c8332ad1e8e5458168566)