### PR TITLE
Fix medium ticket detail column flow

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5095,9 +5095,20 @@ dialog.modal:not([open]) {
 }
 
 @media (min-width: 961px) and (max-width: 1799px) {
+  .management__column--details {
+    grid-column: 1;
+    grid-row: 1 / 3;
+  }
+
+  .management__column--content {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
   .management__column--activity,
   .management__column--conversation {
     grid-column: 2;
+    grid-row: 2;
   }
 }
 


### PR DESCRIPTION
### Motivation
- On medium-width displays the ticket detail right-hand content (Add a reply / Conversation history) was being pushed down by the left details column; the layout should place these sections directly beneath the main content and immediately to the right of Assets without changing high-resolution behavior.

### Description
- Add medium-breakpoint grid placement rules in `app/static/css/app.css` so `.management__column--details` spans the left column across both rows and `.management__column--content` occupies the right column first row while `.management__column--activity` / `.management__column--conversation` sit in the right column second row.
- This change is scoped to the `@media (min-width: 961px) and (max-width: 1799px)` rules and does not alter the existing `@media (min-width: 1800px)` high-resolution layout.

### Testing
- Ran a small assertion script that verified the new CSS rules are present and it succeeded (`CSS responsive layout assertions passed`).
- Ran `pytest tests/test_admin_ticket_detail.py` as part of the targeted test run and those tests passed.
- Ran `pytest tests/test_static_cache_busting.py tests/test_admin_ticket_detail.py` where `tests/test_static_cache_busting.py` failed due to the test environment returning `405 Method Not Allowed` for `/auth/login` (existing environment issue), while the admin ticket detail tests still passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38b32da2ac832d84cb14a6b379ada7)