### PR TITLE
Prevent duplicate AI waiting-assistant responses by adding atomic reservations

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -189,6 +189,20 @@ class Database:
                     adapted_sql, adapted_params = self._adapt_params_for_mysql(sql, params)
                     await cursor.execute(adapted_sql, adapted_params)
 
+    async def execute_rowcount(self, sql: str, params: tuple | dict | None = None) -> int:
+        if self._use_sqlite:
+            if not self._sqlite_conn:
+                raise RuntimeError("SQLite database not initialised")
+            cursor = await self._sqlite_conn.execute(sql, params or ())
+            await self._sqlite_conn.commit()
+            return int(cursor.rowcount or 0)
+        else:
+            async with self.acquire() as conn:
+                async with conn.cursor() as cursor:
+                    adapted_sql, adapted_params = self._adapt_params_for_mysql(sql, params)
+                    await cursor.execute(adapted_sql, adapted_params)
+                    return int(cursor.rowcount or 0)
+
     async def execute_returning_lastrowid(
         self, sql: str, params: tuple | dict | None = None
     ) -> int:

--- a/app/repositories/chat.py
+++ b/app/repositories/chat.py
@@ -539,6 +539,38 @@ async def increment_ai_bot_response(room_id: int, when: datetime | None = None) 
     )
 
 
