### PR TITLE
Fix ticket conversation column placement

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5089,12 +5089,14 @@ dialog.modal:not([open]) {
   align-items: flex-start;
 }
 
-.management__column--activity {
+.management__column--activity,
+.management__column--conversation {
   min-width: 0;
 }
 
 @media (min-width: 961px) and (max-width: 1799px) {
-  .management__column--activity {
+  .management__column--activity,
+  .management__column--conversation {
     grid-column: 2;
   }
 }
@@ -5102,6 +5104,11 @@ dialog.modal:not([open]) {
 @media (min-width: 1800px) {
   .management__body--columns {
     grid-template-columns: minmax(280px, 320px) minmax(360px, 1fr) minmax(0, 1fr);
+  }
+
+  .management__column--activity,
+  .management__column--conversation {
+    grid-column: 3;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the ticket "Conversation history" card from wrapping under the left details column so it reliably appears below the "Add a reply" panel in the right-hand column across breakpoints.

### Description
- Update `app/static/css/app.css` to include `.management__column--conversation` alongside `.management__column--activity`, set `min-width: 0`, and explicitly assign both columns to the same grid column in the relevant media queries so the conversation panel stays in the right-hand column.

### Testing
- Ran `python -m compileall app` which completed successfully and `git diff --check` which produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3280f34c40832db76ed9db439df659)