### PR TITLE
Handle OneDrive export permission failures

### DIFF
--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -3146,9 +3146,11 @@ async def m365_export_staff_onedrive(staff_id: int, request: Request):
             folder_conflict_behavior=str(settings.m365_onedrive_export_folder_conflict_behavior or "fail"),
         )
     except staff_onboarding_workflow_service.WorkflowStepError as exc:
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+        status_code = exc.http_status if exc.http_status in {400, 403, 404, 409, 429} else status.HTTP_502_BAD_GATEWAY
+        raise HTTPException(status_code=status_code, detail=str(exc))
     except m365_service.M365Error as exc:
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc))
+        status_code = exc.http_status if exc.http_status in {400, 403, 404, 409, 429} else status.HTTP_502_BAD_GATEWAY
+        raise HTTPException(status_code=status_code, detail=str(exc))
 
     await audit_service.log_action(
         entity_type="staff",

--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -2010,6 +2010,35 @@ async def _wait_for_graph_copy(access_token: str, monitor_url: str, *, timeout_s
     )
 
 
+def _onedrive_export_permission_message(exc: M365Error | WorkflowStepError) -> str:
+    """Return an actionable message for Graph-denied OneDrive export writes."""
+
+    graph_code = getattr(exc, "graph_error_code", None)
+    suffix = f" Graph error code: {graph_code}." if graph_code else ""
+    return (
+        "Microsoft Graph denied access while creating the OneDrive export folder in the "
+        "selected SharePoint document library. Confirm the company's M365 enterprise app "
+        "has admin-consented application permissions to write SharePoint/OneDrive content "
+        "(Sites.ReadWrite.All or Files.ReadWrite.All), and if the tenant uses Sites.Selected, "
+        "grant the app write access to the selected export SharePoint site before retrying."
+        f"{suffix}"
+    )
+
+
+def _raise_onedrive_export_graph_error(exc: M365Error | WorkflowStepError, *, operation: str) -> None:
+    """Preserve Graph status codes and add context for OneDrive export failures."""
+
+    http_status = getattr(exc, "http_status", None)
+    if http_status == 403:
+        raise WorkflowStepError(
+            _onedrive_export_permission_message(exc),
+            request_payload={"operation": operation},
+            http_status=403,
+            create_ticket_on_failure=True,
+        ) from exc
+    raise exc
+
+
 async def export_onedrive_for_staff(
     *,
     company_id: int,
@@ -2086,15 +2115,18 @@ async def _run_export_onedrive_step(
         if destination_parent_item_id.lower() == "root"
         else f"https://graph.microsoft.com/v1.0/drives/{encoded_destination_drive_id}/items/{quote(destination_parent_item_id, safe='')}/children"
     )
-    destination_folder = await m365_service._graph_post(  # pyright: ignore[reportPrivateUsage]
-        access_token,
-        destination_children_url,
-        {
-            "name": safe_folder_name,
-            "folder": {},
-            "@microsoft.graph.conflictBehavior": conflict_behavior,
-        },
-    )
+    try:
+        destination_folder = await m365_service._graph_post(  # pyright: ignore[reportPrivateUsage]
+            access_token,
+            destination_children_url,
+            {
+                "name": safe_folder_name,
+                "folder": {},
+                "@microsoft.graph.conflictBehavior": conflict_behavior,
+            },
+        )
+    except M365Error as exc:
+        _raise_onedrive_export_graph_error(exc, operation="create_destination_folder")
     destination_folder_id = str(destination_folder.get("id") or "").strip()
     if not destination_folder_id:
         raise WorkflowStepError("Graph did not return an ID for the OneDrive export destination folder")
@@ -2119,11 +2151,14 @@ async def _run_export_onedrive_step(
             "name": child_name or None,
         }
         copy_payload = {key: value for key, value in copy_payload.items() if value is not None}
-        _, monitor_url = await _graph_post_for_location(
-            access_token,
-            f"https://graph.microsoft.com/v1.0/users/{encoded_user_id}/drive/items/{quote(child_id, safe='')}/copy",
-            copy_payload,
-        )
+        try:
+            _, monitor_url = await _graph_post_for_location(
+                access_token,
+                f"https://graph.microsoft.com/v1.0/users/{encoded_user_id}/drive/items/{quote(child_id, safe='')}/copy",
+                copy_payload,
+            )
+        except WorkflowStepError as exc:
+            _raise_onedrive_export_graph_error(exc, operation="copy_source_item")
         if monitor_url:
             monitor_urls.append(monitor_url)
         copied_items.append({"id": child_id, "name": child_name})

--- a/tests/test_staff_offboarding_export_onedrive.py
+++ b/tests/test_staff_offboarding_export_onedrive.py
@@ -143,3 +143,44 @@ async def test_export_onedrive_requires_destination_drive_id(monkeypatch):
             step_config={},
             vars_map={},
         )
+
+
+@pytest.mark.anyio
+async def test_export_onedrive_destination_403_raises_actionable_permission_error(monkeypatch):
+    monkeypatch.setattr(
+        workflows.m365_service,
+        "acquire_access_token",
+        AsyncMock(return_value="token"),
+    )
+    monkeypatch.setattr(
+        workflows,
+        "_resolve_staff_m365_user",
+        AsyncMock(return_value={"id": "user-id", "userPrincipalName": "user@example.com"}),
+    )
+    monkeypatch.setattr(
+        workflows.m365_service,
+        "_graph_get",
+        AsyncMock(return_value={"id": "root-id", "name": "root"}),
+    )
+
+    async def forbidden_post(token, url, payload):
+        raise workflows.M365Error(
+            "Microsoft Graph POST failed (403): Access denied",
+            http_status=403,
+            graph_error_code="accessDenied",
+        )
+
+    monkeypatch.setattr(workflows.m365_service, "_graph_post", forbidden_post)
+
+    with pytest.raises(workflows.WorkflowStepError) as exc_info:
+        await workflows._run_export_onedrive_step(
+            company_id=42,
+            staff={"id": 7, "email": "user@example.com"},
+            step_config={"destination_drive_id": "drive-id"},
+            vars_map={},
+        )
+
+    assert exc_info.value.http_status == 403
+    assert "Sites.ReadWrite.All" in str(exc_info.value)
+    assert "Sites.Selected" in str(exc_info.value)
+    assert exc_info.value.request_payload == {"operation": "create_destination_folder"}


### PR DESCRIPTION
### Motivation
- Manual OneDrive exports were surfacing Microsoft Graph permission failures as generic 502 errors, hiding actionable client guidance.
- Provide clear, actionable messaging for Graph `403 accessDenied` scenarios (Sites.ReadWrite.All / Files.ReadWrite.All and Sites.Selected guidance) so admins can repair permissions and retry.

### Description
- Added `_onedrive_export_permission_message` and `_raise_onedrive_export_graph_error` helpers to `app/services/staff_onboarding_workflows.py` to produce an actionable 403 WorkflowStepError with operation context when Graph write calls are denied.
- Wrapped the destination-folder creation Graph POST and per-item copy monitor POST calls in `export_onedrive_for_staff`/`_run_export_onedrive_step` to convert Graph `403` failures into the new actionable `WorkflowStepError` while preserving non-403 exceptions.
- Updated the manual export route in `app/features/staff/handlers.py` to preserve client-actionable HTTP statuses (`400, 403, 404, 409, 429`) from `WorkflowStepError`/`M365Error` instead of always returning `502 Bad Gateway`.
- Added a regression test `test_export_onedrive_destination_403_raises_actionable_permission_error` to `tests/test_staff_offboarding_export_onedrive.py` that exercises an `accessDenied` response and asserts the actionable message, preserved `http_status`, and operation payload are returned.

### Testing
- Ran `pytest -q tests/test_staff_offboarding_export_onedrive.py` and the test suite passed (`4 passed`) with the new regression test included.
- Ran `python -m py_compile app/services/staff_onboarding_workflows.py app/features/staff/handlers.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3490c78138832d8c5affd9181c24c7)