### PR TITLE
Fix AI tag removal slug matching

### DIFF
--- a/app/api/routes/tag_exclusions.py
+++ b/app/api/routes/tag_exclusions.py
@@ -35,6 +35,23 @@ class RemoveTagRequest(BaseModel):
     exclude_globally: bool = Field(False, description="Also add the tag to the shared AI tag exclusion list")
 
 
+def _remove_matching_ai_tag(ai_tags: list[Any], normalized_slug: str) -> tuple[list[Any], bool]:
+    """Remove AI tags whose slugified value matches ``normalized_slug``.
+
+    Older generated tags may be stored with display casing or spaces. The UI sends
+    the visible tag value, so compare normalized forms while preserving all
+    unrelated stored tag values.
+    """
+    removed = False
+    updated_tags: list[Any] = []
+    for tag in ai_tags:
+        if normalized_slug and slugify_tag(str(tag)) == normalized_slug:
+            removed = True
+            continue
+        updated_tags.append(tag)
+    return updated_tags, removed
+
+
 @router.get("", response_model=TagExclusionListResponse)
 async def list_tag_exclusions(
     current_user: dict = Depends(require_super_admin),
@@ -128,8 +145,8 @@ async def remove_ticket_tag(
         ai_tags = []
     
     normalized_slug = slugify_tag(request.tag_slug)
-    if normalized_slug and normalized_slug in ai_tags:
-        updated_tags = [tag for tag in ai_tags if tag != normalized_slug]
+    updated_tags, removed = _remove_matching_ai_tag(ai_tags, normalized_slug)
+    if removed:
         await tickets_repo.update_ticket(ticket_id, ai_tags=updated_tags)
         return {"success": True, "removed": normalized_slug, "remaining_tags": updated_tags}
     
@@ -162,10 +179,10 @@ async def remove_kb_article_tag(
         excluded_ai_tags = []
     
     normalized_slug = slugify_tag(request.tag_slug)
-    if normalized_slug and normalized_slug in ai_tags:
-        updated_tags = [tag for tag in ai_tags if tag != normalized_slug]
+    updated_tags, removed = _remove_matching_ai_tag(ai_tags, normalized_slug)
+    if removed:
         # Add to excluded list to prevent re-adding on refresh
-        if normalized_slug not in excluded_ai_tags:
+        if normalized_slug not in {slugify_tag(str(tag)) for tag in excluded_ai_tags}:
             excluded_ai_tags.append(normalized_slug)
         if request.exclude_globally and not await tag_exclusions_repo.is_tag_excluded(normalized_slug):
             user_id = current_user.get("id")

--- a/tests/test_tag_exclusion_routes.py
+++ b/tests/test_tag_exclusion_routes.py
@@ -1,0 +1,92 @@
+from typing import Any
+
+import pytest
+
+from app.api.routes import tag_exclusions
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_remove_kb_article_tag_matches_display_tag_by_slug(monkeypatch):
+    updates: dict[str, Any] = {}
+
+    async def fake_get_article_by_id(article_id: int):
+        assert article_id == 42
+        return {
+            "id": article_id,
+            "ai_tags": ["Printer Offline", "VPN"],
+            "excluded_ai_tags": [],
+        }
+
+    async def fake_update_article(article_id: int, **kwargs: Any):
+        updates.update(kwargs)
+        return {"id": article_id, **kwargs}
+
+    monkeypatch.setattr(tag_exclusions.kb_repo, "get_article_by_id", fake_get_article_by_id)
+    monkeypatch.setattr(tag_exclusions.kb_repo, "update_article", fake_update_article)
+
+    result = await tag_exclusions.remove_kb_article_tag(
+        42,
+        tag_exclusions.RemoveTagRequest(tag_slug="printer-offline"),
+        current_user={"id": 7},
+    )
+
+    assert result == {"success": True, "removed": "printer-offline", "remaining_tags": ["VPN"]}
+    assert updates == {"ai_tags": ["VPN"], "excluded_ai_tags": ["printer-offline"]}
+
+
+@pytest.mark.anyio
+async def test_remove_kb_article_tag_deduplicates_existing_exclusion_by_slug(monkeypatch):
+    updates: dict[str, Any] = {}
+
+    async def fake_get_article_by_id(article_id: int):
+        return {
+            "id": article_id,
+            "ai_tags": ["Printer Offline", "VPN"],
+            "excluded_ai_tags": ["Printer Offline"],
+        }
+
+    async def fake_update_article(article_id: int, **kwargs: Any):
+        updates.update(kwargs)
+        return {"id": article_id, **kwargs}
+
+    monkeypatch.setattr(tag_exclusions.kb_repo, "get_article_by_id", fake_get_article_by_id)
+    monkeypatch.setattr(tag_exclusions.kb_repo, "update_article", fake_update_article)
+
+    await tag_exclusions.remove_kb_article_tag(
+        42,
+        tag_exclusions.RemoveTagRequest(tag_slug="printer-offline"),
+        current_user={"id": 7},
+    )
+
+    assert updates["ai_tags"] == ["VPN"]
+    assert updates["excluded_ai_tags"] == ["Printer Offline"]
+
+
+@pytest.mark.anyio
+async def test_remove_ticket_tag_matches_display_tag_by_slug(monkeypatch):
+    updates: dict[str, Any] = {}
+
+    async def fake_get_ticket(ticket_id: int):
+        assert ticket_id == 99
+        return {"id": ticket_id, "ai_tags": ["Password Reset", "Laptop"]}
+
+    async def fake_update_ticket(ticket_id: int, **kwargs: Any):
+        updates.update(kwargs)
+        return {"id": ticket_id, **kwargs}
+
+    monkeypatch.setattr(tag_exclusions.tickets_repo, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(tag_exclusions.tickets_repo, "update_ticket", fake_update_ticket)
+
+    result = await tag_exclusions.remove_ticket_tag(
+        99,
+        tag_exclusions.RemoveTagRequest(tag_slug="password-reset"),
+        current_user={"id": 7},
+    )
+
+    assert result == {"success": True, "removed": "password-reset", "remaining_tags": ["Laptop"]}
+    assert updates == {"ai_tags": ["Laptop"]}


### PR DESCRIPTION
### Motivation
- Users could not remove or exclude AI tags from tickets or knowledge base articles when the stored tag used display formatting (spaces/casing) while the UI sent a slugified tag, causing a “Tag not found in article” error. 
- Excluding a tag for an article could create duplicate exclusions when an existing excluded tag normalized to the same slug.

### Description
- Add a helper ` _remove_matching_ai_tag` in `app/api/routes/tag_exclusions.py` that removes tags by comparing `slugify_tag(str(tag))` to the requested normalized slug while preserving unrelated stored values. 
- Update `remove_ticket_tag` and `remove_kb_article_tag` to use the new helper so display-form stored tags like `"Printer Offline"` match requests for `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a327e038f18832daf5446cb389d4e5e)