### PR TITLE
Use dropdown actions menu on staff table

### DIFF
--- a/app/templates/staff/index.html
+++ b/app/templates/staff/index.html
@@ -369,15 +369,46 @@
               </td>
               {% if can_edit_staff or can_request_staff_offboarding %}
                 <td class="table__actions">
-                  <div class="table__action-buttons">
-                    <button type="button" class="button button--ghost" data-staff-edit="{{ member.id }}">{{ 'Edit' if can_edit_staff else 'Actions' }}</button>
-                    {% if is_super_admin and has_m365 and manual_onedrive_export_enabled and member.email %}
-                      <button type="button" class="button button--ghost" data-staff-export-onedrive="{{ member.id }}">Export OneDrive</button>
-                    {% endif %}
-                    {% if is_super_admin %}
-                      <button type="button" class="button button--ghost" data-staff-verify="{{ member.id }}" {% if not member.mobile_phone %}disabled{% endif %}>Send code</button>
-                    {% endif %}
-                  </div>
+                  <details class="header-title-menu__dropdown" data-header-menu>
+                    <summary class="header-title-menu__toggle" data-header-menu-toggle aria-haspopup="true">
+                      Actions
+                      <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" class="header-title-menu__icon">
+                        <path d="M6.2 8.2a1 1 0 0 1 1.4 0L12 12.6l4.4-4.4a1 1 0 0 1 1.4 1.4l-5.1 5.1a1 1 0 0 1-1.4 0L6.2 9.6a1 1 0 0 1 0-1.4z" />
+                      </svg>
+                      <span class="visually-hidden">Toggle row actions menu</span>
+                    </summary>
+                    <ul class="header-title-menu__list" role="menu">
+                      <li class="header-title-menu__item" role="none">
+                        <button
+                          type="button"
+                          class="header-title-menu__link"
+                          role="menuitem"
+                          data-staff-edit="{{ member.id }}"
+                        >{{ 'Edit' if can_edit_staff else 'Actions' }}</button>
+                      </li>
+                      {% if is_super_admin and has_m365 and manual_onedrive_export_enabled and member.email %}
+                        <li class="header-title-menu__item" role="none">
+                          <button
+                            type="button"
+                            class="header-title-menu__link"
+                            role="menuitem"
+                            data-staff-export-onedrive="{{ member.id }}"
+                          >Export OneDrive</button>
+                        </li>
+                      {% endif %}
+                      {% if is_super_admin %}
+                        <li class="header-title-menu__item" role="none">
+                          <button
+                            type="button"
+                            class="header-title-menu__link"
+                            role="menuitem"
+                            data-staff-verify="{{ member.id }}"
+                            {% if not member.mobile_phone %}disabled{% endif %}
+                          >Send code</button>
+                        </li>
+                      {% endif %}
+                    </ul>
+                  </details>
                 </td>
               {% endif %}
             </tr>


### PR DESCRIPTION
### Motivation
- Align the staff table row actions with the dropdown actions pattern used by other tables for consistency and accessibility.
- Replace the inline action buttons to make row actions collapsible on small screens while keeping existing behaviour intact.

### Description
- Replaced the inline `.table__action-buttons` block with a `details/summary` dropdown menu in `app/templates/staff/index.html` for the staff table actions column.
- Preserved existing data attributes and menu items (`data-staff-edit`, `data-staff-export-onedrive`, `data-staff-verify`) so current JavaScript handlers continue to work unchanged.
- Kept the same conditional logic for showing `Edit`, `Export OneDrive`, and `Send code` entries based on permissions and feature flags.

### Testing
- Ran `python3 -m pytest tests/test_staff_permissions_ui.py` and the test suite passed (`4 passed`).
- No functional JS changes were required and existing handlers in `app/static/js/staff.js` continue to operate with the preserved `data-*` attributes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34b283cddc8332b3f440f5ce57d8dc)