### PR TITLE
M365: Mailbox permission change request flow (modal + ticket creation)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3550,12 +3550,14 @@ async def m365_user_mailboxes_page(request: Request):
     credentials = await m365_service.get_credentials(company_id)
     mailboxes = await m365_service.get_user_mailboxes(company_id)
     synced_at = await m365_repo.get_mailbox_synced_at(company_id)
+    active_staff = await staff_repo.list_active_staff_for_offboarding(company_id)
     extra = {
         "title": "User Mailboxes",
         "company": company,
         "mailboxes": mailboxes,
         "synced_at": synced_at,
         "has_credentials": bool(credentials),
+        "active_staff": active_staff,
     }
     return await _render_template("m365/user_mailboxes.html", request, user, extra=extra)
 
@@ -3570,12 +3572,14 @@ async def m365_shared_mailboxes_page(request: Request):
     credentials = await m365_service.get_credentials(company_id)
     mailboxes = await m365_service.get_shared_mailboxes(company_id)
     synced_at = await m365_repo.get_mailbox_synced_at(company_id)
+    active_staff = await staff_repo.list_active_staff_for_offboarding(company_id)
     extra = {
         "title": "Shared Mailboxes",
         "company": company,
         "mailboxes": mailboxes,
         "synced_at": synced_at,
         "has_credentials": bool(credentials),
+        "active_staff": active_staff,
     }
     return await _render_template("m365/shared_mailboxes.html", request, user, extra=extra)
 
@@ -3742,6 +3746,111 @@ async def get_m365_mailbox_permissions(request: Request, upn: str):
             {"error": "Unable to retrieve mailbox permissions at this time."},
             status_code=503,
         )
+
+
+@app.post("/m365/mailboxes/permissions/request", response_class=JSONResponse, tags=["Microsoft 365"])
+async def request_m365_mailbox_permission_changes(request: Request):
+    """Create a ticket requesting mailbox permission additions/removals."""
+    user, membership, company, company_id, redirect = await _load_license_context(request)
+    if redirect:
+        return JSONResponse({"error": "Authentication required"}, status_code=401)
+    if not (
+        user.get("is_super_admin")
+        or _membership_menu_can(user, membership, "menu.m365.user_mailboxes", write=True)
+        or _membership_menu_can(user, membership, "menu.m365.shared_mailboxes", write=True)
+        or _membership_menu_can(user, membership, "menu.m365.user_mailboxes")
+        or _membership_menu_can(user, membership, "menu.m365.shared_mailboxes")
+    ):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Mailbox permission access required")
+
+    try:
+        body = await request.json()
+    except (ValueError, json.JSONDecodeError):
+        body = {}
+
+    mailbox_upn = str((body or {}).get("mailbox_upn") or "").strip()
+    mailbox_display_name = str((body or {}).get("mailbox_display_name") or mailbox_upn).strip()
+    notes = str((body or {}).get("notes") or "").strip()
+    removals_raw = (body or {}).get("removals") or []
+    additions_raw = (body or {}).get("additions") or []
+    if not mailbox_upn:
+        return JSONResponse({"error": "A mailbox is required."}, status_code=400)
+
+    user_mbs = await m365_service.get_user_mailboxes(company_id)
+    shared_mbs = await m365_service.get_shared_mailboxes(company_id)
+    known_upns = {str(mb.get("user_principal_name") or "").strip().lower() for mb in user_mbs + shared_mbs}
+    if mailbox_upn.lower() not in known_upns:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mailbox not found")
+
+    def _clean_change_items(items: Any, *, value_key: str) -> list[dict[str, str]]:
+        cleaned: list[dict[str, str]] = []
+        if not isinstance(items, list):
+            return cleaned
+        seen: set[str] = set()
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            value = str(item.get(value_key) or item.get("upn") or item.get("email") or "").strip()
+            label = str(item.get("label") or value).strip()
+            if not value or value.lower() in seen:
+                continue
+            seen.add(value.lower())
+            cleaned.append({value_key: value, "label": label or value})
+        return cleaned
+
+    removals = _clean_change_items(removals_raw, value_key="upn")
+    additions = _clean_change_items(additions_raw, value_key="email")
+    if not removals and not additions:
+        return JSONResponse({"error": "Select at least one permission change."}, status_code=400)
+
+    active_staff = await staff_repo.list_active_staff_for_offboarding(company_id)
+    active_staff_emails = {str(staff.get("email") or "").strip().lower() for staff in active_staff}
+    additions = [item for item in additions if item["email"].lower() in active_staff_emails]
+    if additions_raw and not additions and not removals:
+        return JSONResponse({"error": "Select at least one active staff member to add."}, status_code=400)
+
+    removal_lines = "".join(f"<li>{escape(item['label'])}</li>" for item in removals) or "<li>None</li>"
+    addition_lines = "".join(f"<li>{escape(item['label'])}</li>" for item in additions) or "<li>None</li>"
+    requester_name = str(user.get("name") or user.get("email") or "Current user")
+    description = (
+        f"<p>{escape(requester_name)} requested mailbox permission changes for "
+        f"<strong>{escape(mailbox_display_name)}</strong> ({escape(mailbox_upn)}).</p>"
+        f"<h3>Request Removal for existing permissions</h3><ul>{removal_lines}</ul>"
+        f"<h3>Add active staff members</h3><ul>{addition_lines}</ul>"
+    )
+    if notes:
+        description += f"<h3>Notes</h3><p>{escape(notes)}</p>"
+
+    requester_id = int(user["id"])
+    ticket = await tickets_service.create_ticket(
+        subject=f"Mailbox permission change request: {mailbox_display_name or mailbox_upn}",
+        description=description,
+        requester_id=requester_id,
+        company_id=company_id,
+        assigned_user_id=None,
+        priority="normal",
+        status=await tickets_service.resolve_status_or_default(None),
+        category="Microsoft 365",
+        module_slug="m365_admin",
+        external_reference=f"m365-mailbox-permissions:{mailbox_upn}",
+        trigger_automations=True,
+        initial_reply_author_id=requester_id,
+    )
+    try:
+        await tickets_repo.add_watcher(ticket["id"], requester_id)
+    except Exception:
+        logger.exception("Failed to add mailbox permission requester as ticket watcher")
+
+    log_info(
+        "M365 mailbox permission change ticket created",
+        company_id=company_id,
+        user_id=user.get("id"),
+        mailbox_upn=mailbox_upn,
+        ticket_id=ticket.get("id"),
+        removals=len(removals),
+        additions=len(additions),
+    )
+    return JSONResponse({"ticket_id": ticket.get("id"), "ticket_number": ticket.get("ticket_number")})
 
 
 @app.post("/m365/checks/report-privacy", response_class=RedirectResponse)

