### PR TITLE
Trigger AI enrichment for inbound SMS tickets

### DIFF
--- a/app/features/receive_sms/routes.py
+++ b/app/features/receive_sms/routes.py
@@ -128,6 +128,16 @@ async def _find_sms_ticket(normalised_phone: str, sms_day: date) -> dict[str, An
     return await tickets_repo.get_ticket(int(row["id"]))
 
 
+async def _refresh_sms_ticket_ai(ticket_id: int) -> None:
+    """Run the same AI enrichment pipeline used by standard ticket creation/reply flows."""
+
+    try:
+        await tickets_service.refresh_ticket_ai_summary(ticket_id)
+    except RuntimeError as exc:
+        log_error("Failed to refresh AI summary for SMS ticket", ticket_id=ticket_id, error=str(exc))
+    await tickets_service.refresh_ticket_ai_tags(ticket_id)
+
+
 @router.post("/inbound", status_code=status.HTTP_201_CREATED)
 async def receive_sms(payload: ReceiveSMSPayload, request: Request, api_key_record: dict = Depends(require_api_key)) -> dict[str, Any]:
     if payload.type != "SMSIn":
@@ -173,6 +183,8 @@ async def receive_sms(payload: ReceiveSMSPayload, request: Request, api_key_reco
                 """,
                 (ticket["id"], payload.from_number, normalised_phone, sms_day),
             )
+        ticket_id = int(ticket["id"])
+        await _refresh_sms_ticket_ai(ticket_id)
         await tickets_service.emit_ticket_updated_event(ticket, actor_type="api_key", actor={"id": api_key_record.get("id")})
     except Exception as exc:
         log_error("Failed to process inbound SMS", error=str(exc), from_number=payload.from_number)

--- a/tests/test_receive_sms_feature_pack.py
+++ b/tests/test_receive_sms_feature_pack.py
@@ -1,7 +1,9 @@
+import asyncio
 from datetime import datetime, timezone
 
 from app.core.config import Settings
 from app.features.receive_sms import PACK
+from app.features.receive_sms import routes as receive_sms_routes
 from app.features.receive_sms.routes import _decode_message, _normalise_phone, _parse_sms_datetime
 
 
@@ -36,3 +38,102 @@ def test_receive_sms_datetime_uses_current_date_when_only_time_sent():
 
     assert parsed.isoformat() == "2026-06-16T14:30:00+00:00"
     assert day.isoformat() == "2026-06-16"
+
+
+def test_receive_sms_created_ticket_refreshes_ai(monkeypatch):
+    async def run_test():
+        calls: list[tuple[str, int]] = []
+
+        async def fake_find_sms_ticket(*_args, **_kwargs):
+            return None
+
+        monkeypatch.setattr(receive_sms_routes, "_find_sms_ticket", fake_find_sms_ticket)
+
+        async def fake_find_contact(_phone):
+            return {"requester_id": 11, "requester_staff_id": None, "company_id": 22}
+
+        async def fake_resolve_status(_status):
+            return "new"
+
+        async def fake_create_ticket(**_kwargs):
+            return {"id": 123, "requester_id": 11, "status": "new"}
+
+        async def fake_execute(*_args, **_kwargs):
+            return None
+
+        async def fake_summary(ticket_id):
+            calls.append(("summary", ticket_id))
+
+        async def fake_tags(ticket_id):
+            calls.append(("tags", ticket_id))
+
+        async def fake_emit(*_args, **_kwargs):
+            return None
+
+        monkeypatch.setattr(receive_sms_routes, "_find_contact", fake_find_contact)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "resolve_status_or_default", fake_resolve_status)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "create_ticket", fake_create_ticket)
+        monkeypatch.setattr(receive_sms_routes.db, "execute", fake_execute)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_summary", fake_summary)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_tags", fake_tags)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "emit_ticket_updated_event", fake_emit)
+
+        payload = receive_sms_routes.ReceiveSMSPayload(
+            type="SMSIn",
+            **{"from": "+61 400 123 456"},
+            name="Customer",
+            message="UHJpbnRlciBpcyBqYW1tZWQ=",
+            date="2026-06-16",
+            time="14:30",
+        )
+
+        result = await receive_sms_routes.receive_sms(payload, request=None, api_key_record={"id": 7})
+
+        assert result["status"] == "created"
+        assert result["ticket_id"] == 123
+        assert calls == [("summary", 123), ("tags", 123)]
+
+    asyncio.run(run_test())
+
+
+def test_receive_sms_existing_ticket_reply_refreshes_ai(monkeypatch):
+    async def run_test():
+        calls: list[tuple[str, int]] = []
+
+        async def fake_find_sms_ticket(*_args, **_kwargs):
+            return {"id": 456, "requester_id": 11, "status": "open"}
+
+        async def fake_create_reply(**kwargs):
+            calls.append(("reply", int(kwargs["ticket_id"])))
+            return {"id": 99}
+
+        async def fake_summary(ticket_id):
+            calls.append(("summary", ticket_id))
+
+        async def fake_tags(ticket_id):
+            calls.append(("tags", ticket_id))
+
+        async def fake_emit(*_args, **_kwargs):
+            return None
+
+        monkeypatch.setattr(receive_sms_routes, "_find_sms_ticket", fake_find_sms_ticket)
+        monkeypatch.setattr(receive_sms_routes.tickets_repo, "create_reply", fake_create_reply)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_summary", fake_summary)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_tags", fake_tags)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "emit_ticket_updated_event", fake_emit)
+
+        payload = receive_sms_routes.ReceiveSMSPayload(
+            type="SMSIn",
+            **{"from": "+61 400 123 456"},
+            message="QW55IHVwZGF0ZT8=",
+            date="2026-06-16",
+            time="15:00",
+        )
+
+        result = await receive_sms_routes.receive_sms(payload, request=None, api_key_record={"id": 7})
+
+        assert result["status"] == "appended"
+        assert result["ticket_id"] == 456
+        assert calls == [("reply", 456), ("summary", 456), ("tags", 456)]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
### Motivation
- SMS-originated tickets were not running the AI enrichment pipeline (AI Summary, AI Tags and AI status/resolution state) that regular tickets receive.

### Description
- Add helper `async def _refresh_sms_ticket_ai(ticket_id: int)` that invokes `tickets_service.refresh_ticket_ai_summary` and `tickets_service.refresh_ticket_ai_tags` and logs failures. (`app/features/receive_sms/routes.py`).
- Invoke `_refresh_sms_ticket_ai` after creating or appending/reopening an SMS ticket and before emitting the ticket update event in the inbound SMS handler `receive_sms`. (`app/features/receive_sms/routes.py`).
- Add regression tests to `tests/test_receive_sms_feature_pack.py` covering both created SMS tickets and appended replies to ensure AI summary and tag refreshes are invoked, and adapt the tests to run the async flows via `asyncio.run` wrappers. (`tests/test_receive_sms_feature_pack.py`).

### Testing
- Ran `pytest -q tests/test_receive_sms_feature_pack.py` and the test file passed (`6 passed`).
- Ran `python -m compileall -q app/features/receive_sms/routes.py tests/test_receive_sms_feature_pack.py` which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a328c94b3a4832db3de71ea1d3d8277)