### PR TITLE
Add manual M365 OneDrive export flow with SharePoint site selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,6 +116,15 @@ M365_PKCE_CLIENT_ID=
 M365_CLIENT_SECRET_LIFETIME_DAYS=730
 # Number of days before expiry to automatically renew the M365 client secret (default: 14)
 M365_CLIENT_SECRET_RENEWAL_DAYS=14
+# Manual Staff table OneDrive export behavior. The destination SharePoint site
+# and document-library drive are configured per company in Admin > Companies >
+# Edit company > Microsoft 365 after that company's Office 365 configuration is completed.
+M365_ONEDRIVE_EXPORT_DESTINATION_PARENT_ITEM_ID=root
+M365_ONEDRIVE_EXPORT_MARK_SOURCE_READ_ONLY=true
+M365_ONEDRIVE_EXPORT_WAIT_FOR_COMPLETION=true
+M365_ONEDRIVE_EXPORT_COPY_TIMEOUT_SECONDS=3600
+# One of fail, rename, or replace. Use fail to avoid accidentally overwriting a prior export.
+M365_ONEDRIVE_EXPORT_FOLDER_CONFLICT_BEHAVIOR=fail
 
 # Operational controls
 CRON_TIMEZONE=UTC

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -145,6 +145,21 @@ class Settings(BaseSettings):
     m365_client_secret_renewal_days: int = Field(
         default=14, validation_alias="M365_CLIENT_SECRET_RENEWAL_DAYS", ge=1
     )
