### PR TITLE
Fix ticket reply placement below Assets

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -898,9 +898,6 @@
             </div>
           </details>
 
-        </div>
-
-        <div class="management__column management__column--activity">
           <details class="card card--panel card-collapsible" open>
             <summary class="card__header card__header--collapsible">
               <h2 class="card__title">Add a reply</h2>


### PR DESCRIPTION
### Motivation
- The admin ticket detail page rendered the "Add a reply" form and "Conversation history" in the activity column so they were pushed too low on the page instead of appearing directly after the `Assets` card, so the UI needed to place the reply UI immediately after assets.

### Description
- Adjusted `app/templates/admin/ticket_detail.html` to move the `Add a reply` panel and `Conversation history` markup into the main ticket content column so they render directly after the `Assets` card.

### Testing
- Parsed the updated Jinja template via `jinja2.Environment().parse()` for `app/templates/admin/ticket_detail.html`, which succeeded.
- Ran `git diff --check`, which reported no issues.
- Ran `pytest tests/test_admin_ticket_detail.py tests/test_ticket_booking_link.py`, which produced 2 passing tests and 4 failures caused by the test environment attempting to connect to MySQL on `localhost:3306`, resulting in external dependency failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3890ff65f8832dba62298afe864fd2)