### PR TITLE
Fix Hudu password label workflow handling

### DIFF
--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -878,9 +878,14 @@ def _normalise_workflow_steps(policy_config: dict[str, Any], *, direction: str) 
         step_type = str(config.get("type") or raw_step.get("type") or raw_step.get("key") or "").strip().lower()
         if not step_type:
             continue
-        step_name = str(raw_step.get("name") or config.get("name") or f"step_{index + 1}_{step_type}").strip()
+        step_name = str(raw_step.get("name") or f"step_{index + 1}_{step_type}").strip()
         step_record = dict(config)
-        step_record["name"] = step_name
+        # Keep the workflow step display name separate from action-specific fields.
+        # Some actions (for example hudu_push_password) legitimately use config.name
+        # as their payload label, so overwriting it with the step name changes the
+        # external API payload.
+        step_record["_workflow_step_name"] = step_name
+        step_record.setdefault("name", step_name)
         step_record["type"] = step_type
         steps.append(step_record)
     return steps
@@ -2587,7 +2592,7 @@ async def _execute_policy_steps(
                 secret_vars.add(str(name))
 
     for index, step in enumerate(steps):
-        step_name = str(step.get("name") or f"step_{index + 1}")
+        step_name = str(step.get("_workflow_step_name") or step.get("name") or f"step_{index + 1}")
         if step_name in succeeded_steps:
             continue
         if str(step.get("type")).strip().lower() in {"wait_external_checkpoint", "wait_for_webhook"}:

--- a/tests/test_staff_onboarding_workflow_policy_steps.py
+++ b/tests/test_staff_onboarding_workflow_policy_steps.py
@@ -53,6 +53,29 @@ def test_normalise_workflow_steps_uses_step_type_from_config():
     assert steps[0]["type"] == "m365_create_user"
 
 
+
+def test_normalise_workflow_steps_preserves_hudu_password_label_config():
+    policy_config = {
+        "steps": [
+            {
+                "name": "Push password to Hudu",
+                "enabled": True,
+                "config": {
+                    "type": "hudu_push_password",
+                    "name": "${vars.staff.full_name} - M365 Password",
+                    "password": "${vars.generated_password}",
+                },
+            }
+        ]
+    }
+
+    steps = workflows._normalise_workflow_steps(policy_config, direction=workflows.DIRECTION_ONBOARDING)
+
+    assert len(steps) == 1
+    assert steps[0]["_workflow_step_name"] == "Push password to Hudu"
+    assert steps[0]["name"] == "${vars.staff.full_name} - M365 Password"
+    assert steps[0]["type"] == "hudu_push_password"
+
 def test_normalise_workflow_steps_uses_offboarding_steps_for_offboarding_direction():
     policy_config = {
         "steps": [{"name": "Onboarding only", "type": "provision_account"}],


### PR DESCRIPTION
### Motivation
- Normalising workflow steps overwrote action-specific `config.name` with the workflow step display name, causing Hudu password pushes to use the step title instead of the configured Password name/label.
- Keep workflow display names for tracking and retries while preserving action payload fields that external APIs expect intact.

### Description
- Stop overwriting action `config.name` when normalising steps by storing the workflow display name separately in `_workflow_step_name` and only setting `name` on the config if not already present.  (change in `app/services/staff_onboarding_workflows.py`)
- Use `_workflow_step_name` when resolving execution step names (e.g. for success/skip matching and webhook checkpoint naming) so execution tracking still uses the display name. (change in `app/services/staff_onboarding_workflows.py`)
- Add a regression test to assert that `hudu_push_password` preserves the configured password label while the workflow step display name is kept separately. (change in `tests/test_staff_onboarding_workflow_policy_steps.py`)

### Testing
- Ran `pytest -q tests/test_staff_onboarding_workflow_policy_steps.py tests/test_hudu_service.py` and the tests passed. (`30 passed, 108 warnings` observed when running the suite containing these tests.)
- The added unit test verifies the Hudu password label is preserved and existing Hudu service tests continue to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39c208d964832dbdfc36527a443734)