### PR TITLE
Support staff signup verification and invite templates

### DIFF
--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import secrets
 from datetime import datetime, timedelta
 from html import escape
@@ -20,6 +21,7 @@ from app.core.config import get_settings
 from app.core.logging import log_error, log_info
 from app.repositories import auth as auth_repo
 from app.repositories import companies as company_repo
+from app.repositories import staff as staff_repo
 from app.repositories import users as user_repo
 from app.repositories import user_companies as user_company_repo
 from app.schemas.auth import (
@@ -43,6 +45,7 @@ from app.security.passwords import verify_password
 from app.security.session import SessionData, ensure_datetime, session_manager
 from app.services import company_access
 from app.services import impersonation as impersonation_service
+from app.services import message_templates as message_templates_service
 from app.services import email as email_service
 from app.services import staff_access as staff_access_service
 
@@ -51,6 +54,79 @@ router = APIRouter(prefix="/auth", tags=["Authentication"])
 settings = get_settings()
 LOGIN_RATE_LIMIT_WINDOW = 300  # 5 minutes
 LOGIN_RATE_LIMIT_ATTEMPTS = 5
+
+
+
+def _html_to_text(html: str) -> str:
+    text = re.sub(r"<\s*br\s*/?\s*>", "\n", html, flags=re.IGNORECASE)
+    text = re.sub(r"</p\s*>", "\n\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", "", text)
+    return text.replace("&nbsp;", " ").strip()
+
+
+def _template_context(*, user: dict[str, Any], token: str, link: str, company: dict[str, Any] | None = None) -> dict[str, Any]:
+    first_name = user.get("first_name") or ""
+    last_name = user.get("last_name") or ""
+    full_name = " ".join(part for part in (first_name, last_name) if part).strip() or user.get("email") or "there"
+    portal_url = str(settings.portal_url).rstrip("/") if settings.portal_url else ""
+    return {
+        "app": {"name": settings.app_name},
+        "portal": {"url": portal_url, "login_url": f"{portal_url}/login" if portal_url else "/login"},
+        "user": {
+            "email": user.get("email") or "",
+            "first_name": first_name,
+            "last_name": last_name,
+            "name": full_name,
+        },
+        "company": {"name": (company or {}).get("name") or ""},
+        "token": token,
+        "link": link,
+        "verification": {"link": link, "token": token},
+        "invitation": {"link": link, "token": token},
+    }
+
+
+async def _render_email_template(slug: str, context: dict[str, Any], default_html: str) -> tuple[str, str]:
+    rendered, content_type = await message_templates_service.render_template_content(
+        slug,
+        context,
+        default_content=default_html,
+        default_content_type="text/html",
+    )
+    if content_type == "text/html":
+        return rendered, _html_to_text(rendered)
+    text_body = rendered
+    html_body = "<p>" + escape(text_body).replace("\n\n", "</p><p>").replace("\n", "<br>") + "</p>"
+    return html_body, text_body
+
+
+async def _send_signup_verification_email(user: dict[str, Any], token: str) -> None:
+    base_url = str(settings.portal_url).rstrip("/") if settings.portal_url else None
+    verify_path = f"/auth/verify-email?token={token}"
+    verify_link = f"{base_url}{verify_path}" if base_url else verify_path
+    context = _template_context(user=user, token=token, link=verify_link)
+    default_html = (
+        "<p>Hello {{ user.name }},</p>"
+        "<p>Thanks for signing up for {{ app.name }}. Please verify your email address before signing in.</p>"
+        "<p><a href=\"{{ verification.link }}\">Verify your signup</a></p>"
+        "<p>This link expires in 24 hours. If you did not create this account, you can ignore this email.</p>"
+    )
+    html_body, text_body = await _render_email_template("signup_verification", context, default_html)
+    try:
+        sent, event_metadata = await email_service.send_email(
+            subject=f"Verify your {settings.app_name} signup",
+            recipients=[user["email"]],
+            text_body=text_body,
+            html_body=html_body,
+        )
+        if not sent:
+            logger.warning(
+                "Signup verification email skipped because SMTP is not configured",
+                user_id=user["id"],
+                event_id=(event_metadata or {}).get("id") if isinstance(event_metadata, dict) else None,
+            )
+    except email_service.EmailDispatchError as exc:  # pragma: no cover - log and continue
+        logger.error("Failed to dispatch signup verification email", user_id=user["id"], error=str(exc))
 
 
 def _serialize_session(session: SessionData) -> SessionInfo:
@@ -116,7 +192,7 @@ def _log_login_success(request: Request, user: dict[str, Any]) -> None:
 
 @router.post(
     "/register",
-    response_model=LoginResponse,
+    response_model=None,
     status_code=status.HTTP_201_CREATED,
     summary="Register a new account",
 )
@@ -133,40 +209,52 @@ async def register(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email already registered")
 
     matched_company_id: int | None = None
+    matched_staff: dict[str, Any] | None = None
     if not is_first_user:
-        domain = payload.email.split("@")[-1].strip().lower()
-        matched = await company_repo.get_company_by_email_domain(domain)
-        if not matched:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Registration is restricted to approved company domains",
-            )
+        staff_matches = await staff_repo.list_staff_by_email(payload.email)
+        active_staff_matches = [staff for staff in staff_matches if bool(staff.get("enabled", True))]
+        if active_staff_matches:
+            matched_staff = active_staff_matches[0]
+            raw_staff_company_id = matched_staff.get("company_id")
+            try:
+                matched_company_id = int(raw_staff_company_id) if raw_staff_company_id is not None else None
+            except (TypeError, ValueError):
+                matched_company_id = None
 
-        raw_company_id = matched.get("id")
-        if raw_company_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Registration is restricted to approved company domains",
-            )
+        if matched_company_id is None:
+            domain = payload.email.split("@")[-1].strip().lower()
+            matched = await company_repo.get_company_by_email_domain(domain)
+            if not matched:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Registration is restricted to approved company domains or existing staff records",
+                )
 
