### PR TITLE
Add Matrix AI Waiting Assistant (Ollama) with queuing, analysis, UI and worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -430,3 +430,16 @@ GITHUB_TOKEN=
 # GitHub repository (owner/name) that hosts the tray MSI release asset.
 # Defaults to bradhawkins85/MyPortal; override only if using a fork.
 GITHUB_TRAY_MSI_REPO=bradhawkins85/MyPortal
+
+# Matrix Bot AI Waiting Assistant
+# Sends limited automated assistance while users wait for an assigned technician.
+MATRIXBOT_AI_WAITING_ASSISTANT_ENABLED=false
+MATRIXBOT_AI_OLLAMA_ENABLED=false
+MATRIXBOT_AI_OLLAMA_URL=http://127.0.0.1:11434
+MATRIXBOT_AI_OLLAMA_MODEL=llama3
+MATRIXBOT_AI_RESPONSE_DELAY_MINUTES=5
+MATRIXBOT_AI_MAX_RESPONSES=2
+MATRIXBOT_AI_KB_CONFIDENCE_THRESHOLD=50
+MATRIXBOT_AI_QUEUE_RETRY_MINUTES=5
+MATRIXBOT_AI_QUEUE_TIMEOUT_MINUTES=60
+MATRIXBOT_AI_SHOW_MATCH_TAGS=true

--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -22,6 +22,7 @@ from app.services import chat_ticket_sync
 from app.services import tray_chat_notifications
 from app.services import matrix as matrix_service
 from app.services import matrix_admin
+from app.services import matrix_ai_waiting_assistant
 from app.services.realtime import refresh_notifier
 from app.services.sanitization import sanitize_rich_text
 
@@ -208,6 +209,8 @@ async def send_message(
     )
 
     await chat_repo.update_room(room_id, last_message_at=now)