+    m365_onedrive_export_destination_parent_item_id: str = Field(
+        default="root", validation_alias="M365_ONEDRIVE_EXPORT_DESTINATION_PARENT_ITEM_ID"
+    )
+    m365_onedrive_export_mark_source_read_only: bool = Field(
+        default=True, validation_alias="M365_ONEDRIVE_EXPORT_MARK_SOURCE_READ_ONLY"
+    )
+    m365_onedrive_export_wait_for_completion: bool = Field(
+        default=True, validation_alias="M365_ONEDRIVE_EXPORT_WAIT_FOR_COMPLETION"
+    )
+    m365_onedrive_export_copy_timeout_seconds: int = Field(
+        default=3600, validation_alias="M365_ONEDRIVE_EXPORT_COPY_TIMEOUT_SECONDS", ge=1
+    )
+    m365_onedrive_export_folder_conflict_behavior: str = Field(
+        default="fail", validation_alias="M365_ONEDRIVE_EXPORT_FOLDER_CONFLICT_BEHAVIOR"
+    )
     default_timezone: str = Field(default="UTC", validation_alias="CRON_TIMEZONE")
     enable_csrf: bool = Field(default=True, validation_alias="ENABLE_CSRF")
     feature_packs: str = Field(

--- a/app/features/companies/handlers.py
+++ b/app/features/companies/handlers.py
@@ -494,6 +494,15 @@ async def _render_company_edit_page(
             "offboarding_email_forwarding_enabled",
             bool(int(company_record.get("offboarding_email_forwarding_enabled", 1) or 1)),
         ),
+        "onedrive_export_site_id": _string_value(
+            "onedrive_export_site_id", (company_record.get("onedrive_export_site_id") or "").strip()
+        ),
+        "onedrive_export_drive_id": _string_value(
+            "onedrive_export_drive_id", (company_record.get("onedrive_export_drive_id") or "").strip()
+        ),
+        "onedrive_export_site_name": _string_value(
+            "onedrive_export_site_name", (company_record.get("onedrive_export_site_name") or "").strip()
+        ),
         "trello_board_id": _string_value(
             "trello_board_id", (company_record.get("trello_board_id") or "").strip()
         ),
@@ -695,6 +704,8 @@ async def _render_company_edit_page(
 
     # Fetch Microsoft 365 credentials for the company
     m365_credential_view: dict[str, Any] | None = None
+    onedrive_export_site_options: list[dict[str, Any]] = []
+    onedrive_export_sites_error: str | None = None
     if is_super_admin:
         try:
             m365_creds = await m365_service.get_credentials(company_id)
@@ -711,6 +722,10 @@ async def _render_company_edit_page(
                     "client_id": m365_creds.get("client_id"),
                     "token_expires_at": expires_display,
                 }
+                try:
+                    onedrive_export_site_options = await m365_service.list_sharepoint_export_sites(company_id)
+                except m365_service.M365Error as exc:
+                    onedrive_export_sites_error = str(exc)
         except RuntimeError as exc:  # pragma: no cover - defensive guard for tests
             if "Database pool not initialised" in str(exc):
                 pass
@@ -774,6 +789,8 @@ async def _render_company_edit_page(
         "show_inactive_tasks": show_inactive_tasks,
         "m365_credential": m365_credential_view,
         "m365_has_credentials": m365_credential_view is not None,
+        "onedrive_export_site_options": onedrive_export_site_options,
+        "onedrive_export_sites_error": onedrive_export_sites_error,
         "m365_admin_credentials_configured": bool(all(await _main()._get_m365_admin_credentials(company_id))),
         "staff_field_config": staff_field_config,
         "staff_custom_field_definitions": staff_custom_field_definitions,
@@ -1258,6 +1275,19 @@ async def admin_update_company(company_id: int, request: Request):
     offboarding_email_forwarding_enabled = bool(
         form.get("offboardingEmailForwardingEnabled")
     )
+    onedrive_export_selection_raw = str(form.get("onedriveExportSite") or "").strip()
+    onedrive_export_site_id_raw = ""
+    onedrive_export_drive_id_raw = ""
+    onedrive_export_site_name_raw = ""
+    if onedrive_export_selection_raw:
+        try:
+            selection_data = json.loads(onedrive_export_selection_raw)
+        except json.JSONDecodeError:
+            selection_data = {}
+        if isinstance(selection_data, dict):
+            onedrive_export_site_id_raw = str(selection_data.get("site_id") or "").strip()
+            onedrive_export_drive_id_raw = str(selection_data.get("drive_id") or "").strip()
+            onedrive_export_site_name_raw = str(selection_data.get("site_name") or "").strip()[:255]
     _selected_methods = [
         m
         for m, enabled in [
@@ -1275,6 +1305,10 @@ async def admin_update_company(company_id: int, request: Request):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Company not found"
         )
+    if "onedriveExportSite" not in form:
+        onedrive_export_site_id_raw = str(existing.get("onedrive_export_site_id") or "").strip()
+        onedrive_export_drive_id_raw = str(existing.get("onedrive_export_drive_id") or "").strip()
+        onedrive_export_site_name_raw = str(existing.get("onedrive_export_site_name") or "").strip()[:255]
     form_values = {
         "name": name,
         "syncro_company_id": syncro_company_raw,
@@ -1290,6 +1324,9 @@ async def admin_update_company(company_id: int, request: Request):
         "payment_method": payment_method,
         "require_po": require_po,
         "offboarding_email_forwarding_enabled": offboarding_email_forwarding_enabled,
+        "onedrive_export_site_id": onedrive_export_site_id_raw,
+        "onedrive_export_drive_id": onedrive_export_drive_id_raw,
+        "onedrive_export_site_name": onedrive_export_site_name_raw,
     }
     try:
         email_domains = company_domains.parse_email_domain_text(email_domains_text)
@@ -1309,6 +1346,15 @@ async def admin_update_company(company_id: int, request: Request):
             company_id=company_id,
             form_values=form_values,
             error_message="Enter a company name.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    if onedrive_export_selection_raw and (not onedrive_export_site_id_raw or not onedrive_export_drive_id_raw):
+        return await _render_company_edit_page(
+            request,
+            current_user,
+            company_id=company_id,
+            form_values=form_values,
+            error_message="Select a valid SharePoint site for OneDrive exports.",
             status_code=status.HTTP_400_BAD_REQUEST,
         )
     syncro_company_id = syncro_company_raw or None
@@ -1340,6 +1386,9 @@ async def admin_update_company(company_id: int, request: Request):
         "offboarding_email_forwarding_enabled": 1
         if offboarding_email_forwarding_enabled
         else 0,
+        "onedrive_export_site_id": onedrive_export_site_id_raw or None,
+        "onedrive_export_site_name": onedrive_export_site_name_raw or None,
+        "onedrive_export_drive_id": onedrive_export_drive_id_raw or None,
     }
     try:
         await company_repo.update_company(company_id, **updates)

--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -576,6 +576,7 @@ async def staff_page(
         "active_staff_for_offboarding": cast(list[dict[str, Any]], _serialise_for_json(active_staff_for_offboarding)),
         "offboarding_email_forwarding_enabled": offboarding_email_forwarding_enabled,
         "has_m365": has_m365,
+        "manual_onedrive_export_enabled": bool(str((company_record or {}).get("onedrive_export_drive_id") or "").strip()),
     }
     return await _render_template("staff/index.html", request, user, extra=extra)
 
@@ -657,6 +658,14 @@ _OFFBOARDING_STEP_CATALOG: list[dict[str, Any]] = [
         "type": "m365_remove_sharepoint_site_member",
         "name": "Remove from SharePoint sites",
         "description": "Removes the staff member from one or more SharePoint sites using Graph site IDs.",
+    },
+    {
+        "type": "m365_export_onedrive",
+        "name": "Export OneDrive",
+        "description": (
+            "Copies the user's OneDrive root into the configured SharePoint document library folder, "
+            "naming the exported folder after the user's UPN and optionally setting the source OneDrive to read-only."
+        ),
     },
     {
         "type": "send_welcome_email",
@@ -1275,6 +1284,67 @@ _WORKFLOW_STEP_FORM_SCHEMA: dict[str, dict[str, Any]] = {
                 "label": "User object ID (optional)",
                 "type": "text",
                 "default": "",
+            },
+        ],
+    },
+    "m365_export_onedrive": {
+        "fields": [
+            {
+                "name": "destination_drive_id",
+                "label": "Destination SharePoint drive ID (optional)",
+                "type": "text",
+                "default": "",
+                "description": (
+                    "Optional override. Leave blank to use the SharePoint site selected in the company's settings. "
+                    "If overriding, this is the Graph drive ID for the destination SharePoint document library. "
+                    "To find it in Microsoft Graph Explorer: get the site with "
+                    "GET /sites/<tenant>.sharepoint.com:/sites/<site-name>, then list libraries with "
+                    "GET /sites/<site-id>/drives and copy the target library's id. "
+                    "For the default document library, GET /sites/<site-id>/drive also returns the id."
+                ),
+            },
+            {
+                "name": "destination_parent_item_id",
+                "label": "Destination parent folder item ID",
+                "type": "text",
+                "default": "root",
+                "description": (
+                    "Drive item ID of the SharePoint folder that will receive the UPN-named export folder. "
+                    "Use root for the library root, or list folders with "
+                    "GET /drives/<drive-id>/root/children and copy the destination folder's id."
+                ),
+            },
+            {
+                "name": "mark_source_read_only",
+                "label": "Mark source OneDrive read-only",
+                "type": "checkbox",
+                "default": True,
+                "description": "Attempts to remove inherited permissions and grant the user read access after export.",
+            },
+            {
+                "name": "wait_for_completion",
+                "label": "Wait for copy completion",
+                "type": "checkbox",
+                "default": True,
+            },
+            {
+                "name": "copy_timeout_seconds",
+                "label": "Copy timeout seconds",
+                "type": "number",
+                "default": 3600,
+                "description": "Maximum time to wait for Graph to complete the asynchronous copy operation.",
+            },
+            {
+                "name": "folder_conflict_behavior",
+                "label": "Destination folder conflict behavior",
+                "type": "select",
+                "default": "fail",
+                "description": "Controls what happens when the destination already contains a folder with the user's UPN.",
+                "options": [
+                    {"value": "fail", "label": "Fail (safest)"},
+                    {"value": "rename", "label": "Rename new export"},
+                    {"value": "replace", "label": "Replace existing"},
+                ],
             },
         ],
     },
@@ -3035,6 +3105,68 @@ async def invite_staff_member(staff_id: int, request: Request):
         invited_user_id=created_user["id"],
     )
     return JSONResponse({"success": True})
+
+
+async def m365_export_staff_onedrive(staff_id: int, request: Request):
+    """Manually export a staff member's OneDrive to the company-configured SharePoint location."""
+    (
+        user,
+        membership,
+        company,
+        staff_permission,
+        company_id,
+        redirect,
+    ) = await _load_staff_context(request, require_super_admin=True)
+    if redirect:
+        return redirect
+
+    staff = await staff_repo.get_staff_by_id(staff_id)
+    if not staff:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Staff not found")
+    if not bool(user.get("is_super_admin")) and staff.get("company_id") != company_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied")
+    staff_company_id = int(staff.get("company_id") or company_id or 0)
+    staff_company = await company_repo.get_company_by_id(staff_company_id)
+    destination_drive_id = str((staff_company or {}).get("onedrive_export_drive_id") or "").strip()
+    if not destination_drive_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Select a OneDrive export SharePoint site in this company's settings before exporting.",
+        )
+
+    try:
+        result = await staff_onboarding_workflow_service.export_onedrive_for_staff(
+            company_id=staff_company_id,
+            staff=staff,
+            destination_drive_id=destination_drive_id,
+            destination_parent_item_id=str(settings.m365_onedrive_export_destination_parent_item_id or "root"),
+            mark_source_read_only=bool(settings.m365_onedrive_export_mark_source_read_only),
+            wait_for_completion=bool(settings.m365_onedrive_export_wait_for_completion),
+            copy_timeout_seconds=int(settings.m365_onedrive_export_copy_timeout_seconds),
+            folder_conflict_behavior=str(settings.m365_onedrive_export_folder_conflict_behavior or "fail"),
+        )
+    except staff_onboarding_workflow_service.WorkflowStepError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+    except m365_service.M365Error as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+
+    await audit_service.log_action(
+        entity_type="staff",
+        entity_id=staff_id,
+        action="staff.m365.onedrive_exported",
+        user_id=int(user["id"]) if user.get("id") is not None else None,
+        metadata={
+            "email": staff.get("email"),
+            "destination_drive_id": result.get("destination_drive_id"),
+            "destination_parent_item_id": result.get("destination_parent_item_id"),
+            "destination_folder_id": result.get("destination_folder_id"),
+            "destination_folder_name": result.get("destination_folder_name"),
+            "copy_status": result.get("copy_status"),
+            "source_items_submitted": result.get("source_items_submitted"),
+            "source_marked_read_only": result.get("source_marked_read_only"),
+        },
+    )
+    return JSONResponse({"success": True, "export": result})
 
 
 async def m365_reset_staff_password(staff_id: int, request: Request):

