### PR TITLE
Fix ticket reply automation filters and add reply context

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -1028,7 +1028,7 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
                 author_id = int(author_id)
             except (TypeError, ValueError, AttributeError):
                 author_id = None
-        await tickets_repo.create_reply(
+        created_reply = await tickets_repo.create_reply(
             ticket_id=ticket_id,
             author_id=author_id,
             body=sanitized_body.html,
@@ -1077,6 +1077,7 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
             ticket_id,
             actor_type="technician",
             actor=current_user,
+            reply=created_reply,
         )
     except Exception as exc:  # pragma: no cover - defensive logging
         log_error("Failed to create ticket reply", error=str(exc))

--- a/app/features/tickets/portal_routes.py
+++ b/app/features/tickets/portal_routes.py
@@ -290,7 +290,7 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
         )
 
     try:
-        await tickets_repo.create_reply(
+        created_reply = await tickets_repo.create_reply(
             ticket_id=ticket_id,
             author_id=user_id,
             body=sanitized_body.html,
@@ -348,6 +348,7 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
         ticket_id,
         actor_type=actor_type,
         actor=user,
+        reply=created_reply,
     )
     await tickets_service.broadcast_ticket_event(action="reply", ticket_id=ticket_id)
 

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -605,6 +605,7 @@ async def _emit_ticket_event(
     *,
     actor_type: str | None = None,
     actor: Mapping[str, Any] | None = None,
+    reply: Mapping[str, Any] | None = None,
     trigger_automations: bool = True,
 ) -> None:
     """Shared helper that builds ticket context and fires an automation event."""
@@ -657,6 +658,12 @@ async def _emit_ticket_event(
         "ticket": enriched,
         "ticket_update": metadata,
     }
+    if isinstance(reply, Mapping):
+        is_internal = bool(reply.get("is_internal"))
+        reply_context = dict(reply)
+        reply_context["is_internal"] = is_internal
+        reply_context["kind"] = "internal_note" if is_internal else "message"
+        context["reply"] = reply_context
 
     if not trigger_automations:
         return
@@ -669,6 +676,7 @@ async def emit_ticket_replied_event(
     *,
     actor_type: str | None = None,
     actor: Mapping[str, Any] | None = None,
+    reply: Mapping[str, Any] | None = None,
     trigger_automations: bool = True,
 ) -> None:
     """Emit a ``tickets.replied`` automation event with actor metadata."""
@@ -678,6 +686,7 @@ async def emit_ticket_replied_event(
         ticket,
         actor_type=actor_type,
         actor=actor,
+        reply=reply,
         trigger_automations=trigger_automations,
     )
 

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -130,6 +130,22 @@
       }),
     },
     {
+      label: 'Reply is an internal note',
+      value: toJsonTemplate({
+        match: {
+          'reply.is_internal': true,
+        },
+      }),
+    },
+    {
+      label: 'Reply is a public message',
+      value: toJsonTemplate({
+        match: {
+          'reply.is_internal': false,
+        },
+      }),
+    },
+    {
       label: 'Module equals Trello',
       value: toJsonTemplate({
         match: {
@@ -1655,7 +1671,27 @@
         const fieldInput = document.createElement('input');
         fieldInput.className = 'form-input';
         fieldInput.type = 'text';
-        fieldInput.placeholder = 'ticket.status';
+        fieldInput.placeholder = 'ticket.status or reply.is_internal';
+        fieldInput.setAttribute('list', 'automation-filter-field-suggestions');
+        if (!document.getElementById('automation-filter-field-suggestions')) {
+          const datalist = document.createElement('datalist');
+          datalist.id = 'automation-filter-field-suggestions';
+          [
+            'ticket.status',
+            'ticket.priority',
+            'ticket.age_days',
+            'ticket.updated_age_hours',
+            'ticket.last_reply_age_hours',
+            'ticket_update.actor_type',
+            'reply.is_internal',
+            'reply.kind',
+          ].forEach((field) => {
+            const option = document.createElement('option');
+            option.value = field;
+            datalist.appendChild(option);
+          });
+          document.body.appendChild(datalist);
+        }
         fieldInput.value = row.fieldPath || '';
         fieldInput.addEventListener('input', () => handleRowChange(index, 'fieldPath', fieldInput.value));
 
@@ -1784,17 +1820,6 @@
         advancedEditor.value = initialRaw;
         modeInput.value = 'advanced';
         setAdvancedMode(true);
-      }
-    } else if (FILTER_SNIPPETS.length > 0) {
-      try {
-        const defaultSnippet = FILTER_SNIPPETS[0];
-        const parsed = JSON.parse(defaultSnippet.value);
-        const rows = filtersToRows(parsed);
-        if (rows.length) {
-          builderState = { all: rows };
-        }
-      } catch (error) {
-        // Ignore malformed fallback snippet.
       }
     }
 

--- a/tests/test_automations_service.py
+++ b/tests/test_automations_service.py
@@ -848,3 +848,21 @@ async def test_execute_scheduled_ticket_automation_runs_actions_for_matching_tic
     assert captured[0][1]["ticket_id"] == 1
     assert captured[0][1]["status"] == "closed"
     assert captured[0][1]["context"]["ticket"]["id"] == 1
+
+
+def test_filters_match_supports_reply_internal_note_context():
+    internal_context = {"reply": {"is_internal": True, "kind": "internal_note"}}
+    public_context = {"reply": {"is_internal": False, "kind": "message"}}
+
+    assert automations_service._filters_match(
+        {"match": {"reply.is_internal": True}},
+        internal_context,
+    )
+    assert automations_service._filters_match(
+        {"match": {"reply.kind": "message"}},
+        public_context,
+    )
+    assert not automations_service._filters_match(
+        {"match": {"reply.is_internal": True}},
+        public_context,
+    )

--- a/tests/test_ticket_reply_automation_context.py
+++ b/tests/test_ticket_reply_automation_context.py
@@ -1,0 +1,38 @@
+from typing import Any
+
+import pytest
+
+from app.services import tickets as tickets_service
+
+
+@pytest.mark.anyio
+async def test_emit_ticket_replied_event_includes_internal_reply_context(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    async def fake_get_ticket(ticket_id: int):
+        assert ticket_id == 123
+        return {"id": 123, "status": "open", "subject": "Example"}
+
+    async def fake_enrich(ticket):
+        return dict(ticket)
+
+    async def fake_handle_event(event_name, context):
+        captured["event_name"] = event_name
+        captured["context"] = context
+        return []
+
+    monkeypatch.setattr(tickets_service.tickets_repo, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(tickets_service, "_enrich_ticket_context", fake_enrich)
+    monkeypatch.setattr(tickets_service.automations_service, "handle_event", fake_handle_event)
+
+    await tickets_service.emit_ticket_replied_event(
+        123,
+        actor_type="technician",
+        actor={"id": 7, "email": "tech@example.test"},
+        reply={"id": 55, "is_internal": 1, "body": "hidden"},
+    )
+
+    assert captured["event_name"] == "tickets.replied"
+    assert captured["context"]["reply"]["id"] == 55
+    assert captured["context"]["reply"]["is_internal"] is True
+    assert captured["context"]["reply"]["kind"] == "internal_note"


### PR DESCRIPTION
### Motivation

- Prevent saved automation trigger filters from reverting to `ticket.status = open` when admins edit or save filters due to the builder seeding an empty default snippet. 
- Allow automations to distinguish replies that are internal notes vs public messages so admins can block actions (like outgoing emails) for internal notes. 
- Provide admin UX improvements (snippets and field suggestions) so configuring reply-based filters is discoverable and less error prone. 

### Description

- Stop seeding the filter builder with a default snippet when there are no initial filters, removing the silent `ticket.status = open` fallback in `app/static/js/automation.js`. 
- Add filter snippets for `reply.is_internal` and `reply.kind` and add a `datalist` of suggested field paths (including `reply.is_internal` / `reply.kind`) to the automation filter UI in `app/static/js/automation.js`. 
- Enrich the ticket reply automation event context with `reply` data, normalising `reply.is_internal` to a boolean and adding `reply.kind` as `internal_note` or `message` in `app/services/tickets.py`. 
- Ensure reply creation flows pass the created reply into the automation emitter by returning the created reply and forwarding it from `app/features/tickets/admin_routes.py` and `app/features/tickets/portal_routes.py`. 
- Add regression tests that assert filter matching for reply internal-note context and that the emitted `tickets.replied` event contains the reply context in `tests/test_automations_service.py` and `tests/test_ticket_reply_automation_context.py`. 

### Testing

- Ran unit tests for the modified areas with `pytest -q tests/test_automations_service.py tests/test_ticket_reply_automation_context.py` and observed all tests pass (18 passed in the targeted run). 
- Verified targeted compilation with `python -m py_compile app/services/tickets.py app/features/tickets/admin_routes.py app/features/tickets/portal_routes.py` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a30e90af7b8832d808898e4e47d7f53)