### PR TITLE
Split article recommendation into multiple plain/HTML messages and send them sequentially

### DIFF
--- a/app/services/matrix_ai_waiting_assistant.py
+++ b/app/services/matrix_ai_waiting_assistant.py
@@ -388,31 +388,33 @@ async def _send_bot_message(
     return True
 
 
-def _build_article_recommendation_message(article: Mapping[str, Any], link: str, summary: str) -> tuple[str, str]:
+def _build_article_recommendation_messages(article: Mapping[str, Any], link: str, summary: str) -> list[tuple[str, str]]:
     title = str(article.get("title") or "Knowledge base article").strip() or "Knowledge base article"
     clean_link = str(link).strip()
-    clean_summary = " ".join(str(summary or "").split())
-    body_parts = [
-        f"While you wait, this article may help: {title}",
-        clean_link,
-    ]
-    if clean_summary:
-        body_parts.append(clean_summary)
-    body_parts.append(_AI_DISCLAIMER)
-    body = "\n\n".join(body_parts)
+    clean_summary = " ".join(str(summary or "").split()) or "No summary is available for this article."
 
     safe_title = html.escape(title)
     safe_link = html.escape(clean_link, quote=True)
-    safe_summary = html.escape(clean_summary)
-    safe_disclaimer = html.escape(_AI_DISCLAIMER)
-    formatted_parts = [
-        f"<p>While you wait, this article may help: {safe_title}</p>",
-        f'<p><a href="{safe_link}">{safe_link}</a></p>',
+    messages = [
+        (
+            f"While you wait, this article may help: {title}",
+            f"<p>While you wait, this article may help: {safe_title}</p>",
+        ),
+        (
+            clean_link,
+            f'<p><a href="{safe_link}">{safe_link}</a></p>',
+        ),
     ]
-    if safe_summary:
-        formatted_parts.append(f"<p>{safe_summary}</p>")
-    formatted_parts.append(f"<p>{safe_disclaimer}</p>")
-    formatted_body = "".join(formatted_parts)
+    messages.append((clean_summary, f"<p>{html.escape(clean_summary)}</p>"))
+    messages.append((_AI_DISCLAIMER, f"<p>{html.escape(_AI_DISCLAIMER)}</p>"))
+    return messages
+
+
+# Backwards-compatible helper for callers/tests that need a single Matrix payload.
+def _build_article_recommendation_message(article: Mapping[str, Any], link: str, summary: str) -> tuple[str, str]:
+    messages = _build_article_recommendation_messages(article, link, summary)
+    body = "\n\n".join(part[0] for part in messages)
+    formatted_body = "".join(part[1] for part in messages)
     return body, formatted_body
 
 
@@ -543,16 +545,23 @@ async def _process_queue_item(item: Mapping[str, Any]) -> None:
                     base = str(settings.public_base_url or settings.portal_url or "").rstrip("/")
                     path = f"/knowledge-base/articles/{article['slug']}"
                     link = f"{base}{path}" if base else path
-                    message, formatted_message = _build_article_recommendation_message(article, link, summary)
+                    messages = _build_article_recommendation_messages(article, link, summary)
                     expected_count = int(room.get("ai_bot_response_count") or 0)
                     reserved_count = expected_count + 1
                     reserved = await chat_repo.reserve_ai_bot_response(room_id, expected_count=expected_count, when=_utcnow())
-                    if reserved and await _send_bot_message(
-                        room,
-                        message,
-                        formatted_body=formatted_message,
-                        response_count=reserved_count,
-                    ):
+                    sent_all = False
+                    if reserved:
+                        sent_all = True
+                        for message, formatted_message in messages:
+                            if not await _send_bot_message(
+                                room,
+                                message,
+                                formatted_body=formatted_message,
+                                response_count=reserved_count,
+                            ):
+                                sent_all = False
+                                break
+                    if reserved and sent_all:
                         selected["sent"] = True
                         selected["sent_at"] = _utcnow().isoformat()
                         sent = True

--- a/tests/services/test_matrix_ai_waiting_assistant.py
+++ b/tests/services/test_matrix_ai_waiting_assistant.py
@@ -210,25 +210,31 @@ def test_ollama_generate_records_webhook_monitor_success(monkeypatch):
     assert successes[0]["response_status"] == 200
 
 
-def test_build_article_recommendation_message_formats_plain_text_and_html():
+def test_build_article_recommendation_messages_formats_four_plain_text_and_html_messages():
     article = {"title": "TouchPad <setup>"}
     link = "https://portal.example.test/knowledge-base/articles/touchpad?x=1&y=2"
     summary = " Enable the touchpad.\nUse Fn + F10. "
 
-    body, formatted_body = assistant._build_article_recommendation_message(article, link, summary)
+    messages = assistant._build_article_recommendation_messages(article, link, summary)
 
-    assert body == (
-        "While you wait, this article may help: TouchPad <setup>\n\n"
-        "https://portal.example.test/knowledge-base/articles/touchpad?x=1&y=2\n\n"
-        "Enable the touchpad. Use Fn + F10.\n\n"
-        f"{assistant._AI_DISCLAIMER}"
-    )
-    assert '<p>While you wait, this article may help: TouchPad &lt;setup&gt;</p>' in formatted_body
-    assert (
-        '<a href="https://portal.example.test/knowledge-base/articles/touchpad?x=1&amp;y=2">'
-        'https://portal.example.test/knowledge-base/articles/touchpad?x=1&amp;y=2</a>'
-    ) in formatted_body
-    assert '<p>Enable the touchpad. Use Fn + F10.</p>' in formatted_body
+    assert messages == [
+        (
+            "While you wait, this article may help: TouchPad <setup>",
+            "<p>While you wait, this article may help: TouchPad &lt;setup&gt;</p>",
+        ),
+        (
+            "https://portal.example.test/knowledge-base/articles/touchpad?x=1&y=2",
+            (
+                '<p><a href="https://portal.example.test/knowledge-base/articles/touchpad?x=1&amp;y=2">'
+                'https://portal.example.test/knowledge-base/articles/touchpad?x=1&amp;y=2</a></p>'
+            ),
+        ),
+        ("Enable the touchpad. Use Fn + F10.", "<p>Enable the touchpad. Use Fn + F10.</p>"),
+        (
+            assistant._AI_DISCLAIMER,
+            f"<p>{assistant._AI_DISCLAIMER}</p>",
+        ),
+    ]
 
 
 def test_send_bot_message_forwards_formatted_body(monkeypatch):


### PR DESCRIPTION
### Motivation

- Refactor the article recommendation payload so each logical part (title, link, summary, disclaimer) is produced as its own plain-text and HTML pair to allow sending separate Matrix messages reliably.
- Preserve existing callers/tests that expect a single combined payload by providing a backwards-compatible helper that joins the parts.
- Ensure reservation/counting logic for AI bot responses correctly handles sending multiple message parts as a single recommendation.

### Description

- Add `_build_article_recommendation_messages` which returns a `list[tuple[str, str]]` of plain-text and HTML message pairs for the article title, link, summary, and disclaimer. 
- Add a backwards-compatible `_build_article_recommendation_message` that joins the plain parts with `\n\n` and concatenates HTML parts for callers that expect a single payload. 
- Update the recommendation sending flow in `_process_queue_item` to iterate over the message pairs and send each via `_send_bot_message`, marking the article as sent only if all parts are delivered and releasing the reservation on partial failure. 
- Update the unit test to expect four message tuples and adjust its name to `test_build_article_recommendation_messages_formats_four_plain_text_and_html_messages`.

### Testing

- Ran the modified unit tests in `tests/services/test_matrix_ai_waiting_assistant.py`, including `test_build_article_recommendation_messages_formats_four_plain_text_and_html_messages`, and they passed. 
- Executed the service test file with `pytest` and observed no failures for the changed tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33407185dc832d9a8b35012d371815)