### PR TITLE
Use 'new' ticket status for tickets created from staff edits

### DIFF
--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -246,7 +246,7 @@ async def _create_staff_edit_request_ticket(
         company_id=int(existing.get("company_id") or user.get("company_id") or 0) or None,
         assigned_user_id=None,
         priority="normal",
-        status="open",
+        status="new",
         category="Staff Change Request",
         module_slug="staff",
         external_reference=f"staff-change-request:{existing.get('id')}",

--- a/tests/test_staff_edit_change_request_ticket.py
+++ b/tests/test_staff_edit_change_request_ticket.py
@@ -79,6 +79,7 @@ async def test_staff_rw_edit_creates_ticket_instead_of_updating_staff(monkeypatc
     create_kwargs = create_ticket_mock.await_args.kwargs
     assert create_kwargs["requester_id"] == 7
     assert create_kwargs["company_id"] == 9
+    assert create_kwargs["status"] == "new"
     assert create_kwargs["module_slug"] == "staff"
     assert "Staff member being edited" in create_kwargs["description"]
     assert "Requested by" in create_kwargs["description"]


### PR DESCRIPTION
### Motivation
- Tickets created as a result of editing a staff member should be initial review requests, so they must be created with the "new" status instead of immediately being marked as "open".

### Description
- Change the staff edit flow to create helpdesk tickets with `status="new"` rather than `status="open"` when calling `tickets_service.create_ticket` for staff edit requests.
- Preserves existing subject, description and metadata; only the initial ticket status was adjusted.

### Testing
- No automated tests were executed as part of this change; please run `pytest tests/test_staff_edit_change_request_ticket.py` and `pytest tests/test_ticket_default_status.py` to validate the behavior locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b5aef535c8332b2278b5f49bca15b)