### PR TITLE
Add SMS ticket reply automations

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -762,6 +762,11 @@ async def add_reply(
         actor_type="technician" if has_helpdesk_access else "requester",
         actor=current_user,
     )
+    await tickets_service.emit_ticket_replied_event(
+        ticket_id,
+        actor_type="technician" if has_helpdesk_access else "requester",
+        actor=current_user,
+    )
     updated_ticket = await tickets_repo.get_ticket(ticket_id)
     ticket_payload = updated_ticket or ticket
     ticket_response = TicketResponse(**ticket_payload)

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -1073,6 +1073,11 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
             actor_type="technician",
             actor=current_user,
         )
+        await tickets_service.emit_ticket_replied_event(
+            ticket_id,
+            actor_type="technician",
+            actor=current_user,
+        )
     except Exception as exc:  # pragma: no cover - defensive logging
         log_error("Failed to create ticket reply", error=str(exc))
         return await main_module._render_ticket_detail(

--- a/app/features/tickets/portal_routes.py
+++ b/app/features/tickets/portal_routes.py
@@ -344,6 +344,11 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
         actor_type=actor_type,
         actor=user,
     )
+    await tickets_service.emit_ticket_replied_event(
+        ticket_id,
+        actor_type=actor_type,
+        actor=user,
+    )
     await tickets_service.broadcast_ticket_event(action="reply", ticket_id=ticket_id)
 
     return flash_redirect(f"/tickets/{ticket_id}", "Reply posted.", "success")

--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -22,6 +22,7 @@ from app.services import value_templates
 TRIGGER_EVENTS: list[dict[str, str]] = [
     {"value": "tickets.created", "label": "Ticket created"},
     {"value": "tickets.updated", "label": "Ticket updated"},
+    {"value": "tickets.replied", "label": "Ticket reply added"},
     {"value": "tickets.details_updated", "label": "Ticket Details Updated"},
     {"value": "tickets.closed", "label": "Ticket closed"},
     {"value": "tickets.assigned", "label": "Ticket assigned"},
@@ -32,6 +33,7 @@ _EVENT_ALIASES: dict[str, tuple[str, ...]] = {
     # Backward compatibility for legacy singular ticket event names.
     "tickets.created": ("ticket.created",),
     "tickets.updated": ("ticket.updated",),
+    "tickets.replied": ("ticket.replied",),
     "tickets.closed": ("ticket.closed",),
     "tickets.assigned": ("ticket.assigned",),
 }

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -402,6 +402,27 @@ def _build_user_snapshot(user: Mapping[str, Any] | None) -> Mapping[str, Any] | 
     return snapshot
 
 
+
+def _extract_sms_recipient_from_external_reference(value: Any) -> str | None:
+    """Return the mobile number embedded in an SMS ticket external reference."""
+
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw.lower().startswith("sms:"):
+        return None
+    parts = raw.split(":", 2)
+    if len(parts) < 2:
+        return None
+    recipient = parts[1].strip()
+    return recipient or None
+
+
+def _attach_sms_context(ticket: TicketRecord) -> None:
+    recipient = _extract_sms_recipient_from_external_reference(ticket.get("external_reference"))
+    ticket["sms"] = {"recipient": recipient} if recipient else None
+
+
 async def _enrich_ticket_context(ticket: Mapping[str, Any]) -> TicketRecord:
     enriched: TicketRecord = dict(ticket)
 
@@ -532,6 +553,7 @@ async def _enrich_ticket_context(ticket: Mapping[str, Any]) -> TicketRecord:
         )
         latest_reply = reply
     enriched["latest_reply"] = latest_reply
+    _attach_sms_context(enriched)
 
     return enriched
 
@@ -640,6 +662,24 @@ async def _emit_ticket_event(
         return
 
     await automations_service.handle_event(event_name, context)
+
+
+async def emit_ticket_replied_event(
+    ticket: Mapping[str, Any] | int,
+    *,
+    actor_type: str | None = None,
+    actor: Mapping[str, Any] | None = None,
+    trigger_automations: bool = True,
+) -> None:
+    """Emit a ``tickets.replied`` automation event with actor metadata."""
+
+    await _emit_ticket_event(
+        "tickets.replied",
+        ticket,
+        actor_type=actor_type,
+        actor=actor,
+        trigger_automations=trigger_automations,
+    )
 
 
 async def emit_ticket_updated_event(

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -226,6 +226,22 @@
         }),
       },
     ],
