### PR TITLE
Add scheduled automation ticket preview

### DIFF
--- a/app/api/routes/automations.py
+++ b/app/api/routes/automations.py
@@ -9,6 +9,7 @@ from app.schemas.automations import (
     AutomationExecutionResult,
     AutomationResponse,
     AutomationRunResponse,
+    AutomationTicketPreviewResponse,
     AutomationUpdate,
 )
 from app.services import audit as audit_service
@@ -139,6 +140,21 @@ async def delete_automation(
         before=existing,
         after=None,
     )
+
+
+@router.get("/{automation_id}/preview", response_model=AutomationTicketPreviewResponse)
+async def preview_scheduled_ticket_automation(
+    automation_id: int,
+    limit: int = Query(default=1000, ge=1, le=5000),
+    current_user: dict = Depends(require_super_admin),
+) -> AutomationTicketPreviewResponse:
+    try:
+        result = await automation_service.preview_scheduled_ticket_automation_by_id(automation_id, limit=limit)
+    except ValueError as exc:
+        message = str(exc)
+        status_code = status.HTTP_400_BAD_REQUEST if "Only scheduled" in message else status.HTTP_404_NOT_FOUND
+        raise HTTPException(status_code=status_code, detail=message) from exc
+    return AutomationTicketPreviewResponse(**result)
 
 
 @router.get("/{automation_id}/runs", response_model=list[AutomationRunResponse])

--- a/app/features/automations/handlers.py
+++ b/app/features/automations/handlers.py
@@ -571,6 +571,29 @@ async def admin_update_automation_status(automation_id: int, request: Request):
     return flash_redirect("/admin/automations", f"Automation {automation_id} updated.", "success")
 
 
+async def admin_preview_automation(automation_id: int, request: Request, limit: int = Query(default=1000, ge=1, le=5000)):
+    from app.repositories import automations as automation_repo
+    from app.services import automations as automations_service
+
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return redirect
+    automation = await automation_repo.get_automation(automation_id)
+    if not automation:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+    try:
+        preview = await automations_service.preview_scheduled_ticket_automation(automation, limit=limit)
+    except ValueError as exc:
+        return flash_redirect("/admin/automations", str(exc), "error")
+    extra = {
+        "title": f"Preview automation #{automation_id}",
+        "automation": automation,
+        "preview": preview,
+        "limit": limit,
+    }
+    return await _main()._render_template("admin/automations_preview.html", request, current_user, extra=extra)
+
+
 async def admin_execute_automation(automation_id: int, request: Request):
     from app.services import automations as automations_service
 

