### PR TITLE
Add 'Convert to shared mailbox' option to offboarding step

### DIFF
--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -615,7 +615,7 @@ _OFFBOARDING_STEP_CATALOG: list[dict[str, Any]] = [
         "type": "offboard_account",
         "name": "Disable sign-in & remove access",
         "description": (
-            "Disables sign-in and optionally removes licenses/group membership. "
+            "Disables sign-in and optionally converts the mailbox to shared before removing licenses/group membership. "
             "Can also optionally cancel future Exchange calendar events, set out-of-office reply, and configure email forwarding using "
             "${vars.offboarding.*} variables from the request."
         ),
@@ -1078,6 +1078,13 @@ _WORKFLOW_STEP_FORM_SCHEMA: dict[str, dict[str, Any]] = {
     "offboard_account": {
         "fields": [
             {"name": "disable_sign_in", "label": "Disable sign-in", "type": "checkbox", "default": True},
+            {
+                "name": "convert_to_shared_mailbox",
+                "label": "Convert to shared mailbox",
+                "type": "checkbox",
+                "default": False,
+                "description": "Converts the Exchange Online mailbox to Shared before assigned licenses are removed.",
+            },
             {"name": "revoke_licenses", "label": "Remove assigned licenses", "type": "checkbox", "default": False},
             {
                 "name": "remove_from_groups",

--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -4963,6 +4963,32 @@ async def get_shared_mailboxes(company_id: int) -> list[dict[str, Any]]:
     ]
 
 
+async def convert_mailbox_to_shared(company_id: int, upn: str) -> None:
+    """Convert a user mailbox to a shared mailbox using Exchange Online.
+
+    Issues ``Set-Mailbox -Identity <upn> -Type Shared`` via the Exchange Online
+    PowerShell REST ``InvokeCommand`` API. This should be completed before
+    license removal in offboarding workflows so Exchange Online can access the
+    mailbox while it is still licensed.
+    """
+    normalised = str(upn or "").strip()
+    if not normalised:
+        raise M365Error("A user principal name is required", http_status=400)
+
+    exo_token, tenant_id = await _acquire_exo_access_token(company_id)
+    await _exo_invoke_command(
+        exo_token,
+        tenant_id,
+        "Set-Mailbox",
+        {"Identity": normalised, "Type": "Shared"},
+    )
+    log_info(
+        "M365 mailbox converted to shared for offboarded user",
+        company_id=company_id,
+        upn=normalised,
+    )
+
+
 async def enable_user_archive(company_id: int, upn: str) -> None:
     """Enable the in-place (online) archive mailbox for ``upn``.
 

--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -1942,6 +1942,12 @@ async def _run_offboarding_step(
     disable_sign_in = bool(
         _step.get("disable_sign_in", policy_config.get("offboarding_disable_sign_in", True))
     )
+    convert_to_shared_mailbox = bool(
+        _step.get(
+            "convert_to_shared_mailbox",
+            policy_config.get("offboarding_convert_to_shared_mailbox", False),
+        )
+    )
     remove_licenses = bool(
         _step.get("revoke_licenses", policy_config.get("offboarding_remove_licenses", True))
     )
@@ -2083,6 +2089,20 @@ async def _run_offboarding_step(
             else:
                 raise
 
+    if convert_to_shared_mailbox and user_upn:
+        try:
+            await m365_service.convert_mailbox_to_shared(company_id, user_upn)
+            steps_executed.append("convert_to_shared_mailbox")
+        except M365Error as exc:
+            if exc.http_status == 404:
+                log_warning(
+                    "Offboarding: mailbox conversion skipped (mailbox not found)",
+                    user_id=user_id,
+                    user_upn=user_upn,
+                )
+            else:
+                raise
+
     if remove_licenses:
         license_payload = await m365_service._graph_get(  # pyright: ignore[reportPrivateUsage]
             access_token,
@@ -2151,6 +2171,7 @@ async def _run_offboarding_step(
         "licenses_removed": removed_license_count,
         "groups_removed": removed_group_count,
         "mailbox_rules_disabled": mailbox_rules_disabled_count,
+        "converted_to_shared_mailbox": "convert_to_shared_mailbox" in steps_executed,
         "out_of_office_set": "set_out_of_office" in steps_executed,
         "email_forwarding_set": "set_email_forwarding" in steps_executed,
         "mailbox_access_requested_for": mailbox_grant_email_list,

--- a/tests/test_m365_exo_mailbox_permissions.py
+++ b/tests/test_m365_exo_mailbox_permissions.py
@@ -1059,3 +1059,21 @@ async def test_exo_get_mailbox_permission_returns_empty_when_pwsh_not_found():
             )
 
     assert result == []
+
+
+@pytest.mark.anyio
+async def test_convert_mailbox_to_shared_invokes_set_mailbox(monkeypatch):
+    acquire = AsyncMock(return_value=("exo-token", "tenant-1"))
+    invoke = AsyncMock(return_value={})
+    monkeypatch.setattr(m365_service, "_acquire_exo_access_token", acquire)
+    monkeypatch.setattr(m365_service, "_exo_invoke_command", invoke)
+
+    await m365_service.convert_mailbox_to_shared(42, " user@example.com ")
+
+    acquire.assert_awaited_once_with(42)
+    invoke.assert_awaited_once_with(
+        "exo-token",
+        "tenant-1",
+        "Set-Mailbox",
+        {"Identity": "user@example.com", "Type": "Shared"},
+    )

--- a/tests/test_staff_onboarding_workflow_policy_steps.py
+++ b/tests/test_staff_onboarding_workflow_policy_steps.py
@@ -649,3 +649,52 @@ async def test_execute_policy_step_disable_myportal_account_missing_email(monkey
         )
 
     get_user.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_run_offboarding_step_converts_mailbox_before_license_removal(monkeypatch):
+    monkeypatch.setattr(workflows.m365_service, "acquire_access_token", AsyncMock(return_value="token"))
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_staff_m365_user",
+        AsyncMock(return_value={"id": "user-2", "userPrincipalName": "offboard.user@example.com"}),
+    )
+    call_order: list[str] = []
+
+    async def _convert(company_id: int, upn: str) -> None:
+        call_order.append("convert")
+        assert company_id == 9
+        assert upn == "offboard.user@example.com"
+
+    async def _graph_get(_token: str, url: str) -> dict[str, object]:
+        call_order.append("get_licenses")
+        assert url.endswith("/users/user-2/licenseDetails")
+        return {"value": [{"skuId": "sku-1"}]}
+
+    async def _graph_post(_token: str, url: str, payload: dict[str, object]) -> dict[str, object]:
+        call_order.append("remove_licenses")
+        assert url.endswith("/users/user-2/assignLicense")
+        assert payload == {"addLicenses": [], "removeLicenses": ["sku-1"]}
+        return {}
+
+    monkeypatch.setattr(workflows.m365_service, "convert_mailbox_to_shared", AsyncMock(side_effect=_convert))
+    monkeypatch.setattr(workflows.m365_service, "_graph_get", AsyncMock(side_effect=_graph_get))
+    monkeypatch.setattr(workflows.m365_service, "_graph_post", AsyncMock(side_effect=_graph_post))
+
+    result = await workflows._run_offboarding_step(
+        company_id=9,
+        staff={"id": 704, "email": "offboard.user@example.com"},
+        policy_config={},
+        step_config={
+            "disable_sign_in": False,
+            "convert_to_shared_mailbox": True,
+            "revoke_licenses": True,
+            "remove_from_groups": False,
+        },
+        vars_map={},
+    )
+
+    assert call_order == ["convert", "get_licenses", "remove_licenses"]
+    assert "convert_to_shared_mailbox" in result["steps_executed"]
+    assert result["converted_to_shared_mailbox"] is True
+    assert result["licenses_removed"] == 1


### PR DESCRIPTION
### Motivation
- Ensure Exchange Online mailbox conversion to a shared mailbox can be performed as part of offboarding so mailbox settings can be applied while the mailbox is still licensed. 
- Execute conversion before assigned license removal to avoid 404s when writing mailbox settings or other EXO operations.

### Description
- Add a `convert_to_shared_mailbox` checkbox and description to the `Disable sign-in & remove access` offboarding step UI schema so workflows can opt in to conversion. 
- Implement `m365.convert_mailbox_to_shared(company_id, upn)` which calls Exchange Online `Set-Mailbox -Type Shared` via the existing EXO `InvokeCommand` flow. 
- Update offboarding execution in `_run_offboarding_step` to read the new option and call the conversion before license removal, handle `404` mailbox-not-found warnings, and record `converted_to_shared_mailbox` in the step result. 
- Add regression tests: `test_run_offboarding_step_converts_mailbox_before_license_removal` to assert ordering and `test_convert_mailbox_to_shared_invokes_set_mailbox` to assert the EXO invocation payload. 

### Testing
- Ran `python -m py_compile app/features/staff/handlers.py app/services/m365.py app/services/staff_onboarding_workflows.py` which succeeded. 
- Ran `git diff --check` which reported no problems. 
- Executed unit tests for the changed behavior with `pytest -q tests/test_staff_onboarding_workflow_policy_steps.py tests/test_m365_exo_mailbox_permissions.py` and the added tests passed; the targeted test run reported `75 passed` with warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a30b3e663dc832d9b72e90d0674f6e3)