+async def reserve_ai_bot_response(room_id: int, expected_count: int, when: datetime | None = None) -> bool:
+    """Atomically reserve the next waiting-assistant response slot.
+
+    Multiple app workers can scan the same unattended room at the same time.
+    Reserving with an expected response count ensures only one worker can claim
+    each response number before sending a Matrix message.
+    """
+    when = when or datetime.now(timezone.utc).replace(tzinfo=None)
+    rowcount = await db.execute_rowcount(
+        """UPDATE chat_rooms
+           SET ai_bot_response_count = COALESCE(ai_bot_response_count, 0) + 1,
+               ai_last_bot_response_at = %s,
+               updated_at = %s
+           WHERE id = %s AND COALESCE(ai_bot_response_count, 0) = %s""",
+        (when, when, room_id, expected_count),
+    )
+    return rowcount == 1
+
+
+async def release_ai_bot_response_reservation(room_id: int, reserved_count: int) -> None:
+    await db.execute(
+        """UPDATE chat_rooms
+           SET ai_bot_response_count = CASE
+                   WHEN COALESCE(ai_bot_response_count, 0) >= %s THEN ai_bot_response_count - 1
+                   ELSE ai_bot_response_count
+               END,
+               updated_at = %s
+           WHERE id = %s AND COALESCE(ai_bot_response_count, 0) = %s""",
+        (reserved_count, datetime.now(timezone.utc).replace(tzinfo=None), room_id, reserved_count),
+    )
+
+
 async def update_ai_analysis(
     room_id: int,
     *,

--- a/app/services/matrix_ai_waiting_assistant.py
+++ b/app/services/matrix_ai_waiting_assistant.py
@@ -319,7 +319,7 @@ async def _audit(action: str, room_id: int, value: Mapping[str, Any] | None = No
         log_error("AI waiting assistant audit failed", action=action, room_id=room_id, error=str(exc))
 
 
-async def _send_bot_message(room: Mapping[str, Any], body: str) -> bool:
+async def _send_bot_message(room: Mapping[str, Any], body: str, *, response_count: int | None = None) -> bool:
     matrix_room_id = str(room["matrix_room_id"])
     monitor_event = await _create_monitor_event(
         "MATRIXBOT_AI Matrix message",
@@ -369,7 +369,8 @@ async def _send_bot_message(room: Mapping[str, Any], body: str) -> bool:
         sender_display_name="AI Waiting Assistant",
         sent_at=now,
     )
-    await chat_repo.increment_ai_bot_response(int(room["id"]), now)
+    if response_count is None:
+        await chat_repo.increment_ai_bot_response(int(room["id"]), now)
     await refresh_notifier.broadcast_refresh(
         topics=[f"chat:room:{int(room['id'])}"],
         data={"message": _json_safe({**msg, "sent_at": now.isoformat()}), "room_id": int(room["id"])},
@@ -431,8 +432,13 @@ async def scan_waiting_rooms_once() -> None:
             continue
         count = int(room.get("ai_bot_response_count") or 0)
         if count == 0:
-            if await _send_bot_message(room, _ACK_MESSAGE):
+            reserved = await chat_repo.reserve_ai_bot_response(int(room["id"]), expected_count=0, when=_utcnow())
+            if not reserved:
+                continue
+            if await _send_bot_message(room, _ACK_MESSAGE, response_count=1):
                 await _audit("matrix_ai_waiting_assistant.acknowledgement_sent", int(room["id"]))
+            else:
+                await chat_repo.release_ai_bot_response_reservation(int(room["id"]), reserved_count=1)
             continue
         if count == 1 and settings.matrixbot_ai_max_responses >= 2:
             active = await chat_repo.get_active_ai_queue_item(int(room["id"]))
@@ -475,7 +481,8 @@ async def _process_queue_item(item: Mapping[str, Any]) -> None:
             if not tags:
                 continue
             matched = sorted(keyword_set & set(tags))
-            confidence = (len(matched) / len(tags)) * 100 if tags else 0.0
+            confidence_base = max(1, min(len(tags), len(keyword_set))) if tags else 1
+            confidence = min(100.0, (len(matched) / confidence_base) * 100) if tags else 0.0
             if confidence >= settings.matrixbot_ai_kb_confidence_threshold:
                 relevant = await _article_relevant(transcript, article)
                 candidates.append({
@@ -498,11 +505,16 @@ async def _process_queue_item(item: Mapping[str, Any]) -> None:
                     path = f"/knowledge-base/articles/{article['slug']}"
                     link = f"{base}{path}" if base else path
                     message = f"While you wait, this article may help: {article['title']}\n{link}\n\n{summary}\n\n{_AI_DISCLAIMER}"
-                    if await _send_bot_message(room, message):
+                    expected_count = int(room.get("ai_bot_response_count") or 0)
+                    reserved_count = expected_count + 1
+                    reserved = await chat_repo.reserve_ai_bot_response(room_id, expected_count=expected_count, when=_utcnow())
+                    if reserved and await _send_bot_message(room, message, response_count=reserved_count):
                         selected["sent"] = True
                         selected["sent_at"] = _utcnow().isoformat()
                         sent = True
                         await _audit("matrix_ai_waiting_assistant.article_recommendation_sent", room_id, selected)
+                    elif reserved:
+                        await chat_repo.release_ai_bot_response_reservation(room_id, reserved_count=reserved_count)
         latest_confidence = eligible[0]["confidence"] if eligible else (max((c["confidence"] for c in candidates), default=None))
         await chat_repo.update_ai_analysis(room_id, extracted_keywords=keywords, matched_articles=candidates, confidence=latest_confidence)
         await chat_repo.update_ai_queue_item(int(item["id"]), status="completed", result_payload={"keywords": keywords, "matches": candidates, "sent": sent})

--- a/tests/services/test_matrix_ai_waiting_assistant.py
+++ b/tests/services/test_matrix_ai_waiting_assistant.py
@@ -44,15 +44,23 @@ def test_scan_waiting_rooms_sends_ack_before_analysis(monkeypatch):
 
     monkeypatch.setattr(assistant.chat_repo, "has_technician_participant", fake_has_technician_participant)
 
-    async def fake_send(room, body):
+    async def fake_send(room, body, **kwargs):
         sent.append(body)
         return True
+
+    async def fake_reserve(room_id, expected_count, when=None):
+        return True
+
+    async def fake_release(room_id, reserved_count):
+        raise AssertionError("successful acknowledgement should not release reservation")
 
     async def fake_active(room_id):
         queued.append(room_id)
         return None
 
     monkeypatch.setattr(assistant, "_send_bot_message", fake_send)
+    monkeypatch.setattr(assistant.chat_repo, "reserve_ai_bot_response", fake_reserve)
+    monkeypatch.setattr(assistant.chat_repo, "release_ai_bot_response_reservation", fake_release)
     async def fake_audit(*args, **kwargs):
         return None
 
@@ -63,6 +71,43 @@ def test_scan_waiting_rooms_sends_ack_before_analysis(monkeypatch):
 
     assert sent == [assistant._ACK_MESSAGE]
     assert queued == []
+
+
+def test_scan_waiting_rooms_skips_ack_when_response_slot_already_reserved(monkeypatch):
+    settings = SimpleNamespace(
+        matrix_enabled=True,
+        matrixbot_ai_waiting_assistant_enabled=True,
+        matrixbot_ai_ollama_enabled=True,
+        matrixbot_ai_ollama_url="http://ollama.test",
+        matrixbot_ai_ollama_model="llama3",
+        matrixbot_ai_max_responses=2,
+        matrixbot_ai_response_delay_minutes=5,
+    )
+    sent: list[str] = []
+
+    monkeypatch.setattr(assistant, "get_settings", lambda: settings)
+
+    async def fake_list(due_before):
+        return [{"id": 42, "status": "open", "assigned_tech_user_id": None, "ai_bot_response_count": 0}]
+
+    async def fake_has_technician_participant(room_id):
+        return False
+
+    async def fake_reserve(room_id, expected_count, when=None):
+        return False
+
+    async def fake_send(room, body, **kwargs):
+        sent.append(body)
+        return True
+
+    monkeypatch.setattr(assistant.chat_repo, "list_ai_waiting_candidate_rooms", fake_list)
+    monkeypatch.setattr(assistant.chat_repo, "has_technician_participant", fake_has_technician_participant)
+    monkeypatch.setattr(assistant.chat_repo, "reserve_ai_bot_response", fake_reserve)
+    monkeypatch.setattr(assistant, "_send_bot_message", fake_send)
+
+    asyncio.run(assistant.scan_waiting_rooms_once())
+
+    assert sent == []
 
 
 def test_scan_waiting_rooms_queues_second_response_analysis(monkeypatch):


### PR DESCRIPTION
### Motivation
- Prevent multiple app workers from sending the same AI Waiting Assistant acknowledgement or article recommendation for the same response count by making the reservation and claim of a response slot atomic. 

### Description
- Add `execute_rowcount` to the database layer so callers can determine how many rows a conditional `UPDATE` affected. 
- Add `reserve_ai_bot_response` and `release_ai_bot_response_reservation` helpers to `app/repositories/chat.py` to atomically claim and release a waiting-assistant response slot. 
- Update `app/services/matrix_ai_waiting_assistant.py` to reserve a response slot before sending the ACK or article recommendation, skip sending if the slot is already reserved, and release the reservation if the Matrix send fails. 
- Adjust KB confidence scoring to compute match confidence against the smaller of article tags and extracted chat keywords to avoid unfairly filtering relevant articles. 
- Add a regression test to `tests/services/test_matrix_ai_waiting_assistant.py` to ensure the assistant skips sending an acknowledgement if another worker already reserved the slot. 

### Testing
- Compiled modified modules with `python3 -m py_compile` and the compile step succeeded. 
- Ran `pytest -q tests/services/test_matrix_ai_waiting_assistant.py` and the tests passed (`8 passed`). 
- A combined test run including `tests/test_chat_feature_pack.py` was run and initially highlighted unrelated feature-pack route expectation differences; the AI waiting assistant unit tests for this change passed independently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3274d74690832d838831bcc5281015)