--- a/app/features/staff/routes.py
+++ b/app/features/staff/routes.py
@@ -96,6 +96,11 @@ router.add_api_route("/staff/enabled", handlers.set_staff_enabled, methods=["POS
 router.add_api_route("/staff/{staff_id}/verify", handlers.verify_staff_member, methods=["POST"])
 router.add_api_route("/staff/{staff_id}/invite", handlers.invite_staff_member, methods=["POST"])
 router.add_api_route(
+    "/api/staff/{staff_id}/m365/export-onedrive",
+    handlers.m365_export_staff_onedrive,
+    methods=["POST"],
+)
+router.add_api_route(
     "/api/staff/{staff_id}/m365/reset-password",
     handlers.m365_reset_staff_password,
     methods=["POST"],

--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -1049,6 +1049,52 @@ async def _graph_get(
     return response.json()
 
 
+async def list_sharepoint_export_sites(company_id: int) -> list[dict[str, Any]]:
+    """Return SharePoint sites with their default document-library drive IDs for export selection."""
+
+    access_token = await acquire_access_token(company_id, force_client_credentials=True)
+    sites = await _graph_get_all(
+        access_token,
+        "https://graph.microsoft.com/v1.0/sites?search=*&$select=id,displayName,name,webUrl&$top=200",
+    )
+    options: list[dict[str, Any]] = []
+    for site in sites:
+        site_id = str(site.get("id") or "").strip()
+        if not site_id:
+            continue
+        try:
+            drive = await _graph_get(
+                access_token,
+                f"https://graph.microsoft.com/v1.0/sites/{quote(site_id, safe='')}/drive?$select=id,name,webUrl",
+            )
+        except M365Error as exc:
+            log_warning(
+                "Skipping SharePoint site without accessible default drive",
+                company_id=company_id,
+                site_id=site_id,
+                http_status=exc.http_status,
+                error=str(exc),
+            )
+            continue
+        drive_id = str(drive.get("id") or "").strip()
+        if not drive_id:
+            continue
+        display_name = str(site.get("displayName") or site.get("name") or site.get("webUrl") or site_id).strip()
+        options.append(
+            {
+                "site_id": site_id,
+                "site_name": display_name,
+                "site_web_url": site.get("webUrl"),
+                "drive_id": drive_id,
+                "drive_name": drive.get("name") or "Documents",
+                "drive_web_url": drive.get("webUrl"),
+                "label": f"{display_name} ({drive.get('name') or 'Documents'})",
+            }
+        )
+    options.sort(key=lambda item: str(item.get("label") or "").lower())
+    return options
+
+
 async def _graph_get_all(access_token: str, url: str) -> list[dict[str, Any]]:
     """GET a Microsoft Graph collection endpoint, following ``@odata.nextLink`` pagination.
 

--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -1101,6 +1101,14 @@ async def _execute_policy_step(
     if step_type == "m365_assign_license":
         return await _run_licensing_step(company_id=company_id, staff=staff, policy_config=policy_config)
 
+    if step_type == "m365_export_onedrive":
+        return await _run_export_onedrive_step(
+            company_id=company_id,
+            staff=staff,
+            step_config=step,
+            vars_map=vars_map,
+        )
+
     if step_type in {"http_get", "http_post"}:
         method = "GET" if step_type == "http_get" else "POST"
         url = _validate_web_url(_resolve_template_value(step.get("url"), vars_map=vars_map), field_name="url")
@@ -1951,6 +1959,222 @@ async def _resolve_staff_m365_user(
     if not matched or not matched.get("id"):
         raise WorkflowStepError(f"Unable to locate M365 user for {email}")
     return matched
+
+
+async def _graph_post_for_location(access_token: str, url: str, payload: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    headers = {"Authorization": f"Bearer {access_token}"}
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.post(url, headers=headers, json=payload)
+    if response.status_code not in (200, 201, 202, 204):
+        log_error(
+            "Microsoft Graph POST failed",
+            url=url,
+            status=response.status_code,
+            body=response.text,
+        )
+        raise WorkflowStepError(
+            f"Microsoft Graph POST failed ({response.status_code})",
+            request_payload={"url": url, "payload": payload},
+            http_status=response.status_code,
+        )
+    body = {} if response.status_code == 204 or not response.text else response.json()
+    return body, response.headers.get("Location")
+
+
+async def _wait_for_graph_copy(access_token: str, monitor_url: str, *, timeout_seconds: int) -> dict[str, Any]:
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=max(1, timeout_seconds))
+    headers = {"Authorization": f"Bearer {access_token}"}
+    last_payload: dict[str, Any] = {}
+    async with httpx.AsyncClient(timeout=30) as client:
+        while datetime.now(timezone.utc) < deadline:
+            response = await client.get(monitor_url, headers=headers)
+            if response.status_code >= 400:
+                raise WorkflowStepError(
+                    f"OneDrive export copy monitor failed ({response.status_code})",
+                    request_payload={"monitor_url": monitor_url},
+                    http_status=response.status_code,
+                )
+            last_payload = response.json() if response.text else {}
+            status_text = str(last_payload.get("status") or "").strip().lower()
+            if status_text in {"completed", "complete", "succeeded"}:
+                return last_payload
+            if status_text in {"failed", "deleted", "cancelled", "canceled"}:
+                raise WorkflowStepError(
+                    f"OneDrive export copy failed: {status_text or 'unknown'}",
+                    request_payload={"monitor_url": monitor_url, "monitor_payload": last_payload},
+                )
+            await asyncio.sleep(5)
+    raise WorkflowStepError(
+        "OneDrive export copy did not complete before timeout",
+        request_payload={"monitor_url": monitor_url, "last_payload": last_payload},
+    )
+
+
+async def export_onedrive_for_staff(
+    *,
+    company_id: int,
+    staff: dict[str, Any],
+    destination_drive_id: str,
+    destination_parent_item_id: str = "root",
+    mark_source_read_only: bool = True,
+    wait_for_completion: bool = True,
+    copy_timeout_seconds: int = 3600,
+    folder_conflict_behavior: str = "fail",
+) -> dict[str, Any]:
+    """Export a staff member's OneDrive using explicit destination settings."""
+
+    return await _run_export_onedrive_step(
+        company_id=company_id,
+        staff=staff,
+        step_config={
+            "destination_drive_id": destination_drive_id,
+            "destination_parent_item_id": destination_parent_item_id,
+            "mark_source_read_only": mark_source_read_only,
+            "wait_for_completion": wait_for_completion,
+            "copy_timeout_seconds": copy_timeout_seconds,
+            "folder_conflict_behavior": folder_conflict_behavior,
+        },
+        vars_map={},
+    )
+
+
+async def _run_export_onedrive_step(
+    *,
+    company_id: int,
+    staff: dict[str, Any],
+    step_config: dict[str, Any] | None = None,
+    vars_map: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    _vars = vars_map or {}
+    _step = step_config or {}
+    destination_drive_id = str(_resolve_template_value(_step.get("destination_drive_id"), vars_map=_vars) or "").strip()
+    if not destination_drive_id:
+        company = await company_repo.get_company_by_id(company_id)
+        destination_drive_id = str((company or {}).get("onedrive_export_drive_id") or "").strip()
+    destination_parent_item_id = str(
+        _resolve_template_value(_step.get("destination_parent_item_id"), vars_map=_vars) or "root"
+    ).strip() or "root"
+    if not destination_drive_id:
+        raise WorkflowStepError(
+            "Export OneDrive requires a destination_drive_id or a company OneDrive export site setting"
+        )
+
+    conflict_behavior = str(
+        _resolve_template_value(_step.get("folder_conflict_behavior"), vars_map=_vars) or "fail"
+    ).strip().lower()
+    if conflict_behavior not in {"fail", "rename", "replace"}:
+        raise WorkflowStepError("folder_conflict_behavior must be fail, rename, or replace")
+
+    access_token = await m365_service.acquire_access_token(company_id, force_client_credentials=True)
+    user = await _resolve_staff_m365_user(company_id, staff, access_token=access_token)
+    user_id = str(user["id"]).strip()
+    user_upn = str(user.get("userPrincipalName") or staff.get("email") or "").strip()
+    if not user_upn:
+        raise WorkflowStepError("Unable to resolve user UPN for OneDrive export")
+    encoded_user_id = quote(user_id, safe="")
+    safe_folder_name = user_upn.replace("/", "_").replace("\\", "_")
+
+    source_root = await m365_service._graph_get(  # pyright: ignore[reportPrivateUsage]
+        access_token,
+        f"https://graph.microsoft.com/v1.0/users/{encoded_user_id}/drive/root?$select=id,name,webUrl",
+    )
+    source_root_id = str(source_root.get("id") or "root").strip() or "root"
+
+    destination_folder = await m365_service._graph_post(  # pyright: ignore[reportPrivateUsage]
+        access_token,
+        f"https://graph.microsoft.com/v1.0/drives/{quote(destination_drive_id, safe='')}/items/{quote(destination_parent_item_id, safe='')}/children",
+        {
+            "name": safe_folder_name,
+            "folder": {},
+            "@microsoft.graph.conflictBehavior": conflict_behavior,
+        },
+    )
+    destination_folder_id = str(destination_folder.get("id") or "").strip()
+    if not destination_folder_id:
+        raise WorkflowStepError("Graph did not return an ID for the OneDrive export destination folder")
+
+    source_children = await m365_service._graph_get_all(  # pyright: ignore[reportPrivateUsage]
+        access_token,
+        f"https://graph.microsoft.com/v1.0/users/{encoded_user_id}/drive/items/{quote(source_root_id, safe='')}/children",
+    )
+
+    monitor_urls: list[str] = []
+    copied_items: list[dict[str, str]] = []
+    for child in source_children:
+        child_id = str(child.get("id") or "").strip()
+        child_name = str(child.get("name") or "").strip()
+        if not child_id:
+            continue
+        copy_payload = {
+            "parentReference": {
+                "driveId": destination_drive_id,
+                "id": destination_folder_id,
+            },
+            "name": child_name or None,
+        }
+        copy_payload = {key: value for key, value in copy_payload.items() if value is not None}
+        _, monitor_url = await _graph_post_for_location(
+            access_token,
+            f"https://graph.microsoft.com/v1.0/users/{encoded_user_id}/drive/items/{quote(child_id, safe='')}/copy",
+            copy_payload,
+        )
+        if monitor_url:
+            monitor_urls.append(monitor_url)
+        copied_items.append({"id": child_id, "name": child_name})
+
+    monitor_payloads: list[dict[str, Any]] = []
+    if monitor_urls and bool(_step.get("wait_for_completion", True)):
+        timeout_seconds = int(_step.get("copy_timeout_seconds") or 3600)
+        for monitor_url in monitor_urls:
+            monitor_payloads.append(
+                await _wait_for_graph_copy(access_token, monitor_url, timeout_seconds=timeout_seconds)
+            )
+
+    read_only_applied = False
+    if bool(_step.get("mark_source_read_only", True)):
+        try:
+            await m365_service._graph_post(  # pyright: ignore[reportPrivateUsage]
+                access_token,
+                f"https://graph.microsoft.com/v1.0/users/{encoded_user_id}/drive/items/{quote(source_root_id, safe='')}/invite",
+                {
+                    "requireSignIn": True,
+                    "sendInvitation": False,
+                    "roles": ["read"],
+                    "recipients": [{"email": user_upn}],
+                    "retainInheritedPermissions": False,
+                },
+            )
+            read_only_applied = True
+        except M365Error as exc:
+            log_warning(
+                "Offboarding Export OneDrive: unable to mark source read-only",
+                user_id=user_id,
+                user_upn=user_upn,
+                http_status=exc.http_status,
+                error=str(exc),
+            )
+
+    completed_count = sum(
+        1 for payload in monitor_payloads if str(payload.get("status") or "").strip().lower() in {"completed", "complete", "succeeded"}
+    )
+    copy_status = "completed" if monitor_payloads and completed_count == len(monitor_payloads) else ("accepted" if monitor_urls else "submitted")
+
+    return {
+        "company_id": int(company_id),
+        "staff_id": int(staff["id"]),
+        "m365_user_id": user_id,
+        "user_principal_name": user_upn,
+        "destination_drive_id": destination_drive_id,
+        "destination_parent_item_id": destination_parent_item_id,
+        "destination_folder_id": destination_folder_id,
+        "destination_folder_name": safe_folder_name,
+        "destination_folder_web_url": destination_folder.get("webUrl"),
+        "copy_monitor_urls": monitor_urls,
+        "copy_status": copy_status,
+        "source_items_submitted": len(copied_items),
+        "source_items": copied_items,
+        "source_marked_read_only": read_only_applied,
+    }
 
 
 async def _run_offboarding_step(

--- a/app/static/js/staff.js
+++ b/app/static/js/staff.js
@@ -515,6 +515,7 @@
       workflowRetry: container.querySelector('[data-edit-action="workflow-retry"]'),
       workflowResume: container.querySelector('[data-edit-action="workflow-resume"]'),
       workflowForceComplete: container.querySelector('[data-edit-action="workflow-force-complete"]'),
+      m365ExportOneDrive: container.querySelector('[data-edit-action="m365-export-onedrive"]'),
       m365ResetPassword: container.querySelector('[data-edit-action="m365-reset-password"]'),
       m365EnableSignIn: container.querySelector('[data-edit-action="m365-enable-sign-in"]'),
       m365DisableSignIn: container.querySelector('[data-edit-action="m365-disable-sign-in"]'),
@@ -813,6 +814,8 @@
       setActionVisibility(editActionButtons.workflowResume, { visible: workflowContext.canResume, disabled: false });
       setActionVisibility(editActionButtons.workflowForceComplete, { visible: workflowContext.canForceComplete, disabled: false });
       const canM365Actions = Boolean(flags && flags.isSuperAdmin && flags.hasM365 && member.email);
+      const canExportOneDrive = Boolean(canM365Actions && flags.manualOneDriveExportEnabled);
+      setActionVisibility(editActionButtons.m365ExportOneDrive, { visible: canExportOneDrive, disabled: false });
       setActionVisibility(editActionButtons.m365ResetPassword, { visible: canM365Actions, disabled: false });
       setActionVisibility(editActionButtons.m365EnableSignIn, { visible: canM365Actions, disabled: false });
       setActionVisibility(editActionButtons.m365DisableSignIn, { visible: canM365Actions, disabled: false });
@@ -1018,6 +1021,20 @@
       });
     }
 
+    async function exportM365OneDrive(staffId) {
+      const member = staffById.get(String(staffId)) || staffById.get(Number(staffId));
+      const name = member ? `${member.first_name || ''} ${member.last_name || ''}`.trim() || member.email || 'this staff member' : 'this staff member';
+      if (!window.confirm(`Export OneDrive for ${name}? This may take some time and uses the SharePoint destination configured in .env.`)) {
+        return;
+      }
+      const data = await requestJson(`/api/staff/${staffId}/m365/export-onedrive`, { method: 'POST' });
+      const exported = data && data.export ? data.export : {};
+      const folderName = exported.destination_folder_name || 'the configured folder';
+      const status = exported.copy_status || 'submitted';
+      window.alert(`OneDrive export ${status} for ${folderName}. Submitted ${exported.source_items_submitted || 0} root item(s).`);
+      window.location.reload();
+    }
+
     async function resetM365Password(staffId) {
       const data = await requestJson(`/api/staff/${staffId}/m365/reset-password`, { method: 'POST' });
       const password = data && data.password ? data.password : '';
@@ -1046,6 +1063,20 @@
           return;
         }
         openOffboardingRequestModal(id);
+      });
+    });
+
+    container.querySelectorAll('[data-staff-export-onedrive]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const id = button.getAttribute('data-staff-export-onedrive');
+        if (!id) {
+          return;
+        }
+        try {
+          await exportM365OneDrive(id);
+        } catch (error) {
+          alert(`Failed to export OneDrive: ${error.message}`);
+        }
       });
     });
 
