### PR TITLE
Potential fix for code scanning alert no. 882: Request without certificate validation

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -2697,7 +2697,7 @@ async def _invoke_tacticalrmm(
         event_future.set_result(event_id)
     attempt_number = 1
     try:
-        async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT, verify=verify_ssl) as client:
+        async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT, verify=True) as client:
             response = await client.request(method, url, json=request_body, headers=headers)
         response.raise_for_status()
     except httpx.HTTPStatusError as exc:


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/882](https://github.com/bradhawkins85/MyPortal/security/code-scanning/882)

The safest fix is to stop passing a potentially false boolean into TLS verification and enforce certificate validation at request time.

Best single fix (without changing broader functionality beyond eliminating the insecure mode): in `app/services/modules.py`, change the `httpx.AsyncClient` construction in the TacticalRMM request block to always use `verify=True` instead of `verify=verify_ssl`.

This requires no new methods/imports/dependencies and is localized to the block around line 2700.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
