### PR TITLE
Suppress direct creation notifications for Syncro imports

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -1050,6 +1050,7 @@ async def _upsert_ticket(
             external_reference=external_reference,
             ticket_number=ticket_number,
             trigger_automations=True,
+            send_creation_notification=False,
             id=ticket_id_to_use,
         )
         created_id = created.get("id")

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -1246,6 +1246,7 @@ async def create_ticket(
     initial_reply_author_id: int | None = None,
     id: int | None = None,
     requester_email: str | None = None,
+    send_creation_notification: bool = True,
 ) -> TicketRecord:
     """Create a ticket and emit the corresponding automation event."""
 
@@ -1306,17 +1307,18 @@ async def create_ticket(
 
     enriched_ticket = await _enrich_ticket_context(ticket)
 
-    try:
-        await _send_ticket_creation_email(
-            enriched_ticket,
-            requester_email_fallback=requester_email,
-        )
-    except Exception as exc:  # pragma: no cover - defensive logging
-        log_error(
-            "Failed to send ticket creation email",
-            ticket_id=ticket.get("id"),
-            error=str(exc),
-        )
+    if send_creation_notification:
+        try:
+            await _send_ticket_creation_email(
+                enriched_ticket,
+                requester_email_fallback=requester_email,
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            log_error(
+                "Failed to send ticket creation email",
+                ticket_id=ticket.get("id"),
+                error=str(exc),
+            )
 
     if trigger_automations:
         try:

--- a/tests/test_ticket_creation_email.py
+++ b/tests/test_ticket_creation_email.py
@@ -347,6 +347,61 @@ async def test_create_ticket_passes_requester_email_fallback(monkeypatch):
     assert captured["requester_email_fallback"] == "sender@example.com"
 
 
+@pytest.mark.anyio
+async def test_create_ticket_can_skip_creation_notification(monkeypatch):
+    """create_ticket can suppress direct creation notifications while keeping automations."""
+    from app.repositories import tickets as tickets_repo
+    from app.services import automations as automations_service
+
+    async def fake_create_ticket_repo(**kwargs):
+        return {"id": 61, **{k: v for k, v in kwargs.items() if k != "id"}}
+
+    automation_events: list[str] = []
+
+    async def fake_handle_event(event_name, context):
+        automation_events.append(event_name)
+        return []
+
+    async def fake_get_company(company_id):
+        return None
+
+    async def fake_get_user(user_id):
+        return {"id": user_id, "email": "requester@example.com"}
+
+    async def fake_resolve_status(value):
+        return value or "open"
+
+    notification_called = False
+
+    async def fake_send_creation_email(enriched_ticket, *, requester_email_fallback=None):
+        nonlocal notification_called
+        notification_called = True
+
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket_repo)
+    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
+    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
+    monkeypatch.setattr(tickets_service, "_send_ticket_creation_email", fake_send_creation_email)
+
+    await tickets_service.create_ticket(
+        subject="Imported ticket",
+        description="Imported from Syncro",
+        requester_id=9,
+        company_id=None,
+        assigned_user_id=None,
+        priority="normal",
+        status="open",
+        category=None,
+        module_slug=None,
+        external_reference="12345",
+        send_creation_notification=False,
+    )
+
+    assert not notification_called
+    assert automation_events == ["tickets.created"]
+
+
 # ---------------------------------------------------------------------------
 # _send_ticket_creation_email – template rendering for external requester
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Syncro ticket imports were triggering the direct "Your ticket #... has been created" notification to requesters even when we only want automations to run for imported tickets.
- The goal is to prevent external/direct creation notifications for imported tickets while still executing `tickets.created` automations and existing integration flows.

### Description
- Added a `send_creation_notification: bool = True` parameter to `create_ticket` in `app/services/tickets.py` to allow callers to opt out of the direct creation notification path.
- Wrapped the existing `_send_ticket_creation_email` call in `create_ticket` with `if send_creation_notification:` so the default behavior is unchanged but callers can disable it.
- Updated `app/services/ticket_importer.py` to call `create_ticket(..., send_creation_notification=False)` when creating tickets from Syncro imports while keeping `trigger_automations=True` so automations still fire.
- Added a regression test `test_create_ticket_can_skip_creation_notification` to `tests/test_ticket_creation_email.py` that verifies notifications can be suppressed without preventing `tickets.created` automations.

### Testing
- Ran `pytest tests/test_ticket_creation_email.py tests/test_ticket_importer.py -q` and all tests passed (output: `75 passed`) with only warnings reported.
- Verified no other tests in the exercised scope failed after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33c7d25e58832da825521c868752cb)