### PR TITLE
Handle duplicate stock feed SKUs

### DIFF
--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -393,9 +393,12 @@ async def list_products_summary(filters: ProductFilters) -> list[dict[str, Any]]
         "    p.stock,",
         "    p.archived,",
         "    p.category_id,",
-        "    c.name AS category_name",
+        "    c.name AS category_name,",
+        "    sf.duplicate_sku_import,",
+        "    sf.duplicate_sku_count",
         "FROM shop_products AS p",
         "LEFT JOIN shop_categories AS c ON c.id = p.category_id",
+        "LEFT JOIN stock_feed AS sf ON sf.sku = COALESCE(NULLIF(p.vendor_sku, ''), p.sku)",
     ]
     params: list[Any] = []
 
@@ -2248,6 +2251,8 @@ def _normalise_product_summary(row: dict[str, Any]) -> dict[str, Any]:
         "archived": bool(row.get("archived")),
         "category_id": _coerce_optional_int(row.get("category_id")),
         "category_name": row.get("category_name") or None,
+        "duplicate_sku_import": bool(_coerce_int(row.get("duplicate_sku_import"))),
+        "duplicate_sku_count": _coerce_int(row.get("duplicate_sku_count")),
     }
 
 

--- a/app/repositories/stock_feed.py
+++ b/app/repositories/stock_feed.py
@@ -190,6 +190,8 @@ def _normalise_row(row: dict[str, Any]) -> dict[str, Any]:
         "manufacturer": row.get("manufacturer") or None,
         "image_url": row.get("image_url") or None,
         "opt_accessori": row.get("opt_accessori") or None,
+        "duplicate_sku_import": bool(_coerce_int(row.get("duplicate_sku_import"))),
+        "duplicate_sku_count": _coerce_int(row.get("duplicate_sku_count")),
     }
 
 
@@ -224,10 +226,12 @@ async def replace_feed(items: Sequence[Mapping[str, Any]]) -> None:
                             " sku, product_name, product_name2, rrp, category_name,"
                             " on_hand_nsw, on_hand_qld, on_hand_vic, on_hand_sa,"
                             " dbp, weight, length, width, height, pub_date,"
-                            " warranty_length, manufacturer, image_url, opt_accessori"
+                            " warranty_length, manufacturer, image_url, opt_accessori,"
+                            " duplicate_sku_import, duplicate_sku_count"
                             ") VALUES ("
                             " %s, %s, %s, %s, %s,"
-                            " %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s"
+                            " %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,"
+                            " %s, %s, %s, %s, %s, %s"
                             ")"
                         ),
                         [
@@ -251,6 +255,8 @@ async def replace_feed(items: Sequence[Mapping[str, Any]]) -> None:
                                 item.get("manufacturer"),
                                 item.get("image_url"),
                                 item.get("opt_accessori"),
+                                1 if item.get("duplicate_sku_import") else 0,
+                                item.get("duplicate_sku_count", 0),
                             )
                             for item in items
                         ],

--- a/app/services/products.py
+++ b/app/services/products.py
@@ -367,6 +367,43 @@ def _parse_stock_feed_xml(payload: str) -> list[dict[str, Any]]:
     return items
 
 
