### PR TITLE
Fix offboarding calendar cleanup: include QueryWindowInDays in Remove-CalendarEvents

### DIFF
--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -5086,9 +5086,11 @@ async def start_managed_folder_assistant_all_mailboxes(company_id: int) -> dict[
 async def remove_calendar_events(company_id: int, upn: str) -> None:
     """Cancel organized meetings for ``upn`` using Exchange Online cmdlets.
 
-    Uses ``Remove-CalendarEvents`` with ``-CancelOrganizedMeetings`` so
-    future meetings owned by the departing user are cancelled as part of
-    offboarding.
+    Uses ``Remove-CalendarEvents`` with ``-CancelOrganizedMeetings`` and an
+    explicit ``QueryWindowInDays`` value so future meetings owned by the
+    departing user are cancelled as part of offboarding. Exchange Online treats
+    ``QueryWindowInDays`` as required for this cmdlet; omitting it causes the
+    REST InvokeCommand API to reject the request with HTTP 400.
     """
     normalised = str(upn or "").strip()
     if not normalised:
@@ -5102,6 +5104,8 @@ async def remove_calendar_events(company_id: int, upn: str) -> None:
         {
             "Identity": normalised,
             "CancelOrganizedMeetings": True,
+            # Maximum supported window: five years of future events.
+            "QueryWindowInDays": 1825,
         },
     )
     log_info(

--- a/tests/test_m365_mailboxes.py
+++ b/tests/test_m365_mailboxes.py
@@ -1923,6 +1923,7 @@ async def test_remove_calendar_events_invokes_exchange_cmdlet():
         {
             "Identity": "offboard.user@example.com",
             "CancelOrganizedMeetings": True,
+            "QueryWindowInDays": 1825,
         },
     )
 


### PR DESCRIPTION
### Motivation
- Exchange Online InvokeCommand returned HTTP 400 for `Remove-CalendarEvents` when `QueryWindowInDays` was omitted, causing offboarding workflows that cancel future meetings to fail. 

### Description
- Add an explicit `QueryWindowInDays: 1825` parameter and explanatory docstring to `remove_calendar_events` in `app/services/m365.py` so the Exchange cmdlet request is accepted. 
- Update the regression test in `tests/test_m365_mailboxes.py` to assert the `QueryWindowInDays` parameter is included in the `Remove-CalendarEvents` invocation. 

### Testing
- Ran `pytest tests/test_m365_mailboxes.py::test_remove_calendar_events_invokes_exchange_cmdlet tests/test_staff_onboarding_workflow_policy_steps.py::test_run_offboarding_step_removes_calendar_events_when_enabled -q` which passed. 
- Ran `pytest tests/test_m365_mailboxes.py tests/test_staff_onboarding_workflow_policy_steps.py -q` which passed (no failures in those files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31fb9207c4832db9ae526017d7a667)