### PR TITLE
Refresh and preserve workflow webhook preview on save

### DIFF
--- a/app/templates/staff/workflows_offboarding.html
+++ b/app/templates/staff/workflows_offboarding.html
@@ -373,6 +373,7 @@
             type: stepType,
             enabled: step.enabled !== false,
             config: { ...stepConfig, type: stepType },
+            webhook_preview: step.webhook_preview && typeof step.webhook_preview === 'object' ? { ...step.webhook_preview } : null,
             retry_policy: parsedPolicies.retry_policy,
             failure_policy: parsedPolicies.failure_policy,
           };
@@ -553,8 +554,31 @@
               return;
             }
             const result = await response.json();
-            wf.id = result.policy && result.policy.id;
+            const savedPolicy = result.policy || {};
+            wf.id = savedPolicy.id || wf.id;
+            wf.workflow_key = savedPolicy.workflow_key || wf.workflow_key;
+            wf.workflow_name = savedPolicy.workflow_name || wf.workflow_name;
+            wf.delay_type = savedPolicy.delay_type || wf.delay_type;
+            wf.enabled = savedPolicy.enabled !== false;
+            wf.max_retries = Number(savedPolicy.max_retries || wf.max_retries || 0);
+            wf.existingConfig = savedPolicy.config_json || wf.existingConfig || {};
+            const savedSteps = Array.isArray((wf.existingConfig || {})[STEP_LIST_KEY]) ? (wf.existingConfig || {})[STEP_LIST_KEY] : [];
+            wf.steps = savedSteps.map((step) => {
+              const stepType = step.type || step.key || 'offboard_account';
+              const stepConfig = step.config && typeof step.config === 'object' ? { ...step.config } : { type: stepType };
+              const parsedPolicies = readPolicies({ ...step, config: stepConfig });
+              return {
+                name: step.name || stepType || 'offboarding-step',
+                type: stepType,
+                enabled: step.enabled !== false,
+                config: { ...stepConfig, type: stepType },
+                webhook_preview: step.webhook_preview && typeof step.webhook_preview === 'object' ? { ...step.webhook_preview } : null,
+                retry_policy: parsedPolicies.retry_policy,
+                failure_policy: parsedPolicies.failure_policy,
+              };
+            });
             titleEl.textContent = wf.workflow_name || wf.workflow_key || 'Offboarding workflow';
+            renderStepsForWorkflow(wf, stepsContainer);
             messageEl.textContent = 'Workflow saved.';
           } catch {
             messageEl.textContent = 'Failed to save workflow.';

--- a/app/templates/staff/workflows_onboarding.html
+++ b/app/templates/staff/workflows_onboarding.html
@@ -404,6 +404,7 @@
             type: stepType,
             enabled: step.enabled !== false,
             config: { ...stepConfig, type: stepType },
+            webhook_preview: step.webhook_preview && typeof step.webhook_preview === 'object' ? { ...step.webhook_preview } : null,
             retry_policy: parsedPolicies.retry_policy,
             failure_policy: parsedPolicies.failure_policy,
           };
@@ -584,8 +585,31 @@
               return;
             }
             const result = await response.json();
-            wf.id = result.policy && result.policy.id;
+            const savedPolicy = result.policy || {};
+            wf.id = savedPolicy.id || wf.id;
+            wf.workflow_key = savedPolicy.workflow_key || wf.workflow_key;
+            wf.workflow_name = savedPolicy.workflow_name || wf.workflow_name;
+            wf.delay_type = savedPolicy.delay_type || wf.delay_type;
+            wf.enabled = savedPolicy.enabled !== false;
+            wf.max_retries = Number(savedPolicy.max_retries || wf.max_retries || 0);
+            wf.existingConfig = savedPolicy.config_json || wf.existingConfig || {};
+            const savedSteps = Array.isArray((wf.existingConfig || {})[STEP_LIST_KEY]) ? (wf.existingConfig || {})[STEP_LIST_KEY] : [];
+            wf.steps = savedSteps.map((step) => {
+              const stepType = step.type || step.key || 'create_user';
+              const stepConfig = step.config && typeof step.config === 'object' ? { ...step.config } : { type: stepType };
+              const parsedPolicies = readPolicies({ ...step, config: stepConfig });
+              return {
+                name: step.name || stepType || 'onboarding-step',
+                type: stepType,
+                enabled: step.enabled !== false,
+                config: { ...stepConfig, type: stepType },
+                webhook_preview: step.webhook_preview && typeof step.webhook_preview === 'object' ? { ...step.webhook_preview } : null,
+                retry_policy: parsedPolicies.retry_policy,
+                failure_policy: parsedPolicies.failure_policy,
+              };
+            });
             titleEl.textContent = wf.workflow_name || wf.workflow_key || 'Onboarding workflow';
+            renderStepsForWorkflow(wf, stepsContainer);
             messageEl.textContent = 'Workflow saved.';
           } catch {
             messageEl.textContent = 'Failed to save workflow.';


### PR DESCRIPTION
### Motivation
- The UI for the "Pause For Webhook" workflow step did not display the generated webhook URL and POST Key immediately after saving, causing confusion for users who expect the values to appear without a page reload.
- Preserve and surface the server-generated `webhook_preview` so callback details are visible when editing saved workflows.

### Description
- Preserve `webhook_preview` when mapping saved steps into the editor by reading `step.webhook_preview` into each step object in `createWorkflowCard` for both onboarding and offboarding templates (`app/templates/staff/workflows_onboarding.html` and `app/templates/staff/workflows_offboarding.html`).
- After a successful save, refresh the local workflow state from the API response by reading `result.policy` and updating `wf.id`, `wf.workflow_key`, `wf.workflow_name`, `wf.delay_type`, `wf.enabled`, `wf.max_retries`, and `wf.existingConfig`, then rebuild `wf.steps` (including preserved `webhook_preview`) and call `renderStepsForWorkflow(wf, stepsContainer)` so the generated webhook URL and POST Key are shown immediately.
- Applied these changes consistently to both onboarding and offboarding workflow UIs to ensure feature parity.

### Testing
- Ran `pytest -q tests/test_staff_onboarding_workflow_policy_steps.py` and the tests completed successfully with the suite passing.
- Verified that saving a workflow updates the in-memory workflow object and that `renderStepsForWorkflow` is invoked after save so preview fields appear without a reload.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39dbc24e3c832d8157ca724c4e5d56)