### PR TITLE
Exempt staff workflow webhook callbacks from CSRF validation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -749,6 +749,10 @@ app.add_middleware(
         "/api/backup-status",
         "/api/tray/enrol",
         "/api/tray/popup-chat",
+        # Public Wait For Webhook callbacks authenticate with an unguessable
+        # webhook URL plus the per-step post key in the JSON payload, not a
+        # browser session. Requiring CSRF here blocks legitimate automation.
+        "/api/staff/workflow-webhooks",
     ),
 )
 

--- a/tests/test_csrf_middleware.py
+++ b/tests/test_csrf_middleware.py
@@ -116,7 +116,7 @@ def test_api_key_header_skips_csrf_validation():
     assert response.json() == {"status": "created"}
 
 
-def test_main_app_exempts_tray_popup_chat_path():
+def test_main_app_exempts_public_callback_paths():
     from app.main import app as main_app
 
     csrf_middleware = next(
@@ -126,3 +126,4 @@ def test_main_app_exempts_tray_popup_chat_path():
     assert csrf_middleware is not None
     exempt_paths = csrf_middleware.kwargs.get("exempt_paths", ())
     assert "/api/tray/popup-chat" in exempt_paths
+    assert "/api/staff/workflow-webhooks" in exempt_paths


### PR DESCRIPTION
### Motivation
- Public "Wait For Webhook" callbacks used to resume staff workflows were rejected by the CSRF check because they are invoked by external automation without a browser session.

### Description
- Add `"/api/staff/workflow-webhooks"` to the `CSRFMiddleware` `exempt_paths` list in `app/main.py` so these public webhook callbacks are not blocked by CSRF validation.
- Add an inline comment documenting the security model for the exemption (authentication relies on an unguessable webhook URL plus the per-step post key in the JSON payload).
- Update the CSRF middleware test in `tests/test_csrf_middleware.py` to assert the new public callback path is included in the exemption list.

### Testing
- Ran `pytest tests/test_csrf_middleware.py -q` and the test suite passed (all tests in that file succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39defbebdc832da556d15908365049)