### PR TITLE
Fix assets feature main module lookup

### DIFF
--- a/app/features/assets/routes.py
+++ b/app/features/assets/routes.py
@@ -45,6 +45,7 @@ def _main():
 
 
 async def _load_asset_context(request: Request):
+    main_module = _main()
     user, redirect = await main_module._require_authenticated_user(request)
     if redirect:
         return user, None, None, None, redirect
@@ -78,6 +79,7 @@ async def _load_asset_context(request: Request):
 
 @router.get("/assets", response_class=HTMLResponse)
 async def assets_page(request: Request):
+    main_module = _main()
     user, membership, company, company_id, redirect = await _load_asset_context(request)
     if redirect:
         return redirect
@@ -254,6 +256,7 @@ async def assets_page(request: Request):
 
 @router.get("/assets/settings", response_class=HTMLResponse)
 async def assets_settings_page(request: Request):
+    main_module = _main()
     user, _membership, _, _, redirect = await _load_asset_context(request)
     if redirect:
         return redirect


### PR DESCRIPTION
### Motivation
- Resolve a `NameError` caused by handlers in the assets feature referencing `main_module` before it was loaded, which broke the `/assets` and `/assets/settings` pages and related flows.

### Description
- Load `app.main` via the existing `_main()` helper and assign `main_module = _main()` at the start of `_load_asset_context`, `assets_page`, and `assets_settings_page` so shared authentication, permission, serialization, and rendering helpers are available.

### Testing
- Ran `python -m compileall app/features/assets/routes.py` and the module compiled successfully. 
- Ran `pytest tests/test_asset_csv_export.py tests/test_assets_permissions.py -q` and both tests passed. 
- Running `pytest tests/test_asset_csv_export.py tests/test_assets_permissions.py tests/test_assets_feature_pack.py -q` surfaced an unrelated failing assertion in `test_assets_pack_loads_and_reloads_cleanly` (the feature registry load in the isolated FastAPI app did not mount the expected routes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a32838d4374832d82293072066e5de0)