### PR TITLE
Add AI tag synonyms admin UI

### DIFF
--- a/app/features/matrix_chat_assign/routes.py
+++ b/app/features/matrix_chat_assign/routes.py
@@ -304,6 +304,7 @@ async def chat_delete_auto_assign_rule(rule_id: int, request: Request):
 
 
 @router.get("/chat/configuration", response_class=HTMLResponse)
+@router.get("/admin/chat/ai-tag-synonyms", response_class=HTMLResponse)
 async def chat_configuration_page(request: Request):
     main_module = _main()
     current_user, redirect = await main_module._require_super_admin_page(request)
@@ -313,6 +314,7 @@ async def chat_configuration_page(request: Request):
 
 
 @router.post("/chat/configuration/synonyms", response_class=HTMLResponse)
+@router.post("/admin/chat/ai-tag-synonyms", response_class=HTMLResponse)
 async def chat_create_synonym_group(request: Request):
     main_module = _main()
     current_user, redirect = await main_module._require_super_admin_page(request)
@@ -336,10 +338,11 @@ async def chat_create_synonym_group(request: Request):
             error_message="Failed to create synonym group.",
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
-    return flash_redirect("/chat/configuration", "Synonym group created.", "success")
+    return flash_redirect("/admin/chat/ai-tag-synonyms", "Synonym group created.", "success")
 
 
 @router.post("/chat/configuration/synonyms/{group_id}", response_class=HTMLResponse)
+@router.post("/admin/chat/ai-tag-synonyms/{group_id}", response_class=HTMLResponse)
 async def chat_update_synonym_group(group_id: int, request: Request):
     main_module = _main()
     current_user, redirect = await main_module._require_super_admin_page(request)
@@ -364,11 +367,12 @@ async def chat_update_synonym_group(group_id: int, request: Request):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
     if not updated:
-        return flash_redirect("/chat/configuration", "Synonym group not found.", "error")
-    return flash_redirect("/chat/configuration", "Synonym group updated.", "success")
+        return flash_redirect("/admin/chat/ai-tag-synonyms", "Synonym group not found.", "error")
+    return flash_redirect("/admin/chat/ai-tag-synonyms", "Synonym group updated.", "success")
 
 
 @router.post("/chat/configuration/synonyms/{group_id}/delete", response_class=HTMLResponse)
+@router.post("/admin/chat/ai-tag-synonyms/{group_id}/delete", response_class=HTMLResponse)
 async def chat_delete_synonym_group(group_id: int, request: Request):
     main_module = _main()
     current_user, redirect = await main_module._require_super_admin_page(request)
@@ -376,5 +380,5 @@ async def chat_delete_synonym_group(group_id: int, request: Request):
         return redirect
     deleted = await synonyms_repo.delete_group(group_id)
     if not deleted:
-        return flash_redirect("/chat/configuration", "Synonym group not found.", "error")
-    return flash_redirect("/chat/configuration", "Synonym group deleted.", "success")
+        return flash_redirect("/admin/chat/ai-tag-synonyms", "Synonym group not found.", "error")
+    return flash_redirect("/admin/chat/ai-tag-synonyms", "Synonym group deleted.", "success")

--- a/app/templates/admin/matrix_chat_configuration.html
+++ b/app/templates/admin/matrix_chat_configuration.html
@@ -1,12 +1,13 @@
 {% extends "base.html" %}
 {% from "macros/header.html" import page_header_actions %}
 
-{% block header_title %}Chat Configuration{% endblock %}
+{% block header_title %}AI Tag Synonyms{% endblock %}
 
 {% block header_actions %}
   {{ page_header_actions([
     {"label": "Chat rooms", "type": "link", "href": "/chat"},
-    {"label": "Auto-assign rules", "type": "link", "href": "/chat/auto-assign"}
+    {"label": "Auto-assign rules", "type": "link", "href": "/chat/auto-assign"},
+    {"label": "API docs", "type": "link", "href": "/docs#/Chat/list_ai_tag_synonym_groups_api_chat_ai_tag_synonyms_get"}
   ]) }}
 {% endblock %}
 
@@ -22,13 +23,13 @@
         <div>
           <h2 class="card__title">AI Waiting Assistant tag synonyms</h2>
           <p class="card__subtitle">
-            Super admins can add similar words used when matching extracted chat keywords to knowledge-base article tags.
+            Configure the synonym groups used by <code>/api/chat/ai-tag-synonyms</code> when the AI Waiting Assistant matches extracted chat keywords to knowledge-base article tags.
             Enter comma-separated terms; each group needs at least two unique terms.
           </p>
         </div>
       </header>
 
-      <form action="/chat/configuration/synonyms" method="post" class="form management__form" autocomplete="off">
+      <form action="/admin/chat/ai-tag-synonyms" method="post" class="form management__form" autocomplete="off">
         {% if csrf_token %}
           <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
         {% endif %}
@@ -68,7 +69,7 @@
               <tr>
                 <td data-label="ID" data-column-key="id">{{ group.id }}</td>
                 <td data-label="Terms" data-column-key="terms">
-                  <form action="/chat/configuration/synonyms/{{ group.id }}" method="post" class="inline-form chat-synonym-form">
+                  <form action="/admin/chat/ai-tag-synonyms/{{ group.id }}" method="post" class="inline-form chat-synonym-form">
                     {% if csrf_token %}
                       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
                     {% endif %}
