### PR TITLE
Route asset Open Chat to /chat/{id}; auto-assign tray-created chats; update empty chat copy

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -756,6 +756,7 @@ async def start_device_chat(
     room = await chat_repo.get_open_room_by_device_id(int(device["id"]))
     matrix_room_id = str((room or {}).get("matrix_room_id") or "")
 
+    created_room = False
     if not room:
         # Reuse Matrix room creation + chat_rooms persistence so the message
         # appears in the standard /chat experience.
@@ -780,6 +781,51 @@ async def start_device_chat(
 
         # Link the room back to its device so the UI can highlight it.
         await _attach_room_to_device(int(room["id"]), int(device["id"]))
+        created_room = True
+
+    if created_room and not room.get("assigned_tech_user_id"):
+        room_id = int(room["id"])
+        user_id = int(current_user["id"])
+        await chat_repo.reassign_tech(room_id, user_id)
+        await matrix_ai_waiting_assistant.handle_technician_takeover(room_id, user_id)
+
+        tech_mxid = current_user.get("matrix_user_id") or ""
+        bot_mxid = _settings.matrix_bot_user_id or ""
+        if tech_mxid:
+            try:
+                await matrix_service.invite_user(matrix_room_id, tech_mxid)
+            except Exception as exc:
+                log_error(
+                    "Failed to invite technician to tray chat during auto-assign",
+                    room_id=room_id,
+                    mxid=tech_mxid,
+                    error=str(exc),
+                )
+            try:
+                await matrix_service.set_user_power_level(matrix_room_id, tech_mxid, 100)
+            except Exception as exc:
+                log_error(
+                    "Failed to set Matrix power level during tray chat auto-assign",
+                    room_id=room_id,
+                    mxid=tech_mxid,
+                    error=str(exc),
+                )
+            await chat_repo.add_participant(
+                room_id, tech_mxid, role="technician", user_id=user_id
+            )
+        elif bot_mxid:
+            try:
+                await matrix_service.invite_user(matrix_room_id, bot_mxid)
+            except Exception as exc:
+                log_error(
+                    "Failed to invite bot user to tray chat during auto-assign",
+                    room_id=room_id,
+                    mxid=bot_mxid,
+                    error=str(exc),
+                )
+            await chat_repo.add_participant(
+                room_id, bot_mxid, role="technician", user_id=user_id
+            )
 
     initial_message = (payload.message or "").strip()[:4000]
     initiator_name = current_user.get("display_name") or current_user.get("email")

--- a/app/static/js/assets.js
+++ b/app/static/js/assets.js
@@ -258,7 +258,7 @@
           }
           const data = await response.json();
           if (data.room_id) {
-            window.location.href = `/chat?room=${encodeURIComponent(data.room_id)}`;
+            window.location.href = `/chat/${encodeURIComponent(data.room_id)}`;
             return;
           }
           throw new Error('Chat room was not returned.');

--- a/app/templates/chat/room.html
+++ b/app/templates/chat/room.html
@@ -125,7 +125,7 @@
       {% include "chat/_message.html" %}
     {% endfor %}
     {% if not messages %}
-      <div class="chat-empty" id="chat-empty">No messages yet. Say hello!</div>
+      <div class="chat-empty" id="chat-empty">No messages yet, say hello from your Matrix client app</div>
     {% endif %}
   </div>
 

--- a/app/templates/tray/chat_popup.html
+++ b/app/templates/tray/chat_popup.html
@@ -162,7 +162,7 @@
 
   <div id="chat-messages" role="log" aria-live="polite" aria-label="Chat messages">
     {% if not messages %}
-    <div id="chat-empty">No messages yet. Say hello!</div>
+    <div id="chat-empty">No messages yet, say hello from your Matrix client app</div>
     {% endif %}
     {% for msg in messages %}
     <div class="chat-message{% if msg.sender_matrix_id == ('@tray-device-' ~ device_id ~ ':tray') %} chat-message--self{% endif %}"

--- a/tests/test_tray_app.py
+++ b/tests/test_tray_app.py
@@ -1166,3 +1166,26 @@ def test_tray_icon_rejects_invalid_magic_bytes():
     assert not is_valid_ico(b"")
     assert not is_valid_ico(b"\x89PNG\r\n\x1a\n" + b"\x00" * 20)
     assert not is_valid_ico(b"\x00\x00\x02\x00" + b"\x00" * 20)
+
+
+def test_assets_open_chat_uses_path_room_url():
+    source = Path("app/static/js/assets.js").read_text()
+    assert "window.location.href = `/chat/${encodeURIComponent(data.room_id)}`;" in source
+    assert "window.location.href = `/chat?room=${encodeURIComponent(data.room_id)}`;" not in source
+
+
+def test_tray_chat_start_auto_assigns_created_room():
+    source = Path("app/api/routes/tray.py").read_text()
+    assert "created_room and not room.get(\"assigned_tech_user_id\")" in source
+    assert "await chat_repo.reassign_tech(room_id, user_id)" in source
+    assert "handle_technician_takeover(room_id, user_id)" in source
+
+
+def test_empty_chat_message_mentions_matrix_client_app():
+    room_template = Path("app/templates/chat/room.html").read_text()
+    popup_template = Path("app/templates/tray/chat_popup.html").read_text()
+    expected = "No messages yet, say hello from your Matrix client app"
+    assert expected in room_template
+    assert expected in popup_template
+    assert "No messages yet. Say hello!" not in room_template
+    assert "No messages yet. Say hello!" not in popup_template


### PR DESCRIPTION
### Motivation
- Ensure the Assets "Open Chat" action uses the canonical room path (`/chat/{room_id}`) instead of the legacy query parameter so links are consistent and nicer to share. 
- Automatically claim/assign a newly-created tray-initiated chat to the technician who started it to avoid leaving freshly-created rooms unassigned. 
- Clarify the empty-chat prompt to direct users to use their Matrix client app.

### Description
- Change `app/static/js/assets.js` to redirect to `/chat/${room_id}` instead of `/chat?room=${room_id}` when tray-created chats are opened. 
- Update `app/api/routes/tray.py` to mark when a room was newly created and, if so and the room is unassigned, call `chat_repo.reassign_tech(...)`, `matrix_ai_waiting_assistant.handle_technician_takeover(...)`, invite/grant Matrix power to the tech (if available), and add the technician as a participant. 
- Update the empty-state copy in both `app/templates/chat/room.html` and `app/templates/tray/chat_popup.html` to: "No messages yet, say hello from your Matrix client app". 
- Add regression tests in `tests/test_tray_app.py` to cover the asset chat URL change, the tray chat auto-assignment hook, and the empty-state copy.

### Testing
- Compiled `app/api/routes/tray.py` with `python -m py_compile` and it succeeded. 
- Ran targeted pytest tests: `tests/test_tray_app.py::test_assets_open_chat_uses_path_room_url`, `tests/test_tray_app.py::test_tray_chat_start_auto_assigns_created_room`, and `tests/test_tray_app.py::test_empty_chat_message_mentions_matrix_client_app`, and all three passed. 
- An earlier attempt to run a broader matrix-related test (`tests/test_matrix_chat.py`) failed in the environment due to a missing `respx` dependency, which is unrelated to these changes and does not affect the targeted tray/asset tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39d1ada4a4832db5797987ce7c8023)