### PR TITLE
Fix automation trigger filter saves

### DIFF
--- a/app/features/automations/handlers.py
+++ b/app/features/automations/handlers.py
@@ -282,6 +282,18 @@ def _parse_automation_form_submission(
             f"{invalid_section} is invalid JSON.",
             status.HTTP_400_BAD_REQUEST,
         )
+    if trigger_filters is not None:
+        if not isinstance(trigger_filters, dict):
+            invalid_section = "Advanced JSON trigger filters" if trigger_filters_mode == "advanced" else "Trigger filter builder payload"
+            return (
+                None,
+                form_state,
+                f"{invalid_section} must be a JSON object.",
+                status.HTTP_400_BAD_REQUEST,
+            )
+        if not trigger_filters:
+            trigger_filters = None
+            form_state["triggerFiltersRaw"] = ""
 
     try:
         action_payload = json.loads(action_payload_raw) if action_payload_raw else None

--- a/app/repositories/automations.py
+++ b/app/repositories/automations.py
@@ -222,6 +222,9 @@ async def update_automation(automation_id: int, **fields: Any) -> AutomationReco
         if key in {"trigger_filters", "action_payload"}:
             assignments.append(f"{key} = %s")
             params.append(_serialise(value))
+        elif key in {"next_run_at", "scheduled_time"}:
+            assignments.append(f"{key} = %s")
+            params.append(_prepare_for_storage(value))
         else:
             assignments.append(f"{key} = %s")
             params.append(value)

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -1575,12 +1575,12 @@
       if (!filters || typeof filters !== 'object') {
         return [];
       }
+      if (Array.isArray(filters.all)) {
+        return filters.all.map((node) => filterNodeToRow(node)).filter(Boolean);
+      }
       const asNode = filterNodeToRow(filters);
       if (asNode) {
         return [asNode];
-      }
-      if (Array.isArray(filters.all)) {
-        return filters.all.map((node) => filterNodeToRow(node)).filter(Boolean);
       }
       return [];
     };

--- a/tests/test_automation_form_parsing.py
+++ b/tests/test_automation_form_parsing.py
@@ -130,3 +130,45 @@ def test_parse_form_accepts_schema_payload():
     assert error_message is None
     assert status_code == 200
     assert data["action_payload"]["actions"][0]["payload"]["body"] == "Automated reply"
+
+
+def test_parse_event_form_rejects_non_object_trigger_filters():
+    form = FormData(
+        [
+            ("name", "Bad filter automation"),
+            ("kind", "event"),
+            ("status", "active"),
+            ("triggerEvent", "tickets.created"),
+            ("triggerFilters", json.dumps([{"match": {"ticket.status": "open"}}])),
+        ]
+    )
+
+    data, form_state, error_message, status_code = _parse_automation_form_submission(
+        form, kind="event"
+    )
+
+    assert data is None
+    assert status_code == 400
+    assert "object" in (error_message or "").lower()
+    assert form_state["triggerFiltersRaw"].startswith("[")
+
+
+def test_parse_event_form_treats_empty_trigger_filter_object_as_none():
+    form = FormData(
+        [
+            ("name", "Empty filter automation"),
+            ("kind", "event"),
+            ("status", "active"),
+            ("triggerEvent", "tickets.created"),
+            ("triggerFilters", "{}"),
+        ]
+    )
+
+    data, form_state, error_message, status_code = _parse_automation_form_submission(
+        form, kind="event"
+    )
+
+    assert error_message is None
+    assert status_code == 200
+    assert data["trigger_filters"] is None
+    assert form_state["triggerFiltersRaw"] == ""


### PR DESCRIPTION
### Motivation
- Prevent invalid or ambiguous trigger filter payloads from being persisted and ensure the automation form round-trip preserves user edits.
- Preserve builder-created top-level `all` clauses when reopening and resaving the filter UI so rows are not collapsed.
- Keep datetime fields consistent with UTC storage when updating an automation record.

### Description
- Validate parsed `trigger_filters` in `app/features/automations/handlers.py` to require a JSON object and return a clear `400` validation error for arrays/scalars, and normalise empty `{}` to `None` while clearing `form_state["triggerFiltersRaw"]` so empty filters are not saved.
- Update the filter builder in `app/static/js/automation.js` to prefer preserving `filters.all` arrays before attempting to parse a single-node filter so all builder rows are restored correctly.
- Update `app/repositories/automations.py` so `update_automation` prepares `next_run_at` and `scheduled_time` with `_prepare_for_storage` before writing to the database to maintain UTC storage semantics on resaves.
- Add regression tests in `tests/test_automation_form_parsing.py` that assert non-object trigger filters are rejected and that an empty object is treated as no filter.

### Testing
- Ran Python compilation check: `python -m py_compile app/features/automations/handlers.py app/repositories/automations.py` which succeeded.
- Ran targeted unit tests: `pytest -q tests/test_automation_form_parsing.py` and the test suite passed (all tests in that file passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a320ca78a00832d8424ce4ac060f5bc)