### PR TITLE
Fix BCP modal close button duplication

### DIFF
--- a/app/static/css/bcp.css
+++ b/app/static/css/bcp.css
@@ -900,13 +900,28 @@
 .bcp-theme .modal-close,
 .bcp-theme .modal-header button,
 .bcp-theme .close {
+  position: static;
+  inset: auto;
+  width: auto;
+  height: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: none;
   background: none;
+  box-shadow: none;
   color: var(--bcp-text-soft);
   font-size: 1.4rem;
+  line-height: 1;
   cursor: pointer;
   padding: 0.25rem;
   border-radius: 0.5rem;
+}
+
+.bcp-theme .modal-close::before,
+.bcp-theme .modal-header button::before,
+.bcp-theme .close::before {
+  content: none;
 }
 
 .bcp-theme .modal-close:hover,

--- a/app/templates/admin/roles.html
+++ b/app/templates/admin/roles.html
@@ -77,10 +77,12 @@
 
   <div class="modal" id="role-modal" role="dialog" aria-modal="true" aria-labelledby="role-modal-title" aria-describedby="role-modal-subtitle" aria-hidden="true" hidden>
     <div class="modal__content" role="document">
-      <button type="button" class="modal__close" data-modal-close aria-label="Close role form"></button>
       <header class="modal__header">
-        <h2 class="modal__title" id="role-modal-title">Create role</h2>
-        <p class="modal__subtitle" id="role-modal-subtitle">Create a least-privilege permission set for company members.</p>
+        <div>
+          <h2 class="modal__title" id="role-modal-title">Create role</h2>
+          <p class="modal__subtitle" id="role-modal-subtitle">Create a least-privilege permission set for company members.</p>
+        </div>
+        <button type="button" class="modal__close" data-modal-close aria-label="Close role form"></button>
       </header>
     <form id="role-form" class="form" autocomplete="off">
       <input type="hidden" name="role_id" id="role-id" />


### PR DESCRIPTION
### Motivation
- BCP-themed modals were inheriting the global absolute-positioned modal close styles which caused a second, non-clickable close glyph to appear beside the real close button, so the BCP header close controls need their own static layout and the generated glyph suppressed.

### Description
- Override close control styling in `app/static/css/bcp.css` by resetting `.bcp-theme .modal-close, .bcp-theme .modal-header button, .bcp-theme .close` to static/inline-flex layout and disabling the inherited `::before` generated content so only the real clickable close button is rendered.

### Testing
- Ran a small Python verification that checks the CSS override is present (script succeeded). 
- Ran `git diff --check` to ensure no whitespace/errors (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b59e42f148332a7477bf30de72487)