### PR TITLE
Include Trello card link and content in created tickets

### DIFF
--- a/app/api/routes/trello.py
+++ b/app/api/routes/trello.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -249,6 +250,32 @@ def _build_public_callback_url(request: Request) -> str:
     return f"{scheme}://{host}{_WEBHOOK_PATH}"
 
 
+
+def _build_trello_ticket_description(
+    card_desc: str | None,
+    card_url: str | None,
+) -> str | None:
+    """Return safe HTML containing the Trello card link and card content."""
+    parts: list[str] = []
+    safe_url = str(card_url or "").strip()
+    if safe_url:
+        escaped_url = html.escape(safe_url, quote=True)
+        parts.append(
+            '<p><strong>Trello card:</strong> '
+            f'<a href="{escaped_url}" target="_blank" rel="noopener noreferrer">'
+            f'{escaped_url}</a></p>'
+        )
+
+    safe_desc = str(card_desc or "").strip()
+    if safe_desc:
+        escaped_desc = html.escape(safe_desc).replace("\n", "<br>")
+        parts.append(
+            "<p><strong>Trello card content:</strong></p>"
+            f"<p>{escaped_desc}</p>"
+        )
+
+    return "\n".join(parts) if parts else None
+
 # ---------------------------------------------------------------------------
 # Internal handlers
 # ---------------------------------------------------------------------------
@@ -273,13 +300,20 @@ async def _handle_create_card(
     company = await trello_service.get_company_for_board(board_id)
     company_id: int | None = int(company["id"]) if company else None
 
-    card_name: str = str(card_data.get("name") or "").strip() or "(no title)"
-    card_desc: str | None = str(card_data.get("desc") or "").strip() or None
+    full_card = await trello_service.get_card(card_id, company=company) if company else None
+    card_payload = full_card or card_data
+
+    card_name: str = str(card_payload.get("name") or "").strip() or "(no title)"
+    card_desc: str | None = str(card_payload.get("desc") or "").strip() or None
+    card_url: str | None = str(
+        card_payload.get("url") or card_payload.get("shortUrl") or ""
+    ).strip() or None
+    ticket_description = _build_trello_ticket_description(card_desc, card_url)
 
     try:
         ticket = await tickets_service.create_ticket(
             subject=card_name,
-            description=card_desc,
+            description=ticket_description,
             requester_id=None,
             company_id=company_id,
             assigned_user_id=None,

--- a/tests/test_trello_create_ticket_description.py
+++ b/tests/test_trello_create_ticket_description.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import asyncio
+
+from app.api.routes import trello as trello_routes
+
+
+def test_build_trello_ticket_description_includes_link_and_escaped_content():
+    description = trello_routes._build_trello_ticket_description(
+        "First line\n<script>alert('x')</script>",
+        "https://trello.com/c/abc123/card?x=<bad>",
+    )
+
+    assert description is not None
+    assert '<strong>Trello card:</strong>' in description
+    assert 'href="https://trello.com/c/abc123/card?x=&lt;bad&gt;"' in description
+    assert 'target="_blank" rel="noopener noreferrer"' in description
+    assert '<strong>Trello card content:</strong>' in description
+    assert "First line<br>&lt;script&gt;alert(&#x27;x&#x27;)&lt;/script&gt;" in description
+    assert "<script>" not in description
+
+
+def test_build_trello_ticket_description_returns_none_without_link_or_content():
+    assert trello_routes._build_trello_ticket_description(None, None) is None
+    assert trello_routes._build_trello_ticket_description("  ", "  ") is None
+
+
+def test_handle_create_card_fetches_full_card_and_creates_ticket_with_link(monkeypatch):
+    async def run_test():
+        created_payload: dict = {}
+
+        monkeypatch.setattr(trello_routes.trello_service, "find_ticket_for_card", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            trello_routes.trello_service,
+            "get_company_for_board",
+            AsyncMock(return_value={"id": 42, "trello_api_key": "key", "trello_token": "token"}),
+        )
+        monkeypatch.setattr(
+            trello_routes.trello_service,
+            "get_card",
+            AsyncMock(
+                return_value={
+                    "name": "Full card title",
+                    "desc": "Full card body",
+                    "url": "https://trello.com/c/full-card",
+                }
+            ),
+        )
+        monkeypatch.setattr(trello_routes.trello_service, "post_ticket_created_comment", AsyncMock())
+
+        async def fake_create_ticket(**kwargs):
+            created_payload.update(kwargs)
+            return {"id": 123, "ticket_number": "T-123"}
+
+        monkeypatch.setattr(trello_routes.tickets_service, "create_ticket", fake_create_ticket)
+
+        await trello_routes._handle_create_card(
+            "board-1",
+            "card-1",
+            {"name": "Webhook title", "desc": "Webhook body", "shortUrl": "https://trello.com/c/short"},
+            {},
+        )
+
+        assert created_payload["subject"] == "Full card title"
+        assert created_payload["company_id"] == 42
+        assert created_payload["external_reference"] == "card-1"
+        assert "https://trello.com/c/full-card" in created_payload["description"]
+        assert "Full card body" in created_payload["description"]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
### Motivation
- Ensure tickets created from Trello `createCard` events include a direct link to the Trello card and the card content so staff can quickly view the originating card and context.
- Prevent XSS and unsafe external links by escaping card content and adding secure link attributes when embedding Trello URLs in ticket descriptions.

### Description
- Fetch the full Trello card payload via `trello_service.get_card(card_id, company=company)` when company credentials are available and prefer the fetched payload over the minimal webhook data. (modified `app/api/routes/trello.py`)
- Build a safe HTML ticket description including an escaped Trello card link (`target="_blank" rel="noopener noreferrer"`) and escaped/linebreak-preserving card content via new helper `_build_trello_ticket_description`. (added to `app/api/routes/trello.py`)
- Import the `html` module and wire the generated `ticket_description` into `tickets_service.create_ticket` so created tickets include the link and content. (modified `app/api/routes/trello.py`)
- Add regression tests covering description formatting and the create-card flow using the fetched card payload. (new `tests/test_trello_create_ticket_description.py`)

### Testing
- Ran focused unit tests with `pytest -q tests/test_trello_create_ticket_description.py` and they passed (`3 passed`).
- Verified files compile with `python -m py_compile app/api/routes/trello.py tests/test_trello_create_ticket_description.py` which succeeded.
- Running a broader test set including `tests/test_trello_callback_url.py` and `tests/test_trello_feature_pack.py` surfaced an existing feature-pack route-registration assertion failure (`test_trello_pack_loads_and_reloads_cleanly`), so the new focused tests pass while the full-suite run currently reports 1 failing unrelated test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33c63f2bbc832da4befea48c571c65)