### PR TITLE
Start AI waiting-assistant on unassigned chat open and wire tray messages to assistant

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -120,6 +120,15 @@ async def create_room(
     except Exception as exc:
         log_error("create_room: auto-assign failed", room_id=room["id"], error=str(exc))
 
+    if not (current_user.get("is_super_admin") or current_user.get("is_helpdesk_technician")):
+        try:
+            refreshed_room = await chat_repo.get_room(int(room["id"]))
+            if refreshed_room and not refreshed_room.get("assigned_tech_user_id"):
+                room = refreshed_room
+                await matrix_ai_waiting_assistant.handle_chat_opened(int(room["id"]))
+        except Exception as exc:
+            log_error("create_room: AI waiting assistant open hook failed", room_id=room["id"], error=str(exc))
+
     await audit_service.log_action(
         action="create",
         entity_type="chat_room",

--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -60,6 +60,7 @@ from app.schemas.tray import (
 from app.services import audit as audit_service
 from app.services import chat_ticket_sync
 from app.services import matrix as matrix_service
+from app.services import matrix_ai_waiting_assistant
 from app.services import tacticalrmm as tacticalrmm_service
 from app.services import tickets as tickets_service
 from app.services import tray as tray_service
@@ -1622,6 +1623,7 @@ async def popup_chat_send_message(
         sent_at=sent_at,
     )
     await chat_repo.update_room(room_id, last_message_at=sent_at, updated_at=sent_at)
+    await matrix_ai_waiting_assistant.handle_user_message(room_id, sent_at)
 
     try:
         await chat_ticket_sync.sync_chat_message_to_ticket(

--- a/app/features/chat/routes.py
+++ b/app/features/chat/routes.py
@@ -21,6 +21,7 @@ from app.security.encryption import decrypt_secret, encrypt_secret
 from app.security.session import SessionData
 from app.services import matrix as matrix_service
 from app.services import tray as tray_service
+from app.services import matrix_ai_waiting_assistant
 from app.core.logging import log_error, log_info
 
 
@@ -312,6 +313,18 @@ async def tray_chat_popup(
             )
         except Exception as exc:
             log_error("tray_chat_popup: auto-assign failed", room_id=room_id_new, error=str(exc))
+
+        # A tray chat can be opened before the user types a message.  If no
+        # technician has been assigned, start the AI waiting-assistant timer so
+        # it can acknowledge the new chat instead of waiting for Matrix /sync
+        # message activity.
+        try:
+            refreshed_room = await chat_repo.get_room(room_id_new)
+            if refreshed_room and not refreshed_room.get("assigned_tech_user_id"):
+                chat_room = refreshed_room
+                await matrix_ai_waiting_assistant.handle_chat_opened(room_id_new)
+        except Exception as exc:
+            log_error("tray_chat_popup: AI waiting assistant open hook failed", room_id=room_id_new, error=str(exc))
 
         log_info(
             "Tray chat popup: created room",

--- a/app/services/matrix_ai_waiting_assistant.py
+++ b/app/services/matrix_ai_waiting_assistant.py
@@ -383,6 +383,22 @@ async def handle_user_message(room_id: int, sent_at: datetime | None = None) -> 
     await _audit("matrix_ai_waiting_assistant.user_activity", room_id)
 
 
+async def handle_chat_opened(room_id: int, opened_at: datetime | None = None) -> None:
+    """Start the waiting-assistant timer when an unassigned customer chat opens.
+
+    Some Matrix-backed rooms are created when a tray popup or customer chat
+    window opens, before the customer sends a first message.  Treat that open
+    event as customer activity so the acknowledgement can be sent when no
+    technician has taken the chat.
+    """
+    room = await chat_repo.get_room(room_id)
+    if not room or room.get("status") != "open" or room.get("assigned_tech_user_id"):
+        return
+    await chat_repo.mark_user_activity(room_id, opened_at)
+    await chat_repo.cancel_active_ai_queue_for_room(room_id, "chat_opened_timer_reset")
+    await _audit("matrix_ai_waiting_assistant.chat_opened", room_id)
+
+
 async def handle_technician_takeover(room_id: int, user_id: int | None = None) -> None:
     await chat_repo.cancel_active_ai_queue_for_room(room_id, "technician_assigned")
     await _audit("matrix_ai_waiting_assistant.technician_takeover", room_id, {"user_id": user_id})

--- a/tests/services/test_matrix_ai_waiting_assistant.py
+++ b/tests/services/test_matrix_ai_waiting_assistant.py
@@ -185,3 +185,51 @@ def test_send_bot_message_records_webhook_monitor_failure(monkeypatch):
     assert events[0]["payload"]["message_preview"] == "hello"
     assert failures[0]["event_id"] == 456
     assert failures[0]["error_message"] == "matrix unavailable"
+
+
+def test_handle_chat_opened_marks_unassigned_open_room(monkeypatch):
+    room = {"id": 42, "status": "open", "assigned_tech_user_id": None}
+    marked: list[int] = []
+    cancelled: list[tuple[int, str]] = []
+    audited: list[str] = []
+
+    async def fake_get_room(room_id):
+        return room
+
+    async def fake_mark(room_id, when=None):
+        marked.append(room_id)
+
+    async def fake_cancel(room_id, reason):
+        cancelled.append((room_id, reason))
+
+    async def fake_audit(action, room_id, value=None):
+        audited.append(action)
+
+    monkeypatch.setattr(assistant.chat_repo, "get_room", fake_get_room)
+    monkeypatch.setattr(assistant.chat_repo, "mark_user_activity", fake_mark)
+    monkeypatch.setattr(assistant.chat_repo, "cancel_active_ai_queue_for_room", fake_cancel)
+    monkeypatch.setattr(assistant, "_audit", fake_audit)
+
+    asyncio.run(assistant.handle_chat_opened(42))
+
+    assert marked == [42]
+    assert cancelled == [(42, "chat_opened_timer_reset")]
+    assert audited == ["matrix_ai_waiting_assistant.chat_opened"]
+
+
+def test_handle_chat_opened_ignores_assigned_room(monkeypatch):
+    room = {"id": 42, "status": "open", "assigned_tech_user_id": 7}
+    marked: list[int] = []
+
+    async def fake_get_room(room_id):
+        return room
+
+    async def fake_mark(room_id, when=None):
+        marked.append(room_id)
+
+    monkeypatch.setattr(assistant.chat_repo, "get_room", fake_get_room)
+    monkeypatch.setattr(assistant.chat_repo, "mark_user_activity", fake_mark)
+
+    asyncio.run(assistant.handle_chat_opened(42))
+
+    assert marked == []

--- a/tests/test_tray_popup_chat_ticket_sync.py
+++ b/tests/test_tray_popup_chat_ticket_sync.py
@@ -70,6 +70,11 @@ async def test_popup_chat_send_message_syncs_linked_ticket(monkeypatch):
     async def fake_sync_chat_message_to_ticket(**kwargs):
         synced.update(kwargs)
 
+    assistant_activity: list[tuple[int, object]] = []
+
+    async def fake_handle_user_message(room_id: int, sent_at):
+        assistant_activity.append((room_id, sent_at))
+
     monkeypatch.setattr(tray_routes.chat_repo, "get_room", fake_get_room)
     monkeypatch.setattr(tray_routes.tray_repo, "get_device_by_id", fake_get_device_by_id)
     monkeypatch.setattr(tray_routes.chat_repo, "add_message", fake_add_message)
@@ -78,6 +83,11 @@ async def test_popup_chat_send_message_syncs_linked_ticket(monkeypatch):
         tray_routes.chat_ticket_sync,
         "sync_chat_message_to_ticket",
         fake_sync_chat_message_to_ticket,
+    )
+    monkeypatch.setattr(
+        tray_routes.matrix_ai_waiting_assistant,
+        "handle_user_message",
+        fake_handle_user_message,
     )
     response = await tray_routes.popup_chat_send_message(_PopupRequest(), 42)
 
@@ -89,3 +99,4 @@ async def test_popup_chat_send_message_syncs_linked_ticket(monkeypatch):
     assert room_updates
     assert room_updates[0]["room_id"] == 42
     assert room_updates[0]["last_message_at"] == room_updates[0]["updated_at"]
+    assert assistant_activity == [(42, room_updates[0]["last_message_at"])]


### PR DESCRIPTION
### Motivation
- Newly created Matrix-backed chat rooms can be opened before the customer sends a first message so the AI waiting assistant never started its acknowledgement timer for unassigned chats.  
- Tray popup messages also needed to reset/trigger the waiting assistant when a customer replies from the tray client.  

### Description
- Add `handle_chat_opened(room_id, opened_at=None)` to `app/services/matrix_ai_waiting_assistant.py` to treat an unassigned open room as customer activity (marks last activity, cancels old queue items, writes audit).  
- Call `matrix_ai_waiting_assistant.handle_chat_opened()` after auto-assignment when creating rooms via the public API (`app/api/routes/chat.py`) and tray popup creation (`app/features/chat/routes.py`) for non-technician users, skipping super-admins/technicians.  
- Invoke `matrix_ai_waiting_assistant.handle_user_message()` from tray popup message sends (`app/api/routes/tray.py`) so tray-side replies reset/trigger the assistant flow.  
- Add unit tests covering `handle_chat_opened` behavior and tray popup message wiring in `tests/services/test_matrix_ai_waiting_assistant.py` and `tests/test_tray_popup_chat_ticket_sync.py`.  

### Testing
- Ran the targeted unit tests with `python -m pytest tests/services/test_matrix_ai_waiting_assistant.py tests/test_tray_popup_chat_ticket_sync.py -q`, and they passed.  
- Verified Python source compiles with `python -m compileall` for the modified modules with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a324720d144832da84867bc3ab52d5e)