-        try:
-            matched_company_id = int(raw_company_id)
-        except (TypeError, ValueError) as exc:
-            log_error(
-                "Failed to coerce matched company identifier during registration",
-                error=str(exc),
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Registration is restricted to approved company domains",
-            ) from exc
+            raw_company_id = matched.get("id")
+            if raw_company_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Registration is restricted to approved company domains or existing staff records",
+                )
+
+            try:
+                matched_company_id = int(raw_company_id)
+            except (TypeError, ValueError) as exc:
+                log_error(
+                    "Failed to coerce matched company identifier during registration",
+                    error=str(exc),
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Registration is restricted to approved company domains or existing staff records",
+                ) from exc
 
     created = await user_repo.create_user(
         email=payload.email,
         password=payload.password,
-        first_name=payload.first_name,
-        last_name=payload.last_name,
-        mobile_phone=payload.mobile_phone,
+        first_name=payload.first_name or (matched_staff or {}).get("first_name"),
+        last_name=payload.last_name or (matched_staff or {}).get("last_name"),
+        mobile_phone=payload.mobile_phone or (matched_staff or {}).get("mobile_phone"),
         company_id=payload.company_id if is_first_user else matched_company_id,
         is_super_admin=is_first_user,
     )
@@ -178,6 +266,22 @@ async def register(
         )
 
     await staff_access_service.apply_pending_access_for_user(created)
