### PR TITLE
Potential fix for code scanning alert no. 1908: Overly permissive file permissions

### DIFF
--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -1505,7 +1505,7 @@ class SchedulerService:
     def _ensure_update_flag_directory(self) -> None:
         _SYSTEM_UPDATE_FLAG_PATH.parent.mkdir(parents=True, exist_ok=True)
         try:
-            os.chmod(_SYSTEM_UPDATE_FLAG_PATH.parent, 0o750)
+            os.chmod(_SYSTEM_UPDATE_FLAG_PATH.parent, 0o700)
         except OSError:
             # Best-effort permission hardening; failures are non-fatal for scheduling.
             pass


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/1908](https://github.com/bradhawkins85/MyPortal/security/code-scanning/1908)

Use owner-only permissions for the update-flag directory.

- In general, fix by reducing chmod masks so only the process owner can access sensitive files/directories unless group sharing is explicitly required.
- Best fix here: change `os.chmod(_SYSTEM_UPDATE_FLAG_PATH.parent, 0o750)` to `0o700`.
- Edit only `app/services/scheduler.py` at the `_ensure_update_flag_directory` method (around line 1508).
- No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
