### PR TITLE
Fix tray installer release workflows

### DIFF
--- a/.github/workflows/build-macos-installer.yml
+++ b/.github/workflows/build-macos-installer.yml
@@ -1,7 +1,7 @@
 # Build the MyPortal Tray macOS PKG and DMG installers and upload them to the
 # GitHub release that triggered this workflow.
 #
-# Triggered by: publishing a new GitHub release (any tag).
+# Triggered by: publishing a new GitHub release (any tag), or manually via workflow_dispatch.
 # Runner:       macos-latest (required for pkgbuild, productbuild, hdiutil,
 #               lipo, iconutil, and electron-builder --mac).
 
@@ -9,7 +9,15 @@ name: Build macOS Installer
 
 on:
   release:
-    types: [created]
+    # Build installers when a release is published. Using only `created` misses
+    # common flows where a draft release is created first and published later.
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to build installers for (defaults to current ref)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -41,14 +49,15 @@ jobs:
           cache-dependency-path: tray/chat-shell/package-lock.json
 
       - name: Build macOS chat shell
-        run: make build-chat-shell-mac VERSION='${{ github.event.release.tag_name }}'
+        run: make build-chat-shell-mac VERSION='${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}'
 
       - name: Build macOS PKG and DMG
-        run: make build-dmg VERSION='${{ github.event.release.tag_name }}'
+        run: make build-dmg VERSION='${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}'
 
       - name: Upload macOS installers to release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}
           files: |
             tray/dist/darwin/myportal-tray.pkg
             tray/dist/darwin/myportal-tray.dmg

--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -1,7 +1,7 @@
 # Build the MyPortal Tray MSI installer on Windows and upload it to the
-# GitHub release that triggered this workflow.
+# GitHub release that triggered this workflow, or the release selected manually.
 #
-# Triggered by: publishing a new GitHub release (any tag).
+# Triggered by: publishing a new GitHub release (any tag), or manually via workflow_dispatch.
 # Runner:       windows-latest (required — WiX v7 only works on Windows)
 #
 # The MSI is built with WiX v7 (installed as a .NET global tool).
@@ -12,7 +12,15 @@ name: Build MSI
 
 on:
   release:
-    types: [created]
+    # Build installers when a release is published. Using only `created` misses
+    # common flows where a draft release is created first and published later.
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to build installers for (defaults to current ref)'
+        required: false
+        type: string
 
 permissions:
   contents: write   # needed to upload the artifact to the release
@@ -53,7 +61,7 @@ jobs:
           $env:GOOS      = "windows"
           $env:GOARCH    = "amd64"
           $env:CGO_ENABLED = "0"
-          $version = "${{ github.event.release.tag_name }}"
+          $version = "${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}"
           $ldflags = "-X 'github.com/bradhawkins85/myportal-tray/internal/updater.AgentVersion=$version'"
 
           New-Item -ItemType Directory -Force -Path dist\windows | Out-Null
@@ -88,4 +96,5 @@ jobs:
       - name: Upload MSI to release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}
           files: tray/dist/windows/myportal-tray.msi


### PR DESCRIPTION
### Motivation
- The tray installer workflows only ran on `release: types: [created]`, which misses common flows where a draft release is published later and causes built `.msi`/`.pkg`/`.dmg` assets to not be generated or attached to the intended release.
- Manual reruns of installer builds were not supported, making it hard to rebuild installers for an existing tag or release.

### Description
- Change workflow triggers to run on `release: types: [published]` instead of `created` in `.github/workflows/build-msi.yml` and `.github/workflows/build-macos-installer.yml` to ensure builds run when a release is published.
- Add `workflow_dispatch` support with an optional `tag_name` input to both workflows to allow manual reruns targeting a specific tag.
- Resolve the effective release tag using `${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}` and wire that value into build/version variables and into the upload steps.
- Pass the resolved tag to `softprops/action-gh-release` via `tag_name` so uploaded installer artifacts attach to the intended release.

### Testing
- Validated both modified workflow files parse as YAML using `python`/`yaml.safe_load` with no syntax errors.
- Ran `git diff --check` to ensure there were no whitespace/diff issues and the changes are clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33d26492f0832dac6b7aa76ca4893e)