### PR TITLE
Adjust management column grid for responsive breakpoints and add static layout tests

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5095,15 +5095,34 @@ dialog.modal:not([open]) {
 }
 
 @media (min-width: 961px) and (max-width: 1799px) {
+  .management__column--details {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+  }
+
+  .management__column--content {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
   .management__column--activity,
   .management__column--conversation {
     grid-column: 2;
+    grid-row: 2;
   }
 }
 
 @media (min-width: 1800px) {
   .management__body--columns {
     grid-template-columns: minmax(280px, 320px) minmax(360px, 1fr) minmax(0, 1fr);
+  }
+
+  .management__column--details {
+    grid-column: 1;
+  }
+
+  .management__column--content {
+    grid-column: 2;
   }
 
   .management__column--activity,

--- a/tests/test_ticket_detail_layout.py
+++ b/tests/test_ticket_detail_layout.py
@@ -1,0 +1,48 @@
+"""Static layout checks for the admin ticket detail page.
+
+These tests protect the responsive column placement used by the admin ticket
+detail page without needing a running browser or database-backed FastAPI app.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+APP = REPO / "app"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_admin_ticket_reply_stays_in_activity_column():
+    """High-resolution layouts should keep replies in the third grid column."""
+    template = _read(APP / "templates" / "admin" / "ticket_detail.html")
+
+    assert '<div class="management__column management__column--content">' in template
+    assert '<div class="management__column management__column--activity">' in template
+    assert template.index('data-ticket-assets-card') < template.index(
+        'management__column management__column--activity'
+    )
+    assert template.index('management__column management__column--activity') < template.index(
+        "Add a reply"
+    )
+    assert template.index("Add a reply") < template.index("Conversation history")
+
+
+def test_admin_ticket_grid_places_activity_below_assets_until_wide_layout():
+    """Medium desktop layouts should place activity below content, not details."""
+    css = _read(APP / "static" / "css" / "app.css")
+
+    assert "@media (min-width: 961px) and (max-width: 1799px)" in css
+    assert ".management__column--details {\n    grid-column: 1;\n    grid-row: 1 / span 2;" in css
+    assert ".management__column--content {\n    grid-column: 2;\n    grid-row: 1;" in css
+    assert (
+        ".management__column--activity,\n"
+        "  .management__column--conversation {\n"
+        "    grid-column: 2;\n"
+        "    grid-row: 2;"
+    ) in css
+    assert "@media (min-width: 1800px)" in css
+    assert ".management__column--activity,\n  .management__column--conversation {\n    grid-column: 3;" in css


### PR DESCRIPTION
### Motivation

- Ensure the admin ticket detail page places the details, content, and activity columns correctly across medium and extra-wide breakpoints to preserve reply placement and visual hierarchy.
- Add static, repository-only tests to validate the template and CSS layout without requiring a running browser or database-backed app.
- Prevent regressions in responsive column ordering when adjusting grid templates.

### Description

- Updated `app/static/css/app.css` to define `.management__column--details` and `.management__column--content` grid placement inside the `@media (min-width: 961px) and (max-width: 1799px)` rule so details span two rows and activity/conversation are placed in the second row, and added explicit column placement for the `@media (min-width: 1800px)` layout.
- Kept `.management__column--activity` and `.management__column--conversation` as a reusable set and set their grid columns for both medium and extra-wide breakpoints to maintain reply and conversation ordering.
- Added `tests/test_ticket_detail_layout.py` which reads the template and CSS files from the repo and asserts that the content and CSS rules place assets, activity, and conversation elements in the intended order and columns.

### Testing

- Added `tests/test_ticket_detail_layout.py` unit tests that statically inspect `app/templates/admin/ticket_detail.html` and `app/static/css/app.css` to verify element ordering and media-query rules.
- Ran the test suite with `pytest` and the new layout tests executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3890ff65f8832dba62298afe864fd2)