@@ -1409,6 +1440,19 @@
           }, getActionStep((editActionButtons.workflowForceComplete.dataset.currentStep || '').trim()), getActionNote() || '');
         } catch (error) {
           setInlineError(editActionError, `Failed to force-complete workflow step: ${error.message}`);
+        }
+      });
+    }
+    if (editActionButtons.m365ExportOneDrive) {
+      editActionButtons.m365ExportOneDrive.addEventListener('click', async () => {
+        if (!currentEditStaffId) {
+          return;
+        }
+        try {
+          setInlineError(editActionError, '');
+          await exportM365OneDrive(currentEditStaffId);
+        } catch (error) {
+          setInlineError(editActionError, `Failed to export OneDrive: ${error.message}`);
         }
       });
     }

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -270,6 +270,48 @@
             <p class="form-help">When enabled, admins can select a staff member to forward emails to when submitting an offboarding request. Disable if your company uses a fixed forwarding address configured in the workflow step.</p>
           </div>
           <div class="form-field">
+            <label class="form-label" for="edit-company-onedrive-export-site">OneDrive export SharePoint site</label>
+            {% if m365_has_credentials %}
+              <select
+                id="edit-company-onedrive-export-site"
+                name="onedriveExportSite"
+                class="form-input"
+              >
+                <option value="">Do not enable manual OneDrive exports</option>
+                {% if form_data.onedrive_export_drive_id %}
+                  {% set saved_site_payload = {
+                    'site_id': form_data.onedrive_export_site_id,
+                    'site_name': form_data.onedrive_export_site_name,
+                    'drive_id': form_data.onedrive_export_drive_id
+                  } %}
+                  <option value="{{ saved_site_payload | tojson | forceescape }}" selected>
+                    Current: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}
+                  </option>
+                {% endif %}
+                {% for site in onedrive_export_site_options %}
+                  {% set site_payload = {
+                    'site_id': site.site_id,
+                    'site_name': site.site_name,
+                    'drive_id': site.drive_id
+                  } %}
+                  <option
+                    value="{{ site_payload | tojson | forceescape }}"
+                  >{{ site.label }}</option>
+                {% endfor %}
+              </select>
+              <p class="form-help">Select the SharePoint site/default document library that will receive OneDrive export folders. The system stores the selected library drive ID against this company.</p>
+              {% if form_data.onedrive_export_drive_id and not onedrive_export_site_options %}
+                <p class="form-help">Current saved export site: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}</p>
+              {% endif %}
+              {% if onedrive_export_sites_error %}
+                <p class="form-help form-help--error">Unable to load SharePoint sites: {{ onedrive_export_sites_error }}</p>
+              {% endif %}
+            {% else %}
+              <input class="form-input" id="edit-company-onedrive-export-site" value="Configure Microsoft 365 credentials first" readonly />
+              <p class="form-help">Complete this company's Office 365 configuration before selecting a OneDrive export destination.</p>
+            {% endif %}
+          </div>
+          <div class="form-field">
             <label class="form-label">Payment method</label>
             <div class="form-checkbox-group">
               <label class="form-checkbox__label">

