### PR TITLE
Fix ticket conversation layout when reply is collapsed

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -1085,9 +1085,6 @@
             </div>
           </details>
 
-        </div>
-
-        <div class="management__column management__column--conversation">
           <article class="card card--panel">
             <header class="card__header">
               <h2 class="card__title">Conversation history</h2>


### PR DESCRIPTION
### Motivation
- Ensure that when the "Add a reply" panel is collapsed the `Conversation history` card moves up immediately instead of leaving an empty grid gap.

### Description
- Tidy up `app/templates/admin/ticket_detail.html` by removing the extra closing wrapper so the `Conversation history` article remains inside the same right-column stack as the reply panel.

### Testing
- Ran `python3 -m pytest tests/test_tickets_service_create.py` and the suite passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a32821f90d0832d9d70d71b8fdde44e)