### PR TITLE
Prevent Ollama generation for Syncro imports

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -1220,20 +1220,14 @@ async def _upsert_ticket(
             priority=priority,
             status=status,
             category=category_value,
-            module_slug=None,
+            module_slug="syncro",
             external_reference=external_reference,
             ticket_number=ticket_number,
-            trigger_automations=True,
+            trigger_automations=False,
             send_creation_notification=False,
             id=ticket_id_to_use,
         )
         created_id = created.get("id")
-        if created_id is not None:
-            try:
-                await tickets_service.refresh_ticket_ai_summary(int(created_id))
-            except RuntimeError:
-                pass
-            await tickets_service.refresh_ticket_ai_tags(int(created_id))
         ticket_db_id = int(created_id) if created_id is not None else None
         if created_id is not None and any((created_at, updated_at, closed_at)):
             timestamp_updates: dict[str, Any] = {}

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -118,10 +118,50 @@ async def test_import_ticket_by_id_creates_new_ticket(monkeypatch):
     assert created_calls["status"] == "in_progress"
     assert created_calls["ticket_number"] == "101"
     assert created_calls["requester_id"] is None
+    assert created_calls["module_slug"] == "syncro"
+    assert created_calls["trigger_automations"] is False
     # Now the ticket ID should match the Syncro ticket number
     assert created_calls["id"] == 101
     assert update_calls[0][0] == 101
     assert "created_at" in update_calls[0][1]
+
+
+@pytest.mark.anyio
+async def test_import_ticket_by_id_does_not_queue_ollama_generation(monkeypatch):
+    async def fake_get_ticket(ticket_id, rate_limiter=None):
+        return {
+            "id": ticket_id,
+            "subject": "Imported ticket",
+            "status": "New",
+            "problem": "Imported from Syncro",
+        }
+
+    async def fake_get_existing(_external_reference):
+        return None
+
+    async def fake_create_ticket(**kwargs):
+        assert kwargs["module_slug"] == "syncro"
+        assert kwargs["trigger_automations"] is False
+        return {"id": kwargs.get("id") or 222, **kwargs}
+
+    async def fail_refresh_summary(_ticket_id):
+        raise AssertionError("Syncro imports must not queue Ollama summary generation")
+
+    async def fail_refresh_tags(_ticket_id):
+        raise AssertionError("Syncro imports must not queue Ollama tag generation")
+
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_service, "refresh_ticket_ai_summary", fail_refresh_summary)
+    monkeypatch.setattr(tickets_service, "refresh_ticket_ai_tags", fail_refresh_tags)
+    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", lambda _email: None)
+
+    summary = await ticket_importer.import_ticket_by_id(222, rate_limiter=None)
+
+    assert summary.created == 1
+    assert summary.updated == 0
+    assert summary.skipped == 0
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- Imported Syncro tickets were triggering downstream AI generation via `module.ollama.generate` because creation automations and explicit AI refresh calls ran for imports. 
- Imported tickets should be treated as system-imported data and must not enqueue Ollama summary/tag generation or other automations.

### Description
- When creating tickets during a Syncro import, set `module_slug="syncro"` and disable automations by passing `trigger_automations=False` to `tickets_service.create_ticket` in `app/services/ticket_importer.py`.
- Remove the immediate post-create calls to `tickets_service.refresh_ticket_ai_summary` and `tickets_service.refresh_ticket_ai_tags` for Syncro-imported tickets so `module.ollama.generate` is not explicitly queued.
- Update `tests/test_ticket_importer.py` to assert the created ticket includes `module_slug == "syncro"` and `trigger_automations is False`, and add a new test `test_import_ticket_by_id_does_not_queue_ollama_generation` which fails the test if AI refresh functions are invoked.

### Testing
- Ran `pytest tests/test_ticket_importer.py -q` and the file's test suite passed (`63 passed`).
- The new regression test `test_import_ticket_by_id_does_not_queue_ollama_generation` verifies that Syncro imports do not call AI refresh paths and passed as part of the test run.
- No other automated test suites were modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a349411a93483328188f7ac5a3da093)