--- a/app/templates/m365/shared_mailboxes.html
+++ b/app/templates/m365/shared_mailboxes.html
@@ -418,12 +418,15 @@
         requestStatus.textContent = 'Submitting request…';
         requestStatus.className = 'panel__subtitle';
         requestStatus.style.display = 'block';
+        var headers = {
+          'Content-Type': 'application/json'
+        };
+{% if csrf_token %}
+        headers['X-CSRF-Token'] = '{{ csrf_token }}';
+{% endif %}
         fetch('/m365/mailboxes/permissions/request', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'{% if csrf_token %},
-            'X-CSRF-Token': '{{ csrf_token }}'{% endif %}
-          },
+          headers: headers,
           body: JSON.stringify({
             mailbox_upn: requestUpn.value,
             mailbox_display_name: requestDisplayName.value,

--- a/app/templates/m365/shared_mailboxes.html
+++ b/app/templates/m365/shared_mailboxes.html
@@ -119,7 +119,30 @@
           <ul id="perm-can-access" style="margin:0 0 1.25rem;padding-left:1.25rem"></ul>
           <h3 id="perm-accessible-by-heading" style="font-size:1rem">Users that can access me</h3>
           <p class="panel__subtitle" style="margin-top:0">Users assigned full access to this mailbox.</p>
-          <ul id="perm-accessible-by" style="margin:0;padding-left:1.25rem"></ul>
+          <ul id="perm-accessible-by" style="margin:0 0 1.25rem;padding-left:1.25rem"></ul>
+
+          <form id="mailbox-permission-request-form" class="form" style="border-top:1px solid var(--color-border, #ddd);padding-top:1rem">
+            <input type="hidden" id="perm-request-upn" name="mailbox_upn" value="">
+            <input type="hidden" id="perm-request-display-name" name="mailbox_display_name" value="">
+            <h3 style="font-size:1rem;margin:0 0 .25rem">Request permission changes</h3>
+            <p class="panel__subtitle" style="margin-top:0">Select existing permissions to remove or active staff members to add, then save to create a ticket.</p>
+            <div class="form__group">
+              <label class="form__label">Request Removal for existing permissions</label>
+              <div id="perm-removal-options" class="checkbox-list" style="display:grid;gap:.5rem"></div>
+            </div>
+            <div class="form__group">
+              <label class="form__label">Add active staff members</label>
+              <div id="perm-add-options" class="checkbox-list" style="display:grid;gap:.5rem;max-height:14rem;overflow:auto;border:1px solid var(--color-border, #ddd);border-radius:.5rem;padding:.75rem"></div>
+            </div>
+            <div class="form__group">
+              <label class="form__label" for="perm-request-notes">Notes</label>
+              <textarea id="perm-request-notes" class="form__control" rows="3" placeholder="Add any details for the support team."></textarea>
+            </div>
+            <p id="perm-request-status" class="panel__subtitle" role="status" style="display:none"></p>
+            <div class="form__actions" style="justify-content:flex-end">
+              <button type="submit" class="button button--primary" id="perm-request-save">Save</button>
+            </div>
+          </form>
         </div>
       </div>
     </div>
@@ -221,6 +244,15 @@
     var contentEl = document.getElementById('perm-content');
     var canAccessList = document.getElementById('perm-can-access');
     var accessibleByList = document.getElementById('perm-accessible-by');
+    var requestForm = document.getElementById('mailbox-permission-request-form');
+    var requestUpn = document.getElementById('perm-request-upn');
+    var requestDisplayName = document.getElementById('perm-request-display-name');
+    var removalOptions = document.getElementById('perm-removal-options');
+    var addOptions = document.getElementById('perm-add-options');
+    var notesEl = document.getElementById('perm-request-notes');
+    var requestStatus = document.getElementById('perm-request-status');
+    var saveBtn = document.getElementById('perm-request-save');
+    var activeStaff = {{ active_staff | default([]) | tojson }};
     var activeTrigger = null;
 
     function escapeHtml(str) {
@@ -275,12 +307,58 @@
       }
     }
 
+    function optionValue(item, keys) {
+      for (var i = 0; i < keys.length; i += 1) {
+        if (item && item[keys[i]]) return String(item[keys[i]]);
+      }
+      return '';
+    }
+
+    function buildCheckboxes(container, items, emptyText, getValue, getLabel) {
+      container.innerHTML = '';
+      if (!items || !items.length) {
+        var empty = document.createElement('p');
+        empty.className = 'text-muted';
+        empty.style.margin = '0';
+        empty.textContent = emptyText;
+        container.appendChild(empty);
+        return;
+      }
+      items.forEach(function (item, index) {
+        var id = container.id + '-' + index;
+        var label = document.createElement('label');
+        label.className = 'checkbox';
+        label.setAttribute('for', id);
+        var checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = id;
+        checkbox.value = getValue(item);
+        checkbox.dataset.label = getLabel(item);
+        label.appendChild(checkbox);
+        label.appendChild(document.createTextNode(' ' + getLabel(item)));
+        container.appendChild(label);
+      });
+    }
+
+    function resetRequestForm(upn, displayName) {
+      if (requestUpn) requestUpn.value = upn || '';
+      if (requestDisplayName) requestDisplayName.value = displayName || upn || '';
+      if (notesEl) notesEl.value = '';
+      if (requestStatus) {
+        requestStatus.style.display = 'none';
+        requestStatus.textContent = '';
+        requestStatus.className = 'panel__subtitle';
+      }
+      if (saveBtn) saveBtn.disabled = false;
+    }
+
     document.querySelectorAll('[data-perm-btn]').forEach(function (btn) {
       btn.addEventListener('click', function () {
         var upn = btn.getAttribute('data-upn');
         var displayName = btn.getAttribute('data-display-name');
 
         titleEl.textContent = displayName;
+        resetRequestForm(upn, displayName);
         loadingEl.style.display = 'block';
         errorEl.style.display = 'none';
         contentEl.style.display = 'none';
@@ -297,6 +375,19 @@
             }
             buildList(canAccessList, result.data.can_access, 'display_name', 'email');
             buildList(accessibleByList, result.data.accessible_by, 'display_name', 'upn');
+            buildCheckboxes(removalOptions, result.data.accessible_by, 'No existing mailbox permissions found.', function (item) {
+              return optionValue(item, ['upn', 'email', 'user_principal_name']);
+            }, function (item) {
+              var name = optionValue(item, ['display_name', 'name']);
+              var upnValue = optionValue(item, ['upn', 'email', 'user_principal_name']);
+              return name && upnValue ? name + ' (' + upnValue + ')' : (name || upnValue || 'Unknown user');
+            });
+            buildCheckboxes(addOptions, activeStaff, 'No active staff members found.', function (item) {
+              return optionValue(item, ['email']);
+            }, function (item) {
+              var name = [item.first_name, item.last_name].filter(Boolean).join(' ') || item.email;
+              return name && item.email ? name + ' (' + item.email + ')' : (name || 'Unknown staff');
+            });
             contentEl.style.display = 'block';
           })
           .catch(function () {
@@ -306,6 +397,59 @@
           });
       });
     });
