### PR TITLE
Add Offboarded Staff SharePoint site creation and UI control

### DIFF
--- a/app/api/routes/companies.py
+++ b/app/api/routes/companies.py
@@ -465,6 +465,31 @@ async def list_onedrive_export_sites(
     return {"sites": sites}
 
 
+@router.post("/{company_id}/onedrive-export-sites/offboarded-staff")
+async def create_offboarded_staff_export_site(
+    company_id: int,
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    """Create the default Offboarded Staff SharePoint export site on demand."""
+    company = await company_repo.get_company_by_id(company_id)
+    if not company:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+
+    try:
+        return await m365_service.create_offboarded_staff_export_site(company_id)
+    except m365_service.M365Error as exc:
+        raise HTTPException(
+            status_code=exc.http_status or status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error creating Offboarded Staff site: {str(exc)}",
+        ) from exc
+
+
 @router.post("/{company_id}/lookup-hudu-id")
 async def lookup_hudu_company_id(
     company_id: int,

--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -76,6 +76,9 @@ _SITES_READ_ALL_ROLE = "332a536c-c7ef-4017-ab91-336970924f0d"
 # Sites.ReadWrite.All is preferred over Files.ReadWrite.All because it is scoped
 # to SharePoint site content rather than all files across the tenant.
 _SITES_READWRITE_ALL_ROLE = "9492366f-7969-46a4-8d15-ed1a20078fff"
+# Microsoft Graph application permission required to create the backing Microsoft
+# 365 group for the default Offboarded Staff SharePoint export site.
+_GROUP_READWRITE_ALL_ROLE = "62a82d76-70ea-41e2-9197-370581804d09"
 
 # Pattern matching auto-generated package mailbox names, e.g. package_9024cbae-6e9a-4cee-934e-5f05143cd7ae
 PACKAGE_MAILBOX_RE = re.compile(
@@ -128,6 +131,7 @@ _PROVISION_APP_ROLES: list[str] = [
     _SITES_READ_ALL_ROLE,  # Sites.Read.All
     # SharePoint document library writes (OneDrive export folder creation/copy):
     _SITES_READWRITE_ALL_ROLE,  # Sites.ReadWrite.All
+    _GROUP_READWRITE_ALL_ROLE,  # Group.ReadWrite.All (create Offboarded Staff export site)
     # MFA registration details report and per-user MFA state checks:
     # - GET /v1.0/reports/authenticationMethods/userRegistrationDetails
     # - GET /beta/users/{id}/authentication/requirements
@@ -213,6 +217,7 @@ _GRAPH_ROLE_NAMES: dict[str, str] = {
     "a8ead177-1889-4546-9387-f25e658e2a79": "SharePointTenantSettings.Read.All",
     "332a536c-c7ef-4017-ab91-336970924f0d": "Sites.Read.All",
     "9492366f-7969-46a4-8d15-ed1a20078fff": "Sites.ReadWrite.All",
+    "62a82d76-70ea-41e2-9197-370581804d09": "Group.ReadWrite.All",
     "38d9df27-64da-44fd-b7c5-a6fbac20248f": "UserAuthenticationMethod.Read.All",
     "434d7c66-07c6-4b1f-ab21-417cf2cdaaca": "OrgSettings-Forms.Read.All",
 }
@@ -1063,6 +1068,33 @@ async def _graph_get(
     return response.json()
 
 
+_OFFBOARDED_STAFF_SITE_DISPLAY_NAME = "Offboarded Staff"
+_OFFBOARDED_STAFF_SITE_ALIAS = "OffboardedStaff"
+
+
+def _sharepoint_export_site_option(site: dict[str, Any], drive: dict[str, Any]) -> dict[str, Any] | None:
+    site_id = str(site.get("id") or "").strip()
+    drive_id = str(drive.get("id") or "").strip()
+    if not site_id or not drive_id:
+        return None
+    display_name = str(site.get("displayName") or site.get("name") or site.get("webUrl") or site_id).strip()
+    drive_name = drive.get("name") or "Documents"
+    return {
+        "site_id": site_id,
+        "site_name": display_name,
+        "site_web_url": site.get("webUrl"),
+        "drive_id": drive_id,
+        "drive_name": drive_name,
+        "drive_web_url": drive.get("webUrl"),
+        "label": f"{display_name} ({drive_name})",
+    }
+
+
+def _is_offboarded_staff_site(site: dict[str, Any]) -> bool:
+    values = (site.get("site_name"), site.get("displayName"), site.get("name"))
+    return any(str(value or "").strip().casefold() == _OFFBOARDED_STAFF_SITE_DISPLAY_NAME.casefold() for value in values)
+
+
 async def list_sharepoint_export_sites(company_id: int) -> list[dict[str, Any]]:
     """Return SharePoint sites with their default document-library drive IDs for export selection."""
 
@@ -1104,20 +1136,72 @@ async def list_sharepoint_export_sites(company_id: int) -> list[dict[str, Any]]:
         drive_id = str(drive.get("id") or "").strip()
         if not drive_id:
             continue
-        display_name = str(site.get("displayName") or site.get("name") or site.get("webUrl") or site_id).strip()
-        options.append(
-            {
-                "site_id": site_id,
-                "site_name": display_name,
-                "site_web_url": site.get("webUrl"),
-                "drive_id": drive_id,
-                "drive_name": drive.get("name") or "Documents",
-                "drive_web_url": drive.get("webUrl"),
-                "label": f"{display_name} ({drive.get('name') or 'Documents'})",
-            }
-        )
+        option = _sharepoint_export_site_option(site, drive)
+        if option:
+            options.append(option)
     options.sort(key=lambda item: str(item.get("label") or "").lower())
     return options
+
+
+async def create_offboarded_staff_export_site(company_id: int) -> dict[str, Any]:
+    """Create the default Offboarded Staff SharePoint site and return its export option."""
+
+    existing_sites = await list_sharepoint_export_sites(company_id)
+    for option in existing_sites:
+        if _is_offboarded_staff_site(option):
+            return {"status": "exists", "site": option}
+
+    access_token = await acquire_access_token(company_id, force_client_credentials=True)
+    payload = {
+        "displayName": _OFFBOARDED_STAFF_SITE_DISPLAY_NAME,
+        "description": "Default destination for staff OneDrive exports created by MyPortal.",
+        "groupTypes": ["Unified"],
+        "mailEnabled": True,
+        "mailNickname": _OFFBOARDED_STAFF_SITE_ALIAS,
+        "securityEnabled": False,
+        "visibility": "Private",
+    }
+    try:
+        group = await _graph_post(access_token, "https://graph.microsoft.com/v1.0/groups", payload)
+    except M365Error as exc:
+        if exc.http_status == 403:
+            raise M365Error(
+                "Microsoft Graph permission denied while creating the Offboarded Staff site. "
+                "Grant Group.ReadWrite.All and Sites.ReadWrite.All application permissions, then reconnect the company.",
+                http_status=exc.http_status,
+                graph_error_code=exc.graph_error_code,
+            ) from exc
+        raise
+
+    group_id = str(group.get("id") or "").strip()
+    if not group_id:
+        raise M365Error("Microsoft Graph did not return a group ID for the Offboarded Staff site")
+
+    last_exc: M365Error | None = None
+    for attempt in range(1, 7):
+        try:
+            site = await _graph_get(
+                access_token,
+                f"https://graph.microsoft.com/v1.0/groups/{quote(group_id, safe='')}/sites/root?$select=id,displayName,name,webUrl",
+            )
+            drive = await _graph_get(
+                access_token,
+                f"https://graph.microsoft.com/v1.0/sites/{quote(str(site.get('id') or ''), safe='')}/drive?$select=id,name,webUrl",
+            )
+            option = _sharepoint_export_site_option(site, drive)
+            if option:
+                return {"status": "created", "site": option}
+        except M365Error as exc:
+            last_exc = exc
+            if exc.http_status not in (400, 404):
+                raise
+        await asyncio.sleep(min(attempt * 2, 10))
+
+    raise M365Error(
+        "Created the Offboarded Staff Microsoft 365 group, but its SharePoint site is not ready yet. Refresh sites again in a few minutes.",
+        http_status=last_exc.http_status if last_exc else None,
+        graph_error_code=last_exc.graph_error_code if last_exc else None,
+    )
 
 
 async def _graph_get_all(access_token: str, url: str) -> list[dict[str, Any]]:

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -2944,6 +2944,7 @@
     const xeroButton = document.querySelector('[data-lookup-xero-id]');
     const huduButton = document.querySelector('[data-lookup-hudu-id]');
     const onedriveSitesButton = document.querySelector('[data-lookup-onedrive-export-sites]');
+    const createOffboardedStaffSiteButton = document.querySelector('[data-create-offboarded-staff-site]');
     const huntressButton = document.querySelector('[data-lookup-huntress-id]');
     const tacticalInput = document.getElementById('edit-company-tactical');
     const xeroInput = document.getElementById('edit-company-xero');
@@ -2951,6 +2952,47 @@
     const onedriveSitesSelect = document.querySelector('[data-onedrive-export-sites-select]');
     const onedriveSitesError = document.querySelector('[data-onedrive-export-sites-error]');
     const huntressInput = document.getElementById('edit-company-huntress');
+
+    const offboardedStaffSiteName = 'Offboarded Staff';
+
+    const addOneDriveSiteOption = (site, { select = false } = {}) => {
+      if (!onedriveSitesSelect || !site) {
+        return;
+      }
+      const siteId = String(site.site_id || '').trim();
+      const driveId = String(site.drive_id || '').trim();
+      if (!siteId || !driveId) {
+        return;
+      }
+      const payload = {
+        site_id: siteId,
+        site_name: String(site.site_name || '').trim(),
+        drive_id: driveId,
+      };
+      const optionValue = JSON.stringify(payload);
+      let option = Array.from(onedriveSitesSelect.options).find((candidate) => candidate.value === optionValue);
+      if (!option) {
+        option = document.createElement('option');
+        option.value = optionValue;
+        option.textContent = site.label || `${payload.site_name || siteId} (${site.drive_name || 'Documents'})`;
+        onedriveSitesSelect.appendChild(option);
+      }
+      if (select) {
+        option.selected = true;
+        onedriveSitesSelect.classList.add('form-input--success');
+        setTimeout(() => onedriveSitesSelect.classList.remove('form-input--success'), 2000);
+      }
+    };
+
+    const refreshCreateOffboardedStaffVisibility = (sites) => {
+      if (!createOffboardedStaffSiteButton) {
+        return;
+      }
+      const hasOffboardedStaffSite = Array.isArray(sites) && sites.some((site) => {
+        return String(site.site_name || site.displayName || site.name || '').trim().toLowerCase() === offboardedStaffSiteName.toLowerCase();
+      });
+      createOffboardedStaffSiteButton.hidden = hasOffboardedStaffSite;
+    };
 
     const spinnerHtml = '<span class="button__icon" aria-hidden="true"><svg viewBox="0 0 24 24" focusable="false" class="spin-animation"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none" opacity="0.25"/><path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/></svg></span>';
 
@@ -3035,24 +3077,7 @@
           onedriveSitesSelect.replaceChildren(...existingOptions);
 
           sites.forEach((site) => {
-            const siteId = String(site.site_id || '').trim();
-            const driveId = String(site.drive_id || '').trim();
-            if (!siteId || !driveId) {
-              return;
-            }
-            const payload = {
-              site_id: siteId,
-              site_name: String(site.site_name || '').trim(),
-              drive_id: driveId,
-            };
-            const optionValue = JSON.stringify(payload);
-            if (Array.from(onedriveSitesSelect.options).some((option) => option.value === optionValue)) {
-              return;
-            }
-            const option = document.createElement('option');
-            option.value = optionValue;
-            option.textContent = site.label || `${payload.site_name || siteId} (${site.drive_name || 'Documents'})`;
-            onedriveSitesSelect.appendChild(option);
+            addOneDriveSiteOption(site);
           });
 
           if (selectedValue) {
@@ -3061,6 +3086,8 @@
               previousOption.selected = true;
             }
           }
+
+          refreshCreateOffboardedStaffVisibility(sites);
 
           if (!sites.length) {
             alert('No SharePoint sites were found for this Microsoft 365 tenant.');
@@ -3083,6 +3110,42 @@
         }
       });
     }
+
+    if (createOffboardedStaffSiteButton && onedriveSitesSelect) {
+      createOffboardedStaffSiteButton.addEventListener('click', async () => {
+        const originalText = createOffboardedStaffSiteButton.innerHTML;
+        createOffboardedStaffSiteButton.disabled = true;
+        createOffboardedStaffSiteButton.innerHTML = spinnerHtml;
+        if (onedriveSitesError) {
+          onedriveSitesError.hidden = true;
+          onedriveSitesError.textContent = '';
+        }
+
+        try {
+          const result = await requestJson(`/api/companies/${companyId}/onedrive-export-sites/offboarded-staff`, {
+            method: 'POST',
+          });
+          if (result?.site) {
+            addOneDriveSiteOption(result.site, { select: true });
+            refreshCreateOffboardedStaffVisibility([result.site]);
+          }
+          alert(result?.status === 'exists' ? 'Offboarded Staff already exists and has been selected.' : 'Offboarded Staff was created and selected.');
+        } catch (error) {
+          console.error('Failed to create Offboarded Staff site:', error);
+          const message = error instanceof Error ? error.message : 'Failed to create Offboarded Staff site. Please try again.';
+          if (onedriveSitesError) {
+            onedriveSitesError.textContent = `Unable to create Offboarded Staff site: ${message}`;
+            onedriveSitesError.hidden = false;
+          } else {
+            alert(message);
+          }
+        } finally {
+          createOffboardedStaffSiteButton.disabled = false;
+          createOffboardedStaffSiteButton.innerHTML = originalText;
+        }
+      });
+    }
+
 
     if (huduButton && huduInput) {
       huduButton.addEventListener('click', async () => {

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -307,8 +307,18 @@
                     </svg>
                   </span>
                 </button>
+                <button
+                  type="button"
+                  class="button button--ghost"
+                  data-create-offboarded-staff-site
+                  title="Create the Offboarded Staff SharePoint site for OneDrive exports"
+                  aria-label="Create Offboarded Staff SharePoint site"
+                  hidden
+                >
+                  Create Offboarded Staff
+                </button>
               </div>
-              <p class="form-help">Click the lookup button to load SharePoint sites/default document libraries, then select the destination that will receive OneDrive export folders.</p>
+              <p class="form-help">Click the lookup button to load SharePoint sites/default document libraries, then select the destination that will receive OneDrive export folders. If Offboarded Staff is missing after lookup, use the create button to add it.</p>
               {% if form_data.onedrive_export_drive_id %}
                 <p class="form-help">Current saved export site: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}</p>
               {% endif %}

--- a/tests/test_m365_sharepoint_export_sites.py
+++ b/tests/test_m365_sharepoint_export_sites.py
@@ -73,3 +73,78 @@ def test_provision_app_roles_includes_sites_readwrite_all_for_onedrive_export_wr
         "Sites.Read.All",
         "Sites.ReadWrite.All",
     }
+
+
+@pytest.mark.anyio
+async def test_create_offboarded_staff_export_site_returns_existing_site(monkeypatch):
+    existing = {
+        "site_id": "site-existing",
+        "site_name": "Offboarded Staff",
+        "drive_id": "drive-existing",
+        "label": "Offboarded Staff (Documents)",
+    }
+
+    async def fake_list(company_id):
+        assert company_id == 42
+        return [existing]
+
+    async def fail_acquire(*args, **kwargs):  # pragma: no cover - should not be called
+        raise AssertionError("existing Offboarded Staff site should not create a new group")
+
+    monkeypatch.setattr(m365_service, "list_sharepoint_export_sites", fake_list)
+    monkeypatch.setattr(m365_service, "acquire_access_token", fail_acquire)
+
+    result = await m365_service.create_offboarded_staff_export_site(42)
+
+    assert result == {"status": "exists", "site": existing}
+
+
+@pytest.mark.anyio
+async def test_create_offboarded_staff_export_site_creates_group_and_returns_drive(monkeypatch):
+    calls = []
+
+    async def fake_list(company_id):
+        return []
+
+    async def fake_acquire(company_id, force_client_credentials=False):
+        assert company_id == 42
+        assert force_client_credentials is True
+        return "token"
+
+    async def fake_post(token, url, payload):
+        calls.append((url, payload))
+        assert token == "token"
+        assert url == "https://graph.microsoft.com/v1.0/groups"
+        assert payload["displayName"] == "Offboarded Staff"
+        assert payload["mailNickname"] == "OffboardedStaff"
+        assert payload["groupTypes"] == ["Unified"]
+        return {"id": "group-1"}
+
+    async def fake_get(token, url, *, extra_headers=None):
+        assert token == "token"
+        if "/groups/group-1/sites/root" in url:
+            return {"id": "site-1", "displayName": "Offboarded Staff", "webUrl": "https://contoso/sites/offboardedstaff"}
+        if "/sites/site-1/drive" in url:
+            return {"id": "drive-1", "name": "Documents", "webUrl": "https://contoso/sites/offboardedstaff/docs"}
+        raise AssertionError(f"unexpected Graph URL: {url}")
+
+    async def fake_sleep(delay):
+        raise AssertionError("site was ready immediately; sleep should not be called")
+
+    monkeypatch.setattr(m365_service, "list_sharepoint_export_sites", fake_list)
+    monkeypatch.setattr(m365_service, "acquire_access_token", fake_acquire)
+    monkeypatch.setattr(m365_service, "_graph_post", fake_post)
+    monkeypatch.setattr(m365_service, "_graph_get", fake_get)
+    monkeypatch.setattr(m365_service.asyncio, "sleep", fake_sleep)
+
+    result = await m365_service.create_offboarded_staff_export_site(42)
+
+    assert result["status"] == "created"
+    assert result["site"]["site_name"] == "Offboarded Staff"
+    assert result["site"]["drive_id"] == "drive-1"
+    assert len(calls) == 1
+
+
+def test_provision_app_roles_includes_group_readwrite_all_for_offboarded_staff_site_creation():
+    assert m365_service._GROUP_READWRITE_ALL_ROLE in m365_service._PROVISION_APP_ROLES
+    assert m365_service._GRAPH_ROLE_NAMES[m365_service._GROUP_READWRITE_ALL_ROLE] == "Group.ReadWrite.All"


### PR DESCRIPTION
### Motivation
- Provide an easy recover path when the company OneDrive export picker does not show the expected "Offboarded Staff" SharePoint site after refreshing tenant sites. 
- Allow admins to create the default Offboarded Staff site on-demand and immediately select it as the OneDrive export destination.

### Description
- Add a new authenticated API endpoint `POST /api/companies/{company_id}/onedrive-export-sites/offboarded-staff` that returns an existing export option or creates the backing Microsoft 365 group and waits for its SharePoint site/drive to become available (`app/api/routes/companies.py`).
- Implement service logic to detect an existing Offboarded Staff site or create the Microsoft 365 group via Graph, poll for the group's SharePoint site and drive, and return the same option shape used by the export picker (`app/services/m365.py`).
- Add the `Group.ReadWrite.All` app permission to `_PROVISION_APP_ROLES` and `_GRAPH_ROLE_NAMES` to reflect the permission needed to create the Microsoft 365 group (`app/services/m365.py`).
- Add a hidden `Create Offboarded Staff` button and helper text to the company edit template and client-side JS that shows the button when the refreshed site list lacks Offboarded Staff, calls the new endpoint, and inserts/selects the returned site option (`app/templates/admin/company_edit.html`, `app/static/js/admin.js`).
- Add focused unit tests for reuse of an existing site, group creation and drive discovery, and the new Graph permission registration (`tests/test_m365_sharepoint_export_sites.py`).

### Testing
- Compiled updated Python modules with `python3 -m py_compile app/services/m365.py app/api/routes/companies.py` and there were no syntax errors. 
- Ran the new/updated unit tests with `pytest -q tests/test_m365_sharepoint_export_sites.py`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34964069f48332bea0ab9bddf9ebb2)