### PR TITLE
Render admin ticket statuses as text

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -883,7 +883,6 @@
       return acc;
     }, {});
 
-    const csrfToken = table.getAttribute('data-csrf-token') || '';
     const canBulkDelete = table.getAttribute('data-can-bulk-delete') === 'true';
     const bulkDeleteFormId = table.getAttribute('data-bulk-delete-form-id') || '';
     const emptyMessage = table.getAttribute('data-table-empty-label') || 'No records found.';
@@ -963,66 +962,18 @@
       return date.toISOString().replace('T', ' ').slice(0, 16);
     }
 
-    function createStatusCell(ticketId, currentStatus) {
+    function createStatusCell(currentStatus) {
       const cell = document.createElement('td');
       cell.dataset.label = 'Status';
+      cell.dataset.column = 'status';
+      cell.className = 'tickets-table__cell tickets-table__cell--status';
       const normalisedStatus = String(currentStatus || 'open');
       cell.dataset.value = normalisedStatus;
 
-      const wrapper = document.createElement('div');
-      wrapper.className = 'ticket-status';
-
-      const labelId = `ticket-status-label-${ticketId}`;
-      const hiddenLabel = document.createElement('span');
-      hiddenLabel.className = 'visually-hidden';
-      hiddenLabel.id = labelId;
-      hiddenLabel.textContent = 'Ticket status';
-      wrapper.appendChild(hiddenLabel);
-
-      const form = document.createElement('form');
-      form.id = `ticket-status-form-${ticketId}`;
-      form.action = `/admin/tickets/${ticketId}/status`;
-      form.method = 'post';
-      form.className = 'inline-form ticket-status__form';
-      form.setAttribute('data-ticket-status-form', '');
-      form.setAttribute('aria-labelledby', labelId);
-
-      if (csrfToken) {
-        const csrfInput = document.createElement('input');
-        csrfInput.type = 'hidden';
-        csrfInput.name = '_csrf';
-        csrfInput.value = csrfToken;
-        form.appendChild(csrfInput);
-      }
-
-      const label = document.createElement('label');
-      label.className = 'visually-hidden';
-      label.htmlFor = `ticket-status-${ticketId}`;
-      label.textContent = 'Status';
-      form.appendChild(label);
-
-      const select = document.createElement('select');
-      select.id = `ticket-status-${ticketId}`;
-      select.name = 'status';
-      select.className = 'form-input form-input--compact';
-      select.setAttribute('data-ticket-status-select', '');
-
-      const optionValues = Array.from(
-        new Set([...statusOptions.map((option) => option.value), normalisedStatus])
-      );
-      optionValues.forEach((option) => {
-        const optionElement = document.createElement('option');
-        optionElement.value = option;
-        optionElement.textContent = statusLabels[option] || option.replace(/_/g, ' ');
-        if (option === normalisedStatus) {
-          optionElement.selected = true;
-        }
-        select.appendChild(optionElement);
-      });
-
-      form.appendChild(select);
-      wrapper.appendChild(form);
-      cell.appendChild(wrapper);
+      const statusText = document.createElement('span');
+      statusText.className = 'ticket-status__text';
+      statusText.textContent = statusLabels[normalisedStatus] || normalisedStatus.replace(/_/g, ' ');
+      cell.appendChild(statusText);
       return cell;
     }
 
@@ -1066,7 +1017,7 @@
       subjectCell.appendChild(subjectLink);
       row.appendChild(subjectCell);
 
-      const statusCell = createStatusCell(ticketId, ticket.status);
+      const statusCell = createStatusCell(ticket.status);
       row.appendChild(statusCell);
 
       const priorityCell = document.createElement('td');

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -450,35 +450,7 @@
                       'closed': 'badge--muted'
                     } %}
                     <td data-label="Status" data-column="status" data-value="{{ ticket_status }}" class="tickets-table__cell tickets-table__cell--status">
-                      <div class="ticket-status">
-                        <span class="visually-hidden" id="ticket-status-label-{{ ticket.id }}">Ticket status</span>
-                        <form
-                          id="ticket-status-form-{{ ticket.id }}"
-                          action="/admin/tickets/{{ ticket.id }}/status"
-                          method="post"
-                          class="inline-form ticket-status__form"
-                          data-ticket-status-form
-                          aria-labelledby="ticket-status-label-{{ ticket.id }}"
-                        >
-                          {% if csrf_token %}
-                            <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
-                          {% endif %}
-                          <label class="visually-hidden" for="ticket-status-{{ ticket.id }}">Status</label>
-                          <select
-                            id="ticket-status-{{ ticket.id }}"
-                            name="status"
-                            class="form-input form-input--compact"
-                            data-ticket-status-select
-                          >
-                            {% if ticket_status not in ticket_status_label_map %}
-                              <option value="{{ ticket_status }}" selected>{{ status_label }}</option>
-                            {% endif %}
-                            {% for status_option in ticket_status_definitions %}
-                              <option value="{{ status_option.tech_status }}" {% if status_option.tech_status == ticket_status %}selected{% endif %}>{{ status_option.tech_label }}</option>
-                            {% endfor %}
-                          </select>
-                        </form>
-                      </div>
+                      <span class="ticket-status__text">{{ status_label }}</span>
                     </td>
                     <td data-label="Priority" data-column="priority" class="tickets-table__cell tickets-table__cell--priority">{{ ticket.priority or 'normal' }}</td>
                     <td data-label="Company" data-column="company" class="tickets-table__cell tickets-table__cell--company">{{ company.name if company else (ticket.company_id or '—') }}</td>


### PR DESCRIPTION
### Motivation
- The admin tickets list displayed a status dropdown for each row suggesting inline edits, but that inline change path is non-functional and status changes must be made inside the ticket; the UI should therefore show the status as plain text to avoid confusion.

### Description
- Replaced the inline status `<select>` form in the admin tickets list with a text-only status label in `app/templates/admin/tickets.html` so the Status column is rendered as regular text.
- Updated the client-side table renderer in `app/static/js/admin.js` (the `createStatusCell` function and row-building logic) to produce the same text-only status element for dynamically refreshed rows while preserving `data-column`/`data-value` metadata used for sorting/filtering.
- Removed the inline status form creation and submit bindings from the table-rendering path so list rows no longer imply editable controls.

### Testing
- Ran `python -m py_compile app/main.py` which succeeded to validate syntax.
- Ran `pytest tests/test_admin_ticket_detail.py tests/test_ticket_column_customisation.py` which passed (tests covering the admin ticket UI/column behaviour succeeded).
- Also ran `pytest tests/test_admin_ticket_detail.py tests/test_ticket_column_customisation.py tests/test_tickets_dashboard_api.py` where 2 failures occurred in `tests/test_tickets_dashboard_api.py` related to ticket status API expectations and are unrelated to the UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39c026a934832d9755c56229ed6dd1)