### PR TITLE
Prevent duplicate tray UI instances

### DIFF
--- a/tray/ui/main.go
+++ b/tray/ui/main.go
@@ -60,6 +60,17 @@ var (
 
 func main() {
 	_ = logger.Init("ui")
+	lockAcquired, lockErr := acquireSingleInstanceLock()
+	if lockErr != nil {
+		logger.Warn("Single-instance check failed: %v", lockErr)
+	} else if !lockAcquired {
+		logger.Info("MyPortal Tray UI is already running for this user; exiting duplicate instance")
+		return
+	}
+	if lockAcquired {
+		defer releaseSingleInstanceLock()
+	}
+
 	logger.Info("MyPortal Tray UI (webview) starting")
 
 	refreshPortalURL()

--- a/tray/ui/main_nowebview.go
+++ b/tray/ui/main_nowebview.go
@@ -91,6 +91,17 @@ func requestChatTokenForRoom(roomID int) string {
 
 func main() {
 	_ = logger.Init("ui")
+	lockAcquired, lockErr := acquireSingleInstanceLock()
+	if lockErr != nil {
+		logger.Warn("Single-instance check failed: %v", lockErr)
+	} else if !lockAcquired {
+		logger.Info("MyPortal Tray UI is already running for this user; exiting duplicate instance")
+		return
+	}
+	if lockAcquired {
+		defer releaseSingleInstanceLock()
+	}
+
 	logger.Info("MyPortal Tray UI starting")
 
 	refreshPortalURL()

--- a/tray/ui/single_instance_other.go
+++ b/tray/ui/single_instance_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+func acquireSingleInstanceLock() (bool, error) {
+	return true, nil
+}
+
+func releaseSingleInstanceLock() {}

--- a/tray/ui/single_instance_windows.go
+++ b/tray/ui/single_instance_windows.go
@@ -1,0 +1,69 @@
+//go:build windows
+
+package main
+
+import (
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+var singleInstanceMutex windows.Handle
+
+// acquireSingleInstanceLock prevents more than one tray UI process from
+// running for the same Windows user. The mutex name includes the current
+// user's SID so different users on the same computer can each have their own
+// tray icon while duplicate launches for one user exit immediately.
+func acquireSingleInstanceLock() (bool, error) {
+	name := `Local\MyPortalTrayUI-` + currentUserSIDForMutex()
+	namePtr, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return false, err
+	}
+
+	handle, err := windows.CreateMutex(nil, true, namePtr)
+	if err == windows.ERROR_ALREADY_EXISTS {
+		if handle != 0 {
+			_ = windows.CloseHandle(handle)
+		}
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	singleInstanceMutex = handle
+	return true, nil
+}
+
+func releaseSingleInstanceLock() {
+	if singleInstanceMutex == 0 {
+		return
+	}
+	_ = windows.ReleaseMutex(singleInstanceMutex)
+	_ = windows.CloseHandle(singleInstanceMutex)
+	singleInstanceMutex = 0
+}
+
+func currentUserSIDForMutex() string {
+	token := windows.Token(0)
+	if err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_QUERY, &token); err == nil {
+		defer token.Close()
+		if tokenUser, err := token.GetTokenUser(); err == nil && tokenUser.User.Sid != nil {
+			return sanitizeMutexComponent(tokenUser.User.Sid.String())
+		}
+	}
+
+	// Fallback only if the token/SID lookup fails. Keeping the name in the Local
+	// namespace still prevents duplicate UI instances within this logon session.
+	return "session"
+}
+
+func sanitizeMutexComponent(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	replacer := strings.NewReplacer(`\`, "-", `/`, "-", `:`, "-", `*`, "-", `?`, "-", `"`, "-", `<`, "-", `>`, "-", `|`, "-")
+	return replacer.Replace(value)
+}


### PR DESCRIPTION
### Motivation
- Prevent multiple `myportal-tray-ui.exe` processes from creating duplicate tray icons for the same interactive user session on Windows.
- Ensure different interactive users on the same machine can still run separate tray UI instances.
- Keep cross-platform builds working by providing a no-op implementation on non-Windows platforms.

### Description
- Add a Windows-only single-instance guard using a named mutex that includes the current user SID: `tray/ui/single_instance_windows.go` implements `acquireSingleInstanceLock`, `releaseSingleInstanceLock`, and SID-derived mutex naming.
- Wire the single-instance check into both UI entrypoints by calling `acquireSingleInstanceLock()` early in `tray/ui/main.go` and `tray/ui/main_nowebview.go`, and deferring `releaseSingleInstanceLock()` when acquired.
- Add a no-op non-Windows implementation `tray/ui/single_instance_other.go` so non-Windows builds remain unchanged and cross-compilation continues to work.

### Testing
- Ran `cd tray && go test -tags nowebview ./ui` which passed for the nowebview unit tests on this host.
- `cd tray && go test ./ui` failed in this Linux CI environment due to missing `ayatana-appindicator3-0.1` development package required by `systray` (environment limitation, not code failure).
- Cross-compiled Windows tests (`GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -tags nowebview ./ui` and `go test -c -tags nowebview ./ui -o /tmp/myportal-ui-nowebview.test.exe`) compiled successfully but could not execute the Windows binary on Linux (`exec format error`), as expected when running Windows binaries on Linux.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31f24dfb3c832dbbe231813d74284f)