### PR TITLE
Potential fix for code scanning alert no. 1261: Invocation of non-function

### DIFF
--- a/app/templates/compliance/control_requirements.html
+++ b/app/templates/compliance/control_requirements.html
@@ -54,7 +54,7 @@
       <div class="compliance-summary__grid">
         <div class="compliance-summary__item">
           <span class="compliance-summary__label">Total requirements</span>
-          <span class="compliance-summary__value">{{ requirements_ml1|length + requirements_ml2|length + requirements_ml3|length }}</span>
+          <span class="compliance-summary__value">{{ (requirements_ml1|length) + (requirements_ml2|length) + (requirements_ml3|length) }}</span>
         </div>
         <div class="compliance-summary__item">
           <span class="compliance-summary__label">Compliant</span>
@@ -75,7 +75,7 @@
         <div class="compliance-summary__item">
           <span class="compliance-summary__label">Not started</span>
           <span class="compliance-summary__value">
-            {% set total_reqs = requirements_ml1|length + requirements_ml2|length + requirements_ml3|length %}
+            {% set total_reqs = (requirements_ml1|length) + (requirements_ml2|length) + (requirements_ml3|length) %}
             {% set tracked_count = requirement_compliance_map|length %}
             {% set not_started_count = requirement_compliance_map.values()|selectattr('status', 'equalto', 'not_started')|list|length + (total_reqs - tracked_count) %}
             {{ not_started_count }}


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/1261](https://github.com/bradhawkins85/MyPortal/security/code-scanning/1261)

To fix this safely, make operator precedence explicit in the total calculation by parenthesizing each `|length` term before addition.

Best single fix (no functional change): in `app/templates/compliance/control_requirements.html`, update both total-requirement calculations (line 57 display and line 78 assignment) from:

- `requirements_ml1|length + requirements_ml2|length + requirements_ml3|length`

to:

- `(requirements_ml1|length) + (requirements_ml2|length) + (requirements_ml3|length)`

This preserves behavior while removing ambiguity that can trigger “invocation of non-function” analysis results.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