+
+
+    if (requestForm) {
+      requestForm.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var removals = Array.prototype.slice.call(removalOptions.querySelectorAll('input:checked')).map(function (input) {
+          return { upn: input.value, label: input.dataset.label || input.value };
+        });
+        var additions = Array.prototype.slice.call(addOptions.querySelectorAll('input:checked')).map(function (input) {
+          return { email: input.value, label: input.dataset.label || input.value };
+        });
+        if (!removals.length && !additions.length) {
+          requestStatus.textContent = 'Select at least one permission change before saving.';
+          requestStatus.className = 'alert alert--error';
+          requestStatus.style.display = 'block';
+          return;
+        }
+        saveBtn.disabled = true;
+        requestStatus.textContent = 'Submitting request…';
+        requestStatus.className = 'panel__subtitle';
+        requestStatus.style.display = 'block';
+        fetch('/m365/mailboxes/permissions/request', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'{% if csrf_token %},
+            'X-CSRF-Token': '{{ csrf_token }}'{% endif %}
+          },
+          body: JSON.stringify({
+            mailbox_upn: requestUpn.value,
+            mailbox_display_name: requestDisplayName.value,
+            removals: removals,
+            additions: additions,
+            notes: notesEl.value
+          })
+        })
+        .then(function (resp) { return resp.json().then(function (data) { return { ok: resp.ok, data: data }; }); })
+        .then(function (result) {
+          if (!result.ok || (result.data && result.data.error)) {
+            saveBtn.disabled = false;
+            requestStatus.textContent = (result.data && result.data.error) || 'Failed to submit request.';
+            requestStatus.className = 'alert alert--error';
+            return;
+          }
+          requestStatus.textContent = 'Request saved as ticket #' + (result.data.ticket_number || result.data.ticket_id) + '.';
+          requestStatus.className = 'alert alert--success';
+        })
+        .catch(function () {
+          saveBtn.disabled = false;
+          requestStatus.textContent = 'Failed to submit request. Please try again.';
+          requestStatus.className = 'alert alert--error';
+        });
+      });
+    }
   }());
   </script>
   <script>

