### PR TITLE
Move ticket Assets panel to right timeline and add TRMM / tray-chat actions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8250,6 +8250,7 @@ async def _render_ticket_detail(
                 "serial_number": (str(asset.get("serial_number") or "").strip() or None),
                 "status": (str(asset.get("status") or "").strip() or None),
                 "tactical_asset_id": (str(asset.get("tactical_asset_id") or "").strip() or None),
+                "tray_device_uid": (str(asset.get("tray_device_uid") or "").strip() or None),
             }
         )
 

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -852,7 +852,14 @@ async def list_ticket_assets(ticket_id: int) -> list[dict[str, Any]]:
             a.status,
             a.type,
             a.os_name,
-            a.tactical_asset_id
+            a.tactical_asset_id,
+            (
+                SELECT td.device_uid
+                FROM tray_devices AS td
+                WHERE td.asset_id = ta.asset_id AND td.status = 'active'
+                ORDER BY td.last_seen_utc DESC, td.updated_at DESC, td.id DESC
+                LIMIT 1
+            ) AS tray_device_uid
         FROM ticket_assets AS ta
         INNER JOIN assets AS a ON a.id = ta.asset_id
         WHERE ta.ticket_id = %s
@@ -875,6 +882,7 @@ async def list_ticket_assets(ticket_id: int) -> list[dict[str, Any]]:
             "type": str(row.get("type") or "").strip() or None,
             "os_name": str(row.get("os_name") or "").strip() or None,
             "tactical_asset_id": str(row.get("tactical_asset_id") or "").strip() or None,
+            "tray_device_uid": str(row.get("tray_device_uid") or "").strip() or None,
             "linked_at": _make_aware(row.get("created_at")),
         }
         assets.append(asset)

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2601,6 +2601,49 @@ button.header-title-menu__link {
   font-size: 0.95rem;
 }
 
