### PR TITLE
Defer OneDrive export site lookup

### DIFF
--- a/app/api/routes/companies.py
+++ b/app/api/routes/companies.py
@@ -21,6 +21,7 @@ from app.schemas.company_recurring_invoice_items import (
 from app.schemas.users import StaffRequesterOption
 from app.services import audit as audit_service
 from app.services import company_id_lookup
+from app.services import m365 as m365_service
 
 router = APIRouter(prefix="/api/companies", tags=["Companies"])
 
@@ -435,6 +436,33 @@ async def lookup_xero_contact_id(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error looking up Xero contact ID: {str(exc)}"
         )
+
+
+@router.get("/{company_id}/onedrive-export-sites")
+async def list_onedrive_export_sites(
+    company_id: int,
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    """Lookup SharePoint sites and default drives for OneDrive export selection on demand."""
+    company = await company_repo.get_company_by_id(company_id)
+    if not company:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+
+    try:
+        sites = await m365_service.list_sharepoint_export_sites(company_id)
+    except m365_service.M365Error as exc:
+        raise HTTPException(
+            status_code=exc.http_status or status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error loading SharePoint sites: {str(exc)}",
+        ) from exc
+
+    return {"sites": sites}
 
 
 @router.post("/{company_id}/lookup-hudu-id")

--- a/app/features/companies/handlers.py
+++ b/app/features/companies/handlers.py
@@ -704,8 +704,6 @@ async def _render_company_edit_page(
 
     # Fetch Microsoft 365 credentials for the company
     m365_credential_view: dict[str, Any] | None = None
-    onedrive_export_site_options: list[dict[str, Any]] = []
-    onedrive_export_sites_error: str | None = None
     if is_super_admin:
         try:
             m365_creds = await m365_service.get_credentials(company_id)
@@ -722,10 +720,6 @@ async def _render_company_edit_page(
                     "client_id": m365_creds.get("client_id"),
                     "token_expires_at": expires_display,
                 }
-                try:
-                    onedrive_export_site_options = await m365_service.list_sharepoint_export_sites(company_id)
-                except m365_service.M365Error as exc:
-                    onedrive_export_sites_error = str(exc)
         except RuntimeError as exc:  # pragma: no cover - defensive guard for tests
             if "Database pool not initialised" in str(exc):
                 pass
@@ -789,8 +783,6 @@ async def _render_company_edit_page(
         "show_inactive_tasks": show_inactive_tasks,
         "m365_credential": m365_credential_view,
         "m365_has_credentials": m365_credential_view is not None,
-        "onedrive_export_site_options": onedrive_export_site_options,
-        "onedrive_export_sites_error": onedrive_export_sites_error,
         "m365_admin_credentials_configured": bool(all(await _main()._get_m365_admin_credentials(company_id))),
         "staff_field_config": staff_field_config,
         "staff_custom_field_definitions": staff_custom_field_definitions,

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -2943,10 +2943,13 @@
     const tacticalButton = document.querySelector('[data-lookup-tactical-id]');
     const xeroButton = document.querySelector('[data-lookup-xero-id]');
     const huduButton = document.querySelector('[data-lookup-hudu-id]');
+    const onedriveSitesButton = document.querySelector('[data-lookup-onedrive-export-sites]');
     const huntressButton = document.querySelector('[data-lookup-huntress-id]');
     const tacticalInput = document.getElementById('edit-company-tactical');
     const xeroInput = document.getElementById('edit-company-xero');
     const huduInput = document.getElementById('edit-company-hudu');
+    const onedriveSitesSelect = document.querySelector('[data-onedrive-export-sites-select]');
+    const onedriveSitesError = document.querySelector('[data-onedrive-export-sites-error]');
     const huntressInput = document.getElementById('edit-company-huntress');
 
     const spinnerHtml = '<span class="button__icon" aria-hidden="true"><svg viewBox="0 0 24 24" focusable="false" class="spin-animation"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none" opacity="0.25"/><path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg></span>';
@@ -3005,6 +3008,78 @@
         } finally {
           xeroButton.disabled = false;
           xeroButton.innerHTML = originalText;
+        }
+      });
+    }
+
+
+    if (onedriveSitesButton && onedriveSitesSelect) {
+      onedriveSitesButton.addEventListener('click', async () => {
+        const originalText = onedriveSitesButton.innerHTML;
+        const selectedValue = onedriveSitesSelect.value;
+        onedriveSitesButton.disabled = true;
+        onedriveSitesButton.innerHTML = spinnerHtml;
+        if (onedriveSitesError) {
+          onedriveSitesError.hidden = true;
+          onedriveSitesError.textContent = '';
+        }
+
+        try {
+          const result = await requestJson(`/api/companies/${companyId}/onedrive-export-sites`, {
+            method: 'GET',
+          });
+          const sites = Array.isArray(result?.sites) ? result.sites : [];
+          const existingOptions = Array.from(onedriveSitesSelect.options).filter((option) => {
+            return option.value === '' || option.selected;
+          });
+          onedriveSitesSelect.replaceChildren(...existingOptions);
+
+          sites.forEach((site) => {
+            const siteId = String(site.site_id || '').trim();
+            const driveId = String(site.drive_id || '').trim();
+            if (!siteId || !driveId) {
+              return;
+            }
+            const payload = {
+              site_id: siteId,
+              site_name: String(site.site_name || '').trim(),
+              drive_id: driveId,
+            };
+            const optionValue = JSON.stringify(payload);
+            if (Array.from(onedriveSitesSelect.options).some((option) => option.value === optionValue)) {
+              return;
+            }
+            const option = document.createElement('option');
+            option.value = optionValue;
+            option.textContent = site.label || `${payload.site_name || siteId} (${site.drive_name || 'Documents'})`;
+            onedriveSitesSelect.appendChild(option);
+          });
+
+          if (selectedValue) {
+            const previousOption = Array.from(onedriveSitesSelect.options).find((option) => option.value === selectedValue);
+            if (previousOption) {
+              previousOption.selected = true;
+            }
+          }
+
+          if (!sites.length) {
+            alert('No SharePoint sites were found for this Microsoft 365 tenant.');
+          } else {
+            onedriveSitesSelect.classList.add('form-input--success');
+            setTimeout(() => onedriveSitesSelect.classList.remove('form-input--success'), 2000);
+          }
+        } catch (error) {
+          console.error('Failed to lookup SharePoint sites:', error);
+          const message = error instanceof Error ? error.message : 'Failed to lookup SharePoint sites. Please try again.';
+          if (onedriveSitesError) {
+            onedriveSitesError.textContent = `Unable to load SharePoint sites: ${message}`;
+            onedriveSitesError.hidden = false;
+          } else {
+            alert(message);
+          }
+        } finally {
+          onedriveSitesButton.disabled = false;
+          onedriveSitesButton.innerHTML = originalText;
         }
       });
     }

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -272,40 +272,47 @@
           <div class="form-field">
             <label class="form-label" for="edit-company-onedrive-export-site">OneDrive export SharePoint site</label>
             {% if m365_has_credentials %}
