### PR TITLE
Fix password reset invitation route

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8484,14 +8484,44 @@ async def login_page(request: Request):
     if user_count == 0:
         return RedirectResponse(url="/register", status_code=status.HTTP_303_SEE_OTHER)
 
-    context = {
-        "request": request,
-        "app_name": settings.app_name,
-        "current_year": datetime.utcnow().year,
-        "title": "Sign in",
-        "plausible_config": {"enabled": False},
-    }
+    context = await _build_public_context(
+        request,
+        extra={
+            "title": "Sign in",
+        },
+    )
     return templates.TemplateResponse(context["request"], "auth/login.html", context)
+
+
+@app.get("/forgot-password", response_class=HTMLResponse)
+async def forgot_password_page(request: Request):
+    session = await session_manager.load_session(request)
+    if session:
+        return RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER)
+
+    context = await _build_public_context(
+        request,
+        extra={
+            "title": "Forgot password",
+        },
+    )
+    return templates.TemplateResponse(context["request"], "auth/forgot_password.html", context)
+
+
+@app.get("/reset-password", response_class=HTMLResponse)
+async def reset_password_page(request: Request, token: str = ""):
+    session = await session_manager.load_session(request)
+    if session:
+        return RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER)
+
+    context = await _build_public_context(
+        request,
+        extra={
+            "title": "Reset password",
+            "reset_token": token.strip(),
+        },
+    )
+    return templates.TemplateResponse(context["request"], "auth/reset_password.html", context)
 
 
 @app.get("/register", response_class=HTMLResponse)
@@ -8508,14 +8538,13 @@ async def register_page(request: Request):
 
     is_first_user = user_count == 0
 
-    context = {
-        "request": request,
-        "app_name": settings.app_name,
-        "current_year": datetime.utcnow().year,
-        "title": "Create super administrator" if is_first_user else "Create your account",
-        "is_first_user": is_first_user,
-        "plausible_config": {"enabled": False},
-    }
+    context = await _build_public_context(
+        request,
+        extra={
+            "title": "Create super administrator" if is_first_user else "Create your account",
+            "is_first_user": is_first_user,
+        },
+    )
     return templates.TemplateResponse(context["request"], "auth/register.html", context)
 
 

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -832,16 +832,27 @@ html {
   }
 }
 
