### PR TITLE
Prevent manual KB tag control from submitting article form

### DIFF
--- a/app/static/js/knowledge_base_admin.js
+++ b/app/static/js/knowledge_base_admin.js
@@ -122,7 +122,7 @@
         </span>`;
       })
       .join('');
-    const addHtml = `<form class="kb-admin__manual-tag-form" data-kb-manual-tag-form><input class="form-input" type="text" name="manual_tag" maxlength="48" placeholder="Add missed keyword" aria-label="Add manual AI tag"><button type="submit" class="button button--ghost button--sm">Add tag</button></form>`;
+    const addHtml = `<div class="kb-admin__manual-tag-form" data-kb-manual-tag-form><input class="form-input" type="text" name="manual_tag" maxlength="48" placeholder="Add missed keyword" aria-label="Add manual AI tag"><button type="button" class="button button--ghost button--sm" data-kb-manual-tag-add>Add tag</button></div>`;
     aiTagsContainer.innerHTML = emptyHtml + generatedHtml + manualHtml + addHtml;
 
     // Add click listeners to remove tags
@@ -144,13 +144,29 @@
         if (tagValue && confirm(`Remove manual tag "${tagValue}"?`)) await removeManualTag(tagValue);
       });
     });
-    const manualForm = aiTagsContainer.querySelector('[data-kb-manual-tag-form]');
-    if (manualForm) {
-      manualForm.addEventListener('submit', async (event) => {
-        event.preventDefault();
-        const value = new FormData(manualForm).get('manual_tag');
+    const manualTagWrapper = aiTagsContainer.querySelector('[data-kb-manual-tag-form]');
+    if (manualTagWrapper) {
+      const manualTagInput = manualTagWrapper.querySelector('input[name="manual_tag"]');
+      const manualTagButton = manualTagWrapper.querySelector('[data-kb-manual-tag-add]');
+      const submitManualTag = async () => {
+        const value = manualTagInput ? manualTagInput.value : '';
         await addManualTag(value);
-      });
+        if (manualTagInput) {
+          manualTagInput.value = '';
+          manualTagInput.focus();
+        }
+      };
+      if (manualTagButton) {
+        manualTagButton.addEventListener('click', submitManualTag);
+      }
+      if (manualTagInput) {
+        manualTagInput.addEventListener('keydown', async (event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            await submitManualTag();
+          }
+        });
+      }
     }
   }
 

--- a/tests/test_knowledge_base_feedback_api.py
+++ b/tests/test_knowledge_base_feedback_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -178,3 +179,12 @@ def test_add_manual_ai_tag_persists_and_returns_refreshed_article(monkeypatch, a
     assert response.json()["manual_ai_tags"] == ["vpn"]
     assert stored_article["manual_ai_tags"] == ["vpn"]
     assert stored_article["excluded_ai_tags"] == []
+
+
+def test_manual_ai_tag_control_is_not_nested_form_submitter():
+    script = Path("app/static/js/knowledge_base_admin.js").read_text()
+
+    assert "data-kb-manual-tag-form" in script
+    assert "<form class=\"kb-admin__manual-tag-form" not in script
+    assert "data-kb-manual-tag-add" in script
+    assert "manualTagInput.addEventListener('keydown'" in script


### PR DESCRIPTION
### Motivation
- The manual "Add tag" control in the KB editor was rendered as a nested `<form>`, causing the editor form to submit (and regenerate AI tags) when adding a manual tag instead of persisting the custom tag.

### Description
- Replaced the nested form with a non-submitting wrapper and a `type="button"` add control in `app/static/js/knowledge_base_admin.js` to avoid triggering the article save path.
- Added explicit click and Enter-key handling that calls the manual tag API (`addManualTag`) and clears/refocuses the input after submission in `app/static/js/knowledge_base_admin.js`.
- Added a regression check in `tests/test_knowledge_base_feedback_api.py` that asserts the manual tag UI is not a nested `<form>`, that the new `data-kb-manual-tag-add` hook exists, and that the input has the Enter key handler.

### Testing
- Ran `pytest -q tests/test_knowledge_base_feedback_api.py` and the test suite for that file passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3287c968a0832d99d1d526c3bd5fea)