### PR TITLE
Add Receive SMS ticket feature pack

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -148,15 +148,15 @@ class Settings(BaseSettings):
     default_timezone: str = Field(default="UTC", validation_alias="CRON_TIMEZONE")
     enable_csrf: bool = Field(default=True, validation_alias="ENABLE_CSRF")
     feature_packs: str = Field(
-        default="tickets,service_status,notifications,knowledge_base,chat,assets,automations,reports,reporting,backups,issue_tracker,webhooks,shop,quotes,invoices,compliance,continuity,help,subscriptions,companies,api_keys,call_recordings,cart,orders,staff,message_templates,plausible,smtp,sms_gateway,imap,password_pusher,solidtime,trello,huntress,hudu,m365_mail,m365_admin,reprocess_ai,xero,tacticalrmm,syncro,uptimekuma,chatgpt_mcp,ollama,ntfy,matrix_chat_assign,marketing",
+        default="tickets,service_status,notifications,knowledge_base,chat,assets,automations,reports,reporting,backups,issue_tracker,webhooks,shop,quotes,invoices,compliance,continuity,help,subscriptions,companies,api_keys,call_recordings,cart,orders,staff,message_templates,plausible,smtp,sms_gateway,receive_sms,imap,password_pusher,solidtime,trello,huntress,hudu,m365_mail,m365_admin,reprocess_ai,xero,tacticalrmm,syncro,uptimekuma,chatgpt_mcp,ollama,ntfy,matrix_chat_assign,marketing",
         validation_alias="FEATURE_PACKS",
         description=(
             "Comma-separated list of feature pack slugs (subpackages of "
             "``app.features``) to load on startup.  Each pack can be "
             "hot-reloaded via ``POST /api/features/{slug}/reload``.  "
-            "Defaults to 'tickets,service_status,notifications,knowledge_base,chat,assets,automations,reports,reporting,backups,issue_tracker,webhooks,shop,quotes,invoices,compliance,continuity,help,subscriptions,companies,api_keys,call_recordings,cart,orders,staff,message_templates,plausible,smtp,sms_gateway,imap,password_pusher,solidtime,trello,huntress,hudu,m365_mail,m365_admin,reprocess_ai,xero,tacticalrmm,syncro,uptimekuma,chatgpt_mcp,ollama,ntfy,matrix_chat_assign,marketing' "
+            "Defaults to 'tickets,service_status,notifications,knowledge_base,chat,assets,automations,reports,reporting,backups,issue_tracker,webhooks,shop,quotes,invoices,compliance,continuity,help,subscriptions,companies,api_keys,call_recordings,cart,orders,staff,message_templates,plausible,smtp,sms_gateway,receive_sms,imap,password_pusher,solidtime,trello,huntress,hudu,m365_mail,m365_admin,reprocess_ai,xero,tacticalrmm,syncro,uptimekuma,chatgpt_mcp,ollama,ntfy,matrix_chat_assign,marketing' "
             "because the ticket, service-status, notifications, knowledge-base, "
-            "chat, assets, automations, reports, reporting, backups, issue-tracker, webhooks, shop, quotes, invoices, compliance, continuity, help, subscriptions, companies, API keys, call recordings, cart, orders, staff, message templates, Plausible, SMTP, SMS Gateway, IMAP, Password Pusher, Solidtime, Trello, Huntress, Hudu, M365 Mail, M365 Admin, Reprocess AI, Xero, TacticalRMM, Syncro, Uptime Kuma, ChatGPT MCP, Ollama, ntfy, Matrix Chat Auto-Assign, and Marketing integrations all live in those packs; set to an empty string "
+            "chat, assets, automations, reports, reporting, backups, issue-tracker, webhooks, shop, quotes, invoices, compliance, continuity, help, subscriptions, companies, API keys, call recordings, cart, orders, staff, message templates, Plausible, SMTP, SMS Gateway, Receive SMS, IMAP, Password Pusher, Solidtime, Trello, Huntress, Hudu, M365 Mail, M365 Admin, Reprocess AI, Xero, TacticalRMM, Syncro, Uptime Kuma, ChatGPT MCP, Ollama, ntfy, Matrix Chat Auto-Assign, and Marketing integrations all live in those packs; set to an empty string "
             "to disable all packs (those routes will then 404)."
         ),
     )

