### PR TITLE
Move Matrix Chat Auto-Assign into Chat section and ensure AI waits for technician reply

### DIFF
--- a/app/features/chat/routes.py
+++ b/app/features/chat/routes.py
@@ -84,11 +84,12 @@ async def chat_index(
         "show_closed_filter": show_closed_filter,
         "unattended_filter": unattended,
         "is_staff": is_staff,
+        "is_super_admin": is_super_admin,
     }
     return await main_module._render_template("chat/index.html", request, current_user, extra=extra)
 
 
-@router.get("/chat/{room_id}", response_class=HTMLResponse)
+@router.get("/chat/{room_id:int}", response_class=HTMLResponse)
 async def chat_room_page(
     request: Request,
     room_id: int,

--- a/app/features/matrix_chat_assign/__init__.py
+++ b/app/features/matrix_chat_assign/__init__.py
@@ -2,10 +2,10 @@
 
 Owns the admin management page for configuring chat auto-assign rules:
 
-* ``GET  /admin/modules/matrix-chat-assign``
-* ``POST /admin/modules/matrix-chat-assign/rules``
-* ``POST /admin/modules/matrix-chat-assign/rules/{rule_id}``
-* ``POST /admin/modules/matrix-chat-assign/rules/{rule_id}/delete``
+* ``GET  /chat/auto-assign``
+* ``POST /chat/auto-assign/rules``
+* ``POST /chat/auto-assign/rules/{rule_id}``
+* ``POST /chat/auto-assign/rules/{rule_id}/delete``
 """
 
 from __future__ import annotations

--- a/app/features/matrix_chat_assign/routes.py
+++ b/app/features/matrix_chat_assign/routes.py
@@ -1,4 +1,4 @@
-"""Admin routes for Matrix chat auto-assign rules."""
+"""Chat-section routes for Matrix chat auto-assign rules."""
 
 from __future__ import annotations
 
@@ -124,8 +124,8 @@ def _normalize_conditions(*, is_default: bool, conditions: list[dict[str, Any]])
     return conditions
 
 
-@router.get("/admin/modules/matrix-chat-assign", response_class=HTMLResponse)
-async def admin_matrix_chat_assign_page(
+@router.get("/chat/auto-assign", response_class=HTMLResponse)
+async def chat_auto_assign_page(
     request: Request,
     rule_id: int | None = Query(default=None, alias="ruleId"),
 ):
@@ -136,8 +136,8 @@ async def admin_matrix_chat_assign_page(
     return await _render_dashboard(request, current_user, editing_rule_id=rule_id)
 
 
-@router.post("/admin/modules/matrix-chat-assign/rules", response_class=HTMLResponse)
-async def admin_create_auto_assign_rule(request: Request):
+@router.post("/chat/auto-assign/rules", response_class=HTMLResponse)
+async def chat_create_auto_assign_rule(request: Request):
     main_module = _main()
     current_user, redirect = await main_module._require_super_admin_page(request)
     if redirect:
@@ -184,15 +184,15 @@ async def admin_create_auto_assign_rule(request: Request):
         )
 
     return flash_redirect(
-        "/admin/modules/matrix-chat-assign", "Rule created successfully.", "success"
+        "/chat/auto-assign", "Rule created successfully.", "success"
     )
 
 
 @router.post(
-    "/admin/modules/matrix-chat-assign/rules/{rule_id}",
+    "/chat/auto-assign/rules/{rule_id}",
     response_class=HTMLResponse,
 )
-async def admin_update_auto_assign_rule(rule_id: int, request: Request):
+async def chat_update_auto_assign_rule(rule_id: int, request: Request):
     main_module = _main()
     current_user, redirect = await main_module._require_super_admin_page(request)
     if redirect:
@@ -201,7 +201,7 @@ async def admin_update_auto_assign_rule(rule_id: int, request: Request):
     existing = await assign_repo.get_rule(rule_id)
     if not existing:
         return flash_redirect(
-            "/admin/modules/matrix-chat-assign", "Rule not found.", "error"
+            "/chat/auto-assign", "Rule not found.", "error"
         )
 
     form = await request.form()
@@ -248,15 +248,15 @@ async def admin_update_auto_assign_rule(rule_id: int, request: Request):
         )
 
     return flash_redirect(
-        "/admin/modules/matrix-chat-assign", "Rule updated successfully.", "success"
+        "/chat/auto-assign", "Rule updated successfully.", "success"
     )
 
 
 @router.post(
-    "/admin/modules/matrix-chat-assign/rules/{rule_id}/delete",
+    "/chat/auto-assign/rules/{rule_id}/delete",
     response_class=HTMLResponse,
 )
-async def admin_delete_auto_assign_rule(rule_id: int, request: Request):
+async def chat_delete_auto_assign_rule(rule_id: int, request: Request):
     main_module = _main()
     current_user, redirect = await main_module._require_super_admin_page(request)
     if redirect:
@@ -267,11 +267,11 @@ async def admin_delete_auto_assign_rule(rule_id: int, request: Request):
     except Exception as exc:
         log_error("Failed to delete auto-assign rule", rule_id=rule_id, error=str(exc))
         return flash_redirect(
-            "/admin/modules/matrix-chat-assign",
+            "/chat/auto-assign",
             "Failed to delete rule.",
             "error",
         )
 
     return flash_redirect(
-        "/admin/modules/matrix-chat-assign", "Rule deleted.", "success"
+        "/chat/auto-assign", "Rule deleted.", "success"
     )

--- a/app/repositories/chat.py
+++ b/app/repositories/chat.py
@@ -179,6 +179,31 @@ async def has_technician_participant(room_id: int) -> bool:
     return row is not None
 
 
+async def has_technician_message(room_id: int) -> bool:
+    """Return whether a technician/admin has actually replied in the room.
+
+    Auto-assignment can add an assigned technician (and sometimes invite/add a
+    Matrix participant) before any human has responded.  The waiting assistant
+    should continue to help customers until a technician/admin sends a message.
+    """
+    row = await db.fetch_one(
+        """SELECT 1
+           FROM chat_messages m
+           JOIN chat_room_participants p
+             ON p.room_id = m.room_id
+            AND (
+                (m.sender_user_id IS NOT NULL AND p.user_id = m.sender_user_id)
+                OR p.matrix_user_id = m.sender_matrix_id
+            )
+           WHERE m.room_id = %s
+             AND m.redacted_at IS NULL
+             AND p.role IN ('technician', 'admin')
+           LIMIT 1""",
+        (room_id,),
+    )
+    return row is not None
+
+
 async def get_participant(
     room_id: int,
     *,
@@ -600,8 +625,17 @@ async def list_ai_waiting_candidate_rooms(due_before: datetime) -> list[dict[str
              AND r.ai_last_user_message_at <= %s
              AND COALESCE(r.ai_bot_response_count, 0) < 100
              AND NOT EXISTS (
-                 SELECT 1 FROM chat_room_participants p
-                 WHERE p.room_id = r.id AND p.role IN ('technician', 'admin')
+                 SELECT 1
+                 FROM chat_messages m
+                 JOIN chat_room_participants p
+                   ON p.room_id = m.room_id
+                  AND (
+                      (m.sender_user_id IS NOT NULL AND p.user_id = m.sender_user_id)
+                      OR p.matrix_user_id = m.sender_matrix_id
+                  )
+                 WHERE m.room_id = r.id
+                   AND m.redacted_at IS NULL
+                   AND p.role IN ('technician', 'admin')
              )
            ORDER BY r.ai_last_user_message_at ASC
            LIMIT 250""",

--- a/app/services/matrix_ai_waiting_assistant.py
+++ b/app/services/matrix_ai_waiting_assistant.py
@@ -423,15 +423,16 @@ async def handle_user_message(room_id: int, sent_at: datetime | None = None) -> 
 
 
 async def handle_chat_opened(room_id: int, opened_at: datetime | None = None) -> None:
-    """Start the waiting-assistant timer when an unassigned customer chat opens.
+    """Start the waiting-assistant timer when a customer chat opens.
 
     Some Matrix-backed rooms are created when a tray popup or customer chat
     window opens, before the customer sends a first message.  Treat that open
     event as customer activity so the acknowledgement can be sent when no
-    technician has taken the chat.
+    technician has replied. Auto-assignment alone must not suppress the waiting
+    assistant because assigned technicians may not have responded yet.
     """
     room = await chat_repo.get_room(room_id)
-    if not room or room.get("status") != "open" or await chat_repo.has_technician_participant(room_id):
+    if not room or room.get("status") != "open" or await chat_repo.has_technician_message(room_id):
         return
     await chat_repo.mark_user_activity(room_id, opened_at)
     await chat_repo.cancel_active_ai_queue_for_room(room_id, "chat_opened_timer_reset")
@@ -454,7 +455,7 @@ async def _eligible_room(room: Mapping[str, Any]) -> bool:
     room_id = int(room.get("id") or 0)
     if room.get("status") != "open" or not room_id:
         return False
-    if await chat_repo.has_technician_participant(room_id):
+    if await chat_repo.has_technician_message(room_id):
         return False
     return int(room.get("ai_bot_response_count") or 0) < get_settings().matrixbot_ai_max_responses
 

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -756,7 +756,7 @@ DEFAULT_MODULES: list[dict[str, Any]] = [
         "description": "Automatically assign new Matrix chat rooms to technicians based on configurable rules (customer name, contact name, subject, time of day, day of week). Includes a default fallback rule.",
         "icon": "💬",
         "settings": {
-            "manage_url": "/admin/modules/matrix-chat-assign",
+            "manage_url": "/chat/auto-assign",
         },
     },
 ]

--- a/app/templates/admin/matrix_chat_assign.html
+++ b/app/templates/admin/matrix_chat_assign.html
@@ -37,9 +37,9 @@
 
 {% block content %}
 {% set is_editing = editing_rule is not none %}
-{% set form_action = '/admin/modules/matrix-chat-assign/rules' %}
+{% set form_action = '/chat/auto-assign/rules' %}
 {% if is_editing %}
-  {% set form_action = '/admin/modules/matrix-chat-assign/rules/' ~ editing_rule.id %}
+  {% set form_action = '/chat/auto-assign/rules/' ~ editing_rule.id %}
 {% endif %}
 
 <div class="management management--single" data-layout>
@@ -153,7 +153,7 @@
                         >Edit</button>
                       </li>
                       <li class="header-title-menu__item" role="none">
-                        <form action="/admin/modules/matrix-chat-assign/rules/{{ rule.id }}/delete"
+                        <form action="/chat/auto-assign/rules/{{ rule.id }}/delete"
                               method="post" class="inline-form"
                               onsubmit="return confirm('Delete rule \'{{ rule.name | replace("'", "\\'") }}\'?');">
                           {% if csrf_token %}
@@ -338,7 +338,7 @@
     day_of_week: ['in'],
   };
   const STRING_OPERATORS = ['contains', 'equals', 'starts_with'];
-  const RULES_BASE_PATH = '/admin/modules/matrix-chat-assign/rules';
+  const RULES_BASE_PATH = '/chat/auto-assign/rules';
 
   const modal = document.getElementById('rule-modal');
   const form = document.getElementById('rule-form');

--- a/app/templates/chat/index.html
+++ b/app/templates/chat/index.html
@@ -4,10 +4,14 @@
 {% from "macros/header.html" import page_header_actions %}
 
 {% block header_actions %}
-  {{ page_header_actions([
+  {% set chat_actions = [
     {"label": "New chat", "variant": "primary", "type": "button",
      "attrs": {"data-create-chat-modal-open": "", "aria-haspopup": "dialog", "aria-controls": "create-chat-modal"}},
-  ]) }}
+  ] %}
+  {% if is_super_admin | default(false) %}
+    {% set chat_actions = chat_actions + [{"label": "Auto-assign rules", "type": "link", "href": "/chat/auto-assign"}] %}
+  {% endif %}
+  {{ page_header_actions(chat_actions) }}
 {% endblock %}
 
 {% block content %}

--- a/migrations/272_matrix_ai_technician_message_index.sql
+++ b/migrations/272_matrix_ai_technician_message_index.sql
@@ -1,0 +1,6 @@
+-- Matrix AI waiting assistant now treats a room as attended only after a
+-- technician/admin sends a chat message.  Index the message lookup used by
+-- the unattended-room scanner and eligibility checks.
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_room_sender_user_matrix
+  ON chat_messages (room_id, sender_user_id, sender_matrix_id, redacted_at);

--- a/tests/services/test_matrix_ai_waiting_assistant.py
+++ b/tests/services/test_matrix_ai_waiting_assistant.py
@@ -39,10 +39,10 @@ def test_scan_waiting_rooms_sends_ack_before_analysis(monkeypatch):
 
     monkeypatch.setattr(assistant.chat_repo, "list_ai_waiting_candidate_rooms", fake_list)
 
-    async def fake_has_technician_participant(room_id):
+    async def fake_has_technician_message(room_id):
         return False
 
-    monkeypatch.setattr(assistant.chat_repo, "has_technician_participant", fake_has_technician_participant)
+    monkeypatch.setattr(assistant.chat_repo, "has_technician_message", fake_has_technician_message)
 
     async def fake_send(room, body, **kwargs):
         sent.append(body)
@@ -90,7 +90,7 @@ def test_scan_waiting_rooms_skips_ack_when_response_slot_already_reserved(monkey
     async def fake_list(due_before):
         return [{"id": 42, "status": "open", "assigned_tech_user_id": None, "ai_bot_response_count": 0}]
 
-    async def fake_has_technician_participant(room_id):
+    async def fake_has_technician_message(room_id):
         return False
 
     async def fake_reserve(room_id, expected_count, when=None):
@@ -101,7 +101,7 @@ def test_scan_waiting_rooms_skips_ack_when_response_slot_already_reserved(monkey
         return True
 
     monkeypatch.setattr(assistant.chat_repo, "list_ai_waiting_candidate_rooms", fake_list)
-    monkeypatch.setattr(assistant.chat_repo, "has_technician_participant", fake_has_technician_participant)
+    monkeypatch.setattr(assistant.chat_repo, "has_technician_message", fake_has_technician_message)
     monkeypatch.setattr(assistant.chat_repo, "reserve_ai_bot_response", fake_reserve)
     monkeypatch.setattr(assistant, "_send_bot_message", fake_send)
 
@@ -133,10 +133,10 @@ def test_scan_waiting_rooms_queues_second_response_analysis(monkeypatch):
     monkeypatch.setattr(assistant.chat_repo, "list_ai_waiting_candidate_rooms", fake_list)
     monkeypatch.setattr(assistant.chat_repo, "get_active_ai_queue_item", fake_active)
 
-    async def fake_has_technician_participant(room_id):
+    async def fake_has_technician_message(room_id):
         return False
 
-    monkeypatch.setattr(assistant.chat_repo, "has_technician_participant", fake_has_technician_participant)
+    monkeypatch.setattr(assistant.chat_repo, "has_technician_message", fake_has_technician_message)
 
     async def fake_create(**kwargs):
         created.append(kwargs)
@@ -313,8 +313,8 @@ def test_send_bot_message_records_webhook_monitor_failure(monkeypatch):
     assert failures[0]["error_message"] == "matrix unavailable"
 
 
-def test_handle_chat_opened_marks_unassigned_open_room(monkeypatch):
-    room = {"id": 42, "status": "open", "assigned_tech_user_id": None}
+def test_handle_chat_opened_marks_auto_assigned_room_without_technician_message(monkeypatch):
+    room = {"id": 42, "status": "open", "assigned_tech_user_id": 7}
     marked: list[int] = []
     cancelled: list[tuple[int, str]] = []
     audited: list[str] = []
@@ -328,7 +328,7 @@ def test_handle_chat_opened_marks_unassigned_open_room(monkeypatch):
     async def fake_cancel(room_id, reason):
         cancelled.append((room_id, reason))
 
-    async def fake_has_technician_participant(room_id):
+    async def fake_has_technician_message(room_id):
         return False
 
     async def fake_audit(action, room_id, value=None):
@@ -337,7 +337,7 @@ def test_handle_chat_opened_marks_unassigned_open_room(monkeypatch):
     monkeypatch.setattr(assistant.chat_repo, "get_room", fake_get_room)
     monkeypatch.setattr(assistant.chat_repo, "mark_user_activity", fake_mark)
     monkeypatch.setattr(assistant.chat_repo, "cancel_active_ai_queue_for_room", fake_cancel)
-    monkeypatch.setattr(assistant.chat_repo, "has_technician_participant", fake_has_technician_participant)
+    monkeypatch.setattr(assistant.chat_repo, "has_technician_message", fake_has_technician_message)
     monkeypatch.setattr(assistant, "_audit", fake_audit)
 
     asyncio.run(assistant.handle_chat_opened(42))
@@ -347,7 +347,7 @@ def test_handle_chat_opened_marks_unassigned_open_room(monkeypatch):
     assert audited == ["matrix_ai_waiting_assistant.chat_opened"]
 
 
-def test_handle_chat_opened_ignores_room_with_technician_participant(monkeypatch):
+def test_handle_chat_opened_ignores_room_with_technician_message(monkeypatch):
     room = {"id": 42, "status": "open", "assigned_tech_user_id": 7}
     marked: list[int] = []
 
@@ -357,12 +357,12 @@ def test_handle_chat_opened_ignores_room_with_technician_participant(monkeypatch
     async def fake_mark(room_id, when=None):
         marked.append(room_id)
 
-    async def fake_has_technician_participant(room_id):
+    async def fake_has_technician_message(room_id):
         return True
 
     monkeypatch.setattr(assistant.chat_repo, "get_room", fake_get_room)
     monkeypatch.setattr(assistant.chat_repo, "mark_user_activity", fake_mark)
-    monkeypatch.setattr(assistant.chat_repo, "has_technician_participant", fake_has_technician_participant)
+    monkeypatch.setattr(assistant.chat_repo, "has_technician_message", fake_has_technician_message)
 
     asyncio.run(assistant.handle_chat_opened(42))
 


### PR DESCRIPTION
### Motivation
- Surface Matrix chat auto-assign configuration from the Chat UI rather than as a generic admin module so super-admins can manage rules from the Chat area. 
- Prevent auto-assignment/participant invites from suppressing the Matrix AI waiting assistant; the assistant should continue until a human technician/admin actually replies. 

### Description
- Moved the auto-assign management routes and form actions from `/admin/modules/matrix-chat-assign` to the Chat section at `/chat/auto-assign` and exposed the page via an "Auto-assign rules" header action on the Chat page for super-admins (`app/features/matrix_chat_assign/routes.py`, `app/templates/chat/index.html`, `app/templates/admin/matrix_chat_assign.html`, `app/services/modules.py`).
- Added a new repository helper `has_technician_message(room_id)` that detects whether a technician/admin has actually sent a message in the room and updated the unattended-room query to consider technician messages (not just participant presence) (`app/repositories/chat.py`).
- Updated the Matrix AI waiting assistant to use the new message-based attendance check in both the open-room handler and the unattended-room eligibility check so AI replies continue until a technician message is present (`app/services/matrix_ai_waiting_assistant.py`).
- Added a migration index to support efficient lookups for the technician-message attendance check (`migrations/272_matrix_ai_technician_message_index.sql`) and adjusted tests and route typing (`/chat/{room_id:int}`) where required.

### Testing
- Ran `pytest -q tests/services/test_matrix_ai_waiting_assistant.py tests/test_chat_auto_assign_repository.py` and all tests passed. 
- Ran `pytest -q tests/test_admin_modules_page.py tests/test_layout_macros.py` and all tests passed. 
- Verified Python syntax/compilation with `python -m py_compile` on the modified modules and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a328bbe42c4832d915f926473b51e5c)