### PR TITLE
Launch tray chat automatically on technician chat start

### DIFF
--- a/tray/ui/chat_notification.go
+++ b/tray/ui/chat_notification.go
@@ -34,6 +34,7 @@ type chatMessagePayload struct {
 
 var (
 	showChatSessionNotificationFunc = showChatSessionNotification
+	openChatWindowFunc              = openChatWindow
 
 	notificationActionOnce    sync.Once
 	notificationActionBaseURL string
@@ -51,6 +52,8 @@ func handleChatOpen(payload chatOpenPayload) {
 	if actionURL == "" {
 		logger.Warn("handleChatOpen: could not register chat notification action for room_id=%d", payload.RoomID)
 	}
+
+	go openChatWindowFunc(chatOpenURL(payload.RoomID), gConfig)
 
 	title, body := chatNotificationText(payload)
 	showChatSessionNotificationFunc(title, body, actionURL)
@@ -104,6 +107,14 @@ func chatNotificationText(payload chatOpenPayload) (string, string) {
 		body += "\n" + message
 	}
 	return title, body
+}
+
+func chatOpenURL(roomID int) string {
+	chatURL := requestChatTokenForRoom(roomID)
+	if chatURL == "" {
+		chatURL = buildChatURL(roomID)
+	}
+	return chatURL
 }
 
 func summarizeChatMessage(message string) string {
@@ -177,16 +188,13 @@ func handleNotificationOpenChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	chatURL := requestChatTokenForRoom(action.RoomID)
-	if chatURL == "" {
-		chatURL = buildChatURL(action.RoomID)
-	}
+	chatURL := chatOpenURL(action.RoomID)
 	if chatURL == "" {
 		http.Error(w, "Unable to open chat. Please try again from the MyPortal tray icon.", http.StatusBadGateway)
 		return
 	}
 
-	go openChatWindow(chatURL, gConfig)
+	go openChatWindowFunc(chatURL, gConfig)
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_, _ = fmt.Fprint(w, "<html><body><p>Opening MyPortal Chat…</p><script>window.close();</script></body></html>")
 }

--- a/tray/ui/main_nowebview_test.go
+++ b/tray/ui/main_nowebview_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/bradhawkins85/myportal-tray/internal/api"
 	"github.com/bradhawkins85/myportal-tray/internal/ipc"
 )
 
@@ -43,6 +45,65 @@ func TestHandleIPCMessageDispatchesChatMessageNotification(t *testing.T) {
 		}
 	}
 	if gotURL == "" {
+		t.Fatalf("chat notification action URL should not be empty")
+	}
+}
+
+func TestHandleIPCMessageDispatchesChatOpenNotificationAndLaunchesChatShell(t *testing.T) {
+	previousNotify := showChatSessionNotificationFunc
+	previousOpen := openChatWindowFunc
+	previousPortalURL := gPortalURL
+	gPortalURL = "https://portal.example.test"
+	defer func() {
+		showChatSessionNotificationFunc = previousNotify
+		openChatWindowFunc = previousOpen
+		gPortalURL = previousPortalURL
+	}()
+
+	var gotTitle string
+	var gotBody string
+	var gotActionURL string
+	showChatSessionNotificationFunc = func(title, body, chatURL string) {
+		gotTitle = title
+		gotBody = body
+		gotActionURL = chatURL
+	}
+
+	opened := make(chan string, 1)
+	openChatWindowFunc = func(chatURL string, _ *api.ConfigResponse) {
+		opened <- chatURL
+	}
+
+	payload, err := json.Marshal(chatOpenPayload{
+		RoomID:      77,
+		Subject:     "Laptop support",
+		InitiatedBy: "Alex Tech",
+		Message:     "I am starting a support chat.",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	handleIPCMessage(ipc.Message{Type: "chat_open", Payload: payload})
+
+	select {
+	case chatURL := <-opened:
+		if !strings.Contains(chatURL, "/tray/chat?room=77") {
+			t.Fatalf("opened chatURL = %q, want room-specific tray chat URL", chatURL)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected chat_open to launch the chat window automatically")
+	}
+
+	if gotTitle != "New MyPortal chat" {
+		t.Fatalf("title = %q", gotTitle)
+	}
+	for _, want := range []string{"Alex Tech", "Laptop support", "I am starting a support chat."} {
+		if !strings.Contains(gotBody, want) {
+			t.Fatalf("body = %q, want it to contain %q", gotBody, want)
+		}
+	}
+	if gotActionURL == "" {
 		t.Fatalf("chat notification action URL should not be empty")
 	}
 }


### PR DESCRIPTION
### Motivation
- When a technician starts a chat from the web UI, the tray client should open the dedicated chat window automatically so the logged-in user is immediately notified and presented the chat session.
- The server and tray already send a `chat_open` IPC event; the tray should act on that event to improve the UX for technician-initiated sessions.

### Description
- Automatically launch the tray chat window on receipt of a `chat_open` IPC event by calling the existing open routine from `tray/ui/chat_notification.go` and exposing a testable `openChatWindowFunc` wrapper, while preserving the notification behavior; changed file: `tray/ui/chat_notification.go`.
- Centralized chat URL resolution into `chatOpenURL(roomID int)` so both automatic launches and notification-action clicks use the same authenticated token path with the existing `buildChatURL` fallback; changed file: `tray/ui/chat_notification.go`.
- Added a nowebview regression test `TestHandleIPCMessageDispatchesChatOpenNotificationAndLaunchesChatShell` that asserts both the notification and automatic launch behavior; changed file: `tray/ui/main_nowebview_test.go`.

### Testing
- Ran the tray UI unit tests with `cd tray && go test -tags nowebview ./ui` and the suite passed (`ok github.com/bradhawkins85/myportal-tray/ui`).
- Ran `pytest -q tests/test_tray_devices_page.py::test_start_device_chat_reuses_existing_open_tray_room` and the test passed (1 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31fc9019b4832da7ec7361c1594658)