### PR TITLE
Add `in` / `not_in` operators for automation ticket filters

### DIFF
--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -185,6 +185,14 @@ _REGEX_PATTERN_MAX_LENGTH = 256
 _REGEX_INPUT_MAX_LENGTH = 4096
 
 
+def _split_membership_values(expected: Any) -> list[Any]:
+    if isinstance(expected, str):
+        return [item.strip() for item in expected.split(",") if item.strip()]
+    if isinstance(expected, Sequence) and not isinstance(expected, (str, bytes, bytearray)):
+        return list(expected)
+    return [expected]
+
+
 def _string_operator_matches(actual: Any, expected: Any, operator: str) -> bool:
     if not isinstance(actual, str) or not isinstance(expected, str):
         return False
@@ -236,9 +244,14 @@ def _coerce_comparable(value: Any) -> Any:
 
 def _compare_values(actual: Any, expected: Any, operator: str) -> bool:
     if isinstance(actual, Sequence) and not isinstance(actual, (str, bytes, bytearray)):
-        if operator == "not_contains":
+        if operator in {"not_contains", "not_in"}:
             return all(_compare_values(candidate, expected, operator) for candidate in actual)
         return any(_compare_values(candidate, expected, operator) for candidate in actual)
+
+    if operator in {"in", "not_in"}:
+        candidates = _split_membership_values(expected)
+        matched = any(_value_matches(actual, candidate) for candidate in candidates)
+        return matched if operator == "in" else not matched
 
     string_operators = {"starts_with", "ends_with", "contains", "not_contains", "regex"}
     if operator in string_operators:
@@ -313,6 +326,8 @@ def _filters_match(filters: Mapping[str, Any] | None, context: Mapping[str, Any]
 
     operator_keys = {
         "not_equals": "not_equals",
+        "in": "in",
+        "not_in": "not_in",
         "gt": "greater_than",
         "greater_than": "greater_than",
         "gte": "greater_than_or_equal",

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -1517,6 +1517,8 @@
       const operatorNodes = {
         match: 'equals',
         not_equals: 'not_equals',
+        in: 'in',
+        not_in: 'not_in',
         greater_than: 'greater_than',
         gt: 'greater_than',
         greater_than_or_equal: 'greater_than_or_equal',
@@ -1598,6 +1600,8 @@
       const typedValue = parseTypedValue(row.valueType, row.value);
       const operatorKey = {
         not_equals: 'not_equals',
+        in: 'in',
+        not_in: 'not_in',
         greater_than: 'greater_than',
         greater_than_or_equal: 'greater_than_or_equal',
         less_than: 'less_than',
@@ -1729,6 +1733,8 @@
         [
           ['equals', 'equals'],
           ['not_equals', 'not equals'],
+          ['in', 'in'],
+          ['not_in', 'not in'],
           ['greater_than', 'greater than'],
           ['greater_than_or_equal', 'greater than or equal'],
           ['less_than', 'less than'],
@@ -1745,7 +1751,10 @@
           operatorSelect.appendChild(option);
         });
         operatorSelect.value = row.operator || 'equals';
-        operatorSelect.addEventListener('change', () => handleRowChange(index, 'operator', operatorSelect.value));
+        operatorSelect.addEventListener('change', () => {
+          handleRowChange(index, 'operator', operatorSelect.value);
+          valueInput.placeholder = operatorSelect.value === 'in' || operatorSelect.value === 'not_in' ? 'Resolved, Closed' : 'value';
+        });
 
         const valueTypeSelect = document.createElement('select');
         valueTypeSelect.className = 'form-input';
@@ -1762,7 +1771,7 @@
         const valueInput = document.createElement('input');
         valueInput.className = 'form-input';
         valueInput.type = 'text';
-        valueInput.placeholder = 'value';
+        valueInput.placeholder = row.operator === 'in' || row.operator === 'not_in' ? 'Resolved, Closed' : 'value';
         valueInput.value = row.value || '';
         valueInput.disabled = row.valueType === 'null';
 

--- a/app/templates/admin/automations_create_event.html
+++ b/app/templates/admin/automations_create_event.html
@@ -117,7 +117,7 @@
                   >{{ values.get('triggerFiltersRaw', '') }}</textarea>
                 </div>
                 <p class="form-help" data-filter-builder-error hidden></p>
-                <p class="form-help">Build common trigger filters with structured conditions. Use Advanced JSON for complex nested logic.</p>
+                <p class="form-help">Build common trigger filters with structured conditions. Use in/not in with comma-separated values such as Resolved, Closed for multi-value ticket status filters. Use Advanced JSON for complex nested logic.</p>
               </div>
               <div class="form-field" data-automation-actions>
                 <label class="form-label">Trigger actions</label>

--- a/tests/test_automations_service.py
+++ b/tests/test_automations_service.py
@@ -765,6 +765,45 @@ def test_filters_match_supports_ticket_age_comparisons():
     )
 
 
+def test_filters_match_supports_in_and_not_in_comma_separated_values():
+    resolved_context = {"ticket": {"status": "Resolved"}}
+    open_context = {"ticket": {"status": "Open"}}
+
+    assert automations_service._filters_match(
+        {"in": {"ticket.status": "Resolved, Closed"}},
+        resolved_context,
+    )
+    assert not automations_service._filters_match(
+        {"in": {"ticket.status": "Resolved, Closed"}},
+        open_context,
+    )
+    assert automations_service._filters_match(
+        {"not_in": {"ticket.status": "Resolved, Closed"}},
+        open_context,
+    )
+    assert not automations_service._filters_match(
+        {"not_in": {"ticket.status": "Resolved, Closed"}},
+        resolved_context,
+    )
+
+
+def test_filters_match_not_in_rejects_matching_sequence_members():
+    context = {"ticket": {"labels": ["vip", "escalated"]}}
+
+    assert automations_service._filters_match(
+        {"in": {"ticket.labels": "vip, customer"}},
+        context,
+    )
+    assert not automations_service._filters_match(
+        {"not_in": {"ticket.labels": "vip, customer"}},
+        context,
+    )
+    assert automations_service._filters_match(
+        {"not_in": {"ticket.labels": "spam, customer"}},
+        context,
+    )
+
+
 @pytest.mark.anyio
 async def test_execute_scheduled_ticket_automation_runs_actions_for_matching_tickets(monkeypatch):
     scanned_tickets = [


### PR DESCRIPTION
### Motivation
- Enable automation trigger filters to include or exclude tickets by multiple values using a comma-separated list (e.g. exclude `Resolved, Closed`).
- Expose these operators in the filter builder UI so admins can create multi-value status/label filters without writing raw JSON.

### Description
- Added backend membership support: introduced `_split_membership_values` and implemented `in` / `not_in` handling in `_compare_values` and the operator dispatch (`_filters_match`). (changes in `app/services/automations.py`).
- Updated the filter builder to recognize and serialize `in` / `not_in`, add options to operator selectors, and show a comma-separated placeholder (changes in `app/static/js/automation.js`).
- Improved admin UI help text to describe comma-separated usage in the trigger filters panel (change in `app/templates/admin/automations_create_event.html`).
- Added regression tests covering comma-separated `in` / `not_in` behavior for both scalar status fields and sequence fields like labels (`tests/test_automations_service.py`).

### Testing
- Ran the new regression tests with `python -m pytest tests/test_automations_service.py::test_filters_match_supports_in_and_not_in_comma_separated_values tests/test_automations_service.py::test_filters_match_not_in_rejects_matching_sequence_members`, and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a389fb8f11c832d8190eade6ff7a4f0)