--- a/app/features/automations/routes.py
+++ b/app/features/automations/routes.py
@@ -34,6 +34,12 @@ router.add_api_route(
     response_class=HTMLResponse,
 )
 router.add_api_route(
+    "/admin/automations/{automation_id}/preview",
+    handlers.admin_preview_automation,
+    methods=["GET"],
+    response_class=HTMLResponse,
+)
+router.add_api_route(
     "/admin/automations/{automation_id}/edit",
     handlers.admin_edit_automation_page,
     methods=["GET"],

--- a/app/schemas/automations.py
+++ b/app/schemas/automations.py
@@ -75,3 +75,31 @@ class AutomationExecutionResult(BaseModel):
     started_at: datetime
     finished_at: datetime
     next_run_at: Optional[datetime]
+
+
+class AutomationTicketPreviewItem(BaseModel):
+    id: int
+    ticket_number: Optional[str] = None
+    subject: Optional[str] = None
+    status: Optional[str] = None
+    priority: Optional[str] = None
+    company_id: Optional[int] = None
+    requester_id: Optional[int] = None
+    assigned_user_id: Optional[int] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    last_reply_at: Optional[datetime] = None
+    last_activity_at: Optional[datetime] = None
+    age_days: Optional[float] = None
+    last_activity_age_days: Optional[float] = None
+
+
+class AutomationTicketPreviewResponse(BaseModel):
+    automation_id: int
+    automation_name: Optional[str] = None
+    mode: str
+    checked_at: datetime
+    scan_limit: int
+    scanned: int
+    matched: int
+    tickets: list[AutomationTicketPreviewItem]

--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -585,6 +585,78 @@ async def _invoke_automation_actions_for_context(
     return {"status": "skipped", "reason": "No action module configured"}, None
 
 
+async def preview_scheduled_ticket_automation(
+    automation: Mapping[str, Any],
+    *,
+    limit: int = 1000,
+) -> dict[str, Any]:
+    """Return tickets that would be actioned by a scheduled ticket automation.
+
+    This mirrors the scheduled ticket scan path but never invokes automation
+    actions, so admins can safely inspect the next run impact before enabling
+    or manually executing an automation.
+    """
+
+    if str(automation.get("kind") or "").strip().lower() != "scheduled":
+        raise ValueError("Only scheduled automations can be previewed")
+
+    now = datetime.now(timezone.utc)
+    raw_filters = automation.get("trigger_filters")
+    filters = raw_filters if isinstance(raw_filters, Mapping) else None
+    scan_limit = max(1, min(int(limit or 1000), 5000))
+    scanned = await tickets_repo.list_tickets_for_automation_scan(limit=scan_limit)
+    matches: list[dict[str, Any]] = []
+
+    from app.services import tickets as tickets_service
+
+    for ticket in scanned:
+        ticket_context = _attach_ticket_age_context(ticket, now=now)
+        try:
+            enriched_ticket = await tickets_service._enrich_ticket_context(ticket_context)
+        except Exception:  # pragma: no cover - defensive fallback
+            enriched_ticket = ticket_context
+        context = {
+            "ticket": _attach_ticket_age_context(enriched_ticket, now=now),
+            "ticket_update": {
+                "actor_type": "automation",
+                "actor_label": "Automation",
+                "actor_user": None,
+            },
+            "schedule": {
+                "automation_id": automation.get("id"),
+                "automation_name": automation.get("name"),
+                "checked_at": now.isoformat(),
+                "preview": True,
+            },
+        }
+        if not _filters_match(filters, context):
+            continue
+        match = dict(enriched_ticket)
+        match["last_reply_at"] = ticket_context.get("last_reply_at")
+        match["last_activity_at"] = ticket_context.get("last_activity_at")
+        match["age_days"] = ticket_context.get("age_days")
+        match["last_activity_age_days"] = ticket_context.get("last_activity_age_days")
+        matches.append(match)
+
+    return {
+        "automation_id": automation.get("id"),
+        "automation_name": automation.get("name"),
+        "mode": "scheduled_ticket_preview",
+        "checked_at": now,
+        "scan_limit": scan_limit,
+        "scanned": len(scanned),
+        "matched": len(matches),
+        "tickets": matches,
+    }
+
+
+async def preview_scheduled_ticket_automation_by_id(automation_id: int, *, limit: int = 1000) -> dict[str, Any]:
+    automation = await automation_repo.get_automation(automation_id)
+    if not automation:
+        raise ValueError(f"Automation {automation_id} not found")
+    return await preview_scheduled_ticket_automation(automation, limit=limit)
+
+
 async def _execute_scheduled_ticket_automation(automation: Mapping[str, Any]) -> dict[str, Any]:
     """Run a scheduled automation once for each ticket matching its filters."""
 

--- a/app/templates/admin/automations.html
+++ b/app/templates/admin/automations.html
@@ -118,6 +118,11 @@
                           <li class="header-title-menu__item" role="none">
                             <a class="header-title-menu__link" role="menuitem" href="/admin/automations/{{ automation.id }}/edit">Edit</a>
                           </li>
+                          {% if automation.kind == 'scheduled' %}
+                          <li class="header-title-menu__item" role="none">
+                            <a class="header-title-menu__link" role="menuitem" href="/admin/automations/{{ automation.id }}/preview">Preview tickets</a>
+                          </li>
+                          {% endif %}
                           <li class="header-title-menu__item" role="none">
                             <form action="/admin/automations/{{ automation.id }}/execute" method="post" class="inline-form">
                               {% include "partials/csrf.html" %}

--- a/app/templates/admin/automations_preview.html
+++ b/app/templates/admin/automations_preview.html
@@ -1,0 +1,99 @@
+{% extends "base.html" %}
+{% from "macros/header.html" import page_header_actions %}
+
+{% block header_title %}Automation preview{% endblock %}
+
+{% block header_actions %}
+  {{ page_header_actions([
+    {"label": "Back to automations", "type": "link", "variant": "ghost", "href": "/admin/automations"},
+    {"label": "Edit automation", "type": "link", "variant": "primary", "href": "/admin/automations/" ~ automation.id ~ "/edit"}
+  ]) }}
+{% endblock %}
+
+{% block content %}
+  <div class="management management--single" data-layout>
+    <section class="management__content">
+      <header class="management__header">
+        <div>
+          <p class="eyebrow">Scheduled ticket automation</p>
+          <h1 class="page-title">{{ automation.name }}</h1>
+          <p class="page-subtitle">Preview the tickets that will be actioned the next time this automation runs. No actions are executed from this page.</p>
+        </div>
+        <form method="get" class="management__filters">
+          <label class="form-label" for="preview-limit">Scan limit</label>
+          <input id="preview-limit" name="limit" type="number" min="1" max="5000" class="form-input" value="{{ limit }}" />
+          <button type="submit" class="button">Refresh preview</button>
+        </form>
+      </header>
+
+      <div class="management__body">
+        <div class="management__stats">
+          <article class="stat-card">
+            <h3 class="stat-card__title">Tickets scanned</h3>
+            <p class="stat-card__value">{{ preview.scanned }}</p>
+          </article>
+          <article class="stat-card">
+            <h3 class="stat-card__title">Tickets matched</h3>
+            <p class="stat-card__value">{{ preview.matched }}</p>
+          </article>
+          <article class="stat-card">
+            <h3 class="stat-card__title">Next run</h3>
+            <p class="stat-card__value stat-card__value--small">{{ automation.next_run_at.astimezone().strftime('%Y-%m-%d %H:%M') if automation.next_run_at else '—' }}</p>
+          </article>
+          <article class="stat-card">
+            <h3 class="stat-card__title">Checked</h3>
+            <p class="stat-card__value stat-card__value--small">{{ preview.checked_at.astimezone().strftime('%Y-%m-%d %H:%M') }}</p>
+          </article>
+        </div>
+
+        <div class="management__toolbar">
+          <div class="management__toolbar-search">
+            <input type="search" class="form-input" placeholder="Filter preview tickets" aria-label="Filter preview tickets" data-table-filter="automation-preview-table" />
+          </div>
+        </div>
+
+        <div class="table-wrapper">
+          <table class="table" id="automation-preview-table" data-table data-table-id="automation-preview">
+            <thead>
+              <tr>
+                <th scope="col" data-sort="int" data-column-key="id">ID</th>
+                <th scope="col" data-sort="string" data-column-key="number">Number</th>
+                <th scope="col" data-sort="string" data-column-key="subject">Subject</th>
+                <th scope="col" data-sort="string" data-column-key="status">Status</th>
+                <th scope="col" data-sort="string" data-column-key="priority">Priority</th>
+                <th scope="col" data-sort="int" data-column-key="company">Company</th>
+                <th scope="col" data-sort="string" data-column-key="updated">Updated</th>
+                <th scope="col" data-sort="float" data-column-key="age">Age (days)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% if preview.tickets %}
+                {% for ticket in preview.tickets %}
+                  <tr>
+                    <td data-label="ID" data-column-key="id"><a href="/admin/tickets/{{ ticket.id }}">{{ ticket.id }}</a></td>
+                    <td data-label="Number" data-column-key="number">{{ ticket.ticket_number or '—' }}</td>
+                    <td data-label="Subject" data-column-key="subject">{{ ticket.subject or '—' }}</td>
+                    <td data-label="Status" data-column-key="status">{{ ticket.status or '—' }}</td>
+                    <td data-label="Priority" data-column-key="priority">{{ ticket.priority or '—' }}</td>
+                    <td data-label="Company" data-column-key="company">{{ ticket.company_id or '—' }}</td>
+                    <td data-label="Updated" data-column-key="updated">{{ ticket.updated_at.astimezone().strftime('%Y-%m-%d %H:%M') if ticket.updated_at else '—' }}</td>
+                    <td data-label="Age (days)" data-column-key="age">{{ '%.1f'|format(ticket.age_days) if ticket.age_days is not none else '—' }}</td>
+                  </tr>
+                {% endfor %}
+              {% else %}
+                <tr>
+                  <td colspan="8" class="table__empty">No tickets match this automation's filters in the current scan window.</td>
+                </tr>
+              {% endif %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+  {{ super() }}
+  <script src="{{ static_url('/static/js/tables.js') }}" defer></script>
+{% endblock %}

--- a/tests/test_automations_service.py
+++ b/tests/test_automations_service.py
@@ -866,3 +866,69 @@ def test_filters_match_supports_reply_internal_note_context():
         {"match": {"reply.is_internal": True}},
         public_context,
     )
+
+
+@pytest.mark.anyio
+async def test_preview_scheduled_ticket_automation_returns_matches_without_actions(monkeypatch):
+    scanned_tickets = [
+        {
+            "id": 10,
+            "ticket_number": "T-10",
+            "status": "open",
+            "subject": "Stale ticket",
+            "created_at": datetime.now(timezone.utc) - timedelta(days=40),
+            "updated_at": datetime.now(timezone.utc) - timedelta(days=35),
+            "latest_reply_at": datetime.now(timezone.utc) - timedelta(days=34),
+        },
+        {
+            "id": 11,
+            "ticket_number": "T-11",
+            "status": "closed",
+            "subject": "Closed ticket",
+            "created_at": datetime.now(timezone.utc) - timedelta(days=40),
+            "updated_at": datetime.now(timezone.utc) - timedelta(days=35),
+            "latest_reply_at": datetime.now(timezone.utc) - timedelta(days=34),
+        },
+    ]
+
+    async def fake_list_tickets_for_automation_scan(*, limit: int = 1000):
+        assert limit == 25
+        return scanned_tickets
+
+    async def fake_enrich(ticket):
+        return dict(ticket)
+
+    async def fail_trigger_module(*args, **kwargs):  # pragma: no cover - should never be called
+        raise AssertionError("preview must not execute automation actions")
+
+    from app.services import tickets as tickets_service
+
+    monkeypatch.setattr(
+        automations_service.tickets_repo,
+        "list_tickets_for_automation_scan",
+        fake_list_tickets_for_automation_scan,
+    )
+    monkeypatch.setattr(tickets_service, "_enrich_ticket_context", fake_enrich)
+    monkeypatch.setattr(automations_service.modules_service, "trigger_module", fail_trigger_module)
+
+    result = await automations_service.preview_scheduled_ticket_automation(
+        {
+            "id": 12,
+            "name": "Preview stale open tickets",
+            "kind": "scheduled",
+            "trigger_filters": {
+                "all": [
+                    {"match": {"ticket.status": "open"}},
+                    {"greater_than": {"ticket.age_days": 30}},
+                ]
+            },
+            "action_module": "update-ticket",
+        },
+        limit=25,
+    )
+
+    assert result["mode"] == "scheduled_ticket_preview"
+    assert result["scanned"] == 2
+    assert result["matched"] == 1
+    assert result["tickets"][0]["id"] == 10
+    assert result["tickets"][0]["ticket_number"] == "T-10"


### PR DESCRIPTION
### Motivation

- Provide admins a safe way to preview which tickets a scheduled automation will act on before running or enabling it. 
- Avoid accidental side effects by ensuring previewing never executes automation actions or triggers modules. 

### Description

- Added `preview_scheduled_ticket_automation` and `preview_scheduled_ticket_automation_by_id` to `app/services/automations.py` that reuse existing filter matching and ticket enrichment but never invoke module actions, and enforce a capped `limit`. 
- Exposed a typed API endpoint `GET /api/automations/{automation_id}/preview` with response model `AutomationTicketPreviewResponse` in `app/api/routes/automations.py` and added preview item/response schemas to `app/schemas/automations.py`. 
- Added an admin preview route, handler and template (`/admin/automations/{automation_id}/preview`) plus a “Preview tickets” row action in the automations table (`app/features/automations/routes.py`, `app/features/automations/handlers.py`, `app/templates/admin/automations.html`, `app/templates/admin/automations_preview.html`). 
- Added a regression test to `tests/test_automations_service.py` asserting the preview returns matches and does not execute module actions. 

### Testing

- Compiled modified modules with `python -m compileall` targeting the changed files, which completed successfully. 
- Ran unit tests for automations with `pytest tests/test_automations_service.py -q`, which passed (test run produced successful results; warnings about Pydantic deprecation are informational). 
- UI screenshot capture was not performed because no browser/Playwright runtime is available in the container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3899ecdaf0832d849949789681aa16)