--- a/app/features/receive_sms/__init__.py
+++ b/app/features/receive_sms/__init__.py
@@ -1,0 +1,18 @@
+"""Receive SMS feature pack."""
+
+from __future__ import annotations
+
+from app.core.features import FeaturePack
+
+from .routes import router
+
+
+PACK = FeaturePack(
+    slug="receive_sms",
+    version="1.0.0",
+    routers=(router,),
+    description="Receives authenticated Android SMS webhooks and converts them into tickets.",
+)
+
+
+__all__ = ["PACK"]

--- a/app/features/receive_sms/routes.py
+++ b/app/features/receive_sms/routes.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import base64
+import re
+from datetime import date, datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from app.api.dependencies.api_keys import require_api_key
+from app.core.database import db
+from app.core.logging import log_error
+from app.repositories import tickets as tickets_repo
+from app.services import tickets as tickets_service
+from app.services.sanitization import sanitize_rich_text
+
+router = APIRouter(prefix="/api/integration-modules/receive-sms", tags=["Receive SMS"])
+
+
+class ReceiveSMSPayload(BaseModel):
+    type: str = Field(..., description="Webhook type; must be SMSIn.")
+    from_number: str = Field(..., alias="from", description="Sender phone number.")
+    name: str | None = Field(default=None, description="Sender display name supplied by the phone.")
+    message: str = Field(..., description="Base64 encoded SMS body.")
+    date: str = Field(..., description="SMS sent date from the Android device.")
+    time: str | None = Field(default=None, description="SMS sent time from the Android device.")
+
+
+def _normalise_phone(value: str) -> str:
+    return re.sub(r"\D+", "", (value or "").strip())
+
+
+def _parse_sms_datetime(date_value: str, time_value: str | None) -> tuple[datetime, date]:
+    raw_date = (date_value or "").strip()
+    raw_time = (time_value or "").strip()
+    candidates = []
+    if raw_time:
+        candidates.extend([f"{raw_date} {raw_time}", f"{raw_date}T{raw_time}"])
+    candidates.append(raw_date)
+    formats = [
+        "%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M",
+        "%d/%m/%Y %H:%M:%S", "%d/%m/%Y %H:%M", "%d-%m-%Y %H:%M:%S", "%d-%m-%Y %H:%M",
+        "%Y-%m-%d", "%d/%m/%Y", "%d-%m-%Y",
+    ]
+    for candidate in candidates:
+        for fmt in formats:
+            try:
+                parsed = datetime.strptime(candidate, fmt)
+            except ValueError:
+                continue
+            parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed, parsed.date()
+    try:
+        parsed = datetime.fromisoformat((f"{raw_date}T{raw_time}" if raw_time else raw_date).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        parsed = parsed.astimezone(timezone.utc)
+        return parsed, parsed.date()
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid SMS date/time") from exc
+
+
+def _decode_message(value: str) -> str:
+    try:
+        decoded = base64.b64decode(value, validate=True)
+        return decoded.decode("utf-8")
+    except Exception as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Message must be valid base64 encoded UTF-8") from exc
+
+
+async def _find_contact(phone: str) -> dict[str, Any]:
+    normalised = _normalise_phone(phone)
+    if not normalised:
+        return {"requester_id": None, "company_id": None}
+    like = f"%{normalised}%"
+    user = await db.fetch_one(
+        """
+        SELECT id, company_id FROM users
+        WHERE REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(COALESCE(mobile_phone, ''), ' ', ''), '-', ''), '(', ''), ')', ''), '+', '') LIKE %s
+        ORDER BY id ASC LIMIT 1
+        """,
+        (like,),
+    )
+    if user:
+        return {"requester_id": int(user["id"]), "company_id": user.get("company_id")}
+    staff = await db.fetch_one(
+        """
+        SELECT id, company_id FROM staff
+        WHERE REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(COALESCE(mobile_phone, ''), ' ', ''), '-', ''), '(', ''), ')', ''), '+', '') LIKE %s
+        ORDER BY id ASC LIMIT 1
+        """,
+        (like,),
+    )
+    if staff:
+        return {"requester_staff_id": int(staff["id"]), "company_id": staff.get("company_id"), "requester_id": None}
+    return {"requester_id": None, "requester_staff_id": None, "company_id": None}
+
+
+async def _find_sms_ticket(normalised_phone: str, sms_day: date) -> dict[str, Any] | None:
+    row = await db.fetch_one(
+        """
+        SELECT t.id FROM tickets t
+        INNER JOIN sms_ticket_links l ON l.ticket_id = t.id
+        WHERE l.from_number_normalized = %s AND l.sms_date = %s
+        ORDER BY t.id DESC LIMIT 1
+        """,
+        (normalised_phone, sms_day),
+    )
+    if not row:
+        return None
+    return await tickets_repo.get_ticket(int(row["id"]))
+
+
+@router.post("/inbound", status_code=status.HTTP_201_CREATED)
+async def receive_sms(payload: ReceiveSMSPayload, request: Request, api_key_record: dict = Depends(require_api_key)) -> dict[str, Any]:
+    if payload.type != "SMSIn":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported SMS webhook type")
+    message_text = _decode_message(payload.message).strip()
+    if not message_text:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Decoded message cannot be empty")
+    sms_at, sms_day = _parse_sms_datetime(payload.date, payload.time)
+    normalised_phone = _normalise_phone(payload.from_number)
+    if not normalised_phone:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Sender phone number is required")
+
+    body = sanitize_rich_text(message_text).html
+    ticket = await _find_sms_ticket(normalised_phone, sms_day)
+    action = "created"
+    try:
+        if ticket:
+            if str(ticket.get("status") or "").lower() in {"closed", "resolved"}:
+                reopened_status = await tickets_service.resolve_status_or_default("open")
+                ticket = await tickets_repo.set_ticket_status(int(ticket["id"]), reopened_status)
+                action = "reopened"
+            else:
+                action = "appended"
+            await tickets_repo.create_reply(
+                ticket_id=int(ticket["id"]), author_id=ticket.get("requester_id"), body=body,
+                is_internal=False, external_reference=f"sms:{normalised_phone}:{sms_at.isoformat()}", created_at=sms_at,
+            )
+        else:
+            contact = await _find_contact(payload.from_number)
+            status_value = await tickets_service.resolve_status_or_default(None)
+            subject_name = (payload.name or payload.from_number).strip()
+            ticket = await tickets_service.create_ticket(
+                subject=f"SMS from {subject_name}", description=body,
+                requester_id=contact.get("requester_id"), requester_staff_id=contact.get("requester_staff_id"),
+                company_id=contact.get("company_id"), assigned_user_id=None, priority="normal", status=status_value,
+                category="SMS", module_slug="receive_sms", external_reference=f"sms:{normalised_phone}:{sms_day.isoformat()}",
+                trigger_automations=True, initial_reply_author_id=contact.get("requester_id"),
+            )
+            await db.execute(
+                """
+                INSERT INTO sms_ticket_links (ticket_id, from_number, from_number_normalized, sms_date, created_at, updated_at)
+                VALUES (%s, %s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
+                """,
+                (ticket["id"], payload.from_number, normalised_phone, sms_day),
+            )
+        await tickets_service.emit_ticket_updated_event(ticket, actor_type="api_key", actor={"id": api_key_record.get("id")})
+    except Exception as exc:
+        log_error("Failed to process inbound SMS", error=str(exc), from_number=payload.from_number)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to process inbound SMS") from exc
+    return {"status": action, "ticket_id": ticket.get("id"), "sms_date": sms_day.isoformat()}

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1095,7 +1095,8 @@ async def create_reply(
         )
         if row:
             normalised = _normalise_reply(row)
-            if not normalised.get("is_internal") and not str(normalised.get("external_reference") or "").startswith("chat:"):
+            reply_external = str(normalised.get("external_reference") or "")
+            if not normalised.get("is_internal") and not reply_external.startswith("chat:"):
                 try:
                     from app.services import chat_ticket_sync
 
@@ -1106,6 +1107,28 @@ async def create_reply(
                 except Exception as exc:  # pragma: no cover - defensive logging
                     log_error(
                         "Failed to sync public ticket reply to linked chat",
+                        ticket_id=ticket_id,
+                        reply_id=normalised.get("id"),
+                        error=str(exc),
+                    )
+            if not normalised.get("is_internal") and not reply_external.startswith("sms:"):
+                try:
+                    ticket_row = await get_ticket(ticket_id)
+                    if ticket_row and ticket_row.get("module_slug") == "receive_sms":
+                        sms_link = await db.fetch_one(
+                            "SELECT from_number FROM sms_ticket_links WHERE ticket_id = %s ORDER BY id DESC LIMIT 1",
+                            (ticket_id,),
+                        )
+                        if sms_link and sms_link.get("from_number"):
+                            from app.services import sms as sms_service
+
+                            await sms_service.send_sms(
+                                message=str(body or ""),
+                                phone_numbers=[str(sms_link["from_number"])],
+                            )
+                except Exception as exc:  # pragma: no cover - defensive logging
+                    log_error(
+                        "Failed to send SMS for public ticket reply",
                         ticket_id=ticket_id,
                         reply_id=normalised.get("id"),
                         error=str(exc),

--- a/migrations/268_receive_sms_module.sql
+++ b/migrations/268_receive_sms_module.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS sms_ticket_links (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    ticket_id INT NOT NULL,
+    from_number VARCHAR(64) NOT NULL,
+    from_number_normalized VARCHAR(32) NOT NULL,
+    sms_date DATE NOT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    UNIQUE KEY uq_sms_ticket_links_sender_day (from_number_normalized, sms_date),
+    KEY idx_sms_ticket_links_ticket (ticket_id),
+    CONSTRAINT fk_sms_ticket_links_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE
+);

--- a/tests/test_receive_sms_feature_pack.py
+++ b/tests/test_receive_sms_feature_pack.py
@@ -1,0 +1,18 @@
+from app.core.config import Settings
+from app.features.receive_sms import PACK
+from app.features.receive_sms.routes import _decode_message, _normalise_phone, _parse_sms_datetime
+
+
+def test_receive_sms_pack_metadata_and_default_enabled():
+    assert PACK.slug == "receive_sms"
+    assert PACK.routers
+    default_feature_packs = str(Settings.model_fields["feature_packs"].default).split(",")
+    assert "receive_sms" in default_feature_packs
+
+
+def test_receive_sms_helpers_decode_and_normalise():
+    assert _decode_message("SGVsbG8gV29ybGQ=") == "Hello World"
+    assert _normalise_phone("+61 (400) 123-456") == "61400123456"
+    parsed, day = _parse_sms_datetime("2026-06-16", "14:30")
+    assert parsed.isoformat() == "2026-06-16T14:30:00+00:00"
+    assert day.isoformat() == "2026-06-16"


### PR DESCRIPTION
### Motivation
- Provide an authenticated inbound webhook to accept Android SMS POSTs, decode base64 bodies, and turn them into tickets.
- Link same-sender same-day SMS messages to the same ticket and reopen closed/resolved tickets on customer response.
- Ensure technician replies to SMS-originated tickets are sent back via the SMS gateway while avoiding echoing inbound messages.

### Description
- Added a new feature pack `receive_sms` with an authenticated `POST /api/integration-modules/receive-sms/inbound` route that validates `type == "SMSIn"`, decodes Base64 UTF-8 `message`, parses date/time into UTC, sanitizes content with `sanitize_rich_text`, and returns the ticket/action result.
- Implemented contact lookup by phone against `users.mobile_phone` and `staff.mobile_phone` and logic to either append a reply to an existing same-day ticket or create a new ticket when no match exists, using `tickets_service` and `tickets_repo`.
- Added `sms_ticket_links` DB migration to map `from_number`/normalized number + `sms_date` to tickets with a unique sender/day constraint for future reply linking.
- Extended reply handling in `app/repositories/tickets.py` so public replies on tickets created by the `receive_sms` module dispatch via the existing `send_sms` service, while replies whose `external_reference` already start with `sms:` are not echoed back.
- Enabled the `receive_sms` pack in the default `FEATURE_PACKS` list so it is loaded by default and included in API docs.
- The inbound endpoint is protected with API header auth via the existing `require_api_key` dependency.

### Testing
- Compiled the new modules with `python -m compileall` which completed without errors.
- Added `tests/test_receive_sms_feature_pack.py` for pack metadata and helper parsing and ran `pytest -q tests/test_receive_sms_feature_pack.py` which passed.
- Ran `pytest -q tests/test_receive_sms_feature_pack.py tests/test_api_key_permissions.py` and all tests passed (10 passed in the run used for verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a30b8634e84832dbac102dae11e4ac7)