-              <select
-                id="edit-company-onedrive-export-site"
-                name="onedriveExportSite"
-                class="form-input"
-              >
-                <option value="">Do not enable manual OneDrive exports</option>
-                {% if form_data.onedrive_export_drive_id %}
-                  {% set saved_site_payload = {
-                    'site_id': form_data.onedrive_export_site_id,
-                    'site_name': form_data.onedrive_export_site_name,
-                    'drive_id': form_data.onedrive_export_drive_id
-                  } %}
-                  <option value="{{ saved_site_payload | tojson | forceescape }}" selected>
-                    Current: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}
-                  </option>
-                {% endif %}
-                {% for site in onedrive_export_site_options %}
-                  {% set site_payload = {
-                    'site_id': site.site_id,
-                    'site_name': site.site_name,
-                    'drive_id': site.drive_id
-                  } %}
-                  <option
-                    value="{{ site_payload | tojson | forceescape }}"
-                  >{{ site.label }}</option>
-                {% endfor %}
-              </select>
-              <p class="form-help">Select the SharePoint site/default document library that will receive OneDrive export folders. The system stores the selected library drive ID against this company.</p>
-              {% if form_data.onedrive_export_drive_id and not onedrive_export_site_options %}
+              <div class="form-field__group">
+                <select
+                  id="edit-company-onedrive-export-site"
+                  name="onedriveExportSite"
+                  class="form-input"
+                  data-onedrive-export-sites-select
+                >
+                  <option value="">Do not enable manual OneDrive exports</option>
+                  {% if form_data.onedrive_export_drive_id %}
+                    {% set saved_site_payload = {
+                      'site_id': form_data.onedrive_export_site_id,
+                      'site_name': form_data.onedrive_export_site_name,
+                      'drive_id': form_data.onedrive_export_drive_id
+                    } %}
+                    <option value="{{ saved_site_payload | tojson | forceescape }}" selected>
+                      Current: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}
+                    </option>
+                  {% endif %}
+                </select>
+                <button
+                  type="button"
+                  class="button button--ghost"
+                  data-lookup-onedrive-export-sites
+                  title="Lookup SharePoint sites for OneDrive exports"
+                  aria-label="Lookup SharePoint sites for OneDrive exports from Microsoft Graph"
+                >
+                  <span class="button__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8z"/>
+                      <path d="M20 12h2a10 10 0 0 0-10-10v2a8 8 0 0 1 8 8z"/>
+                      <path d="M12 20v2a10 10 0 0 0 10-10h-2a8 8 0 0 1-8 8z"/>
+                      <path d="M4 12H2a10 10 0 0 0 10 10v-2a8 8 0 0 1-8-8z"/>
+                    </svg>
+                  </span>
+                </button>
+              </div>
+              <p class="form-help">Click the lookup button to load SharePoint sites/default document libraries, then select the destination that will receive OneDrive export folders.</p>
+              {% if form_data.onedrive_export_drive_id %}
                 <p class="form-help">Current saved export site: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}</p>
               {% endif %}