--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -371,6 +371,9 @@
                 <td class="table__actions">
                   <div class="table__action-buttons">
                     <button type="button" class="button button--ghost" data-staff-edit="{{ member.id }}">{{ 'Edit' if can_edit_staff else 'Actions' }}</button>
+                    {% if is_super_admin and has_m365 and manual_onedrive_export_enabled and member.email %}
+                      <button type="button" class="button button--ghost" data-staff-export-onedrive="{{ member.id }}">Export OneDrive</button>
+                    {% endif %}
                     {% if is_super_admin %}
                       <button type="button" class="button button--ghost" data-staff-verify="{{ member.id }}" {% if not member.mobile_phone %}disabled{% endif %}>Send code</button>
                     {% endif %}
@@ -822,6 +825,7 @@
           <button type="button" class="button button--ghost" id="edit-action-workflow-retry" data-edit-action="workflow-retry">Workflow retry</button>
           <button type="button" class="button button--ghost" id="edit-action-workflow-resume" data-edit-action="workflow-resume">Workflow resume</button>
           <button type="button" class="button button--ghost" id="edit-action-workflow-force-complete" data-edit-action="workflow-force-complete">Workflow force-complete</button>
+          <button type="button" class="button button--ghost" id="edit-action-m365-export-onedrive" data-edit-action="m365-export-onedrive" hidden>Export OneDrive</button>
           <button type="button" class="button button--ghost" id="edit-action-m365-reset-password" data-edit-action="m365-reset-password" hidden>Reset O365 Password</button>
           <button type="button" class="button button--ghost" id="edit-action-m365-enable-sign-in" data-edit-action="m365-enable-sign-in" hidden>Enable O365 Sign-in</button>
           <button type="button" class="button button--ghost" id="edit-action-m365-disable-sign-in" data-edit-action="m365-disable-sign-in" hidden>Disable O365 Sign-in</button>