+    if not (current_user.get("is_super_admin") or current_user.get("is_helpdesk_technician")):
+        await matrix_ai_waiting_assistant.handle_user_message(room_id, now)
 
     try:
         await chat_ticket_sync.sync_chat_message_to_ticket(
@@ -307,6 +310,7 @@ async def join_room(
     # Auto-assign this tech if the room has no assigned technician yet
     if not room.get("assigned_tech_user_id"):
         await chat_repo.assign_tech(room_id, user_id)
+        await matrix_ai_waiting_assistant.handle_technician_takeover(room_id, user_id)
 
     await audit_service.log_action(
         action="join",
@@ -342,6 +346,7 @@ async def assign_room(
         raise HTTPException(status_code=409, detail="Room is already assigned to another technician")
 
     await chat_repo.reassign_tech(room_id, user_id)
+    await matrix_ai_waiting_assistant.handle_technician_takeover(room_id, user_id)
 
     tech_mxid = current_user.get("matrix_user_id") or ""
     bot_mxid = _settings.matrix_bot_user_id or ""
@@ -392,6 +397,7 @@ async def close_room(
         raise HTTPException(status_code=403, detail="Not authorized to close this room")
 
     await chat_repo.update_room(room_id, status="closed", updated_at=datetime.utcnow())
+    await matrix_ai_waiting_assistant.handle_chat_closed(room_id)
 
     try:
         await matrix_service.send_message(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -334,6 +334,16 @@ class Settings(BaseSettings):
     matrix_default_room_preset: str = Field(default="private_chat", validation_alias="MATRIX_DEFAULT_ROOM_PRESET")
     matrix_e2ee_enabled: bool = Field(default=False, validation_alias="MATRIX_E2EE_ENABLED")
     matrix_invite_domain: str | None = Field(default=None, validation_alias="MATRIX_INVITE_DOMAIN")
+    matrixbot_ai_waiting_assistant_enabled: bool = Field(default=False, validation_alias="MATRIXBOT_AI_WAITING_ASSISTANT_ENABLED")
+    matrixbot_ai_ollama_enabled: bool = Field(default=False, validation_alias="MATRIXBOT_AI_OLLAMA_ENABLED")
+    matrixbot_ai_ollama_url: str | None = Field(default=None, validation_alias="MATRIXBOT_AI_OLLAMA_URL")
+    matrixbot_ai_ollama_model: str | None = Field(default=None, validation_alias="MATRIXBOT_AI_OLLAMA_MODEL")
+    matrixbot_ai_response_delay_minutes: int = Field(default=5, validation_alias="MATRIXBOT_AI_RESPONSE_DELAY_MINUTES", ge=1)
+    matrixbot_ai_max_responses: int = Field(default=2, validation_alias="MATRIXBOT_AI_MAX_RESPONSES", ge=0)
+    matrixbot_ai_kb_confidence_threshold: float = Field(default=50.0, validation_alias="MATRIXBOT_AI_KB_CONFIDENCE_THRESHOLD", ge=0, le=100)
+    matrixbot_ai_queue_retry_minutes: int = Field(default=5, validation_alias="MATRIXBOT_AI_QUEUE_RETRY_MINUTES", ge=1)
+    matrixbot_ai_queue_timeout_minutes: int = Field(default=60, validation_alias="MATRIXBOT_AI_QUEUE_TIMEOUT_MINUTES", ge=1)
+    matrixbot_ai_show_match_tags: bool = Field(default=True, validation_alias="MATRIXBOT_AI_SHOW_MATCH_TAGS")
 
     # IP Whitelisting Configuration
     ip_whitelist_enabled: bool = Field(
@@ -438,6 +448,9 @@ class Settings(BaseSettings):
         "matrix_enabled",
         "matrix_is_self_hosted",
         "matrix_e2ee_enabled",
+        "matrixbot_ai_waiting_assistant_enabled",
+        "matrixbot_ai_ollama_enabled",
+        "matrixbot_ai_show_match_tags",
         mode="before",
     )
     @classmethod

--- a/app/features/chat/routes.py
+++ b/app/features/chat/routes.py
@@ -136,6 +136,10 @@ async def chat_room_page(
     room_dict = dict(room)
     room_dict["assigned_tech_display_name"] = assigned_tech_display_name
     room_dict["creator_display_name"] = creator_display_name
+    if is_staff:
+        room_dict["ai_extracted_keywords_list"] = chat_repo.decode_ai_json_field(room.get("ai_extracted_keywords")) or []
+        room_dict["ai_matched_articles_list"] = chat_repo.decode_ai_json_field(room.get("ai_matched_articles")) or []
+        room_dict["ai_show_match_tags"] = settings.matrixbot_ai_show_match_tags
 
     main_module = _main()
     extra = {

--- a/app/main.py
+++ b/app/main.py
@@ -2733,9 +2733,10 @@ async def on_startup() -> None:
 
     await scheduler_service.start()
     if settings.matrix_enabled:
-        from app.services import matrix_sync
+        from app.services import matrix_sync, matrix_ai_waiting_assistant
         import asyncio as _asyncio
         _asyncio.create_task(matrix_sync.run_sync_loop())
+        _asyncio.create_task(matrix_ai_waiting_assistant.run_worker_loop())
 
     # Load feature packs.  Empty by default; populated as areas of the
     # app are migrated under ``app/features/`` in follow-up PRs.
@@ -2772,8 +2773,9 @@ async def on_shutdown() -> None:
     global _app_ready
     _app_ready = False
     if settings.matrix_enabled:
-        from app.services import matrix_sync
+        from app.services import matrix_sync, matrix_ai_waiting_assistant
         matrix_sync.stop_sync_loop()
+        matrix_ai_waiting_assistant.stop_worker_loop()
     if _feature_pack_watcher is not None:
         await _feature_pack_watcher.stop()
     await feature_registry.unload_all()

--- a/app/repositories/chat.py
+++ b/app/repositories/chat.py
@@ -116,6 +116,9 @@ async def create_room(
 _ROOM_UPDATABLE_FIELDS = frozenset({
     "status", "updated_at", "last_message_at", "subject", "linked_ticket_id",
     "assigned_tech_user_id",
+    "ai_bot_response_count", "ai_last_bot_response_at", "ai_last_analysis_at",
+    "ai_last_user_message_at", "ai_extracted_keywords", "ai_matched_articles",
+    "ai_last_confidence",
 })
 
 _INVITE_UPDATABLE_FIELDS = frozenset({
@@ -481,3 +484,165 @@ async def save_sync_state(next_batch: str) -> None:
                ON DUPLICATE KEY UPDATE next_batch = VALUES(next_batch), updated_at = VALUES(updated_at)""",
             (next_batch, now),
         )
+
+_AI_QUEUE_ACTIVE_STATUSES = ("queued", "processing")
+
+
+def _json_dumps(value: Any) -> str | None:
+    if value is None:
+        return None
+    import json
+    return json.dumps(value)
+
+
+def _json_loads(value: Any) -> Any:
+    if value in (None, ""):
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    import json
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return None
+
+
+async def mark_user_activity(room_id: int, when: datetime | None = None) -> None:
+    when = when or datetime.now(timezone.utc).replace(tzinfo=None)
+    await db.execute(
+        """UPDATE chat_rooms
+           SET last_message_at = %s, updated_at = %s, ai_last_user_message_at = %s
+           WHERE id = %s""",
+        (when, when, when, room_id),
+    )
+
+
+async def increment_ai_bot_response(room_id: int, when: datetime | None = None) -> None:
+    when = when or datetime.now(timezone.utc).replace(tzinfo=None)
+    await db.execute(
+        """UPDATE chat_rooms
+           SET ai_bot_response_count = COALESCE(ai_bot_response_count, 0) + 1,
+               ai_last_bot_response_at = %s,
+               updated_at = %s
+           WHERE id = %s""",
+        (when, when, room_id),
+    )
+
+
+async def update_ai_analysis(
+    room_id: int,
+    *,
+    extracted_keywords: list[str] | None = None,
+    matched_articles: list[dict[str, Any]] | None = None,
+    confidence: float | None = None,
+    analysed_at: datetime | None = None,
+) -> None:
+    analysed_at = analysed_at or datetime.now(timezone.utc).replace(tzinfo=None)
+    await db.execute(
+        """UPDATE chat_rooms
+           SET ai_extracted_keywords = %s,
+               ai_matched_articles = %s,
+               ai_last_confidence = %s,
+               ai_last_analysis_at = %s,
+               updated_at = %s
+           WHERE id = %s""",
+        (_json_dumps(extracted_keywords or []), _json_dumps(matched_articles or []), confidence, analysed_at, analysed_at, room_id),
+    )
+
+
+async def list_ai_waiting_candidate_rooms(due_before: datetime) -> list[dict[str, Any]]:
+    rows = await db.fetch_all(
+        """SELECT * FROM chat_rooms
+           WHERE status = 'open'
+             AND assigned_tech_user_id IS NULL
+             AND ai_last_user_message_at IS NOT NULL
+             AND ai_last_user_message_at <= %s
+             AND COALESCE(ai_bot_response_count, 0) < 100
+           ORDER BY ai_last_user_message_at ASC
+           LIMIT 250""",
+        (due_before,),
+    )
+    return [dict(r) for r in rows]
+
+
+async def create_ai_queue_item(
+    *,
+    chat_room_id: int,
+    queue_identifier: str,
+    expires_at: datetime,
+    next_attempt_at: datetime,
+    created_for_response_number: int = 2,
+    analysis_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    if db.is_sqlite():
+        await db.execute(
+            """INSERT OR IGNORE INTO matrix_ai_analysis_queue
+               (queue_identifier, chat_room_id, created_at, expires_at, status, next_attempt_at,
+                created_for_response_number, analysis_payload)
+               VALUES (?, ?, ?, ?, 'queued', ?, ?, ?)""",
+            (queue_identifier, chat_room_id, now, expires_at, next_attempt_at, created_for_response_number, _json_dumps(analysis_payload)),
+        )
+    else:
+        await db.execute(
+            """INSERT IGNORE INTO matrix_ai_analysis_queue
+               (queue_identifier, chat_room_id, created_at, expires_at, status, next_attempt_at,
+                created_for_response_number, analysis_payload)
+               VALUES (%s, %s, %s, %s, 'queued', %s, %s, %s)""",
+            (queue_identifier, chat_room_id, now, expires_at, next_attempt_at, created_for_response_number, _json_dumps(analysis_payload)),
+        )
+    row = await db.fetch_one("SELECT * FROM matrix_ai_analysis_queue WHERE queue_identifier = %s", (queue_identifier,))
+    return dict(row) if row else {}
+
+
+async def get_active_ai_queue_item(chat_room_id: int) -> dict[str, Any] | None:
+    row = await db.fetch_one(
+        """SELECT * FROM matrix_ai_analysis_queue
+           WHERE chat_room_id = %s AND status IN ('queued','processing')
+           ORDER BY created_at DESC LIMIT 1""",
+        (chat_room_id,),
+    )
+    return dict(row) if row else None
+
+
+async def list_due_ai_queue_items(due_before: datetime, limit: int = 25) -> list[dict[str, Any]]:
+    rows = await db.fetch_all(
+        """SELECT * FROM matrix_ai_analysis_queue
+           WHERE status IN ('queued','processing') AND next_attempt_at <= %s
+           ORDER BY next_attempt_at ASC LIMIT %s""",
+        (due_before, limit),
+    )
+    return [dict(r) for r in rows]
+
+
+async def update_ai_queue_item(queue_id: int, **fields: Any) -> None:
+    allowed = {"last_attempt_at", "retry_count", "status", "cancellation_reason", "next_attempt_at", "result_payload"}
+    invalid = set(fields) - allowed
+    if invalid:
+        raise ValueError(f"Cannot update matrix_ai_analysis_queue fields: {invalid}")
+    if "result_payload" in fields:
+        fields["result_payload"] = _json_dumps(fields["result_payload"])
+    set_clauses = ", ".join(f"{key} = %s" for key in fields)
+    await db.execute(f"UPDATE matrix_ai_analysis_queue SET {set_clauses} WHERE id = %s", tuple(fields.values()) + (queue_id,))
+
+
+async def cancel_active_ai_queue_for_room(chat_room_id: int, reason: str) -> None:
+    await db.execute(
+        """UPDATE matrix_ai_analysis_queue
+           SET status = 'cancelled', cancellation_reason = %s
+           WHERE chat_room_id = %s AND status IN ('queued','processing')""",
+        (reason[:255], chat_room_id),
+    )
+
+
+def decode_ai_json_field(value: Any) -> Any:
+    return _json_loads(value)
+
+
+async def cancel_all_active_ai_queue(reason: str) -> None:
+    await db.execute(
+        """UPDATE matrix_ai_analysis_queue
+           SET status = 'cancelled', cancellation_reason = %s
+           WHERE status IN ('queued','processing')""",
+        (reason[:255],),
+    )

--- a/app/services/matrix_ai_waiting_assistant.py
+++ b/app/services/matrix_ai_waiting_assistant.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+from urllib.parse import urljoin
+
+import bleach
+import httpx
+
+from app.core.config import get_settings
+from app.core.logging import log_error
+from app.repositories import chat as chat_repo
+from app.repositories import knowledge_base as kb_repo
+from app.services import audit as audit_service
+from app.services import matrix as matrix_service
+from app.services.realtime import refresh_notifier
+
+_running = False
+_stop = False
+_WORD_RE = re.compile(r"[a-zA-Z0-9][a-zA-Z0-9._/-]{2,}")
+_ACK_MESSAGE = "Thanks — your request has been received. A technician will be assigned shortly."
+_AI_DISCLAIMER = "This recommendation was generated using AI and may not apply to your specific issue."
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _as_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value.replace(tzinfo=None) if value.tzinfo else value
+    if isinstance(value, str) and value.strip():
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+        except ValueError:
+            return None
+    return None
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+def _enabled() -> bool:
+    settings = get_settings()
+    return bool(
+        settings.matrix_enabled
+        and settings.matrixbot_ai_waiting_assistant_enabled
+        and settings.matrixbot_ai_ollama_enabled
+        and (settings.matrixbot_ai_ollama_url or settings.matrixbot_ai_ollama_model)
+        and settings.matrixbot_ai_max_responses > 0
+    )
+
+
+def _normalise_tags(tags: list[Any]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for tag in tags:
+        text = str(tag or "").strip().lower()
+        if not text or text in seen or len(text) > 80:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result[:40]
+
+
+def _extract_json_object(text: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(text)
+        return parsed if isinstance(parsed, dict) else {}
+    except json.JSONDecodeError:
+        pass
+    start = text.find("{")
+    end = text.rfind("}")
+    if start >= 0 and end > start:
+        try:
+            parsed = json.loads(text[start : end + 1])
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+async def _ollama_generate(prompt: str, *, json_format: bool = False) -> str:
+    settings = get_settings()
+    base_url = (settings.matrixbot_ai_ollama_url or "http://127.0.0.1:11434").rstrip("/")
+    model = (settings.matrixbot_ai_ollama_model or "llama3").strip()
+    body: dict[str, Any] = {"model": model, "prompt": prompt, "stream": False}
+    if json_format:
+        body["format"] = "json"
+    async with httpx.AsyncClient(timeout=45) as client:
+        response = await client.post(urljoin(f"{base_url}/", "api/generate"), json=body)
+    response.raise_for_status()
+    payload = response.json()
+    return str(payload.get("response") or "").strip()
+
+
+async def _chat_transcript(room_id: int) -> str:
+    messages = await chat_repo.get_messages(room_id, limit=200)
+    lines: list[str] = []
+    for msg in messages:
+        body = bleach.clean(str(msg.get("body") or ""), tags=[], strip=True)
+        if not body.strip():
+            continue
+        sender = msg.get("sender_display_name") or msg.get("sender_matrix_id") or "Participant"
+        lines.append(f"{sender}: {' '.join(body.split())}")
+    return "\n".join(lines)[-12000:]
+
+
+async def _extract_keywords(transcript: str) -> list[str]:
+    prompt = f"""Extract keywords, products, technologies, error messages, categories, and other concepts from this support chat.
+Return JSON only with a key named keywords containing an array of lowercase strings. Do not include personal names, email addresses, phone numbers, or secrets.
+
+Chat transcript:
+{transcript}
+"""
+    text = await _ollama_generate(prompt, json_format=True)
+    data = _extract_json_object(text)
+    keywords = data.get("keywords") if isinstance(data, dict) else []
+    if isinstance(keywords, list):
+        parsed = _normalise_tags(keywords)
+        if parsed:
+            return parsed
+    return _normalise_tags(_WORD_RE.findall(transcript.lower()))[:20]
+
+
+async def _article_relevant(transcript: str, article: Mapping[str, Any]) -> bool:
+    content = bleach.clean(str(article.get("content") or ""), tags=[], strip=True)
+    prompt = f"""Decide whether this knowledge base article is genuinely relevant to the user's support issue.
+Return JSON only: {{"relevant": true}} or {{"relevant": false}}.
+
+Support chat:
+{transcript[:6000]}
+
+Article title: {article.get('title') or ''}
+Article summary: {article.get('summary') or ''}
+Article content excerpt: {content[:5000]}
+"""
+    text = await _ollama_generate(prompt, json_format=True)
+    data = _extract_json_object(text)
+    return bool(data.get("relevant"))
+
+
+async def _summarise_article(article: Mapping[str, Any]) -> str:
+    content = bleach.clean(str(article.get("content") or ""), tags=[], strip=True)
+    prompt = f"""Summarize this knowledge base article in plain language for a user waiting for support.
+Use no more than three concise sentences. Focus on the article purpose or resolution steps.
+
+Title: {article.get('title') or ''}
+Summary: {article.get('summary') or ''}
+Content: {content[:6000]}
+"""
+    summary = await _ollama_generate(prompt)
+    sentences = re.split(r"(?<=[.!?])\s+", " ".join(summary.split()))
+    return " ".join(sentences[:3]).strip()[:900]
+
+
+async def _audit(action: str, room_id: int, value: Mapping[str, Any] | None = None) -> None:
+    try:
+        await audit_service.log_action(
+            action=action,
+            entity_type="chat_room",
+            entity_id=room_id,
+            user_id=None,
+            new_value=dict(value or {}),
+        )
+    except Exception as exc:
+        log_error("AI waiting assistant audit failed", action=action, room_id=room_id, error=str(exc))
+
+
+async def _send_bot_message(room: Mapping[str, Any], body: str) -> bool:
+    try:
+        response = await matrix_service.send_message(str(room["matrix_room_id"]), body)
+        event_id = response.get("event_id")
+    except Exception as exc:
+        log_error("AI waiting assistant Matrix send failed", room_id=room.get("id"), error=str(exc))
+        return False
+    now = _utcnow()
+    msg = await chat_repo.add_message(
+        room_id=int(room["id"]),
+        matrix_event_id=event_id,
+        sender_matrix_id=get_settings().matrix_bot_user_id or "@myportal-ai-waiting-assistant",
+        body=body,
+        sender_user_id=None,
+        sender_display_name="AI Waiting Assistant",
+        sent_at=now,
+    )
+    await chat_repo.increment_ai_bot_response(int(room["id"]), now)
+    await refresh_notifier.broadcast_refresh(
+        topics=[f"chat:room:{int(room['id'])}"],
+        data={"message": _json_safe({**msg, "sent_at": now.isoformat()}), "room_id": int(room["id"])},
+    )
+    return True
+
+
+async def handle_user_message(room_id: int, sent_at: datetime | None = None) -> None:
+    await chat_repo.mark_user_activity(room_id, sent_at)
+    await chat_repo.cancel_active_ai_queue_for_room(room_id, "new_user_message_timer_reset")
+    await _audit("matrix_ai_waiting_assistant.user_activity", room_id)
+
+
+async def handle_technician_takeover(room_id: int, user_id: int | None = None) -> None:
+    await chat_repo.cancel_active_ai_queue_for_room(room_id, "technician_assigned")
+    await _audit("matrix_ai_waiting_assistant.technician_takeover", room_id, {"user_id": user_id})
+
+
+async def handle_chat_closed(room_id: int) -> None:
+    await chat_repo.cancel_active_ai_queue_for_room(room_id, "chat_closed")
+    await _audit("matrix_ai_waiting_assistant.queue_cancelled", room_id, {"reason": "chat_closed"})
+
+
+async def _eligible_room(room: Mapping[str, Any]) -> bool:
+    if not _enabled():
+        return False
+    if room.get("status") != "open" or room.get("assigned_tech_user_id"):
+        return False
+    return int(room.get("ai_bot_response_count") or 0) < get_settings().matrixbot_ai_max_responses
+
+
+async def scan_waiting_rooms_once() -> None:
+    if not _enabled():
+        return
+    settings = get_settings()
+    due_before = _utcnow() - timedelta(minutes=settings.matrixbot_ai_response_delay_minutes)
+    rooms = await chat_repo.list_ai_waiting_candidate_rooms(due_before)
+    for room in rooms:
+        if not await _eligible_room(room):
+            continue
+        count = int(room.get("ai_bot_response_count") or 0)
+        if count == 0:
+            if await _send_bot_message(room, _ACK_MESSAGE):
+                await _audit("matrix_ai_waiting_assistant.acknowledgement_sent", int(room["id"]))
+            continue
+        if count == 1 and settings.matrixbot_ai_max_responses >= 2:
+            active = await chat_repo.get_active_ai_queue_item(int(room["id"]))
+            if active:
+                continue
+            now = _utcnow()
+            queue = await chat_repo.create_ai_queue_item(
+                chat_room_id=int(room["id"]),
+                queue_identifier=uuid.uuid4().hex,
+                expires_at=now + timedelta(minutes=settings.matrixbot_ai_queue_timeout_minutes),
+                next_attempt_at=now,
+                created_for_response_number=2,
+            )
+            await _audit("matrix_ai_waiting_assistant.analysis_queued", int(room["id"]), {"queue_id": queue.get("id")})
+
+
+async def _process_queue_item(item: Mapping[str, Any]) -> None:
+    room_id = int(item["chat_room_id"])
+    room = await chat_repo.get_room(room_id)
+    settings = get_settings()
+    now = _utcnow()
+    if not room or not await _eligible_room(room):
+        await chat_repo.update_ai_queue_item(int(item["id"]), status="cancelled", cancellation_reason="room_no_longer_eligible")
+        await _audit("matrix_ai_waiting_assistant.queue_cancelled", room_id, {"reason": "room_no_longer_eligible"})
+        return
+    expires_at = _as_datetime(item.get("expires_at"))
+    if expires_at and expires_at <= now:
+        await chat_repo.update_ai_queue_item(int(item["id"]), status="timed_out", cancellation_reason="maximum_lifetime_exceeded")
+        await _audit("matrix_ai_waiting_assistant.queue_timed_out", room_id, {"queue_id": item.get("id")})
+        return
+    await chat_repo.update_ai_queue_item(int(item["id"]), status="processing", last_attempt_at=now, retry_count=int(item.get("retry_count") or 0) + 1)
+    await _audit("matrix_ai_waiting_assistant.analysis_requested", room_id, {"queue_id": item.get("id")})
+    try:
+        transcript = await _chat_transcript(room_id)
+        keywords = await _extract_keywords(transcript)
+        keyword_set = set(keywords)
+        candidates: list[dict[str, Any]] = []
+        for article in await kb_repo.list_articles(include_unpublished=False):
+            tags = _normalise_tags(article.get("ai_tags") or [])
+            if not tags:
+                continue
+            matched = sorted(keyword_set & set(tags))
+            confidence = (len(matched) / len(tags)) * 100 if tags else 0.0
+            if confidence >= settings.matrixbot_ai_kb_confidence_threshold:
+                relevant = await _article_relevant(transcript, article)
+                candidates.append({
+                    "id": article.get("id"), "slug": article.get("slug"), "title": article.get("title"),
+                    "article_tags": tags, "matched_tags": matched, "confidence": round(confidence, 2),
+                    "semantic_relevant": relevant, "sent": False, "analysed_at": now.isoformat(),
+                })
+        eligible = [c for c in candidates if c["semantic_relevant"]]
+        eligible.sort(key=lambda c: c["confidence"], reverse=True)
+        sent = False
+        if eligible and int(room.get("ai_bot_response_count") or 0) < settings.matrixbot_ai_max_responses:
+            already = chat_repo.decode_ai_json_field(room.get("ai_matched_articles")) or []
+            sent_ids = {str(a.get("id") or a.get("slug")) for a in already if a.get("sent")}
+            selected = next((c for c in eligible if str(c.get("id") or c.get("slug")) not in sent_ids), None)
+            if selected:
+                article = await kb_repo.get_article_by_id(int(selected["id"]))
+                if article:
+                    summary = await _summarise_article(article)
+                    base = str(settings.public_base_url or settings.portal_url or "").rstrip("/")
+                    path = f"/knowledge-base/articles/{article['slug']}"
+                    link = f"{base}{path}" if base else path
+                    message = f"While you wait, this article may help: {article['title']}\n{link}\n\n{summary}\n\n{_AI_DISCLAIMER}"
+                    if await _send_bot_message(room, message):
+                        selected["sent"] = True
+                        selected["sent_at"] = _utcnow().isoformat()
+                        sent = True
+                        await _audit("matrix_ai_waiting_assistant.article_recommendation_sent", room_id, selected)
+        latest_confidence = eligible[0]["confidence"] if eligible else (max((c["confidence"] for c in candidates), default=None))
+        await chat_repo.update_ai_analysis(room_id, extracted_keywords=keywords, matched_articles=candidates, confidence=latest_confidence)
+        await chat_repo.update_ai_queue_item(int(item["id"]), status="completed", result_payload={"keywords": keywords, "matches": candidates, "sent": sent})
+        await _audit("matrix_ai_waiting_assistant.analysis_completed", room_id, {"matches": len(candidates), "sent": sent})
+    except Exception as exc:
+        log_error("AI waiting assistant Ollama analysis failed", room_id=room_id, error=str(exc))
+        retry_at = now + timedelta(minutes=settings.matrixbot_ai_queue_retry_minutes)
+        if expires_at and retry_at >= expires_at:
+            await chat_repo.update_ai_queue_item(int(item["id"]), status="timed_out", cancellation_reason="ollama_unavailable_timeout")
+            await _audit("matrix_ai_waiting_assistant.queue_timed_out", room_id, {"error": str(exc)[:200]})
+        else:
+            await chat_repo.update_ai_queue_item(int(item["id"]), status="queued", next_attempt_at=retry_at)
+            await _audit("matrix_ai_waiting_assistant.ollama_retry_queued", room_id, {"error": str(exc)[:200], "retry_at": retry_at.isoformat()})
+
+
+async def process_queue_once() -> None:
+    if not _enabled():
+        return
+    due = await chat_repo.list_due_ai_queue_items(_utcnow(), limit=25)
+    await asyncio.gather(*(_process_queue_item(item) for item in due))
+
+
+async def run_worker_loop() -> None:
+    global _running, _stop
+    if _running:
+        return
+    _running = True
+    _stop = False
+    try:
+        while not _stop:
+            try:
+                if not _enabled():
+                    await chat_repo.cancel_all_active_ai_queue("feature_or_ollama_disabled")
+                    await asyncio.sleep(60)
+                    continue
+                await scan_waiting_rooms_once()
+                await process_queue_once()
+            except Exception as exc:
+                log_error("AI waiting assistant worker error", error=str(exc))
+            await asyncio.sleep(60)
+    finally:
+        _running = False
+
+
+def stop_worker_loop() -> None:
+    global _stop
+    _stop = True

--- a/app/services/matrix_sync.py
+++ b/app/services/matrix_sync.py
@@ -10,6 +10,7 @@ from app.repositories import chat as chat_repo
 from app.services import matrix as matrix_service
 from app.services import chat_ticket_sync
 from app.services import tray_chat_notifications
+from app.services import matrix_ai_waiting_assistant
 
 _settings = get_settings()
 _running = False
@@ -72,6 +73,12 @@ async def process_sync_response(sync_data: dict[str, Any]) -> None:
             )
 
             await chat_repo.update_room(room["id"], last_message_at=sent_at, updated_at=sent_at)
+            participants = await chat_repo.get_participants(room["id"])
+            participant = next((p for p in participants if p.get("matrix_user_id") == sender), None)
+            sender_role = (participant or {}).get("role")
+            is_waiting_user = sender != (_settings.matrix_bot_user_id or "") and sender_role not in ("technician", "admin")
+            if is_waiting_user:
+                await matrix_ai_waiting_assistant.handle_user_message(room["id"], sent_at)
             await tray_chat_notifications.notify_tray_device_of_chat_message(
                 room=room,
                 message=message,

--- a/app/templates/admin/knowledge_base.html
+++ b/app/templates/admin/knowledge_base.html
@@ -42,6 +42,7 @@
             <th scope="col" data-sort="string" data-column-key="title">Title</th>
             <th scope="col" data-sort="string" data-column-key="scope">Scope</th>
             <th scope="col" data-sort="string" data-column-key="status">Status</th>
+            <th scope="col" data-sort="string" data-column-key="ai-tags">AI tags</th>
             <th scope="col" data-sort="date" data-column-key="updated">Updated</th>
           </tr>
         </thead>
@@ -73,13 +74,16 @@
                 <span class="status status--warning">Draft</span>
               {% endif %}
             </td>
+            <td data-label="AI tags" data-value="{{ (article.ai_tags or []) | join(', ') }}" data-column-key="ai-tags">
+              {% for tag in article.ai_tags or [] %}<span class="tag tag--muted">{{ tag }}</span>{% else %}<span class="text-muted">—</span>{% endfor %}
+            </td>
             <td data-label="Updated" data-value="{{ article.updated_at_iso or '' }}" data-column-key="updated">
               <span data-utc="{{ article.updated_at_iso or '' }}">{{ article.updated_at_iso or '—' }}</span>
             </td>
           </tr>
           {% else %}
           <tr>
-            <td colspan="4" class="table__empty">No knowledge base articles are available yet.</td>
+            <td colspan="5" class="table__empty">No knowledge base articles are available yet.</td>
           </tr>
           {% endfor %}
         </tbody>

--- a/app/templates/chat/room.html
+++ b/app/templates/chat/room.html
@@ -72,6 +72,53 @@
   {% endif %}
 </div>
 {% endif %}
+
+{% if room.ai_show_match_tags %}
+<section class="chat-ai-diagnostics card card--panel" aria-labelledby="chat-ai-diagnostics-title">
+  <div class="card__header">
+    <div>
+      <h2 class="card__title" id="chat-ai-diagnostics-title">AI Waiting Assistant analysis</h2>
+      <p class="card__subtitle">Technician-only visibility into extracted chat tags, article tag matches, confidence scoring, and sent recommendations.</p>
+    </div>
+  </div>
+  <div class="chat-ai-diagnostics__grid">
+    <div>
+      <strong>Extracted chat keywords</strong>
+      <div class="tag-list chat-ai-diagnostics__tags">
+        {% for keyword in room.ai_extracted_keywords_list %}<span class="tag">{{ keyword | e }}</span>{% endfor %}
+        {% if not room.ai_extracted_keywords_list %}<span class="card__empty">No AI keywords extracted yet.</span>{% endif %}
+      </div>
+    </div>
+    <dl class="chat-ai-diagnostics__stats">
+      <dt>Responses sent</dt><dd>{{ room.ai_bot_response_count or 0 }}</dd>
+      <dt>Last response</dt><dd>{% if room.ai_last_bot_response_at %}<span data-utc="{{ room.ai_last_bot_response_at }}">{{ room.ai_last_bot_response_at }}</span>{% else %}—{% endif %}</dd>
+      <dt>Last analysis</dt><dd>{% if room.ai_last_analysis_at %}<span data-utc="{{ room.ai_last_analysis_at }}">{{ room.ai_last_analysis_at }}</span>{% else %}—{% endif %}</dd>
+      <dt>Latest confidence</dt><dd>{% if room.ai_last_confidence is not none %}{{ '%.2f'|format(room.ai_last_confidence) }}%{% else %}—{% endif %}</dd>
+    </dl>
+  </div>
+  <div class="table-responsive">
+    <table class="table chat-ai-diagnostics__table">
+      <thead><tr><th>Suggested article</th><th>Confidence</th><th>Matched tags</th><th>Article tags</th><th>Semantic</th><th>Timestamp</th><th>Sent</th></tr></thead>
+      <tbody>
+        {% for match in room.ai_matched_articles_list %}
+        <tr>
+          <td>{% if match.slug %}<a href="/knowledge-base/articles/{{ match.slug }}" target="_blank" rel="noopener">{{ match.title or match.slug }}</a>{% else %}{{ match.title or 'Article #' ~ match.id }}{% endif %}</td>
+          <td>{{ '%.2f'|format(match.confidence or 0) }}%</td>
+          <td>{% for tag in match.matched_tags or [] %}<span class="tag tag--success">{{ tag | e }}</span>{% else %}—{% endfor %}</td>
+          <td>{% for tag in match.article_tags or [] %}<span class="tag tag--muted">{{ tag | e }}</span>{% else %}—{% endfor %}</td>
+          <td>{{ 'Relevant' if match.semantic_relevant else 'Not relevant' }}</td>
+          <td>{% if match.analysed_at %}<span data-utc="{{ match.analysed_at }}">{{ match.analysed_at }}</span>{% else %}—{% endif %}</td>
+          <td>{{ 'Yes' if match.sent else 'No' }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="7" class="card__empty">No article matches recorded yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endif %}
+
 <div class="chat-layout">
   <div class="chat-messages" id="chat-messages">
     {% for msg in messages %}
@@ -171,6 +218,13 @@
 .chat-meta-bar__link { color: #bfdbfe; font-weight: 600; text-decoration: none; }
 .chat-meta-bar__link:hover { text-decoration: underline; }
 .chat-layout { display: flex; flex-direction: column; height: calc(100vh - 12rem); }
+.chat-ai-diagnostics { margin: 0 0 1rem; }
+.chat-ai-diagnostics__grid { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 1rem; margin-bottom: 1rem; }
+.chat-ai-diagnostics__tags { margin-top: 0.5rem; }
+.chat-ai-diagnostics__stats { display: grid; grid-template-columns: auto auto; gap: 0.35rem 0.75rem; margin: 0; }
+.chat-ai-diagnostics__stats dt { font-weight: 700; color: var(--color-text-muted, #6b7280); }
+.chat-ai-diagnostics__table th, .chat-ai-diagnostics__table td { vertical-align: top; }
+@media (max-width: 800px) { .chat-ai-diagnostics__grid { grid-template-columns: 1fr; } }
 .chat-messages { flex: 1; overflow-y: auto; padding: 1rem; display: flex; flex-direction: column; gap: 0.75rem; }
 .chat-message { padding: 0.5rem 0.75rem; border-radius: 0.5rem; background: var(--color-surface-raised, #f8fafc); max-width: 80%; color: var(--color-text, #111827); }
 .chat-message--self { align-self: flex-end; background: var(--color-primary-subtle, #eff6ff); }

--- a/migrations/269_matrix_ai_waiting_assistant.sql
+++ b/migrations/269_matrix_ai_waiting_assistant.sql
@@ -1,0 +1,30 @@
+-- Matrix Bot AI Waiting Assistant
+-- Tracks waiting-assistant state on chat rooms and persists Ollama analysis work.
+
+ALTER TABLE chat_rooms ADD COLUMN IF NOT EXISTS ai_bot_response_count INT NOT NULL DEFAULT 0;
+ALTER TABLE chat_rooms ADD COLUMN IF NOT EXISTS ai_last_bot_response_at DATETIME NULL;
+ALTER TABLE chat_rooms ADD COLUMN IF NOT EXISTS ai_last_analysis_at DATETIME NULL;
+ALTER TABLE chat_rooms ADD COLUMN IF NOT EXISTS ai_last_user_message_at DATETIME NULL;
+ALTER TABLE chat_rooms ADD COLUMN IF NOT EXISTS ai_extracted_keywords JSON NULL;
+ALTER TABLE chat_rooms ADD COLUMN IF NOT EXISTS ai_matched_articles JSON NULL;
+ALTER TABLE chat_rooms ADD COLUMN IF NOT EXISTS ai_last_confidence DECIMAL(5,2) NULL;
+
+CREATE TABLE IF NOT EXISTS matrix_ai_analysis_queue (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  queue_identifier VARCHAR(64) NOT NULL UNIQUE,
+  chat_room_id INT NOT NULL,
+  created_at DATETIME NOT NULL,
+  last_attempt_at DATETIME NULL,
+  retry_count INT NOT NULL DEFAULT 0,
+  expires_at DATETIME NOT NULL,
+  status ENUM('queued','processing','completed','cancelled','timed_out','failed') NOT NULL DEFAULT 'queued',
+  cancellation_reason VARCHAR(255) NULL,
+  next_attempt_at DATETIME NOT NULL,
+  created_for_response_number INT NOT NULL DEFAULT 2,
+  analysis_payload JSON NULL,
+  result_payload JSON NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_matrix_ai_queue_room_status ON matrix_ai_analysis_queue (chat_room_id, status);
+CREATE INDEX IF NOT EXISTS idx_matrix_ai_queue_due ON matrix_ai_analysis_queue (status, next_attempt_at, expires_at);
+CREATE INDEX IF NOT EXISTS idx_chat_rooms_ai_waiting ON chat_rooms (status, assigned_tech_user_id, ai_last_user_message_at, ai_bot_response_count);

--- a/tests/services/test_matrix_ai_waiting_assistant.py
+++ b/tests/services/test_matrix_ai_waiting_assistant.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import asyncio
+
+from app.services import matrix_ai_waiting_assistant as assistant
+
+
+def test_extract_keywords_uses_ollama_json(monkeypatch):
+    async def fake_generate(prompt: str, *, json_format: bool = False) -> str:
+        assert json_format is True
+        assert "Chat transcript" in prompt
+        return '{"keywords":["Windows 11", "VPN", "vpn", "", "Error 809"]}'
+
+    monkeypatch.setattr(assistant, "_ollama_generate", fake_generate)
+
+    keywords = asyncio.run(assistant._extract_keywords("User: VPN fails with Error 809 on Windows 11"))
+
+    assert keywords == ["windows 11", "vpn", "error 809"]
+
+
+def test_scan_waiting_rooms_sends_ack_before_analysis(monkeypatch):
+    settings = SimpleNamespace(
+        matrix_enabled=True,
+        matrixbot_ai_waiting_assistant_enabled=True,
+        matrixbot_ai_ollama_enabled=True,
+        matrixbot_ai_ollama_url="http://ollama.test",
+        matrixbot_ai_ollama_model="llama3",
+        matrixbot_ai_max_responses=2,
+        matrixbot_ai_response_delay_minutes=5,
+    )
+    sent: list[str] = []
+    queued: list[int] = []
+
+    monkeypatch.setattr(assistant, "get_settings", lambda: settings)
+    async def fake_list(due_before):
+        return [{"id": 42, "status": "open", "assigned_tech_user_id": None, "ai_bot_response_count": 0}]
+
+    monkeypatch.setattr(assistant.chat_repo, "list_ai_waiting_candidate_rooms", fake_list)
+
+    async def fake_send(room, body):
+        sent.append(body)
+        return True
+
+    async def fake_active(room_id):
+        queued.append(room_id)
+        return None
+
+    monkeypatch.setattr(assistant, "_send_bot_message", fake_send)
+    async def fake_audit(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(assistant, "_audit", fake_audit)
+    monkeypatch.setattr(assistant.chat_repo, "get_active_ai_queue_item", fake_active)
+
+    asyncio.run(assistant.scan_waiting_rooms_once())
+
+    assert sent == [assistant._ACK_MESSAGE]
+    assert queued == []
+
+
+def test_scan_waiting_rooms_queues_second_response_analysis(monkeypatch):
+    settings = SimpleNamespace(
+        matrix_enabled=True,
+        matrixbot_ai_waiting_assistant_enabled=True,
+        matrixbot_ai_ollama_enabled=True,
+        matrixbot_ai_ollama_url="http://ollama.test",
+        matrixbot_ai_ollama_model="llama3",
+        matrixbot_ai_max_responses=2,
+        matrixbot_ai_response_delay_minutes=5,
+        matrixbot_ai_queue_timeout_minutes=60,
+    )
+    created: list[dict] = []
+
+    monkeypatch.setattr(assistant, "get_settings", lambda: settings)
+    async def fake_list(due_before):
+        return [{"id": 42, "status": "open", "assigned_tech_user_id": None, "ai_bot_response_count": 1}]
+
+    async def fake_active(room_id):
+        return None
+
+    monkeypatch.setattr(assistant.chat_repo, "list_ai_waiting_candidate_rooms", fake_list)
+    monkeypatch.setattr(assistant.chat_repo, "get_active_ai_queue_item", fake_active)
+
+    async def fake_create(**kwargs):
+        created.append(kwargs)
+        return {"id": 7}
+
+    monkeypatch.setattr(assistant.chat_repo, "create_ai_queue_item", fake_create)
+    async def fake_audit(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(assistant, "_audit", fake_audit)
+
+    asyncio.run(assistant.scan_waiting_rooms_once())
+
+    assert created[0]["chat_room_id"] == 42
+    assert created[0]["created_for_response_number"] == 2


### PR DESCRIPTION
### Motivation

- Provide limited automated assistance to users waiting in Matrix chat rooms by suggesting relevant knowledge-base articles using an Ollama model.
- Persist AI analysis and manage a retryable queue so recommendations are rate-limited and cancellable when a technician takes over or the chat closes. 
- Surface AI diagnostics to technicians and allow tagging/searchability of KB articles for better matching.

### Description

- Added configuration and environment variables for the feature and Ollama integration (`MATRIXBOT_AI_*` in `.env.example`) and corresponding `Settings` fields in `app/core/config.py` such as `matrixbot_ai_waiting_assistant_enabled`, `matrixbot_ai_ollama_url`, `matrixbot_ai_response_delay_minutes`, and others.
- Implemented a new worker service in `app/services/matrix_ai_waiting_assistant.py` that scans waiting rooms, sends an acknowledgement, queues analysis work, calls Ollama for keyword extraction/validation/summary, persists results, and posts article recommendations to Matrix; the worker is started/stopped from `app/main.py` and exposes handlers: `handle_user_message`, `handle_technician_takeover`, and `handle_chat_closed`.
- Extended `app/repositories/chat.py` with AI-related columns and APIs (ai fields, queue CRUD and helpers like `create_ai_queue_item`, `list_ai_waiting_candidate_rooms`, `update_ai_analysis`, `increment_ai_bot_response`, and helpers to cancel or list queue items) and added JSON helpers.
- Added DB migration `migrations/269_matrix_ai_waiting_assistant.sql` to add `chat_rooms` AI columns and create the `matrix_ai_analysis_queue` table and indexes.
- Integrated runtime hooks so chat operations call the assistant: `send_message`, `join_room`, `assign_room`, and `close_room` in `app/api/routes/chat.py` now notify the assistant, and `app/services/matrix_sync.py` updates the assistant on incoming user messages.
- UI updates include technician-only AI diagnostics on the chat room page `app/templates/chat/room.html` and an `AI tags` column in `app/templates/admin/knowledge_base.html` to show/add article tags.
- Added unit tests in `tests/services/test_matrix_ai_waiting_assistant.py` covering keyword extraction, acknowledgement sending, and queue creation logic.

### Testing

- Ran the new unit tests with `pytest tests/services/test_matrix_ai_waiting_assistant.py` (3 tests) and they passed.
- The change includes automated guards to disable the worker when configuration or Ollama is not enabled; no other test failures were observed while exercising the assistant unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2bb844596c832d9662269a0634dd21)