### PR TITLE
Fix reporting page error query handling

### DIFF
--- a/app/features/reporting/handlers.py
+++ b/app/features/reporting/handlers.py
@@ -136,6 +136,7 @@ def _validate_reporting_input(payload: dict[str, Any]) -> str | None:
 async def reporting_page(
     request: Request,
     report: int | None = Query(default=None),
+    error: str | None = Query(default=None),
 ):
     from app.repositories import reporting as reporting_repo
     from app.services import audit as audit_service

--- a/tests/test_reporting_page_handler.py
+++ b/tests/test_reporting_page_handler.py
@@ -1,0 +1,80 @@
+"""Regression coverage for the reporting page handler."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from starlette.requests import Request
+
+from app.features.reporting import handlers as reporting_handlers
+from app.repositories import reporting as reporting_repo
+
+
+def _request() -> Request:
+    return Request({"type": "http", "method": "GET", "path": "/reporting", "headers": []})
+
+
+def test_reporting_page_renders_without_error_query(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_require_reporting_access(request):
+        return {"id": 1, "is_super_admin": True}, True, None
+
+    async def fake_list_queries():
+        return []
+
+    async def fake_render_template(template, request, user, *, extra):
+        captured["template"] = template
+        captured["extra"] = extra
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(reporting_handlers, "_require_reporting_access", fake_require_reporting_access)
+    monkeypatch.setattr(
+        reporting_handlers,
+        "_main",
+        lambda: SimpleNamespace(_render_template=fake_render_template),
+    )
+    monkeypatch.setattr(reporting_repo, "list_queries", fake_list_queries)
+
+    async def _run() -> None:
+        response = await reporting_handlers.reporting_page(_request(), report=None, error=None)
+        assert response.status_code == 200
+
+    asyncio.new_event_loop().run_until_complete(_run())
+
+    assert captured["template"] == "reporting/index.html"
+    assert captured["extra"]["error_message"] is None
+
+
+def test_reporting_page_sanitises_error_query(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_require_reporting_access(request):
+        return {"id": 1, "is_super_admin": True}, True, None
+
+    async def fake_list_queries():
+        return []
+
+    async def fake_render_template(template, request, user, *, extra):
+        captured["extra"] = extra
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(reporting_handlers, "_require_reporting_access", fake_require_reporting_access)
+    monkeypatch.setattr(
+        reporting_handlers,
+        "_main",
+        lambda: SimpleNamespace(_render_template=fake_render_template),
+    )
+    monkeypatch.setattr(reporting_repo, "list_queries", fake_list_queries)
+
+    async def _run() -> None:
+        await reporting_handlers.reporting_page(
+            _request(),
+            report=None,
+            error="  Failed to run report  ",
+        )
+
+    asyncio.new_event_loop().run_until_complete(_run())
+
+    assert captured["extra"]["error_message"] == "Failed to run report"


### PR DESCRIPTION
### Motivation
- Prevent a runtime error when rendering `/reporting` by ensuring the handler accepts an optional `error` query parameter and sanitises it for display.

### Description
- Add an `error: str | None = Query(default=None)` parameter to `reporting_page` in `app/features/reporting/handlers.py` so `_reporting_message(error)` can be called safely.
- Add `tests/test_reporting_page_handler.py` with two regression tests that assert the page renders with no error and that an incoming `error` query is trimmed and presented safely.

### Testing
- Ran `pytest -q tests/test_reporting_page_handler.py` and the new tests passed.
- Ran `python -m compileall app/features/reporting/handlers.py tests/test_reporting_page_handler.py` and byte-compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3283db6874832d98cd6ffb070fa55e)