+.ticket-assets-linked__item--actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-gap-base);
+  padding-right: var(--space-gap-base);
+}
+
+.ticket-assets-linked__item--actions .ticket-assets-linked__name,
+.ticket-assets-linked__item--actions .ticket-assets-linked__meta {
+  grid-column: 1;
+}
+
+.ticket-assets-linked__actions {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-gap-tight);
+}
+
+.ticket-assets-linked__action[disabled],
+.ticket-assets-linked__action[aria-disabled="true"] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.ticket-assets-linked__actions .ticket-assets-linked__remove {
+  position: static;
+}
+
+@media (max-width: 640px) {
+  .ticket-assets-linked__item--actions {
+    grid-template-columns: 1fr;
+  }
+
+  .ticket-assets-linked__actions {
+    grid-column: 1;
+    grid-row: auto;
+    justify-content: flex-start;
+  }
+}
+
 .button--ghost {
   background: transparent;
   border: 1px solid rgba(148, 163, 184, 0.4);

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -295,6 +295,7 @@
     const initialSelection = normaliseIdList(parseJsonArray(select.dataset.selectedAssets, []));
     const initialLinkedRecords = parseJsonArray(linkedContainer.dataset.initialLinked, []);
     const emptyMessage = linkedContainer.dataset.emptyMessage || 'No assets are linked to this ticket yet.';
+    const detailsFormId = linkedContainer.dataset.detailsFormId || '';
     const tacticalBaseUrlRaw = linkedContainer.dataset.tacticalBaseUrl || '';
     const initialCompanyId = select.dataset.initialCompanyId || '';
 
@@ -443,7 +444,7 @@
 
       entries.forEach((record) => {
         const item = document.createElement('li');
-        item.className = 'ticket-assets-linked__item';
+        item.className = 'ticket-assets-linked__item ticket-assets-linked__item--actions';
         item.setAttribute('data-linked-asset', '');
         const assetIdValue = String(record.asset_id ?? record.id);
         item.setAttribute('data-asset-id', assetIdValue);
@@ -455,6 +456,9 @@
         hiddenInput.type = 'hidden';
         hiddenInput.name = 'assetIds';
         hiddenInput.value = assetIdValue;
+        if (detailsFormId) {
+          hiddenInput.setAttribute('form', detailsFormId);
+        }
         item.appendChild(hiddenInput);
 
         const label = formatAssetLabel(record);
@@ -492,12 +496,53 @@
           item.appendChild(metaElement);
         }
 
+        const actions = document.createElement('div');
+        actions.className = 'ticket-assets-linked__actions';
+
+        if (tacticalUrl) {
+          const tacticalAction = document.createElement('a');
+          tacticalAction.href = tacticalUrl;
+          tacticalAction.target = '_blank';
+          tacticalAction.rel = 'noreferrer noopener';
+          tacticalAction.className = 'button button--ghost button--icon ticket-assets-linked__action';
+          tacticalAction.title = 'Open in Tactical RMM';
+          tacticalAction.setAttribute('aria-label', `Open ${displayName} in Tactical RMM`);
+          tacticalAction.innerHTML = '<span aria-hidden="true">🖥️</span>';
+          actions.appendChild(tacticalAction);
+        } else {
+          const tacticalAction = document.createElement('button');
+          tacticalAction.type = 'button';
+          tacticalAction.className = 'button button--ghost button--icon ticket-assets-linked__action';
+          tacticalAction.disabled = true;
+          tacticalAction.setAttribute('aria-disabled', 'true');
+          tacticalAction.title = 'Tactical RMM search is not configured';
+          tacticalAction.setAttribute('aria-label', `Tactical RMM search is not configured for ${displayName}`);
+          tacticalAction.innerHTML = '<span aria-hidden="true">🖥️</span>';
+          actions.appendChild(tacticalAction);
+        }
+
+        const chatButton = document.createElement('button');
+        chatButton.type = 'button';
+        chatButton.className = 'button button--ghost button--icon ticket-assets-linked__action';
+        chatButton.setAttribute('data-linked-asset-chat', '');
+        chatButton.title = 'Open chat';
+        chatButton.setAttribute('aria-label', `Open chat with ${displayName}`);
+        if (record.tray_device_uid) {
+          chatButton.setAttribute('data-device-uid', record.tray_device_uid);
+        } else {
+          chatButton.disabled = true;
+          chatButton.setAttribute('aria-disabled', 'true');
+        }
+        chatButton.innerHTML = '<span aria-hidden="true">💬</span>';
+        actions.appendChild(chatButton);
+
         const removeButton = document.createElement('button');
         removeButton.type = 'button';
         removeButton.className = 'button button--ghost button--icon ticket-assets-linked__remove';
         removeButton.setAttribute('data-linked-asset-remove', '');
         removeButton.innerHTML = '<span class="visually-hidden">Remove asset</span>×';
-        item.appendChild(removeButton);
+        actions.appendChild(removeButton);
+        item.appendChild(actions);
 
         linkedList.appendChild(item);
       });
@@ -694,6 +739,41 @@
     linkedContainer.addEventListener('click', (event) => {
       const target = event.target instanceof Element ? event.target : null;
       if (!target) {
+        return;
+      }
+
+      const chatButton = target.closest('[data-linked-asset-chat]');
+      if (chatButton) {
+        const uid = chatButton.getAttribute('data-device-uid') || '';
+        if (!uid) {
+          return;
+        }
+        chatButton.disabled = true;
+        fetch(`/api/tray/${encodeURIComponent(uid)}/chat/start`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': getCsrfToken(),
+            Accept: 'application/json',
+          },
+          body: JSON.stringify({ subject: 'Helpdesk chat' }),
+        })
+          .then(async (response) => {
+            if (!response.ok) {
+              throw new Error(await response.text());
+            }
+            return response.json();
+          })
+          .then((data) => {
+            if (data.room_id) {
+              window.location.href = `/chat?room=${encodeURIComponent(data.room_id)}`;
+            }
+          })
+          .catch((error) => {
+            console.error('Failed to open tray chat', error);
+            window.alert(`Failed to open chat: ${error.message || 'Unknown error'}`);
+            chatButton.disabled = false;
+          });
         return;
       }
 

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -106,7 +106,7 @@
               </div>
             </summary>
             <div class="card-collapsible__content">
