### PR TITLE
Import embedded Syncro ticket images

### DIFF
--- a/app/services/syncro.py
+++ b/app/services/syncro.py
@@ -4,6 +4,7 @@ import asyncio
 from collections import deque
 from time import monotonic
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -452,6 +453,43 @@ async def get_assets(customer_id: str | int) -> list[dict[str, Any]]:
         if total_pages and page >= total_pages:
             break
     return results
+
+
+async def download_file(
+    url_or_path: str,
+    *,
+    timeout: float = 30.0,
+    rate_limiter: AsyncRateLimiter | None = None,
+) -> tuple[bytes, str | None]:
+    """Download a Syncro-hosted file using the configured API credentials."""
+    settings = await _get_effective_settings()
+    limiter = rate_limiter or await _get_or_create_rate_limiter(settings["rate_limit_per_minute"])
+    await limiter.acquire()
+    candidate = str(url_or_path or "").strip()
+    if not candidate:
+        raise SyncroAPIError("Syncro download URL is empty")
+    base_url = settings["base_url"]
+    is_relative = not candidate.startswith(("http://", "https://"))
+    if is_relative:
+        url = f"{base_url}{candidate if candidate.startswith('/') else f'/{candidate}'}"
+    else:
+        parsed = urlparse(candidate)
+        if parsed.scheme not in {"http", "https"}:
+            raise SyncroAPIError("Syncro download URL must use HTTP or HTTPS")
+        url = candidate
+    headers: dict[str, str] = {}
+    if settings.get("api_key") and (is_relative or urlparse(url).netloc == urlparse(base_url).netloc):
+        headers["Authorization"] = f"Bearer {settings['api_key']}"
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        try:
+            response = await client.get(url, headers=headers)
+        except httpx.HTTPError as exc:
+            log_error("Syncro file download failed", url=url, error=str(exc))
+            raise SyncroAPIError(str(exc)) from exc
+    if response.status_code >= 400:
+        log_error("Syncro file download responded with error", url=url, status=response.status_code)
+        raise SyncroAPIError(f"Syncro file download responded with {response.status_code}")
+    return response.content, response.headers.get("content-type")
 
 
 async def list_customers(

--- a/app/services/ticket_attachments.py
+++ b/app/services/ticket_attachments.py
@@ -169,6 +169,59 @@ async def save_uploaded_file(
         raise
 
 
+async def save_file_bytes(
+    ticket_id: int,
+    *,
+    contents: bytes,
+    original_filename: str,
+    mime_type: str | None,
+    access_level: str,
+    uploaded_by_user_id: int | None,
+) -> dict[str, Any]:
+    """Save raw file bytes and create a ticket attachment record."""
+    upload_name = original_filename or "upload"
+    pseudo_file = type(
+        "AttachmentUpload",
+        (),
+        {"filename": upload_name, "content_type": mime_type, "size": len(contents)},
+    )()
+    is_valid, error = validate_file_upload(pseudo_file)
+    if not is_valid:
+        raise ValueError(error or "Invalid file upload")
+    file_size = len(contents)
+    if file_size > MAX_FILE_SIZE:
+        raise ValueError(f"File size {file_size} exceeds maximum")
+
+    secure_filename = _generate_secure_filename(upload_name)
+    upload_dir = _get_upload_directory()
+    file_path = upload_dir / secure_filename
+    try:
+        with open(file_path, "wb") as f:
+            f.write(contents)
+        log_info(f"Saved file {secure_filename} ({file_size} bytes) for ticket {ticket_id}")
+    except Exception as e:
+        log_error(f"Failed to save file: {e}")
+        if file_path.exists():
+            file_path.unlink()
+        raise IOError(f"Failed to save file: {e}") from e
+
+    try:
+        return await attachments_repo.create_attachment(
+            ticket_id=ticket_id,
+            filename=secure_filename,
+            original_filename=upload_name,
+            file_size=file_size,
+            mime_type=mime_type,
+            access_level=access_level,
+            uploaded_by_user_id=uploaded_by_user_id,
+        )
+    except Exception as e:
+        log_error(f"Failed to create attachment record: {e}")
+        if file_path.exists():
+            file_path.unlink()
+        raise
+
+
 async def delete_attachment_file(attachment: dict[str, Any]) -> None:
     """Delete an attachment file and database record."""
     filename = attachment.get("filename")

--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -4,8 +4,11 @@ from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from html import unescape
+import mimetypes
+from pathlib import PurePosixPath
 import re
 import json
+from urllib.parse import unquote, urlparse
 from typing import Any
 
 from app.core.logging import log_error, log_info
@@ -14,7 +17,12 @@ from app.repositories import companies as company_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import users as user_repo
 from app.repositories import webhook_events as webhook_events_repo
-from app.services import syncro, tickets as tickets_service, webhook_monitor
+from app.services import (
+    syncro,
+    ticket_attachments as attachments_service,
+    tickets as tickets_service,
+    webhook_monitor,
+)
 
 _ALLOWED_PRIORITIES = {"urgent", "high", "normal", "low"}
 _ALLOWED_STATUSES = {"open", "in_progress", "pending", "resolved", "closed"}
@@ -196,6 +204,134 @@ def _extract_comment_body(comment: dict[str, Any]) -> str | None:
         or comment.get("text")
         or comment.get("content")
     )
+
+
+_IMAGE_MIME_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml"}
+_IMAGE_EXTENSIONS = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/svg+xml": ".svg",
+}
+
+
+def _extract_comment_image_candidates(comment: dict[str, Any]) -> list[dict[str, str | None]]:
+    """Return image attachment candidates embedded in a Syncro comment."""
+    candidates: list[dict[str, str | None]] = []
+
+    def add(url: Any, filename: Any = None, content_type: Any = None) -> None:
+        url_text = str(url or "").strip()
+        if not url_text:
+            return
+        mime = _clean_text(content_type)
+        if mime and ";" in mime:
+            mime = mime.split(";", 1)[0].strip().lower()
+        if mime and not mime.startswith("image/"):
+            return
+        filename_text = _clean_text(filename)
+        key = (url_text, filename_text or "")
+        if any((item["url"], item.get("filename") or "") == key for item in candidates):
+            return
+        candidates.append({"url": url_text, "filename": filename_text, "mime_type": mime})
+
+    for key in ("attachments", "files", "uploads", "images"):
+        raw = comment.get(key)
+        if not isinstance(raw, list):
+            continue
+        for item in raw:
+            if isinstance(item, str):
+                add(item)
+            elif isinstance(item, dict):
+                add(
+                    item.get("url")
+                    or item.get("download_url")
+                    or item.get("downloadUrl")
+                    or item.get("file_url")
+                    or item.get("fileUrl")
+                    or item.get("attachment_url")
+                    or item.get("attachmentUrl"),
+                    item.get("filename")
+                    or item.get("file_name")
+                    or item.get("fileName")
+                    or item.get("name"),
+                    item.get("content_type")
+                    or item.get("contentType")
+                    or item.get("mime_type")
+                    or item.get("mimeType"),
+                )
+
+    for body_key in ("body", "comment", "text", "content"):
+        body = comment.get(body_key)
+        if not isinstance(body, str) or "<img" not in body.lower():
+            continue
+        for match in re.finditer(
+            r"<img\b[^>]*\bsrc=[\"']([^\"']+)[\"'][^>]*>",
+            body,
+            flags=re.IGNORECASE,
+        ):
+            tag = match.group(0)
+            filename_match = re.search(
+                r"\b(?:alt|title)=[\"']([^\"']+)[\"']",
+                tag,
+                flags=re.IGNORECASE,
+            )
+            add(unescape(match.group(1)), unescape(filename_match.group(1)) if filename_match else None)
+    return candidates
+
+
+def _filename_for_image_candidate(
+    candidate: dict[str, str | None], content_type: str | None, index: int
+) -> str:
+    filename = (candidate.get("filename") or "").strip()
+    if filename and filename.lower() not in {"[embedded image]", "embedded image"}:
+        name = PurePosixPath(unquote(urlparse(filename).path)).name or filename
+    else:
+        parsed_name = PurePosixPath(unquote(urlparse(candidate.get("url") or "").path)).name
+        name = parsed_name or f"syncro-comment-image-{index}"
+    if "." not in name:
+        ext = _IMAGE_EXTENSIONS.get((content_type or candidate.get("mime_type") or "").lower(), ".img")
+        name = f"{name}{ext}"
+    return name[:255]
+
+
+async def _import_comment_images(ticket_id: int, comment: dict[str, Any], author_id: int | None) -> None:
+    candidates = _extract_comment_image_candidates(comment)
+    for index, candidate in enumerate(candidates, start=1):
+        try:
+            contents, downloaded_type = await syncro.download_file(candidate["url"] or "")
+            content_type = (
+                (downloaded_type or candidate.get("mime_type") or "")
+                .split(";", 1)[0]
+                .strip()
+                .lower()
+                or None
+            )
+            if content_type not in _IMAGE_MIME_TYPES:
+                guessed, _ = mimetypes.guess_type(candidate.get("url") or "")
+                content_type = guessed if guessed in _IMAGE_MIME_TYPES else content_type
+            if content_type not in _IMAGE_MIME_TYPES:
+                log_error(
+                    "Skipping Syncro embedded image with unsupported MIME type",
+                    ticket_id=ticket_id,
+                    mime_type=content_type,
+                )
+                continue
+            await attachments_service.save_file_bytes(
+                ticket_id=ticket_id,
+                contents=contents,
+                original_filename=_filename_for_image_candidate(candidate, content_type, index),
+                mime_type=content_type,
+                access_level="closed",
+                uploaded_by_user_id=author_id,
+            )
+        except Exception as exc:  # pragma: no cover - import should continue if an image fails
+            log_error(
+                "Failed to import Syncro embedded image",
+                ticket_id=ticket_id,
+                url=candidate.get("url"),
+                error=str(exc),
+            )
 
 
 def _extract_comment_author_name(comment: dict[str, Any]) -> str | None:
