### PR TITLE
Add Sites.ReadWrite.All to M365 provisioning and diagnostics (fix OneDrive export writes)

### DIFF
--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -71,6 +71,11 @@ _SHAREPOINT_TENANT_SETTINGS_ROLE = "a8ead177-1889-4546-9387-f25e658e2a79"
 # Microsoft Graph application permission required to enumerate SharePoint sites
 # and read their default document libraries for OneDrive export destinations.
 _SITES_READ_ALL_ROLE = "332a536c-c7ef-4017-ab91-336970924f0d"
+# Microsoft Graph application permission required to create OneDrive export
+# folders and copy OneDrive content into the selected SharePoint document library.
+# Sites.ReadWrite.All is preferred over Files.ReadWrite.All because it is scoped
+# to SharePoint site content rather than all files across the tenant.
+_SITES_READWRITE_ALL_ROLE = "9492366f-7969-46a4-8d15-ed1a20078fff"
 
 # Pattern matching auto-generated package mailbox names, e.g. package_9024cbae-6e9a-4cee-934e-5f05143cd7ae
 PACKAGE_MAILBOX_RE = re.compile(
@@ -121,6 +126,8 @@ _PROVISION_APP_ROLES: list[str] = [
     _SHAREPOINT_TENANT_SETTINGS_ROLE,  # SharePointTenantSettings.Read.All
     # SharePoint sites and default document libraries (OneDrive export destination picker):
     _SITES_READ_ALL_ROLE,  # Sites.Read.All
+    # SharePoint document library writes (OneDrive export folder creation/copy):
+    _SITES_READWRITE_ALL_ROLE,  # Sites.ReadWrite.All
     # MFA registration details report and per-user MFA state checks:
     # - GET /v1.0/reports/authenticationMethods/userRegistrationDetails
     # - GET /beta/users/{id}/authentication/requirements
@@ -205,6 +212,7 @@ _GRAPH_ROLE_NAMES: dict[str, str] = {
     "e0b77adb-e790-44a3-b0a0-257d06303687": "SecuritySecureScore.Read.All",
     "a8ead177-1889-4546-9387-f25e658e2a79": "SharePointTenantSettings.Read.All",
     "332a536c-c7ef-4017-ab91-336970924f0d": "Sites.Read.All",
+    "9492366f-7969-46a4-8d15-ed1a20078fff": "Sites.ReadWrite.All",
     "38d9df27-64da-44fd-b7c5-a6fbac20248f": "UserAuthenticationMethod.Read.All",
     "434d7c66-07c6-4b1f-ab21-417cf2cdaaca": "OrgSettings-Forms.Read.All",
 }

--- a/tests/test_m365_sharepoint_export_sites.py
+++ b/tests/test_m365_sharepoint_export_sites.py
@@ -56,3 +56,20 @@ async def test_list_sharepoint_export_sites_403_mentions_sites_read_all(monkeypa
 def test_provision_app_roles_includes_sites_read_all_for_sharepoint_export_picker():
     assert m365_service._SITES_READ_ALL_ROLE in m365_service._PROVISION_APP_ROLES
     assert m365_service._GRAPH_ROLE_NAMES[m365_service._SITES_READ_ALL_ROLE] == "Sites.Read.All"
+
+
+def test_provision_app_roles_includes_sites_readwrite_all_for_onedrive_export_writes():
+    assert m365_service._SITES_READWRITE_ALL_ROLE in m365_service._PROVISION_APP_ROLES
+    assert (
+        m365_service._GRAPH_ROLE_NAMES[m365_service._SITES_READWRITE_ALL_ROLE]
+        == "Sites.ReadWrite.All"
+    )
+    graph_permissions = next(
+        app["permissions"]
+        for app in m365_service.ENTERPRISE_APP_CATALOG
+        if app["app_id"] == m365_service._GRAPH_APP_ID
+    )
+    assert {permission["name"] for permission in graph_permissions} >= {
+        "Sites.Read.All",
+        "Sites.ReadWrite.All",
+    }


### PR DESCRIPTION
### Motivation
- OneDrive export operations can fail with Graph `accessDenied` when the enterprise app lacks a write-scoped SharePoint permission, so diagnostics and provisioning must include the proper write role.
- The diagnostics catalog previously listed only `Sites.Read.All` for SharePoint/site enumeration, omitting the write permission needed to create/copy export folders.
- Ensure provisioning, repair flows, and diagnostics surface the actionable `Sites.ReadWrite.All` requirement so admins can grant the correct application permission.

### Description
- Added a new constant ` _SITES_READWRITE_ALL_ROLE` with the `Sites.ReadWrite.All` role GUID in `app/services/m365.py`.
- Included ` _SITES_READWRITE_ALL_ROLE` in the `_PROVISION_APP_ROLES` list so provisioning/repair attempts consider it when granting application permissions.
- Added the `Sites.ReadWrite.All` display name to `_GRAPH_ROLE_NAMES` so the enterprise-app diagnostics catalog reports it alongside `Sites.Read.All`.
- Added a regression test `test_provision_app_roles_includes_sites_readwrite_all_for_onedrive_export_writes` in `tests/test_m365_sharepoint_export_sites.py` to assert the role appears in both `_PROVISION_APP_ROLES` and `ENTERPRISE_APP_CATALOG` permissions.

### Testing
- Ran `pytest tests/test_m365_sharepoint_export_sites.py tests/test_m365_connect_permissions.py` and the targeted tests passed (`35 passed`) with warnings about deprecations, indicating the new assertions and existing permission tests succeed.
- Performed static compilation checks via `python -m py_compile app/services/m365.py tests/test_m365_sharepoint_export_sites.py` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3493a0a39c832db07d4dcdcae26662)