### PR TITLE
Add Wait For Webhook support to staff onboarding workflows

### DIFF
--- a/app/api/routes/staff.py
+++ b/app/api/routes/staff.py
@@ -20,6 +20,7 @@ from app.schemas.staff import (
     StaffCreate,
     StaffExternalCheckpointCallback,
     StaffExternalCheckpointResponse,
+    StaffWorkflowWebhookCallback,
     StaffWorkflowManualActionRequest,
     StaffWorkflowManualActionResponse,
     StaffRequestCreate,
@@ -830,6 +831,42 @@ async def _confirm_external_checkpoint(
         response_status=status.HTTP_202_ACCEPTED,
         response_payload=response_payload,
     )
+    return StaffExternalCheckpointResponse.model_validate(response_payload)
+
+
+@router.post(
+    "/workflow-webhooks/{webhook_public_id}",
+    response_model=StaffExternalCheckpointResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Resume a staff workflow from a Wait For Webhook step",
+    description=(
+        "Receives POST callbacks for onboarding/offboarding Wait For Webhook steps. "
+        "The unique webhook URL identifies the pending workflow checkpoint and "
+        "the request body must include the matching postKey before the workflow resumes."
+    ),
+)
+async def confirm_workflow_webhook(
+    webhook_public_id: str,
+    payload: StaffWorkflowWebhookCallback,
+    _: None = Depends(require_database),
+):
+    try:
+        result = await staff_onboarding_workflow_service.confirm_webhook_checkpoint_and_resume(
+            webhook_public_id=webhook_public_id.strip(),
+            post_key=payload.post_key,
+            source=payload.source.strip(),
+            callback_payload=payload.payload,
+            company_id=payload.company_id,
+            staff_id=payload.staff_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    response_payload = {
+        "state": result.get("state") or "unknown",
+        "executionId": int(result.get("execution_id") or 0),
+        "staffId": int(result.get("staff_id") or 0),
+        "companyId": int(result.get("company_id") or 0),
+    }
     return StaffExternalCheckpointResponse.model_validate(response_payload)
 
 

--- a/app/repositories/staff_onboarding_workflows.py
+++ b/app/repositories/staff_onboarding_workflows.py
@@ -691,18 +691,22 @@ async def create_external_checkpoint(
     company_id: int,
     staff_id: int,
     confirmation_token_hash: str,
+    webhook_public_id: str | None = None,
+    webhook_post_key_hash: str | None = None,
 ) -> dict[str, Any]:
     await db.execute(
         """
         INSERT INTO staff_onboarding_external_checkpoints
-            (execution_id, company_id, staff_id, confirmation_token_hash, status, created_at, updated_at)
-        VALUES (%s, %s, %s, %s, 'pending', %s, %s)
+            (execution_id, company_id, staff_id, confirmation_token_hash, webhook_public_id, webhook_post_key_hash, status, created_at, updated_at)
+        VALUES (%s, %s, %s, %s, %s, %s, 'pending', %s, %s)
         """,
         (
             execution_id,
             company_id,
             staff_id,
             confirmation_token_hash,
+            webhook_public_id,
+            webhook_post_key_hash,
             _utc_now_naive(),
             _utc_now_naive(),
         ),
@@ -740,6 +744,33 @@ async def get_pending_external_checkpoint(
         LIMIT 1
         """,
         (execution_id, company_id, staff_id, confirmation_token_hash),
+    )
+    return dict(row) if row else None
+
+
+async def get_pending_external_checkpoint_by_webhook_id(
+    *,
+    webhook_public_id: str,
+    company_id: int | None = None,
+    staff_id: int | None = None,
+) -> dict[str, Any] | None:
+    conditions = ["webhook_public_id = %s", "status = 'pending'"]
+    params: list[Any] = [webhook_public_id]
+    if company_id is not None:
+        conditions.append("company_id = %s")
+        params.append(int(company_id))
+    if staff_id is not None:
+        conditions.append("staff_id = %s")
+        params.append(int(staff_id))
+    row = await db.fetch_one(
+        f"""
+        SELECT *
+        FROM staff_onboarding_external_checkpoints
+        WHERE {' AND '.join(conditions)}
+        ORDER BY id DESC
+        LIMIT 1
+        """,
+        tuple(params),
     )
     return dict(row) if row else None
 

--- a/app/schemas/staff.py
+++ b/app/schemas/staff.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Optional
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import AliasChoices, BaseModel, EmailStr, Field
 
 
 class StaffBase(BaseModel):
@@ -113,6 +113,18 @@ class StaffExternalCheckpointResponse(BaseModel):
     execution_id: int = Field(validation_alias="executionId")
     staff_id: int = Field(validation_alias="staffId")
     company_id: int = Field(validation_alias="companyId")
+
+
+class StaffWorkflowWebhookCallback(BaseModel):
+    post_key: str = Field(
+        validation_alias=AliasChoices("post_key", "postKey"),
+        min_length=24,
+        max_length=255,
+    )
+    source: str = Field(default="workflow-webhook", min_length=2, max_length=128)
+    company_id: Optional[int] = Field(default=None, validation_alias=AliasChoices("company_id", "companyId"))
+    staff_id: Optional[int] = Field(default=None, validation_alias=AliasChoices("staff_id", "staffId"))
+    payload: dict[str, Any] | None = None
 
 
 class StaffWorkflowManualActionRequest(BaseModel):

--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
+import hmac
 import json
 import re
 import secrets
@@ -11,6 +14,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import httpx
 
+from app.core.config import get_settings
 from app.core.logging import log_error, log_info, log_warning
 from app.repositories import companies as company_repo
 from app.repositories import company_memberships as membership_repo
@@ -57,6 +61,27 @@ def _default_workflow_key(direction: str) -> str:
         workflow_repo.DEFAULT_OFFBOARDING_WORKFLOW_KEY
         if direction == DIRECTION_OFFBOARDING
         else workflow_repo.DEFAULT_WORKFLOW_KEY
+    )
+
+
+def _workflow_webhook_secret(scope: str, *, length: int = 32) -> str:
+    settings = get_settings()
+    secret_key = str(settings.secret_key)
+    digest = hmac.new(secret_key.encode("utf-8"), scope.encode("utf-8"), hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")[:length]
+
+
+def _build_static_workflow_webhook_credentials(
+    *,
+    company_id: int,
+    direction: str,
+    workflow_key: str,
+    step_name: str,
+) -> tuple[str, str]:
+    workflow_scope = f"staff-workflow-webhook:v1:{company_id}:{direction}:{workflow_key}:{step_name}"
+    return (
+        _workflow_webhook_secret(f"{workflow_scope}:url", length=32),
+        _workflow_webhook_secret(f"{workflow_scope}:post-key", length=43),
     )
 
 # Kid-friendly word list: words are stored exclusively in the database table
@@ -2285,20 +2310,36 @@ async def _execute_policy_steps(
         step_name = str(step.get("name") or f"step_{index + 1}")
         if step_name in succeeded_steps:
             continue
-        if str(step.get("type")).strip().lower() == "wait_external_checkpoint":
+        if str(step.get("type")).strip().lower() in {"wait_external_checkpoint", "wait_for_webhook"}:
             confirmation_token = secrets.token_urlsafe(32)
+            webhook_public_id, webhook_post_key = _build_static_workflow_webhook_credentials(
+                company_id=company_id,
+                direction=direction,
+                workflow_key=str(policy_config.get("workflow_key") or ""),
+                step_name=step_name,
+            )
             await workflow_repo.create_external_checkpoint(
                 execution_id=execution_id,
                 company_id=company_id,
                 staff_id=int(staff["id"]),
                 confirmation_token_hash=hash_api_key(confirmation_token),
+                webhook_public_id=webhook_public_id,
+                webhook_post_key_hash=hash_api_key(webhook_post_key),
             )
+            settings = get_settings()
+            base_url = str(settings.public_base_url or settings.portal_url or "").strip().rstrip("/")
+            webhook_path = f"/api/staff/workflow-webhooks/{webhook_public_id}"
             await workflow_repo.update_execution_state(
                 execution_id,
                 state=waiting_external_state,
                 current_step=f"{index}:{step_name}",
             )
-            return {"paused": True, "confirmation_token": confirmation_token}
+            return {
+                "paused": True,
+                "confirmation_token": confirmation_token,
+                "webhook_post_key": webhook_post_key,
+                "webhook_url": f"{base_url}{webhook_path}" if base_url else webhook_path,
+            }
 
         resolved_step = _resolve_template_value(step, vars_map=vars_map)
         if isinstance(resolved_step, dict):
@@ -2580,6 +2621,7 @@ async def resume_staff_onboarding_workflow_after_external_confirmation(
     workflow_key = str(policy.get("workflow_key") or _default_workflow_key(direction))
     max_retries = max(0, int(policy.get("max_retries") or 0))
     policy_config = policy.get("config") if isinstance(policy.get("config"), dict) else {}
+    policy_config.setdefault("workflow_key", workflow_key)
     delay_type = str(policy.get("delay_type") or "scheduled").strip().lower()
     # "immediate" workflows do not control staff-level status transitions —
     # they run their configured steps (e.g. notifications) independently.
@@ -2697,6 +2739,8 @@ async def resume_staff_onboarding_workflow_after_external_confirmation(
                 "state": paused_state,
                 "execution_id": execution_id,
                 "confirmation_token": execution_result.get("confirmation_token"),
+                "webhook_url": execution_result.get("webhook_url"),
+                "webhook_post_key": execution_result.get("webhook_post_key"),
                 "helpdesk_ticket_id": ticket_id,
             }
 
@@ -3229,3 +3273,52 @@ async def confirm_external_checkpoint_and_resume(
         execution_id=int(execution["id"]),
         initiated_by_user_id=None,
     )
+
+
+async def confirm_webhook_checkpoint_and_resume(
+    *,
+    webhook_public_id: str,
+    post_key: str,
+    source: str,
+    callback_payload: dict[str, Any] | None,
+    company_id: int | None = None,
+    staff_id: int | None = None,
+) -> dict[str, Any]:
+    checkpoint = await workflow_repo.get_pending_external_checkpoint_by_webhook_id(
+        webhook_public_id=webhook_public_id,
+        company_id=company_id,
+        staff_id=staff_id,
+    )
+    if not checkpoint:
+        raise ValueError("Invalid or already completed webhook URL")
+    expected_hash = str(checkpoint.get("webhook_post_key_hash") or "")
+    if not expected_hash or not secrets.compare_digest(expected_hash, hash_api_key(post_key)):
+        raise ValueError("Invalid webhook POST key")
+    company_id = int(checkpoint["company_id"])
+    staff_id = int(checkpoint["staff_id"])
+    execution_id = int(checkpoint["execution_id"])
+    await workflow_repo.confirm_external_checkpoint(
+        int(checkpoint["id"]),
+        source=source[:128],
+        callback_timestamp=_utc_now_naive(),
+        proof_reference_id=webhook_public_id,
+        payload_hash=None,
+        callback_payload=callback_payload or {},
+        confirmed_by_api_key_id=None,
+    )
+    await audit_service.log_action(
+        user_id=None,
+        action="staff.workflow.webhook_confirmed",
+        entity_type="staff",
+        entity_id=staff_id,
+        metadata={"company_id": company_id, "execution_id": execution_id, "webhook_public_id": webhook_public_id},
+    )
+    result = await resume_staff_onboarding_workflow_after_external_confirmation(
+        company_id=company_id,
+        staff_id=staff_id,
+        execution_id=execution_id,
+        initiated_by_user_id=None,
+    )
+    result.setdefault("company_id", company_id)
+    result.setdefault("staff_id", staff_id)
+    return result

--- a/migrations/270_staff_workflow_wait_for_webhook.sql
+++ b/migrations/270_staff_workflow_wait_for_webhook.sql
@@ -1,0 +1,8 @@
+-- Migration 270: Unique Wait For Webhook callback URLs for staff onboarding/offboarding workflows
+
+ALTER TABLE staff_onboarding_external_checkpoints
+    ADD COLUMN IF NOT EXISTS webhook_public_id VARCHAR(96) NULL AFTER confirmation_token_hash,
+    ADD COLUMN IF NOT EXISTS webhook_post_key_hash CHAR(64) NULL AFTER webhook_public_id;
+
+CREATE INDEX IF NOT EXISTS idx_staff_onboarding_external_checkpoints_webhook
+    ON staff_onboarding_external_checkpoints (webhook_public_id, status);


### PR DESCRIPTION
### Motivation
- Introduce a secure webhook-based checkpoint for staff onboarding/offboarding workflows so external systems can resume paused workflows via a unique URL and POST key.

### Description
- Add a new public route `POST /api/staff/workflow-webhooks/{webhook_public_id}` implemented in `app/api/routes/staff.py` that accepts a `StaffWorkflowWebhookCallback` and resumes the matching workflow checkpoint.
- Extend the onboarding workflow repository to persist `webhook_public_id` and `webhook_post_key_hash` in `staff_onboarding_external_checkpoints`, add `create_external_checkpoint` parameter support, and implement `get_pending_external_checkpoint_by_webhook_id` in `app/repositories/staff_onboarding_workflows.py`.
- Generate static, deterministic webhook credentials via `_workflow_webhook_secret` and `_build_static_workflow_webhook_credentials` in `app/services/staff_onboarding_workflows.py`, treat `wait_for_webhook` step types as external checkpoints, and return `webhook_url` and `webhook_post_key` when a workflow is paused.
- Implement `confirm_webhook_checkpoint_and_resume` to validate the POST key, mark the checkpoint confirmed, audit the action, and resume the workflow in `app/services/staff_onboarding_workflows.py`.
- Add a new `StaffWorkflowWebhookCallback` schema and update `app/schemas/staff.py` to include alias handling for incoming fields using `AliasChoices`.
- Include a migration `migrations/270_staff_workflow_wait_for_webhook.sql` to add `webhook_public_id` and `webhook_post_key_hash` columns and an index to `staff_onboarding_external_checkpoints`.

### Testing
- Ran `pytest` against the codebase and the test suite completed successfully.
- Applied and verified the new migration `migrations/270_staff_workflow_wait_for_webhook.sql` in a local test database without errors.
- Exercised the new endpoint flow in local integration testing by creating a workflow that pauses on `wait_for_webhook`, confirming the returned `webhook_post_key` and `webhook_url`, and successfully resuming the workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31f3ec938c832d998f2965dce489ed)