### PR TITLE
Build macOS tray DMG installer

### DIFF
--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -1,0 +1,54 @@
+# Build the MyPortal Tray macOS PKG and DMG installers and upload them to the
+# GitHub release that triggered this workflow.
+#
+# Triggered by: publishing a new GitHub release (any tag).
+# Runner:       macos-latest (required for pkgbuild, productbuild, hdiutil,
+#               lipo, iconutil, and electron-builder --mac).
+
+name: Build macOS Installer
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  build-macos-installer:
+    name: Build macOS PKG and DMG
+    runs-on: macos-latest
+
+    defaults:
+      run:
+        working-directory: tray
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: tray/go.mod
+          cache-dependency-path: tray/go.sum
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: tray/chat-shell/package-lock.json
+
+      - name: Build macOS chat shell
+        run: make build-chat-shell-mac VERSION='${{ github.event.release.tag_name }}'
+
+      - name: Build macOS PKG and DMG
+        run: make build-dmg VERSION='${{ github.event.release.tag_name }}'
+
+      - name: Upload macOS installers to release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            tray/dist/darwin/myportal-tray.pkg
+            tray/dist/darwin/myportal-tray.dmg

--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -533,7 +533,16 @@ build_tray_installers() {
     if [[ -f "${tray_dir}/dist/windows/myportal-tray.msi" ]]; then
       cp "${tray_dir}/dist/windows/myportal-tray.msi" "${static_tray_dir}/myportal-tray.msi"
       echo "MSI installer built and copied → app/static/tray/" >&2
-    else
+    fi
+    if [[ -f "${tray_dir}/dist/darwin/myportal-tray.pkg" ]]; then
+      cp "${tray_dir}/dist/darwin/myportal-tray.pkg" "${static_tray_dir}/myportal-tray.pkg"
+      echo "PKG installer copied → app/static/tray/" >&2
+    fi
+    if [[ -f "${tray_dir}/dist/darwin/myportal-tray.dmg" ]]; then
+      cp "${tray_dir}/dist/darwin/myportal-tray.dmg" "${static_tray_dir}/myportal-tray.dmg"
+      echo "DMG installer copied → app/static/tray/" >&2
+    fi
+    if [[ ! -f "${tray_dir}/dist/windows/myportal-tray.msi" ]]; then
       echo "Warning: MSI build reported success but myportal-tray.msi was not found at expected path." >&2
     fi
   else

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -985,9 +985,19 @@ build_tray_app() {
         echo "Install WiX v7 manually with: dotnet tool install --global wix --version \"7.*\"" >&2
       fi
       ;;
+    Darwin)
+      echo "Skipping MSI build: WiX only supports Windows hosts (host: ${host_os})."
+      echo "Building macOS PKG and DMG installers…"
+      if (cd "$tray_dir" && PATH="${go_dir}:${PATH}" make build-dmg); then
+        echo "macOS installers built: ${tray_dir}/dist/darwin/myportal-tray.pkg and .dmg"
+      else
+        echo "Warning: macOS installer build failed." >&2
+      fi
+      ;;
     *)
       echo "Skipping MSI build: WiX only supports Windows hosts (host: ${host_os})."
       echo "Build the MSI on a Windows machine and copy it to ${static_tray_dir}/myportal-tray.msi."
+      echo "Build the macOS PKG/DMG on a macOS machine and copy them to ${static_tray_dir}/."
       ;;
   esac
 
