### PR TITLE
Add Sites.Read.All permission and actionable 403 for SharePoint export site picker

### DIFF
--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -68,6 +68,9 @@ _TEAMS_ADMIN_ROLE_TEMPLATE_ID = "69091246-20e8-4a56-aa4d-066075b2a7a8"
 # Microsoft Graph application permission required for SharePoint Online best-practice checks.
 # Grants access to GET /admin/sharepoint/settings via the Graph API.
 _SHAREPOINT_TENANT_SETTINGS_ROLE = "a8ead177-1889-4546-9387-f25e658e2a79"
+# Microsoft Graph application permission required to enumerate SharePoint sites
+# and read their default document libraries for OneDrive export destinations.
+_SITES_READ_ALL_ROLE = "332a536c-c7ef-4017-ab91-336970924f0d"
 
 # Pattern matching auto-generated package mailbox names, e.g. package_9024cbae-6e9a-4cee-934e-5f05143cd7ae
 PACKAGE_MAILBOX_RE = re.compile(
@@ -116,6 +119,8 @@ _PROVISION_APP_ROLES: list[str] = [
     "e0b77adb-e790-44a3-b0a0-257d06303687",  # SecuritySecureScore.Read.All (required by /security/secureScores)
     # SharePoint Online tenant settings (required for SPO best-practice checks)
     _SHAREPOINT_TENANT_SETTINGS_ROLE,  # SharePointTenantSettings.Read.All
+    # SharePoint sites and default document libraries (OneDrive export destination picker):
+    _SITES_READ_ALL_ROLE,  # Sites.Read.All
     # MFA registration details report and per-user MFA state checks:
     # - GET /v1.0/reports/authenticationMethods/userRegistrationDetails
     # - GET /beta/users/{id}/authentication/requirements
@@ -199,6 +204,7 @@ _GRAPH_ROLE_NAMES: dict[str, str] = {
     "bf394140-e372-4bf9-a898-299cfc7564e5": "SecurityEvents.Read.All",
     "e0b77adb-e790-44a3-b0a0-257d06303687": "SecuritySecureScore.Read.All",
     "a8ead177-1889-4546-9387-f25e658e2a79": "SharePointTenantSettings.Read.All",
+    "332a536c-c7ef-4017-ab91-336970924f0d": "Sites.Read.All",
     "38d9df27-64da-44fd-b7c5-a6fbac20248f": "UserAuthenticationMethod.Read.All",
     "434d7c66-07c6-4b1f-ab21-417cf2cdaaca": "OrgSettings-Forms.Read.All",
 }
@@ -1053,10 +1059,21 @@ async def list_sharepoint_export_sites(company_id: int) -> list[dict[str, Any]]:
     """Return SharePoint sites with their default document-library drive IDs for export selection."""
 
     access_token = await acquire_access_token(company_id, force_client_credentials=True)
-    sites = await _graph_get_all(
-        access_token,
-        "https://graph.microsoft.com/v1.0/sites?search=*&$select=id,displayName,name,webUrl&$top=200",
-    )
+    try:
+        sites = await _graph_get_all(
+            access_token,
+            "https://graph.microsoft.com/v1.0/sites?search=*&$select=id,displayName,name,webUrl&$top=200",
+        )
+    except M365Error as exc:
+        if exc.http_status == 403:
+            raise M365Error(
+                "Microsoft Graph permission denied while loading SharePoint sites. "
+                "Grant the Sites.Read.All application permission to the Microsoft 365 enterprise app, "
+                "then reconnect the company from Microsoft 365 settings so MyPortal can repair missing permissions.",
+                http_status=exc.http_status,
+                graph_error_code=exc.graph_error_code,
+            ) from exc
+        raise
     options: list[dict[str, Any]] = []
     for site in sites:
         site_id = str(site.get("id") or "").strip()

--- a/tests/test_m365_sharepoint_export_sites.py
+++ b/tests/test_m365_sharepoint_export_sites.py
@@ -32,3 +32,27 @@ async def test_list_sharepoint_export_sites_includes_default_drive(monkeypatch):
     assert [site["site_name"] for site in sites] == ["Alpha", "Beta"]
     assert sites[0]["drive_id"] == "drive-1"
     assert sites[0]["label"] == "Alpha (Documents)"
+
+
+@pytest.mark.anyio
+async def test_list_sharepoint_export_sites_403_mentions_sites_read_all(monkeypatch):
+    async def fake_acquire(company_id, force_client_credentials=False):
+        return "token"
+
+    async def fake_get_all(token, url):
+        raise m365_service.M365Error("Microsoft Graph request failed (403)", http_status=403)
+
+    monkeypatch.setattr(m365_service, "acquire_access_token", fake_acquire)
+    monkeypatch.setattr(m365_service, "_graph_get_all", fake_get_all)
+
+    with pytest.raises(m365_service.M365Error) as exc_info:
+        await m365_service.list_sharepoint_export_sites(42)
+
+    assert exc_info.value.http_status == 403
+    assert "Sites.Read.All" in str(exc_info.value)
+    assert "reconnect the company" in str(exc_info.value)
+
+
+def test_provision_app_roles_includes_sites_read_all_for_sharepoint_export_picker():
+    assert m365_service._SITES_READ_ALL_ROLE in m365_service._PROVISION_APP_ROLES
+    assert m365_service._GRAPH_ROLE_NAMES[m365_service._SITES_READ_ALL_ROLE] == "Sites.Read.All"


### PR DESCRIPTION
### Motivation
- The OneDrive export SharePoint site picker could fail to enumerate sites with a generic 403 (`Microsoft Graph request failed (403)`) when the integration app lacked the Sites.Read.All application permission.
- Provide clearer guidance and ensure the provisioned app requests the permission so admins can repair permissions and continue using the export picker.

### Description
- Added a new constant ` _SITES_READ_ALL_ROLE` for the Graph `Sites.Read.All` application permission and included it in ` _PROVISION_APP_ROLES` so the provisioned enterprise app requests this permission.
- Added `Sites.Read.All` to the human-readable `_GRAPH_ROLE_NAMES` mapping and the enterprise app diagnostics catalog so the permission appears in diagnostic output.
- Wrapped the site enumeration call in `list_sharepoint_export_sites` with a `try/except` that converts a Graph 403 into an actionable `M365Error` message instructing admins to grant `Sites.Read.All` and reconnect the company.
- Added regression tests in `tests/test_m365_sharepoint_export_sites.py` to cover successful site/drive listing and the new 403 guidance, and added an assertion ensuring the new role is present in the provisioned roles.

### Testing
- Ran `pytest tests/test_m365_sharepoint_export_sites.py tests/test_m365_connect_permissions.py::test_try_grant_missing_permissions_grants_sharepoint_when_missing -q` and the tests passed (`4 passed`) with only deprecation warnings unrelated to the change.
- Executed the updated `tests/test_m365_sharepoint_export_sites.py` which includes the success and 403 cases and verified they both pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a348d125548832dbd0e492a7cf0e6ae)