### PR TITLE
Improve Hudu password auth guidance

### DIFF
--- a/app/services/hudu.py
+++ b/app/services/hudu.py
@@ -14,6 +14,24 @@ class HuduConfigurationError(Exception):
     """Raised when Hudu is not configured or credentials are missing."""
 
 
+class HuduAuthenticationError(Exception):
+    """Raised when Hudu rejects API authentication or authorization."""
+
+
+_PASSWORD_ACCESS_MESSAGE = (
+    "Hudu rejected the API key while accessing asset passwords. "
+    "Confirm the configured Hudu API key is current, has Passwords access enabled, "
+    "is allowed for this company/IP address, and is not Magic Dash only."
+)
+
+
+def _raise_for_status(response: httpx.Response, *, password_access: bool = False) -> None:
+    if response.status_code == 401:
+        message = _PASSWORD_ACCESS_MESSAGE if password_access else "Invalid Hudu API key"
+        raise HuduAuthenticationError(message)
+    response.raise_for_status()
+
+
 async def _load_settings() -> dict[str, Any]:
     """Load and validate Hudu module settings."""
     module = await modules_service.get_module("hudu", redact=False)
@@ -63,7 +81,7 @@ async def search_companies(name: str) -> list[dict[str, Any]]:
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.get(url, headers=_make_headers(api_key), params=params)
-        response.raise_for_status()
+        _raise_for_status(response)
 
     data = response.json()
     companies = data.get("companies", [])
@@ -93,7 +111,7 @@ async def get_company_url(hudu_id: str) -> str | None:
             response = await client.get(url, headers=_make_headers(api_key))
         if response.status_code == 404:
             return None
-        response.raise_for_status()
+        _raise_for_status(response)
         data = response.json()
         company = data.get("company") or {}
         full_url = str(company.get("full_url") or "").strip()
@@ -157,7 +175,7 @@ async def create_person(
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(url, headers=_make_headers(api_key), json=body)
-        response.raise_for_status()
+        _raise_for_status(response)
 
     data = response.json()
     return data.get("person") or data
@@ -206,7 +224,7 @@ async def create_asset_password(
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(endpoint, headers=_make_headers(api_key), json=body)
-        response.raise_for_status()
+        _raise_for_status(response, password_access=True)
 
     data = response.json()
     return data.get("asset_password") or data

--- a/tests/test_hudu_service.py
+++ b/tests/test_hudu_service.py
@@ -76,3 +76,45 @@ async def test_create_asset_password_uses_flat_endpoint_with_company_id_and_send
     assert pw_body["username"] == "alice@example.com"
 
     assert result["id"] == 42
+
+
+@pytest.mark.anyio
+async def test_create_asset_password_401_reports_password_access_guidance(monkeypatch):
+    """401s on the password endpoint should guide admins to Hudu password API scope."""
+
+    class DummyResponse:
+        status_code = 401
+
+        def raise_for_status(self):  # pragma: no cover - _raise_for_status handles 401 first
+            raise AssertionError("raise_for_status should not be called for 401 responses")
+
+    class DummyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, *, headers=None, json=None, **kwargs):
+            return DummyResponse()
+
+    async def fake_load_settings():
+        return {"base_url": "https://hudu.example.com", "api_key": "test-api-key-abc"}
+
+    monkeypatch.setattr(hudu_service, "_load_settings", fake_load_settings)
+    monkeypatch.setattr(hudu_service.httpx, "AsyncClient", DummyClient)
+
+    with pytest.raises(hudu_service.HuduAuthenticationError) as exc_info:
+        await hudu_service.create_asset_password(
+            company_id="99",
+            name="Test Password",
+            password="s3cr3t",
+        )
+
+    error = str(exc_info.value)
+    assert "Hudu rejected the API key" in error
+    assert "Passwords access enabled" in error
+    assert "company/IP address" in error


### PR DESCRIPTION
### Motivation
- Convert raw `401 Unauthorized` responses from Hudu into clearer, actionable authentication/authorization guidance when pushing asset passwords. 
- Ensure callers (for example onboarding workflows that push passwords) receive a helpful error explaining common causes like API key scope or company/IP restrictions instead of an opaque HTTP client error.

### Description
- Add a new `HuduAuthenticationError` exception and a password-specific guidance message `_PASSWORD_ACCESS_MESSAGE` in `app/services/hudu.py`.
- Introduce a helper `_raise_for_status(response, password_access: bool = False)` that converts `401` responses into `HuduAuthenticationError` and otherwise delegates to `response.raise_for_status()`.
- Replace direct `response.raise_for_status()` calls with `_raise_for_status()` across Hudu client functions and use `password_access=True` for the asset password POST endpoint so password endpoint 401s produce the targeted guidance.
- Add a regression test `test_create_asset_password_401_reports_password_access_guidance` in `tests/test_hudu_service.py` to assert 401 handling and message content.

### Testing
- Ran `pytest tests/test_hudu_service.py` which executed the existing endpoint test and the new 401 guidance test and both tests passed.
- Test output: `2 passed` for `tests/test_hudu_service.py` (no failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34e3fb257483329fb83adba043ad87)