### PR TITLE
Fix SharePointTenantSettings.Read.All grant when Graph omits role

### DIFF
--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -222,6 +222,25 @@ _GRAPH_ROLE_NAMES: dict[str, str] = {
     "434d7c66-07c6-4b1f-ab21-417cf2cdaaca": "OrgSettings-Forms.Read.All",
 }
 
+
+# Microsoft Graph application permissions that must be requested/granted even
+# when a tenant's servicePrincipal appRoles projection does not include them.
+# SharePointTenantSettings.Read.All is assignable in tenants where the Entra
+# portal can add it manually, but Graph service-principal lookups can omit it;
+# filtering it out here caused diagnostics repair/re-authorisation to leave the
+# permission missing while still reporting it as an actionable failure.
+_FORCE_GRANT_GRAPH_APP_ROLES: frozenset[str] = frozenset(
+    {
+        _SHAREPOINT_TENANT_SETTINGS_ROLE,
+    }
+)
+
+
+def _is_graph_role_grantable(role_id: str, graph_sp_role_ids: set[str]) -> bool:
+    """Return whether a Graph application role should be requested/granted."""
+    return role_id in graph_sp_role_ids or role_id in _FORCE_GRANT_GRAPH_APP_ROLES
+
+
 # Catalog of enterprise apps and their expected application permissions.
 # Used by the diagnostics page to display Pass/Fail per permission per app.
 ENTERPRISE_APP_CATALOG: list[dict[str, Any]] = [
@@ -1534,9 +1553,15 @@ async def provision_app_registration(
 
     _teams_sp_id, teams_sp_role_ids = await _get_sp_app_role_ids(access_token, _TEAMS_APP_ID)
 
-    # Filter Graph roles to only those present in this tenant's Graph SP.
-    valid_graph_roles: list[str] = [r for r in _PROVISION_APP_ROLES if r in graph_sp_role_ids]
-    skipped_graph_roles: list[str] = [r for r in _PROVISION_APP_ROLES if r not in graph_sp_role_ids]
+    # Filter Graph roles to those present in this tenant's Graph SP, plus
+    # explicitly force-granted roles whose availability lookup can be stale or
+    # incomplete even though Graph accepts the assignment.
+    valid_graph_roles: list[str] = [
+        r for r in _PROVISION_APP_ROLES if _is_graph_role_grantable(r, graph_sp_role_ids)
+    ]
+    skipped_graph_roles: list[str] = [
+        r for r in _PROVISION_APP_ROLES if not _is_graph_role_grantable(r, graph_sp_role_ids)
+    ]
     if skipped_graph_roles:
         log_warning(
             "Some required Graph permissions are not available in this tenant's "
@@ -3565,8 +3590,12 @@ async def try_grant_missing_permissions(
                     company_id=company_id,
                 )
             else:
-                grantable = [r for r in missing if r in graph_sp_role_ids]
-                not_in_tenant = [r for r in missing if r not in graph_sp_role_ids]
+                grantable = [
+                    r for r in missing if _is_graph_role_grantable(r, graph_sp_role_ids)
+                ]
+                not_in_tenant = [
+                    r for r in missing if not _is_graph_role_grantable(r, graph_sp_role_ids)
+                ]
                 if not_in_tenant:
                     log_info(
                         "try_grant_missing_permissions: skipping roles not present "

--- a/tests/test_m365_connect_permissions.py
+++ b/tests/test_m365_connect_permissions.py
@@ -507,6 +507,55 @@ async def test_try_grant_missing_permissions_grants_sharepoint_when_missing():
 
 
 @pytest.mark.anyio("asyncio")
+async def test_try_grant_missing_permissions_grants_sharepoint_when_role_lookup_omits_it():
+    """Repair must still grant SharePointTenantSettings.Read.All if Graph omits it from appRoles."""
+    present_roles = [r for r in _PROVISION_APP_ROLES if r != _SHAREPOINT_TENANT_SETTINGS_ROLE]
+    all_assignments = (
+        [{"appRoleId": r, "resourceId": "graph-sp-id"} for r in present_roles]
+        + [
+            {"appRoleId": _EXO_MANAGE_AS_APP_ROLE, "resourceId": "exo-sp-id"},
+            {"appRoleId": _TEAMS_MANAGE_AS_APP_ROLE, "resourceId": "teams-sp-id"},
+        ]
+    )
+    graph_roles_without_sharepoint = [
+        {"id": r} for r in present_roles if r != _SHAREPOINT_TENANT_SETTINGS_ROLE
+    ]
+
+    granted: list[dict] = []
+
+    async def mock_graph_get(token: str, url: str) -> dict:
+        if "appRoleAssignments" in url:
+            return {"value": all_assignments}
+        if _GRAPH_APP_ID in url:
+            return {"value": [{"id": "graph-sp-id", "appRoles": graph_roles_without_sharepoint}]}
+        if _EXO_APP_ID in url:
+            return {"value": [{"id": "exo-sp-id"}]}
+        if _TEAMS_APP_ID in url:
+            return _teams_sp_response()
+        if "roleManagement/directory/roleAssignments" in url:
+            return {"value": [{"id": "existing-role"}]}
+        return _sp_response("sp-123")
+
+    async def mock_graph_post(token: str, url: str, payload: dict) -> dict:
+        granted.append(payload)
+        return {"id": "new-assignment"}
+
+    with (
+        patch.object(m365_service, "get_credentials", AsyncMock(return_value=_fake_creds())),
+        patch.object(m365_service, "_graph_get", side_effect=mock_graph_get),
+        patch.object(m365_service, "_graph_post", side_effect=mock_graph_post),
+    ):
+        result = await m365_service.try_grant_missing_permissions(
+            company_id=1,
+            access_token="admin-token",
+        )
+
+    assert result is True
+    assert [g["appRoleId"] for g in granted] == [_SHAREPOINT_TENANT_SETTINGS_ROLE]
+    assert granted[0]["resourceId"] == "graph-sp-id"
+
+
+@pytest.mark.anyio("asyncio")
 async def test_check_enterprise_app_permissions_marks_sharepoint_as_fail_when_missing():
     """Diagnostics should treat missing SharePointTenantSettings.Read.All as actionable fail."""
     with (

--- a/tests/test_m365_provision.py
+++ b/tests/test_m365_provision.py
@@ -27,7 +27,14 @@ def _make_sp_data(sp_id: str = "sp-object-id") -> dict[str, Any]:
 
 
 def _make_graph_sp_response(graph_sp_id: str = "graph-sp-id") -> dict[str, Any]:
-    return {"value": [{"id": graph_sp_id}]}
+    return {
+        "value": [
+            {
+                "id": graph_sp_id,
+                "appRoles": [{"id": role_id} for role_id in m365_service._PROVISION_APP_ROLES],
+            }
+        ]
+    }
 
 
 def _make_role_assignment() -> dict[str, Any]:
@@ -203,6 +210,73 @@ async def test_provision_app_registration_default_display_name():
         if "/applications" in p["url"] and "addPassword" not in p["url"]
     )
     assert app_create["payload"]["displayName"] == "MyPortal Integration"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_provision_app_registration_keeps_sharepoint_permission_when_lookup_omits_it():
+    """Provisioning must request SharePointTenantSettings.Read.All even if Graph appRoles omits it."""
+    captured_payloads: list[dict] = []
+    sharepoint_role = m365_service._SHAREPOINT_TENANT_SETTINGS_ROLE
+    graph_roles_without_sharepoint = [
+        {"id": role_id}
+        for role_id in m365_service._PROVISION_APP_ROLES
+        if role_id != sharepoint_role
+    ]
+
+    async def mock_graph_post(token: str, url: str, payload: dict) -> dict:
+        captured_payloads.append({"url": url, "payload": payload})
+        if "/applications" in url and "addPassword" not in url and "owners" not in url:
+            return _make_app_data()
+        if "/servicePrincipals" in url and "appRoleAssignments" not in url:
+            return _make_sp_data()
+        if "appRoleAssignments" in url:
+            return _make_role_assignment()
+        if "owners/$ref" in url:
+            return {}
+        if "addPassword" in url:
+            return _make_secret_data()
+        return {}
+
+    async def mock_graph_get(token: str, url: str, **kwargs: Any) -> dict:
+        if "filter=displayName" in url:
+            return {"value": []}
+        if m365_service._TEAMS_APP_ID in url:
+            return {
+                "value": [
+                    {
+                        "id": "teams-sp-id",
+                        "appRoles": [{"id": m365_service._TEAMS_MANAGE_AS_APP_ROLE}],
+                    }
+                ]
+            }
+        return {"value": [{"id": "graph-sp-id", "appRoles": graph_roles_without_sharepoint}]}
+
+    with (
+        patch.object(m365_service, "_graph_post", side_effect=mock_graph_post),
+        patch.object(m365_service, "_graph_get", side_effect=mock_graph_get),
+    ):
+        await m365_service.provision_app_registration(access_token="token")
+        await drain_provision_background_tasks()
+
+    app_create = next(
+        p for p in captured_payloads
+        if "/applications" in p["url"] and "addPassword" not in p["url"]
+    )
+    graph_access = next(
+        access
+        for access in app_create["payload"]["requiredResourceAccess"]
+        if access["resourceAppId"] == m365_service._GRAPH_APP_ID
+    )
+    requested_graph_roles = {role["id"] for role in graph_access["resourceAccess"]}
+    granted_graph_roles = {
+        p["payload"]["appRoleId"]
+        for p in captured_payloads
+        if "appRoleAssignments" in p["url"]
+        and p["payload"].get("resourceId") == "graph-sp-id"
+    }
+
+    assert sharepoint_role in requested_graph_roles
+    assert sharepoint_role in granted_graph_roles
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation
- Diagnostics and re-authorisation flows could leave `SharePointTenantSettings.Read.All` unassigned because the Microsoft Graph service principal `appRoles` projection sometimes omits that role, causing actionable failures in the Office 365 checks.

### Description
- Add `_FORCE_GRANT_GRAPH_APP_ROLES` and helper `_is_graph_role_grantable` to treat `SharePointTenantSettings.Read.All` as grantable even when the Graph SP lookup doesn't list it.
- Update `provision_app_registration` to include force-granted Graph roles in the created app's `requiredResourceAccess` so provisioning still requests the permission.
- Update `try_grant_missing_permissions` to attempt grants for force-granted roles during diagnostics/repair rather than skipping them.
- Add regression tests in `tests/test_m365_connect_permissions.py` and `tests/test_m365_provision.py` that simulate Graph lookups omitting the SharePoint role and verify provisioning and repair still request/grant it.

### Testing
- Ran `pytest -q tests/test_m365_connect_permissions.py tests/test_m365_provision.py` and the test modules passed (all tests green).
- Ran the new regression tests individually and they passed, confirming the repair and provisioning flows now handle the omitted Graph role correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34a310289883329ae5b9ca6ea4438a)