--- a/app/templates/m365/user_mailboxes.html
+++ b/app/templates/m365/user_mailboxes.html
@@ -139,7 +139,30 @@
           <ul id="perm-can-access" style="margin:0 0 1.25rem;padding-left:1.25rem"></ul>
           <h3 id="perm-accessible-by-heading" style="font-size:1rem">Users that can access me</h3>
           <p class="panel__subtitle" style="margin-top:0">Users assigned full access to this mailbox.</p>
-          <ul id="perm-accessible-by" style="margin:0;padding-left:1.25rem"></ul>
+          <ul id="perm-accessible-by" style="margin:0 0 1.25rem;padding-left:1.25rem"></ul>
+
+          <form id="mailbox-permission-request-form" class="form" style="border-top:1px solid var(--color-border, #ddd);padding-top:1rem">
+            <input type="hidden" id="perm-request-upn" name="mailbox_upn" value="">
+            <input type="hidden" id="perm-request-display-name" name="mailbox_display_name" value="">
+            <h3 style="font-size:1rem;margin:0 0 .25rem">Request permission changes</h3>
+            <p class="panel__subtitle" style="margin-top:0">Select existing permissions to remove or active staff members to add, then save to create a ticket.</p>
+            <div class="form__group">
+              <label class="form__label">Request Removal for existing permissions</label>
+              <div id="perm-removal-options" class="checkbox-list" style="display:grid;gap:.5rem"></div>
+            </div>
+            <div class="form__group">
+              <label class="form__label">Add active staff members</label>
+              <div id="perm-add-options" class="checkbox-list" style="display:grid;gap:.5rem;max-height:14rem;overflow:auto;border:1px solid var(--color-border, #ddd);border-radius:.5rem;padding:.75rem"></div>
+            </div>
+            <div class="form__group">
+              <label class="form__label" for="perm-request-notes">Notes</label>
+              <textarea id="perm-request-notes" class="form__control" rows="3" placeholder="Add any details for the support team."></textarea>
+            </div>
+            <p id="perm-request-status" class="panel__subtitle" role="status" style="display:none"></p>
+            <div class="form__actions" style="justify-content:flex-end">
+              <button type="submit" class="button button--primary" id="perm-request-save">Save</button>
+            </div>
+          </form>
         </div>
       </div>
     </div>
