### PR TITLE
Normalize llama.cpp OpenAI-compatible AI responses

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -2119,6 +2119,65 @@ def _parse_event_response(event: Mapping[str, Any]) -> Any:
     return response_body
 
 
+def _extract_openai_compatible_text(payload: Any) -> str | None:
+    """Extract assistant text from OpenAI-compatible chat completion payloads.
+
+    llama.cpp's OpenAI-compatible server returns successful generations in the
+    ``choices[].message.content`` shape. Ticket AI processors expect an
+    Ollama-like ``response``/``message`` field, so normalize that text into the
+    parsed response while preserving the original provider payload.
+    """
+
+    if not isinstance(payload, Mapping):
+        return None
+
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return None
+
+    first = choices[0]
+    if not isinstance(first, Mapping):
+        return None
+
+    message = first.get("message")
+    if isinstance(message, Mapping):
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, Mapping):
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+                elif isinstance(item, str):
+                    parts.append(item)
+            joined = "".join(parts).strip()
+            if joined:
+                return joined
+
+    text = first.get("text")
+    if isinstance(text, str) and text.strip():
+        return text
+
+    return None
+
+
+def _normalise_ai_response_payload(payload: Any) -> Any:
+    """Add Ollama-style text keys to OpenAI-compatible AI responses."""
+
+    text = _extract_openai_compatible_text(payload)
+    if not text or not isinstance(payload, Mapping):
+        return payload
+
+    normalised = dict(payload)
+    normalised.setdefault("response", text)
+    normalised.setdefault("message", text)
+    normalised.setdefault("text", text)
+    return normalised
+
+
 def _build_event_result(event: Mapping[str, Any], extra: Mapping[str, Any] | None = None) -> dict[str, Any]:
     result: dict[str, Any] = {}
     if extra:
@@ -2137,7 +2196,7 @@ def _build_event_result(event: Mapping[str, Any], extra: Mapping[str, Any] | Non
         result["last_error"] = event.get("last_error")
     parsed_response = _parse_event_response(event)
     if parsed_response is not None:
-        result["response"] = parsed_response
+        result["response"] = _normalise_ai_response_payload(parsed_response)
     return result
 
 

--- a/tests/test_modules_service.py
+++ b/tests/test_modules_service.py
@@ -494,6 +494,10 @@ def test_invoke_ollama_supports_llamacpp_openai_compatible_endpoint(monkeypatch)
     result = asyncio.run(modules._invoke_ollama({"provider": "llamacpp", "base_url": "http://llama.local:8080", "model": "local-model"}, {"prompt": "Hi"}))
 
     assert result["provider"] == "llamacpp"
+    assert result["response"]["response"] == "ok"
+    assert result["response"]["message"] == "ok"
+    assert result["response"]["text"] == "ok"
+    assert result["response"]["choices"] == [{"message": {"content": "ok"}}]
     assert client_factory.captured_kwargs["url"] == "http://llama.local:8080/v1/chat/completions"
     assert "Authorization" not in client_factory.captured_kwargs["headers"]
 


### PR DESCRIPTION
### Motivation
- Ticket AI processors expect Ollama-style text fields (`response`/`message`/`text`) but OpenAI-compatible llama.cpp endpoints return `choices[].message.content`, causing `module.ollama.llamacpp.generate` to appear successful yet yield no usable payload for downstream ticket actions. 
- Ensure AI-generated responses from OpenAI-compatible endpoints are consumable by existing Ollama-based post-processing without losing the original provider payload.

### Description
- Added `_extract_openai_compatible_text` to parse assistant text from OpenAI-compatible chat completion shapes (e.g. `choices[].message.content`).
- Added `_normalise_ai_response_payload` which injects Ollama-style `response`, `message`, and `text` keys into provider payloads while preserving the original payload.
- Integrated normalization into the module event result path by applying `_normalise_ai_response_payload` inside ` _build_event_result` so `trigger_module` consumers receive normalized responses.
- Updated unit test `tests/test_modules_service.py` to assert the normalized fields are present and that the original `choices` array remains intact.

### Testing
- Ran `pytest tests/test_modules_service.py::test_invoke_ollama_supports_llamacpp_openai_compatible_endpoint -q` and it passed.
- Ran `python -m py_compile app/services/modules.py` to validate syntax and it passed.
- Ran `pytest tests/test_modules_service.py -q`; targeted changes passed but the full run reported 2 failing tests unrelated to this change due to an uninitialised database pool in Xero credential tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38cb237f44832d8e2ad5ade97aa70a)