### PR TITLE
Admin ticket detail: add responsive 4th column and move reply/conversation

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5073,6 +5073,17 @@ dialog.modal:not([open]) {
   align-items: flex-start;
 }
 
+.management__column--conversation,
+.management__column--activity {
+  min-width: 0;
+}
+
+@media (min-width: 1800px) {
+  .management__body--columns {
+    grid-template-columns: minmax(280px, 320px) minmax(360px, 1.15fr) minmax(0, 1fr) minmax(0, 1fr);
+  }
+}
+
 .management__column {
   display: flex;
   flex-direction: column;

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -898,6 +898,9 @@
             </div>
           </details>
 
+        </div>
+
+        <div class="management__column management__column--activity">
           <article class="card card--panel">
             <header class="card__header">
               <h2 class="card__title">Add a reply</h2>
@@ -1077,6 +1080,9 @@
             </form>
           </article>
 
+        </div>
+
+        <div class="management__column management__column--conversation">
           <article class="card card--panel">
             <header class="card__header">
               <h2 class="card__title">Conversation history</h2>


### PR DESCRIPTION
### Motivation
- Provide a 4-column layout for high-resolution displays so the ticket conversation can be shown in its own column and not crowd other details.
- Move the "Add a reply" form to the top of the additional column to match the updated high-resolution UX requirements.
- Ensure the 3rd and 4th columns share available space equally on large screens and remain responsive at smaller breakpoints.

### Description
- Updated `app/templates/admin/ticket_detail.html` to split the right-hand content into two new columns by adding `management__column--activity` (holds `Add a reply`) and `management__column--conversation` (holds `Conversation history`).
- Adjusted markup so the `Add a reply` card appears at the top of the additional (third) column and the conversation history is placed into the new fourth column.
- Added CSS in `app/static/css/app.css` with `@media (min-width: 1800px)` to expand `.management__body--columns` to four columns and set the last two columns to equal `minmax(0, 1fr)` units, and added `min-width: 0` rules for the new columns to allow proper flex/shrink behavior.

### Testing
- Parsed the Jinja template with `Environment().parse(...)` and it succeeded.
- Verified the new responsive CSS via assertions against `app/static/css/app.css` (checks for the `@media (min-width: 1800px)` rule and the `minmax(0, 1fr)` column definitions) and the checks passed.
- Ran `pytest` for `tests/test_admin_ticket_detail.py` and `tests/test_ticket_booking_link.py`; some tests failed (4 failed, 2 passed) due to this environment attempting to connect to a local MySQL service on `localhost:3306`, causing DB connection errors rather than template/CSS regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3277ba7e90832dafd36bb303e4f02b)