### PR TITLE
Fix OneDrive export root folder endpoint

### DIFF
--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -2080,9 +2080,15 @@ async def _run_export_onedrive_step(
     )
     source_root_id = str(source_root.get("id") or "root").strip() or "root"
 
+    encoded_destination_drive_id = quote(destination_drive_id, safe="")
+    destination_children_url = (
+        f"https://graph.microsoft.com/v1.0/drives/{encoded_destination_drive_id}/root/children"
+        if destination_parent_item_id.lower() == "root"
+        else f"https://graph.microsoft.com/v1.0/drives/{encoded_destination_drive_id}/items/{quote(destination_parent_item_id, safe='')}/children"
+    )
     destination_folder = await m365_service._graph_post(  # pyright: ignore[reportPrivateUsage]
         access_token,
-        f"https://graph.microsoft.com/v1.0/drives/{quote(destination_drive_id, safe='')}/items/{quote(destination_parent_item_id, safe='')}/children",
+        destination_children_url,
         {
             "name": safe_folder_name,
             "folder": {},

--- a/tests/test_staff_offboarding_export_onedrive.py
+++ b/tests/test_staff_offboarding_export_onedrive.py
@@ -85,6 +85,55 @@ async def test_export_onedrive_creates_upn_folder_copies_children_and_marks_read
 
 
 @pytest.mark.anyio
+async def test_export_onedrive_uses_drive_root_children_endpoint_for_default_parent(monkeypatch):
+    calls = {"get": [], "get_all": [], "post_location": [], "post": []}
+
+    monkeypatch.setattr(
+        workflows.m365_service,
+        "acquire_access_token",
+        AsyncMock(return_value="token"),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_staff_m365_user",
+        AsyncMock(return_value={"id": "user-id", "userPrincipalName": "user@example.com"}),
+    )
+
+    async def fake_graph_get(token, url):
+        calls["get"].append((token, url))
+        return {"id": "root-id", "name": "root"}
+
+    async def fake_graph_get_all(token, url):
+        calls["get_all"].append((token, url))
+        return []
+
+    async def fake_graph_post(token, url, payload):
+        calls["post"].append((token, url, payload))
+        if url.endswith("/children"):
+            return {"id": "dest-folder-id", "name": payload["name"]}
+        return {"value": []}
+
+    monkeypatch.setattr(workflows.m365_service, "_graph_get", fake_graph_get)
+    monkeypatch.setattr(workflows.m365_service, "_graph_get_all", fake_graph_get_all)
+    monkeypatch.setattr(workflows.m365_service, "_graph_post", fake_graph_post)
+
+    result = await workflows._run_export_onedrive_step(
+        company_id=42,
+        staff={"id": 7, "email": "user@example.com"},
+        step_config={
+            "destination_drive_id": "drive-id",
+            "destination_parent_item_id": "root",
+            "mark_source_read_only": False,
+        },
+        vars_map={},
+    )
+
+    assert result["destination_folder_id"] == "dest-folder-id"
+    assert calls["post"][0][1] == "https://graph.microsoft.com/v1.0/drives/drive-id/root/children"
+    assert "/items/root/children" not in calls["post"][0][1]
+
+
+@pytest.mark.anyio
 async def test_export_onedrive_requires_destination_drive_id(monkeypatch):
     monkeypatch.setattr(workflows.company_repo, "get_company_by_id", AsyncMock(return_value={}))
     with pytest.raises(workflows.WorkflowStepError, match="destination_drive_id"):


### PR DESCRIPTION
### Motivation
- OneDrive export was posting folder-creation requests to the wrong Graph path for the default `root` parent, which can trigger downstream failures and a 502 response from the API handler. 
- Use the proper Microsoft Graph endpoint for drive root children to avoid incorrect `/items/root/children` requests and improve reliability.

### Description
- Build a `destination_children_url` that uses `https://graph.microsoft.com/v1.0/drives/{drive-id}/root/children` when the configured `destination_parent_item_id` equals `root`, otherwise fall back to the `/items/{id}/children` URL. 
- URL parts are safely encoded with `quote` before constructing the final Graph path and the new `destination_children_url` is passed to the existing `_graph_post` call. 
- Added a regression test `test_export_onedrive_uses_drive_root_children_endpoint_for_default_parent` to assert the correct Graph URL is used for the default root parent.

### Testing
- Ran `pytest tests/test_staff_offboarding_export_onedrive.py -q` and the suite passed (`3 passed`) with warnings only. 
- The new regression test verifies that the code calls `https://graph.microsoft.com/v1.0/drives/drive-id/root/children` and does not use `/items/root/children`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a348f10dcc8832d9276e6306a58ff5c)