### PR TITLE
Enforce mandatory TOTP enrolment

### DIFF
--- a/app/api/dependencies/auth.py
+++ b/app/api/dependencies/auth.py
@@ -5,6 +5,7 @@ from fastapi import Depends, HTTPException, Request, status
 from app.core.logging import set_request_context
 from app.repositories import company_memberships as membership_repo
 from app.repositories import tray as tray_repo
+from app.repositories import auth as auth_repo
 from app.repositories import user_companies as user_company_repo
 from app.repositories import users as user_repo
 from app.security.session import SessionData, session_manager
@@ -19,7 +20,26 @@ async def get_current_session(request: Request) -> SessionData:
     return session
 
 
+TOTP_ENROLLMENT_EXEMPT_PATHS = frozenset(
+    {
+        "/auth/logout",
+        "/auth/session",
+        "/auth/totp",
+        "/auth/totp/setup",
+        "/auth/totp/verify",
+        "/auth/password/change",
+    }
+)
+
+
+def _is_totp_enrollment_exempt_path(path: str) -> bool:
+    if path in TOTP_ENROLLMENT_EXEMPT_PATHS:
+        return True
+    return path.startswith("/auth/totp/")
+
+
 async def get_current_user(
+    request: Request,
     session: SessionData = Depends(get_current_session),
 ) -> dict:
     user = await user_repo.get_user_by_id(session.user_id)
@@ -31,6 +51,14 @@ async def get_current_user(
     user_id = user.get("id")
     if isinstance(user_id, int):
         set_request_context(user_id=user_id)
+        if not _is_totp_enrollment_exempt_path(request.url.path):
+            has_totp = await auth_repo.user_has_totp_authenticator(user_id)
+            if not has_totp:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Two-factor authentication enrolment is required before continuing",
+                    headers={"X-MyPortal-2FA-Enrolment-Required": "true"},
+                )
     return user
 
 

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -146,10 +146,18 @@ def _serialize_session(session: SessionData) -> SessionInfo:
     )
 
 
-def _build_login_response(user: dict, session: SessionData) -> LoginResponse:
+def _build_login_response(
+    user: dict,
+    session: SessionData,
+    *,
+    requires_totp_enrollment: bool = False,
+    redirect: str | None = None,
+) -> LoginResponse:
     return LoginResponse(
         user=UserResponse.model_validate(user),
         session=_serialize_session(session),
+        requires_totp_enrollment=requires_totp_enrollment,
+        redirect=redirect,
     )
 
 
@@ -300,7 +308,12 @@ async def register(
     )
     if active_company_id is not None:
         created["company_id"] = active_company_id
