### PR TITLE
Add string operator filters, ticket automation context fields, and UI support

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1193,6 +1193,49 @@ async def get_time_totals_by_ticket_ids(ticket_ids: list[int]) -> dict[int, dict
     return result
 
 
+async def get_automation_filter_context(ticket_id: int) -> dict[str, int | bool]:
+    """Return aggregate ticket values used by automation filter matching."""
+
+    time_row = await db.fetch_one(
+        """
+        SELECT
+            SUM(CASE WHEN is_billable = 1 AND minutes_spent IS NOT NULL THEN minutes_spent ELSE 0 END) AS billable_minutes,
+            SUM(CASE WHEN is_billable = 0 AND minutes_spent IS NOT NULL THEN minutes_spent ELSE 0 END) AS non_billable_minutes
+        FROM ticket_replies
+        WHERE ticket_id = %s AND minutes_spent IS NOT NULL AND minutes_spent > 0
+        """,
+        (ticket_id,),
+    )
+    attachment_row = await db.fetch_one(
+        "SELECT COUNT(*) AS attachment_count FROM ticket_attachments WHERE ticket_id = %s",
+        (ticket_id,),
+    )
+    task_row = await db.fetch_one(
+        """
+        SELECT
+            COUNT(*) AS task_count,
+            SUM(CASE WHEN is_completed = 0 THEN 1 ELSE 0 END) AS open_task_count
+        FROM ticket_tasks
+        WHERE ticket_id = %s
+        """,
+        (ticket_id,),
+    )
+
+    attachment_count = int((attachment_row or {}).get("attachment_count") or 0)
+    task_count = int((task_row or {}).get("task_count") or 0)
+    open_task_count = int((task_row or {}).get("open_task_count") or 0)
+    return {
+        "billable_minutes": int((time_row or {}).get("billable_minutes") or 0),
+        "non_billable_minutes": int((time_row or {}).get("non_billable_minutes") or 0),
+        "attachment_count": attachment_count,
+        "has_attachments": attachment_count > 0,
+        "task_count": task_count,
+        "has_tasks": task_count > 0,
+        "open_task_count": open_task_count,
+        "has_open_tasks": open_task_count > 0,
+    }
+
+
 async def validate_replies_belong_to_ticket(reply_ids: list[int], ticket_id: int) -> tuple[bool, str | None]:
     """
     Validate that all reply IDs belong to the specified ticket.

--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -181,10 +181,36 @@ def _string_value_matches(actual: Any, expected: str) -> bool:
     pattern = _compile_like_pattern(expected)
     return bool(pattern.fullmatch(actual))
 
+_REGEX_PATTERN_MAX_LENGTH = 256
+_REGEX_INPUT_MAX_LENGTH = 4096
+
+
+def _string_operator_matches(actual: Any, expected: Any, operator: str) -> bool:
+    if not isinstance(actual, str) or not isinstance(expected, str):
+        return False
+    if operator == "starts_with":
+        return actual.startswith(expected)
+    if operator == "ends_with":
+        return actual.endswith(expected)
+    if operator == "contains":
+        return expected in actual
+    if operator == "not_contains":
+        return expected not in actual
+    if operator == "regex":
+        if len(expected) > _REGEX_PATTERN_MAX_LENGTH:
+            return False
+        try:
+            return bool(re.search(expected, actual[:_REGEX_INPUT_MAX_LENGTH]))
+        except re.error:
+            return False
+    return False
+
 
 def _value_matches(actual: Any, expected: Any) -> bool:
     if isinstance(expected, Sequence) and not isinstance(expected, (str, bytes, bytearray)):
         return any(_value_matches(actual, candidate) for candidate in expected)
+    if isinstance(actual, Sequence) and not isinstance(actual, (str, bytes, bytearray)):
+        return any(_value_matches(candidate, expected) for candidate in actual)
     if isinstance(expected, str):
         return _string_value_matches(actual, expected)
     return actual == expected
@@ -209,6 +235,15 @@ def _coerce_comparable(value: Any) -> Any:
 
 
 def _compare_values(actual: Any, expected: Any, operator: str) -> bool:
+    if isinstance(actual, Sequence) and not isinstance(actual, (str, bytes, bytearray)):
+        if operator == "not_contains":
+            return all(_compare_values(candidate, expected, operator) for candidate in actual)
+        return any(_compare_values(candidate, expected, operator) for candidate in actual)
+
+    string_operators = {"starts_with", "ends_with", "contains", "not_contains", "regex"}
+    if operator in string_operators:
+        return _string_operator_matches(actual, expected, operator)
+
     actual_value = _coerce_comparable(actual)
     expected_value = _coerce_comparable(expected)
     try:
@@ -286,6 +321,11 @@ def _filters_match(filters: Mapping[str, Any] | None, context: Mapping[str, Any]
         "less_than": "less_than",
         "lte": "less_than_or_equal",
         "less_than_or_equal": "less_than_or_equal",
+        "starts_with": "starts_with",
+        "ends_with": "ends_with",
+        "contains": "contains",
+        "not_contains": "not_contains",
+        "regex": "regex",
     }
     for filter_key, operator in operator_keys.items():
         comparison_filters = filters.get(filter_key)

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -554,6 +554,20 @@ async def _enrich_ticket_context(ticket: Mapping[str, Any]) -> TicketRecord:
         )
         latest_reply = reply
     enriched["latest_reply"] = latest_reply
+
+    if isinstance(ticket_id, int):
+        filter_context = await _safely_call(tickets_repo.get_automation_filter_context, ticket_id)
+        if isinstance(filter_context, Mapping):
+            enriched.update(filter_context)
+    enriched.setdefault("billable_minutes", 0)
+    enriched.setdefault("non_billable_minutes", 0)
+    enriched.setdefault("attachment_count", 0)
+    enriched.setdefault("has_attachments", False)
+    enriched.setdefault("task_count", 0)
+    enriched.setdefault("has_tasks", False)
+    enriched.setdefault("open_task_count", 0)
+    enriched.setdefault("has_open_tasks", False)
+
     _attach_sms_context(enriched)
 
     return enriched

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -1525,6 +1525,11 @@
         lt: 'less_than',
         less_than_or_equal: 'less_than_or_equal',
         lte: 'less_than_or_equal',
+        starts_with: 'starts_with',
+        ends_with: 'ends_with',
+        contains: 'contains',
+        not_contains: 'not_contains',
+        regex: 'regex',
       };
       const operatorKey = Object.keys(operatorNodes).find((key) => (
         node[key] && typeof node[key] === 'object' && !Array.isArray(node[key])
@@ -1597,6 +1602,11 @@
         greater_than_or_equal: 'greater_than_or_equal',
         less_than: 'less_than',
         less_than_or_equal: 'less_than_or_equal',
+        starts_with: 'starts_with',
+        ends_with: 'ends_with',
+        contains: 'contains',
+        not_contains: 'not_contains',
+        regex: 'regex',
       }[row.operator] || 'match';
       const matchNode = { [operatorKey]: { [fieldPath]: typedValue } };
       if (row.conditionType === 'all') {
@@ -1677,8 +1687,27 @@
           const datalist = document.createElement('datalist');
           datalist.id = 'automation-filter-field-suggestions';
           [
+            'ticket.subject',
             'ticket.status',
             'ticket.priority',
+            'ticket.requester_email',
+            'ticket.requester_display_name',
+            'ticket.assigned_user_email',
+            'ticket.assigned_user_display_name',
+            'ticket.company_name',
+            'ticket.company.id',
+            'ticket.category',
+            'ticket.external_reference',
+            'ticket.billable_minutes',
+            'ticket.non_billable_minutes',
+            'ticket.has_attachments',
+            'ticket.attachment_count',
+            'ticket.has_tasks',
+            'ticket.task_count',
+            'ticket.has_open_tasks',
+            'ticket.open_task_count',
+            'ticket.ai_tags',
+            'ticket.labels',
             'ticket.age_days',
             'ticket.updated_age_hours',
             'ticket.last_reply_age_hours',
@@ -1704,6 +1733,11 @@
           ['greater_than_or_equal', 'greater than or equal'],
           ['less_than', 'less than'],
           ['less_than_or_equal', 'less than or equal'],
+          ['starts_with', 'starts with'],
+          ['ends_with', 'ends with'],
+          ['contains', 'contains'],
+          ['not_contains', 'not contains'],
+          ['regex', 'custom regex'],
         ].forEach(([value, label]) => {
           const option = document.createElement('option');
           option.value = value;

--- a/tests/test_automation_trigger_filters.py
+++ b/tests/test_automation_trigger_filters.py
@@ -41,3 +41,78 @@ def test_filters_like_requires_string_actual_value():
     filters = {"match": {"ticket.subject": "% wont turn on"}}
 
     assert not automations_service._filters_match(filters, context)
+
+
+def test_filters_match_ai_tags_sequence_contains_expected_tag():
+    context = {"ticket": {"ai_tags": ["printer", "network-outage"]}}
+    filters = {"match": {"ticket.ai_tags": "network-%"}}
+
+    assert automations_service._filters_match(filters, context)
+
+
+def test_filters_match_ticket_boolean_and_time_automation_fields():
+    context = {
+        "ticket": {
+            "has_attachments": True,
+            "has_open_tasks": False,
+            "billable_minutes": 45,
+            "non_billable_minutes": 10,
+        }
+    }
+
+    assert automations_service._filters_match(
+        {
+            "all": [
+                {"match": {"ticket.has_attachments": True}},
+                {"match": {"ticket.has_open_tasks": False}},
+                {"greater_than": {"ticket.billable_minutes": 30}},
+                {"less_than_or_equal": {"ticket.non_billable_minutes": 10}},
+            ]
+        },
+        context,
+    )
+
+
+def test_filters_match_string_operator_variants():
+    context = {"ticket": {"subject": "Network outage for payroll"}}
+
+    assert automations_service._filters_match(
+        {"starts_with": {"ticket.subject": "Network"}}, context
+    )
+    assert automations_service._filters_match(
+        {"ends_with": {"ticket.subject": "payroll"}}, context
+    )
+    assert automations_service._filters_match(
+        {"contains": {"ticket.subject": "outage"}}, context
+    )
+    assert automations_service._filters_match(
+        {"not_contains": {"ticket.subject": "printer"}}, context
+    )
+    assert automations_service._filters_match(
+        {"regex": {"ticket.subject": r"Network\s+outage"}}, context
+    )
+
+
+def test_filters_match_string_operators_support_sequences():
+    context = {"ticket": {"ai_tags": ["printer", "network-outage"]}}
+
+    assert automations_service._filters_match(
+        {"contains": {"ticket.ai_tags": "network"}}, context
+    )
+    assert automations_service._filters_match(
+        {"not_contains": {"ticket.ai_tags": "billing"}}, context
+    )
+    assert not automations_service._filters_match(
+        {"not_contains": {"ticket.ai_tags": "printer"}}, context
+    )
+
+
+def test_filters_match_custom_regex_rejects_invalid_or_oversized_patterns():
+    context = {"ticket": {"subject": "Network outage for payroll"}}
+
+    assert not automations_service._filters_match(
+        {"regex": {"ticket.subject": "["}}, context
+    )
+    assert not automations_service._filters_match(
+        {"regex": {"ticket.subject": "a" * 257}}, context
+    )


### PR DESCRIPTION
### Motivation
- Extend automation filter capabilities to support additional string operators and richer ticket context for matching rules.
- Surface aggregate ticket fields (time, attachments, tasks) into the automation context so filters can act on those values.

### Description
- Added `get_automation_filter_context` in `app/repositories/tickets.py` to aggregate `billable_minutes`, `non_billable_minutes`, `attachment_count`, `task_count`, and related boolean flags for a ticket.
- Updated `app/services/tickets.py` to call `tickets_repo.get_automation_filter_context` from `_enrich_ticket_context` and to set default values for the new fields on the enriched ticket record.
- Extended `app/services/automations.py` with string operator support via `_string_operator_matches` and constants `_REGEX_PATTERN_MAX_LENGTH` and `_REGEX_INPUT_MAX_LENGTH`, updated `_value_matches` and `_compare_values` to handle sequences and the new string operators, and mapped new operator keys in `_operator_filters_match`.
- Updated the automation UI in `app/static/js/automation.js` to include the new string operators in the builder, add new ticket field suggestions (time, attachment, task, and some user/company fields), and serialize/deserialize the new operators.
- Added unit tests in `tests/test_automation_trigger_filters.py` covering sequence matching for tags, boolean/time automation fields, string operator variants (`starts_with`, `ends_with`, `contains`, `not_contains`, `regex`), sequence support for string operators, and regex validation for invalid/oversized patterns.

### Testing
- Ran the automation filter unit tests with `pytest tests/test_automation_trigger_filters.py` and the new test cases all passed.
- Existing string-like filter tests (`_filters_match` and LIKE-style patterns) were re-run and remained passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a386d0813bc832da19650d6669244c0)