@@ -832,6 +968,7 @@ async def _sync_ticket_replies(
             external_reference=external_ref,
             created_at=created_at,
         )
+        await _import_comment_images(ticket_id, comment, author_id)
         if external_ref:
             known_refs.add(external_ref)
 

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -1629,3 +1629,79 @@ async def test_import_ticket_no_asset_link_when_ticket_has_no_assets(monkeypatch
     # No assets in the ticket -- list_company_assets should not even be called
     assert len(list_assets_calls) == 0
     assert len(replace_calls) == 0
+
+
+def test_extract_comment_image_candidates_from_html_img():
+    comment = {
+        "body": '<p>[embedded image]</p><img src="https://example.test/files/image.png" alt="screen.png">'
+    }
+
+    assert ticket_importer._extract_comment_image_candidates(comment) == [
+        {
+            "url": "https://example.test/files/image.png",
+            "filename": "screen.png",
+            "mime_type": None,
+        }
+    ]
+
+
+def test_extract_comment_image_candidates_from_attachments_only_images():
+    comment = {
+        "attachments": [
+            {"download_url": "/attachments/1", "filename": "photo", "content_type": "image/png"},
+            {"download_url": "/attachments/2", "filename": "note.txt", "content_type": "text/plain"},
+        ]
+    }
+
+    assert ticket_importer._extract_comment_image_candidates(comment) == [
+        {"url": "/attachments/1", "filename": "photo", "mime_type": "image/png"}
+    ]
+
+
+@pytest.mark.anyio
+async def test_sync_ticket_replies_imports_embedded_images(monkeypatch):
+    async def fake_list_replies(ticket_id, include_internal=True):  # noqa: ARG001
+        return []
+
+    reply_calls = []
+
+    async def fake_create_reply(**kwargs):
+        reply_calls.append(kwargs)
+        return {"id": 1, **kwargs}
+
+    async def fake_download_file(url):
+        assert url == "https://example.test/files/image.png"
+        return b"png-bytes", "image/png"
+
+    attachment_calls = []
+
+    async def fake_save_file_bytes(**kwargs):
+        attachment_calls.append(kwargs)
+        return {"id": 10, **kwargs}
+
+    monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
+    monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
+    monkeypatch.setattr(syncro, "download_file", fake_download_file)
+    monkeypatch.setattr(ticket_importer.attachments_service, "save_file_bytes", fake_save_file_bytes)
+
+    await ticket_importer._sync_ticket_replies(
+        123,
+        [
+            {
+                "id": 77,
+                "body": '<p>[embedded image]</p><img src="https://example.test/files/image.png" alt="screen.png">',
+                "tech": "agent",
+                "hidden": False,
+            }
+        ],
+        requester_id=None,
+        contact_email=None,
+    )
+
+    assert reply_calls[0]["external_reference"] == "77"
+    assert len(attachment_calls) == 1
+    assert attachment_calls[0]["ticket_id"] == 123
+    assert attachment_calls[0]["contents"] == b"png-bytes"
+    assert attachment_calls[0]["original_filename"] == "screen.png"
+    assert attachment_calls[0]["mime_type"] == "image/png"
+    assert attachment_calls[0]["access_level"] == "closed"


### PR DESCRIPTION
### Motivation
- Syncro ticket imports were not including images referenced in comment bodies or attachment lists, showing "[embedded image]" instead of importing the actual file.
- The goal is to download image files referenced by Syncro comments (absolute URLs or relative Syncro attachment paths), store them as ticket attachments, and preserve author/time metadata while keeping imports resilient and secure.

### Description
- Added `download_file` to `app/services/syncro.py` to fetch files via HTTP(S) or relative Syncro paths with rate limiting, redirect support, and logic that only sends the Syncro bearer token to the configured Syncro host or relative URLs.
- Added `save_file_bytes` to `app/services/ticket_attachments.py` to persist raw file bytes using the same validation, secure filename generation, max-size checks, and cleanup behavior as uploaded attachments.
- Extended `app/services/ticket_importer.py` to detect image candidates from comment attachment arrays and inline `<img>` tags, validate MIME/extension, download each image and save it via `save_file_bytes`, and skip problematic images while continuing the import.
- Hooked embedded-image importing into the reply sync flow so images are imported immediately after the corresponding reply is created, implemented safe filename derivation, and limited accepted image MIME types.
- Added regression tests in `tests/test_ticket_importer.py` covering HTML `<img>` extraction, attachment-array image extraction, and end-to-end import of a downloaded embedded image.

### Testing
- Ran static compile checks: `python -m py_compile app/services/ticket_importer.py app/services/ticket_attachments.py app/services/syncro.py` which succeeded.
- Ran the ticket importer test suite: `pytest -q tests/test_ticket_importer.py -q` and all tests in that file passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a33d9f70a40832da3ed70c323c4c6ec)