### PR TITLE
Fix admin ticket dashboard reply status

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7966,6 +7966,16 @@ async def _render_tickets_dashboard(
     public_status_map = {
         definition.tech_status: definition.public_status for definition in dashboard.status_definitions
     }
+    reply_default_status = next(
+        (definition.tech_status for definition in dashboard.status_definitions if definition.is_default),
+        None,
+    )
+    if not reply_default_status:
+        reply_default_status = (
+            "pending"
+            if "pending" in dashboard.available_statuses
+            else (dashboard.available_statuses[0] if dashboard.available_statuses else "open")
+        )
     labour_types = await labour_types_service.list_labour_types()
     ticket_ids = [int(t.get("id")) for t in dashboard.tickets if t.get("id") is not None]
     ticket_time_lookup = await tickets_repo.get_time_totals_by_ticket_ids(ticket_ids)

--- a/tests/test_ticket_access.py
+++ b/tests/test_ticket_access.py
@@ -17,7 +17,7 @@ from app.api.routes import tickets as tickets_routes
 from app.core.database import db
 from app import main as main_module
 from app.main import app, scheduler_service
-from app.services.tickets import HELPDESK_PERMISSION_KEY
+from app.services.tickets import HELPDESK_PERMISSION_KEY, TicketStatusDefinition
 from app.security.session import SessionData, session_manager
 
 
@@ -1008,6 +1008,22 @@ def test_admin_ticket_assign_options_only_include_helpdesk_users(monkeypatch):
         captured["permission"] = permission
         return [{"id": 1, "email": "tech@example.com"}]
 
+    async def fake_list_status_definitions():
+        return [
+            TicketStatusDefinition(
+                tech_status="open",
+                tech_label="Open",
+                public_status="Open",
+                is_default=False,
+            ),
+            TicketStatusDefinition(
+                tech_status="pending",
+                tech_label="Pending",
+                public_status="Pending",
+                is_default=True,
+            ),
+        ]
+
     async def fake_render_template(template_name, request, user, *, extra=None):
         captured["template_name"] = template_name
         captured["extra"] = extra or {}
@@ -1023,6 +1039,7 @@ def test_admin_ticket_assign_options_only_include_helpdesk_users(monkeypatch):
         "list_users_with_permission",
         fake_list_helpdesk_users,
     )
+    monkeypatch.setattr(main_module.tickets_service, "list_status_definitions", fake_list_status_definitions)
     monkeypatch.setattr(main_module, "_render_template", fake_render_template)
 
     request = Request({"type": "http", "app": app, "headers": []})
@@ -1037,6 +1054,7 @@ def test_admin_ticket_assign_options_only_include_helpdesk_users(monkeypatch):
     lookup = captured["extra"].get("ticket_user_lookup")
     assert lookup[1]["email"] == "tech@example.com"
     assert lookup[2]["email"] == "general@example.com"
+    assert captured["extra"]["ticket_reply_default_status"] == "pending"
     assert captured["template_name"] == "admin/tickets.html"
 
 


### PR DESCRIPTION
### Motivation
- The admin tickets dashboard template expects `ticket_reply_default_status` but the dashboard renderer could pass an undefined `reply_default_status`, causing errors when rendering `/admin/tickets`.

### Description
- Compute `reply_default_status` inside `_render_tickets_dashboard` by selecting the `tech_status` of the status definition where `is_default` is true, and fall back to `"pending"`, the first available status, or `"open"` if none exist; this value is added to the template `extra` context as `ticket_reply_default_status` (`app/main.py`).
- Add a unit regression that mocks `list_status_definitions` and verifies the dashboard template context includes `ticket_reply_default_status` (tests updated in `tests/test_ticket_access.py`).

### Testing
- `python -m py_compile app/main.py` — succeeded.
- Targeted unit test `pytest tests/test_ticket_access.py::test_admin_ticket_assign_options_only_include_helpdesk_users` — passed and confirms `ticket_reply_default_status` is present in template context.
- Combined run including the phone-search tests `pytest tests/test_ticket_access.py::test_admin_ticket_assign_options_only_include_helpdesk_users tests/test_admin_tickets_phone_search.py` — the targeted regression passed, while three existing phone-search route tests in `tests/test_admin_tickets_phone_search.py` failed (returned 404) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38b06876a8832d9cbc0891147158c6)