### PR TITLE
Restrict waiting assistant KB recommendations

### DIFF
--- a/app/services/matrix_ai_waiting_assistant.py
+++ b/app/services/matrix_ai_waiting_assistant.py
@@ -17,6 +17,7 @@ from app.core.logging import log_error
 from app.repositories import chat as chat_repo
 from app.repositories import knowledge_base as kb_repo
 from app.services import audit as audit_service
+from app.services import knowledge_base as knowledge_base_service
 from app.services import matrix as matrix_service
 from app.services import webhook_monitor
 from app.services.realtime import refresh_notifier
@@ -257,6 +258,46 @@ async def _chat_transcript(room_id: int) -> str:
         sender = msg.get("sender_display_name") or msg.get("sender_matrix_id") or "Participant"
         lines.append(f"{sender}: {' '.join(body.split())}")
     return "\n".join(lines)[-12000:]
+
+
+def _room_kb_access_context(room: Mapping[str, Any]) -> knowledge_base_service.ArticleAccessContext:
+    """Build the KB access context for a waiting-assistant chat room.
+
+    The waiting assistant acts on behalf of the customer waiting in the room,
+    not as a technician or background super-admin process.  Limit article
+    recommendations to anonymous articles, articles explicitly available to
+    the room creator, and company-scoped articles available to the room's
+    company.  Company-admin-only articles are intentionally excluded because
+    a chat room only carries company membership, not verified admin status.
+    """
+
+    user_id: int | None = None
+    try:
+        candidate_user_id = room.get("created_by_user_id")
+        if candidate_user_id is not None:
+            user_id = int(candidate_user_id)
+    except (TypeError, ValueError):
+        user_id = None
+
+    memberships: dict[int, Mapping[str, Any]] = {}
+    try:
+        company_id = int(room.get("company_id"))
+    except (TypeError, ValueError):
+        company_id = 0
+    if company_id > 0:
+        memberships[company_id] = {"company_id": company_id, "is_admin": False}
+
+    user = {"id": user_id, "is_super_admin": False} if user_id is not None else None
+    return knowledge_base_service.ArticleAccessContext(
+        user=user,
+        user_id=user_id,
+        is_super_admin=False,
+        memberships=memberships,
+    )
+
+
+def _article_visible_to_room(article: Mapping[str, Any], room: Mapping[str, Any]) -> bool:
+    return knowledge_base_service._article_visible(article, _room_kb_access_context(room))
 
 
 async def _extract_keywords(transcript: str) -> list[str]:
@@ -518,6 +559,8 @@ async def _process_queue_item(item: Mapping[str, Any]) -> None:
         keyword_set = set(keywords)
         candidates: list[dict[str, Any]] = []
         for article in await kb_repo.list_articles(include_unpublished=False):
+            if not _article_visible_to_room(article, room):
+                continue
             tags = _normalise_tags(article.get("ai_tags") or [])
             if not tags:
                 continue
@@ -540,7 +583,7 @@ async def _process_queue_item(item: Mapping[str, Any]) -> None:
             selected = next((c for c in eligible if str(c.get("id") or c.get("slug")) not in sent_ids), None)
             if selected:
                 article = await kb_repo.get_article_by_id(int(selected["id"]))
-                if article:
+                if article and _article_visible_to_room(article, room):
                     summary = await _summarise_article(article)
                     base = str(settings.public_base_url or settings.portal_url or "").rstrip("/")
                     path = f"/knowledge-base/articles/{article['slug']}"

--- a/tests/services/test_matrix_ai_waiting_assistant.py
+++ b/tests/services/test_matrix_ai_waiting_assistant.py
@@ -373,3 +373,28 @@ def test_handle_chat_opened_ignores_room_with_technician_message(monkeypatch):
     asyncio.run(assistant.handle_chat_opened(42))
 
     assert marked == []
+
+
+def test_article_visible_to_room_respects_company_restrictions():
+    room = {"company_id": 10, "created_by_user_id": 20}
+
+    assert assistant._article_visible_to_room(
+        {"permission_scope": "company", "company_ids": [10]},
+        room,
+    ) is True
+    assert assistant._article_visible_to_room(
+        {"permission_scope": "company", "company_ids": [99]},
+        room,
+    ) is False
+    assert assistant._article_visible_to_room(
+        {"permission_scope": "company_admin", "company_admin_ids": [10]},
+        room,
+    ) is False
+    assert assistant._article_visible_to_room(
+        {"permission_scope": "user", "allowed_user_ids": [20]},
+        room,
+    ) is True
+    assert assistant._article_visible_to_room(
+        {"permission_scope": "user", "allowed_user_ids": [21]},
+        room,
+    ) is False


### PR DESCRIPTION
### Motivation
- Ensure the AI Waiting Assistant only recommends knowledge base articles the waiting customer is permitted to see, preventing the assistant from surfacing company-admin or otherwise restricted content.
- Avoid performing expensive relevance analysis on articles that are not visible to the room context.

### Description
- Add ` _room_kb_access_context(room)` which builds an `ArticleAccessContext` for a chat room using the room `created_by_user_id` and `company_id` to represent the waiting customer (non-admin) in KB visibility checks.
- Add `_article_visible_to_room(article, room)` wrapper that calls `knowledge_base_service._article_visible` with the room-scoped context and import `knowledge_base` as `knowledge_base_service`.
- Filter KB candidates in `_process_queue_item` by calling `_article_visible_to_room` before tag/confidence analysis and re-check the selected article with `_article_visible_to_room` immediately before sending recommendations.
- Add a regression test `test_article_visible_to_room_respects_company_restrictions` in `tests/services/test_matrix_ai_waiting_assistant.py` covering company, company-admin, and user-scoped visibility rules.

### Testing
- Ran `pytest tests/services/test_matrix_ai_waiting_assistant.py -q` and the suite passed (`11 passed`, with warnings but no failures).
- Unit test coverage includes the new `test_article_visible_to_room_respects_company_restrictions` which validated the visibility behaviour (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3382451578832d9ef236dac20a2883)