### PR TITLE
Fix shop product summary null duplicate SKU flags

### DIFF
--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -2251,8 +2251,8 @@ def _normalise_product_summary(row: dict[str, Any]) -> dict[str, Any]:
         "archived": bool(row.get("archived")),
         "category_id": _coerce_optional_int(row.get("category_id")),
         "category_name": row.get("category_name") or None,
-        "duplicate_sku_import": bool(_coerce_int(row.get("duplicate_sku_import"))),
-        "duplicate_sku_count": _coerce_int(row.get("duplicate_sku_count")),
+        "duplicate_sku_import": bool(_coerce_int(row.get("duplicate_sku_import"), default=0)),
+        "duplicate_sku_count": _coerce_int(row.get("duplicate_sku_count"), default=0),
     }
 
 

--- a/tests/test_shop_product_summary.py
+++ b/tests/test_shop_product_summary.py
@@ -1,0 +1,25 @@
+from app.repositories import shop as shop_repo
+
+
+def test_normalise_product_summary_defaults_missing_stock_feed_flags() -> None:
+    row = {
+        "id": 1,
+        "name": "Widget",
+        "sku": "W-1",
+        "vendor_sku": None,
+        "image_url": None,
+        "price": "10.50",
+        "vip_price": None,
+        "buy_price": None,
+        "stock": 3,
+        "archived": 0,
+        "category_id": None,
+        "category_name": None,
+        "duplicate_sku_import": None,
+        "duplicate_sku_count": None,
+    }
+
+    product = shop_repo._normalise_product_summary(row)
+
+    assert product["duplicate_sku_import"] is False
+    assert product["duplicate_sku_count"] == 0


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and incorrect values when the left-joined `stock_feed` provides NULL for duplicate-SKU metadata by ensuring sane defaults in the shop product summary normalisation.

### Description
- Default `duplicate_sku_import` and `duplicate_sku_count` to zero/false by calling `_coerce_int(..., default=0)` and wrapping the import flag with `bool` inside `_normalise_product_summary`.
- Add a regression test `tests/test_shop_product_summary.py` that asserts `duplicate_sku_import` becomes `False` and `duplicate_sku_count` becomes `0` when the source values are `None`.

### Testing
- Ran `python -m pytest tests/test_shop_product_summary.py -q` and it passed.
- Ran `python -m pytest tests/test_shop_product_summary.py tests/test_shop_product_search.py tests/test_shop_repository_recommendations.py -q` and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33d2edc7e0832d973d1776c3bbd601)