-            <form action="/admin/tickets/{{ ticket.id }}/details" method="post" class="form card__form">
+            <form id="ticket-details-form" action="/admin/tickets/{{ ticket.id }}/details" method="post" class="form card__form">
               {% if csrf_token %}
                 <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
               {% endif %}
@@ -209,118 +209,6 @@
                   value="{{ ticket.external_reference or '' }}"
                   placeholder="Syncro ID or external case"
                 />
-              </div>
-              <div class="form-field">
-                <label class="form-label" for="ticket-assets">Assets</label>
-                <select
-                  id="ticket-assets"
-                  class="form-input"
-                  data-ticket-asset-selector
-                  data-assets-endpoint-template="/api/companies/{companyId}/assets"
-                  data-initial-options="{{ ticket_asset_options | tojson | forceescape }}"
-                  data-selected-assets="{{ ticket_asset_selection | tojson | forceescape }}"
-                  data-placeholder="Select an asset to link"
-                  data-initial-company-id="{{ ticket.company_id or '' }}"
-                  {% if not ticket.company_id %}disabled aria-disabled="true"{% endif %}
-                >
-                  <option value="">Select an asset to link</option>
-                  {% for option in ticket_asset_options %}
-                    <option value="{{ option.id }}">{{ option.label }}</option>
-                  {% endfor %}
-                </select>
-                <p
-                  class="form-help"
-                  data-ticket-asset-help
-                  data-help-enabled="Choose an asset to link. Linked devices appear below."
-                  data-help-disabled="Link the ticket to a company before selecting assets."
-                  data-help-empty="No assets are available for the linked company."
-                  data-help-exhausted="All company assets are already linked to this ticket."
-                >
-                  {% if not ticket.company_id %}
-                    Link the ticket to a company before selecting assets.
-                  {% elif not ticket_asset_options %}
-                    No assets are available for the linked company.
-                  {% else %}
-                    Choose an asset to link. Linked devices appear below.
-                  {% endif %}
-                </p>
-                <div
-                  class="ticket-assets-linked"
-                  data-ticket-linked-assets
-                  data-initial-linked="{{ ticket_asset_linked_data | tojson | forceescape }}"
-                  data-tactical-base-url="{{ tacticalrmm_base_url or '' }}"
-                  data-empty-message="No assets are linked to this ticket yet."
-                >
-                  <ul class="ticket-assets-linked__list" data-linked-assets-list>
-                    {% for asset in ticket_assets %}
-                      {% set serial_value = asset.serial_number %}
-                      {% set status_value = asset.status %}
-                      {% set status_label = status_value.replace('_', ' ').title() if status_value %}
-                      {% set meta_parts = [] %}
-                      {% if status_label %}
-                        {% set _ = meta_parts.append(status_label) %}
-                      {% endif %}
-                      {% set base_name = asset.name or ('Asset ' ~ asset.asset_id) %}
-                      {% set display_name = base_name | trim %}
-                      {% if not display_name %}
-                        {% set display_name = 'Asset ' ~ asset.asset_id %}
-                      {% endif %}
-                      {% set tooltip_label = display_name %}
-                      {% if meta_parts %}
-                        {% set tooltip_label = display_name ~ ' · ' ~ (meta_parts | join(' · ')) %}
-                      {% endif %}
-                      {% set tactical_link = None %}
-                      {% if tacticalrmm_base_url and asset.name and asset.name | trim %}
-                        {% set tactical_link = tacticalrmm_base_url ~ '/?search=' ~ (asset.name | trim | urlencode) %}
-                      {% endif %}
-                      <li
-                        class="ticket-assets-linked__item"
-                        data-linked-asset
-                        data-asset-id="{{ asset.asset_id }}"
-                        data-tactical-id="{{ asset.tactical_asset_id or '' }}"
-                      >
-                        <input type="hidden" name="assetIds" value="{{ asset.asset_id }}" />
-                        {% if tactical_link %}
-                          <a
-                            href="{{ tactical_link }}"
-                            target="_blank"
-                            rel="noreferrer noopener"
-                            class="ticket-assets-linked__name"
-                            data-linked-asset-name
-                            title="{{ tooltip_label }}"
-                          >
-                            {{ display_name }}
-                          </a>
-                        {% else %}
-                          <span class="ticket-assets-linked__name" data-linked-asset-name title="{{ tooltip_label }}">
-                            {{ display_name }}
-                          </span>
-                        {% endif %}
-                        {% if meta_parts %}
-                          <p class="ticket-assets-linked__meta">{{ meta_parts | join(' · ') }}</p>
-                        {% endif %}
-                        <button
-                          type="button"
-                          class="button button--ghost button--icon ticket-assets-linked__remove"
-                          data-linked-asset-remove
-                        >
-                          <span class="visually-hidden">Remove asset</span>
-                          ×
-                        </button>
-                      </li>
-                    {% endfor %}
-                  </ul>
-                  <p class="ticket-assets-linked__empty" data-linked-assets-empty {% if ticket_assets %}hidden{% endif %}>
-                    No assets are linked to this ticket yet.
-                  </p>
-                </div>
-              </div>
-              <div class="form-field">
-                <label class="form-label form-label--checkbox">
-                  <input type="checkbox" name="sendTrayNotification" value="1" />
-                  Send tray push notification
-                </label>
-                <p class="form-help">Optionally notify linked tray devices that this ticket was updated.</p>
               </div>
               <div class="form-actions">
                 <button type="submit" class="button button--primary">Save changes</button>