-    response_model = _build_login_response(created, session)
+    response_model = _build_login_response(
+        created,
+        session,
+        requires_totp_enrollment=True,
+        redirect="/security/2fa",
+    )
     response = JSONResponse(
         content=response_model.model_dump(mode="json"),
         status_code=status.HTTP_201_CREATED,
@@ -372,6 +385,7 @@ async def login(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
 
     totp_devices = await auth_repo.get_totp_authenticators(user["id"])
+    requires_totp_enrollment = not bool(totp_devices)
     if totp_devices:
         if not payload.totp_code:
             _log_login_failure(request, payload.email, "totp_required")
@@ -397,7 +411,12 @@ async def login(
     )
     if active_company_id is not None:
         user["company_id"] = active_company_id
-    response_model = _build_login_response(user, session)
+    response_model = _build_login_response(
+        user,
+        session,
+        requires_totp_enrollment=requires_totp_enrollment,
+        redirect="/security/2fa" if requires_totp_enrollment else None,
+    )
     response = JSONResponse(content=response_model.model_dump(mode="json"))
     session_manager.apply_session_cookies(response, session, request)
     _log_login_success(request, user)
@@ -697,5 +716,10 @@ async def delete_totp(
     authenticator_id: int,
     current_user: dict = Depends(get_current_user),
 ) -> Response:
+    if await auth_repo.count_totp_authenticators(current_user["id"]) <= 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="At least one authenticator is required for every account",
+        )
     await auth_repo.delete_totp_authenticator(current_user["id"], authenticator_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/main.py
+++ b/app/main.py
@@ -1084,6 +1084,24 @@ MARKETING_PERMISSION_KEY = "marketing.access"
 _PHONE_SEARCH_LIMIT = 100
 
 
+TOTP_ENROLLMENT_PAGE_PATH = "/security/2fa"
+TOTP_ENROLLMENT_ALLOWED_PAGE_PATHS = frozenset(
+    {
+        TOTP_ENROLLMENT_PAGE_PATH,
+        "/admin/profile",
+    }
+)
+
+
+async def _user_requires_totp_enrollment(user: Mapping[str, Any]) -> bool:
+    user_id = user.get("id")
+    try:
+        user_id_int = int(user_id)
+    except (TypeError, ValueError):
+        return True
+    return not await auth_repo.user_has_totp_authenticator(user_id_int)
+
+
 async def _require_authenticated_user(request: Request) -> tuple[dict[str, Any] | None, RedirectResponse | None]:
     session = await session_manager.load_session(request)
     if not session:
@@ -1091,6 +1109,11 @@ async def _require_authenticated_user(request: Request) -> tuple[dict[str, Any] 
     user = await user_repo.get_user_by_id(session.user_id)
     if not user:
         return None, RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+    if (
+        request.url.path not in TOTP_ENROLLMENT_ALLOWED_PAGE_PATHS
+        and await _user_requires_totp_enrollment(user)
+    ):
+        return None, RedirectResponse(url=TOTP_ENROLLMENT_PAGE_PATH, status_code=status.HTTP_303_SEE_OTHER)
     active_company_id = session.active_company_id
     if active_company_id is None:
         active_company_id = await _resolve_initial_company_id(user)
@@ -8469,10 +8492,32 @@ def _form_bool(form: Mapping[str, Any], key: str) -> bool:
     return bool(value)
 
 
+@app.get(TOTP_ENROLLMENT_PAGE_PATH, response_class=HTMLResponse)
+async def totp_enrollment_page(request: Request):
+    user, redirect = await _require_authenticated_user(request)
+    if redirect:
+        return redirect
+    assert user is not None
+    if not await _user_requires_totp_enrollment(user):
+        return RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER)
+
+    context = await _build_base_context(
+        request,
+        user,
+        extra={
+            "title": "Set up two-factor authentication",
+        },
+    )
+    return templates.TemplateResponse(context["request"], "auth/totp_enrol.html", context)
+
+
 @app.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request):
     session = await session_manager.load_session(request)
     if session:
+        user = await user_repo.get_user_by_id(session.user_id)
+        if user and await _user_requires_totp_enrollment(user):
+            return RedirectResponse(url=TOTP_ENROLLMENT_PAGE_PATH, status_code=status.HTTP_303_SEE_OTHER)
         return RedirectResponse(url="/", status_code=status.HTTP_303_SEE_OTHER)
 
     try:

--- a/app/repositories/auth.py
+++ b/app/repositories/auth.py
@@ -262,6 +262,20 @@ async def get_totp_authenticators(user_id: int) -> list[dict[str, Any]]:
     return decoded
 
 
+async def count_totp_authenticators(user_id: int) -> int:
+    row = await db.fetch_one(
+        "SELECT COUNT(*) AS count FROM user_totp_authenticators WHERE user_id = %s",
+        (user_id,),
+    )
+    if not row:
+        return 0
+    return int(row.get("count") or 0)
+
+
+async def user_has_totp_authenticator(user_id: int) -> bool:
+    return await count_totp_authenticators(user_id) > 0
+
+
 async def create_totp_authenticator(
     *, user_id: int, name: str, secret: str
 ) -> dict[str, Any]:

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -69,6 +69,8 @@ class SessionInfo(BaseModel):
 class LoginResponse(BaseModel):
     session: SessionInfo
     user: UserResponse
+    requires_totp_enrollment: bool = False
+    redirect: Optional[str] = None
 
 
 class SessionResponse(LoginResponse):

--- a/app/static/js/totp_enrol.js
+++ b/app/static/js/totp_enrol.js
@@ -1,0 +1,160 @@
+(function () {
+  const root = document.getElementById('totp-enrol-root');
+  if (!root) {
+    return;
+  }
+
+  const secretInput = document.getElementById('totp-secret');
+  const linkInput = document.getElementById('totp-link');
+  const form = document.getElementById('totp-enrol-form');
+  const nameInput = document.getElementById('totp-name');
+  const codeInput = document.getElementById('totp-code');
+  const submitButton = root.querySelector('[data-totp-submit]');
+  const refreshButton = root.querySelector('[data-totp-refresh]');
+  const logoutButton = root.querySelector('[data-logout]');
+
+  function getCsrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : null;
+  }
+
+  function toast(message, variant = 'info') {
+    if (window.__portalToast && typeof window.__portalToast.show === 'function') {
+      window.__portalToast.show(message, { variant });
+      return;
+    }
+    window.alert(message);
+  }
+
+  function formatError(data, fallback) {
+    if (!data || !data.detail) {
+      return fallback;
+    }
+    if (Array.isArray(data.detail)) {
+      return data.detail.map((entry) => entry.msg || entry).join(', ');
+    }
+    return data.detail;
+  }
+
+  async function requestJson(url, options = {}) {
+    const headers = new Headers(options.headers || {});
+    if (!headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+    const csrf = getCsrfToken();
+    if (csrf && !headers.has('X-CSRF-Token')) {
+      headers.set('X-CSRF-Token', csrf);
+    }
+    const response = await fetch(url, {
+      credentials: 'same-origin',
+      ...options,
+      headers,
+    });
+    if (!response.ok) {
+      let detail = `${response.status} ${response.statusText}`;
+      try {
+        detail = formatError(await response.json(), detail);
+      } catch (error) {
+        // Keep the HTTP status fallback when the response is not JSON.
+      }
+      throw new Error(detail);
+    }
+    if (response.status === 204) {
+      return null;
+    }
+    return response.json();
+  }
+
+  async function startSetup() {
+    if (refreshButton) {
+      refreshButton.disabled = true;
+    }
+    try {
+      const result = await requestJson('/auth/totp/setup', { method: 'POST' });
+      if (secretInput) {
+        secretInput.value = result.secret || '';
+      }
+      if (linkInput) {
+        linkInput.value = result.otpauth_url || '';
+      }
+      if (codeInput) {
+        codeInput.value = '';
+        codeInput.focus();
+      }
+    } catch (error) {
+      toast(error.message || 'Unable to start authenticator setup.', 'error');
+    } finally {
+      if (refreshButton) {
+        refreshButton.disabled = false;
+      }
+    }
+  }
+
+  if (form) {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const code = codeInput ? codeInput.value.trim().replace(/\s+/g, '') : '';
+      if (!/^\d{6}$/.test(code)) {
+        toast('Enter the six-digit authenticator code.', 'error');
+        return;
+      }
+      if (submitButton) {
+        submitButton.disabled = true;
+        submitButton.textContent = 'Verifying…';
+      }
+      try {
+        await requestJson('/auth/totp/verify', {
+          method: 'POST',
+          body: JSON.stringify({
+            code,
+            name: nameInput && nameInput.value.trim() ? nameInput.value.trim() : null,
+          }),
+        });
+        toast('Two-factor authentication is enabled.', 'success');
+        window.location.assign('/');
+      } catch (error) {
+        toast(error.message || 'Unable to verify authenticator.', 'error');
+      } finally {
+        if (submitButton) {
+          submitButton.disabled = false;
+          submitButton.textContent = 'Verify and continue';
+        }
+      }
+    });
+  }
+
+  if (refreshButton) {
+    refreshButton.addEventListener('click', () => startSetup());
+  }
+
+  if (logoutButton) {
+    logoutButton.addEventListener('click', async () => {
+      try {
+        await requestJson('/auth/logout', { method: 'POST' });
+      } catch (error) {
+        // Continue to the login page even if the session was already gone.
+      }
+      window.location.assign('/login');
+    });
+  }
+
+  root.querySelectorAll('[data-copy-target]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const targetId = button.getAttribute('data-copy-target');
+      const target = targetId ? document.getElementById(targetId) : null;
+      if (!target || !target.value) {
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(target.value);
+        toast('Copied to clipboard.', 'success');
+      } catch (error) {
+        target.focus();
+        target.select();
+        toast('Copy failed. Select the field text manually.', 'error');
+      }
+    });
+  });
+
+  startSetup();
+})();

