### PR TITLE
Enhance knowledge base AI tag controls

### DIFF
--- a/app/api/routes/knowledge_base.py
+++ b/app/api/routes/knowledge_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFile, File, status
+from pydantic import BaseModel, Field
 
 from app.api.dependencies.auth import get_current_session, get_current_user, get_optional_user, require_super_admin
 from app.repositories import knowledge_base as kb_repo
@@ -95,6 +96,7 @@ async def list_articles(
                 permission_scope=article["permission_scope"],
                 is_published=article["is_published"],
                 ai_tags=article.get("ai_tags", []),
+                manual_ai_tags=article.get("manual_ai_tags", []),
                 updated_at=article.get("updated_at"),
                 updated_at_iso=article.get("updated_at_iso"),
                 published_at_iso=article.get("published_at_iso"),
@@ -134,6 +136,7 @@ async def get_article(
         is_published=article["is_published"],
         ai_tags=article.get("ai_tags", []),
         excluded_ai_tags=article.get("excluded_ai_tags", []),
+        manual_ai_tags=article.get("manual_ai_tags", []),
         allowed_user_ids=article.get("allowed_user_ids", []),
         allowed_company_ids=article.get("allowed_company_ids", []),
         company_admin_ids=article.get("company_admin_ids", []),
@@ -189,6 +192,7 @@ async def create_article(
         is_published=article["is_published"],
         ai_tags=article.get("ai_tags", []),
         excluded_ai_tags=article.get("excluded_ai_tags", []),
+        manual_ai_tags=article.get("manual_ai_tags", []),
         allowed_user_ids=article.get("allowed_user_ids", []),
         allowed_company_ids=article.get("allowed_company_ids", []),
         company_admin_ids=article.get("company_admin_ids", []),
@@ -241,6 +245,7 @@ async def update_article(
         is_published=article["is_published"],
         ai_tags=article.get("ai_tags", []),
         excluded_ai_tags=article.get("excluded_ai_tags", []),
+        manual_ai_tags=article.get("manual_ai_tags", []),
         allowed_user_ids=article.get("allowed_user_ids", []),
         allowed_company_ids=article.get("allowed_company_ids", []),
         company_admin_ids=article.get("company_admin_ids", []),
@@ -269,6 +274,56 @@ async def delete_article(
         before=_audit_article_summary(existing_article),
         after=None,
     )
+
+
+class KnowledgeBaseManualTagRequest(BaseModel):
+    tag_slug: str = Field(..., min_length=1, max_length=48, description="Manual AI tag slug to add")
+
+
+@router.post("/articles/{article_id}/manual-ai-tags", status_code=status.HTTP_200_OK)
+async def add_article_manual_ai_tag(
+    article_id: int,
+    payload: KnowledgeBaseManualTagRequest,
+    current_user: dict = Depends(require_super_admin),
+) -> dict[str, list[str] | str]:
+    """Add a manual AI tag to a knowledge base article without affecting generated tags."""
+    from app.services.tagging import slugify_tag
+
+    article = await kb_repo.get_article_by_id(article_id)
+    if not article:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Article not found")
+    tag = slugify_tag(payload.tag_slug)
+    if not tag:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid tag slug")
+    manual_tags = list(article.get("manual_ai_tags") or [])
+    ai_tags = list(article.get("ai_tags") or [])
+    excluded_tags = list(article.get("excluded_ai_tags") or [])
+    if tag in excluded_tags:
+        excluded_tags = [existing for existing in excluded_tags if existing != tag]
+    if tag in ai_tags:
+        ai_tags = [existing for existing in ai_tags if existing != tag]
+    if tag not in manual_tags:
+        manual_tags.append(tag)
+    await kb_repo.update_article(article_id, ai_tags=ai_tags, manual_ai_tags=manual_tags, excluded_ai_tags=excluded_tags)
+    return {"status": "updated", "manual_ai_tags": manual_tags, "ai_tags": ai_tags}
+
+
+@router.delete("/articles/{article_id}/manual-ai-tags/{tag_slug}", status_code=status.HTTP_200_OK)
+async def remove_article_manual_ai_tag(
+    article_id: int,
+    tag_slug: str,
+    current_user: dict = Depends(require_super_admin),
+) -> dict[str, list[str] | str]:
+    """Remove a manual AI tag from a knowledge base article."""
+    from app.services.tagging import slugify_tag
+
+    article = await kb_repo.get_article_by_id(article_id)
+    if not article:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Article not found")
+    tag = slugify_tag(tag_slug)
+    manual_tags = [existing for existing in list(article.get("manual_ai_tags") or []) if existing != tag]
+    await kb_repo.update_article(article_id, manual_ai_tags=manual_tags)
+    return {"status": "updated", "manual_ai_tags": manual_tags}
 
 
 @router.post("/articles/{article_id}/refresh-ai-tags", status_code=status.HTTP_200_OK)

--- a/app/api/routes/tag_exclusions.py
+++ b/app/api/routes/tag_exclusions.py
@@ -32,6 +32,7 @@ class TagExclusionListResponse(BaseModel):
 
 class RemoveTagRequest(BaseModel):
     tag_slug: str = Field(..., min_length=1, max_length=48, description="Tag slug to remove")
+    exclude_globally: bool = Field(False, description="Also add the tag to the shared AI tag exclusion list")
 
 
 @router.get("", response_model=TagExclusionListResponse)
@@ -166,6 +167,13 @@ async def remove_kb_article_tag(
         # Add to excluded list to prevent re-adding on refresh
         if normalized_slug not in excluded_ai_tags:
             excluded_ai_tags.append(normalized_slug)
+        if request.exclude_globally and not await tag_exclusions_repo.is_tag_excluded(normalized_slug):
+            user_id = current_user.get("id")
+            try:
+                user_id_int = int(user_id) if user_id else None
+            except (TypeError, ValueError):
+                user_id_int = None
+            await tag_exclusions_repo.add_tag_exclusion(normalized_slug, user_id_int)
         await kb_repo.update_article(article_id, ai_tags=updated_tags, excluded_ai_tags=excluded_ai_tags)
         return {"success": True, "removed": normalized_slug, "remaining_tags": updated_tags}
     

--- a/app/repositories/knowledge_base.py
+++ b/app/repositories/knowledge_base.py
@@ -41,6 +41,7 @@ def _normalise_article(row: dict[str, Any]) -> dict[str, Any]:
     article["permission_scope"] = permission
     article["ai_tags"] = _normalise_tags(article.get("ai_tags"))
     article["excluded_ai_tags"] = _normalise_tags(article.get("excluded_ai_tags"))
+    article["manual_ai_tags"] = _normalise_tags(article.get("manual_ai_tags"))
     return article
 
 
@@ -284,8 +285,8 @@ async def update_article(article_id: int, **updates: Any) -> dict[str, Any]:
                 params.append(json.dumps([]))
             else:
                 params.append(json.dumps(list(value)))
-        elif column == "excluded_ai_tags":
-            columns.append("excluded_ai_tags = %s")
+        elif column in {"excluded_ai_tags", "manual_ai_tags"}:
+            columns.append(f"{column} = %s")
             if value is None:
                 params.append(json.dumps([]))
             else:

--- a/app/schemas/knowledge_base.py
+++ b/app/schemas/knowledge_base.py
@@ -56,6 +56,7 @@ class KnowledgeBaseArticleResponse(BaseModel):
     is_published: bool
     ai_tags: list[str]
     excluded_ai_tags: list[str] = Field(default_factory=list)
+    manual_ai_tags: list[str] = Field(default_factory=list)
     allowed_user_ids: list[int]
     allowed_company_ids: list[int]
     company_admin_ids: list[int]
@@ -75,6 +76,7 @@ class KnowledgeBaseArticleListItem(BaseModel):
     permission_scope: PermissionScope
     is_published: bool
     ai_tags: list[str]
+    manual_ai_tags: list[str] = Field(default_factory=list)
     updated_at: datetime | None
     updated_at_iso: str | None
     published_at_iso: str | None

--- a/app/services/knowledge_base.py
+++ b/app/services/knowledge_base.py
@@ -14,7 +14,7 @@ from app.core.logging import log_error
 from app.repositories import knowledge_base as kb_repo
 from app.services import company_access
 from app.services import modules as modules_service
-from app.services.tagging import filter_helpful_texts
+from app.services.tagging import filter_helpful_texts, get_all_excluded_tags, slugify_tag
 from app.services.realtime import RefreshNotifier, refresh_notifier
 from app.services.knowledge_base_conditionals import (
     get_conditional_companies,
@@ -275,7 +275,12 @@ async def _schedule_article_ai_tags(
         if not text:
             log_error("Knowledge base AI tag generation returned empty response")
             return
-        tags = _parse_ai_tag_text(text)
+        try:
+            excluded_slugs = await get_all_excluded_tags()
+        except Exception as exc:
+            log_error("Knowledge base AI tag exclusion lookup failed", error=str(exc))
+            excluded_slugs = set()
+        tags = [tag for tag in _parse_ai_tag_text(text) if tag not in excluded_slugs]
         if not tags:
             log_error("Knowledge base AI tag parsing yielded no tags")
             return
@@ -283,9 +288,10 @@ async def _schedule_article_ai_tags(
         # Fetch the current article to get excluded tags
         article = await kb_repo.get_article_by_id(article_id)
         if article:
-            excluded_tags = article.get("excluded_ai_tags", [])
-            # Filter out any tags that have been manually excluded
-            tags = [tag for tag in tags if tag not in excluded_tags]
+            excluded_tags = {slugify_tag(str(tag)) for tag in article.get("excluded_ai_tags", [])}
+            manual_tags = {slugify_tag(str(tag)) for tag in article.get("manual_ai_tags", [])}
+            # Filter out article-specific excludes and preserve manual tags separately.
+            tags = [tag for tag in tags if tag not in excluded_tags and tag not in manual_tags]
         
         await kb_repo.update_article(article_id, ai_tags=tags)
         resolved_notifier = notifier or refresh_notifier
@@ -457,6 +463,7 @@ def _serialise_article(
         "summary": article.get("summary"),
         "ai_tags": list(article.get("ai_tags") or []),
         "excluded_ai_tags": list(article.get("excluded_ai_tags") or []),
+        "manual_ai_tags": list(article.get("manual_ai_tags") or []),
         "permission_scope": str(article.get("permission_scope")),
         "is_published": bool(article.get("is_published")),
         "updated_at": article.get("updated_at_utc"),

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -3061,6 +3061,22 @@ button.header-title-menu__link {
   color: rgba(226, 232, 240, 0.85);
 }
 
+.tag--manual {
+  background: rgba(168, 85, 247, 0.24);
+  color: #e9d5ff;
+}
+
+.kb-admin__manual-tag-form {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-compact);
+}
+
+.kb-admin__manual-tag-form .form-input {
+  min-width: 12rem;
+  width: auto;
+}
+
 .status {
   display: inline-flex;
   align-items: center;

--- a/app/static/js/knowledge_base_admin.js
+++ b/app/static/js/knowledge_base_admin.js
@@ -26,6 +26,8 @@
   const state = {
     activeSlug: null,
     activeId: null,
+    aiTags: [],
+    manualAiTags: [],
   };
 
   const table = document.getElementById('kb-admin-table');
@@ -94,40 +96,65 @@
     return div.innerHTML;
   }
 
-  function renderAiTags(tags) {
+  function renderAiTags(tags, manualTags) {
     if (!aiTagsContainer) {
       return;
     }
-    if (!Array.isArray(tags) || tags.length === 0) {
-      aiTagsContainer.innerHTML = '<span class="card__empty">No AI tags yet. Tags will be generated when you save the article.</span>';
-      return;
-    }
-    const html = tags
+    const generatedTags = Array.isArray(tags) ? tags : [];
+    const addedTags = Array.isArray(manualTags) ? manualTags : [];
+    const emptyHtml = generatedTags.length === 0 && addedTags.length === 0
+      ? '<span class="card__empty">No AI tags yet. Tags will be generated when you save the article.</span>'
+      : '';
+    const generatedHtml = generatedTags
       .map((tag) => {
-        return `<button type="button" class="tag tag--removable" data-tag-value="${escapeHtml(tag)}" title="Click to remove this tag">
+        return `<span class="tag tag--removable" data-tag-value="${escapeHtml(tag)}">
           ${escapeHtml(tag)}
-          <span class="tag__remove" aria-hidden="true">×</span>
-        </button>`;
+          <button type="button" class="tag__remove" data-tag-action="remove" aria-label="Remove tag ${escapeHtml(tag)}" title="Remove this tag">×</button>
+          <button type="button" class="tag__exclude" data-tag-action="exclude" aria-label="Exclude tag ${escapeHtml(tag)} from future use" title="Remove and exclude from future use"><svg viewBox="0 0 24 24" width="11" height="11" fill="currentColor" aria-hidden="true"><path d="M8.27 3 3 8.27v7.46L8.27 21h7.46L21 15.73V8.27L15.73 3H8.27zm4.5 13h-1.5v-1.5h1.5V16zm0-3h-1.5V8h1.5v5z"/></svg></button>
+        </span>`;
       })
       .join('');
-    aiTagsContainer.innerHTML = html;
+    const manualHtml = addedTags
+      .map((tag) => {
+        return `<span class="tag tag--manual" data-manual-tag-value="${escapeHtml(tag)}" title="Manual admin-added AI tag">
+          ${escapeHtml(tag)}
+          <button type="button" class="tag__remove" data-tag-action="remove-manual" aria-label="Remove manual tag ${escapeHtml(tag)}" title="Remove manual tag">×</button>
+        </span>`;
+      })
+      .join('');
+    const addHtml = `<form class="kb-admin__manual-tag-form" data-kb-manual-tag-form><input class="form-input" type="text" name="manual_tag" maxlength="48" placeholder="Add missed keyword" aria-label="Add manual AI tag"><button type="submit" class="button button--ghost button--sm">Add tag</button></form>`;
+    aiTagsContainer.innerHTML = emptyHtml + generatedHtml + manualHtml + addHtml;
 
     // Add click listeners to remove tags
-    aiTagsContainer.querySelectorAll('[data-tag-value]').forEach((button) => {
+    aiTagsContainer.querySelectorAll('[data-tag-action="remove"]').forEach((button) => {
       button.addEventListener('click', async () => {
-        const tagValue = button.dataset.tagValue;
-        if (!tagValue || !state.activeId) {
-          return;
-        }
-        if (!confirm(`Remove tag "${tagValue}"? This tag will not be automatically re-added.`)) {
-          return;
-        }
-        await removeTag(tagValue);
+        const tagValue = button.closest('[data-tag-value]')?.dataset.tagValue;
+        if (tagValue && confirm(`Remove tag "${tagValue}" from this article?`)) await removeTag(tagValue, false);
       });
     });
+    aiTagsContainer.querySelectorAll('[data-tag-action="exclude"]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const tagValue = button.closest('[data-tag-value]')?.dataset.tagValue;
+        if (tagValue && confirm(`Remove tag "${tagValue}" and add it to the shared exclusion list?`)) await removeTag(tagValue, true);
+      });
+    });
+    aiTagsContainer.querySelectorAll('[data-tag-action="remove-manual"]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const tagValue = button.closest('[data-manual-tag-value]')?.dataset.manualTagValue;
+        if (tagValue && confirm(`Remove manual tag "${tagValue}"?`)) await removeManualTag(tagValue);
+      });
+    });
+    const manualForm = aiTagsContainer.querySelector('[data-kb-manual-tag-form]');
+    if (manualForm) {
+      manualForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        const value = new FormData(manualForm).get('manual_tag');
+        await addManualTag(value);
+      });
+    }
   }
 
-  async function removeTag(tagSlug) {
+  async function removeTag(tagSlug, excludeGlobally) {
     if (!state.activeId) {
       return;
     }
@@ -138,18 +165,66 @@
           'Content-Type': 'application/json',
           Accept: 'application/json',
         },
-        body: JSON.stringify({ tag_slug: tagSlug }),
+        body: JSON.stringify({ tag_slug: tagSlug, exclude_globally: Boolean(excludeGlobally) }),
       });
       if (!response.ok) {
         const detail = await response.json().catch(() => ({}));
         throw new Error((detail && detail.detail) || `Failed to remove tag: ${response.status}`);
       }
       const result = await response.json();
-      renderAiTags(result.remaining_tags || []);
-      setStatus('Tag removed successfully.', 'success');
+      state.aiTags = result.remaining_tags || [];
+      renderAiTags(state.aiTags, state.manualAiTags);
+      setStatus(excludeGlobally ? 'Tag removed and added to the shared exclusion list.' : 'Tag removed successfully.', 'success');
       setTimeout(() => setStatus(''), 3000);
     } catch (error) {
       alert(error.message || 'Failed to remove tag. Please try again.');
+    }
+  }
+
+
+  async function addManualTag(tagSlug) {
+    if (!state.activeId || !tagSlug) {
+      return;
+    }
+    try {
+      const response = await fetch(`/api/knowledge-base/articles/${state.activeId}/manual-ai-tags`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ tag_slug: tagSlug }),
+      });
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        throw new Error((detail && detail.detail) || `Failed to add manual tag: ${response.status}`);
+      }
+      const result = await response.json();
+      state.aiTags = result.ai_tags || state.aiTags;
+      state.manualAiTags = result.manual_ai_tags || [];
+      renderAiTags(state.aiTags, state.manualAiTags);
+      setStatus('Manual AI tag added.', 'success');
+    } catch (error) {
+      alert(error.message || 'Failed to add manual tag. Please try again.');
+    }
+  }
+
+  async function removeManualTag(tagSlug) {
+    if (!state.activeId || !tagSlug) {
+      return;
+    }
+    try {
+      const response = await fetch(`/api/knowledge-base/articles/${state.activeId}/manual-ai-tags/${encodeURIComponent(tagSlug)}`, {
+        method: 'DELETE',
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}));
+        throw new Error((detail && detail.detail) || `Failed to remove manual tag: ${response.status}`);
+      }
+      const result = await response.json();
+      state.manualAiTags = result.manual_ai_tags || [];
+      renderAiTags(state.aiTags, state.manualAiTags);
+      setStatus('Manual AI tag removed.', 'success');
+    } catch (error) {
+      alert(error.message || 'Failed to remove manual tag. Please try again.');
     }
   }
 
