### PR TITLE
Handle shop product deletes with existing orders

### DIFF
--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -2554,9 +2554,29 @@ async def admin_delete_shop_product(request: Request, product_id: int):
     if not product:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
 
-    deleted = await shop_repo.delete_product(product_id)
-    if not deleted:
+    delete_result = await shop_repo.delete_product(product_id)
+    if delete_result in (False, "missing"):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+
+    if delete_result == "archived":
+        _main().log_info(
+            "Shop product archived because it has existing orders",
+            product_id=product_id,
+            updated_by=current_user.get("id") if current_user else None,
+        )
+        await audit_service.record(
+            action="shop.product.archive",
+            request=request,
+            entity_type="shop.product",
+            entity_id=product_id,
+            before={"archived": bool(product.get("archived"))},
+            after={"archived": True, "reason": "referenced_by_orders"},
+        )
+        return flash_redirect(
+            "/admin/shop",
+            "Product has existing orders, so it was archived instead of permanently deleted.",
+            "warning",
+        )
 
     image_url = product.get("image_url")
     if image_url:

--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from datetime import date, datetime, timezone
 from decimal import Decimal
 import re
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Literal, Sequence
 
 import aiomysql
 
@@ -1413,14 +1413,31 @@ async def replace_product_features(
                 raise
 
 
-async def delete_product(product_id: int) -> bool:
+ProductDeleteResult = Literal["deleted", "archived", "missing"]
+
+
+def _is_foreign_key_constraint_error(exc: BaseException) -> bool:
+    code = exc.args[0] if exc.args else None
+    return code == 1451
+
+
+async def delete_product(product_id: int) -> ProductDeleteResult:
     async with db.acquire() as conn:
         async with conn.cursor(aiomysql.DictCursor) as cursor:
-            await cursor.execute(
-                "DELETE FROM shop_products WHERE id = %s",
-                (product_id,),
-            )
-            return cursor.rowcount > 0
+            try:
+                await cursor.execute(
+                    "DELETE FROM shop_products WHERE id = %s",
+                    (product_id,),
+                )
+            except aiomysql.IntegrityError as exc:
+                if not _is_foreign_key_constraint_error(exc):
+                    raise
+                await cursor.execute(
+                    "UPDATE shop_products SET archived = 1 WHERE id = %s",
+                    (product_id,),
+                )
+                return "archived" if cursor.rowcount > 0 else "missing"
+            return "deleted" if cursor.rowcount > 0 else "missing"
 
 
 async def create_order(

--- a/tests/test_shop_admin_delete_product.py
+++ b/tests/test_shop_admin_delete_product.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException, status
 from starlette.requests import Request
 
 from app import main
+from app.features.shop import handlers as shop_handlers
 
 
 @pytest.fixture
@@ -45,7 +46,7 @@ async def test_admin_delete_shop_product_removes_image(monkeypatch):
     get_mock = AsyncMock(return_value=product)
     monkeypatch.setattr(main.shop_repo, "get_product_by_id", get_mock)
 
-    delete_mock = AsyncMock(return_value=True)
+    delete_mock = AsyncMock(return_value="deleted")
     monkeypatch.setattr(main.shop_repo, "delete_product", delete_mock)
 
     deleted_paths: list[tuple[str, Any]] = []
@@ -55,7 +56,7 @@ async def test_admin_delete_shop_product_removes_image(monkeypatch):
 
     monkeypatch.setattr(main, "delete_stored_file", fake_delete)
 
-    response = await main.admin_delete_shop_product(request, product_id=1)
+    response = await shop_handlers.admin_delete_shop_product(request, product_id=1)
 
     assert response.status_code == status.HTTP_303_SEE_OTHER
     assert response.headers["location"] == "/admin/shop"
@@ -77,12 +78,47 @@ async def test_admin_delete_shop_product_missing_raises(monkeypatch):
     get_mock = AsyncMock(return_value=None)
     monkeypatch.setattr(main.shop_repo, "get_product_by_id", get_mock)
 
-    delete_mock = AsyncMock(return_value=False)
+    delete_mock = AsyncMock(return_value="missing")
     monkeypatch.setattr(main.shop_repo, "delete_product", delete_mock)
 
     with pytest.raises(HTTPException) as exc:
-        await main.admin_delete_shop_product(request, product_id=99)
+        await shop_handlers.admin_delete_shop_product(request, product_id=99)
 
     assert exc.value.status_code == status.HTTP_404_NOT_FOUND
     get_mock.assert_awaited_once_with(99)
     delete_mock.assert_not_called()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_admin_delete_shop_product_archives_when_orders_reference_product(monkeypatch):
+    request = _make_request()
+
+    current_user = {"id": 7}
+    monkeypatch.setattr(
+        main,
+        "_require_super_admin_page",
+        AsyncMock(return_value=(current_user, None)),
+    )
+
+    product = {"id": 1, "archived": False, "image_url": "uploads/shop/example.png"}
+    get_mock = AsyncMock(return_value=product)
+    monkeypatch.setattr(main.shop_repo, "get_product_by_id", get_mock)
+
+    delete_mock = AsyncMock(return_value="archived")
+    monkeypatch.setattr(main.shop_repo, "delete_product", delete_mock)
+
+    deleted_paths: list[tuple[str, Any]] = []
+
+    def fake_delete(path: str, root: Any) -> None:  # pragma: no cover - simple capture
+        deleted_paths.append((path, root))
+
+    monkeypatch.setattr(main, "delete_stored_file", fake_delete)
+
+    response = await shop_handlers.admin_delete_shop_product(request, product_id=1)
+
+    assert response.status_code == status.HTTP_303_SEE_OTHER
+    assert response.headers["location"] == "/admin/shop"
+    get_mock.assert_awaited_once_with(1)
+    delete_mock.assert_awaited_once_with(1)
+    assert deleted_paths == []
+    assert "_flash" in response.headers.get("set-cookie", "")


### PR DESCRIPTION
### Motivation
- Avoid returning a 500/internal error when attempting to permanently delete a shop product that is referenced by existing orders due to MySQL foreign-key constraint 1451.
- Preserve data integrity by archiving products that cannot be deleted because of existing references, and surface a clear admin-facing message instead of failing.

### Description
- Update `app/repositories/shop.py` so `delete_product` catches `aiomysql.IntegrityError` for foreign-key code `1451` and falls back to setting `archived = 1`, returning a `Literal` result of `"deleted"`, `"archived"`, or `"missing"`.
- Add a helper `_is_foreign_key_constraint_error` and widen the `delete_product` return contract to communicate the outcome instead of a boolean.
- Update `app/features/shop/handlers.py` admin delete handler to interpret the new delete result, record an archive audit event and show a warning flash message when a product is archived as a fallback, and only remove stored product images when the product was actually deleted.
- Update `tests/test_shop_admin_delete_product.py` to invoke the feature handler directly and add coverage for the three outcomes (`deleted`, `missing`, `archived`) and the admin-facing flash behavior.

### Testing
- Ran `pytest -q tests/test_shop_admin_delete_product.py` and all tests passed (`3 passed`).
- Ran `python -m compileall` on the modified modules and compilation succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a348c6e135c832d8cc5b8dbb49bac61)