### PR TITLE
Add multi-field Group By for admin tickets (saved views)

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -412,12 +412,13 @@ async def create_ticket_view(
 ) -> TicketViewModel:
     """Create a new saved ticket view"""
     filters_dict = payload.filters.model_dump() if payload.filters else None
+    grouping_fields = payload.grouping_fields or ([payload.grouping_field] if payload.grouping_field else [])
     view = await ticket_views_repo.create_view(
         user_id=session.user_id,
         name=payload.name,
         description=payload.description,
         filters=filters_dict,
-        grouping_field=payload.grouping_field,
+        grouping_field=grouping_fields,
         sort_field=payload.sort_field,
         sort_direction=payload.sort_direction,
         is_default=payload.is_default,
@@ -445,6 +446,8 @@ async def update_ticket_view(
 ) -> TicketViewModel:
     """Update a saved ticket view"""
     update_data = payload.model_dump(exclude_unset=True)
+    if "grouping_fields" in update_data:
+        update_data["grouping_field"] = update_data.pop("grouping_fields") or None
     
     view = await ticket_views_repo.update_view(view_id, session.user_id, **update_data)
     if not view:

--- a/app/repositories/ticket_views.py
+++ b/app/repositories/ticket_views.py
@@ -50,6 +50,25 @@ def _normalise_ticket_view(row: dict[str, Any]) -> TicketViewRecord:
         else:
             parsed_filters = None
     record["filters"] = parsed_filters
+
+    grouping_value = record.get("grouping_field")
+    grouping_fields: list[str] = []
+    if isinstance(grouping_value, str) and grouping_value.strip():
+        stripped = grouping_value.strip()
+        try:
+            parsed_grouping = json.loads(stripped)
+        except json.JSONDecodeError:
+            parsed_grouping = None
+        if isinstance(parsed_grouping, list):
+            grouping_fields = [item for item in parsed_grouping if isinstance(item, str) and item]
+        elif "," in stripped:
+            grouping_fields = [item.strip() for item in stripped.split(",") if item.strip()]
+        else:
+            grouping_fields = [stripped]
+    elif isinstance(grouping_value, list):
+        grouping_fields = [item for item in grouping_value if isinstance(item, str) and item]
+    record["grouping_fields"] = grouping_fields
+    record["grouping_field"] = grouping_fields[0] if grouping_fields else None
     
     if "is_default" in record:
         record["is_default"] = bool(record.get("is_default"))
@@ -148,6 +167,8 @@ async def create_view(
         await _unset_default_views(user_id)
     
     filters_json = json.dumps(filters) if filters else None
+    if isinstance(grouping_field, list):
+        grouping_field = json.dumps(grouping_field)
     
     query = """
         INSERT INTO ticket_views 
@@ -204,6 +225,8 @@ async def update_view(
     for key, value in kwargs.items():
         if key in allowed_fields:
             if key == "filters" and value is not None:
+                value = json.dumps(value)
+            if key == "grouping_field" and isinstance(value, list):
                 value = json.dumps(value)
             updates.append(f"{key} = %s")
             params.append(value)

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -332,6 +332,7 @@ class TicketViewCreate(BaseModel):
     description: Optional[str] = None
     filters: Optional[TicketViewFilters] = None
     grouping_field: Optional[str] = Field(default=None, max_length=64)
+    grouping_fields: Optional[list[str]] = Field(default=None, max_length=8)
     sort_field: Optional[str] = Field(default=None, max_length=64)
     sort_direction: Optional[str] = Field(default=None, pattern="^(asc|desc)$")
     is_default: bool = False
@@ -345,6 +346,7 @@ class TicketViewUpdate(BaseModel):
     description: Optional[str] = None
     filters: Optional[TicketViewFilters] = None
     grouping_field: Optional[str] = Field(default=None, max_length=64)
+    grouping_fields: Optional[list[str]] = Field(default=None, max_length=8)
     sort_field: Optional[str] = Field(default=None, max_length=64)
     sort_direction: Optional[str] = Field(default=None, pattern="^(asc|desc)$")
     is_default: Optional[bool] = None
@@ -360,6 +362,7 @@ class TicketViewModel(BaseModel):
     description: Optional[str] = None
     filters: Optional[dict] = None
     grouping_field: Optional[str] = None
+    grouping_fields: Optional[list[str]] = None
     sort_field: Optional[str] = None
     sort_direction: Optional[str] = None
     is_default: bool

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2273,6 +2273,23 @@ button.header-title-menu__link {
   transform: rotate(180deg);
 }
 
+.ticket-group-by__hint {
+  margin: -0.25rem 0 0.75rem;
+  color: var(--muted-text, #64748b);
+  font-size: 0.85rem;
+  line-height: 1.35;
+}
+
+.ticket-group-by__clear {
+  width: 100%;
+  margin-top: 0.75rem;
+}
+
+.ticket-group-header__title--nested {
+  color: var(--muted-text, #64748b);
+  font-weight: 600;
+}
+
 .invoice-row--overdue td {
   background: rgba(248, 113, 113, 0.08);
 }

--- a/app/static/js/ticket_views.js
+++ b/app/static/js/ticket_views.js
@@ -36,6 +36,7 @@
         assignedUsers: [],
         search: ''
       };
+      this.groupingFields = [];
       this.groupingField = null;
       this.sortField = null;
       this.sortDirection = 'asc';
@@ -136,13 +137,6 @@
         deleteViewBtn.addEventListener('click', () => this.deleteCurrentView());
       }
 
-      // Grouping selector
-      const groupingSelect = this.container.querySelector('[data-grouping-select]');
-      if (groupingSelect) {
-        groupingSelect.addEventListener('change', (e) => {
-          this.setGrouping(e.target.value);
-        });
-      }
     }
 
     /**
@@ -177,13 +171,41 @@
      * Setup grouping controls
      */
     setupGroupingControls() {
-      // Grouping selector is already in the template, just verify it exists
-      const groupingSelect = this.container.querySelector('[data-grouping-select]');
-      if (groupingSelect) {
-        groupingSelect.addEventListener('change', (e) => {
-          this.setGrouping(e.target.value);
+      const groupBy = document.querySelector('[data-ticket-group-by]');
+      if (!groupBy) return;
+      const button = groupBy.querySelector('[data-group-by-toggle]');
+      const panel = groupBy.querySelector('[data-group-by-panel]');
+      const clear = groupBy.querySelector('[data-group-by-clear]');
+      if (button && panel) {
+        button.addEventListener('click', () => {
+          const isOpen = groupBy.classList.contains('ticket-columns--open');
+          panel.hidden = isOpen;
+          groupBy.classList.toggle('ticket-columns--open', !isOpen);
+          button.setAttribute('aria-expanded', String(!isOpen));
+        });
+        document.addEventListener('click', (event) => {
+          if (!groupBy.contains(event.target)) {
+            panel.hidden = true;
+            groupBy.classList.remove('ticket-columns--open');
+            button.setAttribute('aria-expanded', 'false');
+          }
         });
       }
+      groupBy.querySelectorAll('[data-grouping-field]').forEach((checkbox) => {
+        checkbox.addEventListener('change', (event) => {
+          const field = event.target.getAttribute('data-grouping-field');
+          if (!field) return;
+          if (event.target.checked) {
+            this.setGrouping([...this.groupingFields.filter((item) => item !== field), field]);
+          } else {
+            this.setGrouping(this.groupingFields.filter((item) => item !== field));
+          }
+        });
+      });
+      if (clear) {
+        clear.addEventListener('click', () => this.setGrouping([]));
+      }
+      this.updateGroupingUI();
     }
 
     /**
@@ -236,12 +258,32 @@
     /**
      * Set grouping field and apply
      */
-    setGrouping(field) {
-      this.groupingField = field || null;
-      if (this.groupingField) {
+    setGrouping(fields) {
+      const selected = Array.isArray(fields) ? fields : (fields ? [fields] : []);
+      const allowed = ['status', 'priority', 'company', 'assigned'];
+      this.groupingFields = selected.filter((field, index) => allowed.includes(field) && selected.indexOf(field) === index);
+      this.groupingField = this.groupingFields[0] || null;
+      this.updateGroupingUI();
+      if (this.groupingFields.length) {
         this.applyGrouping();
       } else {
         this.removeGrouping();
+      }
+    }
+
+    updateGroupingUI() {
+      const groupBy = document.querySelector('[data-ticket-group-by]');
+      if (!groupBy) return;
+      const labels = { status: 'Status', priority: 'Priority', company: 'Company', assigned: 'Assigned' };
+      groupBy.querySelectorAll('[data-grouping-field]').forEach((checkbox) => {
+        const field = checkbox.getAttribute('data-grouping-field');
+        checkbox.checked = this.groupingFields.includes(field);
+      });
+      const label = groupBy.querySelector('[data-group-by-label]');
+      if (label) {
+        label.textContent = this.groupingFields.length
+          ? `Group By: ${this.groupingFields.map((field) => labels[field] || field).join(' › ')}`
+          : 'Group By';
       }
     }
 
@@ -255,78 +297,87 @@
       const tbody = table.querySelector('tbody');
       if (!tbody) return;
 
-      // Remove existing grouping
       this.removeGrouping();
 
-      // Get ALL rows (including filtered ones) to preserve them
       const allRows = Array.from(tbody.querySelectorAll('tr:not(.ticket-group-header)'));
-      
-      // Group ALL rows by the selected field (including hidden ones)
-      const groups = {};
       const fieldMap = {
-        'status': 'Status',
-        'priority': 'Priority',
-        'company': 'Company',
-        'assigned': 'Assigned'
+        status: 'Status',
+        priority: 'Priority',
+        company: 'Company',
+        assigned: 'Assigned'
       };
-      const fieldLabel = fieldMap[this.groupingField];
+      const fields = this.groupingFields.length ? this.groupingFields : (this.groupingField ? [this.groupingField] : []);
+      if (!fields.length) return;
 
-      allRows.forEach(row => {
-        const cell = row.querySelector(`[data-label="${fieldLabel}"]`);
-        let groupKey = cell ? (cell.getAttribute('data-value') || cell.textContent.trim()) : 'Unspecified';
-        
-        if (!groups[groupKey]) {
-          groups[groupKey] = [];
-        }
-        groups[groupKey].push(row);
-      });
+      const getGroupValue = (row, field) => {
+        const label = fieldMap[field];
+        const cell = label ? row.querySelector(`[data-label="${label}"]`) : null;
+        const value = cell ? (cell.getAttribute('data-value') || cell.textContent.trim()) : '';
+        return value || 'Unspecified';
+      };
 
-      // Create grouped structure
-      const fragment = document.createDocumentFragment();
-      const groupKeys = Object.keys(groups).sort();
-
-      groupKeys.forEach(groupKey => {
-        // Count only visible rows for the header
-        const visibleRowsInGroup = groups[groupKey].filter(row => !row.classList.contains('ticket-filtered-hidden'));
-        
-        // Create group header row
-        const headerRow = document.createElement('tr');
-        headerRow.className = 'ticket-group-header';
-        headerRow.setAttribute('data-group-key', groupKey);
-        
-        // Hide the group header if there are no visible rows in this group
-        if (visibleRowsInGroup.length === 0) {
-          headerRow.classList.add('ticket-filtered-hidden');
-        }
-        
-        const headerCell = document.createElement('td');
-        headerCell.colSpan = table.querySelector('thead tr').children.length;
-        headerCell.innerHTML = `
-          <div class="ticket-group-header__content">
-            <button type="button" class="ticket-group-header__toggle" data-group-toggle="${groupKey}" aria-expanded="true">
-              <svg class="ticket-group-header__icon" viewBox="0 0 24 24" width="20" height="20">
-                <path d="M6.2 8.2a1 1 0 0 1 1.4 0L12 12.6l4.4-4.4a1 1 0 0 1 1.4 1.4l-5.1 5.1a1 1 0 0 1-1.4 0L6.2 9.6a1 1 0 0 1 0-1.4z" />
-              </svg>
-            </button>
-            <span class="ticket-group-header__title">${groupKey}</span>
-            <span class="ticket-group-header__count">${visibleRowsInGroup.length} ticket${visibleRowsInGroup.length !== 1 ? 's' : ''}</span>
-          </div>
-        `;
-        headerRow.appendChild(headerCell);
-        fragment.appendChild(headerRow);
-
-        // Add ALL rows for this group (including filtered ones)
-        groups[groupKey].forEach(row => {
-          row.setAttribute('data-group', groupKey);
-          fragment.appendChild(row);
+      const buildLevel = (rows, depth, path, fragment) => {
+        const field = fields[depth];
+        const groups = new Map();
+        rows.forEach((row) => {
+          const key = getGroupValue(row, field);
+          if (!groups.has(key)) groups.set(key, []);
+          groups.get(key).push(row);
         });
-      });
 
-      // Clear and repopulate tbody
+        Array.from(groups.keys()).sort().forEach((groupKey) => {
+          const groupRows = groups.get(groupKey);
+          const visibleRowsInGroup = groupRows.filter((row) => !row.classList.contains('ticket-filtered-hidden'));
+          const groupId = [...path, groupKey].join('¦');
+          const headerRow = document.createElement('tr');
+          headerRow.className = 'ticket-group-header';
+          headerRow.setAttribute('data-group-key', groupId);
+          headerRow.setAttribute('data-group-path', groupId);
+          headerRow.setAttribute('data-group-depth', String(depth));
+          if (visibleRowsInGroup.length === 0) headerRow.classList.add('ticket-filtered-hidden');
+
+          const headerCell = document.createElement('td');
+          headerCell.colSpan = table.querySelector('thead tr').children.length;
+          const headerContent = document.createElement('div');
+          headerContent.className = 'ticket-group-header__content';
+          headerContent.style.paddingLeft = `${depth * 1.5}rem`;
+          const toggle = document.createElement('button');
+          toggle.type = 'button';
+          toggle.className = 'ticket-group-header__toggle';
+          toggle.setAttribute('data-group-toggle', groupId);
+          toggle.setAttribute('aria-expanded', 'true');
+          toggle.innerHTML = '<svg class="ticket-group-header__icon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true"><path d="M6.2 8.2a1 1 0 0 1 1.4 0L12 12.6l4.4-4.4a1 1 0 0 1 1.4 1.4l-5.1 5.1a1 1 0 0 1-1.4 0L6.2 9.6a1 1 0 0 1 0-1.4z" /></svg>';
+          const fieldTitle = document.createElement('span');
+          fieldTitle.className = 'ticket-group-header__title ticket-group-header__title--nested';
+          fieldTitle.textContent = `${fieldMap[field]}:`;
+          const groupTitle = document.createElement('span');
+          groupTitle.className = 'ticket-group-header__title';
+          groupTitle.textContent = groupKey;
+          const count = document.createElement('span');
+          count.className = 'ticket-group-header__count';
+          count.textContent = `${visibleRowsInGroup.length} ticket${visibleRowsInGroup.length !== 1 ? 's' : ''}`;
+          headerContent.append(toggle, fieldTitle, groupTitle, count);
+          headerCell.appendChild(headerContent);
+          headerRow.appendChild(headerCell);
+          fragment.appendChild(headerRow);
+
+          if (depth + 1 < fields.length) {
+            buildLevel(groupRows, depth + 1, [...path, groupKey], fragment);
+          } else {
+            groupRows.forEach((row) => fragment.appendChild(row));
+          }
+          groupRows.forEach((row) => {
+            row.setAttribute('data-group', groupId);
+            row.setAttribute('data-group-path', groupId);
+          });
+        });
+      };
+
+      const fragment = document.createDocumentFragment();
+      buildLevel(allRows, 0, [], fragment);
       tbody.innerHTML = '';
       tbody.appendChild(fragment);
 
-      // Attach toggle listeners
       tbody.querySelectorAll('[data-group-toggle]').forEach(toggle => {
         toggle.addEventListener('click', (e) => {
           const groupKey = e.currentTarget.getAttribute('data-group-toggle');
@@ -342,12 +393,16 @@
       const tbody = this.container.querySelector('tbody');
       if (!tbody) return;
 
-      const headerRow = tbody.querySelector(`[data-group-key="${groupKey}"]`);
-      const groupRows = tbody.querySelectorAll(`tr[data-group="${groupKey}"]`);
+      const headerRow = Array.from(tbody.querySelectorAll('[data-group-key]'))
+        .find((row) => row.getAttribute('data-group-key') === groupKey);
+      if (!headerRow) return;
       const toggle = headerRow.querySelector('[data-group-toggle]');
+      if (!toggle) return;
       const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+      const descendantRows = Array.from(tbody.querySelectorAll('tr[data-group-path]'))
+        .filter((row) => row !== headerRow && (row.getAttribute('data-group-path') || '').startsWith(groupKey));
 
-      groupRows.forEach(row => {
+      descendantRows.forEach(row => {
         if (isExpanded) {
           row.classList.add('ticket-group-hidden');
         } else {
@@ -355,7 +410,7 @@
         }
       });
 
-      toggle.setAttribute('aria-expanded', !isExpanded);
+      toggle.setAttribute('aria-expanded', String(!isExpanded));
       headerRow.classList.toggle('ticket-group-header--collapsed', isExpanded);
     }
 
@@ -370,8 +425,9 @@
       tbody.querySelectorAll('.ticket-group-header').forEach(el => el.remove());
       
       // Remove group attributes and classes
-      tbody.querySelectorAll('tr[data-group]').forEach(row => {
+      tbody.querySelectorAll('tr[data-group], tr[data-group-path]').forEach(row => {
         row.removeAttribute('data-group');
+        row.removeAttribute('data-group-path');
         row.classList.remove('ticket-group-hidden');
       });
     }
@@ -400,13 +456,7 @@
           }
           
           // Apply grouping
-          if (view.grouping_field) {
-            this.setGrouping(view.grouping_field);
-            const groupingSelect = this.container.querySelector('[data-grouping-select]');
-            if (groupingSelect) {
-              groupingSelect.value = view.grouping_field;
-            }
-          }
+          this.setGrouping(view.grouping_fields || view.grouping_field || []);
           
           this.applyFilters();
           this.updateViewActions();
@@ -439,7 +489,9 @@
         assignedUsers: [],
         search: ''
       };
+      this.groupingFields = [];
       this.groupingField = null;
+      this.updateGroupingUI();
       
       // Remove all filter classes from rows
       const tbody = this.container.querySelector('tbody');
@@ -485,6 +537,7 @@
           priority: this.filterState.priorities,
         },
         grouping_field: this.groupingField,
+        grouping_fields: this.groupingFields,
         sort_field: this.sortField,
         sort_direction: this.sortDirection,
         ...overrides

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -154,18 +154,8 @@
                 </div>
               </div>
 
-              <!-- Grouping and Search Section -->
+              <!-- Search Section -->
               <div class="ticket-filters__section ticket-filters__section--horizontal">
-                <div class="ticket-filters__group-control">
-                  <label class="form-label" for="ticket-grouping">Group by</label>
-                  <select id="ticket-grouping" name="grouping" class="form-input" data-grouping-select>
-                    <option value="">No grouping</option>
-                    <option value="status">Status</option>
-                    <option value="priority">Priority</option>
-                    <option value="company">Company</option>
-                    <option value="assigned">Assigned user</option>
-                  </select>
-                </div>
                 <div class="ticket-filters__search-control">
                   <label class="form-label" for="ticket-quick-filter">Quick search</label>
                   <input 
@@ -246,6 +236,36 @@
                 />
               </form>
             {% endif %}
+
+            <div class="ticket-columns ticket-group-by" data-ticket-group-by>
+              <button type="button" class="button button--ghost ticket-columns__toggle" data-group-by-toggle aria-haspopup="true" aria-expanded="false">
+                <span data-group-by-label>Group By</span>
+                <span class="ticket-columns__chevron" aria-hidden="true">▾</span>
+              </button>
+              <div class="ticket-columns__panel" data-group-by-panel hidden>
+                <p class="ticket-columns__title">Group tickets by</p>
+                <p class="ticket-group-by__hint">Select multiple fields in the order they should be grouped.</p>
+                <div class="ticket-columns__options">
+                  <label class="ticket-columns__option">
+                    <input type="checkbox" class="ticket-group-by-toggle" data-grouping-field="company" />
+                    <span>Company</span>
+                  </label>
+                  <label class="ticket-columns__option">
+                    <input type="checkbox" class="ticket-group-by-toggle" data-grouping-field="assigned" />
+                    <span>Assigned user</span>
+                  </label>
+                  <label class="ticket-columns__option">
+                    <input type="checkbox" class="ticket-group-by-toggle" data-grouping-field="status" />
+                    <span>Status</span>
+                  </label>
+                  <label class="ticket-columns__option">
+                    <input type="checkbox" class="ticket-group-by-toggle" data-grouping-field="priority" />
+                    <span>Priority</span>
+                  </label>
+                </div>
+                <button type="button" class="button button--ghost button--compact ticket-group-by__clear" data-group-by-clear>Clear grouping</button>
+              </div>
+            </div>
             <div class="ticket-columns" data-ticket-columns>
               <button type="button" class="button button--ghost ticket-columns__toggle" data-columns-toggle aria-haspopup="true">
                 <span>Columns</span>


### PR DESCRIPTION
### Motivation
- Provide an ordered, multi-field grouping UI on `/admin/tickets` so users can group tickets by combinations (e.g. Company → Assigned → Status).
- Persist these multi-field groupings as part of saved views so layouts and filters can be restored consistently.

### Description
- UI: added a `Group By` dropdown next to the existing `Columns` control in `app/templates/admin/tickets.html` with multi-select checkboxes and a clear action. (`data-ticket-group-by`).
- Frontend: extended `TicketViewManager` (`app/static/js/ticket_views.js`) to use `groupingFields` (ordered list), manage the `Group By` panel, update its label, clear selections, and render nested group headers using safe DOM API calls; saved view payloads now include `grouping_fields` in addition to the legacy `grouping_field`.
- Backend API/schema: added `grouping_fields` to request/response models in `app/schemas/tickets.py` and adjusted route handling in `app/api/routes/tickets.py` to accept `grouping_fields` while keeping compatibility with `grouping_field`.
- Repository: updated `app/repositories/ticket_views.py` to normalise legacy `grouping_field` values (string, CSV, JSON array, or list) into `grouping_fields`, to return both `grouping_fields` and a legacy `grouping_field` (first item), and to store list payloads as JSON for persistence.
- Styles: added helper styles for the new control and nested group headers in `app/static/css/app.css`.

### Testing
- JavaScript syntax checked with `node --check app/static/js/ticket_views.js` and the file passed with no syntax errors.
- Python modules compiled with `python3 -m compileall` for the modified schema, repository and routes files and compilation succeeded.
- Unit tests: ran `pytest -q tests/test_create_ticket_module.py tests/test_ticket_default_status.py` and all tests passed (`14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38d6f027fc832da5d548bee076cf52)