### PR TITLE
Fix ticket reply selected status handling

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -27,6 +27,7 @@ from fastapi import APIRouter, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from app.core.logging import log_error, log_info
+from app.features.tickets.form_helpers import get_last_form_value
 from app.security.flash import flash_redirect
 from app.repositories import assets as assets_repo
 from app.repositories import companies as company_repo
@@ -1016,7 +1017,7 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
     default_reply_status = next((definition.tech_status for definition in status_definitions if definition.is_default), None)
     if not default_reply_status:
         default_reply_status = "pending" if "pending" in valid_reply_statuses else (next(iter(valid_reply_statuses), "open"))
-    reply_status = str(form.get("replyStatus") or default_reply_status).strip().lower()
+    reply_status = str(get_last_form_value(form, "replyStatus", default_reply_status) or default_reply_status).strip().lower()
     if reply_status not in valid_reply_statuses:
         return await main_module._render_ticket_detail(
             request,

--- a/app/features/tickets/form_helpers.py
+++ b/app/features/tickets/form_helpers.py
@@ -1,0 +1,22 @@
+"""Form parsing helpers for ticket feature routes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_last_form_value(form: Any, field_name: str, default: Any = None) -> Any:
+    """Return the last submitted value for a repeated form field.
+
+    Starlette's ``FormData.get()`` returns the first value for duplicate keys.
+    Split-button reply forms can submit both the primary button's default
+    status and the technician-selected menu status in some browser paths, so
+    the final submitted value should win.
+    """
+
+    getlist = getattr(form, "getlist", None)
+    if callable(getlist):
+        values = [value for value in getlist(field_name) if value not in (None, "")]
+        if values:
+            return values[-1]
+    return form.get(field_name, default)

--- a/app/features/tickets/portal_routes.py
+++ b/app/features/tickets/portal_routes.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 
 from app.core.logging import log_error
+from app.features.tickets.form_helpers import get_last_form_value
 from app.security.flash import flash_redirect
 from app.repositories import ticket_views as ticket_views_repo
 from app.repositories import tickets as tickets_repo
@@ -296,7 +297,7 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
         default_reply_status = next((definition.tech_status for definition in status_definitions if definition.is_default), None)
         if not default_reply_status:
             default_reply_status = "pending" if "pending" in valid_reply_statuses else (next(iter(valid_reply_statuses), "open"))
-        reply_status = str(form.get("replyStatus") or default_reply_status).strip().lower()
+        reply_status = str(get_last_form_value(form, "replyStatus", default_reply_status) or default_reply_status).strip().lower()
         if reply_status not in valid_reply_statuses:
             return await main_module._render_portal_ticket_detail(
                 request,

--- a/tests/test_admin_ticket_detail.py
+++ b/tests/test_admin_ticket_detail.py
@@ -288,6 +288,70 @@ async def test_admin_reply_saves_attachments(monkeypatch):
 
 
 @pytest.mark.anyio("asyncio")
+async def test_admin_reply_uses_last_duplicate_reply_status(monkeypatch):
+    """A selected split-button status should win over the primary default status."""
+
+    class DummySanitized:
+        html = "<p>reply</p>"
+        text_content = "reply"
+        has_rich_content = True
+
+    form_data = FormData(
+        [
+            ("body", "<p>reply</p>"),
+            ("replyStatus", "waiting_on_client"),
+            ("replyStatus", "resolved"),
+        ]
+    )
+
+    class DummyRequest:
+        url = type("url", (), {"path": "/admin/tickets/8"})()
+
+        async def form(self):
+            return form_data
+
+    monkeypatch.setattr(
+        main, "_require_helpdesk_page", AsyncMock(return_value=({"id": 9, "is_super_admin": True}, None))
+    )
+    monkeypatch.setattr(main, "sanitize_rich_text", lambda value: DummySanitized())
+    monkeypatch.setattr(
+        main.tickets_service,
+        "list_status_definitions",
+        AsyncMock(
+            return_value=[
+                TicketStatusDefinition(
+                    tech_status="waiting_on_client",
+                    tech_label="Waiting on client",
+                    public_status="Waiting on client",
+                    is_default=True,
+                ),
+                TicketStatusDefinition(
+                    tech_status="resolved",
+                    tech_label="Resolved",
+                    public_status="Resolved",
+                    is_default=False,
+                ),
+            ]
+        ),
+    )
+    monkeypatch.setattr(main.tickets_repo, "get_ticket", AsyncMock(return_value={"id": 8, "xero_invoice_number": None}))
+    monkeypatch.setattr(main.tickets_repo, "create_reply", AsyncMock(return_value={"id": 81}))
+    set_status_mock = AsyncMock(return_value={"id": 8, "status": "resolved"})
+    monkeypatch.setattr(main.tickets_repo, "set_ticket_status", set_status_mock)
+    monkeypatch.setattr(main.tickets_repo, "add_watcher", AsyncMock(return_value=None))
+    monkeypatch.setattr(main.tickets_service, "refresh_ticket_ai_summary", AsyncMock(return_value=None))
+    monkeypatch.setattr(main.tickets_service, "refresh_ticket_ai_tags", AsyncMock(return_value=None))
+    monkeypatch.setattr(main.tickets_service, "broadcast_ticket_event", AsyncMock(return_value=None))
+    monkeypatch.setattr(main.tickets_service, "emit_ticket_updated_event", AsyncMock(return_value=None))
+    monkeypatch.setattr(main.tickets_service, "emit_ticket_replied_event", AsyncMock(return_value=None))
+
+    response = await admin_routes.admin_create_ticket_reply(8, DummyRequest())
+
+    assert response.status_code == status.HTTP_303_SEE_OTHER
+    assert set_status_mock.await_args.args == (8, "resolved")
+
+
+@pytest.mark.anyio("asyncio")
 async def test_admin_reply_reports_failed_attachments(monkeypatch):
     """Failed attachment uploads should surface in the success message."""
 


### PR DESCRIPTION
### Motivation
- The split-button reply UI can submit duplicate `replyStatus` fields and Starlette's `FormData.get()` returns the first value, causing the primary button's default status to override a technician-selected menu status.
- Ensure that the technician-selected status (the last submitted value) is applied when posting replies from both admin and portal ticket pages.

### Description
- Add `app/features/tickets/form_helpers.py` with `get_last_form_value(form, field_name, default)` which returns the last non-empty value for repeated form keys. 
- Use `get_last_form_value` when resolving `replyStatus` in `app/features/tickets/admin_routes.py` so the selected split-button status wins over the default submit value. 
- Apply the same fix in `app/features/tickets/portal_routes.py` for helpdesk/super-admin portal replies. 
- Add a regression test `test_admin_reply_uses_last_duplicate_reply_status` in `tests/test_admin_ticket_detail.py` to assert a technician-selected duplicate `replyStatus` is used.

### Testing
- Compiled changed modules with `python -m compileall app/features/tickets/form_helpers.py app/features/tickets/admin_routes.py app/features/tickets/portal_routes.py` which succeeded. 
- Ran targeted tests with `pytest -q tests/test_admin_ticket_detail.py::test_admin_reply_uses_last_duplicate_reply_status tests/test_admin_ticket_detail.py::test_admin_reply_saves_attachments` and both passed. 
- A broader test run including `tests/test_ticket_access.py` surfaced unrelated environment/database issues (`RuntimeError: Database pool not initialised`) causing failures, which appear to be due to the test environment rather than these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38b8ff3f50832d824c8fabdbbf8c0a)