--- a/app/templates/auth/totp_enrol.html
+++ b/app/templates/auth/totp_enrol.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+
+{% block header_title %}Secure your account{% endblock %}
+
+{% block content %}
+<div class="management management--single" data-layout id="totp-enrol-root">
+  <section class="management__content">
+    <header class="management__header">
+      <div>
+        <h1 class="management__title">Set up two-factor authentication</h1>
+        <p class="management__subtitle">Two-factor authentication is required for every MyPortal account before accessing portal data.</p>
+      </div>
+    </header>
+
+    <div class="management__body management__body--columns profile-columns profile-columns--standard">
+      <div class="management__column profile-columns__column">
+        <section class="card card--panel">
+          <header class="card__header card__header--stacked">
+            <div>
+              <h2 class="card__title">Authenticator app enrolment</h2>
+              <p class="card__subtitle">Add MyPortal to an authenticator app, then enter the six-digit code to finish enrolment.</p>
+            </div>
+          </header>
+          <div class="card__body card__body--stacked">
+            <div class="callout callout--warning" role="status">
+              <strong>Required security step.</strong>
+              Access to the portal is paused until this account has at least one authenticator registered.
+            </div>
+
+            <div data-totp-setup>
+              <div class="form-grid">
+                <div class="form-field">
+                  <label class="form-label" for="totp-secret">Secret</label>
+                  <div class="inline-form inline-form--stacked">
+                    <input class="form-input" id="totp-secret" name="totpSecret" readonly />
+                    <button type="button" class="button button--ghost" data-copy-target="totp-secret">Copy</button>
+                  </div>
+                  <p class="form-help">Enter this secret manually if your authenticator cannot open setup links.</p>
+                </div>
+                <div class="form-field">
+                  <label class="form-label" for="totp-link">Setup link</label>
+                  <div class="inline-form inline-form--stacked">
+                    <input class="form-input" id="totp-link" name="totpLink" readonly />
+                    <button type="button" class="button button--ghost" data-copy-target="totp-link">Copy</button>
+                  </div>
+                  <p class="form-help">Open or paste this link in compatible desktop authenticator applications.</p>
+                </div>
+              </div>
+
+              <form class="form" id="totp-enrol-form">
+                <div class="form-field">
+                  <label class="form-label" for="totp-name">Device name</label>
+                  <input class="form-input" id="totp-name" name="totpName" maxlength="100" placeholder="e.g. Work phone" />
+                </div>
+                <div class="form-field">
+                  <label class="form-label" for="totp-code">Authenticator code</label>
+                  <input class="form-input" id="totp-code" name="totpCode" type="text" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" autocorrect="off" autocapitalize="none" required />
+                </div>
+                <div class="form-actions">
+                  <button type="submit" class="button" data-totp-submit>Verify and continue</button>
+                  <button type="button" class="button button--ghost" data-totp-refresh>Generate new secret</button>
+                  <button type="button" class="button button--secondary" data-logout>Sign out</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  </section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script type="module" src="{{ static_url('/static/js/totp_enrol.js') }}"></script>
+{% endblock %}