+def _flag_duplicate_stock_feed_skus(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return feed items with duplicate SKUs collapsed and flagged for review.
+
+    The stock feed table is keyed by SKU, so duplicate XML records cannot all be
+    inserted. Keep the first occurrence to allow the import to complete and mark
+    it so shop admins can manually evaluate the vendor data.
+    """
+    deduped: list[dict[str, Any]] = []
+    by_sku: dict[str, dict[str, Any]] = {}
+    duplicate_counts: dict[str, int] = {}
+
+    for item in items:
+        sku = str(item.get("sku") or "").strip()
+        if not sku:
+            deduped.append(item)
+            continue
+        if sku in by_sku:
+            duplicate_counts[sku] = duplicate_counts.get(sku, 1) + 1
+            continue
+        clean_item = dict(item)
+        clean_item["sku"] = sku
+        by_sku[sku] = clean_item
+        deduped.append(clean_item)
+
+    for sku, count in duplicate_counts.items():
+        by_sku[sku]["duplicate_sku_import"] = True
+        by_sku[sku]["duplicate_sku_count"] = count
+
+    if duplicate_counts:
+        log_error(
+            "Stock feed contained duplicate SKUs; flagged for shop admin review",
+            duplicate_skus=sorted(duplicate_counts),
+        )
+
+    return deduped
+
+
 async def update_stock_feed() -> int:
     """Download the stock feed and persist it for later product updates."""
 
@@ -389,10 +426,11 @@ async def update_stock_feed() -> int:
         log_error("Failed to parse stock feed", error=str(exc))
         raise
 
-    await stock_feed_repo.replace_feed(items)
+    persisted_items = _flag_duplicate_stock_feed_skus(items)
+    await stock_feed_repo.replace_feed(persisted_items)
 
-    # Record DBP price history for every item in the feed.
-    for item in items:
+    # Record DBP price history for every unique item in the feed.
+    for item in persisted_items:
         sku = str(item.get("sku") or "").strip()
         if not sku:
             continue
@@ -402,8 +440,8 @@ async def update_stock_feed() -> int:
         except Exception as exc:  # pragma: no cover - best-effort
             log_error("Failed to record price history", sku=sku, error=str(exc))
 
-    log_info("Stock feed updated", item_count=len(items))
-    return len(items)
+    log_info("Stock feed updated", item_count=len(persisted_items), source_item_count=len(items))
+    return len(persisted_items)
 
 
 async def _get_or_create_category_hierarchy(category_path: str) -> int | None:

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -176,7 +176,12 @@
               </td>
               <td data-label="Name" data-column="name">{{ product.name }}</td>
               <td data-label="SKU" data-column="sku">{{ product.sku }}</td>
-              <td data-label="Vendor SKU" data-column="vendor-sku">{{ product.vendor_sku }}</td>
+              <td data-label="Vendor SKU" data-column="vendor-sku">
+                {{ product.vendor_sku }}
+                {% if product.duplicate_sku_import %}
+                  <span class="badge badge--warning" title="The latest stock feed import contained {{ product.duplicate_sku_count }} records for this vendor SKU. Review this item manually before updating from the feed.">Duplicate in feed</span>
+                {% endif %}
+              </td>
               <td data-label="DBP" data-column="dbp" data-value="{{ product.buy_price if product.buy_price is not none else '' }}">
                 {% if product.buy_price is not none %}
                   ${{ '%.2f'|format(product.buy_price) }}

--- a/migrations/273_stock_feed_duplicate_sku_flags.sql
+++ b/migrations/273_stock_feed_duplicate_sku_flags.sql
@@ -1,0 +1,2 @@
+ALTER TABLE stock_feed ADD COLUMN IF NOT EXISTS duplicate_sku_import TINYINT(1) NOT NULL DEFAULT 0;
+ALTER TABLE stock_feed ADD COLUMN IF NOT EXISTS duplicate_sku_count INT NOT NULL DEFAULT 0;

--- a/tests/test_products_service.py
+++ b/tests/test_products_service.py
@@ -140,6 +140,60 @@ async def test_update_stock_feed_persists_items(monkeypatch):
 
 
 @pytest.mark.anyio("asyncio")
+async def test_update_stock_feed_flags_duplicate_skus(monkeypatch):
+    xml_payload = """
+        <rss><channel>
+            <item><StockCode>DUP123</StockCode><ProductName>First</ProductName><DBP>10.00</DBP></item>
+            <item><StockCode>DUP123</StockCode><ProductName>Second</ProductName><DBP>11.00</DBP></item>
+            <item><StockCode>UNIQUE1</StockCode><ProductName>Unique</ProductName><DBP>12.00</DBP></item>
+        </channel></rss>
+    """
+
+    class DummyResponse:
+        text = xml_payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class DummyClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "DummyClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[override]
+            return False
+
+        async def get(self, url: str, follow_redirects: bool = True) -> DummyResponse:
+            return DummyResponse()
+
+    monkeypatch.setattr(products_service.httpx, "AsyncClient", DummyClient)
+    monkeypatch.setattr(
+        products_service,
+        "get_settings",
+        lambda: SimpleNamespace(stock_feed_url="https://example.com/feed.xml"),
+    )
+    mock_replace = AsyncMock()
+    mock_record_price = AsyncMock()
+    monkeypatch.setattr(products_service.stock_feed_repo, "replace_feed", mock_replace)
+    monkeypatch.setattr(
+        products_service.stock_feed_repo,
+        "record_price_if_changed",
+        mock_record_price,
+    )
+
+    count = await products_service.update_stock_feed()
+
+    assert count == 2
+    items = mock_replace.await_args.args[0]
+    assert [item["sku"] for item in items] == ["DUP123", "UNIQUE1"]
+    assert items[0]["duplicate_sku_import"] is True
+    assert items[0]["duplicate_sku_count"] == 2
+    assert "duplicate_sku_import" not in items[1]
+
+
+@pytest.mark.anyio("asyncio")
 async def test_update_stock_feed_requires_config(monkeypatch):
     monkeypatch.setattr(
         products_service,

--- a/tests/test_shop_admin_column_visibility.py
+++ b/tests/test_shop_admin_column_visibility.py
@@ -91,3 +91,15 @@ async def test_template_contains_columns_dropdown():
     assert 'id="columns-dropdown"' in template
     assert 'id="columns-toggle"' in template
     assert 'id="columns-menu"' in template
+
+
+
+def test_template_contains_duplicate_feed_warning_badge():
+    """Shop admin surfaces duplicate vendor SKUs from the latest stock feed import."""
+    from pathlib import Path
+
+    template = Path('app/templates/admin/shop.html').read_text()
+
+    assert 'product.duplicate_sku_import' in template
+    assert 'Duplicate in feed' in template
+    assert 'product.duplicate_sku_count' in template


### PR DESCRIPTION
### Motivation
- Prevent the XML stock feed import from failing when the feed contains multiple records with the same SKU by collapsing duplicates so the import can complete.
- Surface vendor-supplied duplicate entries to shop admins so they can manually review and decide which record is authoritative.

### Description
- Add `_flag_duplicate_stock_feed_skus` to collapse duplicate SKU entries, mark the kept row with `duplicate_sku_import` and `duplicate_sku_count`, and log the duplicate SKUs. (app/services/products.py)
- Use the deduplicated list when persisting the feed and when recording DBP price history, and include source/ persisted item counts in the update log. (app/services/products.py)
- Persist two new fields on `stock_feed`: `duplicate_sku_import` and `duplicate_sku_count`, and update `replace_feed` to write those values. (app/repositories/stock_feed.py)
- Expose the duplicate flags to product summaries by joining `stock_feed` in shop queries and adding the fields to normalized product summaries. (app/repositories/shop.py)
- Add a warning badge to the shop admin Vendor SKU column to indicate items flagged from the last feed import. (app/templates/admin/shop.html)
- Add a SQL migration to create the two new columns and regression tests that cover duplicate handling and the admin template change. (migrations/273_stock_feed_duplicate_sku_flags.sql, tests/*)

### Testing
- Compiled the modified modules with `python3 -m py_compile app/services/products.py app/repositories/stock_feed.py app/repositories/shop.py` and it succeeded. 
- Ran the targeted test suites with `pytest -q tests/test_products_service.py tests/test_shop_admin_column_visibility.py` and all tests passed (`34 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33ce743944832dae0d33f460c3b627)