@@ -906,7 +981,9 @@
     // Show and populate AI tags
     if (aiTagsSection && article.id) {
       aiTagsSection.hidden = false;
-      renderAiTags(article.ai_tags || []);
+      state.aiTags = article.ai_tags || [];
+      state.manualAiTags = article.manual_ai_tags || [];
+      renderAiTags(state.aiTags, state.manualAiTags);
     }
     
     if (deleteButton) {

--- a/app/templates/admin/knowledge_base.html
+++ b/app/templates/admin/knowledge_base.html
@@ -75,7 +75,7 @@
               {% endif %}
             </td>
             <td data-label="AI tags" data-value="{{ (article.ai_tags or []) | join(', ') }}" data-column-key="ai-tags">
-              {% for tag in article.ai_tags or [] %}<span class="tag tag--muted">{{ tag }}</span>{% else %}<span class="text-muted">—</span>{% endfor %}
+              {% for tag in article.ai_tags or [] %}<span class="tag tag--muted">{{ tag }}</span>{% endfor %}{% for tag in article.manual_ai_tags or [] %}<span class="tag tag--manual" title="Manual admin-added AI tag">{{ tag }}</span>{% endfor %}{% if not article.ai_tags and not article.manual_ai_tags %}<span class="text-muted">—</span>{% endif %}
             </td>
             <td data-label="Updated" data-value="{{ article.updated_at_iso or '' }}" data-column-key="updated">
               <span data-utc="{{ article.updated_at_iso or '' }}">{{ article.updated_at_iso or '—' }}</span>

--- a/migrations/251_knowledge_base_manual_ai_tags.sql
+++ b/migrations/251_knowledge_base_manual_ai_tags.sql
@@ -1,0 +1,8 @@
+-- Store admin-added knowledge base AI tags separately from AI-generated tags.
+-- Manual tags are preserved when generated tags are refreshed.
+ALTER TABLE knowledge_base_articles
+    ADD COLUMN IF NOT EXISTS manual_ai_tags JSON NULL AFTER excluded_ai_tags;
+
+UPDATE knowledge_base_articles
+SET manual_ai_tags = JSON_ARRAY()
+WHERE manual_ai_tags IS NULL;


### PR DESCRIPTION
### Motivation
- Knowledge base AI tags must respect the same shared exclusion list used by tickets so administrators can globally exclude unhelpful keywords. 
- Editors need the same remove/exclude actions available on tickets (remove-only and remove+exclude) when managing KB article tags. 
- Admins must be able to add manual AI tags that are preserved across AI refreshes and visually distinct from generated tags. 

### Description
- Added persistent `manual_ai_tags` JSON column and migration to store admin-added KB tags separately from generated tags. 
- Repository and schema updates normalize and include `manual_ai_tags` everywhere articles are loaded/serialized, and `update_article` now handles `manual_ai_tags`. 
- KB tag generation now consults the shared exclusion set (`get_all_excluded_tags`) and also respects article-specific `excluded_ai_tags` and `manual_ai_tags` so generated tags are filtered and manual tags are preserved. 
- New admin API endpoints to add/remove manual KB tags (`POST /api/knowledge-base/articles/{article_id}/manual-ai-tags` and `DELETE /api/knowledge-base/articles/{article_id}/manual-ai-tags/{tag_slug}`) and extended tag-removal to support `exclude_globally` for adding tags to the shared exclusions. 
- Admin UI changes to display generated tags with remove/exclude controls, allow adding/removing manual tags via an inline form, and render manual tags with a distinct color; added CSS and JS to support new interactions. 

### Testing
- Ran Python compile checks with `python3 -m py_compile app/api/routes/knowledge_base.py app/api/routes/tag_exclusions.py app/services/knowledge_base.py app/repositories/knowledge_base.py` which succeeded. 
- Validated frontend syntax with `node --check app/static/js/knowledge_base_admin.js` which succeeded. 
- Executed service tests with `python3 -m pytest tests/test_knowledge_base_service.py -q` and they passed (all tests green for that suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a327be34b84832d9b28af9b34a48fca)