### PR TITLE
Deduplicate staff entries by normalized email in repository and M365 UI

### DIFF
--- a/app/repositories/staff.py
+++ b/app/repositories/staff.py
@@ -7,6 +7,20 @@ from app.core.database import db
 from app.repositories import staff_custom_fields as staff_custom_fields_repo
 
 
+def _dedupe_by_normalized_email(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return rows with duplicate non-empty emails removed, preserving order."""
+    unique_rows: list[dict[str, Any]] = []
+    seen_emails: set[str] = set()
+    for row in rows:
+        email = str(row.get("email") or "").strip().lower()
+        if email and email in seen_emails:
+            continue
+        if email:
+            seen_emails.add(email)
+        unique_rows.append(row)
+    return unique_rows
+
+
 def _ensure_utc(value: datetime | None) -> datetime | None:
     if value is None:
         return None
@@ -300,7 +314,7 @@ async def list_enabled_staff_users(company_id: int) -> List[dict[str, Any]]:
         )
         record["is_registered_user"] = user_id_int is not None
         results.append(record)
-    return results
+    return _dedupe_by_normalized_email(results)
 
 
 async def get_enabled_staff_requester(company_id: int, staff_id: int) -> dict[str, Any] | None:
@@ -812,7 +826,7 @@ async def list_active_staff_for_offboarding(company_id: int, *, exclude_staff_id
         """,
         tuple(params),
     )
-    return [dict(row) for row in rows]
+    return _dedupe_by_normalized_email([dict(row) for row in rows])
 
 
 async def set_enabled(staff_id: int, enabled: bool) -> None:

--- a/app/templates/m365/shared_mailboxes.html
+++ b/app/templates/m365/shared_mailboxes.html
@@ -314,6 +314,16 @@
       return '';
     }
 
+    function uniqueItems(items, getValue) {
+      var seen = {};
+      return (items || []).filter(function (item) {
+        var value = String(getValue(item) || '').trim().toLowerCase();
+        if (!value || seen[value]) return false;
+        seen[value] = true;
+        return true;
+      });
+    }
+
     function buildCheckboxes(container, items, emptyText, getValue, getLabel) {
       container.innerHTML = '';
       if (!items || !items.length) {
@@ -382,7 +392,9 @@
               var upnValue = optionValue(item, ['upn', 'email', 'user_principal_name']);
               return name && upnValue ? name + ' (' + upnValue + ')' : (name || upnValue || 'Unknown user');
             });
-            buildCheckboxes(addOptions, activeStaff, 'No active staff members found.', function (item) {
+            buildCheckboxes(addOptions, uniqueItems(activeStaff, function (item) {
+              return optionValue(item, ['email']);
+            }), 'No active staff members found.', function (item) {
               return optionValue(item, ['email']);
             }, function (item) {
               var name = [item.first_name, item.last_name].filter(Boolean).join(' ') || item.email;

--- a/app/templates/m365/user_mailboxes.html
+++ b/app/templates/m365/user_mailboxes.html
@@ -334,6 +334,16 @@
       return '';
     }
 
+    function uniqueItems(items, getValue) {
+      var seen = {};
+      return (items || []).filter(function (item) {
+        var value = String(getValue(item) || '').trim().toLowerCase();
+        if (!value || seen[value]) return false;
+        seen[value] = true;
+        return true;
+      });
+    }
+
     function buildCheckboxes(container, items, emptyText, getValue, getLabel) {
       container.innerHTML = '';
       if (!items || !items.length) {
@@ -402,7 +412,9 @@
               var upnValue = optionValue(item, ['upn', 'email', 'user_principal_name']);
               return name && upnValue ? name + ' (' + upnValue + ')' : (name || upnValue || 'Unknown user');
             });
-            buildCheckboxes(addOptions, activeStaff, 'No active staff members found.', function (item) {
+            buildCheckboxes(addOptions, uniqueItems(activeStaff, function (item) {
+              return optionValue(item, ['email']);
+            }), 'No active staff members found.', function (item) {
               return optionValue(item, ['email']);
             }, function (item) {
               var name = [item.first_name, item.last_name].filter(Boolean).join(' ') || item.email;

--- a/tests/test_staff_repository.py
+++ b/tests/test_staff_repository.py
@@ -56,6 +56,36 @@ async def test_list_enabled_staff_users_returns_rows(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_list_enabled_staff_users_deduplicates_by_email(monkeypatch):
+    dummy_rows = [
+        {"staff_id": 11, "user_id": 101, "email": "Casey@Example.com"},
+        {"staff_id": 12, "user_id": 101, "email": " casey@example.com "},
+        {"staff_id": 13, "user_id": None, "email": "other@example.com"},
+    ]
+    dummy_db = _DummyStaffDB(dummy_rows)
+    monkeypatch.setattr(staff, "db", dummy_db)
+
+    result = await staff.list_enabled_staff_users(3)
+
+    assert [row["staff_id"] for row in result] == [11, 13]
+
+
+@pytest.mark.anyio
+async def test_list_active_staff_for_offboarding_deduplicates_by_email(monkeypatch):
+    dummy_rows = [
+        {"id": 1, "first_name": "Evan", "last_name": "One", "email": "evan@example.com"},
+        {"id": 2, "first_name": "Evan", "last_name": "Two", "email": "EVAN@example.com"},
+        {"id": 3, "first_name": "Riley", "last_name": "Three", "email": "riley@example.com"},
+    ]
+    dummy_db = _DummyStaffDB(dummy_rows)
+    monkeypatch.setattr(staff, "db", dummy_db)
+
+    result = await staff.list_active_staff_for_offboarding(3)
+
+    assert [row["id"] for row in result] == [1, 3]
+
+
+@pytest.mark.anyio
 async def test_list_enabled_staff_users_handles_empty(monkeypatch):
     dummy_db = _DummyStaffDB([])
     monkeypatch.setattr(staff, "db", dummy_db)


### PR DESCRIPTION
### Motivation
- Prevent duplicate staff entries from appearing when the same email is present multiple times with different casing or whitespace.
- Ensure both backend lists and the mailbox UI present unique staff options to avoid confusing duplicate selections.

### Description
- Add a backend helper ` _dedupe_by_normalized_email` that normalizes emails (trim + lowercase) and removes duplicates while preserving order. 
- Use ` _dedupe_by_normalized_email` in `list_enabled_staff_users` and `list_active_staff_for_offboarding` to return deduplicated results. 
- Add a client-side `uniqueItems` helper in `app/templates/m365/shared_mailboxes.html` and `app/templates/m365/user_mailboxes.html` and apply it to `activeStaff` before building the `addOptions` checkboxes to dedupe by email in the UI. 
- Add unit tests in `tests/test_staff_repository.py` to assert deduplication behavior for `list_enabled_staff_users` and `list_active_staff_for_offboarding`.

### Testing
- Ran the new unit tests `tests/test_staff_repository.py::test_list_enabled_staff_users_deduplicates_by_email` and `tests/test_staff_repository.py::test_list_active_staff_for_offboarding_deduplicates_by_email`, and they passed.
- Ran existing `tests/test_staff_repository.py` staff repository tests to ensure no regressions, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34b83094a48332bf259252dfd5bcee)