-              {% if onedrive_export_sites_error %}
-                <p class="form-help form-help--error">Unable to load SharePoint sites: {{ onedrive_export_sites_error }}</p>
-              {% endif %}
+              <p class="form-help form-help--error" data-onedrive-export-sites-error hidden></p>
             {% else %}
               <input class="form-input" id="edit-company-onedrive-export-site" value="Configure Microsoft 365 credentials first" readonly />
               <p class="form-help">Complete this company's Office 365 configuration before selecting a OneDrive export destination.</p>


### PR DESCRIPTION
### Motivation
- The company edit page was performing an eager Microsoft Graph lookup for SharePoint/OneDrive export sites when M365 credentials exist, causing slow page loads. 
- Move the expensive graph call to an on-demand action so the page renders quickly and mirrors the existing Xero ID lookup UX.

### Description
- Stop calling `m365_service.list_sharepoint_export_sites()` during initial render of the company edit page and only check whether M365 credentials exist. 
- Add a new on-demand API endpoint `GET /api/companies/{company_id}/onedrive-export-sites` that returns SharePoint sites/default drives and converts `m365_service.M365Error` into appropriate HTTP errors. 
- Update the company edit template to replace the eager select with a select + lookup button and an inline error container, preserving any saved selection. 
- Add client-side logic in `app/static/js/admin.js` to call the new endpoint, show a spinner, populate the select, preserve the previous choice, and surface errors inline.

### Testing
- Ran `python -m py_compile app/api/routes/companies.py app/features/companies/handlers.py` which succeeded. 
- Ran `pytest -q tests/test_m365_sharepoint_export_sites.py` which passed. 
- Running a broader company-edit test set initially highlighted an unrelated test harness expectation (`app.main._get_company_management_scope` monkeypatch target) causing failures; that is not caused by these changes and did not block the update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a349124efac832d93ebf8328e6aa998)