### PR TITLE
Handle Graph 403 during mailbox rule offboarding

### DIFF
--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -2102,12 +2102,27 @@ async def _run_offboarding_step(
                 except WorkflowStepError as exc:
                     if exc.http_status == 404:
                         continue
+                    if exc.http_status == 403:
+                        log_warning(
+                            "Offboarding: message rule disable skipped (Graph permission denied)",
+                            user_id=user_id,
+                            user_upn=user_upn,
+                            rule_id=rule_id,
+                        )
+                        continue
                     raise
-            steps_executed.append("disable_mailbox_rules")
+            if mailbox_rules_disabled_count:
+                steps_executed.append("disable_mailbox_rules")
         except M365Error as exc:
             if exc.http_status == 404:
                 log_warning(
                     "Offboarding: messageRules not available (no Exchange Online mailbox)",
+                    user_id=user_id,
+                    user_upn=user_upn,
+                )
+            elif exc.http_status == 403:
+                log_warning(
+                    "Offboarding: messageRules not accessible (Graph permission denied)",
                     user_id=user_id,
                     user_upn=user_upn,
                 )

--- a/tests/test_staff_onboarding_workflow_policy_steps.py
+++ b/tests/test_staff_onboarding_workflow_policy_steps.py
@@ -523,6 +523,76 @@ async def test_run_offboarding_step_disables_mailbox_rules_when_enabled(monkeypa
 
 
 @pytest.mark.anyio
+async def test_run_offboarding_step_continues_when_mailbox_rule_patch_forbidden(monkeypatch):
+    monkeypatch.setattr(workflows.m365_service, "acquire_access_token", AsyncMock(return_value="token"))
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_staff_m365_user",
+        AsyncMock(return_value={"id": "user-2", "userPrincipalName": "offboard.user@example.com"}),
+    )
+    monkeypatch.setattr(
+        workflows.m365_service,
+        "_graph_get_all",
+        AsyncMock(return_value=[{"id": "rule-1", "isEnabled": True}]),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "_graph_patch",
+        AsyncMock(side_effect=workflows.WorkflowStepError("Forbidden", http_status=403)),
+    )
+
+    result = await workflows._run_offboarding_step(
+        company_id=9,
+        staff={"id": 704, "email": "offboard.user@example.com"},
+        policy_config={},
+        step_config={
+            "disable_sign_in": False,
+            "revoke_licenses": False,
+            "remove_from_groups": False,
+            "disable_mailbox_rules": True,
+        },
+        vars_map={},
+    )
+
+    assert "disable_mailbox_rules" not in result["steps_executed"]
+    assert result["mailbox_rules_disabled"] == 0
+
+
+@pytest.mark.anyio
+async def test_run_offboarding_step_continues_when_mailbox_rules_list_forbidden(monkeypatch):
+    monkeypatch.setattr(workflows.m365_service, "acquire_access_token", AsyncMock(return_value="token"))
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_staff_m365_user",
+        AsyncMock(return_value={"id": "user-2", "userPrincipalName": "offboard.user@example.com"}),
+    )
+    monkeypatch.setattr(
+        workflows.m365_service,
+        "_graph_get_all",
+        AsyncMock(side_effect=workflows.M365Error("Forbidden", http_status=403)),
+    )
+    graph_patch = AsyncMock(return_value={})
+    monkeypatch.setattr(workflows, "_graph_patch", graph_patch)
+
+    result = await workflows._run_offboarding_step(
+        company_id=9,
+        staff={"id": 704, "email": "offboard.user@example.com"},
+        policy_config={},
+        step_config={
+            "disable_sign_in": False,
+            "revoke_licenses": False,
+            "remove_from_groups": False,
+            "disable_mailbox_rules": True,
+        },
+        vars_map={},
+    )
+
+    assert "disable_mailbox_rules" not in result["steps_executed"]
+    assert result["mailbox_rules_disabled"] == 0
+    graph_patch.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_run_offboarding_step_skips_mailbox_rule_disable_when_mailbox_missing(monkeypatch):
     monkeypatch.setattr(workflows.m365_service, "acquire_access_token", AsyncMock(return_value="token"))
     monkeypatch.setattr(


### PR DESCRIPTION
### Motivation
- Offboarding can fail when `disable_mailbox_rules` is enabled if Microsoft Graph returns `403` while listing or patching inbox message rules, so the workflow must tolerate permission-denied responses and continue other offboarding operations.
- Avoid reporting `disable_mailbox_rules` as completed when no rules were actually disabled to improve accuracy of step results.

### Description
- Catch `WorkflowStepError` with `http_status == 403` when patching individual message rules, log a warning, and continue to the next rule instead of failing the step.
- Treat `M365Error` with `http_status == 403` when listing `messageRules` as a non-fatal permission warning and skip mailbox-rule disabling instead of raising.
- Only append `"disable_mailbox_rules"` to the returned `steps_executed` when at least one mailbox rule was actually disabled (`mailbox_rules_disabled_count > 0`).
- Add regression tests `test_run_offboarding_step_continues_when_mailbox_rule_patch_forbidden` and `test_run_offboarding_step_continues_when_mailbox_rules_list_forbidden` to cover both 403 scenarios.

### Testing
- Ran `pytest -q tests/test_staff_onboarding_workflow_policy_steps.py -q` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31fd3c8350832d97e3a2938749969f)