### PR TITLE
Reject issuance/launch for closed chat rooms and prevent silent recreation

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -1456,9 +1456,20 @@ async def issue_chat_token(
             detail="Device has no associated company",
         )
 
-    # When no room was explicitly requested, reconnect to the device's existing
-    # open chat room (if any) so the user continues the same conversation.
-    if room_id is None:
+    # Explicit room requests come from technician-initiated chats and reply
+    # notifications. Never issue a token for a closed/stale room because the
+    # popup must not turn that stale launch into a brand-new user chat.
+    if room_id is not None:
+        requested_room = await chat_repo.get_room(int(room_id))
+        if not requested_room:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat room not found")
+        if requested_room.get("status") != "open":
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Chat room is closed")
+    else:
+        # When no room was explicitly requested, reconnect to the device's
+        # existing open chat room (if any) so the user continues the same
+        # conversation. If none exists, the popup may create a user-initiated
+        # chat when the tray icon/menu action is used.
         existing = await chat_repo.get_open_room_by_device_id(int(device["id"]))
         if existing:
             room_id = int(existing["id"])

--- a/app/features/chat/routes.py
+++ b/app/features/chat/routes.py
@@ -248,18 +248,26 @@ async def tray_chat_popup(
     # 2. Resolve or create the chat room.
     # ------------------------------------------------------------------
     # Prefer room_id embedded in the token (technician-initiated), then
-    # the query-string ``room`` param, then create a new room.
+    # the query-string ``room`` param, then create a new room only for an
+    # unbound user-initiated tray action. Explicit room launches may come from
+    # technician replies or notification actions; if that room is now closed,
+    # do not silently create a new "Chat from <device>" room.
     resolved_room_id: int | None = token_record.get("room_id") or room
+    explicit_room_requested = resolved_room_id is not None
 
     chat_room: dict[str, Any] | None = None
     if resolved_room_id:
         chat_room = await chat_repo.get_room(int(resolved_room_id))
-        # If the resolved room is closed, ignore it and start a fresh one.
-        if chat_room and chat_room.get("status") != "open":
-            chat_room = None
+        if not chat_room:
+            raise HTTPException(status_code=404, detail="Chat room not found")
+        if chat_room.get("status") != "open":
+            raise HTTPException(status_code=409, detail="Chat room is closed")
 
     if not chat_room:
         chat_room = await chat_repo.get_open_room_by_device_id(device_id)
+
+    if not chat_room and explicit_room_requested:
+        raise HTTPException(status_code=409, detail="Chat room is closed")
 
     if not chat_room:
         # User-initiated chat: create a fresh room.

--- a/tests/test_tray_devices_page.py
+++ b/tests/test_tray_devices_page.py
@@ -249,3 +249,102 @@ async def test_tray_chat_popup_reuses_existing_open_room_from_unbound_token(monk
     assert response.body == b"room=42"
     create_matrix_mock.assert_not_called()
     create_room_mock.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_tray_chat_popup_rejects_closed_explicit_room_without_creating_new_room(monkeypatch):
+    import app.features.chat.routes as chat_routes
+    import app.repositories.chat as chat_repo
+    import app.repositories.companies as companies_repo
+    import app.repositories.tray as tray_repo
+    from app.services import matrix as matrix_service
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(
+        chat_routes,
+        "get_settings",
+        lambda: type("Settings", (), {"matrix_enabled": True, "environment": "development"})(),
+    )
+    monkeypatch.setattr(chat_routes.tray_service, "hash_token", lambda token: f"hash:{token}")
+    monkeypatch.setattr(
+        tray_repo,
+        "get_chat_token_by_hash",
+        AsyncMock(
+            return_value={
+                "id": 11,
+                "device_id": 7,
+                "room_id": 42,
+                "expires_at": None,
+                "used_at": None,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        tray_repo,
+        "get_device_by_id",
+        AsyncMock(
+            return_value={
+                "id": 7,
+                "device_uid": "dev-7",
+                "status": "active",
+                "company_id": 3,
+                "hostname": "PC-7",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        companies_repo,
+        "get_company_by_id",
+        AsyncMock(return_value={"id": 3, "tray_chat_enabled": True}),
+    )
+    monkeypatch.setattr(tray_repo, "mark_chat_token_used", AsyncMock())
+    monkeypatch.setattr(
+        chat_repo,
+        "get_room",
+        AsyncMock(return_value={"id": 42, "status": "closed", "tray_device_id": 7}),
+    )
+    get_open_mock = AsyncMock()
+    create_matrix_mock = AsyncMock(return_value={"room_id": "!new:example"})
+    create_room_mock = AsyncMock()
+    monkeypatch.setattr(chat_repo, "get_open_room_by_device_id", get_open_mock)
+    monkeypatch.setattr(matrix_service, "create_room", create_matrix_mock)
+    monkeypatch.setattr(chat_repo, "create_room", create_room_mock)
+
+    request = _make_request("/tray/chat", method="GET")
+    with pytest.raises(HTTPException) as exc:
+        await chat_routes.tray_chat_popup(request, None, token="abc", room=None)
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail == "Chat room is closed"
+    get_open_mock.assert_not_called()
+    create_matrix_mock.assert_not_called()
+    create_room_mock.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_issue_chat_token_rejects_closed_explicit_room(monkeypatch):
+    import app.api.routes.tray as tray_routes
+    import app.repositories.chat as chat_repo
+    import app.repositories.companies as companies_repo
+    import app.repositories.tray as tray_repo
+    from fastapi import HTTPException
+
+    class JsonRequest:
+        async def json(self):
+            return {"room_id": 42}
+
+    monkeypatch.setattr(tray_routes._settings, "matrix_enabled", True)
+    monkeypatch.setattr(companies_repo, "get_company_by_id", AsyncMock(return_value={"id": 3, "tray_chat_enabled": True}))
+    monkeypatch.setattr(chat_repo, "get_room", AsyncMock(return_value={"id": 42, "status": "closed"}))
+    create_token_mock = AsyncMock()
+    monkeypatch.setattr(tray_repo, "create_chat_token", create_token_mock)
+
+    with pytest.raises(HTTPException) as exc:
+        await tray_routes.issue_chat_token(
+            JsonRequest(),
+            {"id": 7, "device_uid": "dev-7", "company_id": 3, "status": "active"},
+        )
+
+    assert exc.value.status_code == 409
+    assert exc.value.detail == "Chat room is closed"
+    create_token_mock.assert_not_called()

--- a/tray/ui/chat_notification.go
+++ b/tray/ui/chat_notification.go
@@ -65,11 +65,9 @@ func handleChatMessage(payload chatMessagePayload) {
 		logger.Warn("handleChatMessage: could not register chat notification action for room_id=%d", payload.RoomID)
 	}
 
-	// Technician replies can arrive after the initial chat_open event, for
-	// example when the tray UI was started after the room was created or when a
-	// previous launch attempt failed. Treat every inbound chat message as a
-	// launch signal as well as a notification so the end user is never left with
-	// only a silent IPC event in ui.log.
+	// Replies should bring an active chat back to the user's attention. Closed
+	// rooms are rejected by the popup/token endpoints so stale notifications do
+	// not create a fresh "Chat from <device>" room.
 	go openChatWindowFunc(chatOpenURL(payload.RoomID), gConfig)
 
 	title, body := chatMessageNotificationText(payload)


### PR DESCRIPTION
### Motivation

- Prevent tokens or popup launches from reopening stale/closed chat rooms and accidentally creating new user chat rooms when a technician-initiated or notification-triggered room is closed.

### Description

- Validate explicit `room_id` requests in `issue_chat_token` by verifying the room exists and has `status == "open"`, returning `404` or `409` when appropriate. 
- In `tray_chat_popup`, treat token-embedded or query `room` parameters as explicit requests, returning `404` for missing rooms and `409` for closed rooms, and only allow automatic creation for unbound user-initiated actions. 
- Adjust tray UI notification comment to clarify that closed rooms are rejected by the popup/token endpoints so stale notifications don't create new rooms. 
- Add tests covering the new rejection behavior: `test_tray_chat_popup_rejects_closed_explicit_room_without_creating_new_room` and `test_issue_chat_token_rejects_closed_explicit_room`.

### Testing

- Ran `pytest tests/test_tray_devices_page.py` which includes the two new tests and existing related tests, and they passed. 
- Ran the project's unit test suite with `pytest` and observed no regressions in the modified areas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a321229da60832d8f8440db3df61df9)