### PR TITLE
Add Syncro ticket status mappings

### DIFF
--- a/app/features/syncro/routes.py
+++ b/app/features/syncro/routes.py
@@ -15,7 +15,7 @@ from app.core.logging import log_error, log_info
 from app.features.staff.helpers import _load_staff_context
 from app.schemas.tickets import SyncroTicketImportRequest
 from app.services import background as background_tasks
-from app.services import company_importer, modules as modules_service, staff_importer, ticket_importer
+from app.services import company_importer, modules as modules_service, staff_importer, ticket_importer, tickets as tickets_service
 
 
 router = APIRouter(tags=["Syncro"])
@@ -62,6 +62,7 @@ def _describe_syncro_module(module: dict[str, Any] | None) -> dict[str, Any]:
             minimum=1,
             maximum=600,
         ),
+        "ticket_status_mappings": settings_payload.get("ticket_status_mappings") or [],
     }
 
 
@@ -75,6 +76,7 @@ async def _render_syncro_ticket_import(
 ) -> HTMLResponse:
     module = await _load_syncro_module()
     module_description = _describe_syncro_module(module)
+    status_definitions = await tickets_service.list_status_definitions()
     if not module_description.get("enabled"):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -85,6 +87,14 @@ async def _render_syncro_ticket_import(
         "success_message": success_message,
         "error_message": error_message,
         "syncro_module": module_description,
+        "ticket_status_definitions": [
+            {
+                "tech_status": definition.tech_status,
+                "tech_label": definition.tech_label,
+                "is_default": definition.is_default,
+            }
+            for definition in status_definitions
+        ],
     }
     response = await _main()._render_template(
         "admin/syncro_ticket_import.html",
@@ -107,6 +117,50 @@ async def admin_syncro_ticket_import_page(
     return await _render_syncro_ticket_import(
         request,
         current_user,
+    )
+
+
+@router.post("/admin/tickets/syncro-import/status-mappings", response_class=HTMLResponse)
+async def update_syncro_ticket_status_mappings(request: Request):
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return redirect
+    module = await _load_syncro_module()
+    if not module or not module.get("enabled"):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Syncro module is disabled",
+        )
+    form = await request.form()
+    syncro_statuses = form.getlist("syncroStatus")
+    myportal_statuses = form.getlist("myportalStatus")
+    allowed_statuses = {definition.tech_status for definition in await tickets_service.list_status_definitions()}
+    mappings: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for syncro_status_raw, myportal_status_raw in zip(syncro_statuses, myportal_statuses, strict=False):
+        syncro_status = str(syncro_status_raw or "").strip()
+        myportal_status = str(myportal_status_raw or "").strip().lower()
+        if not syncro_status and not myportal_status:
+            continue
+        if not syncro_status or myportal_status not in allowed_statuses:
+            return await _render_syncro_ticket_import(
+                request,
+                current_user,
+                error_message="Each mapping needs a Syncro status and a valid MyPortal status.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        key = syncro_status.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        mappings.append({"syncro_status": syncro_status[:128], "myportal_status": myportal_status})
+    existing_settings = dict((module.get("settings") or {}))
+    existing_settings["ticket_status_mappings"] = mappings
+    await modules_service.update_module("syncro", settings=existing_settings)
+    return await _render_syncro_ticket_import(
+        request,
+        current_user,
+        success_message="Syncro ticket status mappings saved.",
     )
 
 

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -516,6 +516,7 @@ DEFAULT_MODULES: list[dict[str, Any]] = [
             "base_url": "",
             "api_key": "",
             "rate_limit_per_minute": 180,
+            "ticket_status_mappings": [],
         },
     },
     {
@@ -1075,11 +1076,31 @@ def _coerce_settings(
             if not api_key and existing_settings and existing_settings.get("api_key"):
                 api_key = str(existing_settings.get("api_key") or "").strip()
         rate_limit = _coerce_int(merged.get("rate_limit_per_minute"), minimum=1, maximum=600) or 180
+        raw_mappings = merged.get("ticket_status_mappings") or []
+        status_mappings: list[dict[str, str]] = []
+        seen_syncro_statuses: set[str] = set()
+        if isinstance(raw_mappings, list):
+            for item in raw_mappings:
+                if not isinstance(item, Mapping):
+                    continue
+                syncro_status = str(item.get("syncro_status") or item.get("syncroStatus") or "").strip()
+                myportal_status = str(item.get("myportal_status") or item.get("myportalStatus") or "").strip().lower()
+                if not syncro_status or not myportal_status:
+                    continue
+                lookup_key = syncro_status.casefold()
+                if lookup_key in seen_syncro_statuses:
+                    continue
+                seen_syncro_statuses.add(lookup_key)
+                status_mappings.append({
+                    "syncro_status": syncro_status[:128],
+                    "myportal_status": myportal_status[:128],
+                })
         merged.update(
             {
                 "base_url": base_url,
                 "api_key": api_key,
                 "rate_limit_per_minute": rate_limit,
+                "ticket_status_mappings": status_mappings,
             }
         )
         _env = os.getenv("SYNCRO_BASE_URL", "").strip().rstrip("/")

--- a/app/services/syncro.py
+++ b/app/services/syncro.py
@@ -73,6 +73,7 @@ async def _load_module_settings() -> dict[str, Any] | None:
                 "base_url": str(settings_payload.get("base_url") or "").strip(),
                 "api_key": str(settings_payload.get("api_key") or "").strip(),
                 "rate_limit_per_minute": _coerce_rate_limit(settings_payload.get("rate_limit_per_minute")),
+                "ticket_status_mappings": settings_payload.get("ticket_status_mappings") or [],
             }
         _MODULE_SETTINGS_EXPIRY = now + 30.0
     return _MODULE_SETTINGS_CACHE
@@ -100,6 +101,7 @@ async def _get_effective_settings() -> dict[str, Any]:
         "base_url": base_url,
         "api_key": api_key or None,
         "rate_limit_per_minute": _coerce_rate_limit(rate_limit),
+        "ticket_status_mappings": (module_settings or {}).get("ticket_status_mappings") or [],
     }
 
 

--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -22,12 +22,39 @@ _DEFAULT_PRIORITY = "normal"
 _DEFAULT_STATUS = "open"
 
 
-async def _get_status_context() -> tuple[set[str], str]:
+async def _get_status_context() -> tuple[set[str], str, dict[str, str]]:
     definitions = await tickets_service.list_status_definitions()
     if definitions:
         slugs = [definition.tech_status for definition in definitions]
-        return set(slugs), slugs[0]
-    return set(_ALLOWED_STATUSES), _DEFAULT_STATUS
+        default = next((definition.tech_status for definition in definitions if definition.is_default), slugs[0])
+    else:
+        slugs = list(_ALLOWED_STATUSES)
+        default = _DEFAULT_STATUS
+    mappings = await _get_syncro_status_mappings(set(slugs))
+    return set(slugs), default, mappings
+
+
+async def _get_syncro_status_mappings(allowed_statuses: Collection[str]) -> dict[str, str]:
+    try:
+        module = await syncro._load_module_settings()
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        log_error("Failed to load Syncro ticket status mappings", error=str(exc))
+        return {}
+    configured = (module or {}).get("ticket_status_mappings") or []
+    mappings: dict[str, str] = {}
+    if not isinstance(configured, list):
+        return mappings
+    for item in configured:
+        if not isinstance(item, dict):
+            continue
+        syncro_status = _clean_text(item.get("syncro_status") or item.get("syncroStatus"))
+        myportal_status = _clean_text(item.get("myportal_status") or item.get("myportalStatus"))
+        if not syncro_status or not myportal_status:
+            continue
+        normalized_myportal = myportal_status.lower().replace(" ", "_")
+        if normalized_myportal in allowed_statuses:
+            mappings[syncro_status.casefold()] = normalized_myportal
+    return mappings
 
 @dataclass(slots=True)
 class TicketImportSummary:
@@ -75,7 +102,12 @@ def _clean_text(value: Any) -> str | None:
     return normalised or None
 
 
-def _normalise_status(value: Any, allowed_statuses: Collection[str], default_status: str) -> str:
+def _normalise_status(
+    value: Any,
+    allowed_statuses: Collection[str],
+    default_status: str,
+    status_mappings: dict[str, str] | None = None,
+) -> str:
     if isinstance(value, dict):
         for key in ("name", "status", "label"):
             text_value = value.get(key)
@@ -85,6 +117,9 @@ def _normalise_status(value: Any, allowed_statuses: Collection[str], default_sta
     text = _clean_text(value)
     if not text:
         return default_status
+    mapped = (status_mappings or {}).get(text.casefold())
+    if mapped in allowed_statuses:
+        return mapped
     normalized = text.lower().replace(" ", "_")
     if normalized in allowed_statuses:
         return normalized
@@ -951,6 +986,7 @@ async def _upsert_ticket(
     ticket: dict[str, Any],
     allowed_statuses: Collection[str],
     default_status: str,
+    status_mappings: dict[str, str] | None = None,
 ) -> str:
     status_choices = set(allowed_statuses)
     syncro_id = ticket.get("id")
@@ -965,6 +1001,7 @@ async def _upsert_ticket(
         ticket.get("status_name") or ticket.get("status"),
         status_choices,
         default_status,
+        status_mappings,
     )
     priority = _normalise_priority(ticket.get("priority"))
     category = _clean_text(ticket.get("type") or ticket.get("category"))
@@ -1105,8 +1142,8 @@ async def import_ticket_by_id(
         log_info("Syncro ticket import completed", mode="single", fetched=summary.fetched, created=0, updated=0, skipped=1)
         return summary
     summary.fetched = 1
-    allowed_statuses, default_status = await _get_status_context()
-    outcome = await _upsert_ticket(ticket, allowed_statuses, default_status)
+    allowed_statuses, default_status, status_mappings = await _get_status_context()
+    outcome = await _upsert_ticket(ticket, allowed_statuses, default_status, status_mappings)
     summary.record(outcome)
     log_info(
         "Syncro ticket import completed",
@@ -1128,14 +1165,14 @@ async def import_ticket_range(
     limiter = rate_limiter or await syncro.get_rate_limiter()
     summary = TicketImportSummary(mode="range")
     log_info("Starting Syncro ticket import", mode="range", start_id=start_id, end_id=end_id)
-    allowed_statuses, default_status = await _get_status_context()
+    allowed_statuses, default_status, status_mappings = await _get_status_context()
     for identifier in range(start_id, end_id + 1):
         ticket = await syncro.get_ticket(identifier, rate_limiter=limiter)
         if not ticket:
             summary.skipped += 1
             continue
         summary.fetched += 1
-        outcome = await _upsert_ticket(ticket, allowed_statuses, default_status)
+        outcome = await _upsert_ticket(ticket, allowed_statuses, default_status, status_mappings)
         summary.record(outcome)
     log_info(
         "Syncro ticket import completed",
@@ -1169,7 +1206,7 @@ async def import_all_tickets(
     limiter = rate_limiter or await syncro.get_rate_limiter()
     summary = TicketImportSummary(mode="all")
     log_info("Starting Syncro ticket import", mode="all")
-    allowed_statuses, default_status = await _get_status_context()
+    allowed_statuses, default_status, status_mappings = await _get_status_context()
     page = 1
     total_pages: int | None = None
     while True:
@@ -1179,7 +1216,7 @@ async def import_all_tickets(
         summary.fetched += len(tickets)
         for ticket in tickets:
             try:
-                outcome = await _upsert_ticket(ticket, allowed_statuses, default_status)
+                outcome = await _upsert_ticket(ticket, allowed_statuses, default_status, status_mappings)
             except Exception as exc:  # pragma: no cover - defensive logging
                 log_error("Failed to import Syncro ticket", syncro_id=ticket.get("id"), error=str(exc))
                 summary.skipped += 1

--- a/app/templates/admin/syncro_ticket_import.html
+++ b/app/templates/admin/syncro_ticket_import.html
@@ -54,6 +54,66 @@
           </div>
         {% endif %}
 
+
+
+        <article class="card card--panel">
+          <header class="card__header">
+            <div>
+              <h2 class="card__title">Status mappings</h2>
+              <p class="card__subtitle">List each Syncro ticket status and choose the MyPortal status that imported tickets should use when the names do not match exactly.</p>
+            </div>
+          </header>
+          <form class="card__form" action="/admin/tickets/syncro-import/status-mappings" method="post">
+            {% include "partials/csrf.html" %}
+            <div class="table-wrapper">
+              <table class="table table--compact">
+                <thead>
+                  <tr>
+                    <th scope="col">Syncro status</th>
+                    <th scope="col">MyPortal status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% set mappings = syncro_module.ticket_status_mappings or [] %}
+                  {% for mapping in mappings %}
+                    <tr>
+                      <td data-label="Syncro status">
+                        <input name="syncroStatus" class="form-input" maxlength="128" value="{{ mapping.syncro_status }}" placeholder="e.g. Waiting on Customer" />
+                      </td>
+                      <td data-label="MyPortal status">
+                        <select name="myportalStatus" class="form-input">
+                          {% for status_option in ticket_status_definitions %}
+                            <option value="{{ status_option.tech_status }}" {% if mapping.myportal_status == status_option.tech_status %}selected{% endif %}>{{ status_option.tech_label }}</option>
+                          {% endfor %}
+                        </select>
+                      </td>
+                    </tr>
+                  {% endfor %}
+                  {% for index in range(3) %}
+                    <tr>
+                      <td data-label="Syncro status">
+                        <input name="syncroStatus" class="form-input" maxlength="128" placeholder="e.g. {{ 'New' if index == 0 else 'In Progress' if index == 1 else 'Customer Reply' }}" />
+                      </td>
+                      <td data-label="MyPortal status">
+                        <select name="myportalStatus" class="form-input">
+                          <option value="">Select a MyPortal status</option>
+                          {% for status_option in ticket_status_definitions %}
+                            <option value="{{ status_option.tech_status }}">{{ status_option.tech_label }}</option>
+                          {% endfor %}
+                        </select>
+                      </td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+            <p class="form-help">Blank rows are ignored. Duplicate Syncro statuses keep the first mapping.</p>
+            <div class="form-actions">
+              <button type="submit" class="button button--primary">Save status mappings</button>
+            </div>
+          </form>
+        </article>
+
         <article class="card card--panel">
           <header class="card__header">
             <div>

--- a/tests/test_syncro_ticket_id_import.py
+++ b/tests/test_syncro_ticket_id_import.py
@@ -116,3 +116,16 @@ async def test_syncro_ticket_import_uses_syncro_id(monkeypatch):
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
+
+
+def test_syncro_status_mapping_takes_precedence():
+    """Configured Syncro statuses map to the selected MyPortal status."""
+    assert (
+        ticket_importer._normalise_status(
+            "Waiting on Customer",
+            {"open", "pending", "closed"},
+            "open",
+            {"waiting on customer": "pending"},
+        )
+        == "pending"
+    )


### PR DESCRIPTION
### Motivation
- Syncro ticket status names can differ from MyPortal status slugs, so imports need a configurable way to map Syncro statuses to the correct MyPortal status to avoid incorrect automatic mapping.

### Description
- Add a UI section to `app/templates/admin/syncro_ticket_import.html` to manage Syncro → MyPortal status mappings and include blank rows for quick edits.
- Add a super-admin POST route at `/admin/tickets/syncro-import/status-mappings` in `app/features/syncro/routes.py` that validates mappings against available MyPortal statuses, ignores blank rows, de-duplicates Syncro statuses case-insensitively, and persists them into the Syncro module settings as `ticket_status_mappings`.
- Persist and coerce `ticket_status_mappings` in module settings via `app/services/modules.py` (default, trimming and length limiting) and expose mappings through the Syncro settings cache in `app/services/syncro.py` for importer access.
- Update the Syncro importer in `app/services/ticket_importer.py` to load configured mappings and apply exact, case-insensitive mapped statuses (via `_get_syncro_status_mappings` and the extended `_normalise_status`) before falling back to existing fuzzy normalization; thread mappings through `_upsert_ticket` calls.
- Add a regression test `test_syncro_status_mapping_takes_precedence` to `tests/test_syncro_ticket_id_import.py` to ensure configured mappings take precedence.

### Testing
- Ran Python byte-compile check on modified modules with `python3 -m py_compile app/services/ticket_importer.py app/services/modules.py app/services/syncro.py app/features/syncro/routes.py` which succeeded.
- Ran the new/related unit tests with `python3 -m pytest tests/test_syncro_ticket_id_import.py -q` and they passed (`7 passed` for the invoked test set).
- Ran `git diff --check` to ensure no whitespace/errors in the diff which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33d1eac0a4832da839fc8b43299062)