### PR TITLE
Show Pause For Webhook credentials in workflow editor

### DIFF
--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -1749,23 +1749,63 @@ def _normalise_workflow_config(raw_config: dict[str, Any] | None) -> dict[str, A
     return validated.model_dump(mode="python")
 
 
+def _workflow_webhook_base_url() -> str:
+    return str(settings.public_base_url or settings.portal_url or "").strip().rstrip("/")
+
+
+def _add_wait_for_webhook_previews(config: dict[str, Any], *, company_id: int, direction: str, workflow_key: str) -> dict[str, Any]:
+    normalised = _normalise_workflow_config(config)
+    steps = normalised.get("steps")
+    if not isinstance(steps, list):
+        return normalised
+    base_url = _workflow_webhook_base_url()
+    for index, step in enumerate(steps):
+        if not isinstance(step, dict):
+            continue
+        step_config = step.get("config") if isinstance(step.get("config"), dict) else {}
+        step_type = str(step.get("type") or step_config.get("type") or "").strip().lower()
+        if step_type not in {"wait_external_checkpoint", "wait_for_webhook"}:
+            continue
+        step_name = str(step.get("name") or step.get("_workflow_step_name") or f"step_{index + 1}")
+        webhook_public_id, webhook_post_key = staff_onboarding_workflow_service._build_static_workflow_webhook_credentials(
+            company_id=company_id,
+            direction=direction,
+            workflow_key=workflow_key,
+            step_name=step_name,
+        )
+        webhook_path = f"/api/staff/workflow-webhooks/{webhook_public_id}"
+        step["webhook_preview"] = {
+            "webhook_url": f"{base_url}{webhook_path}" if base_url else webhook_path,
+            "post_key": webhook_post_key,
+        }
+    return normalised
+
+
 def _normalise_workflow_policy_response(
     policy: dict[str, Any],
     *,
     default_workflow_key: str = staff_workflow_repo.DEFAULT_WORKFLOW_KEY,
 ) -> dict[str, Any]:
     config = policy.get("config") if isinstance(policy.get("config"), dict) else {}
+    company_id = int(policy.get("company_id") or 0)
+    direction = str(policy.get("direction") or staff_workflow_repo.DIRECTION_ONBOARDING)
+    workflow_key = str(policy.get("workflow_key") or default_workflow_key)
     return {
         "id": policy.get("id"),
-        "company_id": int(policy.get("company_id") or 0),
-        "direction": str(policy.get("direction") or staff_workflow_repo.DIRECTION_ONBOARDING),
-        "workflow_key": str(policy.get("workflow_key") or default_workflow_key),
+        "company_id": company_id,
+        "direction": direction,
+        "workflow_key": workflow_key,
         "workflow_name": policy.get("workflow_name"),
         "delay_type": str(policy.get("delay_type") or "scheduled"),
         "sort_order": int(policy.get("sort_order") or 0),
         "enabled": bool(policy.get("is_enabled", True)),
         "max_retries": max(0, int(policy.get("max_retries") or 0)),
-        "config_json": _normalise_workflow_config(config),
+        "config_json": _add_wait_for_webhook_previews(
+            config,
+            company_id=company_id,
+            direction=direction,
+            workflow_key=workflow_key,
+        ),
     }
 
 

--- a/app/templates/staff/workflows_offboarding.html
+++ b/app/templates/staff/workflows_offboarding.html
@@ -162,6 +162,34 @@
         return input;
       };
 