@@ -841,6 +729,171 @@
                   <!-- Tasks will be loaded dynamically -->
                 </ul>
                 <p class="card__empty" data-tasks-empty hidden>No tasks have been added yet.</p>
+              </div>
+            </div>
+          </details>
+
+          <details class="card card--panel card-collapsible" data-ticket-assets-card>
+            <summary class="card__header card__header--collapsible">
+              <h2 class="card__title">Assets</h2>
+              <div class="card__collapsible-meta">
+                <span class="card__toggle-icon" aria-hidden="true"></span>
+              </div>
+            </summary>
+            <div class="card-collapsible__content">
+              <div class="card__body">
+                <div class="form-field">
+                  <label class="form-label" for="ticket-assets">Assets</label>
+                <select
+                  id="ticket-assets"
+                  class="form-input"
+                  data-ticket-asset-selector
+                  data-assets-endpoint-template="/api/companies/{companyId}/assets"
+                  data-initial-options="{{ ticket_asset_options | tojson | forceescape }}"
+                  data-selected-assets="{{ ticket_asset_selection | tojson | forceescape }}"
+                  data-placeholder="Select an asset to link"
+                  data-initial-company-id="{{ ticket.company_id or '' }}"
+                  {% if not ticket.company_id %}disabled aria-disabled="true"{% endif %}
+                >
+                  <option value="">Select an asset to link</option>
+                  {% for option in ticket_asset_options %}
+                    <option value="{{ option.id }}">{{ option.label }}</option>
+                  {% endfor %}
+                </select>
+                <p
+                  class="form-help"
+                  data-ticket-asset-help
+                  data-help-enabled="Choose an asset to link. Linked devices appear below."
+                  data-help-disabled="Link the ticket to a company before selecting assets."
+                  data-help-empty="No assets are available for the linked company."
+                  data-help-exhausted="All company assets are already linked to this ticket."
+                >
+                  {% if not ticket.company_id %}
+                    Link the ticket to a company before selecting assets.
+                  {% elif not ticket_asset_options %}
+                    No assets are available for the linked company.
+                  {% else %}
+                    Choose an asset to link. Linked devices appear below.
+                  {% endif %}
+                </p>
+                <div
+                  class="ticket-assets-linked"
+                  data-ticket-linked-assets
+                  data-initial-linked="{{ ticket_asset_linked_data | tojson | forceescape }}"
+                  data-tactical-base-url="{{ tacticalrmm_base_url or '' }}"
+                  data-empty-message="No assets are linked to this ticket yet."
+                  data-details-form-id="ticket-details-form"
+                >
+                  <ul class="ticket-assets-linked__list" data-linked-assets-list>
+                    {% for asset in ticket_assets %}
+                      {% set serial_value = asset.serial_number %}
+                      {% set status_value = asset.status %}
+                      {% set status_label = status_value.replace('_', ' ').title() if status_value %}
+                      {% set meta_parts = [] %}
+                      {% if status_label %}
+                        {% set _ = meta_parts.append(status_label) %}
+                      {% endif %}
+                      {% set base_name = asset.name or ('Asset ' ~ asset.asset_id) %}
+                      {% set display_name = base_name | trim %}
+                      {% if not display_name %}
+                        {% set display_name = 'Asset ' ~ asset.asset_id %}
+                      {% endif %}
+                      {% set tooltip_label = display_name %}
+                      {% if meta_parts %}
+                        {% set tooltip_label = display_name ~ ' · ' ~ (meta_parts | join(' · ')) %}
+                      {% endif %}
+                      {% set tactical_link = None %}
+                      {% if tacticalrmm_base_url and asset.name and asset.name | trim %}
+                        {% set tactical_link = tacticalrmm_base_url ~ '/?search=' ~ (asset.name | trim | urlencode) %}
+                      {% endif %}
+                      <li
+                        class="ticket-assets-linked__item ticket-assets-linked__item--actions"
+                        data-linked-asset
+                        data-asset-id="{{ asset.asset_id }}"
+                        data-tactical-id="{{ asset.tactical_asset_id or '' }}"
+                      >
+                        <input type="hidden" name="assetIds" value="{{ asset.asset_id }}" form="ticket-details-form" />
+                        {% if tactical_link %}
+                          <a
+                            href="{{ tactical_link }}"
+                            target="_blank"
+                            rel="noreferrer noopener"
+                            class="ticket-assets-linked__name"
+                            data-linked-asset-name
+                            title="{{ tooltip_label }}"
+                          >
+                            {{ display_name }}
+                          </a>
+                        {% else %}
+                          <span class="ticket-assets-linked__name" data-linked-asset-name title="{{ tooltip_label }}">
+                            {{ display_name }}
+                          </span>
+                        {% endif %}
+                        {% if meta_parts %}
+                          <p class="ticket-assets-linked__meta">{{ meta_parts | join(' · ') }}</p>
+                        {% endif %}
+                        <div class="ticket-assets-linked__actions">
+                          {% if tactical_link %}
+                            <a
+                              href="{{ tactical_link }}"
+                              target="_blank"
+                              rel="noreferrer noopener"
+                              class="button button--ghost button--icon ticket-assets-linked__action"
+                              title="Open in Tactical RMM"
+                              aria-label="Open {{ display_name }} in Tactical RMM"
+                            >
+                              <span aria-hidden="true">🖥️</span>
+                            </a>
+                          {% else %}
+                            <button
+                              type="button"
+                              class="button button--ghost button--icon ticket-assets-linked__action"
+                              disabled
+                              aria-disabled="true"
+                              title="Tactical RMM search is not configured"
+                              aria-label="Tactical RMM search is not configured for {{ display_name }}"
+                            >
+                              <span aria-hidden="true">🖥️</span>
+                            </button>
+                          {% endif %}
+                          <button
+                            type="button"
+                            class="button button--ghost button--icon ticket-assets-linked__action"
+                            data-linked-asset-chat
+                            data-device-uid="{{ asset.tray_device_uid or '' }}"
+                            {% if not asset.tray_device_uid %}disabled aria-disabled="true"{% endif %}
+                            title="Open chat"
+                            aria-label="Open chat with {{ display_name }}"
+                          >
+                            <span aria-hidden="true">💬</span>
+                          </button>
+                          <button
+                            type="button"
+                            class="button button--ghost button--icon ticket-assets-linked__remove"
+                            data-linked-asset-remove
+                          >
+                            <span class="visually-hidden">Remove asset</span>
+                            ×
+                          </button>
+                        </div>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                  <p class="ticket-assets-linked__empty" data-linked-assets-empty {% if ticket_assets %}hidden{% endif %}>
+                    No assets are linked to this ticket yet.
+                  </p>
+                </div>
+              </div>
+              <div class="form-field">
+                <label class="form-label form-label--checkbox">
+                  <input type="checkbox" name="sendTrayNotification" value="1" form="ticket-details-form" />
+                  Send tray push notification
+                </label>
+                <p class="form-help">Optionally notify linked tray devices that this ticket was updated.</p>
+              </div>
+              <div class="form-actions">
+                <button type="submit" class="button button--primary" form="ticket-details-form">Save asset changes</button>
+              </div>
               </div>
             </div>
           </details>


