### PR TITLE
Fix cart monetary quantization

### DIFF
--- a/app/features/cart/routes.py
+++ b/app/features/cart/routes.py
@@ -17,6 +17,21 @@ from starlette.datastructures import URL
 router = APIRouter(tags=["Cart"])
 
 
+def _quantize_money(value: Any) -> Decimal:
+    """Return *value* as a two-decimal Decimal for cart money calculations."""
+    if isinstance(value, Decimal):
+        raw = value
+    else:
+        try:
+            raw = Decimal(str(value or 0))
+        except (InvalidOperation, TypeError, ValueError):
+            raw = Decimal("0")
+    try:
+        return raw.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0.00")
+
+
 @lru_cache(maxsize=1)
 def _main():
     from app import main as main_module
@@ -395,21 +410,10 @@ async def view_cart(
             }
 
     def _resolve_product_price(product: Mapping[str, Any]) -> Decimal:
-        try:
-            value = main_module.shop_service.get_product_price(product, is_vip=is_vip).quantize(
-                Decimal("0.01"), rounding=ROUND_HALF_UP
-            )
-        except (InvalidOperation, TypeError, ValueError):
-            value = Decimal("0.00")
-        return value
+        return _quantize_money(main_module.shop_service.get_product_price(product, is_vip=is_vip))
 
     def _normalise_price(value: Any) -> Decimal:
-        if isinstance(value, Decimal):
-            return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
-        try:
-            return Decimal(str(value or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
-        except (InvalidOperation, TypeError, ValueError):
-            return Decimal("0.00")
+        return _quantize_money(value)
 
     for item in items:
         quantity = int(item.get("quantity") or 0)
@@ -507,7 +511,7 @@ async def view_cart(
             product_lookup,
             active_freight_rules,
         )
-        freight_total = freight_summary["freight_total"]
+        freight_total = _quantize_money(freight_summary["freight_total"])
         freight_breakdown = freight_summary["breakdown"]
 
     cart_subtotal = subtotal.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
@@ -596,13 +600,9 @@ async def view_cart(
                     stock_level = 0
                 if stock_level <= 0:
                     return
-                try:
-                    price_value = main_module.shop_service.get_product_price(product, is_vip=is_vip).quantize(
-                        Decimal("0.01"),
-                        rounding=ROUND_HALF_UP,
-                    )
-                except (InvalidOperation, TypeError, ValueError):
-                    price_value = Decimal("0.00")
+                price_value = _quantize_money(
+                    main_module.shop_service.get_product_price(product, is_vip=is_vip)
+                )
                 entry = {
                     "product_id": target_id,
                     "name": product.get("name"),

--- a/app/services/freight_rules.py
+++ b/app/services/freight_rules.py
@@ -29,8 +29,8 @@ def _to_int(value: Any, default: int = 0) -> int:
         return default
 
 
-def _quantize_money(amount: Decimal) -> Decimal:
-    return amount.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+def _quantize_money(amount: Any) -> Decimal:
+    return _to_decimal(amount).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
 def _classify_item_size(product: Mapping[str, Any]) -> str:

--- a/tests/test_company_require_po.py
+++ b/tests/test_company_require_po.py
@@ -1,5 +1,6 @@
 """Tests for the 'Require PO' option on company edit and cart place-order."""
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -9,6 +10,7 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse
 
 from app import main
+from app.repositories import freight_rules as freight_rules_repo
 from app.core.database import db
 from app.security.session import SessionData
 
@@ -232,6 +234,10 @@ def _cart_view_test(monkeypatch, active_session, require_po_value) -> Any:
         captured["extra"] = extra
         return HTMLResponse("ok")
 
+    async def fake_list_rules(*, active_only=False):
+        return []
+
+    monkeypatch.setattr(freight_rules_repo, "list_rules", fake_list_rules)
     monkeypatch.setattr(main, "_load_company_section_context", fake_ctx)
     monkeypatch.setattr(main.cart_repo, "list_items", fake_list_items)
     monkeypatch.setattr(main, "_render_template", fake_render)
@@ -252,6 +258,64 @@ def test_cart_view_passes_require_po_true(monkeypatch, active_session):
 
 def test_cart_view_defaults_require_po_false_when_missing(monkeypatch, active_session):
     assert _cart_view_test(monkeypatch, active_session, None) is False
+
+
+def test_cart_view_accepts_integer_catalog_prices(monkeypatch, active_session):
+    captured: dict[str, Any] = {}
+
+    async def fake_ctx(request, *, permission_field):
+        company = {"id": 1, "name": "E", "is_vip": 0, "payment_method": "invoice_prepay"}
+        return ({"id": 10}, {"company_id": 1, "can_access_cart": True}, company, 1, None)
+
+    async def fake_list_items(session_id):
+        return [
+            {
+                "product_id": 42,
+                "quantity": 2,
+                "unit_price": 9,
+                "product_name": "Widget",
+                "product_sku": "W42",
+            }
+        ]
+
+    async def fake_list_products_by_ids(product_ids, *, company_id=None):
+        return [
+            {
+                "id": 42,
+                "name": "Widget",
+                "sku": "W42",
+                "price": 10,
+                "stock": 5,
+                "cross_sell_products": [],
+                "upsell_products": [],
+            }
+        ]
+
+    async def fake_upsert_item(**kwargs):
+        return None
+
+    async def fake_render(template_name, request_obj, user_obj, *, extra):
+        captured["extra"] = extra
+        return HTMLResponse("ok")
+
+    async def fake_list_rules(*, active_only=False):
+        return []
+
+    monkeypatch.setattr(freight_rules_repo, "list_rules", fake_list_rules)
+    monkeypatch.setattr(main, "_load_company_section_context", fake_ctx)
+    monkeypatch.setattr(main.cart_repo, "list_items", fake_list_items)
+    monkeypatch.setattr(main.cart_repo, "upsert_item", fake_upsert_item)
+    monkeypatch.setattr(main.shop_repo, "list_products_by_ids", fake_list_products_by_ids)
+    monkeypatch.setattr(main.shop_service, "get_product_price", lambda product, *, is_vip=False: 10)
+    monkeypatch.setattr(main, "_render_template", fake_render)
+
+    with TestClient(main.app, follow_redirects=False) as client:
+        response = client.get("/cart")
+
+    assert response.status_code == 200
+    assert captured["extra"]["cart_subtotal"] == Decimal("20.00")
+    assert captured["extra"]["cart_total"] == Decimal("20.00")
+    assert captured["extra"]["cart_items"][0]["unit_price"] == Decimal("10.00")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Prevent AttributeError when catalog or freight prices are returned as non-Decimal types (e.g. int/float/str) by normalizing values before calling `quantize` in cart calculations.
- Ensure cart subtotal, freight and recommendation prices are consistently rounded to two decimals to avoid display/totaling discrepancies.

### Description
- Add `_quantize_money(value: Any) -> Decimal` helper in `app/features/cart/routes.py` to safely convert ints/floats/strings/Decimals to two-decimal `Decimal` values before quantization and use it for product prices, stored prices and freight totals.
- Replace direct `.quantize(...)` calls in the cart view and recommendation preparation with `_quantize_money(...)` to centralize normalization.
- Update `app/services/freight_rules.py` `_quantize_money` to accept `Any` and use `_to_decimal` before quantizing so freight rules tolerate non-Decimal inputs.
- Add a regression test `test_cart_view_accepts_integer_catalog_prices` in `tests/test_company_require_po.py` that stubs repositories/services and verifies `/cart` handles integer catalog prices and computes `cart_subtotal`, `cart_total`, and item `unit_price` as `Decimal("X.00")`.

### Testing
- Compiled modified modules with `python -m py_compile app/features/cart/routes.py app/services/freight_rules.py` and compilation succeeded.
- Ran the new regression test with `python -m pytest tests/test_company_require_po.py::test_cart_view_accepts_integer_catalog_prices -q` which passed.
- Ran `python -m pytest tests/test_cart_feature_pack.py::test_cart_pack_loads_and_reloads_cleanly -q` in this environment and it failed due to the feature-pack mounting behavior on a fresh test app, which appears unrelated to the monetary quantization changes (noted as an environment/registry issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a30b3ba2b48832dab0586dd4da54158)