### PR TITLE
Align offboarding approval workflow UI

### DIFF
--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -353,6 +353,7 @@ async def staff_page(
 
     staff_members: list[dict[str, Any]] = []
     staff_pending_requests: list[dict[str, Any]] = []
+    staff_pending_offboarding_requests: list[dict[str, Any]] = []
     departments: list[str] = []
     field_config: list[dict[str, Any]] = []
     custom_field_definitions: list[dict[str, Any]] = []
@@ -437,7 +438,7 @@ async def staff_page(
             for entry in audit_logs:
                 action = str(entry.get("action") or "").strip()
                 metadata = entry.get("metadata") if isinstance(entry.get("metadata"), dict) else {}
-                if action == "staff.onboarding.requested":
+                if action in {"staff.onboarding.requested", "staff.offboarding.requested"}:
                     raw_ids = metadata.get("approver_user_ids")
                     if isinstance(raw_ids, list):
                         approver_user_ids = [
@@ -498,7 +499,7 @@ async def staff_page(
                     f"Waiting for external completion: callback pending for step "
                     f"{current_step.replace('_', ' ')}."
                 )
-            elif workflow_state == "awaiting_approval":
+            elif workflow_state in {"awaiting_approval", "offboarding_awaiting_approval"}:
                 if approver_emails:
                     member["onboarding_pending_details"] = (
                         "Waiting for approval from: " + ", ".join(approver_emails)
@@ -508,6 +509,12 @@ async def staff_page(
             else:
                 member["onboarding_pending_details"] = None
         company_email_domains = list((company or {}).get("email_domains") or [])
+        staff_pending_offboarding_requests = [
+            member
+            for member in staff_members
+            if str(member.get("account_action") or "").strip().lower() == "offboard requested"
+            or str(member.get("onboarding_status") or "").strip().lower() == staff_onboarding_workflow_service.STATE_OFFBOARDING_AWAITING_APPROVAL
+        ]
         staff_members = [
             member
             for member in staff_members
@@ -560,6 +567,7 @@ async def staff_page(
         "departments": departments,
         "staff_members": cast(list[dict[str, Any]], _serialise_for_json(staff_members)),
         "staff_pending_requests": cast(list[dict[str, Any]], _serialise_for_json(staff_pending_requests)),
+        "staff_pending_offboarding_requests": cast(list[dict[str, Any]], _serialise_for_json(staff_pending_offboarding_requests)),
         "enabled_filter": enabled_value,
         "department_filter": department_filter,
         "show_ex_staff": show_ex_staff_flag,

--- a/app/static/js/staff.js
+++ b/app/static/js/staff.js
@@ -1537,5 +1537,55 @@
       });
     });
 
+
+    function removeApprovalRow(button, tableSelector) {
+      const row = button.closest('tr');
+      if (row) {
+        row.remove();
+      }
+      const tbody = document.querySelector(`${tableSelector} tbody`);
+      if (tbody && !tbody.querySelector('tr')) {
+        const section = document.querySelector(tableSelector)?.closest('section');
+        if (section) {
+          section.remove();
+        }
+      }
+    }
+
+    container.querySelectorAll('[data-offboarding-approve]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const id = button.getAttribute('data-offboarding-approve');
+        if (!id) {
+          return;
+        }
+        const comment = window.prompt('Approval comment (optional):') ?? '';
+        try {
+          await approveOffboarding(id, comment);
+          removeApprovalRow(button, '#staff-offboarding-requests-table');
+        } catch (error) {
+          alert(`Failed to approve offboarding request: ${error.message}`);
+        }
+      });
+    });
+
+    container.querySelectorAll('[data-offboarding-deny]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const id = button.getAttribute('data-offboarding-deny');
+        if (!id) {
+          return;
+        }
+        const reason = window.prompt('Deny reason (required):');
+        if (!reason) {
+          return;
+        }
+        try {
+          await denyOffboarding(id, reason);
+          removeApprovalRow(button, '#staff-offboarding-requests-table');
+        } catch (error) {
+          alert(`Failed to deny offboarding request: ${error.message}`);
+        }
+      });
+    });
+
   });
 })();

--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -81,6 +81,56 @@
     </div>
   </section>
   {% endif %}