--- a/docs/wiki/getting-started/Overview.md
+++ b/docs/wiki/getting-started/Overview.md
@@ -10,7 +10,7 @@ There are no default login credentials; the first visit will prompt you to regis
 
 - Session-based authentication with secure cookies and sliding expiration
 - Built-in rate limiting, CSRF protection, and password reset flows
-- Optional TOTP multi-factor authentication with QR-code provisioning
+- Mandatory TOTP multi-factor authentication enrolment for every user with setup-link provisioning
 - Business information summary tab to confirm the logged-in company
 - Licenses tab showing license name, SKU, count, allocated staff, expiry date and contract term
 - Centralised company membership management with reusable roles and real-time audit logging
@@ -330,9 +330,9 @@ All authentication routes are documented in the interactive Swagger UI and summa
 - `POST /auth/password/reset` – Validates the token and updates the user password with bcrypt hashing.
 - `POST /auth/password/change` – Allows an authenticated user to rotate their password after validating the current credential.
 - `GET /auth/totp` – Lists active TOTP authenticators for the current user.
-- `POST /auth/totp/setup` – Generates a pending TOTP secret and provisioning URI for enrolment.
+- `POST /auth/totp/setup` – Generates a pending TOTP secret and provisioning URI for mandatory enrolment.
 - `POST /auth/totp/verify` – Confirms the authenticator code and persists it for future logins.
-- `DELETE /auth/totp/{id}` – Removes an existing authenticator.
+- `DELETE /auth/totp/{id}` – Removes an existing authenticator when another authenticator remains on the account.
 
 ## API Key Management
 