### PR DESCRIPTION
### Motivation
- Move the ticket `Assets` UI out of the left-side details form into the right column to match the three-panel layout and place it between `Tasks` and `Add a reply`. 
- Keep asset linking edits wired to the existing ticket details endpoint so backend behavior and form handling remain unchanged.
- Provide quick Tactical RMM lookup and technician-initiated chat from each linked asset row to improve workflow for technicians.

### Description
- Moved the assets block from the left details form into a collapsed right-column card located between the `Tasks` card and the `Add a reply` card, using a collapsible `details` card (file: `app/templates/admin/ticket_detail.html`).
- Kept asset inputs submitting to the existing details form by giving the details form an `id="ticket-details-form"` and adding `form="ticket-details-form"` to the hidden `assetIds` inputs so changes still POST to `/admin/tickets/{ticket_id}/details`.
- Added two action buttons per linked asset row: a Tactical RMM search icon that opens the same TRMM search URL as clicking the name, and a tray-chat icon that initiates a chat via `/api/tray/{device_uid}/chat/start` (files: `app/templates/admin/ticket_detail.html`, `app/static/js/ticket_detail.js`).
- Server-side: extend `list_ticket_assets` to include the most-recent active `tray_devices.device_uid` for an asset, and expose `tray_device_uid` in the ticket render context so the chat button can be enabled only when a linked tray device exists (files: `app/repositories/tickets.py`, `app/main.py`).
- Client-side: update `ticket_detail.js` to render the moved panel, attach `form` attribute to hidden inputs, wire tactical URL opening, and call tray chat API with CSRF header when the chat icon is used.
- Styling: add responsive CSS for linked-asset rows and action buttons so names/meta and actions align on desktop and stack on small screens (file: `app/static/css/app.css`).

### Testing
- Template parse: validated `app/templates/admin/ticket_detail.html` with Jinja parse (`Environment().parse(...)`) — succeeded.
- JavaScript syntax: ran `node --check app/static/js/ticket_detail.js` — succeeded.
- Python compile: ran `python -m compileall` on modified modules (`app/repositories/tickets.py`, `app/main.py`) — succeeded.
- Unit tests: ran `pytest tests/test_ticket_tasks_repository.py tests/test_tray_chat_notifications.py` and the targeted tests passed (`10 passed`, some warnings shown); other unrelated feature-pack route manifest tests (`tests/test_tickets_feature_pack.py`) failed earlier due to pre-existing route-manifest expectations unrelated to this UI change.
- Smoke/run: attempted to start `uvicorn` in this environment to capture a screenshot but the process exited in this environment before serving a page (no stable server screenshot captured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3273f1f048832da80c9fa168300e85)