### PR TITLE
Format AI Waiting Assistant KB replies

### DIFF
--- a/app/services/matrix_ai_waiting_assistant.py
+++ b/app/services/matrix_ai_waiting_assistant.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import html
 import json
 import re
 import uuid
@@ -319,7 +320,13 @@ async def _audit(action: str, room_id: int, value: Mapping[str, Any] | None = No
         log_error("AI waiting assistant audit failed", action=action, room_id=room_id, error=str(exc))
 
 
-async def _send_bot_message(room: Mapping[str, Any], body: str, *, response_count: int | None = None) -> bool:
+async def _send_bot_message(
+    room: Mapping[str, Any],
+    body: str,
+    *,
+    formatted_body: str | None = None,
+    response_count: int | None = None,
+) -> bool:
     matrix_room_id = str(room["matrix_room_id"])
     monitor_event = await _create_monitor_event(
         "MATRIXBOT_AI Matrix message",
@@ -331,7 +338,10 @@ async def _send_bot_message(room: Mapping[str, Any], body: str, *, response_coun
         },
     )
     try:
-        response = await matrix_service.send_message(matrix_room_id, body)
+        send_kwargs: dict[str, Any] = {}
+        if formatted_body:
+            send_kwargs["formatted_body"] = formatted_body
+        response = await matrix_service.send_message(matrix_room_id, body, **send_kwargs)
         event_id = response.get("event_id")
         await _record_monitor_success(
             monitor_event,
@@ -376,6 +386,34 @@ async def _send_bot_message(room: Mapping[str, Any], body: str, *, response_coun
         data={"message": _json_safe({**msg, "sent_at": now.isoformat()}), "room_id": int(room["id"])},
     )
     return True
+
+
+def _build_article_recommendation_message(article: Mapping[str, Any], link: str, summary: str) -> tuple[str, str]:
+    title = str(article.get("title") or "Knowledge base article").strip() or "Knowledge base article"
+    clean_link = str(link).strip()
+    clean_summary = " ".join(str(summary or "").split())
+    body_parts = [
+        f"While you wait, this article may help: {title}",
+        clean_link,
+    ]
+    if clean_summary:
+        body_parts.append(clean_summary)
+    body_parts.append(_AI_DISCLAIMER)
+    body = "\n\n".join(body_parts)
+
+    safe_title = html.escape(title)
+    safe_link = html.escape(clean_link, quote=True)
+    safe_summary = html.escape(clean_summary)
+    safe_disclaimer = html.escape(_AI_DISCLAIMER)
+    formatted_parts = [
+        f"<p>While you wait, this article may help: {safe_title}</p>",
+        f'<p><a href="{safe_link}">{safe_link}</a></p>',
+    ]
+    if safe_summary:
+        formatted_parts.append(f"<p>{safe_summary}</p>")
+    formatted_parts.append(f"<p>{safe_disclaimer}</p>")
+    formatted_body = "".join(formatted_parts)
+    return body, formatted_body
 
 
 async def handle_user_message(room_id: int, sent_at: datetime | None = None) -> None:
@@ -504,11 +542,16 @@ async def _process_queue_item(item: Mapping[str, Any]) -> None:
                     base = str(settings.public_base_url or settings.portal_url or "").rstrip("/")
                     path = f"/knowledge-base/articles/{article['slug']}"
                     link = f"{base}{path}" if base else path
-                    message = f"While you wait, this article may help: {article['title']}\n{link}\n\n{summary}\n\n{_AI_DISCLAIMER}"
+                    message, formatted_message = _build_article_recommendation_message(article, link, summary)
                     expected_count = int(room.get("ai_bot_response_count") or 0)
                     reserved_count = expected_count + 1
                     reserved = await chat_repo.reserve_ai_bot_response(room_id, expected_count=expected_count, when=_utcnow())
-                    if reserved and await _send_bot_message(room, message, response_count=reserved_count):
+                    if reserved and await _send_bot_message(
+                        room,
+                        message,
+                        formatted_body=formatted_message,
+                        response_count=reserved_count,
+                    ):
                         selected["sent"] = True
                         selected["sent_at"] = _utcnow().isoformat()
                         sent = True

--- a/tests/services/test_matrix_ai_waiting_assistant.py
+++ b/tests/services/test_matrix_ai_waiting_assistant.py
@@ -210,6 +210,77 @@ def test_ollama_generate_records_webhook_monitor_success(monkeypatch):
     assert successes[0]["response_status"] == 200
 
 
+def test_build_article_recommendation_message_formats_plain_text_and_html():
+    article = {"title": "TouchPad <setup>"}
+    link = "https://portal.example.test/knowledge-base/articles/touchpad?x=1&y=2"
+    summary = " Enable the touchpad.\nUse Fn + F10. "
+
+    body, formatted_body = assistant._build_article_recommendation_message(article, link, summary)
+
+    assert body == (
+        "While you wait, this article may help: TouchPad <setup>\n\n"
+        "https://portal.example.test/knowledge-base/articles/touchpad?x=1&y=2\n\n"
+        "Enable the touchpad. Use Fn + F10.\n\n"
+        f"{assistant._AI_DISCLAIMER}"
+    )
+    assert '<p>While you wait, this article may help: TouchPad &lt;setup&gt;</p>' in formatted_body
+    assert (
+        '<a href="https://portal.example.test/knowledge-base/articles/touchpad?x=1&amp;y=2">'
+        'https://portal.example.test/knowledge-base/articles/touchpad?x=1&amp;y=2</a>'
+    ) in formatted_body
+    assert '<p>Enable the touchpad. Use Fn + F10.</p>' in formatted_body
+
+
+def test_send_bot_message_forwards_formatted_body(monkeypatch):
+    settings = SimpleNamespace(matrix_bot_user_id="@bot:example.test")
+    calls: list[dict] = []
+
+    monkeypatch.setattr(assistant, "get_settings", lambda: settings)
+
+    async def fake_create_manual_event(**kwargs):
+        return {"id": 789}
+
+    async def fake_record_manual_success(event_id, **kwargs):
+        return {"id": event_id, "status": "succeeded"}
+
+    async def fake_send_message(room_id, body, **kwargs):
+        calls.append({"room_id": room_id, "body": body, **kwargs})
+        return {"event_id": "$event"}
+
+    async def fake_add_message(**kwargs):
+        return {"id": 10, **kwargs}
+
+    async def fake_increment(*args, **kwargs):
+        return None
+
+    async def fake_broadcast_refresh(**kwargs):
+        return None
+
+    monkeypatch.setattr(assistant.webhook_monitor, "create_manual_event", fake_create_manual_event)
+    monkeypatch.setattr(assistant.webhook_monitor, "record_manual_success", fake_record_manual_success)
+    monkeypatch.setattr(assistant.matrix_service, "send_message", fake_send_message)
+    monkeypatch.setattr(assistant.chat_repo, "add_message", fake_add_message)
+    monkeypatch.setattr(assistant.chat_repo, "increment_ai_bot_response", fake_increment)
+    monkeypatch.setattr(assistant.refresh_notifier, "broadcast_refresh", fake_broadcast_refresh)
+
+    sent = asyncio.run(
+        assistant._send_bot_message(
+            {"id": 42, "matrix_room_id": "!room:id"},
+            "plain",
+            formatted_body='<p><a href="https://example.test">https://example.test</a></p>',
+        )
+    )
+
+    assert sent is True
+    assert calls == [
+        {
+            "room_id": "!room:id",
+            "body": "plain",
+            "formatted_body": '<p><a href="https://example.test">https://example.test</a></p>',
+        }
+    ]
+
+
 def test_send_bot_message_records_webhook_monitor_failure(monkeypatch):
     settings = SimpleNamespace(matrix_bot_user_id="@bot:example.test")
     events: list[dict] = []


### PR DESCRIPTION
### Motivation
- Improve readability of AI Waiting Assistant knowledge-base recommendations by adding clear blank-line separated plain-text and HTML-formatted output with clickable links.
- Ensure messages rendered by Matrix clients that support HTML show safe, clickable links while keeping plain-text fallbacks for other clients.
- Prevent HTML injection by escaping article fields before inserting into formatted HTML.

### Description
- Add `formatted_body` support to `_send_bot_message` and forward it to `matrix_service.send_message` when present using `formatted_body` keyword argument.
- Introduce `_build_article_recommendation_message(article, link, summary)` to produce a plain-text message with blank-line separators and an HTML-formatted message with escaped title, clickable anchor, summary, and the AI disclaimer.
- Wire the new formatter into the KB recommendation flow so recommendations use both `body` and `formatted_body` when sending to Matrix rooms.
- Add regression tests in `tests/services/test_matrix_ai_waiting_assistant.py` to validate plain-text/HTML formatting and that `_send_bot_message` forwards `formatted_body` to the Matrix service.

### Testing
- Ran `pytest -q tests/services/test_matrix_ai_waiting_assistant.py` which executed the updated and existing tests and they all passed (`10 passed`).
- New tests cover that `_build_article_recommendation_message` produces the expected plain and escaped HTML output and that `_send_bot_message` forwards `formatted_body` to `matrix_service.send_message`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3289aaf6fc832d823661c7a6fa5d1a)