### PR TITLE
Fix email verification link reuse

### DIFF
--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -304,9 +304,21 @@ async def register(
     summary="Verify a signup email address",
 )
 async def verify_email(token: str, _: None = Depends(require_database)) -> Response:
+    token = token.strip()
     record = await auth_repo.get_account_verification_token(token)
-    if not record or int(record.get("used", 0)) == 1:
+    if not record:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification link")
+
+    user = await user_repo.get_user_by_id(record["user_id"])
+    if not user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification link")
+
+    if user.get("email_verified_at"):
+        return RedirectResponse(url="/login?verified=1", status_code=status.HTTP_303_SEE_OTHER)
+
+    if int(record.get("used", 0)) == 1:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification link")
+
     expires_at = record.get("expires_at")
     if expires_at and datetime.utcnow() > ensure_datetime(expires_at):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification link")

--- a/tests/test_auth_email_verification.py
+++ b/tests/test_auth_email_verification.py
@@ -1,0 +1,110 @@
+from datetime import datetime, timedelta
+import asyncio
+
+import pytest
+from fastapi import HTTPException, status
+from fastapi.responses import RedirectResponse
+
+from app.api.routes import auth as auth_routes
+
+
+def test_verify_email_accepts_new_token_and_marks_user_verified(monkeypatch):
+    async def run_test():
+        token = " fresh-token \n"
+        stored_token = "fresh-token"
+        updates: dict[str, object] = {}
+        used_tokens: list[str] = []
+
+        async def fake_get_account_verification_token(received_token: str):
+            assert received_token == stored_token
+            return {
+                "token": stored_token,
+                "user_id": 42,
+                "used": 0,
+                "expires_at": datetime.utcnow() + timedelta(hours=1),
+            }
+
+        async def fake_get_user_by_id(user_id: int):
+            assert user_id == 42
+            return {"id": user_id, "email_verified_at": None}
+
+        async def fake_update_user(user_id: int, **kwargs):
+            updates.update(kwargs)
+            return {"id": user_id, **kwargs}
+
+        async def fake_mark_account_verification_token_used(received_token: str):
+            used_tokens.append(received_token)
+
+        monkeypatch.setattr(auth_routes.auth_repo, "get_account_verification_token", fake_get_account_verification_token)
+        monkeypatch.setattr(auth_routes.user_repo, "get_user_by_id", fake_get_user_by_id)
+        monkeypatch.setattr(auth_routes.user_repo, "update_user", fake_update_user)
+        monkeypatch.setattr(auth_routes.auth_repo, "mark_account_verification_token_used", fake_mark_account_verification_token_used)
+
+        response = await auth_routes.verify_email(token)
+
+        assert isinstance(response, RedirectResponse)
+        assert response.status_code == status.HTTP_303_SEE_OTHER
+        assert response.headers["location"] == "/login?verified=1"
+        assert updates["is_active"] == 1
+        assert isinstance(updates["email_verified_at"], datetime)
+        assert used_tokens == [stored_token]
+
+    asyncio.run(run_test())
+
+
+def test_verify_email_is_idempotent_after_scanner_uses_link(monkeypatch):
+    async def run_test():
+        async def fake_get_account_verification_token(token: str):
+            return {
+                "token": token,
+                "user_id": 42,
+                "used": 1,
+                "expires_at": datetime.utcnow() + timedelta(hours=1),
+            }
+
+        async def fake_get_user_by_id(user_id: int):
+            return {"id": user_id, "email_verified_at": datetime.utcnow(), "is_active": 1}
+
+        async def fail_update_user(*args, **kwargs):  # pragma: no cover - should not be called
+            raise AssertionError("verified users should not be updated again")
+
+        async def fail_mark_used(*args, **kwargs):  # pragma: no cover - should not be called
+            raise AssertionError("verified users should not have token marked again")
+
+        monkeypatch.setattr(auth_routes.auth_repo, "get_account_verification_token", fake_get_account_verification_token)
+        monkeypatch.setattr(auth_routes.user_repo, "get_user_by_id", fake_get_user_by_id)
+        monkeypatch.setattr(auth_routes.user_repo, "update_user", fail_update_user)
+        monkeypatch.setattr(auth_routes.auth_repo, "mark_account_verification_token_used", fail_mark_used)
+
+        response = await auth_routes.verify_email("fresh-token")
+
+        assert isinstance(response, RedirectResponse)
+        assert response.status_code == status.HTTP_303_SEE_OTHER
+        assert response.headers["location"] == "/login?verified=1"
+
+    asyncio.run(run_test())
+
+
+def test_verify_email_rejects_used_token_for_unverified_user(monkeypatch):
+    async def run_test():
+        async def fake_get_account_verification_token(token: str):
+            return {
+                "token": token,
+                "user_id": 42,
+                "used": 1,
+                "expires_at": datetime.utcnow() + timedelta(hours=1),
+            }
+
+        async def fake_get_user_by_id(user_id: int):
+            return {"id": user_id, "email_verified_at": None, "is_active": 0}
+
+        monkeypatch.setattr(auth_routes.auth_repo, "get_account_verification_token", fake_get_account_verification_token)
+        monkeypatch.setattr(auth_routes.user_repo, "get_user_by_id", fake_get_user_by_id)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_routes.verify_email("fresh-token")
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc_info.value.detail == "Invalid or expired verification link"
+
+    asyncio.run(run_test())


### PR DESCRIPTION
### Motivation
- Verification links could fail when copied with surrounding whitespace or when mail scanners / duplicate clicks consume the token and later users click the same link, leading to "Invalid or expired verification link" errors.

### Description
- Trim the incoming `token` before lookup and validate that a corresponding `account_verification_tokens` record exists.
- Fetch the user referenced by the token and return the normal success redirect when `email_verified_at` is already set to make the endpoint idempotent for already-verified accounts.
- Preserve strict checks for used tokens and expiry for still-unverified users, and continue to mark fresh tokens used and set `email_verified_at` on successful verification.
- Add `tests/test_auth_email_verification.py` covering fresh verification, idempotent reuse (scanner/duplicate click), and used-token rejection, with small adjustments to run the async route code in test context.

### Testing
- Ran `python -m py_compile app/api/routes/auth.py tests/test_auth_email_verification.py` which succeeded.
- Ran `pytest -q tests/test_auth_email_verification.py` which passed.
- Ran `pytest -q tests/test_auth_password_reset.py tests/test_auth_email_verification.py` and all tests passed (combined test run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b68d35f788332965143d453c33e80)