+
+  {% if can_approve_onboarding and staff_pending_offboarding_requests %}
+  <section class="card card--panel admin-grid__full">
+    <header class="card__header card__header--stacked">
+      <div>
+        <h2 class="card__title">Pending offboarding approvals <span class="badge">{{ staff_pending_offboarding_requests | length }}</span></h2>
+        <p class="card__subtitle">Offboarding requests awaiting approval. Approve or deny each request below.</p>
+      </div>
+    </header>
+    <div class="table-wrapper">
+      <table class="table" id="staff-offboarding-requests-table" data-table data-table-id="staff-offboarding-requests">
+        <thead>
+          <tr>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">First name</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Last name</th>
+            <th scope="col" data-sort="string" data-mobile-priority="essential">Email</th>
+            <th scope="col" data-sort="string">Department</th>
+            <th scope="col" data-sort="date">Requested offboarding</th>
+            <th scope="col" data-sort="date">Submitted at</th>
+            <th scope="col" data-sort="string">Details</th>
+            <th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for req in staff_pending_offboarding_requests %}
+            <tr data-offboarding-request-id="{{ req.id }}">
+              <td data-label="First name">{{ req.first_name }}</td>
+              <td data-label="Last name">{{ req.last_name }}</td>
+              <td data-label="Email">{{ req.email or '—' }}</td>
+              <td data-label="Department">{{ req.department or '—' }}</td>
+              <td data-label="Requested offboarding" data-value="{{ req.date_offboarded or req.workflow_next_run_at or '' }}" data-utc="{{ req.date_offboarded or req.workflow_next_run_at or '' }}">
+                {% if req.date_offboarded or req.workflow_next_run_at %}{{ req.date_offboarded or req.workflow_next_run_at }}{% else %}<span class="text-muted">—</span>{% endif %}
+              </td>
+              <td data-label="Submitted at" data-value="{{ req.requested_at or '' }}" data-utc="{{ req.requested_at or '' }}">
+                {% if req.requested_at %}{{ req.requested_at }}{% else %}<span class="text-muted">—</span>{% endif %}
+              </td>
+              <td data-label="Details">
+                {% if req.request_notes %}<span class="text-small">{{ req.request_notes }}</span>{% else %}<span class="text-muted">—</span>{% endif %}
+              </td>
+              <td class="table__actions">
+                <button type="button" class="button button--small button--ghost" data-offboarding-approve="{{ req.id }}">Approve</button>
+                <button type="button" class="button button--small button--ghost button--danger" data-offboarding-deny="{{ req.id }}">Deny</button>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+  {% endif %}
   <section class="card card--panel admin-grid__full">
     <header class="card__header">
       <div class="card__controls">
@@ -804,6 +854,7 @@
 
 <script type="application/json" id="staff-data">{{ staff_members | tojson }}</script>
 <script type="application/json" id="staff-pending-requests-data">{{ staff_pending_requests | tojson }}</script>
+<script type="application/json" id="staff-pending-offboarding-requests-data">{{ staff_pending_offboarding_requests | tojson }}</script>
 <script type="application/json" id="staff-custom-field-definitions">{{ staff_custom_field_definitions | tojson }}</script>
 <script type="application/json" id="staff-flags">{{ {
   'isSuperAdmin': is_super_admin,


### PR DESCRIPTION
### Motivation
- Offboarding requests did not surface the same approval UI as onboarding requests, making it harder for approvers to see and act on pending offboard approvals.
- The goal is to present offboarding approvals in the same place and pattern as onboarding approvals so approvers have parity and consistent UX.

### Description
- Add `staff_pending_offboarding_requests` to the staff page context in `app/features/staff/handlers.py` and populate it from staff records with `Offboard Requested` or `offboarding_awaiting_approval` state so offboarding items can be displayed separately. 
- Extend audit/timeline logic in `app/features/staff/handlers.py` to include `staff.offboarding.requested` when resolving approver metadata and pending details. 
- Render a new “Pending offboarding approvals” table in `app/templates/staff/index.html` above the main staff table and expose `staff-pending-offboarding-requests-data` JSON for the client. 
- Wire approve/deny UI actions in `app/static/js/staff.js` to call the existing offboarding endpoints and remove rows from the UI after success using the same interaction pattern as onboarding approvals.

### Testing
- Ran `node --check app/static/js/staff.js` with no syntax errors. 
- Ran `python3 -m compileall app/features/staff/handlers.py` to verify Python modules compile. 
- Ran `git diff --check` to ensure no whitespace/patch issues. 
- Ran `pytest -q tests/test_staff_permissions_ui.py tests/test_staff_onboarding_endpoints.py tests/test_staff_offboarding_choices.py` and all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a30b5cdc698832d85034305d06c5aaa)