### PR TITLE
Prevent duplicate automations for reply-backed ticket events

### DIFF
--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Mapping, Sequence
 from datetime import date, datetime, time, timedelta, timezone
 import re
 from functools import lru_cache
+from time import monotonic
 from typing import Any
 
 from croniter import croniter
@@ -46,6 +47,60 @@ def list_trigger_events() -> list[dict[str, str]]:
 
 
 _BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
+_RECENT_REPLY_EVENT_SECONDS = 10.0
+_RECENT_REPLY_EVENT_EXECUTIONS: dict[tuple[int, int, int], float] = {}
+
+
+def _reply_event_dedupe_key(
+    automation_id: int,
+    event_key: str,
+    context: Mapping[str, Any] | None,
+) -> tuple[int, int, int] | None:
+    """Return a short-lived idempotency key for reply-backed ticket events."""
+
+    if event_key not in {"tickets.updated", "ticket.updated", "tickets.replied", "ticket.replied"}:
+        return None
+    if not isinstance(context, Mapping):
+        return None
+    ticket = context.get("ticket")
+    if not isinstance(ticket, Mapping):
+        return None
+    latest_reply = ticket.get("latest_reply")
+    if not isinstance(latest_reply, Mapping):
+        return None
+    try:
+        ticket_id = int(ticket.get("id"))
+        reply_id = int(latest_reply.get("id"))
+    except (TypeError, ValueError):
+        return None
+    if ticket_id <= 0 or reply_id <= 0:
+        return None
+    return (automation_id, ticket_id, reply_id)
+
+
+def _claim_reply_event_execution(
+    automation_id: int,
+    event_key: str,
+    context: Mapping[str, Any] | None,
+) -> bool:
+    """Prevent duplicate automation runs caused by paired reply/update events."""
+
+    dedupe_key = _reply_event_dedupe_key(automation_id, event_key, context)
+    if dedupe_key is None:
+        return True
+
+    now = monotonic()
+    expired_before = now - _RECENT_REPLY_EVENT_SECONDS
+    for key, seen_at in list(_RECENT_REPLY_EVENT_EXECUTIONS.items()):
+        if seen_at < expired_before:
+            _RECENT_REPLY_EVENT_EXECUTIONS.pop(key, None)
+
+    previous = _RECENT_REPLY_EVENT_EXECUTIONS.get(dedupe_key)
+    if previous is not None and previous >= expired_before:
+        return False
+
+    _RECENT_REPLY_EVENT_EXECUTIONS[dedupe_key] = now
+    return True
 
 
 def _normalise_actions(actions: Any) -> list[dict[str, Any]]:
@@ -797,6 +852,13 @@ async def handle_event(
         if not _filters_match(filters_mapping, context):
             continue
         automation_id = int(automation.get("id"))
+        if not _claim_reply_event_execution(automation_id, event_key, context):
+            matched.append({
+                "automation_id": automation_id,
+                "status": "skipped",
+                "reason": "duplicate_reply_event",
+            })
+            continue
         _schedule_background_execution(
             _execute_automation(automation, context=context),
             automation_id=automation_id,

--- a/tests/test_automations_service.py
+++ b/tests/test_automations_service.py
@@ -848,3 +848,43 @@ async def test_execute_scheduled_ticket_automation_runs_actions_for_matching_tic
     assert captured[0][1]["ticket_id"] == 1
     assert captured[0][1]["status"] == "closed"
     assert captured[0][1]["context"]["ticket"]["id"] == 1
+
+
+@pytest.mark.anyio
+async def test_handle_event_deduplicates_reply_backed_ticket_events(monkeypatch):
+    captured: list[int] = []
+
+    async def fake_list_event_automations(event_name):
+        if event_name == "tickets.updated":
+            return [{"id": 900, "trigger_filters": None, "action_payload": {}}]
+        return []
+
+    def fake_schedule(coro, *, automation_id):
+        captured.append(automation_id)
+        coro.close()
+        return None
+
+    monkeypatch.setattr(
+        automations_service.automation_repo,
+        "list_event_automations",
+        fake_list_event_automations,
+    )
+    monkeypatch.setattr(
+        automations_service,
+        "_schedule_background_execution",
+        fake_schedule,
+    )
+    automations_service._RECENT_REPLY_EVENT_EXECUTIONS.clear()
+
+    context = {"ticket": {"id": 123, "latest_reply": {"id": 456, "body": "Hello"}}}
+
+    first = await automations_service.handle_event("tickets.updated", context)
+    second = await automations_service.handle_event("tickets.updated", context)
+
+    assert captured == [900]
+    assert first == [{"automation_id": 900, "status": "queued"}]
+    assert second == [
+        {"automation_id": 900, "status": "skipped", "reason": "duplicate_reply_event"}
+    ]
+
+    automations_service._RECENT_REPLY_EVENT_EXECUTIONS.clear()


### PR DESCRIPTION
### Motivation
- Reply-created flows were emitting paired/near-simultaneous `tickets.updated`/`tickets.replied` events which caused the same automation (e.g. an SMS send) to be scheduled multiple times for the same ticket reply.
- The goal is to avoid duplicate outbound actions (such as sending the same SMS 2–3 times) by making event handling idempotent for reply-backed events.

### Description
- Add a short-lived in-memory idempotency cache keyed by `(automation_id, ticket_id, reply_id)` and a 10s expiry window to identify reply-backed duplicate events via `_reply_event_dedupe_key` and `_claim_reply_event_execution` in `app/services/automations.py`.
- Apply the duplicate-claim guard inside `handle_event` before scheduling matched automations so duplicate events return a skipped result instead of enqueueing another execution.
- Add a regression test `test_handle_event_deduplicates_reply_backed_ticket_events` in `tests/test_automations_service.py` that verifies repeated `tickets.updated` events for the same reply only schedule one automation execution.

### Testing
- Ran the new unit test and related suites with `pytest -q tests/test_automations_service.py tests/test_sms_automation_context.py tests/test_sms_gateway_module.py` and all tests passed.
- Compiled modified files with `python -m compileall -q app/services/automations.py tests/test_automations_service.py` to ensure syntax correctness and checked diffs; no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a30e8a5eba4832dab5cb87107df327d)