### PR TITLE
Offer password reset for invited registrations

### DIFF
--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -206,6 +206,17 @@ async def register(
 
     existing_user = await user_repo.get_user_by_email(payload.email)
     if existing_user:
+        if int(existing_user.get("force_password_change") or 0) == 1:
+            return JSONResponse(
+                content={
+                    "detail": (
+                        "An account already exists for this email. "
+                        "Send a password reset link to finish setting it up."
+                    ),
+                    "account_setup_reset_available": True,
+                },
+                status_code=status.HTTP_409_CONFLICT,
+            )
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Email already registered")
 
     matched_company_id: int | None = None

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -833,7 +833,8 @@ html {
 }
 
 .form-error,
-.form-success {
+.form-success,
+.form-reset-prompt {
   border-radius: 0.85rem;
   padding: var(--space-gap-tight) var(--space-gap-base);
   font-weight: 600;
@@ -845,6 +846,20 @@ html {
   color: #fecaca;
 }
 
+.form-reset-prompt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-gap-base);
+  background: rgba(96, 165, 250, 0.16);
+  border: 1px solid rgba(96, 165, 250, 0.38);
+  color: #dbeafe;
+}
+
+.form-reset-prompt p {
+  margin: 0;
+}
+
 .form-success {
   background: rgba(134, 239, 172, 0.16);
   border: 1px solid rgba(134, 239, 172, 0.38);
@@ -852,7 +867,8 @@ html {
 }
 
 .form-error[hidden],
-.form-success[hidden] {
+.form-success[hidden],
+.form-reset-prompt[hidden] {
   display: none;
 }
 

--- a/app/static/js/auth.js
+++ b/app/static/js/auth.js
@@ -17,11 +17,19 @@ class AuthForm {
     this.submitButton = form.querySelector('[data-auth-submit]');
     this.errorContainer = form.querySelector('[data-auth-error]');
     this.successContainer = form.querySelector('[data-auth-success]');
+    this.accountSetupResetPrompt = form.querySelector('[data-account-setup-reset]');
+    this.accountSetupResetMessage = form.querySelector('[data-account-setup-reset-message]');
+    this.accountSetupResetButton = form.querySelector('[data-account-setup-reset-submit]');
+    this.accountSetupResetEmail = '';
     this.totpField = form.querySelector('[data-totp-field]');
     this.totpToggle = form.querySelector('[data-auth-toggle-totp]');
     this.defaultButtonLabel = this.submitButton ? this.submitButton.textContent : '';
 
     form.addEventListener('submit', (event) => this.handleSubmit(event));
+
+    if (this.accountSetupResetButton) {
+      this.accountSetupResetButton.addEventListener('click', () => this.sendAccountSetupReset());
+    }
 
     if (this.totpToggle && this.totpField) {
       this.syncTotpVisibility();
@@ -48,6 +56,7 @@ class AuthForm {
 
     this.showError('');
     this.showSuccess('');
+    this.hideAccountSetupReset();
 
     const payload = this.buildPayload();
     if (!payload) {
@@ -71,6 +80,10 @@ class AuthForm {
 
       if (!response.ok) {
         const detail = this.extractDetail(result) || 'Unable to complete the request. Check your credentials and try again.';
+        if (result && result.account_setup_reset_available) {
+          this.showAccountSetupReset(detail, payload.email);
+          return;
+        }
         if (detail && /totp/i.test(detail)) {
           const shouldSelect = /invalid/i.test(detail);
           this.revealTotpField({ focus: true, select: shouldSelect });
@@ -213,6 +226,76 @@ class AuthForm {
 
   showSuccess(message) {
     this.showMessage(this.successContainer, message);
+  }
+
+  showAccountSetupReset(message, email) {
+    this.showError('');
+    this.showSuccess('');
+    this.accountSetupResetEmail = email || '';
+
+    if (!this.accountSetupResetPrompt || !this.accountSetupResetButton) {
+      this.showError(message);
+      return;
+    }
+
+    if (this.accountSetupResetMessage) {
+      this.accountSetupResetMessage.textContent = message;
+    }
+
+    this.accountSetupResetPrompt.removeAttribute('hidden');
+  }
+
+  hideAccountSetupReset() {
+    if (this.accountSetupResetPrompt) {
+      this.accountSetupResetPrompt.setAttribute('hidden', '');
+    }
+    if (this.accountSetupResetMessage) {
+      this.accountSetupResetMessage.textContent = '';
+    }
+    this.accountSetupResetEmail = '';
+  }
+
+  async sendAccountSetupReset() {
+    if (!this.accountSetupResetEmail) {
+      this.showError('Enter your email address and try again.');
+      return;
+    }
+
+    const defaultLabel = this.accountSetupResetButton ? this.accountSetupResetButton.textContent : '';
+    if (this.accountSetupResetButton) {
+      this.accountSetupResetButton.disabled = true;
+      this.accountSetupResetButton.textContent = 'Sending reset link…';
+    }
+
+    try {
+      const response = await fetch('/auth/password/forgot', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({ email: this.accountSetupResetEmail }),
+      });
+      const result = await this.parseJson(response);
+      const detail = this.extractDetail(result) || 'If the email is registered, reset instructions have been sent.';
+
+      if (!response.ok) {
+        this.showError(detail);
+        return;
+      }
+
+      this.hideAccountSetupReset();
+      this.showSuccess(detail);
+    } catch (error) {
+      console.error('Password reset request failed', error);
+      this.showError('A network error occurred while sending the reset link. Please try again.');
+    } finally {
+      if (this.accountSetupResetButton) {
+        this.accountSetupResetButton.disabled = false;
+        this.accountSetupResetButton.textContent = defaultLabel;
+      }
+    }
   }
 
   showMessage(container, message) {

--- a/app/templates/auth/register.html
+++ b/app/templates/auth/register.html
@@ -150,7 +150,12 @@
     {% else %}
     <p class="form-help">After signing in you'll be able to submit tickets and follow your own conversations with the team.</p>
     {% endif %}
+    <div class="form-success" role="status" data-auth-success hidden></div>
     <div class="form-error" role="alert" data-auth-error hidden></div>
+    <div class="form-reset-prompt" role="status" data-account-setup-reset hidden>
+      <p data-account-setup-reset-message></p>
+      <button type="button" class="button button--secondary" data-account-setup-reset-submit>Send password reset</button>
+    </div>
     <div class="form-actions">
       <button type="submit" class="button" data-auth-submit>Create account</button>
     </div>

--- a/tests/test_ticket_access.py
+++ b/tests/test_ticket_access.py
@@ -118,6 +118,11 @@ def test_register_rejects_unapproved_domain_after_first_user(monkeypatch, active
     monkeypatch.setattr(auth_routes.user_repo, "get_user_by_email", fake_get_user_by_email)
     monkeypatch.setattr(auth_routes.user_repo, "create_user", fake_create_user)
     monkeypatch.setattr(
+        auth_routes.staff_repo,
+        "list_staff_by_email",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
         auth_routes.company_repo,
         "get_company_by_email_domain",
         AsyncMock(return_value=None),
@@ -149,7 +154,55 @@ def test_register_rejects_unapproved_domain_after_first_user(monkeypatch, active
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
     data = response.json()
-    assert data["detail"] == "Registration is restricted to approved company domains"
+    assert data["detail"] == "Registration is restricted to approved company domains or existing staff records"
+
+
+def test_register_existing_invited_user_offers_password_reset(monkeypatch):
+    existing_user = {
+        "id": 44,
+        "email": "invited.user@example.com",
+        "first_name": "Invited",
+        "last_name": "User",
+        "force_password_change": 1,
+    }
+
+    async def fake_count_users():
+        return 3
+
+    async def fake_get_user_by_email(email: str):
+        assert email == existing_user["email"]
+        return existing_user
+
+    async def fake_create_user(**kwargs):
+        raise AssertionError("create_user should not be called for an existing invited user")
+
+    monkeypatch.setattr(auth_routes.user_repo, "count_users", fake_count_users)
+    monkeypatch.setattr(auth_routes.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(auth_routes.user_repo, "create_user", fake_create_user)
+
+    app.dependency_overrides[database_dependencies.require_database] = lambda: None
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/auth/register",
+                json={
+                    "email": existing_user["email"],
+                    "password": "strong-password",
+                    "first_name": existing_user["first_name"],
+                    "last_name": existing_user["last_name"],
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == status.HTTP_409_CONFLICT
+    data = response.json()
+    assert data["account_setup_reset_available"] is True
+    assert data["detail"] == (
+        "An account already exists for this email. "
+        "Send a password reset link to finish setting it up."
+    )
 
 
 def test_register_assigns_company_by_email_domain(monkeypatch, active_session):


### PR DESCRIPTION
### Motivation
- Improve the UX when a user attempts to register with an email that already exists as an invited account (password not set) by offering a password-reset flow instead of the generic "Email already registered" error.

### Description
- Return a structured 409 response with `account_setup_reset_available: True` and a human `detail` message when `existing_user` has `force_password_change` set, so the frontend can offer a reset action instead of blocking registration (`app/api/routes/auth.py`).
- Add a hidden reset prompt and submit button to the registration page markup to allow the user to trigger a reset from the UI (`app/templates/auth/register.html`).
- Extend the auth form JavaScript to detect the new `account_setup_reset_available` response, reveal the prompt, and POST to the existing `POST /auth/password/forgot` endpoint to send the reset link; includes success/error handling (`app/static/js/auth.js`).
- Add styling for the inline reset prompt so it appears as an informational callout (`app/static/css/app.css`).
- Add an automated test to assert the new registration-path response for invited users and update an existing test expectation to match the current API message (`tests/test_ticket_access.py`).

### Testing
- Ran `pytest -q tests/test_ticket_access.py::test_register_existing_invited_user_offers_password_reset tests/test_auth_password_reset.py::test_password_forgot_sends_email tests/test_login_page_plausible.py::test_register_page_loads_without_plausible_error` and all specified tests passed. 
- Compiled `app/api/routes/auth.py` with `python -m compileall` with no syntax errors. 
- Verified style/checks via local diff checks with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b6878f1d08332839ccef55dd4f1c0)