### PR TITLE
Launch tray chat window for inbound chat messages

### DIFF
--- a/tray/ui/chat_notification.go
+++ b/tray/ui/chat_notification.go
@@ -65,6 +65,13 @@ func handleChatMessage(payload chatMessagePayload) {
 		logger.Warn("handleChatMessage: could not register chat notification action for room_id=%d", payload.RoomID)
 	}
 
+	// Technician replies can arrive after the initial chat_open event, for
+	// example when the tray UI was started after the room was created or when a
+	// previous launch attempt failed. Treat every inbound chat message as a
+	// launch signal as well as a notification so the end user is never left with
+	// only a silent IPC event in ui.log.
+	go openChatWindowFunc(chatOpenURL(payload.RoomID), gConfig)
+
 	title, body := chatMessageNotificationText(payload)
 	showChatSessionNotificationFunc(title, body, actionURL)
 }

--- a/tray/ui/main_nowebview_test.go
+++ b/tray/ui/main_nowebview_test.go
@@ -13,7 +13,10 @@ import (
 )
 
 func TestHandleIPCMessageDispatchesChatMessageNotification(t *testing.T) {
-	previous := showChatSessionNotificationFunc
+	previousNotify := showChatSessionNotificationFunc
+	previousOpen := openChatWindowFunc
+	previousPortalURL := gPortalURL
+	gPortalURL = "https://portal.example.test"
 	var gotTitle string
 	var gotBody string
 	var gotURL string
@@ -22,7 +25,15 @@ func TestHandleIPCMessageDispatchesChatMessageNotification(t *testing.T) {
 		gotBody = body
 		gotURL = chatURL
 	}
-	t.Cleanup(func() { showChatSessionNotificationFunc = previous })
+	opened := make(chan string, 1)
+	openChatWindowFunc = func(chatURL string, _ *api.ConfigResponse) {
+		opened <- chatURL
+	}
+	t.Cleanup(func() {
+		showChatSessionNotificationFunc = previousNotify
+		openChatWindowFunc = previousOpen
+		gPortalURL = previousPortalURL
+	})
 
 	payload, err := json.Marshal(chatMessagePayload{
 		RoomID:  42,
@@ -46,6 +57,14 @@ func TestHandleIPCMessageDispatchesChatMessageNotification(t *testing.T) {
 	}
 	if gotURL == "" {
 		t.Fatalf("chat notification action URL should not be empty")
+	}
+	select {
+	case chatURL := <-opened:
+		if !strings.Contains(chatURL, "/tray/chat?room=42") {
+			t.Fatalf("opened chatURL = %q, want room-specific tray chat URL", chatURL)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected chat_message to launch the chat window automatically")
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the tray UI opens the room-specific chat window when a `chat_message` IPC event arrives so end users see the chat even if the original `chat_open` event was missed or a prior launch failed.

### Description
- In `tray/ui/chat_notification.go` treat `chat_message` events as a launch signal by calling `openChatWindowFunc(chatOpenURL(payload.RoomID), gConfig)` in `handleChatMessage` so messages both notify and open the chat window.
- Updated the nowebview IPC regression test (`tray/ui/main_nowebview_test.go`) to assert that `chat_message` produces notification text/action data and also opens the `/tray/chat?room=<id>` URL by stubbing `openChatWindowFunc` and verifying it is invoked.
- Kept existing notification action registration behavior so persistent notification actions still work with the added launch behavior.

### Testing
- Ran `go test -tags nowebview ./ui` which succeeded (nowebview unit tests passed).
- Running `go test ./ui` in this Linux environment failed due to missing GUI tray dependency (`ayatana-appindicator3-0.1` pkg-config files), which is an environment issue unrelated to the change.
- `gofmt` was applied to modified files as part of the change verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a320e896a3c832dbce8cb371f0c05e3)