+      const appendWebhookPreview = (step, targetContainer) => {
+        if (String(step.type || '').trim().toLowerCase() !== 'wait_for_webhook') return;
+        const preview = step.webhook_preview && typeof step.webhook_preview === 'object' ? step.webhook_preview : {};
+        const section = document.createElement('section');
+        section.className = 'workflow-section stack-xs';
+        const title = document.createElement('h4');
+        title.className = 'workflow-section__title';
+        title.textContent = 'Webhook callback details';
+        section.appendChild(title);
+        const help = document.createElement('p');
+        help.className = 'text-muted workflow-field-help';
+        help.textContent = preview.webhook_url && preview.post_key
+          ? 'Send a POST request to this URL with the POST Key as postKey in the JSON body. These values are generated from the saved workflow key and step name.'
+          : 'Save the workflow to generate the unique webhook URL and POST Key for this step.';
+        section.appendChild(help);
+        if (preview.webhook_url) {
+          const urlInput = makeInput({ type: 'text' }, preview.webhook_url);
+          urlInput.readOnly = true;
+          section.append(makeLabel('Unique URL'), urlInput);
+        }
+        if (preview.post_key) {
+          const keyInput = makeInput({ type: 'text' }, preview.post_key);
+          keyInput.readOnly = true;
+          section.append(makeLabel('POST Key'), keyInput);
+        }
+        targetContainer.appendChild(section);
+      };
+
       const renderStepsForWorkflow = (wf, stepsContainer) => {
         stepsContainer.innerHTML = '';
         if (!wf.steps.length) {
@@ -259,6 +287,7 @@
           };
 
           actionFields.forEach((field) => appendField(field, body));
+          appendWebhookPreview(step, body);
 
           const retryInput = makeInput({ type: 'number' }, step.retry_policy.max_retries);
           body.append(makeLabel('Max retries'), retryInput);

--- a/app/templates/staff/workflows_onboarding.html
+++ b/app/templates/staff/workflows_onboarding.html
@@ -187,6 +187,34 @@
 
       const getFailureTicketLabel = (mode) => (mode === 'pause' ? 'Create ticket on pause' : 'Create ticket on failure');
 
+      const appendWebhookPreview = (step, targetContainer) => {
+        if (String(step.type || '').trim().toLowerCase() !== 'wait_for_webhook') return;
+        const preview = step.webhook_preview && typeof step.webhook_preview === 'object' ? step.webhook_preview : {};
+        const section = document.createElement('section');
+        section.className = 'workflow-section stack-xs';
+        const title = document.createElement('h4');
+        title.className = 'workflow-section__title';
+        title.textContent = 'Webhook callback details';
+        section.appendChild(title);
+        const help = document.createElement('p');
+        help.className = 'text-muted workflow-field-help';
+        help.textContent = preview.webhook_url && preview.post_key
+          ? 'Send a POST request to this URL with the POST Key as postKey in the JSON body. These values are generated from the saved workflow key and step name.'
+          : 'Save the workflow to generate the unique webhook URL and POST Key for this step.';
+        section.appendChild(help);
+        if (preview.webhook_url) {
+          const urlInput = makeInput({ type: 'text' }, preview.webhook_url);
+          urlInput.readOnly = true;
+          section.append(makeLabel('Unique URL'), urlInput);
+        }
+        if (preview.post_key) {
+          const keyInput = makeInput({ type: 'text' }, preview.post_key);
+          keyInput.readOnly = true;
+          section.append(makeLabel('POST Key'), keyInput);
+        }
+        targetContainer.appendChild(section);
+      };
+
       const renderStepsForWorkflow = (wf, stepsContainer) => {
         stepsContainer.innerHTML = '';
         if (!wf.steps.length) {
@@ -283,6 +311,7 @@
           };
 
           actionFields.forEach((field) => appendField(field, body));
+          appendWebhookPreview(step, body);
 
           const retryInput = makeInput({ type: 'number' }, step.retry_policy.max_retries);
           body.append(makeLabel('Max retries'), retryInput);

--- a/tests/test_staff_onboarding_workflow_policy_steps.py
+++ b/tests/test_staff_onboarding_workflow_policy_steps.py
@@ -185,6 +185,31 @@ def test_workflow_step_catalogs_include_pause_for_webhook():
     assert offboarding_types["wait_for_webhook"]["name"] == "Pause For Webhook"
 
 
+
+
+def test_workflow_policy_response_includes_pause_for_webhook_preview(monkeypatch):
+    monkeypatch.setattr(staff_handlers.settings, "public_base_url", "https://portal.example.test")
+    monkeypatch.setattr(staff_handlers.settings, "portal_url", None)
+
+    response = staff_handlers._normalise_workflow_policy_response(
+        {
+            "id": 10,
+            "company_id": 7,
+            "direction": "onboarding",
+            "workflow_key": "starter",
+            "workflow_name": "Starter",
+            "config": {
+                "steps": [
+                    {"type": "wait_for_webhook", "name": "Pause For Webhook", "config": {"type": "wait_for_webhook"}},
+                ],
+            },
+        }
+    )
+
+    preview = response["config_json"]["steps"][0]["webhook_preview"]
+    assert preview["webhook_url"].startswith("https://portal.example.test/api/staff/workflow-webhooks/")
+    assert len(preview["post_key"]) == 43
+
 def test_normalise_custom_field_group_mappings_supports_dict_and_list_inputs():
     from_dict = workflows._normalise_custom_field_group_mappings(
         {"custom_field_group_mappings": {"field_one": ["group-a", "group-b"], "field_two": "group-c,group-d"}}


### PR DESCRIPTION
### Motivation
- Make it obvious to admins what unique callback URL and POST Key will be used for "Pause For Webhook" steps so external systems can be configured more easily.
- Provide a deterministic preview for saved workflow policies using the same credential derivation used at runtime.

### Description
- Added backend preview generation that injects a `webhook_preview` object (with `webhook_url` and `post_key`) into the policy `config_json` for saved steps of type `wait_for_webhook` / `wait_external_checkpoint` by calling the existing deterministic credential builder (`_build_static_workflow_webhook_credentials`). (see `app/features/staff/handlers.py`)
- Implemented helper `_workflow_webhook_base_url()` and `_add_wait_for_webhook_previews()` and wire them into `_normalise_workflow_policy_response` so policy responses include the preview when appropriate. (see `app/features/staff/handlers.py`)
- Updated onboarding and offboarding workflow editors to render a "Webhook callback details" section for `wait_for_webhook` steps showing read-only Unique URL and POST Key when present, and a save-first hint when previews are not yet available. (see `app/templates/staff/workflows_onboarding.html` and `app/templates/staff/workflows_offboarding.html`)
- Added a regression test to confirm the policy response contains the `webhook_preview` URL and POST Key for a saved Pause For Webhook step. (see `tests/test_staff_onboarding_workflow_policy_steps.py`)

### Testing
- Ran `pytest -q tests/test_staff_onboarding_workflow_policy_steps.py` and the test suite passed after fixes (all tests in that file succeeded).
- Ran static checks (`git diff --check`) to ensure no whitespace/merge issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39d375373c832d98c8f030b0f33f3c)