@@ -85,7 +86,7 @@
                 </td>
                 <td class="table__actions" data-column-key="actions">
                   <button type="button" class="button button--sm" onclick="this.closest('tr').querySelector('.chat-synonym-form').requestSubmit();">Save</button>
-                  <form action="/chat/configuration/synonyms/{{ group.id }}/delete" method="post" class="inline-form" onsubmit="return confirm('Delete this synonym group?');">
+                  <form action="/admin/chat/ai-tag-synonyms/{{ group.id }}/delete" method="post" class="inline-form" onsubmit="return confirm('Delete this synonym group?');">
                     {% if csrf_token %}
                       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
                     {% endif %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -502,6 +502,14 @@
                 </a>
               </li>
               <li class="menu__item">
+                <a href="/admin/chat/ai-tag-synonyms" {% if current_path.startswith('/admin/chat/ai-tag-synonyms') or current_path.startswith('/chat/configuration') %}aria-current="page"{% endif %}>
+                  <span class="menu__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false"><path d="M4 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-5l-5 5v-5H6a2 2 0 0 1-2-2V4zm4 4v2h8V8H8zm0 4v2h5v-2H8z"/></svg>
+                  </span>
+                  <span class="menu__label">AI Tag Synonyms</span>
+                </a>
+              </li>
+              <li class="menu__item">
                 <a href="/admin/call-recordings" {% if current_path.startswith('/admin/call-recordings') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a3 3 0 0 1 3 3v7a3 3 0 0 1-6 0V5a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v7a1 1 0 0 0 2 0V5a1 1 0 0 0-1-1zm6 7a1 1 0 0 1 1 1 7 7 0 0 1-6 6.93V21h3a1 1 0 0 1 0 2H8a1 1 0 0 1 0-2h3v-2.07A7 7 0 0 1 5 12a1 1 0 0 1 2 0 5 5 0 0 0 10 0 1 1 0 0 1 1-1z"/></svg>

--- a/app/templates/chat/index.html
+++ b/app/templates/chat/index.html
@@ -9,7 +9,7 @@
      "attrs": {"data-create-chat-modal-open": "", "aria-haspopup": "dialog", "aria-controls": "create-chat-modal"}},
   ] %}
   {% if is_super_admin | default(false) %}
-    {% set chat_actions = chat_actions + [{"label": "Chat configuration", "type": "link", "href": "/chat/configuration"}, {"label": "Auto-assign rules", "type": "link", "href": "/chat/auto-assign"}] %}
+    {% set chat_actions = chat_actions + [{"label": "AI tag synonyms", "type": "link", "href": "/admin/chat/ai-tag-synonyms"}, {"label": "Auto-assign rules", "type": "link", "href": "/chat/auto-assign"}] %}
   {% endif %}
   {{ page_header_actions(chat_actions) }}
 {% endblock %}

--- a/tests/test_matrix_ai_tag_synonyms_ui.py
+++ b/tests/test_matrix_ai_tag_synonyms_ui.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def test_ai_tag_synonyms_admin_menu_link_is_visible():
+    template = Path("app/templates/base.html").read_text()
+
+    assert "/admin/chat/ai-tag-synonyms" in template
+    assert "AI Tag Synonyms" in template
+
+
+def test_ai_tag_synonyms_page_targets_admin_ui_routes():
+    template = Path("app/templates/admin/matrix_chat_configuration.html").read_text()
+
+    assert "AI Tag Synonyms" in template
+    assert "/api/chat/ai-tag-synonyms" in template
+    assert "action=\"/admin/chat/ai-tag-synonyms\"" in template
+    assert "action=\"/admin/chat/ai-tag-synonyms/{{ group.id }}\"" in template
+    assert "action=\"/admin/chat/ai-tag-synonyms/{{ group.id }}/delete\"" in template


### PR DESCRIPTION
### Motivation
- Provide a dedicated admin UI so super-admins can configure the synonym groups used by the AI Waiting Assistant for the `/api/chat/ai-tag-synonyms` endpoint, because there was no direct UI to manage those groups.

### Description
- Added admin-facing routes that mirror existing chat configuration endpoints at `GET /admin/chat/ai-tag-synonyms` and `POST /admin/chat/ai-tag-synonyms` (and update/delete variants) while preserving the original `/chat/configuration` paths in `app/features/matrix_chat_assign/routes.py`.
- Updated the synonym management template `app/templates/admin/matrix_chat_configuration.html` to change the page title to "AI Tag Synonyms", point forms to the new admin routes, and include a link to the API docs and a clearer description that references `/api/chat/ai-tag-synonyms`.
- Added a sidebar administration entry for "AI Tag Synonyms" in `app/templates/base.html` and updated the Chat page header action in `app/templates/chat/index.html` to link to the new admin UI.
- Added template regression tests in `tests/test_matrix_ai_tag_synonyms_ui.py` to assert the new menu link and form targets.

### Testing
- Ran `pytest tests/test_matrix_ai_tag_synonyms_repository.py tests/test_matrix_ai_tag_synonyms_ui.py -q` and all tests passed (`5 passed`).
- Ran `python -m py_compile app/features/matrix_chat_assign/routes.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33d61ee170832d8b816ef530c80a2e)