@@ -1002,6 +1012,11 @@ build_tray_app() {
   if [[ -f "${tray_dir}/dist/darwin/myportal-tray.pkg" ]]; then
     cp "${tray_dir}/dist/darwin/myportal-tray.pkg" "${static_tray_dir}/myportal-tray.pkg"
     echo "Copied myportal-tray.pkg → app/static/tray/"
+    copied=1
+  fi
+  if [[ -f "${tray_dir}/dist/darwin/myportal-tray.dmg" ]]; then
+    cp "${tray_dir}/dist/darwin/myportal-tray.dmg" "${static_tray_dir}/myportal-tray.dmg"
+    echo "Copied myportal-tray.dmg → app/static/tray/"
     copied=1
   fi
   if [[ "$copied" -eq 0 ]]; then

--- a/tray/Makefile
+++ b/tray/Makefile
@@ -24,7 +24,7 @@ LDFLAGS  := -X 'github.com/bradhawkins85/myportal-tray/internal/updater.AgentVer
 DIST     := dist
 
 .PHONY: all build-all build-windows build-darwin-amd64 build-darwin-arm64 \
-        build-darwin-universal build-msi build-pkg package-all \
+        build-darwin-universal build-msi build-pkg build-dmg package-all \
         build-macos-icons build-chat-shell-win build-chat-shell-mac \
         test lint clean
 
@@ -155,8 +155,8 @@ build-msi: build-windows
 	esac
 
 # -----------------------------------------------------------------------
-# macOS .pkg installer
-# Requires pkgbuild / productbuild — macOS only.
+# macOS .pkg and .dmg installers
+# Requires pkgbuild / productbuild / hdiutil — macOS only.
 # Depends on the universal binary; run build-darwin-universal first if
 # you want a fat binary, otherwise run build-darwin-amd64 / arm64.
 # -----------------------------------------------------------------------
@@ -166,16 +166,23 @@ build-pkg: build-darwin-universal
 	mv installer/macos/myportal-tray-$(VERSION).pkg $(DIST)/darwin/myportal-tray.pkg
 	rm -f installer/macos/myportal-tray-$(VERSION)-unsigned.pkg
 
+# Build a compressed macOS disk image that contains the .pkg installer.
+# This must run on macOS because hdiutil is an Apple platform tool.
+build-dmg: build-pkg
+	@echo "Building macOS .dmg installer..."
+	(cd installer/macos && bash build-dmg.sh "$(VERSION)" "../../$(DIST)/darwin/myportal-tray.pkg")
+	mv installer/macos/myportal-tray-$(VERSION).dmg $(DIST)/darwin/myportal-tray.dmg
+
 # -----------------------------------------------------------------------
 # Package all installers
 # Builds the MSI on Windows hosts that have WiX v7.
-# Builds the macOS .pkg only when pkgbuild is present (macOS runners).
+# Builds the macOS .pkg/.dmg only when pkgbuild and hdiutil are present (macOS runners).
 # -----------------------------------------------------------------------
 package-all: build-msi
-	@if command -v pkgbuild >/dev/null 2>&1; then \
-	    $(MAKE) build-pkg; \
+	@if command -v pkgbuild >/dev/null 2>&1 && command -v hdiutil >/dev/null 2>&1; then \
+	    $(MAKE) build-dmg; \
 	else \
-	    echo "pkgbuild not available; skipping macOS .pkg (macOS-only step)."; \
+	    echo "pkgbuild/hdiutil not available; skipping macOS .pkg/.dmg (macOS-only step)."; \
 	fi
 
 # -----------------------------------------------------------------------

--- a/tray/README.md
+++ b/tray/README.md
@@ -36,7 +36,7 @@ tray/
 - For MSI packaging: .NET SDK 8+ and WiX v7 (`dotnet tool install --global wix --version "7.*"`).
   WiX v7 requires accepting the FireGiant OSMF EULA — the Makefile passes
   `-acceptEula wix7` per https://docs.firegiant.com/wix/osmf/.
-- For macOS chat-shell icon and .pkg packaging: Xcode command-line tools with `iconutil`, `pkgbuild`, and `productbuild` (macOS only)
+- For macOS chat-shell icon and installer packaging: Xcode command-line tools with `iconutil`, `pkgbuild`, `productbuild`, and `hdiutil` (macOS only)
 - For chat shell: **Node.js 20+** and npm (required only on the native host runner for each platform)
 
 ### Cross-compile (CGO=0, no webview — for RMM deployment)
@@ -96,20 +96,20 @@ the MSI / .pkg installer jobs run.
 # Requires dist/windows/myportal-tray-chat.exe from build-chat-shell-win.
 make build-msi          # produces dist/windows/myportal-tray.msi
 
-# macOS .pkg (requires pkgbuild — macOS only)
+# macOS .pkg (requires pkgbuild/productbuild — macOS only)
 # Requires dist/darwin/myportal-tray-chat.app from build-chat-shell-mac.
 make build-pkg          # produces dist/darwin/myportal-tray.pkg
 
-# Build all binaries + MSI (+ .pkg on macOS)
+# macOS .dmg wrapping the .pkg (requires hdiutil — macOS only)
+make build-dmg          # produces dist/darwin/myportal-tray.dmg
+
+# Build all binaries + MSI (+ .pkg and .dmg on macOS)
 make package-all
 ```
 
 The built installers must be copied to `app/static/tray/` on the MyPortal server so
-they are served at `/static/tray/myportal-tray.msi` and `/static/tray/myportal-tray.pkg`.
-The `scripts/upgrade.sh` handles this automatically when WiX is installed on a
-Windows host. On Linux/macOS upgrade hosts the MSI build is skipped (WiX is
-Windows-only) — build the MSI separately on Windows and copy it into
-`app/static/tray/myportal-tray.msi`.
+they are served at `/static/tray/myportal-tray.msi`, `/static/tray/myportal-tray.pkg`, and `/static/tray/myportal-tray.dmg`.
+The `scripts/upgrade.sh` handles this automatically: Windows hosts can build the MSI when WiX is installed, and macOS hosts can build the PKG/DMG when Xcode command-line tools are installed. On Linux hosts, build the installers separately on their native platforms and copy them into `app/static/tray/`.
 
 ### With native webview (requires CGO)
 

--- a/tray/installer/macos/build-dmg.sh
+++ b/tray/installer/macos/build-dmg.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# macOS DMG build script for the MyPortal Tray installer.
+# Requires: hdiutil (macOS only) and a pre-built myportal-tray.pkg.
+#
+# Usage: ./build-dmg.sh <version> [pkg-path]
+# Output: myportal-tray-<version>.dmg
+set -euo pipefail
+
+VERSION="${1:?Usage: $0 <version> [pkg-path]}"
+PKG_PATH="${2:-myportal-tray-${VERSION}.pkg}"
+VOLUME_NAME="MyPortal Tray ${VERSION}"
+DMG_NAME="myportal-tray-${VERSION}.dmg"
+STAGING_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$STAGING_DIR"
+}
+trap cleanup EXIT
+
+if ! command -v hdiutil >/dev/null 2>&1; then
+    echo "hdiutil is required to build a macOS DMG. Run this script on macOS." >&2
+    exit 1
+fi
+
+if [ ! -f "$PKG_PATH" ]; then
+    echo "Package not found: $PKG_PATH" >&2
+    echo "Run 'make build-pkg' first, or pass the package path as the second argument." >&2
+    exit 1
+fi
+
+cp "$PKG_PATH" "$STAGING_DIR/myportal-tray.pkg"
+cat > "$STAGING_DIR/README.txt" <<README
+MyPortal Tray Installer
+
+Open myportal-tray.pkg to install the MyPortal tray service and user agent.
+
+For RMM deployment, use installer/macos/install.sh from the source repository
+or download the package directly from your MyPortal server:
+  /static/tray/myportal-tray.pkg
+README
+
+rm -f "$DMG_NAME"
+hdiutil create \
+    -volname "$VOLUME_NAME" \
+    -srcfolder "$STAGING_DIR" \
+    -ov \
+    -format UDZO \
+    "$DMG_NAME"
+
+echo "Built: $DMG_NAME"


### PR DESCRIPTION
### Motivation
- Provide a macOS DMG installer for the tray utility because releases currently only publish `.pkg` (and `.msi`) artifacts and the DMG wrapper is commonly expected by macOS users and RMM workflows.
- Ensure CI can produce macOS installer artifacts (`.pkg` + `.dmg`) from `macos-latest` runners so macOS packaging is consistent and automatable.

### Description
- Add a DMG packaging script at `tray/installer/macos/build-dmg.sh` that validates `hdiutil`, stages the existing `myportal-tray-<version>.pkg`, and builds a compressed `myportal-tray-<version>.dmg`.
- Add a `build-dmg` Makefile target and include it in `package-all` so macOS builds produce both `.pkg` and `.dmg` when `pkgbuild` and `hdiutil` are available.
- Add a GitHub Actions workflow `.github/workflows/build-macos-installer.yml` that runs on `macos-latest`, builds the chat shell, runs the PKG+DMG path, and uploads `myportal-tray.pkg` and `myportal-tray.dmg` to the release.
- Update automation scripts and documentation: `scripts/upgrade.sh` and `scripts/install_environment.sh` now copy `dist/darwin/myportal-tray.dmg` into `app/static/tray/`, and `tray/README.md` documents the new DMG step and prerequisite `hdiutil`.

### Testing
- Ran `bash -n tray/installer/macos/build-dmg.sh scripts/upgrade.sh scripts/install_environment.sh` to validate shell syntax, which succeeded.
- Parsed the new workflow with `python` + `yaml.safe_load` to validate YAML syntax, which succeeded.
- Performed Makefile dry-runs with `make -n build-dmg VERSION=test -C tray` and `make -n package-all -C tray VERSION=test` to verify the new targets and flows, which succeeded.
- Ran `go test -tags nowebview -count=1 ./...` inside `tray` to exercise the build with the `nowebview` tag, which passed; a full `go test -count=1 ./...` (no tag) failed in this Linux environment due to a missing system package (`ayatana-appindicator3-0.1`) required by the non-`nowebview` systray build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33d02bdba4832d9713e3294a925b5e)