### PR TITLE
Adjust admin ticket detail responsive grid breakpoints and add layout tests

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5094,16 +5094,35 @@ dialog.modal:not([open]) {
   min-width: 0;
 }
 
-@media (min-width: 961px) and (max-width: 1799px) {
+@media (min-width: 961px) and (max-width: 1499px) {
+  .management__column--details {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+  }
+
+  .management__column--content {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
   .management__column--activity,
   .management__column--conversation {
     grid-column: 2;
+    grid-row: 2;
   }
 }
 
-@media (min-width: 1800px) {
+@media (min-width: 1500px) {
   .management__body--columns {
     grid-template-columns: minmax(280px, 320px) minmax(360px, 1fr) minmax(0, 1fr);
+  }
+
+  .management__column--details {
+    grid-column: 1;
+  }
+
+  .management__column--content {
+    grid-column: 2;
   }
 
   .management__column--activity,

--- a/tests/test_ticket_detail_layout.py
+++ b/tests/test_ticket_detail_layout.py
@@ -1,0 +1,48 @@
+"""Static layout checks for the admin ticket detail page.
+
+These tests protect the responsive column placement used by the admin ticket
+detail page without needing a running browser or database-backed FastAPI app.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+APP = REPO / "app"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_admin_ticket_reply_stays_in_activity_column():
+    """High-resolution layouts should keep replies in the third grid column."""
+    template = _read(APP / "templates" / "admin" / "ticket_detail.html")
+
+    assert '<div class="management__column management__column--content">' in template
+    assert '<div class="management__column management__column--activity">' in template
+    assert template.index('data-ticket-assets-card') < template.index(
+        'management__column management__column--activity'
+    )
+    assert template.index('management__column management__column--activity') < template.index(
+        "Add a reply"
+    )
+    assert template.index("Add a reply") < template.index("Conversation history")
+
+
+def test_admin_ticket_grid_places_activity_below_assets_until_wide_layout():
+    """Medium desktop layouts should place activity below content, not details."""
+    css = _read(APP / "static" / "css" / "app.css")
+
+    assert "@media (min-width: 961px) and (max-width: 1499px)" in css
+    assert ".management__column--details {\n    grid-column: 1;\n    grid-row: 1 / span 2;" in css
+    assert ".management__column--content {\n    grid-column: 2;\n    grid-row: 1;" in css
+    assert (
+        ".management__column--activity,\n"
+        "  .management__column--conversation {\n"
+        "    grid-column: 2;\n"
+        "    grid-row: 2;"
+    ) in css
+    assert "@media (min-width: 1500px)" in css
+    assert ".management__column--activity,\n  .management__column--conversation {\n    grid-column: 3;" in css


### PR DESCRIPTION
### Motivation

- Ensure the admin ticket detail page has clearer responsive behavior by tightening breakpoint ranges and explicitly placing columns in the grid for medium and large layouts. 
- Add static tests to guard the column ordering and CSS rules so regressions in responsive layout are caught without a running browser or DB-backed app.

### Description

- Updated `app/static/css/app.css` to change the medium breakpoint from `@media (min-width: 961px) and (max-width: 1799px)` to `@media (min-width: 961px) and (max-width: 1499px)` and added explicit grid placement rules for `.management__column--details`, `.management__column--content`, and set `grid-row: 2` for `.management__column--activity` and `.management__column--conversation` within that range.
- Updated the large breakpoint from `@media (min-width: 1800px)` to `@media (min-width: 1500px)` and added explicit column assignments for `.management__column--details` and `.management__column--content` so activity and conversation move to the third column.
- Added static tests in `tests/test_ticket_detail_layout.py` that validate the template column order in `app/templates/admin/ticket_detail.html` and assert the presence and contents of the updated CSS media queries and rules in `app/static/css/app.css`.

### Testing

- Ran the project test suite with `pytest` and verified the new file `tests/test_ticket_detail_layout.py` executed as part of the suite.
- The new static layout tests passed and confirmed the template ordering and the updated CSS media query rules were present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3890ff65f8832dba62298afe864fd2)