-.form-error {
+.form-error,
+.form-success {
   border-radius: 0.85rem;
   padding: var(--space-gap-tight) var(--space-gap-base);
-  background: rgba(248, 113, 113, 0.15);
-  border: 1px solid rgba(248, 113, 113, 0.35);
-  color: #fecaca;
   font-weight: 600;
 }
 
-.form-error[hidden] {
+.form-error {
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  color: #fecaca;
+}
+
+.form-success {
+  background: rgba(134, 239, 172, 0.16);
+  border: 1px solid rgba(134, 239, 172, 0.38);
+  color: #bbf7d0;
+}
+
+.form-error[hidden],
+.form-success[hidden] {
   display: none;
 }
 

--- a/app/static/js/auth.js
+++ b/app/static/js/auth.js
@@ -7,10 +7,16 @@ class AuthForm {
   constructor(form) {
     this.form = form;
     this.endpoint = form.dataset.endpoint;
-    this.successRedirect = form.dataset.successRedirect || '/';
+    this.successRedirect = Object.prototype.hasOwnProperty.call(form.dataset, 'successRedirect')
+      ? form.dataset.successRedirect
+      : '/';
     this.loadingText = form.dataset.loadingText || 'Submitting…';
+    this.successMessage = form.dataset.successMessage || '';
+    this.successDelay = Number(form.dataset.successDelay || 0);
+    this.shouldResetOnSuccess = form.dataset.successReset === 'true';
     this.submitButton = form.querySelector('[data-auth-submit]');
     this.errorContainer = form.querySelector('[data-auth-error]');
+    this.successContainer = form.querySelector('[data-auth-success]');
     this.totpField = form.querySelector('[data-totp-field]');
     this.totpToggle = form.querySelector('[data-auth-toggle-totp]');
     this.defaultButtonLabel = this.submitButton ? this.submitButton.textContent : '';
@@ -41,6 +47,7 @@ class AuthForm {
     }
 
     this.showError('');
+    this.showSuccess('');
 
     const payload = this.buildPayload();
     if (!payload) {
@@ -78,7 +85,24 @@ class AuthForm {
         return;
       }
 
-      window.location.assign((result && result.redirect) || this.successRedirect);
+      const detail = this.extractDetail(result);
+      const message = this.successMessage || detail;
+      if (message) {
+        this.showSuccess(message);
+      }
+
+      if (this.shouldResetOnSuccess) {
+        this.form.reset();
+      }
+
+      const redirectTarget = (result && result.redirect) || this.successRedirect;
+      if (redirectTarget) {
+        if (this.successDelay > 0 && message) {
+          window.setTimeout(() => window.location.assign(redirectTarget), this.successDelay);
+        } else {
+          window.location.assign(redirectTarget);
+        }
+      }
     } catch (error) {
       console.error('Authentication request failed', error);
       this.showError('A network error occurred while contacting the server. Please try again.');
@@ -97,6 +121,10 @@ class AuthForm {
       }
 
       if (!value && key !== 'password') {
+        continue;
+      }
+
+      if (key === 'confirm_password') {
         continue;
       }
 
@@ -124,6 +152,13 @@ class AuthForm {
       }
 
       payload[key] = trimmed;
+    }
+
+    const passwordInput = this.form.querySelector('input[name="password"]');
+    const confirmPasswordInput = this.form.querySelector('input[name="confirm_password"]');
+    if (passwordInput && confirmPasswordInput && passwordInput.value !== confirmPasswordInput.value) {
+      this.showError('Passwords do not match.');
+      return null;
     }
 
     const totpInput = this.form.querySelector('input[name="totp_code"]');
@@ -173,18 +208,26 @@ class AuthForm {
   }
 
   showError(message) {
-    if (!this.errorContainer) {
+    this.showMessage(this.errorContainer, message);
+  }
+
+  showSuccess(message) {
+    this.showMessage(this.successContainer, message);
+  }
+
+  showMessage(container, message) {
+    if (!container) {
       return;
     }
 
     if (!message) {
-      this.errorContainer.setAttribute('hidden', '');
-      this.errorContainer.textContent = '';
+      container.setAttribute('hidden', '');
+      container.textContent = '';
       return;
     }
 
-    this.errorContainer.removeAttribute('hidden');
-    this.errorContainer.textContent = message;
+    container.removeAttribute('hidden');
+    container.textContent = message;
   }
 
   setLoading(isLoading) {

--- a/app/templates/auth/forgot_password.html
+++ b/app/templates/auth/forgot_password.html
@@ -1,0 +1,68 @@
+{% extends "base.html" %}
+
+{% set title = "Forgot password" %}
+
+{% block sidebar_menu %}
+<li class="menu__item">
+  <a href="/login">
+    <span class="menu__icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M10 4h10a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H10a1 1 0 0 1-1-1v-3h2v2h8V6h-8v2H9V5a1 1 0 0 1 1-1zm-1.707 7.293 2.586-2.586L12.293 10.12 10.414 12l1.879 1.879-1.414 1.414-2.586-2.586a1 1 0 0 1 0-1.414z"/></svg>
+    </span>
+    <span class="menu__label">Sign in</span>
+  </a>
+</li>
+<li class="menu__item">
+  <a href="/forgot-password" aria-current="page">
+    <span class="menu__icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a7 7 0 0 0-7 7v3H4a1 1 0 0 0-1 1v7a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7a1 1 0 0 0-1-1h-1V9a7 7 0 0 0-7-7Zm-5 10V9a5 5 0 0 1 10 0v3H7Zm6 4.73V19h-2v-2.27a2 2 0 1 1 2 0Z"/></svg>
+    </span>
+    <span class="menu__label">Forgot password</span>
+  </a>
+</li>
+{% endblock %}
+
+{% block content %}
+<div class="auth-card">
+  <header class="auth-card__header">
+    <h1 class="auth-card__title">Reset your password</h1>
+    <p class="auth-card__subtitle">Enter your email address and we'll send a secure reset link if the account exists.</p>
+  </header>
+  <form
+    class="auth-form"
+    method="post"
+    data-auth-form
+    data-endpoint="/auth/password/forgot"
+    data-loading-text="Sending reset link&hellip;"
+    data-success-message="If the email is registered, reset instructions have been sent."
+    data-success-reset="true"
+    data-success-redirect=""
+    novalidate
+  >
+    {% include "partials/csrf.html" %}
+    <div class="form-field">
+      <label class="form-label" for="forgot-email">Email address</label>
+      <div class="form-input-wrapper">
+        <input
+          id="forgot-email"
+          class="form-input"
+          type="email"
+          name="email"
+          autocomplete="email"
+          required
+          placeholder="you@example.com"
+        />
+      </div>
+    </div>
+    <div class="form-success" role="status" data-auth-success hidden></div>
+    <div class="form-error" role="alert" data-auth-error hidden></div>
+    <div class="form-actions">
+      <a href="/login" class="button button--secondary">Back to sign in</a>
+      <button type="submit" class="button" data-auth-submit>Send reset link</button>
+    </div>
+  </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script type="module" src="{{ static_url('/static/js/auth.js') }}"></script>
+{% endblock %}

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -84,7 +84,7 @@
         />
       </div>
     </div>
-    <p class="form-help">Forgotten your password? Contact a super administrator to trigger a reset email.</p>
+    <p class="form-help">Forgotten your password? <a href="/forgot-password">Request a reset email</a>.</p>
     <div class="form-error" role="alert" data-auth-error hidden></div>
     <div class="form-actions">
       <a href="/register" class="button button--secondary">Sign up</a>

--- a/app/templates/auth/reset_password.html
+++ b/app/templates/auth/reset_password.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+
+{% set title = "Reset password" %}
+
+{% block sidebar_menu %}
+<li class="menu__item">
+  <a href="/login">
+    <span class="menu__icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M10 4h10a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H10a1 1 0 0 1-1-1v-3h2v2h8V6h-8v2H9V5a1 1 0 0 1 1-1zm-1.707 7.293 2.586-2.586L12.293 10.12 10.414 12l1.879 1.879-1.414 1.414-2.586-2.586a1 1 0 0 1 0-1.414z"/></svg>
+    </span>
+    <span class="menu__label">Sign in</span>
+  </a>
+</li>
+<li class="menu__item">
+  <a href="/reset-password{% if reset_token %}?token={{ reset_token | urlencode }}{% endif %}" aria-current="page">
+    <span class="menu__icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a7 7 0 0 0-7 7v3H4a1 1 0 0 0-1 1v7a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7a1 1 0 0 0-1-1h-1V9a7 7 0 0 0-7-7Zm-5 10V9a5 5 0 0 1 10 0v3H7Zm6 4.73V19h-2v-2.27a2 2 0 1 1 2 0Z"/></svg>
+    </span>
+    <span class="menu__label">Reset password</span>
+  </a>
+</li>
+{% endblock %}
+
+{% block content %}
+<div class="auth-card">
+  <header class="auth-card__header">
+    <h1 class="auth-card__title">Choose a new password</h1>
+    <p class="auth-card__subtitle">Use the token from your invitation or password reset email to choose your password.</p>
+  </header>
+  <form
+    class="auth-form"
+    method="post"
+    data-auth-form
+    data-endpoint="/auth/password/reset"
+    data-loading-text="Updating password&hellip;"
+    data-success-message="Password reset successful. You can now sign in with your new password."
+    data-success-redirect="/login"
+    data-success-delay="1800"
+    novalidate
+  >
+    {% include "partials/csrf.html" %}
+    <div class="form-field">
+      <label class="form-label" for="reset-token">Reset token</label>
+      <div class="form-input-wrapper">
+        <input
+          id="reset-token"
+          class="form-input"
+          type="text"
+          name="token"
+          autocomplete="one-time-code"
+          autocorrect="off"
+          autocapitalize="none"
+          spellcheck="false"
+          value="{{ reset_token | e }}"
+          required
+        />
+      </div>
+      <p class="form-help">This is filled automatically when you open the link from your email.</p>
+    </div>
+    <div class="form-field">
+      <label class="form-label" for="reset-password-new">New password</label>
+      <div class="form-input-wrapper">
+        <input
+          id="reset-password-new"
+          class="form-input"
+          type="password"
+          name="password"
+          autocomplete="new-password"
+          minlength="12"
+          maxlength="128"
+          required
+          placeholder="Use at least 12 characters"
+        />
+      </div>
+    </div>
+    <div class="form-field">
+      <label class="form-label" for="reset-password-confirm">Confirm new password</label>
+      <div class="form-input-wrapper">
+        <input
+          id="reset-password-confirm"
+          class="form-input"
+          type="password"
+          name="confirm_password"
+          autocomplete="new-password"
+          minlength="12"
+          maxlength="128"
+          required
+          placeholder="Repeat your new password"
+        />
+      </div>
+    </div>
+    <div class="form-success" role="status" data-auth-success hidden></div>
+    <div class="form-error" role="alert" data-auth-error hidden></div>
+    <div class="form-actions">
+      <a href="/login" class="button button--secondary">Back to sign in</a>
+      <button type="submit" class="button" data-auth-submit>Reset password</button>
+    </div>
+  </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script type="module" src="{{ static_url('/static/js/auth.js') }}"></script>
+{% endblock %}

--- a/tests/test_auth_password_reset.py
+++ b/tests/test_auth_password_reset.py
@@ -79,3 +79,40 @@ def test_password_forgot_sends_email(monkeypatch):
     assert email_payload["recipients"] == ["user@example.com"]
     assert "fixedtoken" in email_payload["text_body"]
     assert "https://portal.example.com/reset-password?token=fixedtoken" in email_payload["text_body"]
+
+
+def test_reset_password_page_accepts_email_token_link(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings, "enable_csrf", False)
+
+    async def fake_load_session(request):
+        return None
+
+    monkeypatch.setattr("app.main.session_manager.load_session", fake_load_session)
+
+    with TestClient(app) as client:
+        response = client.get("/reset-password?token=fixedtoken")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    assert "Choose a new password" in response.text
+    assert 'value="fixedtoken"' in response.text
+    assert 'data-endpoint="/auth/password/reset"' in response.text
+
+
+def test_forgot_password_page_loads_form(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings, "enable_csrf", False)
+
+    async def fake_load_session(request):
+        return None
+
+    monkeypatch.setattr("app.main.session_manager.load_session", fake_load_session)
+
+    with TestClient(app) as client:
+        response = client.get("/forgot-password")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    assert "Reset your password" in response.text
+    assert 'data-endpoint="/auth/password/forgot"' in response.text


### PR DESCRIPTION
### Motivation
- Invitation/reset links like `/reset-password?token=XXXX` returned JSON 404 because no public HTML route rendered the reset form; users following email links saw `{"detail":"Not Found"}` instead of a page. The change ensures email links render the portal pages and accept the token from the query string.

### Description
- Add public pages and routes: created `/forgot-password` and `/reset-password` endpoints and templates so links render HTML instead of falling back to API JSON responses (files: `app/main.py`, `app/templates/auth/forgot_password.html`, `app/templates/auth/reset_password.html`).
- Prefill token on the reset page and wire the form to the existing API endpoint `/auth/password/reset` (template: `app/templates/auth/reset_password.html`).
- Update the login template to link to the password-reset request flow (file: `app/templates/auth/login.html`).
- Improve client-side auth form behavior in `app/static/js/auth.js` by adding support for non-redirect success messages, optional delayed redirects, success display, and password confirmation validation for the reset form; ensure `confirm_password` is ignored in payloads and password mismatch is validated before submit.
- Add success styling for auth flows (`app/static/css/app.css`) and refine error/success presentation.
- Add regression tests covering the new pages and behavior (`tests/test_auth_password_reset.py`).

### Testing
- Ran targeted tests: `pytest -q tests/test_auth_password_reset.py tests/test_login_page_plausible.py` — all tests passed (5 total in these files as executed).
- Verified Python syntax by compiling `app/main.py` with `python -m compileall -q app/main.py` which succeeded.
- Manual smoke checks exercised: visiting `/forgot-password` and `/reset-password?token=fixedtoken` via TestClient (covered by added tests) and confirmed HTML content, token prefill, and form endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b64d0dc9c8332bbefedccbb382f01)