@@ -864,7 +868,8 @@
   'canRequestStaffOffboarding': can_request_staff_offboarding,
   'isHelpdeskTechnician': is_helpdesk_technician,
   'offboardingEmailForwardingEnabled': offboarding_email_forwarding_enabled,
-  'hasM365': has_m365
+  'hasM365': has_m365,
+  'manualOneDriveExportEnabled': manual_onedrive_export_enabled
 } | tojson }}</script>
 <script type="application/json" id="active-staff-for-offboarding">{{ active_staff_for_offboarding | tojson }}</script>
 

--- a/migrations/274_company_onedrive_export_settings.sql
+++ b/migrations/274_company_onedrive_export_settings.sql
@@ -1,0 +1,8 @@
+-- Migration 274: per-company OneDrive export destination settings.
+-- Stores the SharePoint site/default document-library drive selected by admins
+-- for manual Staff table OneDrive exports and workflow fallback behaviour.
+
+ALTER TABLE companies
+    ADD COLUMN IF NOT EXISTS onedrive_export_site_id VARCHAR(512) NULL,
+    ADD COLUMN IF NOT EXISTS onedrive_export_site_name VARCHAR(255) NULL,
+    ADD COLUMN IF NOT EXISTS onedrive_export_drive_id VARCHAR(512) NULL;

