### PR TITLE
Align ticket reply split button heights

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10272,25 +10272,32 @@ a.stat-strip__stat:focus-visible {
 }
 
 .ticket-reply-submit {
+  --ticket-reply-submit-height: 2.5rem;
   position: relative;
   display: inline-flex;
   align-items: stretch;
 }
 
 .ticket-reply-submit__primary {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--ticket-reply-submit-height);
+  box-sizing: border-box;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
 
 .ticket-reply-submit__status-menu {
   position: relative;
+  display: flex;
 }
 
 .ticket-reply-submit__toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
+  min-height: var(--ticket-reply-submit-height);
+  box-sizing: border-box;
   min-width: 2.75rem;
   padding-inline: 0.85rem;
   border-top-left-radius: 0;


### PR DESCRIPTION
### Motivation
- Make the `Post reply` primary button and the adjacent status dropdown toggle render at the same height so the split-control appears visually consistent.

### Description
- Updated `app/static/css/app.css` to add `--ticket-reply-submit-height` and apply `min-height`/`box-sizing` to the primary button and toggle, and set the status menu wrapper to participate in flex layout so both parts match height.

### Testing
- Ran `git diff --check` which passed. 
- Compiled Python with `python -m py_compile app/main.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38b245a428832d8f783eb5430736e0)