### PR TITLE
Support OpenAI-compatible Matrix AI inference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -453,8 +453,12 @@ GITHUB_TRAY_MSI_REPO=bradhawkins85/MyPortal
 # Sends limited automated assistance while users wait for an assigned technician.
 MATRIXBOT_AI_WAITING_ASSISTANT_ENABLED=false
 MATRIXBOT_AI_OLLAMA_ENABLED=false
+# Provider can be ollama, openai, or llamacpp. Ollama uses /api/generate;
+# OpenAI and llama.cpp use the OpenAI-compatible /v1/chat/completions API.
+MATRIXBOT_AI_OLLAMA_PROVIDER=ollama
 MATRIXBOT_AI_OLLAMA_URL=http://127.0.0.1:11434
 MATRIXBOT_AI_OLLAMA_MODEL=llama3
+MATRIXBOT_AI_OLLAMA_API_KEY=
 MATRIXBOT_AI_RESPONSE_DELAY_MINUTES=5
 MATRIXBOT_AI_MAX_RESPONSES=2
 MATRIXBOT_AI_KB_CONFIDENCE_THRESHOLD=50

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -353,6 +353,8 @@ class Settings(BaseSettings):
     matrixbot_ai_ollama_enabled: bool = Field(default=False, validation_alias="MATRIXBOT_AI_OLLAMA_ENABLED")
     matrixbot_ai_ollama_url: str | None = Field(default=None, validation_alias="MATRIXBOT_AI_OLLAMA_URL")
     matrixbot_ai_ollama_model: str | None = Field(default=None, validation_alias="MATRIXBOT_AI_OLLAMA_MODEL")
+    matrixbot_ai_ollama_provider: str = Field(default="ollama", validation_alias="MATRIXBOT_AI_OLLAMA_PROVIDER")
+    matrixbot_ai_ollama_api_key: str | None = Field(default=None, validation_alias="MATRIXBOT_AI_OLLAMA_API_KEY")
     matrixbot_ai_response_delay_minutes: int = Field(default=5, validation_alias="MATRIXBOT_AI_RESPONSE_DELAY_MINUTES", ge=1)
     matrixbot_ai_max_responses: int = Field(default=2, validation_alias="MATRIXBOT_AI_MAX_RESPONSES", ge=0)
     matrixbot_ai_kb_confidence_threshold: float = Field(default=50.0, validation_alias="MATRIXBOT_AI_KB_CONFIDENCE_THRESHOLD", ge=0, le=100)

--- a/app/services/matrix_ai_waiting_assistant.py
+++ b/app/services/matrix_ai_waiting_assistant.py
@@ -274,45 +274,72 @@ def _extract_json_object(text: str) -> dict[str, Any]:
     return {}
 
 
+def _matrixbot_ai_provider(settings: Any) -> str:
+    provider = str(getattr(settings, "matrixbot_ai_ollama_provider", "ollama") or "ollama").strip().lower()
+    return provider if provider in {"ollama", "openai", "llamacpp"} else "ollama"
+
+
+def _openai_chat_response_text(payload: Mapping[str, Any]) -> str:
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return ""
+    first = choices[0] if isinstance(choices[0], Mapping) else {}
+    message = first.get("message")
+    if isinstance(message, Mapping):
+        content = message.get("content")
+        if isinstance(content, list):
+            return "".join(str(part.get("text") or "") if isinstance(part, Mapping) else str(part) for part in content).strip()
+        return str(content or "").strip()
+    return str(first.get("text") or "").strip()
+
+
 async def _ollama_generate(prompt: str, *, json_format: bool = False) -> str:
     settings = get_settings()
-    base_url = (settings.matrixbot_ai_ollama_url or "http://127.0.0.1:11434").rstrip("/")
-    model = (settings.matrixbot_ai_ollama_model or "llama3").strip()
-    body: dict[str, Any] = {"model": model, "prompt": prompt, "stream": False}
-    if json_format:
-        body["format"] = "json"
-    target_url = urljoin(f"{base_url}/", "api/generate")
+    provider = _matrixbot_ai_provider(settings)
+    default_base_url = "https://api.openai.com" if provider == "openai" else "http://127.0.0.1:11434"
+    configured_base_url = str(settings.matrixbot_ai_ollama_url or "").strip()
+    if provider == "openai" and configured_base_url.rstrip("/") == "http://127.0.0.1:11434":
+        configured_base_url = ""
+    base_url = (configured_base_url or default_base_url).rstrip("/")
+    model = (settings.matrixbot_ai_ollama_model or ("gpt-4.1-mini" if provider == "openai" else "llama3")).strip()
+    headers = {"Content-Type": "application/json"}
+    if provider == "ollama":
+        body: dict[str, Any] = {"model": model, "prompt": prompt, "stream": False}
+        if json_format:
+            body["format"] = "json"
+        target_url = urljoin(f"{base_url}/", "api/generate")
+    else:
+        body = {"model": model, "messages": [{"role": "user", "content": prompt}], "stream": False}
+        if json_format:
+            body["response_format"] = {"type": "json_object"}
+        target_url = urljoin(f"{base_url}/", "v1/chat/completions")
+        api_key = str(getattr(settings, "matrixbot_ai_ollama_api_key", "") or "").strip()
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+    provider_label = "Ollama" if provider == "ollama" else provider
     monitor_event = await _create_monitor_event(
-        "MATRIXBOT_AI Ollama generate",
+        f"MATRIXBOT_AI {provider_label} generate",
         target_url,
-        {"model": model, "json_format": json_format, "prompt": prompt},
+        {"provider": provider, "model": model, "json_format": json_format, "prompt": prompt},
     )
     try:
         async with httpx.AsyncClient(timeout=45) as client:
-            response = await client.post(target_url, json=body)
+            response = await client.post(target_url, json=body, headers=headers)
         response.raise_for_status()
         payload = response.json()
-        result = str(payload.get("response") or "").strip()
+        result = (str(payload.get("response") or "").strip() if provider == "ollama" else _openai_chat_response_text(payload))
         await _record_monitor_success(
             monitor_event,
             response_status=response.status_code,
             response_body=result,
-            request_body={
-                "model": model,
-                "json_format": json_format,
-                "prompt": prompt,
-            },
+            request_body={"provider": provider, "model": model, "json_format": json_format, "prompt": prompt},
         )
         return result
     except Exception as exc:
         await _record_monitor_failure(
             monitor_event,
             error_message=str(exc),
-            request_body={
-                "model": model,
-                "json_format": json_format,
-                "prompt": prompt,
-            },
+            request_body={"provider": provider, "model": model, "json_format": json_format, "prompt": prompt},
         )
         raise
 

--- a/tests/services/test_matrix_ai_waiting_assistant.py
+++ b/tests/services/test_matrix_ai_waiting_assistant.py
@@ -170,6 +170,8 @@ def test_ollama_generate_records_webhook_monitor_success(monkeypatch):
     settings = SimpleNamespace(
         matrixbot_ai_ollama_url="http://ollama.test",
         matrixbot_ai_ollama_model="llama3",
+        matrixbot_ai_ollama_provider="ollama",
+        matrixbot_ai_ollama_api_key=None,
     )
     events: list[dict] = []
     successes: list[dict] = []
@@ -206,7 +208,7 @@ def test_ollama_generate_records_webhook_monitor_success(monkeypatch):
         async def __aexit__(self, exc_type, exc, tb):
             return None
 
-        async def post(self, url, json):
+        async def post(self, url, json, headers=None):
             return FakeResponse()
 
     monkeypatch.setattr(assistant.httpx, "AsyncClient", FakeClient)
@@ -220,6 +222,64 @@ def test_ollama_generate_records_webhook_monitor_success(monkeypatch):
     assert "prompt_preview" not in events[0]["payload"]
     assert successes[0]["event_id"] == 123
     assert successes[0]["response_status"] == 200
+
+
+def test_ollama_generate_supports_openai_compatible_chat_completions(monkeypatch):
+    settings = SimpleNamespace(
+        matrixbot_ai_ollama_url="https://llamacpp.test",
+        matrixbot_ai_ollama_model="local-model",
+        matrixbot_ai_ollama_provider="llamacpp",
+        matrixbot_ai_ollama_api_key="secret-token",
+    )
+    requests: list[dict] = []
+
+    monkeypatch.setattr(assistant, "get_settings", lambda: settings)
+
+    async def fake_create_manual_event(**kwargs):
+        return {"id": 123}
+
+    async def fake_record_manual_success(event_id, **kwargs):
+        return {"id": event_id, "status": "succeeded"}
+
+    monkeypatch.setattr(assistant.webhook_monitor, "create_manual_event", fake_create_manual_event)
+    monkeypatch.setattr(assistant.webhook_monitor, "record_manual_success", fake_record_manual_success)
+
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"choices": [{"message": {"content": '{"answer":"ok"}'}}]}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, json, headers=None):
+            requests.append({"url": url, "json": json, "headers": headers})
+            return FakeResponse()
+
+    monkeypatch.setattr(assistant.httpx, "AsyncClient", FakeClient)
+
+    result = asyncio.run(assistant._ollama_generate("return json", json_format=True))
+
+    assert result == '{"answer":"ok"}'
+    assert requests[0]["url"] == "https://llamacpp.test/v1/chat/completions"
+    assert requests[0]["json"] == {
+        "model": "local-model",
+        "messages": [{"role": "user", "content": "return json"}],
+        "stream": False,
+        "response_format": {"type": "json_object"},
+    }
+    assert requests[0]["headers"]["Authorization"] == "Bearer secret-token"
 
 
 def test_build_article_recommendation_messages_formats_four_plain_text_and_html_messages():


### PR DESCRIPTION
### Motivation
- Allow the Matrix waiting-assistant to use not only local Ollama but also OpenAI or OpenAI-compatible `llamacpp` backends for inference. 
- Provide a configurable API key and provider selection so deployments can target `/api/generate` (Ollama) or OpenAI-compatible `/v1/chat/completions` endpoints. 

### Description
- Added settings for provider and API key: `matrixbot_ai_ollama_provider` and `matrixbot_ai_ollama_api_key` and exposed them via the environment (`MATRIXBOT_AI_OLLAMA_PROVIDER`, `MATRIXBOT_AI_OLLAMA_API_KEY`).
- Enhanced `_ollama_generate` to choose the endpoint and request shape based on provider: Ollama uses `api/generate`, while `openai`/`llamacpp` use `/v1/chat/completions` with optional `Authorization` header and `response_format` when `json_format=True`.
- Introduced `_matrixbot_ai_provider` and `_openai_chat_response_text` helpers and updated webhook-monitor payloads to include the provider and to preserve existing Ollama monitoring semantics.
- Updated `tests/services/test_matrix_ai_waiting_assistant.py` to cover the OpenAI-compatible chat completions path and adjusted test fixtures/signatures accordingly, and updated `.env.example` with documentation and new variables.

### Testing
- Ran `pytest -q tests/services/test_matrix_ai_waiting_assistant.py` and the test module passed (`15 passed`).
- Compiled changed modules with `python -m compileall -q app/core/config.py app/services/matrix_ai_waiting_assistant.py tests/services/test_matrix_ai_waiting_assistant.py` which succeeded.
- Performed `git diff --check` to ensure no whitespace/patch issues (no problems found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38c80719fc832d834eb0a39f9aace9)