### PR TITLE
Add Pause For Webhook to onboarding/offboarding workflow catalogs

### DIFF
--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -684,6 +684,14 @@ _OFFBOARDING_STEP_CATALOG: list[dict[str, Any]] = [
         "description": "Sends workflow details to the requesting user using workflow/system variables.",
     },
     {
+        "type": "wait_for_webhook",
+        "name": "Pause For Webhook",
+        "description": (
+            "Pauses the workflow until the generated webhook URL receives a POST callback with the matching postKey. "
+            "Use this when an external automation must complete before the workflow continues."
+        ),
+    },
+    {
         "type": "http_get",
         "name": "HTTP GET request",
         "description": "Calls an external endpoint with optional headers/query parameters and stores response variables.",
@@ -787,6 +795,14 @@ _ONBOARDING_STEP_CATALOG: list[dict[str, Any]] = [
         "type": "email_requestor",
         "name": "Email requestor",
         "description": "Sends onboarding details (for example login/password) to the requesting user using workflow/system variables.",
+    },
+    {
+        "type": "wait_for_webhook",
+        "name": "Pause For Webhook",
+        "description": (
+            "Pauses the workflow until the generated webhook URL receives a POST callback with the matching postKey. "
+            "Use this when an external automation must complete before the workflow continues."
+        ),
     },
     {
         "type": "http_get",

--- a/tests/test_staff_onboarding_workflow_policy_steps.py
+++ b/tests/test_staff_onboarding_workflow_policy_steps.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.services import staff_onboarding_workflows as workflows
+from app.features.staff import handlers as staff_handlers
 from app.features.staff.handlers import _normalise_workflow_config
 
 
@@ -174,6 +175,14 @@ def test_normalise_workflow_config_preserves_existing_key():
     result = _normalise_workflow_config(raw_config)
 
     assert result["steps"][0]["key"] == "my_custom_key"
+
+
+def test_workflow_step_catalogs_include_pause_for_webhook():
+    onboarding_types = {step["type"]: step for step in staff_handlers._ONBOARDING_STEP_CATALOG}
+    offboarding_types = {step["type"]: step for step in staff_handlers._OFFBOARDING_STEP_CATALOG}
+
+    assert onboarding_types["wait_for_webhook"]["name"] == "Pause For Webhook"
+    assert offboarding_types["wait_for_webhook"]["name"] == "Pause For Webhook"
 
 
 def test_normalise_custom_field_group_mappings_supports_dict_and_list_inputs():


### PR DESCRIPTION
### Motivation
- The onboarding and offboarding workflow step catalogs did not expose the `wait_for_webhook` ("Pause For Webhook") step that other workflow code and migrations expect, so it must be added to both catalogs.

### Description
- Added a `wait_for_webhook` entry named `Pause For Webhook` to both `_ONBOARDING_STEP_CATALOG` and `_OFFBOARDING_STEP_CATALOG` in `app/features/staff/handlers.py`.
- Added a regression test `test_workflow_step_catalogs_include_pause_for_webhook` to `tests/test_staff_onboarding_workflow_policy_steps.py` and imported `staff_handlers` to assert the new step is present in both catalogs.

### Testing
- Ran `pytest tests/test_staff_onboarding_workflow_policy_steps.py -q`, which passed (all tests succeeded: `29 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39c39c02e4832d93eea920b05fc4b0)