+
+    if not is_first_user:
+        await user_repo.update_user(created["id"], is_active=0, email_verified_at=None)
+        token = secrets.token_hex(32)
+        expires_at = datetime.utcnow() + timedelta(hours=24)
+        await auth_repo.create_account_verification_token(
+            user_id=created["id"], token=token, expires_at=expires_at
+        )
+        await _send_signup_verification_email(created, token)
+        return JSONResponse(
+            content={
+                "detail": "Account created. Check your email to verify your signup before signing in.",
+                "verification_required": True,
+            },
+            status_code=status.HTTP_202_ACCEPTED,
+        )
 
     active_company_id = await _determine_active_company_id(created)
     session = await session_manager.create_session(
@@ -192,6 +296,24 @@ async def register(
     )
     session_manager.apply_session_cookies(response, session, request)
     return response
+
+
+
+@router.get(
+    "/verify-email",
+    summary="Verify a signup email address",
+)
+async def verify_email(token: str, _: None = Depends(require_database)) -> Response:
+    record = await auth_repo.get_account_verification_token(token)
+    if not record or int(record.get("used", 0)) == 1:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification link")
+    expires_at = record.get("expires_at")
+    if expires_at and datetime.utcnow() > ensure_datetime(expires_at):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification link")
+
+    await user_repo.update_user(record["user_id"], is_active=1, email_verified_at=datetime.utcnow())
+    await auth_repo.mark_account_verification_token_used(token)
+    return RedirectResponse(url="/login?verified=1", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @router.post(
@@ -223,7 +345,8 @@ async def login(
 
     if int(user.get("is_active", 1)) != 1:
         _log_login_failure(request, payload.email, "account_disabled")
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Account is disabled")
+        detail = "Please verify your email address before signing in." if not user.get("email_verified_at") else "Account is disabled"
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
 
     totp_devices = await auth_repo.get_totp_authenticators(user["id"])
     if totp_devices:

--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -40,6 +40,7 @@ email_service = main_module.email_service
 log_error = main_module.log_error
 log_info = main_module.log_info
 m365_service = main_module.m365_service
+message_templates_service = main_module.message_templates_service
 modules_service = main_module.modules_service
 settings = main_module.settings
 staff_access_service = main_module.staff_access_service
@@ -52,6 +53,27 @@ staff_workflow_repo = main_module.staff_workflow_repo
 tickets_service = main_module.tickets_service
 user_company_repo = main_module.user_company_repo
 user_repo = main_module.user_repo
+
+
+def _html_to_text(html: str) -> str:
+    import re
+
+    text = re.sub(r"<\s*br\s*/?\s*>", "\n", html, flags=re.IGNORECASE)
+    text = re.sub(r"</p\s*>", "\n\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", "", text)
+    return text.replace("&nbsp;", " ").strip()
+
+
+async def _render_message_email(slug: str, context: dict[str, Any], default_html: str) -> tuple[str, str]:
+    rendered, content_type = await message_templates_service.render_template_content(
+        slug,
+        context,
+        default_content=default_html,
+        default_content_type="text/html",
+    )
+    if content_type == "text/html":
+        return rendered, _html_to_text(rendered)
+    return "<p>" + escape(rendered).replace("\n\n", "</p><p>").replace("\n", "<br>") + "</p>", rendered
 
 
 _STAFF_EDIT_REQUEST_FIELDS: tuple[tuple[str, str, str, str], ...] = (
@@ -2886,17 +2908,29 @@ async def invite_staff_member(staff_id: int, request: Request):
 
     existing_user = await user_repo.get_user_by_email(staff["email"])
     if existing_user:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User already exists")
-
-    temp_password = secrets.token_urlsafe(12)
-    created_user = await user_repo.create_user(
-        email=staff["email"],
-        password=temp_password,
-        first_name=staff.get("first_name"),
-        last_name=staff.get("last_name"),
-        mobile_phone=staff.get("mobile_phone"),
-        company_id=staff.get("company_id"),
-    )
+        created_user = existing_user
+        updates: dict[str, Any] = {}
+        if not created_user.get("first_name") and staff.get("first_name"):
+            updates["first_name"] = staff.get("first_name")
+        if not created_user.get("last_name") and staff.get("last_name"):
+            updates["last_name"] = staff.get("last_name")
+        if not created_user.get("mobile_phone") and staff.get("mobile_phone"):
+            updates["mobile_phone"] = staff.get("mobile_phone")
+        if int(created_user.get("is_active", 1)) != 1:
+            updates["is_active"] = 1
+            updates["email_verified_at"] = datetime.utcnow()
+        if updates:
+            created_user = await user_repo.update_user(created_user["id"], **updates)
+    else:
+        temp_password = secrets.token_urlsafe(12)
+        created_user = await user_repo.create_user(
+            email=staff["email"],
+            password=temp_password,
+            first_name=staff.get("first_name"),
+            last_name=staff.get("last_name"),
+            mobile_phone=staff.get("mobile_phone"),
+            company_id=staff.get("company_id"),
+        )
     await staff_access_service.apply_pending_access_for_user(created_user)
     await user_repo.update_user(created_user["id"], force_password_change=1)
     await user_company_repo.upsert_user_company(
@@ -2919,21 +2953,30 @@ async def invite_staff_member(staff_id: int, request: Request):
     inviter_email = user.get("email") or settings.smtp_user or None
     staff_name = staff.get("first_name") or staff.get("last_name") or "there"
     company_name = (company or {}).get("name") if company else None
-    company_phrase = f" for {company_name}" if company_name else ""
-    company_phrase_html = f" for {escape(company_name)}" if company_name else ""
-    text_body = (
-        f"Hello {staff_name},\n\n"
-        f"You've been invited to access {settings.app_name}{company_phrase}. "
-        f"Use the link below to set your password and activate your account:\n\n"
-        f"{reset_link}\n\n"
-        "The link expires in one hour. If you were not expecting this invitation you can ignore this email."
-    )
-    html_body = (
-        f"<p>Hello {escape(staff_name)},</p>"
-        f"<p>You've been invited to access {escape(settings.app_name)}{company_phrase_html}.</p>"
-        f"<p><a href=\"{escape(reset_link)}\">Set your password and activate your account</a></p>"
+    portal_url = str(settings.portal_url).rstrip("/") if settings.portal_url else ""
+    template_context = {
+        "app": {"name": settings.app_name},
+        "portal": {"url": portal_url, "login_url": f"{portal_url}/login" if portal_url else "/login"},
+        "user": {
+            "email": staff.get("email") or "",
+            "first_name": staff.get("first_name") or "",
+            "last_name": staff.get("last_name") or "",
+            "name": staff_name,
+        },
+        "staff": staff,
+        "company": {"name": company_name or ""},
+        "invitation": {"link": reset_link, "token": token},
+        "link": reset_link,
+        "token": token,
+    }
+    company_sentence = " for {{ company.name }}" if company_name else ""
+    default_html = (
+        "<p>Hello {{ user.name }},</p>"
+        f"<p>You've been invited to access {{{{ app.name }}}}{company_sentence}.</p>"
+        "<p><a href=\"{{ invitation.link }}\">Set your password and activate your account</a></p>"
         "<p>The link expires in one hour. If you were not expecting this invitation you can ignore this email.</p>"
     )
+    html_body, text_body = await _render_message_email("staff_invitation", template_context, default_html)
     try:
         sent, event_metadata = await email_service.send_email(
             subject=f"You're invited to {settings.app_name}",

--- a/app/repositories/auth.py
+++ b/app/repositories/auth.py
@@ -223,6 +223,33 @@ async def mark_password_reset_token_used(token: str) -> None:
     )
 
 
+async def create_account_verification_token(
+    *, user_id: int, token: str, expires_at: datetime
+) -> None:
+    await db.execute(
+        """
+        INSERT INTO account_verification_tokens (token, user_id, expires_at, used)
+        VALUES (%s, %s, %s, 0)
+        """,
+        (token, user_id, expires_at),
+    )
+
+
+async def get_account_verification_token(token: str) -> Optional[dict[str, Any]]:
+    row = await db.fetch_one(
+        "SELECT * FROM account_verification_tokens WHERE token = %s",
+        (token,),
+    )
+    return row
+
+
+async def mark_account_verification_token_used(token: str) -> None:
+    await db.execute(
+        "UPDATE account_verification_tokens SET used = 1 WHERE token = %s",
+        (token,),
+    )
+
+
 async def get_totp_authenticators(user_id: int) -> list[dict[str, Any]]:
     rows = await db.fetch_all(
         "SELECT id, name, secret FROM user_totp_authenticators WHERE user_id = %s",

--- a/app/services/message_templates.py
+++ b/app/services/message_templates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import json
+from html import escape as html_escape
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from threading import RLock
@@ -38,6 +39,48 @@ _CONTENT_TYPE_MAP = {
 _CACHE_LOCK = RLock()
 _TEMPLATE_CACHE: dict[str, MessageTemplate] = {}
 _REDIS_CACHE_KEY = "message-templates:records"
+
+
+
+_TOKEN_PATTERN = re.compile(r"{{\s*([a-zA-Z0-9_.-]+)\s*}}")
+
+
+def _resolve_context_value(context: Mapping[str, Any], path: str) -> Any:
+    current: Any = context
+    for part in path.split("."):
+        if isinstance(current, Mapping):
+            current = current.get(part)
+        else:
+            current = getattr(current, part, None)
+        if current is None:
+            return ""
+    return current
+
+
+def render_content(content: str, context: Mapping[str, Any], *, escape_html: bool = False) -> str:
+    """Render ``{{ dotted.path }}`` tokens using the supplied context."""
+
+    def replace(match: re.Match[str]) -> str:
+        value = _resolve_context_value(context, match.group(1))
+        rendered = "" if value is None else str(value)
+        return html_escape(rendered, quote=True) if escape_html else rendered
+
+    return _TOKEN_PATTERN.sub(replace, content)
+
+
+async def render_template_content(
+    slug: str,
+    context: Mapping[str, Any],
+    *,
+    default_content: str,
+    default_content_type: str = "text/html",
+) -> tuple[str, str]:
+    """Render a stored message template or a caller-provided default."""
+
+    template = await get_template_by_slug(slug)
+    content = str((template or {}).get("content") or default_content)
+    content_type = _normalise_content_type((template or {}).get("content_type") or default_content_type)
+    return render_content(content, context, escape_html=content_type == "text/html"), content_type
 
 
 def _normalise_slug(slug: str) -> str:

--- a/app/static/js/auth.js
+++ b/app/static/js/auth.js
@@ -72,7 +72,13 @@ class AuthForm {
         return;
       }
 
-      window.location.assign(this.successRedirect);
+      if (result && result.verification_required) {
+        this.showError(this.extractDetail(result) || 'Check your email to verify your account before signing in.');
+        this.form.reset();
+        return;
+      }
+
+      window.location.assign((result && result.redirect) || this.successRedirect);
     } catch (error) {
       console.error('Authentication request failed', error);
       this.showError('A network error occurred while contacting the server. Please try again.');

--- a/migrations/267_invitation_signup_templates.sql
+++ b/migrations/267_invitation_signup_templates.sql
@@ -1,0 +1,26 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS email_verified_at DATETIME NULL;
+
+CREATE TABLE IF NOT EXISTS account_verification_tokens (
+  token VARCHAR(64) PRIMARY KEY,
+  user_id INT NOT NULL,
+  expires_at DATETIME NOT NULL,
+  used TINYINT(1) NOT NULL DEFAULT 0,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+INSERT IGNORE INTO message_templates (slug, name, description, content_type, content) VALUES
+  (
+    'staff_invitation',
+    'Staff invitation email',
+    'Sent when a staff member is invited to MyPortal. Variables include {{ user.name }}, {{ user.email }}, {{ company.name }}, {{ invitation.link }}, {{ portal.login_url }}, and {{ app.name }}.',
+    'text/html',
+    '<p>Hello {{ user.name }},</p><p>You have been invited to access {{ app.name }} for {{ company.name }}.</p><p><a href="{{ invitation.link }}">Set your password and activate your account</a></p><p>This link expires in one hour. If you were not expecting this invitation, you can ignore this email.</p>'
+  ),
+  (
+    'signup_verification',
+    'Signup verification email',
+    'Sent after signup so the user can verify their email before accessing MyPortal. Variables include {{ user.name }}, {{ user.email }}, {{ verification.link }}, {{ portal.login_url }}, and {{ app.name }}.',
+    'text/html',
+    '<p>Hello {{ user.name }},</p><p>Thanks for signing up for {{ app.name }}. Please verify your email address before signing in.</p><p><a href="{{ verification.link }}">Verify your signup</a></p><p>This link expires in 24 hours. If you did not create this account, you can ignore this email.</p>'
+  );


### PR DESCRIPTION
### Motivation
- Fix failing staff invite flow where invites to existing users returned "User already exists" by reusing or updating existing accounts instead of blocking.
- Allow staff members who already exist in the staff directory to sign up even when domain-based registration would otherwise be blocked.
- Ensure new signups from non-initial users must verify their email before gaining access and provide customizable message templates for invites and verification emails.

### Description
- Update registration logic in `app/api/routes/auth.py` to accept active `staff` records as a valid signup path, pre-fill user fields from staff records, create an inactive user, and emit a 24-hour account verification token instead of immediately logging the user in.  (Adds `_send_signup_verification_email`, `_render_email_template`, `_template_context` helpers.)
- Change login to return a clearer `403` detail when a user is `is_active=0` because `email_verified_at` is not set so the UI can prompt verification. 
- Modify `invite_staff_member` in `app/features/staff/handlers.py` to reuse existing `users` when present (update missing profile fields, activate/verify if needed), apply company membership and staff access, create a password reset token and send a templated invitation instead of failing on "User already exists".
- Add template rendering helpers to `app/services/message_templates.py` providing `render_template_content` and token substitution with safe HTML escaping for `text/html` templates.
- Add account verification repository helpers to `app/repositories/auth.py`: `create_account_verification_token`, `get_account_verification_token`, and `mark_account_verification_token_used`.
- Provide a migration `migrations/267_invitation_signup_templates.sql` that adds `email_verified_at`, creates `account_verification_tokens`, and inserts default `staff_invitation` and `signup_verification` `message_templates` which super-admins can customise via the Message Templates UI.
- Update the client-side signup flow `app/static/js/auth.js` to surface the `verification_required` response to the user instead of redirecting immediately after registration.

### Testing
- Compiled modified modules with `python -m compileall app/api/routes/auth.py app/features/staff/handlers.py app/services/message_templates.py app/repositories/auth.py` which succeeded. 
- Ran the non-async subset of tests with `python -m pytest tests/test_passwords.py tests/test_smtp2go.py -k 'not send_email_via_api and not process_webhook_event'` and the selected tests passed. 
- Attempted full pytest runs; asynchronous tests that use `pytest.mark.asyncio` fail in this environment because the `pytest-asyncio` plugin is not installed, so full-suite runs showed failures unrelated to these changes in this CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b5eb2ad548332b5d23f9ad67af259)