### PR TITLE
Handle duplicate Solidtime project sync

### DIFF
--- a/app/services/solidtime.py
+++ b/app/services/solidtime.py
@@ -935,6 +935,48 @@ def _hash_payload(payload: Any) -> str:
     return hashlib.sha256(serialised.encode("utf-8")).hexdigest()
 
 
+def _is_duplicate_project_error(exc: SolidtimeAPIError) -> bool:
+    """Return True when Solidtime rejected a project create as a duplicate."""
+    message = str(exc).lower()
+    return "project with the same name and client already exists" in message or (
+        "same name" in message and "client" in message and "already exists" in message
+    )
+
+
+def _project_client_id(project: Mapping[str, Any]) -> str | None:
+    """Extract a Solidtime project client ID from flat or expanded API shapes."""
+    return _extract_resource_id(project.get("client_id")) or _extract_resource_id(
+        project.get("client")
+    )
+
+
+async def _find_existing_project_by_name_and_client(
+    org_id: str,
+    *,
+    name: str,
+    client_id: str | None,
+) -> dict[str, Any] | None:
+    """Find an existing Solidtime project matching the unique name/client pair.
+
+    Solidtime enforces project uniqueness by organization, project name, and
+    client. If MyPortal loses or has not yet created the local link row, a
+    create attempt returns HTTP 422. Looking up the existing project lets the
+    sync become idempotent and rebuild the missing local link instead of
+    retrying the same failing create on every reconcile run.
+    """
+    projects = await list_projects(org_id)
+    expected_name = name.strip()
+    expected_client = str(client_id or "").strip() or None
+    for project in projects:
+        project_name = str(project.get("name") or "").strip()
+        if project_name != expected_name:
+            continue
+        project_client = _project_client_id(project)
+        if (project_client or None) == expected_client:
+            return project
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Outbound sync helpers
 # ---------------------------------------------------------------------------
@@ -1051,7 +1093,24 @@ async def sync_ticket_to_project(ticket_id: int) -> dict[str, Any] | None:
                 )
             await update_project(org_id, project_id, body=body)
         else:
-            created = await create_project(org_id, body=body)
+            try:
+                created = await create_project(org_id, body=body)
+            except SolidtimeAPIError as exc:
+                if not _is_duplicate_project_error(exc):
+                    raise
+                existing_project = await _find_existing_project_by_name_and_client(
+                    org_id,
+                    name=str(body.get("name") or ""),
+                    client_id=client_id,
+                )
+                if not existing_project:
+                    raise
+                created = existing_project
+                log_info(
+                    "Linked existing Solidtime project after duplicate create",
+                    ticket_id=ticket_id,
+                    project_id=str(existing_project.get("id") or ""),
+                )
             project_id = str(created.get("id") or "").strip()
             if not project_id:
                 raise SolidtimeAPIError("Solidtime did not return a project ID")

--- a/tests/test_solidtime.py
+++ b/tests/test_solidtime.py
@@ -571,6 +571,86 @@ async def test_sync_ticket_to_project_records_error_on_api_failure(
 
 
 @pytest.mark.anyio
+async def test_sync_ticket_to_project_links_existing_project_on_duplicate_create(
+    reset_solidtime_caches,
+):
+    async def fake_get_module(slug):
+        return {
+            "enabled": True,
+            "settings": {
+                "base_url": "https://app.solidtime.io",
+                "api_token": "tok",
+                "organization_id": "org-uuid",
+                "sync_tickets_to_projects": True,
+                "default_client_id": "client-uuid",
+            },
+        }
+
+    reset_solidtime_caches.setattr(solidtime.module_repo, "get_module", fake_get_module)
+
+    async def fake_get_ticket(ticket_id):
+        return {
+            "id": ticket_id,
+            "ticket_number": "T-422",
+            "subject": "Existing upstream project",
+            "company_id": None,
+            "status": "open",
+        }
+
+    reset_solidtime_caches.setattr(
+        solidtime.tickets_repo, "get_ticket", fake_get_ticket
+    )
+
+    async def fake_get_project_link(ticket_id):
+        return None
+
+    upserts: list[dict[str, object]] = []
+    captured_errors: list[tuple[int, str]] = []
+
+    async def fake_upsert_project_link(**kwargs):
+        upserts.append(kwargs)
+        return {"ticket_id": kwargs["ticket_id"], **kwargs}
+
+    async def fake_mark_project_error(ticket_id, error):
+        captured_errors.append((ticket_id, error))
+
+    reset_solidtime_caches.setattr(
+        solidtime.links_repo, "get_project_link", fake_get_project_link
+    )
+    reset_solidtime_caches.setattr(
+        solidtime.links_repo, "upsert_project_link", fake_upsert_project_link
+    )
+    reset_solidtime_caches.setattr(
+        solidtime.links_repo, "mark_project_link_error", fake_mark_project_error
+    )
+
+    async def fake_create_project(org_id, *, body):
+        raise SolidtimeAPIError(
+            '{"message":"A project with the same name and client already exists '
+            'in the organization."}'
+        )
+
+    async def fake_list_projects(org_id):
+        return [
+            {
+                "id": "existing-project-uuid",
+                "name": "#T-422 – Existing upstream project",
+                "client_id": "client-uuid",
+            }
+        ]
+
+    reset_solidtime_caches.setattr(solidtime, "create_project", fake_create_project)
+    reset_solidtime_caches.setattr(solidtime, "list_projects", fake_list_projects)
+
+    link = await solidtime.sync_ticket_to_project(422)
+
+    assert link is not None
+    assert link["solidtime_project_id"] == "existing-project-uuid"
+    assert upserts and upserts[0]["sync_status"] == "synced"
+    assert captured_errors == []
+
+
+@pytest.mark.anyio
 async def test_sync_ticket_skips_when_module_disabled(reset_solidtime_caches):
     async def fake_get_module(slug):
         return {"enabled": False, "settings": {}}


### PR DESCRIPTION
### Motivation
- Prevent repeated HTTP 422 failures when creating a Solidtime project that already exists upstream, by rebuilding the local link instead of continuously retrying the failing create.
- Make ticket→project sync idempotent in the face of missing local link rows for projects that already exist in Solidtime.

### Description
- Added `_is_duplicate_project_error` to detect Solidtime duplicate-create errors from API responses. (`app/services/solidtime.py`)
- Added `_project_client_id` and `_find_existing_project_by_name_and_client` helpers to locate an existing Solidtime project by the unique name+client pair. (`app/services/solidtime.py`)
- Updated `sync_ticket_to_project` to recover from duplicate-create `SolidtimeAPIError` by looking up the existing project and relinking it, logging the relink and continuing to upsert the local link. (`app/services/solidtime.py`)
- Added a regression test `test_sync_ticket_to_project_links_existing_project_on_duplicate_create` to verify relinking behavior when Solidtime returns a duplicate-project error. (`tests/test_solidtime.py`)

### Testing
- Ran `pytest tests/test_solidtime.py -q` and all tests passed (`41 passed`).
- Ran project formatting (`black`) and `git diff --check` to ensure no stylistic or diff issues; no problems were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31fad924b0832db0e4a5be909d680a)