### PR TITLE
Adjust admin ticket form widths

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -8922,6 +8922,17 @@ a.service-card__ai-icon:hover {
   min-height: 100px;
 }
 
+.management__column--details .form-input,
+.management__column--details .form-textarea {
+  max-width: 90%;
+}
+
+.ticket-reply-form .form-input,
+.ticket-reply-form .form-textarea,
+.ticket-reply-form .rich-text-editor {
+  max-width: 98%;
+}
+
 .form-checkbox-label {
   display: flex;
   align-items: center;

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -909,7 +909,7 @@
               </div>
             </summary>
             <div class="card-collapsible__content">
-            <form action="/admin/tickets/{{ ticket.id }}/replies" method="post" class="form card__form" enctype="multipart/form-data">
+            <form action="/admin/tickets/{{ ticket.id }}/replies" method="post" class="form card__form ticket-reply-form" enctype="multipart/form-data">
               {% if csrf_token %}
                 <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
               {% endif %}


### PR DESCRIPTION
### Motivation

- Narrow form controls in the Ticket Details / Additional Details column so fields do not span the full width and align visually with the three-part layout.
- Scope reply-area width separately so the Add a reply editor and its controls can be slightly wider than the details column without affecting other forms.

### Description

- Add scoped CSS in `app/static/css/app.css` to cap `.form-input` and `.form-textarea` inside the details column (`.management__column--details`) to `max-width: 90%`.
- Add a `ticket-reply-form` class to the Add a reply form in `app/templates/admin/ticket_detail.html` and add CSS to cap reply-area controls, textareas, and the rich text editor to `max-width: 98%` so the reply UI can use a separate width rule.
- Changes touch `app/static/css/app.css` and `app/templates/admin/ticket_detail.html` and are narrowly scoped to avoid impacting other forms.

### Testing

- Ran `python -m pytest tests/test_admin_ticket_detail.py` and the tests completed successfully (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38ba44b668832dbee9b9bd12c5f2cc)