### PR TITLE
Add responsive activity column and adjust management columns layout

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5073,6 +5073,22 @@ dialog.modal:not([open]) {
   align-items: flex-start;
 }
 
+.management__column--activity {
+  min-width: 0;
+}
+
+@media (min-width: 961px) and (max-width: 1799px) {
+  .management__column--activity {
+    grid-column: 2;
+  }
+}
+
+@media (min-width: 1800px) {
+  .management__body--columns {
+    grid-template-columns: minmax(280px, 320px) minmax(360px, 1fr) minmax(0, 1fr);
+  }
+}
+
 .management__column {
   display: flex;
   flex-direction: column;

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -898,6 +898,9 @@
             </div>
           </details>
 
+        </div>
+
+        <div class="management__column management__column--activity">
           <article class="card card--panel">
             <header class="card__header">
               <h2 class="card__title">Add a reply</h2>


### PR DESCRIPTION
### Motivation
- Split the management view to surface ticket activity/reply UI in a distinct column for better visual separation and usability.
- Improve responsive grid behavior so the activity column and main content adapt across medium and very wide viewports.

### Description
- Added CSS rules in `app/static/css/app.css` including `.management__column--activity` with `min-width: 0`, a media query for `@media (min-width: 961px) and (max-width: 1799px)` to place the activity column in the second grid column, and a large-breakpoint rule at `@media (min-width: 1800px)` to switch to a three-column layout.
- Updated `app/templates/admin/ticket_detail.html` to close the previous container and introduce a new `div` with classes `management__column management__column--activity` wrapping the "Add a reply" card so that replies appear in the new activity column.
- Adjusted the overall management columns grid template to reserve space for the activity column on wide screens while preserving existing behavior on smaller viewports.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3277ba7e90832dafd36bb303e4f02b)