### PR TITLE
Add OpenAI-compatible inference providers to Ollama module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -207,9 +207,16 @@ UVICORN_AUTO_UPDATE_RETRY_DELAY=5
 
 # Integration modules — all module settings are configured here.
 # Enable or disable each module from Admin → Integration Modules.
+# AI inference provider for the existing Ollama module. Use:
+#   ollama   - native Ollama /api/generate endpoint
+#   openai   - OpenAI /v1/chat/completions endpoint
+#   llamacpp - self-hosted llama.cpp OpenAI-compatible /v1/chat/completions endpoint
+OLLAMA_PROVIDER=ollama
 OLLAMA_BASE_URL=https://127.0.0.1:11434
 OLLAMA_MODEL=llama3
 OLLAMA_PROMPT=
+# Required for OLLAMA_PROVIDER=openai. Optional for authenticated OpenAI-compatible gateways.
+OPENAI_API_KEY=
 # Minimum number of matching AI tags required between a ticket and knowledge base article
 # for the article to be shown as relevant (default: 1)
 AI_TAG_THRESHOLD=1

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -522,12 +522,14 @@ DEFAULT_MODULES: list[dict[str, Any]] = [
     {
         "slug": "ollama",
         "name": "Ollama",
-        "description": "Generate ticket summaries using an on-prem Ollama model.",
+        "description": "Generate AI summaries with Ollama, OpenAI, or OpenAI-compatible llama.cpp servers.",
         "icon": "🧠",
         "settings": {
+            "provider": "ollama",
             "base_url": "http://127.0.0.1:11434",
             "model": "llama3",
             "prompt": "",
+            "api_key": "",
         },
     },
     {
@@ -857,7 +859,7 @@ _ENV_BACKED_MODULE_FIELDS: dict[str, tuple[str, ...]] = {
     "hudu": ("base_url", "api_key"),
     "m365-admin": ("client_id", "client_secret"),
     "ntfy": ("base_url", "topic", "auth_token"),
-    "ollama": ("base_url", "model", "prompt"),
+    "ollama": ("provider", "base_url", "model", "prompt", "api_key"),
     "ollama-mcp": (
         "shared_secret_hash",
         "allowed_actions",
@@ -997,10 +999,25 @@ def _coerce_settings(
     base = _merge_settings(defaults, existing_settings)
     merged = _merge_settings(base, payload)
     if slug == "ollama":
+        provider = str(merged.get("provider", "")).strip().lower() or "ollama"
+        if provider not in {"ollama", "openai", "llamacpp"}:
+            provider = "ollama"
         base_url = str(merged.get("base_url", "")).strip() or defaults.get("base_url")
         model = str(merged.get("model", "")).strip() or defaults.get("model")
         prompt = str(merged.get("prompt", "")).strip()
-        merged.update({"base_url": base_url, "model": model, "prompt": prompt})
+        api_key_override = (payload or {}).get("api_key")
+        if api_key_override is None:
+            api_key = str(merged.get("api_key") or "").strip()
+        else:
+            candidate = str(api_key_override or "").strip()
+            if not candidate and existing_settings and existing_settings.get("api_key"):
+                api_key = str(existing_settings.get("api_key") or "").strip()
+            else:
+                api_key = candidate
+        merged.update({"provider": provider, "base_url": base_url, "model": model, "prompt": prompt, "api_key": api_key})
+        _env = os.getenv("OLLAMA_PROVIDER", "").strip().lower()
+        if _env in {"ollama", "openai", "llamacpp"}:
+            merged["provider"] = _env
         _env = os.getenv("OLLAMA_BASE_URL", "").strip()
         if _env:
             merged["base_url"] = _env
@@ -1010,6 +1027,9 @@ def _coerce_settings(
         _env = os.getenv("OLLAMA_PROMPT", "").strip()
         if _env:
             merged["prompt"] = _env
+        _env = os.getenv("OPENAI_API_KEY", "").strip()
+        if _env:
+            merged["api_key"] = _env
     elif slug == "smtp":
         merged.update(
             {
@@ -1659,6 +1679,7 @@ def _redact_module_settings(module: dict[str, Any]) -> dict[str, Any]:
     slug = module.get("slug")
     fields_to_redact: dict[str, tuple[str, ...]] = {
         "chatgpt-mcp": ("shared_secret_hash",),
+        "ollama": ("api_key",),
         "ollama-mcp": ("shared_secret_hash",),
         "syncro": ("api_key",),
         "uptimekuma": ("shared_secret_hash",),
@@ -2187,9 +2208,15 @@ async def _invoke_ollama(
     *,
     event_future: asyncio.Future[int | None] | None = None,
 ) -> dict[str, Any]:
+    provider = str(payload.get("provider") or settings.get("provider") or "ollama").strip().lower()
+    if provider not in {"ollama", "openai", "llamacpp"}:
+        provider = "ollama"
+
+    default_base_url = "https://api.openai.com" if provider == "openai" else _DEFAULT_OLLAMA_BASE_URL
     configured_base_url = str(settings.get("base_url") or "").strip()
-    base_url = configured_base_url or _DEFAULT_OLLAMA_BASE_URL
-    base_url = base_url.rstrip("/")
+    if provider == "openai" and configured_base_url.rstrip("/") == _DEFAULT_OLLAMA_BASE_URL.rstrip("/"):
+        configured_base_url = ""
+    base_url = (configured_base_url or default_base_url).rstrip("/")
 
     payload_model = payload.get("model")
     configured_model = str(settings.get("model") or "").strip()
@@ -2199,19 +2226,37 @@ async def _invoke_ollama(
     prompt = str(payload.get("prompt") or payload.get("text") or default_prompt)
     if not prompt:
         raise ValueError("Ollama prompt cannot be empty")
-    endpoint = urljoin(f"{base_url}/", "api/generate")
-    body: dict[str, Any] = {"model": model, "prompt": prompt, "stream": False}
-    # Forward the ``format`` parameter when provided so callers can request
-    # structured output (e.g. ``"json"``).
-    payload_format = payload.get("format")
-    if payload_format is not None:
-        body["format"] = payload_format
+
     request_headers = {"Content-Type": "application/json"}
+    if provider == "ollama":
+        endpoint = urljoin(f"{base_url}/", "api/generate")
+        body: dict[str, Any] = {"model": model, "prompt": prompt, "stream": False}
+        payload_format = payload.get("format")
+        if payload_format is not None:
+            body["format"] = payload_format
+    else:
+        endpoint = urljoin(f"{base_url}/", "v1/chat/completions")
+        messages = payload.get("messages")
+        if not isinstance(messages, list) or not messages:
+            messages = [{"role": "user", "content": prompt}]
+        body = {"model": model, "messages": messages, "stream": False}
+        if payload.get("temperature") is not None:
+            body["temperature"] = payload.get("temperature")
+        if payload.get("max_tokens") is not None:
+            body["max_tokens"] = payload.get("max_tokens")
+        if payload.get("response_format") is not None:
+            body["response_format"] = payload.get("response_format")
+        elif payload.get("format") == "json":
+            body["response_format"] = {"type": "json_object"}
+        api_key = str(payload.get("api_key") or settings.get("api_key") or "").strip()
+        if api_key:
+            request_headers["Authorization"] = f"Bearer {api_key}"
+
     event = await webhook_monitor.create_manual_event(
-        name="module.ollama.generate",
+        name=f"module.ollama.{provider}.generate",
         target_url=endpoint,
         payload={"request_body": body},
-        headers=request_headers,
+        headers={k: ("********" if k.lower() == "authorization" else v) for k, v in request_headers.items()},
         max_attempts=1,
         backoff_seconds=60,
     )
@@ -2221,9 +2266,10 @@ async def _invoke_ollama(
     if event_future and not event_future.done():
         event_future.set_result(event_id)
     attempt_number = 1
+    recorded_headers = {k: ("********" if k.lower() == "authorization" else v) for k, v in request_headers.items()}
     try:
         async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
-            response = await client.post(endpoint, json=body)
+            response = await client.post(endpoint, json=body, headers=request_headers)
         response.raise_for_status()
     except httpx.HTTPStatusError as exc:
         response_body = exc.response.text if exc.response is not None else None
@@ -2234,13 +2280,10 @@ async def _invoke_ollama(
             error_message=f"HTTP {exc.response.status_code}" if exc.response else str(exc),
             response_status=exc.response.status_code if exc.response else None,
             response_body=response_body,
-            request_headers=request_headers,
+            request_headers=recorded_headers,
             request_body=body,
         )
-        return _build_event_result(
-            updated_event,
-            extra={"model": model, "endpoint": endpoint},
-        )
+        return _build_event_result(updated_event, extra={"model": model, "endpoint": endpoint, "provider": provider})
     except Exception as exc:  # pragma: no cover - defensive
         updated_event = await _record_failure(
             event_id,
@@ -2249,13 +2292,10 @@ async def _invoke_ollama(
             error_message=str(exc),
             response_status=None,
             response_body=None,
-            request_headers=request_headers,
+            request_headers=recorded_headers,
             request_body=body,
         )
-        return _build_event_result(
-            updated_event,
-            extra={"model": model, "endpoint": endpoint},
-        )
+        return _build_event_result(updated_event, extra={"model": model, "endpoint": endpoint, "provider": provider})
 
     response_body = response.text
     updated_event = await _record_success(
@@ -2263,13 +2303,10 @@ async def _invoke_ollama(
         attempt_number=attempt_number,
         response_status=response.status_code,
         response_body=response_body,
-        request_headers=request_headers,
+        request_headers=recorded_headers,
         request_body=body,
     )
-    return _build_event_result(
-        updated_event,
-        extra={"model": model, "endpoint": endpoint},
-    )
+    return _build_event_result(updated_event, extra={"model": model, "endpoint": endpoint, "provider": provider})
 
 
 async def _invoke_smtp(

--- a/tests/test_modules_service.py
+++ b/tests/test_modules_service.py
@@ -418,6 +418,85 @@ def test_invoke_ollama_uses_default_model_when_blank(monkeypatch):
     assert client_factory.captured_kwargs["url"] == f"{modules._DEFAULT_OLLAMA_BASE_URL}/api/generate"
 
 
+def test_invoke_ollama_supports_openai_chat_completions(monkeypatch):
+    async def fake_enqueue_event(**kwargs):
+        assert kwargs["name"] == "module.ollama.openai.generate"
+        assert kwargs["headers"]["Authorization"] == "********"
+        return {"id": 22, "status": "pending", "attempt_count": 0}
+
+    fake_event_state = {"id": 22, "status": "pending", "attempt_count": 0}
+    attempts: list[dict[str, object]] = []
+
+    async def fake_record_attempt(**kwargs):
+        attempts.append(kwargs)
+
+    async def fake_mark_event_completed(event_id, *, attempt_number, response_status, response_body):
+        fake_event_state.update({"status": "succeeded", "attempt_count": attempt_number, "response_status": response_status, "response_body": response_body})
+
+    async def fake_get_event(event_id):
+        return dict(fake_event_state)
+
+    class FakeResponse:
+        status_code = 200
+        text = json.dumps({"choices": [{"message": {"content": "ok"}}]})
+        request = httpx.Request("POST", "http://example.com")
+        def raise_for_status(self):
+            return None
+
+    client_factory = _AsyncClientFactory(FakeResponse())
+    monkeypatch.setattr(modules.webhook_monitor, "create_manual_event", fake_enqueue_event)
+    monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
+    monkeypatch.setattr(modules.webhook_repo, "mark_event_completed", fake_mark_event_completed)
+    monkeypatch.setattr(modules.webhook_repo, "mark_event_failed", _noop)
+    monkeypatch.setattr(modules.webhook_repo, "get_event", fake_get_event)
+    monkeypatch.setattr(modules.httpx, "AsyncClient", lambda *a, **kw: client_factory)
+
+    result = asyncio.run(modules._invoke_ollama({"provider": "openai", "model": "gpt-4.1-mini", "api_key": "sk-test"}, {"prompt": "Hi", "format": "json"}))
+
+    assert result["provider"] == "openai"
+    assert client_factory.captured_kwargs["url"] == "https://api.openai.com/v1/chat/completions"
+    assert client_factory.captured_kwargs["headers"]["Authorization"] == "Bearer sk-test"
+    assert client_factory.captured_kwargs["json"]["messages"] == [{"role": "user", "content": "Hi"}]
+    assert client_factory.captured_kwargs["json"]["response_format"] == {"type": "json_object"}
+    assert attempts[0]["request_headers"]["Authorization"] == "********"
+
+
+def test_invoke_ollama_supports_llamacpp_openai_compatible_endpoint(monkeypatch):
+    async def fake_enqueue_event(**kwargs):
+        return {"id": 23, "status": "pending", "attempt_count": 0}
+
+    fake_event_state = {"id": 23, "status": "pending", "attempt_count": 0}
+
+    async def fake_record_attempt(**kwargs):
+        pass
+
+    async def fake_mark_event_completed(event_id, *, attempt_number, response_status, response_body):
+        fake_event_state.update({"status": "succeeded", "attempt_count": attempt_number, "response_status": response_status, "response_body": response_body})
+
+    async def fake_get_event(event_id):
+        return dict(fake_event_state)
+
+    class FakeResponse:
+        status_code = 200
+        text = json.dumps({"choices": [{"message": {"content": "ok"}}]})
+        request = httpx.Request("POST", "http://example.com")
+        def raise_for_status(self):
+            return None
+
+    client_factory = _AsyncClientFactory(FakeResponse())
+    monkeypatch.setattr(modules.webhook_monitor, "create_manual_event", fake_enqueue_event)
+    monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
+    monkeypatch.setattr(modules.webhook_repo, "mark_event_completed", fake_mark_event_completed)
+    monkeypatch.setattr(modules.webhook_repo, "mark_event_failed", _noop)
+    monkeypatch.setattr(modules.webhook_repo, "get_event", fake_get_event)
+    monkeypatch.setattr(modules.httpx, "AsyncClient", lambda *a, **kw: client_factory)
+
+    result = asyncio.run(modules._invoke_ollama({"provider": "llamacpp", "base_url": "http://llama.local:8080", "model": "local-model"}, {"prompt": "Hi"}))
+
+    assert result["provider"] == "llamacpp"
+    assert client_factory.captured_kwargs["url"] == "http://llama.local:8080/v1/chat/completions"
+    assert "Authorization" not in client_factory.captured_kwargs["headers"]
+
 def test_invoke_ollama_records_event_failure(monkeypatch):
     async def fake_enqueue_event(**kwargs):
         return {"id": 4, "status": "pending", "attempt_count": 0}

--- a/wiki/Agent.md
+++ b/wiki/Agent.md
@@ -1,22 +1,25 @@
 # MyPortal Agent
 
-The MyPortal agent provides a permission-aware assistant that searches knowledge base articles, tickets requested or watched by the signed-in user, and available hardware or product recommendations. Responses are generated through the Ollama integration module, and the agent never surfaces content outside of the user's entitlements.
+The MyPortal agent provides a permission-aware assistant that searches knowledge base articles, tickets requested or watched by the signed-in user, and available hardware or product recommendations. Responses are generated through the Ollama/OpenAI integration module, and the agent never surfaces content outside of the user's entitlements.
 
 ## Prerequisites
 
-1. **Ollama runtime** – Install and expose an Ollama instance reachable by the application server. The default configuration expects `https://127.0.0.1:11434`.
+1. **AI runtime** – Install and expose an Ollama instance, configure OpenAI API access, or run a self-hosted llama.cpp server with its OpenAI-compatible API enabled. The default Ollama configuration expects `https://127.0.0.1:11434`.
 2. **Portal configuration** – Ensure the following environment variables are defined (already included in `.env.example`):
-   - `OLLAMA_BASE_URL` – HTTP(S) endpoint for your Ollama host.
-   - `OLLAMA_MODEL` – Default model name (for example `llama3`).
+   - `OLLAMA_PROVIDER` – `ollama`, `openai`, or `llamacpp`.
+   - `OLLAMA_BASE_URL` – HTTP(S) endpoint for Ollama, OpenAI, or an OpenAI-compatible llama.cpp host. Use `https://api.openai.com` for OpenAI.
+   - `OLLAMA_MODEL` – Default model name (for example `llama3`, `gpt-4.1-mini`, or your llama.cpp model alias).
+   - `OLLAMA_PROMPT` – Optional default prompt used by automation flows.
+   - `OPENAI_API_KEY` – Bearer token for OpenAI or authenticated OpenAI-compatible gateways. Leave blank for unauthenticated local Ollama/llama.cpp.
 3. **Database connectivity** – Run migrations through the existing startup process so the `tickets`, `knowledge_base`, and `shop` tables are available. SQLite fallback is supported when MySQL credentials are not configured.
-4. **Webhook monitoring** – The agent records Ollama requests in the webhook monitor (`/admin/webhooks`). Ensure the monitoring tables are migrated and accessible to administrators.
+4. **Webhook monitoring** – The agent records Ollama/OpenAI requests in the webhook monitor (`/admin/webhooks`). Ensure the monitoring tables are migrated and accessible to administrators.
 
 ## Enabling the agent
 
 1. Sign in as a super administrator and navigate to **Admin → Modules**.
-2. Locate the **Ollama** module, configure the base URL, model, and prompt if required, and set the module to **Enabled**.
+2. Locate the **Ollama/OpenAI** module, configure the base URL, model, and prompt if required, and set the module to **Enabled**.
 3. The change takes effect immediately; no service restart is required. The install (`scripts/install_production.sh`) and upgrade (`scripts/upgrade.sh`) scripts already provision the integration module catalogue during deployment.
-4. Verify connectivity from the webhook monitor. Each agent request registers a manual webhook event named `module.ollama.generate`. Failed events are retried by the existing monitoring service.
+4. Verify connectivity from the webhook monitor. Each agent request registers a manual webhook event named `module.ollama.<provider>.generate`. Failed events are retried by the existing monitoring service.
 
 ## Using the agent
 
@@ -26,7 +29,7 @@ The MyPortal agent provides a permission-aware assistant that searches knowledge
   - Knowledge base visibility is enforced through the existing permission scopes.
   - Tickets are limited to records requested by or watched by the user and scoped to their accessible companies.
   - Products are retrieved only when the user or their company memberships allow shop access.
-- Responses include the Ollama model used, the UTC generation timestamp (rendered in the user's local timezone via the browser), and the webhook event identifier for auditing.
+- Responses include the Ollama/OpenAI model used, the UTC generation timestamp (rendered in the user's local timezone via the browser), and the webhook event identifier for auditing.
 
 ## API endpoint
 
@@ -82,20 +85,20 @@ Successful responses return:
 }
 ```
 
-HTTP `401` is returned when the caller is unauthenticated. If the Ollama module is disabled the response status is `skipped` and the payload only contains the contextual sources.
+HTTP `401` is returned when the caller is unauthenticated. If the Ollama/OpenAI module is disabled the response status is `skipped` and the payload only contains the contextual sources.
 
 ## Security notes
 
-- The agent never forwards raw credentials or third-party data to Ollama. Only sanitized snippets from authorised portal entities are included in the prompt.
-- When no accessible context is found the agent instructs Ollama to explain that no answer is available, avoiding hallucinated responses.
-- Responses are rendered as escaped HTML in the browser, ensuring that Markdown returned by Ollama cannot inject unsafe tags.
+- The agent never forwards raw credentials to the configured inference provider. Only sanitized snippets from authorised portal entities are included in the prompt, and API keys are redacted in webhook monitoring.
+- When no accessible context is found the agent instructs Ollama/OpenAI to explain that no answer is available, avoiding hallucinated responses.
+- Responses are rendered as escaped HTML in the browser, ensuring that Markdown returned by Ollama/OpenAI cannot inject unsafe tags.
 
 ## Troubleshooting
 
 | Symptom | Resolution |
 | --- | --- |
-| Agent status reads *"The Ollama module is disabled"* | Enable the Ollama module or verify the configuration in **Admin → Modules**. |
-| Agent returns *"Unable to contact the agent"* | Check network reachability to the Ollama host and review webhook events for failures. |
+| Agent status reads *"The Ollama/OpenAI module is disabled"* | Enable the Ollama/OpenAI module or verify the configuration in **Admin → Modules**. |
+| Agent returns *"Unable to contact the agent"* | Check network reachability to the Ollama/OpenAI host and review webhook events for failures. |
 | Products do not appear as sources | Confirm the user’s company membership has `can_access_shop`, `can_access_cart`, or `can_access_orders` enabled. |
 
 For persistent issues consult the webhook monitor (`/admin/webhooks`) or the application logs generated by the systemd service created during installation.


### PR DESCRIPTION
### Motivation
- Extend the existing Ollama integration so the app can use native Ollama, OpenAI, or OpenAI-compatible self-hosted llama.cpp inference backends.
- Enable optional bearer-token use for OpenAI-compatible gateways while ensuring API keys are redacted in webhook monitoring for security.
- Make the module configurable from environment variables and document operator setup for OpenAI/llama.cpp hosts.

### Description
- Added a selectable `provider` setting to the Ollama module and new `api_key` module setting with defaults in `DEFAULT_MODULES` and env-backed resolution in `_coerce_settings`.
- Implemented provider-aware request construction in `_invoke_ollama`: native Ollama uses `/api/generate`, while `openai` and `llamacpp` use the OpenAI-compatible `/v1/chat/completions` chat-completions flow with support for `messages`, `temperature`, `max_tokens`, and JSON `response_format` mapping.
- Added header redaction for Authorization values when creating webhook monitor events and recorded attempts, and updated `_redact_module_settings` to hide stored `api_key` values.
- Updated `.env.example` with `OLLAMA_PROVIDER` and `OPENAI_API_KEY` docs and updated `wiki/Agent.md` to describe the multi-provider configuration and webhook naming (`module.ollama.<provider>.generate`).
- Added regression tests in `tests/test_modules_service.py` that verify OpenAI chat-completions construction, API-key Bearer auth, Authorization redaction in webhook records, and llama.cpp OpenAI-compatible endpoint usage.

### Testing
- Ran `pytest tests/test_modules_service.py -q -k 'invoke_ollama'`, which exercised the new provider branches and passed.
- Compiled the modified module with `python -m py_compile app/services/modules.py`, which succeeded.
- A full run of `pytest tests/test_modules_service.py -q` earlier surfaced two unrelated Xero validation failures caused by an uninitialised test DB pool in tests that call `_validate_xero`; these failures are environment/test-seed related and not caused by the Ollama/OpenAI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38c0b02ff8832d914b2044da91c0f3)