### PR TITLE
Fix SharePointTenantSettings.Read.All role ID

### DIFF
--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -67,7 +67,7 @@ _TEAMS_ADMIN_ROLE_TEMPLATE_ID = "69091246-20e8-4a56-aa4d-066075b2a7a8"
 
 # Microsoft Graph application permission required for SharePoint Online best-practice checks.
 # Grants access to GET /admin/sharepoint/settings via the Graph API.
-_SHAREPOINT_TENANT_SETTINGS_ROLE = "a8ead177-1889-4546-9387-f25e658e2a79"
+_SHAREPOINT_TENANT_SETTINGS_ROLE = "83d4163d-a2d8-4d3b-9695-4ae3ca98f888"
 # Microsoft Graph application permission required to enumerate SharePoint sites
 # and read their default document libraries for OneDrive export destinations.
 _SITES_READ_ALL_ROLE = "332a536c-c7ef-4017-ab91-336970924f0d"
@@ -214,7 +214,7 @@ _GRAPH_ROLE_NAMES: dict[str, str] = {
     "9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30": "Application.Read.All",
     "bf394140-e372-4bf9-a898-299cfc7564e5": "SecurityEvents.Read.All",
     "e0b77adb-e790-44a3-b0a0-257d06303687": "SecuritySecureScore.Read.All",
-    "a8ead177-1889-4546-9387-f25e658e2a79": "SharePointTenantSettings.Read.All",
+    "83d4163d-a2d8-4d3b-9695-4ae3ca98f888": "SharePointTenantSettings.Read.All",
     "332a536c-c7ef-4017-ab91-336970924f0d": "Sites.Read.All",
     "9492366f-7969-46a4-8d15-ed1a20078fff": "Sites.ReadWrite.All",
     "62a82d76-70ea-41e2-9197-370581804d09": "Group.ReadWrite.All",

--- a/tests/test_m365_connect_permissions.py
+++ b/tests/test_m365_connect_permissions.py
@@ -438,7 +438,7 @@ def test_provision_app_roles_includes_group_member_readwrite_all():
 def test_provision_app_roles_includes_sharepoint_tenant_settings_read_all():
     """_PROVISION_APP_ROLES must include SharePointTenantSettings.Read.All for SPO best-practice checks."""
     assert _SHAREPOINT_TENANT_SETTINGS_ROLE in _PROVISION_APP_ROLES, (
-        "SharePointTenantSettings.Read.All (a8ead177-1889-4546-9387-f25e658e2a79) must be in "
+        "SharePointTenantSettings.Read.All (83d4163d-a2d8-4d3b-9695-4ae3ca98f888) must be in "
         "_PROVISION_APP_ROLES to enable SharePoint Online best-practice checks "
         "(GET /admin/sharepoint/settings)"
     )


### PR DESCRIPTION
### Motivation
- The code referenced the wrong Microsoft Graph application role ID for `SharePointTenantSettings.Read.All`, causing provisioning/diagnostics to target an incorrect role and miss required permissions.

### Description
- Updated the `_SHAREPOINT_TENANT_SETTINGS_ROLE` constant in `app/services/m365.py` to `83d4163d-a2d8-4d3b-9695-4ae3ca98f888`, updated the `_GRAPH_ROLE_NAMES` mapping to use the corrected ID, and adjusted the related assertion message in `tests/test_m365_connect_permissions.py` to reference the new ID.

### Testing
- Ran the targeted pytest cases `tests/test_m365_connect_permissions.py::test_provision_app_roles_includes_sharepoint_tenant_settings_read_all`, `tests/test_m365_connect_permissions.py::test_try_grant_missing_permissions_grants_sharepoint_when_missing`, `tests/test_m365_connect_permissions.py::test_try_grant_missing_permissions_grants_sharepoint_when_role_lookup_omits_it`, and `tests/test_m365_provision.py::test_provision_app_registration_keeps_sharepoint_permission_when_lookup_omits_it`, and all tests passed (4 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34b0e2ff6c83329c59f1fb32028166)