+    'sms-gateway': [
+      {
+        label: 'Send technician reply to SMS requester',
+        value: toJsonTemplate({
+          message: '{{ ticket.latest_reply.body }}',
+          phoneNumbers: ['{{ ticket.sms.recipient }}'],
+        }),
+      },
+      {
+        label: 'Send custom SMS update',
+        value: toJsonTemplate({
+          message: 'Ticket {{ ticket.number }} has been updated: {{ ticket.latest_reply.body }}',
+          phoneNumbers: ['{{ ticket.sms.recipient }}'],
+        }),
+      },
+    ],
     ntfy: [
       {
         label: 'Publish high priority ntfy alert',

--- a/docs/wiki/administration/Automation Variables.md
+++ b/docs/wiki/administration/Automation Variables.md
@@ -29,6 +29,7 @@ paths now available include:
   details
 - `ticket.latest_reply.body` and `ticket.latest_reply.author_email` for the most
   recent conversation entry
+- `ticket.sms.recipient` for the mobile number parsed from an SMS ticket external reference
 - `ticket_update.actor_type` to identify whether the update originated from the
   system, an automation, the requester, a watcher, or a technician
 - `ticket_update.actor_user_email` / `ticket_update.actor_user_display_name`
@@ -75,6 +76,7 @@ emails or webhook requests). Newly added tokens include:
 | `{{ TICKET_LATEST_REPLY_BODY }}` | Body of the most recent reply. |
 | `{{ TICKET_LATEST_REPLY_AUTHOR_EMAIL }}` | Email for the author of the latest reply. |
 | `{{ TICKET_LATEST_REPLY_AUTHOR_DISPLAY_NAME }}` | Display name for the latest reply author. |
+| `{{ TICKET_SMS_RECIPIENT }}` | Mobile number parsed from an SMS ticket external reference. |
 | `{{ ACTIVE_ASSETS }}` / `{{ ACTIVE_ASSETS:7 }}` | Count of assets that synced in the current month, or within the last `N` days when the `:N` suffix is provided. |
 | `{{ count:asset:field-name }}` | Count of assets with a specific custom field checkbox set to true (e.g., `{{ count:asset:bitdefender }}` or `{{ count:asset:threatlocker-installed }}`). |
 | `{{ list:asset:field-name }}` | Comma-separated list of asset names with a specific custom field checkbox set to true (e.g., `{{ list:asset:bitdefender }}`). |

--- a/tests/test_sms_automation_context.py
+++ b/tests/test_sms_automation_context.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from app.services import automations as automations_service
+from app.services.tickets import _extract_sms_recipient_from_external_reference
+
+
+def test_ticket_replied_trigger_event_is_available():
+    values = {item["value"] for item in automations_service.list_trigger_events()}
+    assert "tickets.replied" in values
+
+
+def test_extract_sms_recipient_from_external_reference():
+    assert _extract_sms_recipient_from_external_reference("sms:+61400111222:2026-06-16") == "+61400111222"
+    assert _extract_sms_recipient_from_external_reference("sms:61400111222:2026-06-16") == "61400111222"
+    assert _extract_sms_recipient_from_external_reference("syncro:123") is None
+
+
+def test_sms_gateway_snippet_targets_sms_context():
+    source = Path("app/static/js/automation.js").read_text()
+    assert "'sms-gateway'" in source
+    assert "{{ ticket.sms.recipient }}" in source
+    assert "{{ ticket.latest_reply.body }}" in source


### PR DESCRIPTION
### Motivation
- Provide a first-class automation trigger for ticket replies so admins can target reply events separately from generic ticket updates. 
- Enable sending SMS messages from automations by exposing the SMS recipient parsed from SMS ticket external references and using the existing `sms-gateway` module. 

### Description
- Add a new `tickets.replied` trigger to the automation event list and include the legacy alias `ticket.replied` for backward compatibility in `app/services/automations.py`. 
- Parse SMS recipient numbers from SMS ticket `external_reference` values and attach `ticket.sms.recipient` to enriched ticket context in `app/services/tickets.py`. 
- Introduce `emit_ticket_replied_event` and call it when replies are created in API, admin, and portal flows so reply automations run (`app/api/routes/tickets.py`, `app/features/tickets/admin_routes.py`, `app/features/tickets/portal_routes.py`). 
- Add `sms-gateway` automation snippets that build the HTTP POST body with `message: '{{ ticket.latest_reply.body }}'` and `phoneNumbers: ['{{ ticket.sms.recipient }}']` in `app/static/js/automation.js`. 
- Document the new `ticket.sms.recipient` / `{{ TICKET_SMS_RECIPIENT }}` variable in the automation variables docs and add a regression test file `tests/test_sms_automation_context.py`. 

### Testing
- Ran Python static check: `python -m py_compile app/services/automations.py app/services/tickets.py`, which succeeded. 
- Executed targeted unit tests with `pytest tests/test_sms_automation_context.py tests/test_ticket_details_updated_event.py -q`, and all tests passed. 
- Verified the new automation snippets and documentation updates were added and covered by the new regression test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a30d2a5d584832da8efcd5a4170b617)