--- a/tests/test_m365_sharepoint_export_sites.py
+++ b/tests/test_m365_sharepoint_export_sites.py
@@ -1,0 +1,34 @@
+import pytest
+
+from app.services import m365 as m365_service
+
+
+@pytest.mark.anyio
+async def test_list_sharepoint_export_sites_includes_default_drive(monkeypatch):
+    async def fake_acquire(company_id, force_client_credentials=False):
+        assert company_id == 42
+        assert force_client_credentials is True
+        return "token"
+
+    async def fake_get_all(token, url):
+        assert token == "token"
+        assert "sites?search=*" in url
+        return [
+            {"id": "site-2", "displayName": "Beta", "webUrl": "https://contoso/sites/beta"},
+            {"id": "site-1", "displayName": "Alpha", "webUrl": "https://contoso/sites/alpha"},
+        ]
+
+    async def fake_get(token, url, *, extra_headers=None):
+        if "site-1" in url:
+            return {"id": "drive-1", "name": "Documents", "webUrl": "https://contoso/sites/alpha/docs"}
+        return {"id": "drive-2", "name": "Shared Documents", "webUrl": "https://contoso/sites/beta/docs"}
+
+    monkeypatch.setattr(m365_service, "acquire_access_token", fake_acquire)
+    monkeypatch.setattr(m365_service, "_graph_get_all", fake_get_all)
+    monkeypatch.setattr(m365_service, "_graph_get", fake_get)
+
+    sites = await m365_service.list_sharepoint_export_sites(42)
+
+    assert [site["site_name"] for site in sites] == ["Alpha", "Beta"]
+    assert sites[0]["drive_id"] == "drive-1"
+    assert sites[0]["label"] == "Alpha (Documents)"

