### PR TITLE
Stop automatic SMS sends for SMS ticket replies

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1111,28 +1111,6 @@ async def create_reply(
                         reply_id=normalised.get("id"),
                         error=str(exc),
                     )
-            if not normalised.get("is_internal") and not reply_external.startswith("sms:"):
-                try:
-                    ticket_row = await get_ticket(ticket_id)
-                    if ticket_row and ticket_row.get("module_slug") == "receive_sms":
-                        sms_link = await db.fetch_one(
-                            "SELECT from_number FROM sms_ticket_links WHERE ticket_id = %s ORDER BY id DESC LIMIT 1",
-                            (ticket_id,),
-                        )
-                        if sms_link and sms_link.get("from_number"):
-                            from app.services import sms as sms_service
-
-                            await sms_service.send_sms(
-                                message=str(body or ""),
-                                phone_numbers=[str(sms_link["from_number"])],
-                            )
-                except Exception as exc:  # pragma: no cover - defensive logging
-                    log_error(
-                        "Failed to send SMS for public ticket reply",
-                        ticket_id=ticket_id,
-                        reply_id=normalised.get("id"),
-                        error=str(exc),
-                    )
             return normalised
     fallback_row: dict[str, Any] = {
         "id": reply_id,

--- a/tests/test_sms_automation_context.py
+++ b/tests/test_sms_automation_context.py
@@ -4,6 +4,12 @@ from app.services import automations as automations_service
 from app.services.tickets import _extract_sms_recipient_from_external_reference
 
 
+def test_ticket_reply_repository_does_not_auto_send_sms():
+    source = Path("app/repositories/tickets.py").read_text()
+    assert "send_sms(" not in source
+    assert "sms_ticket_links" not in source
+
+
 def test_ticket_replied_trigger_event_is_available():
     values = {item["value"] for item in automations_service.list_trigger_events()}
     assert "tickets.replied" in values


### PR DESCRIPTION
### Motivation
- Avoid sending SMS directly from the ticket repository when adding public replies to Receive SMS tickets and instead rely on the automation/event pipeline to trigger SMS gateway sends.

### Description
- Removed the repository-level SMS dispatch block from `app/repositories/tickets.py` so `create_reply` no longer sends SMS via `send_sms` or queries `sms_ticket_links`.
- Added a regression test `test_ticket_reply_repository_does_not_auto_send_sms` in `tests/test_sms_automation_context.py` that asserts the repository source does not contain `send_sms(` or `sms_ticket_links`.

### Testing
- Ran `pytest tests/test_sms_automation_context.py tests/test_tickets_repository.py -q` and the test run completed successfully (`21 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a30e237be34832db567695f2dce5b63)