@@ -241,6 +264,15 @@
     var contentEl = document.getElementById('perm-content');
     var canAccessList = document.getElementById('perm-can-access');
     var accessibleByList = document.getElementById('perm-accessible-by');
+    var requestForm = document.getElementById('mailbox-permission-request-form');
+    var requestUpn = document.getElementById('perm-request-upn');
+    var requestDisplayName = document.getElementById('perm-request-display-name');
+    var removalOptions = document.getElementById('perm-removal-options');
+    var addOptions = document.getElementById('perm-add-options');
+    var notesEl = document.getElementById('perm-request-notes');
+    var requestStatus = document.getElementById('perm-request-status');
+    var saveBtn = document.getElementById('perm-request-save');
+    var activeStaff = {{ active_staff | default([]) | tojson }};
     var activeTrigger = null;
 
     function escapeHtml(str) {
@@ -295,12 +327,58 @@
       }
     }
 
+    function optionValue(item, keys) {
+      for (var i = 0; i < keys.length; i += 1) {
+        if (item && item[keys[i]]) return String(item[keys[i]]);
+      }
+      return '';
+    }
+
+    function buildCheckboxes(container, items, emptyText, getValue, getLabel) {
+      container.innerHTML = '';
+      if (!items || !items.length) {
+        var empty = document.createElement('p');
+        empty.className = 'text-muted';
+        empty.style.margin = '0';
+        empty.textContent = emptyText;
+        container.appendChild(empty);
+        return;
+      }
+      items.forEach(function (item, index) {
+        var id = container.id + '-' + index;
+        var label = document.createElement('label');
+        label.className = 'checkbox';
+        label.setAttribute('for', id);
+        var checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = id;
+        checkbox.value = getValue(item);
+        checkbox.dataset.label = getLabel(item);
+        label.appendChild(checkbox);
+        label.appendChild(document.createTextNode(' ' + getLabel(item)));
+        container.appendChild(label);
+      });
+    }
+
+    function resetRequestForm(upn, displayName) {
+      if (requestUpn) requestUpn.value = upn || '';
+      if (requestDisplayName) requestDisplayName.value = displayName || upn || '';
+      if (notesEl) notesEl.value = '';
+      if (requestStatus) {
+        requestStatus.style.display = 'none';
+        requestStatus.textContent = '';
+        requestStatus.className = 'panel__subtitle';
+      }
+      if (saveBtn) saveBtn.disabled = false;
+    }
+
     document.querySelectorAll('[data-perm-btn]').forEach(function (btn) {
       btn.addEventListener('click', function () {
         var upn = btn.getAttribute('data-upn');
         var displayName = btn.getAttribute('data-display-name');
 
         titleEl.textContent = displayName;
+        resetRequestForm(upn, displayName);
         loadingEl.style.display = 'block';
         errorEl.style.display = 'none';
         contentEl.style.display = 'none';
@@ -317,6 +395,19 @@
             }
             buildList(canAccessList, result.data.can_access, 'display_name', 'email');
             buildList(accessibleByList, result.data.accessible_by, 'display_name', 'upn');
+            buildCheckboxes(removalOptions, result.data.accessible_by, 'No existing mailbox permissions found.', function (item) {
+              return optionValue(item, ['upn', 'email', 'user_principal_name']);
+            }, function (item) {
+              var name = optionValue(item, ['display_name', 'name']);
+              var upnValue = optionValue(item, ['upn', 'email', 'user_principal_name']);
+              return name && upnValue ? name + ' (' + upnValue + ')' : (name || upnValue || 'Unknown user');
+            });
+            buildCheckboxes(addOptions, activeStaff, 'No active staff members found.', function (item) {
+              return optionValue(item, ['email']);
+            }, function (item) {
+              var name = [item.first_name, item.last_name].filter(Boolean).join(' ') || item.email;
+              return name && item.email ? name + ' (' + item.email + ')' : (name || 'Unknown staff');
+            });
             contentEl.style.display = 'block';
           })
           .catch(function () {
@@ -326,6 +417,59 @@
           });
       });
     });
