### PR TITLE
Add configurable AI tag synonym groups for Matrix waiting assistant (API, UI, repo, migration)

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -4,17 +4,21 @@ import secrets
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 
-from app.api.dependencies.auth import get_current_user
+from app.api.dependencies.auth import get_current_user, require_super_admin
 from app.core.config import get_settings
 from app.core.logging import log_error
 from app.repositories import chat as chat_repo
+from app.repositories import matrix_ai_tag_synonyms as synonyms_repo
 from app.schemas.chat import (
     ChatMessageCreate,
     ChatRoomCreate,
     ExternalInviteCreate,
+    AiTagSynonymGroupCreate,
+    AiTagSynonymGroupUpdate,
+    AiTagSynonymGroupResponse,
 )
 from app.security.encryption import decrypt_secret, encrypt_secret
 from app.services import audit as audit_service
@@ -47,6 +51,88 @@ def _serialize(obj: Any) -> Any:
 def _require_matrix_enabled() -> None:
     if not _settings.matrix_enabled:
         raise HTTPException(status_code=404, detail="Matrix chat is not enabled")
+
+
+
+
+@router.get(
+    "/ai-tag-synonyms",
+    response_model=list[AiTagSynonymGroupResponse],
+    summary="List AI waiting assistant tag synonym groups",
+)
+async def list_ai_tag_synonym_groups(
+    current_user: dict = Depends(require_super_admin),
+) -> list[dict[str, Any]]:
+    _require_matrix_enabled()
+    return await synonyms_repo.list_groups()
+
+
+@router.post(
+    "/ai-tag-synonyms",
+    response_model=AiTagSynonymGroupResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create an AI waiting assistant tag synonym group",
+)
+async def create_ai_tag_synonym_group(
+    body: AiTagSynonymGroupCreate,
+    current_user: dict = Depends(require_super_admin),
+) -> dict[str, Any]:
+    _require_matrix_enabled()
+    try:
+        return await synonyms_repo.create_group(body.terms)
+    except synonyms_repo.InvalidSynonymGroup as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+
+
+@router.get(
+    "/ai-tag-synonyms/{group_id}",
+    response_model=AiTagSynonymGroupResponse,
+    summary="Get an AI waiting assistant tag synonym group",
+)
+async def get_ai_tag_synonym_group(
+    group_id: int,
+    current_user: dict = Depends(require_super_admin),
+) -> dict[str, Any]:
+    _require_matrix_enabled()
+    group = await synonyms_repo.get_group(group_id)
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Synonym group not found")
+    return group
+
+
+@router.put(
+    "/ai-tag-synonyms/{group_id}",
+    response_model=AiTagSynonymGroupResponse,
+    summary="Update an AI waiting assistant tag synonym group",
+)
+async def update_ai_tag_synonym_group(
+    group_id: int,
+    body: AiTagSynonymGroupUpdate,
+    current_user: dict = Depends(require_super_admin),
+) -> dict[str, Any]:
+    _require_matrix_enabled()
+    try:
+        group = await synonyms_repo.update_group(group_id, body.terms)
+    except synonyms_repo.InvalidSynonymGroup as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+    if not group:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Synonym group not found")
+    return group
+
+
+@router.delete(
+    "/ai-tag-synonyms/{group_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete an AI waiting assistant tag synonym group",
+)
+async def delete_ai_tag_synonym_group(
+    group_id: int,
+    current_user: dict = Depends(require_super_admin),
+) -> None:
+    _require_matrix_enabled()
+    deleted = await synonyms_repo.delete_group(group_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Synonym group not found")
 
 
 @router.get("/rooms", summary="List chat rooms")

--- a/app/features/matrix_chat_assign/__init__.py
+++ b/app/features/matrix_chat_assign/__init__.py
@@ -2,6 +2,10 @@
 
 Owns the admin management page for configuring chat auto-assign rules:
 
+* ``GET  /chat/configuration``
+* ``POST /chat/configuration/synonyms``
+* ``POST /chat/configuration/synonyms/{group_id}``
+* ``POST /chat/configuration/synonyms/{group_id}/delete``
 * ``GET  /chat/auto-assign``
 * ``POST /chat/auto-assign/rules``
 * ``POST /chat/auto-assign/rules/{rule_id}``

--- a/app/features/matrix_chat_assign/routes.py
+++ b/app/features/matrix_chat_assign/routes.py
@@ -10,6 +10,7 @@ from fastapi.responses import HTMLResponse
 from app.core.logging import log_error
 from app.security.flash import flash_redirect
 from app.repositories import chat_auto_assign as assign_repo
+from app.repositories import matrix_ai_tag_synonyms as synonyms_repo
 
 __all__ = ["router"]
 
@@ -29,6 +30,31 @@ def _form_bool(form: Any, key: str) -> bool:
         return value.strip().lower() not in {"", "0", "false", "off"}
     return bool(value)
 
+
+
+def _parse_synonym_terms(raw: Any) -> list[str]:
+    return [part.strip() for part in str(raw or "").split(",") if part.strip()]
+
+
+async def _render_configuration(
+    request: Request,
+    user: dict[str, Any],
+    *,
+    error_message: str | None = None,
+    status_code: int = status.HTTP_200_OK,
+) -> HTMLResponse:
+    main_module = _main()
+    groups = await synonyms_repo.list_groups()
+    extra = {
+        "title": "Chat Configuration",
+        "synonym_groups": groups,
+        "error_message": error_message,
+    }
+    response = await main_module._render_template(
+        "admin/matrix_chat_configuration.html", request, user, extra=extra
+    )
+    response.status_code = status_code
+    return response
 
 def _parse_priority(form: Any) -> int:
     """Parse priority from form data, defaulting to 0."""
@@ -275,3 +301,80 @@ async def chat_delete_auto_assign_rule(rule_id: int, request: Request):
     return flash_redirect(
         "/chat/auto-assign", "Rule deleted.", "success"
     )
+
+
+@router.get("/chat/configuration", response_class=HTMLResponse)
+async def chat_configuration_page(request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_super_admin_page(request)
+    if redirect:
+        return redirect
+    return await _render_configuration(request, current_user)
+
+
+@router.post("/chat/configuration/synonyms", response_class=HTMLResponse)
+async def chat_create_synonym_group(request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_super_admin_page(request)
+    if redirect:
+        return redirect
+    form = await request.form()
+    try:
+        await synonyms_repo.create_group(_parse_synonym_terms(form.get("terms")))
+    except synonyms_repo.InvalidSynonymGroup as exc:
+        return await _render_configuration(
+            request,
+            current_user,
+            error_message=str(exc),
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+    except Exception as exc:
+        log_error("Failed to create chat synonym group", error=str(exc))
+        return await _render_configuration(
+            request,
+            current_user,
+            error_message="Failed to create synonym group.",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    return flash_redirect("/chat/configuration", "Synonym group created.", "success")
+
+
+@router.post("/chat/configuration/synonyms/{group_id}", response_class=HTMLResponse)
+async def chat_update_synonym_group(group_id: int, request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_super_admin_page(request)
+    if redirect:
+        return redirect
+    form = await request.form()
+    try:
+        updated = await synonyms_repo.update_group(group_id, _parse_synonym_terms(form.get("terms")))
+    except synonyms_repo.InvalidSynonymGroup as exc:
+        return await _render_configuration(
+            request,
+            current_user,
+            error_message=str(exc),
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        )
+    except Exception as exc:
+        log_error("Failed to update chat synonym group", group_id=group_id, error=str(exc))
+        return await _render_configuration(
+            request,
+            current_user,
+            error_message="Failed to update synonym group.",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+    if not updated:
+        return flash_redirect("/chat/configuration", "Synonym group not found.", "error")
+    return flash_redirect("/chat/configuration", "Synonym group updated.", "success")
+
+
+@router.post("/chat/configuration/synonyms/{group_id}/delete", response_class=HTMLResponse)
+async def chat_delete_synonym_group(group_id: int, request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_super_admin_page(request)
+    if redirect:
+        return redirect
+    deleted = await synonyms_repo.delete_group(group_id)
+    if not deleted:
+        return flash_redirect("/chat/configuration", "Synonym group not found.", "error")
+    return flash_redirect("/chat/configuration", "Synonym group deleted.", "success")

--- a/app/repositories/matrix_ai_tag_synonyms.py
+++ b/app/repositories/matrix_ai_tag_synonyms.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from app.core.database import db
+
+MAX_GROUPS = 200
+MAX_TERMS_PER_GROUP = 20
+MAX_TERM_LENGTH = 80
+
+
+class InvalidSynonymGroup(ValueError):
+    """Raised when synonym group terms are invalid."""
+
+
+def normalise_term(term: Any) -> str:
+    return " ".join(str(term or "").strip().lower().replace("_", " ").replace("-", " ").split())
+
+
+def validate_terms(terms: Any) -> list[str]:
+    if not isinstance(terms, list):
+        raise InvalidSynonymGroup("Terms must be a list")
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for term in terms:
+        text = normalise_term(term)
+        if not text:
+            continue
+        if len(text) > MAX_TERM_LENGTH:
+            raise InvalidSynonymGroup(f"Term '{text[:30]}…' is too long")
+        if text not in seen:
+            seen.add(text)
+            cleaned.append(text)
+    if len(cleaned) < 2:
+        raise InvalidSynonymGroup("At least two unique terms are required")
+    if len(cleaned) > MAX_TERMS_PER_GROUP:
+        raise InvalidSynonymGroup(f"A synonym group can contain at most {MAX_TERMS_PER_GROUP} terms")
+    return cleaned
+
+
+def _decode_row(row: dict[str, Any]) -> dict[str, Any]:
+    raw_terms = row.get("terms")
+    terms: list[str]
+    if isinstance(raw_terms, list):
+        terms = [str(item) for item in raw_terms]
+    else:
+        try:
+            parsed = json.loads(str(raw_terms or "[]"))
+            terms = [str(item) for item in parsed] if isinstance(parsed, list) else []
+        except json.JSONDecodeError:
+            terms = []
+    row["terms"] = terms
+    return row
+
+
+async def list_groups() -> list[dict[str, Any]]:
+    rows = await db.fetch_all(
+        "SELECT id, terms, created_at, updated_at FROM matrix_ai_tag_synonym_groups ORDER BY id ASC"
+    )
+    return [_decode_row(dict(row)) for row in rows]
+
+
+async def get_group(group_id: int) -> dict[str, Any] | None:
+    row = await db.fetch_one(
+        "SELECT id, terms, created_at, updated_at FROM matrix_ai_tag_synonym_groups WHERE id = %s",
+        (group_id,),
+    )
+    return _decode_row(dict(row)) if row else None
+
+
+async def create_group(terms: list[Any]) -> dict[str, Any]:
+    existing_count = await db.fetch_one("SELECT COUNT(*) AS count FROM matrix_ai_tag_synonym_groups")
+    if int((existing_count or {}).get("count") or 0) >= MAX_GROUPS:
+        raise InvalidSynonymGroup(f"At most {MAX_GROUPS} synonym groups are allowed")
+    cleaned = validate_terms(terms)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    group_id = await db.execute_returning_lastrowid(
+        """INSERT INTO matrix_ai_tag_synonym_groups (terms, created_at, updated_at)
+           VALUES (%s, %s, %s)""",
+        (json.dumps(cleaned, separators=(",", ":")), now, now),
+    )
+    return await get_group(group_id) or {"id": group_id, "terms": cleaned, "created_at": now, "updated_at": now}
+
+
+async def update_group(group_id: int, terms: list[Any]) -> dict[str, Any] | None:
+    cleaned = validate_terms(terms)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    rowcount = await db.execute_rowcount(
+        """UPDATE matrix_ai_tag_synonym_groups
+           SET terms = %s, updated_at = %s
+           WHERE id = %s""",
+        (json.dumps(cleaned, separators=(",", ":")), now, group_id),
+    )
+    if rowcount <= 0:
+        return None
+    return await get_group(group_id)
+
+
+async def delete_group(group_id: int) -> bool:
+    rowcount = await db.execute_rowcount(
+        "DELETE FROM matrix_ai_tag_synonym_groups WHERE id = %s",
+        (group_id,),
+    )
+    return rowcount > 0

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -101,3 +101,18 @@ class MatrixSettingsUpdate(BaseModel):
     default_room_preset: str = "private_chat"
     e2ee_enabled: bool = False
     invite_domain: Optional[str] = None
+
+
+class AiTagSynonymGroupCreate(BaseModel):
+    terms: list[str] = Field(..., min_length=2, max_length=20)
+
+
+class AiTagSynonymGroupUpdate(BaseModel):
+    terms: list[str] = Field(..., min_length=2, max_length=20)
+
+
+class AiTagSynonymGroupResponse(BaseModel):
+    id: int
+    terms: list[str]
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None

--- a/app/services/matrix_ai_waiting_assistant.py
+++ b/app/services/matrix_ai_waiting_assistant.py
@@ -16,6 +16,7 @@ from app.core.config import get_settings
 from app.core.logging import log_error
 from app.repositories import chat as chat_repo
 from app.repositories import knowledge_base as kb_repo
+from app.repositories import matrix_ai_tag_synonyms as tag_synonyms_repo
 from app.services import audit as audit_service
 from app.services import knowledge_base as knowledge_base_service
 from app.services import matrix as matrix_service
@@ -176,16 +177,84 @@ def _enabled() -> bool:
     )
 
 
+DEFAULT_TAG_SYNONYM_GROUPS: tuple[tuple[str, ...], ...] = (
+    ("monitor", "screen", "display"),
+    ("trackpad", "touchpad"),
+    ("computer", "pc", "workstation", "desktop"),
+    ("notebook", "laptop"),
+    ("cellphone", "mobile", "mobile phone", "phone", "smartphone"),
+    ("printer", "mfp", "multifunction printer"),
+    ("wifi", "wi fi", "wi-fi", "wireless"),
+    ("internet", "network", "networking"),
+    ("email", "e mail", "e-mail", "mail"),
+)
+_TAG_SYNONYMS: dict[str, frozenset[str]] = {
+    term: frozenset(group)
+    for group in DEFAULT_TAG_SYNONYM_GROUPS
+    for term in group
+}
+
+
+def _normalise_tag_text(tag: Any) -> str:
+    return " ".join(str(tag or "").strip().lower().replace("_", " ").replace("-", " ").split())
+
+
 def _normalise_tags(tags: list[Any]) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
     for tag in tags:
-        text = str(tag or "").strip().lower()
+        text = _normalise_tag_text(tag)
         if not text or text in seen or len(text) > 80:
             continue
         seen.add(text)
         result.append(text)
     return result[:40]
+
+
+def _build_synonym_lookup(groups: list[list[str]] | tuple[tuple[str, ...], ...]) -> dict[str, frozenset[str]]:
+    lookup: dict[str, frozenset[str]] = {}
+    for group in groups:
+        normalised_group = frozenset(_normalise_tag_text(term) for term in group if _normalise_tag_text(term))
+        for term in normalised_group:
+            lookup[term] = normalised_group
+    return lookup
+
+
+def _tag_terms(tag: str, synonym_lookup: Mapping[str, frozenset[str]] | None = None) -> frozenset[str]:
+    """Return equivalent terms used when comparing extracted and article tags."""
+
+    lookup = synonym_lookup or _TAG_SYNONYMS
+    normalised = _normalise_tag_text(tag)
+    terms = {normalised}
+    if normalised in lookup:
+        terms.update(lookup[normalised])
+    for word in normalised.split():
+        if word in lookup:
+            terms.update(lookup[word])
+    return frozenset(terms)
+
+
+def _matching_tags(
+    keywords: list[str],
+    article_tags: list[str],
+    synonym_lookup: Mapping[str, frozenset[str]] | None = None,
+) -> list[str]:
+    """Return article tags that match keywords directly or through configured synonyms."""
+
+    keyword_terms = set().union(*(_tag_terms(keyword, synonym_lookup) for keyword in keywords)) if keywords else set()
+    return sorted(tag for tag in article_tags if _tag_terms(tag, synonym_lookup) & keyword_terms)
+
+
+async def _load_synonym_lookup() -> dict[str, frozenset[str]]:
+    try:
+        groups = await tag_synonyms_repo.list_groups()
+    except Exception as exc:
+        log_error("AI waiting assistant synonym load failed", error=str(exc))
+        return dict(_TAG_SYNONYMS)
+    configured_groups = [list(group.get("terms") or []) for group in groups if len(group.get("terms") or []) >= 2]
+    if not configured_groups:
+        return dict(_TAG_SYNONYMS)
+    return _build_synonym_lookup(configured_groups)
 
 
 def _extract_json_object(text: str) -> dict[str, Any]:
@@ -557,6 +626,7 @@ async def _process_queue_item(item: Mapping[str, Any]) -> None:
         transcript = await _chat_transcript(room_id)
         keywords = await _extract_keywords(transcript)
         keyword_set = set(keywords)
+        synonym_lookup = await _load_synonym_lookup()
         candidates: list[dict[str, Any]] = []
         for article in await kb_repo.list_articles(include_unpublished=False):
             if not _article_visible_to_room(article, room):
@@ -564,7 +634,7 @@ async def _process_queue_item(item: Mapping[str, Any]) -> None:
             tags = _normalise_tags(article.get("ai_tags") or [])
             if not tags:
                 continue
-            matched = sorted(keyword_set & set(tags))
+            matched = _matching_tags(keywords, tags, synonym_lookup)
             confidence_base = max(1, min(len(tags), len(keyword_set))) if tags else 1
             confidence = min(100.0, (len(matched) / confidence_base) * 100) if tags else 0.0
             if confidence >= settings.matrixbot_ai_kb_confidence_threshold:

--- a/app/templates/admin/matrix_chat_configuration.html
+++ b/app/templates/admin/matrix_chat_configuration.html
@@ -1,0 +1,103 @@
+{% extends "base.html" %}
+{% from "macros/header.html" import page_header_actions %}
+
+{% block header_title %}Chat Configuration{% endblock %}
+
+{% block header_actions %}
+  {{ page_header_actions([
+    {"label": "Chat rooms", "type": "link", "href": "/chat"},
+    {"label": "Auto-assign rules", "type": "link", "href": "/chat/auto-assign"}
+  ]) }}
+{% endblock %}
+
+{% block content %}
+<div class="management management--single" data-layout>
+  <section class="management__content">
+    {% if error_message %}
+      <div class="alert alert--danger" role="alert">{{ error_message }}</div>
+    {% endif %}
+
+    <section class="card card--panel">
+      <header class="card__header">
+        <div>
+          <h2 class="card__title">AI Waiting Assistant tag synonyms</h2>
+          <p class="card__subtitle">
+            Super admins can add similar words used when matching extracted chat keywords to knowledge-base article tags.
+            Enter comma-separated terms; each group needs at least two unique terms.
+          </p>
+        </div>
+      </header>
+
+      <form action="/chat/configuration/synonyms" method="post" class="form management__form" autocomplete="off">
+        {% if csrf_token %}
+          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+        {% endif %}
+        <label class="form-field">
+          <span class="form-label">New synonym group</span>
+          <input
+            type="text"
+            name="terms"
+            class="form-input"
+            maxlength="1200"
+            required
+            placeholder="monitor, screen, display"
+          />
+          <span class="form-help">Example: <code>monitor, screen, display</code> or <code>trackpad, touchpad</code>.</span>
+        </label>
+        <button type="submit" class="button button--primary">Add synonym group</button>
+      </form>
+    </section>
+
+    <section class="card card--panel">
+      <div class="table-wrapper">
+        <table class="table" data-table data-table-id="chat-ai-synonyms">
+          <thead>
+            <tr>
+              <th scope="col" data-sort="number" data-column-key="id">ID</th>
+              <th scope="col" data-sort="string" data-column-key="terms">Terms</th>
+              <th scope="col" class="table__actions" data-column-key="actions">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% if not synonym_groups %}
+              <tr>
+                <td colspan="3" class="table__empty">No synonym groups configured.</td>
+              </tr>
+            {% endif %}
+            {% for group in synonym_groups %}
+              <tr>
+                <td data-label="ID" data-column-key="id">{{ group.id }}</td>
+                <td data-label="Terms" data-column-key="terms">
+                  <form action="/chat/configuration/synonyms/{{ group.id }}" method="post" class="inline-form chat-synonym-form">
+                    {% if csrf_token %}
+                      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                    {% endif %}
+                    <input
+                      type="text"
+                      name="terms"
+                      class="form-input"
+                      value="{{ (group.terms or []) | join(', ') | e }}"
+                      maxlength="1200"
+                      required
+                      aria-label="Terms for synonym group {{ group.id }}"
+                    />
+                  </form>
+                </td>
+                <td class="table__actions" data-column-key="actions">
+                  <button type="button" class="button button--sm" onclick="this.closest('tr').querySelector('.chat-synonym-form').requestSubmit();">Save</button>
+                  <form action="/chat/configuration/synonyms/{{ group.id }}/delete" method="post" class="inline-form" onsubmit="return confirm('Delete this synonym group?');">
+                    {% if csrf_token %}
+                      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                    {% endif %}
+                    <button type="submit" class="button button--sm button--danger">Delete</button>
+                  </form>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </section>
+</div>
+{% endblock %}

--- a/app/templates/chat/index.html
+++ b/app/templates/chat/index.html
@@ -9,7 +9,7 @@
      "attrs": {"data-create-chat-modal-open": "", "aria-haspopup": "dialog", "aria-controls": "create-chat-modal"}},
   ] %}
   {% if is_super_admin | default(false) %}
-    {% set chat_actions = chat_actions + [{"label": "Auto-assign rules", "type": "link", "href": "/chat/auto-assign"}] %}
+    {% set chat_actions = chat_actions + [{"label": "Chat configuration", "type": "link", "href": "/chat/configuration"}, {"label": "Auto-assign rules", "type": "link", "href": "/chat/auto-assign"}] %}
   {% endif %}
   {{ page_header_actions(chat_actions) }}
 {% endblock %}

--- a/migrations/273_matrix_ai_tag_synonyms.sql
+++ b/migrations/273_matrix_ai_tag_synonyms.sql
@@ -1,0 +1,35 @@
+-- Editable Matrix AI waiting-assistant tag synonym groups.
+CREATE TABLE IF NOT EXISTS matrix_ai_tag_synonym_groups (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  terms JSON NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO matrix_ai_tag_synonym_groups (terms)
+SELECT '["monitor","screen","display"]'
+WHERE NOT EXISTS (SELECT 1 FROM matrix_ai_tag_synonym_groups WHERE terms = '["monitor","screen","display"]');
+INSERT INTO matrix_ai_tag_synonym_groups (terms)
+SELECT '["trackpad","touchpad"]'
+WHERE NOT EXISTS (SELECT 1 FROM matrix_ai_tag_synonym_groups WHERE terms = '["trackpad","touchpad"]');
+INSERT INTO matrix_ai_tag_synonym_groups (terms)
+SELECT '["computer","pc","workstation","desktop"]'
+WHERE NOT EXISTS (SELECT 1 FROM matrix_ai_tag_synonym_groups WHERE terms = '["computer","pc","workstation","desktop"]');
+INSERT INTO matrix_ai_tag_synonym_groups (terms)
+SELECT '["notebook","laptop"]'
+WHERE NOT EXISTS (SELECT 1 FROM matrix_ai_tag_synonym_groups WHERE terms = '["notebook","laptop"]');
+INSERT INTO matrix_ai_tag_synonym_groups (terms)
+SELECT '["cellphone","mobile","mobile phone","phone","smartphone"]'
+WHERE NOT EXISTS (SELECT 1 FROM matrix_ai_tag_synonym_groups WHERE terms = '["cellphone","mobile","mobile phone","phone","smartphone"]');
+INSERT INTO matrix_ai_tag_synonym_groups (terms)
+SELECT '["printer","mfp","multifunction printer"]'
+WHERE NOT EXISTS (SELECT 1 FROM matrix_ai_tag_synonym_groups WHERE terms = '["printer","mfp","multifunction printer"]');
+INSERT INTO matrix_ai_tag_synonym_groups (terms)
+SELECT '["wifi","wi fi","wi-fi","wireless"]'
+WHERE NOT EXISTS (SELECT 1 FROM matrix_ai_tag_synonym_groups WHERE terms = '["wifi","wi fi","wi-fi","wireless"]');
+INSERT INTO matrix_ai_tag_synonym_groups (terms)
+SELECT '["internet","network","networking"]'
+WHERE NOT EXISTS (SELECT 1 FROM matrix_ai_tag_synonym_groups WHERE terms = '["internet","network","networking"]');
+INSERT INTO matrix_ai_tag_synonym_groups (terms)
+SELECT '["email","e mail","e-mail","mail"]'
+WHERE NOT EXISTS (SELECT 1 FROM matrix_ai_tag_synonym_groups WHERE terms = '["email","e mail","e-mail","mail"]');

--- a/tests/services/test_matrix_ai_waiting_assistant.py
+++ b/tests/services/test_matrix_ai_waiting_assistant.py
@@ -20,6 +20,18 @@ def test_extract_keywords_uses_ollama_json(monkeypatch):
     assert keywords == ["windows 11", "vpn", "error 809"]
 
 
+def test_matching_tags_matches_known_synonyms():
+    keywords = assistant._normalise_tags(["monitor", "trackpad", "computer"])
+    article_tags = assistant._normalise_tags(["Screen", "Touchpad", "PC", "Printer"])
+
+    assert assistant._matching_tags(keywords, article_tags) == ["pc", "screen", "touchpad"]
+
+def test_matching_tags_normalises_hyphenated_synonyms():
+    keywords = assistant._normalise_tags(["wi-fi", "e-mail"])
+    article_tags = assistant._normalise_tags(["wireless", "mail"])
+
+    assert assistant._matching_tags(keywords, article_tags) == ["mail", "wireless"]
+
 def test_scan_waiting_rooms_sends_ack_before_analysis(monkeypatch):
     settings = SimpleNamespace(
         matrix_enabled=True,
@@ -398,3 +410,9 @@ def test_article_visible_to_room_respects_company_restrictions():
         {"permission_scope": "user", "allowed_user_ids": [21]},
         room,
     ) is False
+
+
+def test_matching_tags_uses_configured_synonym_lookup():
+    lookup = assistant._build_synonym_lookup([["router", "gateway"], ["monitor", "display"]])
+
+    assert assistant._matching_tags(["gateway"], ["router", "screen"], lookup) == ["router"]

--- a/tests/test_matrix_ai_tag_synonyms_repository.py
+++ b/tests/test_matrix_ai_tag_synonyms_repository.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from app.repositories import matrix_ai_tag_synonyms as repo
+
+
+def test_validate_terms_normalises_and_deduplicates():
+    assert repo.validate_terms([" Wi-Fi ", "wireless", "wi_fi", ""]) == ["wi fi", "wireless"]
+
+
+def test_validate_terms_requires_two_unique_terms():
+    with pytest.raises(repo.InvalidSynonymGroup):
+        repo.validate_terms(["monitor", "monitor"])
+
+
+def test_validate_terms_limits_term_count():
+    with pytest.raises(repo.InvalidSynonymGroup):
+        repo.validate_terms([f"term{i}" for i in range(repo.MAX_TERMS_PER_GROUP + 1)])


### PR DESCRIPTION
### Motivation
- Improve KB article recommendation matching by allowing configurable synonym groups so extracted chat keywords can match equivalent article tags.
- Provide administrators a way to manage synonym groups via both an API and an admin UI and persist them in the database.

### Description
- Added a new repository `matrix_ai_tag_synonyms.py` implementing normalization, validation (`InvalidSynonymGroup`), and CRUD operations with limits (`MAX_GROUPS`, `MAX_TERMS_PER_GROUP`, `MAX_TERM_LENGTH`).
- Created migration `273_matrix_ai_tag_synonyms.sql` to add the `matrix_ai_tag_synonym_groups` table and seed default synonym groups.
- Exposed REST endpoints under `GET/POST/PUT/DELETE /api/chat/ai-tag-synonyms` guarded by `require_super_admin` and added Pydantic schemas `AiTagSynonymGroupCreate`, `AiTagSynonymGroupUpdate`, and `AiTagSynonymGroupResponse` in `app/schemas/chat.py`.
- Added admin UI and server-side routes for chat configuration at `/chat/configuration` with create/update/delete flows and template `admin/matrix_chat_configuration.html`, and added a link to the configuration page from the chat index.
- Integrated synonyms into `matrix_ai_waiting_assistant` by adding default synonym groups, building a synonym lookup, and using `_matching_tags` to match keywords to article tags via synonyms.

### Testing
- Ran unit tests for the new repository in `tests/test_matrix_ai_tag_synonyms_repository.py` which verify normalization/deduplication, requirement of two unique terms, and term count limits and they passed.
- Updated and ran `tests/services/test_matrix_ai_waiting_assistant.py` which includes new tests for `_matching_tags`, synonym normalization, and configured lookup behavior and they passed.
- Executed the modified test suite with `pytest` for the changed tests and no failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33d14c1f9c832d93ec57f98039e4e8)