### PR TITLE
Use staff timestamps for enabled staff requester query

### DIFF
--- a/app/repositories/staff.py
+++ b/app/repositories/staff.py
@@ -246,8 +246,8 @@ async def list_enabled_staff_users(company_id: int) -> List[dict[str, Any]]:
             COALESCE(NULLIF(u.first_name, ''), s.first_name) AS first_name,
             COALESCE(NULLIF(u.last_name, ''), s.last_name) AS last_name,
             s.company_id AS company_id,
-            u.created_at AS created_at,
-            u.updated_at AS updated_at,
+            s.created_at AS created_at,
+            s.updated_at AS updated_at,
             COALESCE(u.is_super_admin, 0) AS is_super_admin
         FROM staff AS s
         LEFT JOIN users AS u

--- a/tests/test_staff_repository.py
+++ b/tests/test_staff_repository.py
@@ -40,6 +40,10 @@ async def test_list_enabled_staff_users_returns_rows(monkeypatch):
 
     assert dummy_db.last_params == (3,)
     assert "FROM staff AS s" in (dummy_db.last_sql or "")
+    assert "s.created_at AS created_at" in (dummy_db.last_sql or "")
+    assert "s.updated_at AS updated_at" in (dummy_db.last_sql or "")
+    assert "u.created_at" not in (dummy_db.last_sql or "")
+    assert "u.updated_at" not in (dummy_db.last_sql or "")
     assert result[0]["id"] == 101
     assert result[0]["requester_value"] == "user:101"
     assert result[0]["is_registered_user"] is True


### PR DESCRIPTION
### Motivation
- Prevent SQL errors caused by referencing `users.created_at`/`users.updated_at` in the enabled-staff requester query (observed as `Unknown column 'u.created_at' in 'SELECT'`).

### Description
- Update the requester query in `app/repositories/staff.py` to select `s.created_at` and `s.updated_at` (from the `staff` table) instead of `u.created_at`/`u.updated_at` from the joined `users` table. 
- Add a regression assertion in `tests/test_staff_repository.py` to ensure the generated SQL includes `s.created_at`/`s.updated_at` and does not reference `u.created_at`/`u.updated_at`.

### Testing
- Ran `pytest tests/test_staff_repository.py tests/test_ticket_requester_api.py` and all tests passed. 
- Ran `pytest tests/test_staff_repository.py tests/test_admin_ticket_detail.py tests/test_ticket_requester_api.py`; the run showed a known unrelated failure in `tests/test_admin_ticket_detail.py::test_admin_reply_reports_failed_attachments` while the staff requester tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b609c9c348332a4a0a9b8908bdd5d)