+
+
+    if (requestForm) {
+      requestForm.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var removals = Array.prototype.slice.call(removalOptions.querySelectorAll('input:checked')).map(function (input) {
+          return { upn: input.value, label: input.dataset.label || input.value };
+        });
+        var additions = Array.prototype.slice.call(addOptions.querySelectorAll('input:checked')).map(function (input) {
+          return { email: input.value, label: input.dataset.label || input.value };
+        });
+        if (!removals.length && !additions.length) {
+          requestStatus.textContent = 'Select at least one permission change before saving.';
+          requestStatus.className = 'alert alert--error';
+          requestStatus.style.display = 'block';
+          return;
+        }
+        saveBtn.disabled = true;
+        requestStatus.textContent = 'Submitting request…';
+        requestStatus.className = 'panel__subtitle';
+        requestStatus.style.display = 'block';
+        fetch('/m365/mailboxes/permissions/request', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'{% if csrf_token %},
+            'X-CSRF-Token': '{{ csrf_token }}'{% endif %}
+          },
+          body: JSON.stringify({
+            mailbox_upn: requestUpn.value,
+            mailbox_display_name: requestDisplayName.value,
+            removals: removals,
+            additions: additions,
+            notes: notesEl.value
+          })
+        })
+        .then(function (resp) { return resp.json().then(function (data) { return { ok: resp.ok, data: data }; }); })
+        .then(function (result) {
+          if (!result.ok || (result.data && result.data.error)) {
+            saveBtn.disabled = false;
+            requestStatus.textContent = (result.data && result.data.error) || 'Failed to submit request.';
+            requestStatus.className = 'alert alert--error';
+            return;
+          }
+          requestStatus.textContent = 'Request saved as ticket #' + (result.data.ticket_number || result.data.ticket_id) + '.';
+          requestStatus.className = 'alert alert--success';
+        })
+        .catch(function () {
+          saveBtn.disabled = false;
+          requestStatus.textContent = 'Failed to submit request. Please try again.';
+          requestStatus.className = 'alert alert--error';
+        });
+      });
+    }
   }());
   </script>
   <script>

--- a/app/templates/m365/user_mailboxes.html
+++ b/app/templates/m365/user_mailboxes.html
@@ -441,8 +441,8 @@
         fetch('/m365/mailboxes/permissions/request', {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json'{% if csrf_token %},
-            'X-CSRF-Token': '{{ csrf_token }}'{% endif %}
+            'Content-Type': 'application/json',
+            {% if csrf_token %}'X-CSRF-Token': '{{ csrf_token }}',{% endif %}
           },
           body: JSON.stringify({
             mailbox_upn: requestUpn.value,


### PR DESCRIPTION
### Motivation
- Provide a simple way for users with mailbox read/write access to request changes to existing mailbox permissions (including requesting removal of existing permissions).
- Allow adding active staff members directly from the Mailbox Permissions modal so support requests can include suggested additions.
- Ensure requests are tracked as helpdesk tickets owned by the requesting user and submitted via a single Save action in the modal.

### Description
- Load active staff into both mailbox pages by calling `staff_repo.list_active_staff_for_offboarding(company_id)` and pass `active_staff` to the templates. (`app/main.py`)
- Extend the Mailbox Permissions modal in `m365/user_mailboxes.html` and `m365/shared_mailboxes.html` to render a request form that includes removal checkboxes, active-staff addition checkboxes, a notes textarea, and a `Save` button. (templates)
- Add client-side code to build checkbox lists, reset the form, validate selections, and submit the request payload to the new endpoint `/m365/mailboxes/permissions/request`. (template JS)
- Implement a backend endpoint `request_m365_mailbox_permission_changes` at `POST /m365/mailboxes/permissions/request` that validates the mailbox UPN, filters additions to active staff, assembles an HTML description, creates a ticket under the logged-in user using `tickets_service.create_ticket`, adds the requester as a watcher, logs the event, and returns the created ticket id/number. (`app/main.py`)

### Testing
- Compiled Python with `python -m py_compile app/main.py` which completed successfully.
- Parsed modified Jinja templates with a Jinja2 environment to ensure templates are syntactically valid which passed.
- Ran `git diff --check` to verify there are no whitespace/format issues which returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34b3dc11d48332b2908cad29be71f2)