### PR TITLE
Track MyPortal last login for staff

### DIFF
--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from html import escape
 from typing import Any
 
@@ -387,6 +387,9 @@ async def login(
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid TOTP code")
 
     await auth_repo.clear_login_attempts(identifier)
+
+    login_timestamp = datetime.now(timezone.utc).replace(tzinfo=None)
+    user = await user_repo.record_login(user["id"], login_timestamp)
 
     active_company_id = await _determine_active_company_id(user)
     session = await session_manager.create_session(

--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -365,8 +365,11 @@ async def staff_page(
         )
         custom_field_definitions = await staff_custom_fields_repo.list_field_definitions(company_id)
         staff_members = await staff_repo.list_staff(
-            company_id, enabled=enabled_filter, exclude_ex_staff=not show_ex_staff_flag,
-            exclude_package_staff=not show_ex_staff_flag
+            company_id,
+            enabled=enabled_filter,
+            exclude_ex_staff=not show_ex_staff_flag,
+            exclude_package_staff=not show_ex_staff_flag,
+            include_portal_last_login=is_super_admin,
         )
         company_record = await company_repo.get_company_by_id(company_id)
         active_staff_for_offboarding = _filter_staff_for_offboarding_choices(

--- a/app/repositories/staff.py
+++ b/app/repositories/staff.py
@@ -86,6 +86,8 @@ def _map_staff_row(row: dict[str, Any]) -> dict[str, Any]:
     mapped["requested_at"] = _serialize_datetime(mapped.get("requested_at"))
     mapped["approved_at"] = _serialize_datetime(mapped.get("approved_at"))
     mapped["m365_last_sign_in"] = _serialize_datetime(mapped.get("m365_last_sign_in"))
+    if "portal_last_login_at" in mapped:
+        mapped["portal_last_login_at"] = _serialize_datetime(mapped.get("portal_last_login_at"))
     mapped["created_at"] = _serialize_datetime(mapped.get("created_at"))
     mapped["updated_at"] = _serialize_datetime(mapped.get("updated_at"))
     mapped["onboarding_complete"] = bool(int(mapped.get("onboarding_complete", 0)))
@@ -131,6 +133,7 @@ async def list_staff(
     scheduled_from: datetime | None = None,
     scheduled_to: datetime | None = None,
     due_only: bool = False,
+    include_portal_last_login: bool = False,
     cursor: str | None = None,
     page_size: int | None = None,
 ) -> list[dict[str, Any]]:
@@ -195,14 +198,27 @@ async def list_staff(
         )
         params.extend([cursor_updated_at, cursor_updated_at, cursor_staff_id])
     where_clause = " AND ".join(conditions)
+    portal_last_login_select = (
+        ", u.last_login_at AS portal_last_login_at" if include_portal_last_login else ""
+    )
+    portal_last_login_join = (
+        """
+        LEFT JOIN users AS u
+            ON LOWER(u.email) = LOWER(s.email)
+           AND (u.company_id = s.company_id OR COALESCE(u.is_super_admin, 0) = 1)
+        """
+        if include_portal_last_login
+        else ""
+    )
     if page_size is None:
         page_size = 200
     safe_page_size = max(1, min(int(page_size), 500))
     rows = await db.fetch_all(
         """
-        SELECT s.*, svc.code AS verification_code, svc.admin_name AS verification_admin_name
+        SELECT s.*, svc.code AS verification_code, svc.admin_name AS verification_admin_name{portal_last_login_select}
         FROM staff AS s
         LEFT JOIN staff_verification_codes AS svc ON svc.staff_id = s.id
+        {portal_last_login_join}
         LEFT JOIN (
             SELECT e1.* FROM staff_onboarding_workflow_executions AS e1
             INNER JOIN (
@@ -214,7 +230,11 @@ async def list_staff(
         WHERE {where}
         ORDER BY s.updated_at ASC, s.id ASC
         LIMIT %s
-        """.format(where=where_clause),
+        """.format(
+            where=where_clause,
+            portal_last_login_select=portal_last_login_select,
+            portal_last_login_join=portal_last_login_join,
+        ),
         tuple([*params, safe_page_size]),
     )
     mapped_rows = [_map_staff_row(row) for row in rows]

--- a/app/repositories/users.py
+++ b/app/repositories/users.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, List, Optional
 
 from app.core.database import db
@@ -97,6 +98,10 @@ async def update_user(user_id: int, **updates: Any) -> dict[str, Any]:
         raise ValueError("User not found after update")
     log_info("User updated successfully", user_id=user_id)
     return updated
+
+
+async def record_login(user_id: int, logged_in_at: datetime) -> dict[str, Any]:
+    return await update_user(user_id, last_login_at=logged_in_at)
 
 
 async def delete_user(user_id: int) -> None:

--- a/app/schemas/users.py
+++ b/app/schemas/users.py
@@ -35,6 +35,7 @@ class UserResponse(UserBase):
     id: int
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+    last_login_at: Optional[datetime] = None
     force_password_change: Optional[int] = None
     is_super_admin: bool = False
     matrix_user_id: Optional[str] = None

--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -151,6 +151,12 @@
                 <input type="checkbox" class="staff-column-toggle" data-column="m365-sign-in" checked />
                 O365 Last Sign In
               </label>
+              {% if is_super_admin %}
+                <label class="ticket-columns__option">
+                  <input type="checkbox" class="staff-column-toggle" data-column="portal-last-login" checked />
+                  MyPortal Last Login
+                </label>
+              {% endif %}
               <label class="ticket-columns__option">
                 <input type="checkbox" class="staff-column-toggle" data-column="onboarding-workflow" checked />
                 Onboarding Workflow
@@ -181,6 +187,9 @@
             <th scope="col" data-sort="string" data-column="code">Code</th>
             <th scope="col" data-sort="date" data-column="onboarded" data-mobile-priority="supporting">Onboarded</th>
             <th scope="col" data-sort="date" data-column="m365-sign-in">O365 Last Sign In</th>
+            {% if is_super_admin %}
+              <th scope="col" data-sort="date" data-column="portal-last-login">MyPortal Last Login</th>
+            {% endif %}
             <th scope="col" data-sort="string" data-column="onboarding-workflow">Onboarding Workflow</th>
             {% for field in staff_custom_field_definitions %}
               <th scope="col" data-sort="string" data-column="custom-{{ field.name }}">{{ field.display_name or field.name }}</th>
@@ -213,6 +222,15 @@
                   <span class="text-muted">—</span>
                 {% endif %}
               </td>
+              {% if is_super_admin %}
+                <td data-label="MyPortal Last Login" data-column="portal-last-login" data-value="{{ member.portal_last_login_at or '' }}" data-utc="{{ member.portal_last_login_at or '' }}">
+                  {% if member.portal_last_login_at %}
+                    {{ member.portal_last_login_at }}
+                  {% else %}
+                    <span class="text-muted">Never</span>
+                  {% endif %}
+                </td>
+              {% endif %}
               <td data-label="Onboarding Workflow" data-column="onboarding-workflow">
                 {% set workflow = member.workflow_status or {} %}
                 {% set workflow_state = workflow.get('state') or member.onboarding_status or 'requested' %}

--- a/migrations/268_add_user_last_login_at.sql
+++ b/migrations/268_add_user_last_login_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD COLUMN last_login_at DATETIME NULL;
+CREATE INDEX idx_users_last_login_at ON users (last_login_at);

--- a/tests/test_auth_last_login.py
+++ b/tests/test_auth_last_login.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+
+from app.api.routes import auth as auth_routes
+from app.schemas.auth import LoginRequest
+from app.security.session import SessionData
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _DummyAuthRepo:
+    def __init__(self) -> None:
+        self.cleared_identifier: str | None = None
+
+    async def register_login_attempt(self, identifier: str, *, window_seconds: int, max_attempts: int) -> bool:
+        return True
+
+    async def clear_login_attempts(self, identifier: str) -> None:
+        self.cleared_identifier = identifier
+
+    async def get_totp_authenticators(self, user_id: int):
+        return []
+
+
+class _DummyUserRepo:
+    def __init__(self) -> None:
+        self.recorded_login: tuple[int, datetime] | None = None
+        self.user = {
+            "id": 42,
+            "email": "admin@example.com",
+            "password_hash": "hash",
+            "company_id": 7,
+            "is_active": 1,
+            "is_super_admin": 1,
+            "first_name": "Admin",
+            "last_name": "User",
+        }
+
+    async def get_user_by_email(self, email: str):
+        return dict(self.user) if email == self.user["email"] else None
+
+    async def record_login(self, user_id: int, logged_in_at: datetime):
+        self.recorded_login = (user_id, logged_in_at)
+        updated = dict(self.user)
+        updated["last_login_at"] = logged_in_at
+        return updated
+
+
+class _DummySessionManager:
+    async def create_session(self, user_id: int, request: Request, *, active_company_id: int | None = None):
+        return SessionData(
+            id=99,
+            user_id=user_id,
+            session_token="token",
+            csrf_token="csrf",
+            created_at=datetime(2026, 1, 1),
+            expires_at=datetime(2026, 1, 1, 12),
+            last_seen_at=datetime(2026, 1, 1),
+            ip_address="127.0.0.1",
+            user_agent="pytest",
+            active_company_id=active_company_id,
+        )
+
+    def apply_session_cookies(self, response, session, request):
+        response.set_cookie("session", session.session_token)
+
+
+@pytest.mark.anyio
+async def test_login_records_last_login_timestamp(monkeypatch):
+    auth_repo = _DummyAuthRepo()
+    user_repo = _DummyUserRepo()
+    monkeypatch.setattr(auth_routes, "auth_repo", auth_repo)
+    monkeypatch.setattr(auth_routes, "user_repo", user_repo)
+    monkeypatch.setattr(auth_routes, "verify_password", lambda password, password_hash: True)
+    monkeypatch.setattr(auth_routes, "session_manager", _DummySessionManager())
+    monkeypatch.setattr(auth_routes, "_determine_active_company_id", lambda user: _async_return(user.get("company_id")))
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/auth/login",
+            "headers": [(b"user-agent", b"pytest")],
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+            "scheme": "http",
+        }
+    )
+
+    response = await auth_routes.login(
+        LoginRequest(email="admin@example.com", password="correct horse battery staple"),
+        request,
+        None,
+    )
+
+    assert response.status_code == 200
+    assert user_repo.recorded_login is not None
+    user_id, logged_in_at = user_repo.recorded_login
+    assert user_id == 42
+    assert isinstance(logged_in_at, datetime)
+    assert auth_repo.cleared_identifier == "admin@example.com:127.0.0.1"
+
+
+async def _async_return(value):
+    return value

--- a/tests/test_staff_column_customisation.py
+++ b/tests/test_staff_column_customisation.py
@@ -17,7 +17,7 @@ JS_PATH = (
     / "app" / "static" / "js" / "staff_columns.js"
 )
 
-EXPECTED_COLUMNS = ["last-name", "email", "mobile", "code", "onboarded", "m365-sign-in", "enabled"]
+EXPECTED_COLUMNS = ["last-name", "email", "mobile", "code", "onboarded", "m365-sign-in", "portal-last-login", "enabled"]
 ALWAYS_VISIBLE_COLUMNS = ["first-name"]
 
 
@@ -112,3 +112,13 @@ def test_custom_field_column_toggle_loop_in_panel():
     assert 'staff_custom_field_definitions' in html
     # The loop generates custom-prefixed column toggles matching the table cells
     assert 'data-column="custom-' in html or 'data-column="custom-{{ field.name }}"' in html
+
+
+def test_portal_last_login_column_restricted_to_super_admins():
+    """The MyPortal login column is available only within super-admin template branches."""
+    html = _template_html()
+    assert 'data-column="portal-last-login"' in html
+    assert 'MyPortal Last Login' in html
+    portal_index = html.index('data-column="portal-last-login"')
+    guard_index = html.rfind('{% if is_super_admin %}', 0, portal_index)
+    assert guard_index != -1

--- a/tests/test_staff_repository.py
+++ b/tests/test_staff_repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime
+
 import pytest
 
 from app.repositories import staff
@@ -122,6 +124,41 @@ async def test_list_staff_supports_polling_filters_and_cursor(monkeypatch):
     assert "ORDER BY s.updated_at ASC, s.id ASC" in (dummy_db.last_sql or "")
     assert "LIMIT %s" in (dummy_db.last_sql or "")
     assert dummy_db.last_params[-1] == 100
+
+
+@pytest.mark.anyio
+async def test_list_staff_can_include_portal_last_login(monkeypatch):
+    last_login = datetime(2026, 6, 12, 8, 30)
+    dummy_rows = [
+        {
+            "id": 1,
+            "company_id": 3,
+            "first_name": "Alice",
+            "last_name": "Smith",
+            "email": "alice@example.com",
+            "enabled": 1,
+            "is_ex_staff": 0,
+            "date_onboarded": None,
+            "date_offboarded": None,
+            "m365_last_sign_in": None,
+            "portal_last_login_at": last_login,
+            "created_at": None,
+            "updated_at": None,
+            "onboarding_complete": 0,
+            "onboarding_completed_at": None,
+            "onboarding_status": None,
+        },
+    ]
+    dummy_db = _DummyStaffDB(dummy_rows)
+    monkeypatch.setattr(staff, "db", dummy_db)
+    monkeypatch.setattr(staff, "staff_custom_fields_repo", _DummyCustomFieldsRepo())
+
+    result = await staff.list_staff(3, include_portal_last_login=True)
+
+    assert "u.last_login_at AS portal_last_login_at" in (dummy_db.last_sql or "")
+    assert "LEFT JOIN users AS u" in (dummy_db.last_sql or "")
+    assert "LOWER(u.email) = LOWER(s.email)" in (dummy_db.last_sql or "")
+    assert result[0]["portal_last_login_at"] == "2026-06-12T08:30:00+00:00"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- Super administrators need visibility of when a user last signed in to MyPortal to support auditing and troubleshooting.  
- Persisting the portal login timestamp enables filtering, display and future reporting without relying on external systems.

### Description
- Add a migration `migrations/268_add_user_last_login_at.sql` to create `users.last_login_at` and an index for efficient lookups.  
- Record the UTC login timestamp on successful MyPortal authentication by calling a new repository helper `user_repo.record_login(...)` before creating the session.  
- Introduce `record_login` in `app/repositories/users.py` and expose `last_login_at` in the `UserResponse` schema (`app/schemas/users.py`).  
- Load the matching portal `last_login_at` into staff rows only when the viewer is a super admin by extending `staff.list_staff` with `include_portal_last_login` and adding a restricted `MyPortal Last Login` column and column toggle in the staff template (`app/templates/staff/index.html`); the staff page handler passes `include_portal_last_login=is_super_admin`.

### Testing
- Ran the targeted pytest subset with `python -m pytest tests/test_auth_last_login.py tests/test_staff_column_customisation.py tests/test_staff_repository.py` and all tests passed.  
- Verified code compiles with `python -m py_compile` against modified modules and succeeded.  
- Validated the migration against SQLite with a small script that applies `migrations/268_add_user_last_login_at.sql` to an in-memory DB and confirmed the column and index exist; this check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2b6e4c967c832daada949a42120329)