### PR TITLE
Fix tray popup chat Decimal serialization

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -18,7 +18,8 @@ import html as _html
 import json
 import secrets
 import zlib
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -74,6 +75,21 @@ router = APIRouter(prefix="/api/tray", tags=["Tray App"])
 
 _settings = get_settings()
 
+
+def _serialise_popup_chat_value(obj: Any) -> Any:
+    """Convert popup chat payload values into JSON-compatible objects."""
+
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, Decimal):
+        if obj == obj.to_integral():
+            return int(obj)
+        return float(obj)
+    if isinstance(obj, dict):
+        return {key: _serialise_popup_chat_value(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [_serialise_popup_chat_value(item) for item in obj]
+    return obj
 
 # ---------------------------------------------------------------------------
 # Device-facing endpoints
@@ -1519,8 +1535,6 @@ async def popup_chat_get_room(
     Authenticated by the ``tray_popup`` encrypted session cookie set when
     ``GET /tray/chat?token=...`` is visited.
     """
-    from datetime import date
-
     session = _parse_popup_session(request)
     if not session:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid popup session")
@@ -1534,19 +1548,10 @@ async def popup_chat_get_room(
 
     messages = await chat_repo.get_messages(room_id, limit=50)
 
-    def _serial(obj: Any) -> Any:
-        if isinstance(obj, (datetime, date)):
-            return obj.isoformat()
-        if isinstance(obj, dict):
-            return {k: _serial(v) for k, v in obj.items()}
-        if isinstance(obj, list):
-            return [_serial(item) for item in obj]
-        return obj
-
     return JSONResponse(
         {
-            "room": _serial(dict(room)),
-            "messages": _serial(messages),
+            "room": _serialise_popup_chat_value(dict(room)),
+            "messages": _serialise_popup_chat_value(messages),
             "csrf_token": session.get("csrf"),
         }
     )

--- a/tests/test_tray_popup_chat_serialisation.py
+++ b/tests/test_tray_popup_chat_serialisation.py
@@ -1,0 +1,32 @@
+from datetime import date, datetime
+from decimal import Decimal
+
+from starlette.responses import JSONResponse
+
+from app.api.routes.tray import _serialise_popup_chat_value
+
+
+def test_popup_chat_serialiser_handles_decimal_values() -> None:
+    payload = {
+        "room": {
+            "id": Decimal("42"),
+            "created_at": datetime(2026, 6, 17, 21, 39, 18),
+        },
+        "messages": [
+            {
+                "id": Decimal("7"),
+                "score": Decimal("12.50"),
+                "sent_on": date(2026, 6, 17),
+            }
+        ],
+    }
+
+    serialised = _serialise_popup_chat_value(payload)
+
+    assert serialised == {
+        "room": {"id": 42, "created_at": "2026-06-17T21:39:18"},
+        "messages": [
+            {"id": 7, "score": 12.5, "sent_on": "2026-06-17"},
+        ],
+    }
+    JSONResponse(serialised)


### PR DESCRIPTION
### Motivation
- Prevent server errors when the popup chat endpoint returns payloads containing `Decimal` values which are not JSON serializable. 
- Ensure popup chat responses consistently serialize `datetime`/`date` and numeric values to JSON-safe types.

### Description
- Add a reusable helper `def _serialise_popup_chat_value(obj: Any) -> Any` that recursively converts `datetime`/`date` to ISO strings and `Decimal` to `int` or `float` (as appropriate). 
- Replace the ad-hoc serializer in the `/api/tray/popup-chat/{room_id}` endpoint to use the new helper for both the `room` and `messages` payloads. 
- Import `Decimal` and `date` where needed and add a regression test `tests/test_tray_popup_chat_serialisation.py` that verifies `Decimal` and date/datetime values are converted and accepted by `JSONResponse`.

### Testing
- Run `pytest tests/test_tray_popup_chat_serialisation.py` which passed (1 test passed). 
- Run `python -m compileall app/api/routes/tray.py tests/test_tray_popup_chat_serialisation.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a32879291a0832da028922352504fdb)