### PR TITLE
Fix manual KB article tag persistence

### DIFF
--- a/app/api/routes/knowledge_base.py
+++ b/app/api/routes/knowledge_base.py
@@ -305,7 +305,14 @@ async def add_article_manual_ai_tag(
     if tag not in manual_tags:
         manual_tags.append(tag)
     await kb_repo.update_article(article_id, ai_tags=ai_tags, manual_ai_tags=manual_tags, excluded_ai_tags=excluded_tags)
-    return {"status": "updated", "manual_ai_tags": manual_tags, "ai_tags": ai_tags}
+    refreshed = await kb_repo.get_article_by_id(article_id)
+    if not refreshed:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Article not found after update")
+    return {
+        "status": "updated",
+        "manual_ai_tags": list(refreshed.get("manual_ai_tags") or []),
+        "ai_tags": list(refreshed.get("ai_tags") or []),
+    }
 
 
 @router.delete("/articles/{article_id}/manual-ai-tags/{tag_slug}", status_code=status.HTTP_200_OK)
@@ -323,7 +330,10 @@ async def remove_article_manual_ai_tag(
     tag = slugify_tag(tag_slug)
     manual_tags = [existing for existing in list(article.get("manual_ai_tags") or []) if existing != tag]
     await kb_repo.update_article(article_id, manual_ai_tags=manual_tags)
-    return {"status": "updated", "manual_ai_tags": manual_tags}
+    refreshed = await kb_repo.get_article_by_id(article_id)
+    if not refreshed:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Article not found after update")
+    return {"status": "updated", "manual_ai_tags": list(refreshed.get("manual_ai_tags") or [])}
 
 
 @router.post("/articles/{article_id}/refresh-ai-tags", status_code=status.HTTP_200_OK)

--- a/app/repositories/knowledge_base.py
+++ b/app/repositories/knowledge_base.py
@@ -450,7 +450,10 @@ async def find_relevant_articles_for_ticket(
     relevant_articles: list[tuple[dict[str, Any], int]] = []
     
     for article in all_articles:
-        article_tags = article.get("ai_tags") or []
+        article_tags = [
+            *(article.get("ai_tags") or []),
+            *(article.get("manual_ai_tags") or []),
+        ]
         excluded_tags = article.get("excluded_ai_tags") or []
         
         # Normalize article tags
@@ -487,4 +490,3 @@ async def find_relevant_articles_for_ticket(
         result.append(article_copy)
     
     return result
-

--- a/app/services/knowledge_base.py
+++ b/app/services/knowledge_base.py
@@ -815,6 +815,7 @@ def _score_article(article: Mapping[str, Any], *, query: str, tokens: Sequence[s
     content = article.get("content") or ""
     slug = article.get("slug") or ""
     ai_tags = article.get("ai_tags") or []
+    manual_ai_tags = article.get("manual_ai_tags") or []
     sections = article.get("sections") or []
 
     for value in (title, summary, content, slug):
@@ -823,6 +824,11 @@ def _score_article(article: Mapping[str, Any], *, query: str, tokens: Sequence[s
 
     if isinstance(ai_tags, Sequence) and not isinstance(ai_tags, (str, bytes)):
         for tag in ai_tags:
+            if isinstance(tag, str):
+                haystack_parts.append(tag.lower())
+
+    if isinstance(manual_ai_tags, Sequence) and not isinstance(manual_ai_tags, (str, bytes)):
+        for tag in manual_ai_tags:
             if isinstance(tag, str):
                 haystack_parts.append(tag.lower())
 
@@ -955,4 +961,3 @@ async def search_articles(
         "ollama_model": ollama_model,
         "ollama_summary": ollama_summary,
     }
-

--- a/tests/test_knowledge_base_feedback_api.py
+++ b/tests/test_knowledge_base_feedback_api.py
@@ -139,3 +139,42 @@ def test_submit_feedback_returns_not_found_for_inaccessible_article(monkeypatch,
     assert response.status_code == 404
     assert response.json()["detail"] == "Article not found"
     create_ticket.assert_not_awaited()
+
+
+def test_add_manual_ai_tag_persists_and_returns_refreshed_article(monkeypatch, active_session):
+    user = {"id": 1, "email": "admin@example.com", "company_id": 12, "is_super_admin": True}
+    app.dependency_overrides[knowledge_base_routes.require_super_admin] = lambda: user
+
+    stored_article = {
+        "id": 55,
+        "ai_tags": ["legacy"],
+        "manual_ai_tags": [],
+        "excluded_ai_tags": ["vpn"],
+    }
+
+    async def fake_get_article_by_id(article_id):
+        assert article_id == 55
+        return dict(stored_article)
+
+    async def fake_update_article(article_id, **updates):
+        assert article_id == 55
+        stored_article.update(updates)
+        return dict(stored_article)
+
+    monkeypatch.setattr(knowledge_base_routes.kb_repo, "get_article_by_id", fake_get_article_by_id)
+    monkeypatch.setattr(knowledge_base_routes.kb_repo, "update_article", fake_update_article)
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                "/api/knowledge-base/articles/55/manual-ai-tags",
+                json={"tag_slug": "VPN"},
+                headers={"X-CSRF-Token": active_session.csrf_token},
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["manual_ai_tags"] == ["vpn"]
+    assert stored_article["manual_ai_tags"] == ["vpn"]
+    assert stored_article["excluded_ai_tags"] == []

--- a/tests/test_knowledge_base_service.py
+++ b/tests/test_knowledge_base_service.py
@@ -281,3 +281,28 @@ async def test_update_article_refreshes_ai_tags(monkeypatch):
     assert ai_tag_call["ai_tags"] == ["security", "hardening"]
     assert article["ai_tags"] == ["security", "hardening"]
     trigger_mock.assert_awaited_once()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_search_articles_matches_manual_ai_tags(monkeypatch):
+    articles = [
+        _article_factory(
+            id=41,
+            slug="manual-vpn",
+            title="Remote access guide",
+            summary="Client setup notes",
+            content="<p>Install the client.</p>",
+            ai_tags=[],
+            manual_ai_tags=["vpn", "remote-access"],
+        )
+    ]
+    monkeypatch.setattr(
+        knowledge_base_service.kb_repo,
+        "list_articles",
+        AsyncMock(return_value=articles),
+    )
+
+    context = await knowledge_base_service.build_access_context({"id": 2, "is_super_admin": False})
+    result = await knowledge_base_service.search_articles("vpn", context, use_ollama=False)
+
+    assert [item["slug"] for item in result["results"]] == ["manual-vpn"]


### PR DESCRIPTION
### Motivation
- Manual AI tags added/removed via the admin UI were not reliably reflected back to the UI because the API returned the pre-update state rather than the persisted record.  
- Manually-added tags were not considered when scoring/searching articles or matching KB articles to tickets, making them less discoverable.

### Description
- Update the manual tag APIs to reload the article after `update_article` and return the persisted `manual_ai_tags` and `ai_tags` so the client sees the database state (changes in `app/api/routes/knowledge_base.py`).
- Include `manual_ai_tags` alongside generated `ai_tags` when scoring articles for search relevance and when matching articles to ticket tags (changes in `app/services/knowledge_base.py` and `app/repositories/knowledge_base.py`).
- Add regression tests covering manual tag persistence via the API and searching/matching by manual tags (new assertions in `tests/test_knowledge_base_feedback_api.py` and `tests/test_knowledge_base_service.py`).

### Testing
- Ran `pytest tests/test_knowledge_base_service.py tests/test_knowledge_base_feedback_api.py -q` and the test suite completed successfully.  
- The added regression tests for manual tag persistence and search matching passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a327f3581b8832d83ec8d795fd65efc)