--- a/tests/test_staff_offboarding_export_onedrive.py
+++ b/tests/test_staff_offboarding_export_onedrive.py
@@ -1,0 +1,96 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from app.services import staff_onboarding_workflows as workflows
+
+
+@pytest.mark.anyio
+async def test_export_onedrive_creates_upn_folder_copies_children_and_marks_read_only(monkeypatch):
+    calls = {"get": [], "get_all": [], "post_location": [], "post": []}
+
+    monkeypatch.setattr(
+        workflows.m365_service,
+        "acquire_access_token",
+        AsyncMock(return_value="token"),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_staff_m365_user",
+        AsyncMock(return_value={"id": "user-id", "userPrincipalName": "user@example.com"}),
+    )
+
+    async def fake_graph_get(token, url):
+        calls["get"].append((token, url))
+        return {"id": "root-id", "name": "root"}
+
+    async def fake_graph_get_all(token, url):
+        calls["get_all"].append((token, url))
+        return [
+            {"id": "child-1", "name": "Documents"},
+            {"id": "child-2", "name": "Notes.txt"},
+        ]
+
+    async def fake_graph_post(token, url, payload):
+        calls["post"].append((token, url, payload))
+        if url.endswith("/children"):
+            return {"id": "dest-folder-id", "name": payload["name"], "webUrl": "https://sharepoint/export"}
+        return {"value": []}
+
+    async def fake_post_location(token, url, payload):
+        calls["post_location"].append((token, url, payload))
+        return {}, f"https://graph.microsoft.com/monitor/{len(calls['post_location'])}"
+
+    async def fake_wait(token, monitor_url, *, timeout_seconds):
+        return {"status": "completed"}
+
+    monkeypatch.setattr(workflows.m365_service, "_graph_get", fake_graph_get)
+    monkeypatch.setattr(workflows.m365_service, "_graph_get_all", fake_graph_get_all)
+    monkeypatch.setattr(workflows.m365_service, "_graph_post", fake_graph_post)
+    monkeypatch.setattr(workflows, "_graph_post_for_location", fake_post_location)
+    monkeypatch.setattr(workflows, "_wait_for_graph_copy", fake_wait)
+
+    result = await workflows._run_export_onedrive_step(
+        company_id=42,
+        staff={"id": 7, "email": "user@example.com"},
+        step_config={
+            "destination_drive_id": "drive-id",
+            "destination_parent_item_id": "parent-id",
+            "mark_source_read_only": True,
+            "wait_for_completion": True,
+            "folder_conflict_behavior": "fail",
+        },
+        vars_map={},
+    )
+
+    assert result["destination_folder_name"] == "user@example.com"
+    assert result["destination_folder_id"] == "dest-folder-id"
+    assert result["copy_status"] == "completed"
+    assert result["source_items_submitted"] == 2
+    assert result["source_marked_read_only"] is True
+    assert calls["post"][0][2] == {
+        "name": "user@example.com",
+        "folder": {},
+        "@microsoft.graph.conflictBehavior": "fail",
+    }
+    assert calls["post_location"][0][2] == {
+        "parentReference": {"driveId": "drive-id", "id": "dest-folder-id"},
+        "name": "Documents",
+    }
+    assert calls["post_location"][1][2] == {
+        "parentReference": {"driveId": "drive-id", "id": "dest-folder-id"},
+        "name": "Notes.txt",
+    }
+    assert calls["post"][-1][2]["roles"] == ["read"]
+    assert calls["post"][-1][2]["retainInheritedPermissions"] is False
+
+
+@pytest.mark.anyio
+async def test_export_onedrive_requires_destination_drive_id(monkeypatch):
+    monkeypatch.setattr(workflows.company_repo, "get_company_by_id", AsyncMock(return_value={}))
+    with pytest.raises(workflows.WorkflowStepError, match="destination_drive_id"):
+        await workflows._run_export_onedrive_step(
+            company_id=42,
+            staff={"id": 7, "email": "user@example.com"},
+            step_config={},
+            vars_map={},
+        )


### PR DESCRIPTION
### Motivation
- Provide admins a way to manually export a staff member's OneDrive into a configured SharePoint document library and optionally mark the source read-only for offboarding and ad-hoc exports.
- Surface a selectable list of SharePoint sites/drives per company so exports can target an admin-chosen destination rather than requiring ad-hoc drive IDs.

### Description
- Adds environment toggles and defaults for OneDrive export behavior (`M365_ONEDRIVE_EXPORT_*`) and exposes them via `Settings` in `app/core/config.py`.
- Introduces per-company fields (`onedrive_export_site_id`, `onedrive_export_site_name`, `onedrive_export_drive_id`) and a DB migration `migrations/274_company_onedrive_export_settings.sql` to store the selected SharePoint destination.
- Implements `m365.list_sharepoint_export_sites` to enumerate SharePoint sites with their default document-library drive IDs and integrates it into the company edit page (`app/features/companies/handlers.py` and `app/templates/admin/company_edit.html`) so admins can pick a destination.
- Implements OneDrive export logic in `app/services/staff_onboarding_workflows.py` including Graph helpers (`_graph_post_for_location`, `_wait_for_graph_copy`), the export step runner `_run_export_onedrive_step`, and a convenience `export_onedrive_for_staff` API call used by the handler.
- Adds a new staff handler and route to trigger manual exports (`m365_export_staff_onedrive` in `app/features/staff/handlers.py` and route `/api/staff/{staff_id}/m365/export-onedrive`), and updates the staff UI (`app/templates/staff/index.html` and `app/static/js/staff.js`) to surface an "Export OneDrive" button and client-side flow.
- Adds unit tests for the new behavior: `tests/test_m365_sharepoint_export_sites.py` and `tests/test_staff_offboarding_export_onedrive.py`.

### Testing
- Added `tests/test_m365_sharepoint_export_sites.py` which validates `list_sharepoint_export_sites` returns sites sorted and includes default drive info; the test passed.
- Added `tests/test_staff_offboarding_export_onedrive.py` which exercises `_run_export_onedrive_step` end-to-end with Graph interactions mocked; the test passed.
- Ran the test suite for the modified components locally and the newly added tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a348436f0c8832d8a72666e6429c46d)