--- a/tests/test_totp_enrollment_enforcement.py
+++ b/tests/test_totp_enrollment_enforcement.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timedelta
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.api.dependencies import auth as auth_dependencies
+from app.security.session import SessionData
+
+
+def _request(path: str) -> Request:
+    return Request({"type": "http", "method": "GET", "path": path, "headers": []})
+
+
+def _session() -> SessionData:
+    now = datetime.utcnow()
+    return SessionData(
+        id=1,
+        user_id=42,
+        session_token="session-token",
+        csrf_token="csrf-token",
+        created_at=now,
+        expires_at=now + timedelta(hours=1),
+        last_seen_at=now,
+        ip_address="127.0.0.1",
+        user_agent="pytest",
+    )
+
+
+def test_get_current_user_blocks_non_enrolment_api_without_totp(monkeypatch):
+    async def fake_get_user_by_id(user_id):
+        return {"id": user_id, "email": "user@example.com"}
+
+    async def fake_has_totp(user_id):
+        return False
+
+    monkeypatch.setattr(auth_dependencies.user_repo, "get_user_by_id", fake_get_user_by_id)
+    monkeypatch.setattr(auth_dependencies.auth_repo, "user_has_totp_authenticator", fake_has_totp)
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(auth_dependencies.get_current_user(_request("/api/tickets"), _session()))
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.headers == {"X-MyPortal-2FA-Enrolment-Required": "true"}
+    assert "Two-factor authentication enrolment is required" in exc_info.value.detail
+
+
+def test_get_current_user_allows_totp_setup_api_without_totp(monkeypatch):
+    async def fake_get_user_by_id(user_id):
+        return {"id": user_id, "email": "user@example.com"}
+
+    async def fail_if_checked(user_id):  # pragma: no cover - assertion helper
+        raise AssertionError("TOTP enrolment endpoints must remain reachable")
+
+    monkeypatch.setattr(auth_dependencies.user_repo, "get_user_by_id", fake_get_user_by_id)
+    monkeypatch.setattr(auth_dependencies.auth_repo, "user_has_totp_authenticator", fail_if_checked)
+
+    user = asyncio.run(auth_dependencies.get_current_user(_request("/auth/totp/setup"), _session()))
+
+    assert user["id"] == 42


### PR DESCRIPTION
### Motivation
- Raise the account security baseline by requiring every authenticated user to enroll at least one TOTP authenticator before using non-enrolment endpoints. 
- Keep TOTP setup and recovery flows reachable so users can complete enrolment without being blocked. 

### Description
- Enforce enrolment in the request-authorisation layer by updating `get_current_user` to block requests to non-exempt paths when the user has no TOTP device and return a 403 with header `X-MyPortal-2FA-Enrolment-Required`. (See `app/api/dependencies/auth.py`.)
- Add TOTP helper functions `count_totp_authenticators` and `user_has_totp_authenticator` in `app/repositories/auth.py` and prevent deleting the last authenticator in the TOTP delete route. (See `app/repositories/auth.py` and `app/api/routes/auth.py`.)
- Send enrolment hints in auth responses by extending `LoginResponse` with `requires_totp_enrollment` and `redirect`, and update login/register flows to set these when needed. (See `app/schemas/auth.py` and `app/api/routes/auth.py`.)
- Add a dedicated enrolment workflow and UI: a `/security/2fa` page, Jinja template `auth/totp_enrol.html`, and client script `app/static/js/totp_enrol.js` to generate a secret (`/auth/totp/setup`), verify code (`/auth/totp/verify`), refresh the setup secret, copy setup values and sign out if desired. (See `app/main.py`, `app/templates/auth/totp_enrol.html`, and `app/static/js/totp_enrol.js`.)
- Update docs to reflect mandatory enrolment and add a regression test that verifies enforcement and the exemption for the TOTP setup endpoints. (See `docs/wiki/getting-started/Overview.md` and `tests/test_totp_enrollment_enforcement.py`.)

### Testing
- Ran the new regression test with `python -m pytest tests/test_totp_enrollment_enforcement.py -q` and it passed (`2 passed`).
- Performed static compile checks with `python -m py_compile app/api/dependencies/auth.py app/api/routes/auth.py app/repositories/auth.py app/schemas/auth.py app/main.py` and they succeeded. 
- Verified repository formatting checks with `git diff --check` which reported no issues. 
- Attempted to capture a UI screenshot, but Playwright is not installed in the environment so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2bb3169690832da65fc92941427f4e)