### PR TITLE
Focus chat AI tags on customer messages

### DIFF
--- a/app/services/chat_ticket_sync.py
+++ b/app/services/chat_ticket_sync.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from html import escape, unescape
 from typing import Any, Mapping
 
+from app.core.config import get_settings
 from app.core.logging import log_error, log_info
 from app.repositories import chat as chat_repo
 from app.repositories import tickets as tickets_repo
@@ -105,6 +106,12 @@ async def sync_chat_message_to_ticket(
         return
     chat_message_id = message.get("id")
     if isinstance(chat_message_id, int) and await get_link_by_chat_message_id(chat_message_id):
+        return
+
+    settings = get_settings()
+    bot_user_id = str(settings.matrix_bot_user_id or "").strip()
+    sender_matrix_id = str(message.get("sender_matrix_id") or "").strip()
+    if bot_user_id and sender_matrix_id == bot_user_id:
         return
 
     body = str(message.get("body") or "").strip()

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -79,8 +79,9 @@ _PROMPT_HEADER = (
 )
 
 _TAGS_PROMPT_HEADER = (
-    "You are an AI assistant that analyses helpdesk tickets and suggests between five and ten short tags. "
-    "Tags must describe the issues, affected systems, troubleshooting steps, impacted users, and requested actions. "
+    "You are an AI assistant that analyses customer helpdesk ticket messages and suggests between five and ten short tags. "
+    "Tags must describe the customer-reported issues, affected systems, impacted users, and requested actions. "
+    "Do not use technician replies, internal notes, automated assistant replies, or support-side troubleshooting steps as tag evidence. "
     "Respond ONLY with JSON shaped as {\"tags\": [\"tag-one\", \"tag-two\", ...]} using lowercase kebab-case tags."
 )
 
@@ -1392,6 +1393,38 @@ def _render_prompt(
     return "\n".join(lines)
 
 
+def _is_customer_tag_reply(
+    reply: Mapping[str, Any],
+    ticket: Mapping[str, Any],
+    user_lookup: Mapping[int, Mapping[str, Any]],
+) -> bool:
+    """Return whether a reply should be used as customer evidence for AI tags."""
+
+    if reply.get("is_internal"):
+        return False
+
+    settings = get_settings()
+    bot_user_id = str(settings.matrix_bot_user_id or "").strip()
+    sender_matrix_id = str(reply.get("sender_matrix_id") or "").strip()
+    if bot_user_id and sender_matrix_id and sender_matrix_id == bot_user_id:
+        return False
+
+    author_id = reply.get("author_id")
+    requester_id = ticket.get("requester_id")
+    if isinstance(requester_id, int):
+        return author_id == requester_id
+
+    author_record = user_lookup.get(author_id) if isinstance(author_id, int) else None
+    if author_record:
+        is_super_admin = bool(author_record.get("is_super_admin"))
+        permissions = author_record.get("permissions") or []
+        if isinstance(permissions, str):
+            permissions = [permissions]
+        if is_super_admin or HELPDESK_PERMISSION_KEY in set(permissions):
+            return False
+
+    return True
+
 def _render_tags_prompt(
     ticket: Mapping[str, Any],
     replies: list[Mapping[str, Any]],
@@ -1413,9 +1446,10 @@ def _render_tags_prompt(
     lines.append("Ticket description:")
     lines.append(description)
     lines.append("")
-    lines.append("Conversation highlights (newest first):")
+    lines.append("Customer conversation highlights (newest first):")
 
-    trimmed = list(replies[-12:])
+    customer_replies = [reply for reply in replies if _is_customer_tag_reply(reply, ticket, user_lookup)]
+    trimmed = list(customer_replies[-12:])
     trimmed.reverse()
     if not trimmed:
         lines.append("- No replies have been posted yet.")

--- a/tests/test_ticket_ai_tags_service.py
+++ b/tests/test_ticket_ai_tags_service.py
@@ -321,3 +321,60 @@ async def test_external_reference_not_generated_as_tag(monkeypatch):
     assert "abc-xyz-123" not in tags
     assert "example-com" not in tags
     assert "reply-456" not in tags
+
+
+def test_render_tags_prompt_uses_customer_replies_only(monkeypatch):
+    ticket = {
+        "id": 13,
+        "subject": "Email access issue",
+        "description": "Customer cannot access mailbox.",
+        "status": "open",
+        "priority": "normal",
+        "category": "Email",
+        "module_slug": "helpdesk",
+        "requester_id": 7,
+    }
+    replies = [
+        {
+            "ticket_id": 13,
+            "author_id": 7,
+            "body": "I get an MFA prompt loop when opening Outlook.",
+            "is_internal": False,
+            "created_at": None,
+        },
+        {
+            "ticket_id": 13,
+            "author_id": 3,
+            "body": "Technician reset conditional access and cleared sessions.",
+            "is_internal": False,
+            "created_at": None,
+        },
+        {
+            "ticket_id": 13,
+            "author_id": None,
+            "sender_matrix_id": "@supportbot:example.test",
+            "body": "Thanks — your request has been received. A technician will be assigned shortly.",
+            "is_internal": False,
+            "created_at": None,
+        },
+        {
+            "ticket_id": 13,
+            "author_id": 3,
+            "body": "Internal diagnostic note about Azure logs.",
+            "is_internal": True,
+            "created_at": None,
+        },
+    ]
+
+    class Settings:
+        matrix_bot_user_id = "@supportbot:example.test"
+
+    monkeypatch.setattr(tickets_service, "get_settings", lambda: Settings())
+
+    prompt = tickets_service._render_tags_prompt(ticket, replies, {})
+
+    assert "Customer conversation highlights" in prompt
+    assert "MFA prompt loop" in prompt
+    assert "conditional access" not in prompt
+    assert "request has been received" not in prompt
+    assert "Internal diagnostic" not in prompt


### PR DESCRIPTION
### Motivation
- Improve the quality of AI-generated ticket tags by ensuring tag evidence comes from customer/requester messages only and not from technician notes, internal replies, or automated bot messages.
- Avoid polluting ticket conversation content with automated Matrix waiting-assistant messages when mirroring chat into tickets.

### Description
- Update the tags prompt in `app/services/tickets.py` to clarify tag scope and explicitly instruct the model not to use technician/internal/support-side content as evidence for tags.
- Add `_is_customer_tag_reply` in `app/services/tickets.py` to filter replies used when building the AI tag prompt; the function excludes internal notes, configured Matrix bot messages, non-requester replies (when a requester exists), and staff/super-admin replies when requester context is not present.
- Change `_render_tags_prompt` to include only filtered customer replies (last 12 customer replies) when assembling conversation highlights.
- Prevent configured Matrix waiting-assistant bot messages from being mirrored into linked tickets by checking `sender_matrix_id` against `matrix_bot_user_id` in `app/services/chat_ticket_sync.py` before creating public ticket replies.
- Add a regression test `test_render_tags_prompt_uses_customer_replies_only` in `tests/test_ticket_ai_tags_service.py` to assert requester content is included and technician/internal/bot messages are excluded.

### Testing
- Ran `pytest -q tests/test_ticket_ai_tags_service.py`, and the test suite passed (all tests in that file succeeded).
- Compiled modified modules with `python -m compileall -q app/services/tickets.py app/services/chat_ticket_sync.py` with no syntax errors.
- Unit test additions verify prompt construction and exclusion logic and passed in the CI-local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a328d144b2c832d9b8f2cb84d7345d1)