### PR TITLE
Fix grouped ticket sorting and subgroup collapse

### DIFF
--- a/app/static/js/tables.js
+++ b/app/static/js/tables.js
@@ -21,7 +21,8 @@
     if (!tbody) {
       return;
     }
-    const rows = Array.from(tbody.querySelectorAll('tr'));
+    const hadGroupedRows = tbody.querySelector('.ticket-group-header') !== null;
+    const rows = Array.from(tbody.querySelectorAll('tr:not(.ticket-group-header)'));
     const current = table.getAttribute('data-sort-index') === String(columnIndex)
       ? table.getAttribute('data-sort-order')
       : null;
@@ -39,11 +40,25 @@
       return 0;
     });
 
+    if (hadGroupedRows) {
+      tbody.querySelectorAll('.ticket-group-header').forEach((row) => row.remove());
+    }
+
     const fragment = document.createDocumentFragment();
     rows.forEach((row) => fragment.appendChild(row));
     tbody.appendChild(fragment);
     table.setAttribute('data-sort-index', String(columnIndex));
     table.setAttribute('data-sort-order', ascending ? 'asc' : 'desc');
+
+    table.dispatchEvent(new CustomEvent('table:sorted', {
+      bubbles: true,
+      detail: {
+        columnIndex,
+        sortType: type,
+        sortOrder: ascending ? 'asc' : 'desc',
+        hadGroupedRows
+      }
+    }));
 
     if (controller) {
       controller.refreshRows();
@@ -52,9 +67,10 @@
 
   function attachSorting(table, controller) {
     const headers = table.querySelectorAll('th[data-sort]');
-    headers.forEach((header, index) => {
+    headers.forEach((header) => {
       header.addEventListener('click', () => {
-        sortTable(table, index, header.getAttribute('data-sort') || 'string', controller);
+        const columnIndex = Array.prototype.indexOf.call(header.parentElement.children, header);
+        sortTable(table, columnIndex, header.getAttribute('data-sort') || 'string', controller);
       });
     });
   }

--- a/app/static/js/ticket_views.js
+++ b/app/static/js/ticket_views.js
@@ -73,6 +73,16 @@
      * Setup event listeners for UI controls
      */
     setupEventListeners() {
+      const table = this.container.querySelector('[data-table]');
+      if (table) {
+        table.addEventListener('table:sorted', () => {
+          const fields = this.groupingFields.length ? this.groupingFields : (this.groupingField ? [this.groupingField] : []);
+          if (fields.length) {
+            this.applyGrouping();
+          }
+        });
+      }
+
       // View selector
       const viewSelect = this.container.querySelector('[data-view-select]');
       if (viewSelect) {
@@ -364,12 +374,12 @@
           if (depth + 1 < fields.length) {
             buildLevel(groupRows, depth + 1, [...path, groupKey], fragment);
           } else {
-            groupRows.forEach((row) => fragment.appendChild(row));
+            groupRows.forEach((row) => {
+              row.setAttribute('data-group', groupId);
+              row.setAttribute('data-group-path', groupId);
+              fragment.appendChild(row);
+            });
           }
-          groupRows.forEach((row) => {
-            row.setAttribute('data-group', groupId);
-            row.setAttribute('data-group-path', groupId);
-          });
         });
       };
 


### PR DESCRIPTION
### Motivation

- Sorting a tickets table with grouping enabled moved ticket rows out of their generated group headers, leaving rows displayed above groups instead of inside them.  
- Collapsing nested group headers rotated the arrow but did not hide descendant ticket rows because leaf rows were not consistently assigned `data-group`/`data-group-path` attributes and grouping was not reapplied after sorts.

### Description

- Update `sortTable` in `app/static/js/tables.js` to ignore generated group header rows when building the sortable row list by selecting `tr:not(.ticket-group-header)`.  
- Remove stale `.ticket-group-header` rows before re-appending sorted ticket rows and dispatch a `table:sorted` `CustomEvent` with sort details so other code can respond.  
- Fix header click handling to compute the real column index from the header element rather than relying on the header node list index so sorting targets the expected column.  
- Update `app/static/js/ticket_views.js` to listen for the `table:sorted` event and reapply grouping (`this.applyGrouping()`) after a sort, and ensure leaf-group rows get `data-group` and `data-group-path` set before being appended so subgroup toggles hide/show their descendant ticket rows correctly.

### Testing

- Ran `node --check app/static/js/tables.js` and it succeeded.  
- Ran `node --check app/static/js/ticket_views.js` and it succeeded.  
- Ran `git diff --check` for whitespace/format issues and it reported no problems.  
- Ran `pytest tests/test_ticket_views_route_order.py` which collected 2 tests with 1 passing and 1 failing due to the test environment raising `RuntimeError: Database pool not initialised`, a failure unrelated to these JavaScript changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a38dabfbd54832db52c8ec7ed799ce5)