### PR TITLE
Fix admin audit logs page route

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6518,15 +6518,7 @@ async def admin_tray_delete_ticket_question(question_id: int, request: Request):
 # Per-company tray settings
 # ---------------------------------------------------------------------------
 
-
-
-
-
-
-
-
-
-
+@app.get("/admin/audit-logs", response_class=HTMLResponse)
 async def admin_audit_logs(
     request: Request,
     entity_type: str | None = None,

--- a/tests/test_admin_audit_logs_route.py
+++ b/tests/test_admin_audit_logs_route.py
@@ -1,0 +1,11 @@
+from app.main import app
+
+
+def test_admin_audit_logs_page_route_is_registered():
+    """Regression: the sidebar Audit Trail link must resolve to a page route."""
+
+    assert any(
+        getattr(route, "path", None) == "/admin/audit-logs"
+        and "GET" in getattr(route, "methods", set())
+        for route in app.routes
+    )


### PR DESCRIPTION
### Motivation
- The Admin "Audit Trail" sidebar link returned `{"detail":"Not Found"}` because the page handler was not registered as a `GET` route.

### Description
- Add a `@app.get("/admin/audit-logs", response_class=HTMLResponse)` decorator above the existing `admin_audit_logs` handler in `app/main.py` so the page route is registered.
- Add a regression test `tests/test_admin_audit_logs_route.py` that asserts the `/admin/audit-logs` GET route is present in `app.routes`.

### Testing
- Ran `pytest tests/test_admin_audit_logs_route.py` and the test passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a32846ff10c832da8a390a6ac9ca379)