### PR TITLE
Add 'Create Syncro Ticket' tray action

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -38,6 +38,7 @@ from app.repositories import companies as companies_repo
 from app.repositories import tray as tray_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import users as users_repo
+from app.repositories import staff as staff_repo
 from app.schemas.tray import (
     TrayChatStartRequest,
     TrayChatStartResponse,
@@ -65,6 +66,7 @@ from app.services import matrix as matrix_service
 from app.services import matrix_ai_waiting_assistant
 from app.services import tacticalrmm as tacticalrmm_service
 from app.services import tickets as tickets_service
+from app.services import syncro as syncro_service
 from app.services import tray as tray_service
 from app.services import tray_ticket_questions as tq_service
 from app.services.sanitization import sanitize_rich_text
@@ -90,6 +92,78 @@ def _serialise_popup_chat_value(obj: Any) -> Any:
     if isinstance(obj, list):
         return [_serialise_popup_chat_value(item) for item in obj]
     return obj
+
+
+def _compose_ticket_description(
+    *,
+    payload: TrayTicketSubmitRequest,
+    normalised_email: str,
+    include_contact_block: bool,
+    questions: list[Any] | None,
+    submitted_answers: list[dict[str, Any]],
+) -> str | None:
+    """Build the shared tray ticket description for MyPortal and Syncro."""
+
+    description_parts: list[str] = []
+    if include_contact_block:
+        safe_name = _html.escape(payload.name)
+        safe_email = _html.escape(normalised_email)
+        contact_line = f"**Name:** {safe_name}"
+        if payload.phone:
+            safe_phone = _html.escape(payload.phone)
+            contact_line += f"  |  **Phone:** {safe_phone}"
+        contact_line += f"  |  **Email:** {safe_email}"
+        description_parts.append(contact_line)
+        description_parts.append("")
+
+    if payload.description:
+        description_parts.append(payload.description)
+
+    if questions and submitted_answers:
+        additional = tq_service.build_additional_details(questions, submitted_answers)
+        if additional:
+            if description_parts:
+                description_parts.append("")
+            description_parts.append(additional)
+
+    return "\n".join(description_parts) if description_parts else None
+
+
+async def _resolve_tray_device(
+    payload: TrayTicketSubmitRequest, request: Request
+) -> dict[str, Any]:
+    device = None
+    auth_header = request.headers.get("Authorization", "")
+    token = ""
+    if auth_header.lower().startswith("bearer "):
+        token = auth_header.split(" ", 1)[1].strip()
+    if token:
+        device = await tray_repo.get_device_by_auth_hash(tray_service.hash_token(token))
+        if not device:
+            raise HTTPException(
+                status_code=401, detail="Tray device authentication failed"
+            )
+    if device is None and payload.device_uid:
+        device = await tray_repo.get_device_by_uid(payload.device_uid)
+    if not device or device.get("status") == "revoked":
+        raise HTTPException(status_code=404, detail="Device not found")
+    return device
+
+
+async def _validate_tray_answers(
+    company_id: int | None, payload: TrayTicketSubmitRequest
+) -> tuple[list[Any], list[dict[str, Any]]]:
+    submitted_answers = [
+        {"question_id": a.question_id, "value": a.value}
+        for a in (payload.answers or [])
+    ]
+    questions = await tq_service.get_questions_for_company(company_id)
+    if questions:
+        errors = tq_service.validate_answers(questions, submitted_answers)
+        if errors:
+            raise HTTPException(status_code=422, detail="; ".join(errors))
+    return questions, submitted_answers
+
 
 # ---------------------------------------------------------------------------
 # Device-facing endpoints
@@ -313,9 +387,7 @@ async def heartbeat(
     request: Request,
     device: dict = Depends(get_current_tray_device),
 ) -> JSONResponse:
-    client_ip = payload.last_ip or (
-        request.client.host if request.client else None
-    )
+    client_ip = payload.last_ip or (request.client.host if request.client else None)
     await tray_repo.update_device_heartbeat(
         int(device["id"]),
         console_user=payload.console_user,
@@ -504,6 +576,106 @@ async def tray_submit_ticket(
     )
 
 
+@router.post(
+    "/submit-syncro-ticket",
+    response_model=TrayTicketSubmitResponse,
+    summary="Submit a support ticket from a tray device directly to Syncro",
+)
+async def tray_submit_syncro_ticket(
+    payload: TrayTicketSubmitRequest,
+    request: Request,
+) -> TrayTicketSubmitResponse:
+    """Create a Syncro ticket using the same tray Submit Ticket form.
+
+    The tray device is authenticated the same way as normal MyPortal ticket
+    submission.  The requester email is resolved against local Syncro-backed
+    staff data first, then against Syncro contacts, so the created ticket is
+    linked directly to the matching Syncro contact and customer where possible.
+    """
+
+    device = await _resolve_tray_device(payload, request)
+    company_id: int | None = device.get("company_id")
+    normalised_email = payload.email.strip().lower()
+
+    questions, submitted_answers = await _validate_tray_answers(company_id, payload)
+
+    syncro_customer_id: str | int | None = None
+    syncro_contact_id: str | int | None = None
+
+    if company_id is not None:
+        company = await companies_repo.get_company_by_id(int(company_id))
+        if company and company.get("syncro_company_id"):
+            syncro_customer_id = str(company.get("syncro_company_id"))
+        staff = await staff_repo.get_staff_by_company_and_email(
+            int(company_id), normalised_email
+        )
+        if staff and staff.get("syncro_contact_id"):
+            syncro_contact_id = str(staff.get("syncro_contact_id"))
+
+    if syncro_contact_id is None:
+        staff = await staff_repo.get_staff_by_email(normalised_email)
+        if staff and staff.get("syncro_contact_id"):
+            syncro_contact_id = str(staff.get("syncro_contact_id"))
+            if syncro_customer_id is None and staff.get("company_id"):
+                staff_company = await companies_repo.get_company_by_id(
+                    int(staff["company_id"])
+                )
+                if staff_company and staff_company.get("syncro_company_id"):
+                    syncro_customer_id = str(staff_company.get("syncro_company_id"))
+
+    if syncro_contact_id is None or syncro_customer_id is None:
+        contact = await syncro_service.find_contact_by_email(normalised_email)
+        if contact:
+            syncro_contact_id = syncro_contact_id or contact.get("id")
+            syncro_customer_id = (
+                syncro_customer_id
+                or contact.get("customer_id")
+                or contact.get("customerId")
+            )
+
+    full_description = _compose_ticket_description(
+        payload=payload,
+        normalised_email=normalised_email,
+        include_contact_block=syncro_contact_id is None,
+        questions=questions,
+        submitted_answers=submitted_answers,
+    )
+
+    syncro_payload = syncro_service.build_ticket_payload(
+        subject=payload.subject.strip(),
+        description=full_description,
+        customer_id=syncro_customer_id,
+        contact_id=syncro_contact_id,
+        requester_email=normalised_email if syncro_contact_id is None else None,
+        requester_name=payload.name.strip() if syncro_contact_id is None else None,
+    )
+    try:
+        ticket = await syncro_service.create_ticket(syncro_payload)
+    except syncro_service.SyncroConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except syncro_service.SyncroAPIError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    raw_ticket_id = ticket.get("id") or ticket.get("number") or 0
+    try:
+        ticket_id = int(raw_ticket_id)
+    except (TypeError, ValueError):
+        ticket_id = 0
+
+    log_info(
+        "Tray Syncro ticket submitted",
+        device_uid=device.get("uid") or payload.device_uid,
+        syncro_ticket_id=raw_ticket_id,
+        syncro_customer_id=syncro_customer_id,
+        syncro_contact_id=syncro_contact_id,
+    )
+
+    return TrayTicketSubmitResponse(
+        ticket_id=ticket_id,
+        ticket_number=str(ticket.get("number") or raw_ticket_id or "") or None,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Admin endpoints (install tokens + menu configs)
 # ---------------------------------------------------------------------------
@@ -580,7 +752,9 @@ async def create_menu_config(
         name=payload.name,
         scope=payload.scope,
         scope_ref_id=payload.scope_ref_id,
-        payload_json=json.dumps([n.model_dump(exclude_none=True) for n in payload.payload]),
+        payload_json=json.dumps(
+            [n.model_dump(exclude_none=True) for n in payload.payload]
+        ),
         display_text=safe_text,
         env_allowlist=",".join(payload.env_allowlist),
         branding_icon_url=payload.branding_icon_url,
@@ -604,7 +778,9 @@ async def update_menu_config(
         raise HTTPException(status_code=404, detail="Configuration not found")
     payload_json = None
     if payload.payload is not None:
-        payload_json = json.dumps([n.model_dump(exclude_none=True) for n in payload.payload])
+        payload_json = json.dumps(
+            [n.model_dump(exclude_none=True) for n in payload.payload]
+        )
     safe_text = (
         _sanitise_display_text(payload.display_text)
         if payload.display_text is not None
@@ -648,8 +824,12 @@ async def list_devices(
     status_filter: str | None = None,
     current_user: dict = Depends(get_current_user),
 ) -> JSONResponse:
-    if not (current_user.get("is_super_admin") or current_user.get("is_helpdesk_technician")):
-        raise HTTPException(status_code=403, detail="Helpdesk technician privileges required")
+    if not (
+        current_user.get("is_super_admin") or current_user.get("is_helpdesk_technician")
+    ):
+        raise HTTPException(
+            status_code=403, detail="Helpdesk technician privileges required"
+        )
     rows = await tray_repo.list_devices(company_id=company_id, status=status_filter)
     return JSONResponse([_serialise_device(row) for row in rows])
 
@@ -736,7 +916,9 @@ async def start_device_chat(
         raise HTTPException(status_code=404, detail="Matrix chat is not enabled")
     device = await tray_repo.get_device_by_uid(device_uid)
     if not device or device.get("status") != "active":
-        raise HTTPException(status_code=404, detail="Tray device not found or not active")
+        raise HTTPException(
+            status_code=404, detail="Tray device not found or not active"
+        )
 
     company = None
     if device.get("company_id"):
@@ -768,7 +950,9 @@ async def start_device_chat(
             matrix_room_id = matrix_resp.get("room_id", "")
         except Exception as exc:
             log_error("Failed to create Matrix room for tray chat", error=str(exc))
-            raise HTTPException(status_code=502, detail="Failed to create chat room") from exc
+            raise HTTPException(
+                status_code=502, detail="Failed to create chat room"
+            ) from exc
 
         room = await chat_repo.create_room(
             subject=subject,
@@ -802,7 +986,9 @@ async def start_device_chat(
                     error=str(exc),
                 )
             try:
-                await matrix_service.set_user_power_level(matrix_room_id, tech_mxid, 100)
+                await matrix_service.set_user_power_level(
+                    matrix_room_id, tech_mxid, 100
+                )
             except Exception as exc:
                 log_error(
                     "Failed to set Matrix power level during tray chat auto-assign",
@@ -953,7 +1139,8 @@ async def admin_create_ticket_question(
 ) -> JSONResponse:
     if payload.scope == "company" and payload.company_id is None:
         raise HTTPException(
-            status_code=422, detail="company_id is required for company-scoped questions"
+            status_code=422,
+            detail="company_id is required for company-scoped questions",
         )
     record = await tq_repo.create_question(
         scope=payload.scope,
@@ -973,7 +1160,9 @@ async def admin_create_ticket_question(
             [c.model_dump() for c in payload.conditions],
         )
     record["conditions"] = [c.model_dump() for c in payload.conditions]
-    return JSONResponse(_serialise_question(record) | {"conditions": record["conditions"]})
+    return JSONResponse(
+        _serialise_question(record) | {"conditions": record["conditions"]}
+    )
 
 
 @router.put(
@@ -1105,12 +1294,15 @@ async def _attach_room_to_device(room_id: int, device_id: int) -> None:
             (device_id, room_id),
         )
     except Exception as exc:  # pragma: no cover - defensive
-        log_error("Failed to link chat room to tray device", room_id=room_id, error=str(exc))
+        log_error(
+            "Failed to link chat room to tray device", room_id=room_id, error=str(exc)
+        )
 
 
 # ---------------------------------------------------------------------------
 # Phase 5 – Auto-update version endpoint
 # ---------------------------------------------------------------------------
+
 
 # _rollout_bucket returns a deterministic integer in [0, 100) for a given
 # device identifier, used to assign a device to a rollout cohort.
@@ -1143,7 +1335,9 @@ async def get_tray_version(request: Request) -> JSONResponse:
     if not row:
         row = await tray_repo.get_latest_tray_version("all")
     if not row:
-        return JSONResponse({"version": "0.0.0", "download_url": None, "required": False})
+        return JSONResponse(
+            {"version": "0.0.0", "download_url": None, "required": False}
+        )
 
     rollout_percent = int(row.get("rollout_percent") or 100)
 
@@ -1171,11 +1365,13 @@ async def get_tray_version(request: Request) -> JSONResponse:
             if fallback:
                 row = fallback
 
-    return JSONResponse({
-        "version": row["version"],
-        "download_url": row.get("download_url"),
-        "required": bool(row.get("required")),
-    })
+    return JSONResponse(
+        {
+            "version": row["version"],
+            "download_url": row.get("download_url"),
+            "required": bool(row.get("required")),
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1251,18 +1447,24 @@ async def admin_list_diagnostics(
     current_user: dict = Depends(require_super_admin),
 ) -> JSONResponse:
     rows = await tray_repo.list_diagnostics(device_id=device_id)
-    return JSONResponse([
-        {
-            "id": int(r["id"]),
-            "device_id": int(r["device_id"]),
-            "device_uid": r.get("device_uid"),
-            "hostname": r.get("hostname"),
-            "filename": r["filename"],
-            "size_bytes": int(r.get("size_bytes") or 0),
-            "uploaded_at": r["uploaded_at"].isoformat() if hasattr(r.get("uploaded_at"), "isoformat") else str(r.get("uploaded_at")),
-        }
-        for r in rows
-    ])
+    return JSONResponse(
+        [
+            {
+                "id": int(r["id"]),
+                "device_id": int(r["device_id"]),
+                "device_uid": r.get("device_uid"),
+                "hostname": r.get("hostname"),
+                "filename": r["filename"],
+                "size_bytes": int(r.get("size_bytes") or 0),
+                "uploaded_at": (
+                    r["uploaded_at"].isoformat()
+                    if hasattr(r.get("uploaded_at"), "isoformat")
+                    else str(r.get("uploaded_at"))
+                ),
+            }
+            for r in rows
+        ]
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1303,7 +1505,9 @@ async def admin_publish_version(
         published_by_user_id=int(current_user["id"]),
         rollout_percent=rollout_percent,
     )
-    return JSONResponse({"published": True, "version": version, "rollout_percent": rollout_percent})
+    return JSONResponse(
+        {"published": True, "version": version, "rollout_percent": rollout_percent}
+    )
 
 
 @router.patch(
@@ -1323,8 +1527,12 @@ async def admin_update_version_rollout(
     body = await request.json()
     rollout_percent = int(body.get("rollout_percent", 100))
     rollout_percent = max(1, min(100, rollout_percent))
-    await tray_repo.update_tray_version_rollout(version_id, rollout_percent=rollout_percent)
-    return JSONResponse({"updated": True, "version_id": version_id, "rollout_percent": rollout_percent})
+    await tray_repo.update_tray_version_rollout(
+        version_id, rollout_percent=rollout_percent
+    )
+    return JSONResponse(
+        {"updated": True, "version_id": version_id, "rollout_percent": rollout_percent}
+    )
 
 
 @router.get(
@@ -1342,27 +1550,29 @@ async def admin_list_versions(
             r["version"], r["platform"]
         )
         rollout_start = r.get("rollout_start_at")
-        result.append({
-            "id": int(r["id"]),
-            "version": r["version"],
-            "platform": r["platform"],
-            "download_url": r["download_url"],
-            "required": bool(r.get("required")),
-            "enabled": bool(r.get("enabled")),
-            "rollout_percent": int(r.get("rollout_percent") or 100),
-            "rollout_start_at": (
-                rollout_start.isoformat()
-                if hasattr(rollout_start, "isoformat")
-                else str(rollout_start) if rollout_start else None
-            ),
-            "devices_on_version": devices_on_version,
-            "total_devices": total_devices,
-            "published_at": (
-                r["published_at"].isoformat()
-                if hasattr(r.get("published_at"), "isoformat")
-                else str(r.get("published_at"))
-            ),
-        })
+        result.append(
+            {
+                "id": int(r["id"]),
+                "version": r["version"],
+                "platform": r["platform"],
+                "download_url": r["download_url"],
+                "required": bool(r.get("required")),
+                "enabled": bool(r.get("enabled")),
+                "rollout_percent": int(r.get("rollout_percent") or 100),
+                "rollout_start_at": (
+                    rollout_start.isoformat()
+                    if hasattr(rollout_start, "isoformat")
+                    else str(rollout_start) if rollout_start else None
+                ),
+                "devices_on_version": devices_on_version,
+                "total_devices": total_devices,
+                "published_at": (
+                    r["published_at"].isoformat()
+                    if hasattr(r.get("published_at"), "isoformat")
+                    else str(r.get("published_at"))
+                ),
+            }
+        )
     return JSONResponse(result)
 
 
@@ -1390,16 +1600,24 @@ async def push_notification_to_device(
     """
     device = await tray_repo.get_device_by_uid(device_uid)
     if not device:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Device not found.")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Device not found."
+        )
     if device.get("status") != "active":
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Device is not active.")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Device is not active."
+        )
 
     body = await request.json()
     title = str(body.get("title", "MyPortal")).strip()[:200]
     notification_body = str(body.get("body", "")).strip()[:1000]
 
-    if not (current_user.get("is_super_admin") or current_user.get("is_helpdesk_technician")):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Helpdesk access required.")
+    if not (
+        current_user.get("is_super_admin") or current_user.get("is_helpdesk_technician")
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Helpdesk access required."
+        )
 
     payload = {
         "type": "show_notification",
@@ -1509,7 +1727,9 @@ async def issue_chat_token(
     company_id: int | None = device.get("company_id")
     if company_id:
         company = await companies_repo.get_company_by_id(int(company_id))
-        if not (company and company.get("tray_chat_enabled") and _settings.matrix_enabled):
+        if not (
+            company and company.get("tray_chat_enabled") and _settings.matrix_enabled
+        ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Chat is not enabled for this device",
@@ -1526,9 +1746,13 @@ async def issue_chat_token(
     if room_id is not None:
         requested_room = await chat_repo.get_room(int(room_id))
         if not requested_room:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chat room not found")
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Chat room not found"
+            )
         if requested_room.get("status") != "open":
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Chat room is closed")
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT, detail="Chat room is closed"
+            )
     else:
         # When no room was explicitly requested, reconnect to the device's
         # existing open chat room (if any) so the user continues the same
@@ -1583,14 +1807,20 @@ async def popup_chat_get_room(
     """
     session = _parse_popup_session(request)
     if not session:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid popup session")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid popup session"
+        )
 
     if session.get("room_id") != room_id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Room mismatch")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Room mismatch"
+        )
 
     room = await chat_repo.get_room(room_id)
     if not room:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Room not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Room not found"
+        )
 
     messages = await chat_repo.get_messages(room_id, limit=50)
 
@@ -1618,33 +1848,49 @@ async def popup_chat_send_message(
     """
     session = _parse_popup_session(request)
     if not session:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid popup session")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid popup session"
+        )
 
     if session.get("room_id") != room_id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Room mismatch")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Room mismatch"
+        )
 
     # Validate CSRF token from the X-Tray-CSRF header.
     csrf_header = request.headers.get("X-Tray-CSRF", "")
     if not secrets.compare_digest(csrf_header, session.get("csrf", "")):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="CSRF validation failed")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="CSRF validation failed"
+        )
 
     body: dict[str, Any] = {}
     try:
         body = await request.json()
     except Exception:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid JSON body")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid JSON body"
+        )
 
     message_body = str(body.get("body", "")).strip()
     if not message_body:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Message body is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Message body is required"
+        )
     if len(message_body) > 65535:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Message too long")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Message too long"
+        )
 
     room = await chat_repo.get_room(room_id)
     if not room:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Room not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Room not found"
+        )
     if room.get("status") != "open":
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Chat room is closed")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail="Chat room is closed"
+        )
 
     device_id: int = int(session["device_id"])
     device = await tray_repo.get_device_by_id(device_id)
@@ -1707,8 +1953,12 @@ async def popup_chat_send_message(
     except Exception:
         pass
 
-    msg_data = {k: (v.isoformat() if isinstance(v, datetime) else v) for k, v in msg.items()}
-    await chat_ntfy_notifications.notify_chat_reply(room=room, message=msg_data, actor=None)
+    msg_data = {
+        k: (v.isoformat() if isinstance(v, datetime) else v) for k, v in msg.items()
+    }
+    await chat_ntfy_notifications.notify_chat_reply(
+        room=room, message=msg_data, actor=None
+    )
 
     return JSONResponse(
         msg_data,

--- a/app/repositories/staff.py
+++ b/app/repositories/staff.py
@@ -96,12 +96,16 @@ def _map_staff_row(row: dict[str, Any]) -> dict[str, Any]:
         mapped["verification_code"] = None
     mapped["date_onboarded"] = _serialize_datetime(mapped.get("date_onboarded"))
     mapped["date_offboarded"] = _serialize_datetime(mapped.get("date_offboarded"))
-    mapped["onboarding_completed_at"] = _serialize_datetime(mapped.get("onboarding_completed_at"))
+    mapped["onboarding_completed_at"] = _serialize_datetime(
+        mapped.get("onboarding_completed_at")
+    )
     mapped["requested_at"] = _serialize_datetime(mapped.get("requested_at"))
     mapped["approved_at"] = _serialize_datetime(mapped.get("approved_at"))
     mapped["m365_last_sign_in"] = _serialize_datetime(mapped.get("m365_last_sign_in"))
     if "portal_last_login_at" in mapped:
-        mapped["portal_last_login_at"] = _serialize_datetime(mapped.get("portal_last_login_at"))
+        mapped["portal_last_login_at"] = _serialize_datetime(
+            mapped.get("portal_last_login_at")
+        )
     mapped["created_at"] = _serialize_datetime(mapped.get("created_at"))
     mapped["updated_at"] = _serialize_datetime(mapped.get("updated_at"))
     mapped["onboarding_complete"] = bool(int(mapped.get("onboarding_complete", 0)))
@@ -202,14 +206,14 @@ async def list_staff(
     if due_only:
         conditions.append("e.scheduled_for_utc IS NOT NULL")
         conditions.append("e.scheduled_for_utc <= %s")
-        conditions.append("LOWER(COALESCE(e.state, '')) IN ('approved', 'offboarding_approved')")
+        conditions.append(
+            "LOWER(COALESCE(e.state, '')) IN ('approved', 'offboarding_approved')"
+        )
         params.append(datetime.now(timezone.utc).replace(tzinfo=None))
     decoded_cursor = _decode_staff_cursor(cursor)
     if decoded_cursor is not None:
         cursor_updated_at, cursor_staff_id = decoded_cursor
-        conditions.append(
-            "(s.updated_at > %s OR (s.updated_at = %s AND s.id > %s))"
-        )
+        conditions.append("(s.updated_at > %s OR (s.updated_at = %s AND s.id > %s))")
         params.extend([cursor_updated_at, cursor_updated_at, cursor_staff_id])
     where_clause = " AND ".join(conditions)
     portal_last_login_select = (
@@ -310,14 +314,18 @@ async def list_enabled_staff_users(company_id: int) -> List[dict[str, Any]]:
         record["user_id"] = user_id_int
         record["id"] = user_id_int if user_id_int is not None else staff_id_int
         record["requester_value"] = (
-            f"user:{user_id_int}" if user_id_int is not None else f"staff:{staff_id_int}"
+            f"user:{user_id_int}"
+            if user_id_int is not None
+            else f"staff:{staff_id_int}"
         )
         record["is_registered_user"] = user_id_int is not None
         results.append(record)
     return _dedupe_by_normalized_email(results)
 
 
-async def get_enabled_staff_requester(company_id: int, staff_id: int) -> dict[str, Any] | None:
+async def get_enabled_staff_requester(
+    company_id: int, staff_id: int
+) -> dict[str, Any] | None:
     options = await list_enabled_staff_users(company_id)
     for option in options:
         if option.get("staff_id") == staff_id:
@@ -394,7 +402,9 @@ async def list_all_staff(
     if due_only:
         conditions.append("e.scheduled_for_utc IS NOT NULL")
         conditions.append("e.scheduled_for_utc <= %s")
-        conditions.append("LOWER(COALESCE(e.state, '')) IN ('approved', 'offboarding_approved')")
+        conditions.append(
+            "LOWER(COALESCE(e.state, '')) IN ('approved', 'offboarding_approved')"
+        )
         params.append(datetime.now(timezone.utc).replace(tzinfo=None))
     where_clause = " AND ".join(conditions)
     sql = """
@@ -516,6 +526,23 @@ async def get_staff_by_company_and_email(
         WHERE s.company_id = %s AND LOWER(s.email) = LOWER(%s)
         """,
         (company_id, email),
+    )
+    return _map_staff_row(row) if row else None
+
+
+async def get_staff_by_email(email: str) -> dict[str, Any] | None:
+    """Return the first staff record matching ``email`` across companies."""
+
+    row = await db.fetch_one(
+        """
+        SELECT s.*, svc.code AS verification_code, svc.admin_name AS verification_admin_name
+        FROM staff AS s
+        LEFT JOIN staff_verification_codes AS svc ON svc.staff_id = s.id
+        WHERE LOWER(s.email) = LOWER(%s)
+        ORDER BY s.enabled DESC, s.id ASC
+        LIMIT 1
+        """,
+        (email,),
     )
     return _map_staff_row(row) if row else None
 
@@ -735,7 +762,11 @@ async def update_staff(
             account_action,
             syncro_contact_id,
             onboarding_status,
-            (1 if onboarding_complete else 0) if onboarding_complete is not None else None,
+            (
+                (1 if onboarding_complete else 0)
+                if onboarding_complete is not None
+                else None
+            ),
             _coerce_datetime(onboarding_completed_at),
             approval_status,
             requested_by_user_id,
@@ -757,7 +788,9 @@ async def update_staff(
     return updated
 
 
-async def reset_staff_onboarding_status(staff_id: int, *, onboarding_status: str) -> None:
+async def reset_staff_onboarding_status(
+    staff_id: int, *, onboarding_status: str
+) -> None:
     """Reset onboarding-related fields for a staff record."""
     await db.execute(
         """
@@ -776,7 +809,9 @@ async def delete_staff(staff_id: int) -> None:
     await db.execute("DELETE FROM staff WHERE id = %s", (staff_id,))
 
 
-async def update_m365_last_sign_in(staff_id: int, last_sign_in: datetime | None) -> None:
+async def update_m365_last_sign_in(
+    staff_id: int, last_sign_in: datetime | None
+) -> None:
     """Update only the m365_last_sign_in field for a staff record."""
     await db.execute(
         "UPDATE staff SET m365_last_sign_in = %s WHERE id = %s",
@@ -804,7 +839,9 @@ async def delete_m365_staff_not_in(company_id: int, keep_emails: set[str]) -> in
     return len(to_delete)
 
 
-async def list_active_staff_for_offboarding(company_id: int, *, exclude_staff_id: int | None = None) -> list[dict[str, Any]]:
+async def list_active_staff_for_offboarding(
+    company_id: int, *, exclude_staff_id: int | None = None
+) -> list[dict[str, Any]]:
     """Return enabled, non-ex-staff members for the given company.
 
     Used to populate email-forwarding and mailbox-access dropdowns on the

--- a/app/schemas/tray.py
+++ b/app/schemas/tray.py
@@ -51,6 +51,7 @@ class TrayMenuNode(BaseModel):
     * ``env_var`` — reads an env var named ``name`` and shows / copies it.
     * ``open_chat`` — opens the chat window.
     * ``submit_ticket`` — opens the submit-a-ticket dialog.
+    * ``submit_syncro_ticket`` — opens the same dialog and creates the ticket in Syncro.
     * ``TRMM_Script`` — asks MyPortal to run a selected Tactical RMM script on the linked asset.
     * ``refresh_config`` — asks the tray service to pull the latest menu config.
     * ``separator`` — visual divider.

--- a/app/services/syncro.py
+++ b/app/services/syncro.py
@@ -62,7 +62,9 @@ async def _load_module_settings() -> dict[str, Any] | None:
             return _MODULE_SETTINGS_CACHE
         try:
             module = await modules_service.get_module("syncro", redact=False)
-        except RuntimeError as exc:  # pragma: no cover - database may be unavailable during tests
+        except (
+            RuntimeError
+        ) as exc:  # pragma: no cover - database may be unavailable during tests
             log_error("Unable to load Syncro module configuration", error=str(exc))
             module = None
         if not module:
@@ -73,8 +75,11 @@ async def _load_module_settings() -> dict[str, Any] | None:
                 "enabled": bool(module.get("enabled")),
                 "base_url": str(settings_payload.get("base_url") or "").strip(),
                 "api_key": str(settings_payload.get("api_key") or "").strip(),
-                "rate_limit_per_minute": _coerce_rate_limit(settings_payload.get("rate_limit_per_minute")),
-                "ticket_status_mappings": settings_payload.get("ticket_status_mappings") or [],
+                "rate_limit_per_minute": _coerce_rate_limit(
+                    settings_payload.get("rate_limit_per_minute")
+                ),
+                "ticket_status_mappings": settings_payload.get("ticket_status_mappings")
+                or [],
             }
         _MODULE_SETTINGS_EXPIRY = now + 30.0
     return _MODULE_SETTINGS_CACHE
@@ -86,7 +91,9 @@ async def _get_effective_settings() -> dict[str, Any]:
         raise SyncroConfigurationError("Syncro module is disabled")
     settings = get_settings()
     base_url = _normalise_base_url(
-        module_settings.get("base_url") if module_settings else settings.syncro_webhook_url or ""
+        module_settings.get("base_url")
+        if module_settings
+        else settings.syncro_webhook_url or ""
     )
     if not base_url:
         raise SyncroConfigurationError("Syncro base URL is not configured")
@@ -94,15 +101,14 @@ async def _get_effective_settings() -> dict[str, Any]:
     if not api_key:
         api_key = str(settings.syncro_api_key or "").strip()
     rate_limit = (
-        module_settings.get("rate_limit_per_minute")
-        if module_settings
-        else 180
+        module_settings.get("rate_limit_per_minute") if module_settings else 180
     )
     return {
         "base_url": base_url,
         "api_key": api_key or None,
         "rate_limit_per_minute": _coerce_rate_limit(rate_limit),
-        "ticket_status_mappings": (module_settings or {}).get("ticket_status_mappings") or [],
+        "ticket_status_mappings": (module_settings or {}).get("ticket_status_mappings")
+        or [],
     }
 
 
@@ -211,7 +217,9 @@ async def _request(
     rate_limiter: AsyncRateLimiter | None = None,
 ) -> Any:
     settings = await _get_effective_settings()
-    limiter = rate_limiter or await _get_or_create_rate_limiter(settings["rate_limit_per_minute"])
+    limiter = rate_limiter or await _get_or_create_rate_limiter(
+        settings["rate_limit_per_minute"]
+    )
     await limiter.acquire()
     base_url = settings["base_url"]
     url = f"{base_url}{path if path.startswith('/') else f'/{path}'}"
@@ -236,7 +244,11 @@ async def _request(
             backoff_seconds=0,
         )
     except Exception as exc:  # pragma: no cover - webhook monitor safety
-        log_error("Failed to record Syncro request in webhook monitor", url=url, error=str(exc))
+        log_error(
+            "Failed to record Syncro request in webhook monitor",
+            url=url,
+            error=str(exc),
+        )
         webhook_event = None
 
     event_id: int | None = None
@@ -402,6 +414,70 @@ def _extract_collection(data: Any, *keys: str) -> list[dict[str, Any]]:
     return []
 
 
+def _first_value(payload: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = payload.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+async def find_contact_by_email(email: str) -> dict[str, Any] | None:
+    """Find a Syncro contact by email using the configured API."""
+
+    normalised = str(email or "").strip().lower()
+    if not normalised:
+        return None
+    payload = await _request("GET", "/contacts", params={"email": normalised})
+    for contact in _extract_collection(payload, "contacts", "data"):
+        candidate = (
+            str(_first_value(contact, "email", "email_address") or "").strip().lower()
+        )
+        if candidate == normalised:
+            return contact
+    return None
+
+
+def build_ticket_payload(
+    *,
+    subject: str,
+    description: str | None,
+    customer_id: str | int | None = None,
+    contact_id: str | int | None = None,
+    requester_email: str | None = None,
+    requester_name: str | None = None,
+) -> dict[str, Any]:
+    """Build a Syncro ticket create payload while omitting empty values."""
+
+    ticket: dict[str, Any] = {
+        "subject": subject,
+        "problem_type": "Other",
+        "status": "New",
+    }
+    if description:
+        ticket["description"] = description
+    if customer_id:
+        ticket["customer_id"] = customer_id
+    if contact_id:
+        ticket["contact_id"] = contact_id
+    if requester_email:
+        ticket["email"] = requester_email
+    if requester_name:
+        ticket["name"] = requester_name
+    return {"ticket": ticket}
+
+
+async def create_ticket(payload: dict[str, Any]) -> dict[str, Any]:
+    """Create a ticket in Syncro and return the resulting ticket payload."""
+
+    response = await _request("POST", "/tickets", json=payload, timeout=20.0)
+    if isinstance(response, dict):
+        ticket = response.get("ticket") if "ticket" in response else response
+        if isinstance(ticket, dict):
+            return dict(ticket)
+    raise SyncroAPIError("Syncro ticket create response was not a ticket object")
+
+
 async def get_contacts(customer_id: str | int) -> list[dict[str, Any]]:
     payload = await _request("GET", "/contacts", params={"customer_id": customer_id})
     return _extract_collection(payload, "contacts", "data")
@@ -463,7 +539,9 @@ async def download_file(
 ) -> tuple[bytes, str | None]:
     """Download a Syncro-hosted file using the configured API credentials."""
     settings = await _get_effective_settings()
-    limiter = rate_limiter or await _get_or_create_rate_limiter(settings["rate_limit_per_minute"])
+    limiter = rate_limiter or await _get_or_create_rate_limiter(
+        settings["rate_limit_per_minute"]
+    )
     await limiter.acquire()
     candidate = str(url_or_path or "").strip()
     if not candidate:
@@ -478,7 +556,9 @@ async def download_file(
             raise SyncroAPIError("Syncro download URL must use HTTP or HTTPS")
         url = candidate
     headers: dict[str, str] = {}
-    if settings.get("api_key") and (is_relative or urlparse(url).netloc == urlparse(base_url).netloc):
+    if settings.get("api_key") and (
+        is_relative or urlparse(url).netloc == urlparse(base_url).netloc
+    ):
         headers["Authorization"] = f"Bearer {settings['api_key']}"
     async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
         try:
@@ -487,8 +567,14 @@ async def download_file(
             log_error("Syncro file download failed", url=url, error=str(exc))
             raise SyncroAPIError(str(exc)) from exc
     if response.status_code >= 400:
-        log_error("Syncro file download responded with error", url=url, status=response.status_code)
-        raise SyncroAPIError(f"Syncro file download responded with {response.status_code}")
+        log_error(
+            "Syncro file download responded with error",
+            url=url,
+            status=response.status_code,
+        )
+        raise SyncroAPIError(
+            f"Syncro file download responded with {response.status_code}"
+        )
     return response.content, response.headers.get("content-type")
 
 
@@ -658,7 +744,11 @@ def extract_asset_details(asset: dict[str, Any]) -> dict[str, Any]:
         asset.get("os_name")
         or props.get("os_name")
         or props.get("os")
-        or (kabuto.get("os", {}).get("name") if isinstance(kabuto.get("os"), dict) else None)
+        or (
+            kabuto.get("os", {}).get("name")
+            if isinstance(kabuto.get("os"), dict)
+            else None
+        )
     )
 
     cpu_name = asset.get("cpu_name") or props.get("cpu_name")
@@ -669,12 +759,18 @@ def extract_asset_details(asset: dict[str, Any]) -> dict[str, Any]:
         else:
             cpu_name = first_cpu
 
-    last_sync = asset.get("last_sync") or props.get("last_sync") or kabuto.get("last_synced_at")
+    last_sync = (
+        asset.get("last_sync") or props.get("last_sync") or kabuto.get("last_synced_at")
+    )
 
     motherboard_manufacturer = (
         asset.get("motherboard_manufacturer")
         or props.get("motherboard_manufacturer")
-        or (kabuto.get("motherboard", {}).get("manufacturer") if isinstance(kabuto.get("motherboard"), dict) else None)
+        or (
+            kabuto.get("motherboard", {}).get("manufacturer")
+            if isinstance(kabuto.get("motherboard"), dict)
+            else None
+        )
     )
 
     form_factor = (
@@ -684,7 +780,9 @@ def extract_asset_details(asset: dict[str, Any]) -> dict[str, Any]:
         or general.get("form_factor")
     )
 
-    last_user = asset.get("last_user") or props.get("last_user") or kabuto.get("last_user")
+    last_user = (
+        asset.get("last_user") or props.get("last_user") or kabuto.get("last_user")
+    )
 
     cpu_age_candidates = [
         asset.get("cpu_age"),
@@ -716,9 +814,7 @@ def extract_asset_details(asset: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "id": asset.get("id"),
-        "name": asset.get("name")
-        or props.get("device_name")
-        or general.get("name"),
+        "name": asset.get("name") or props.get("device_name") or general.get("name"),
         "type": asset.get("type") or props.get("type") or general.get("type"),
         "serial_number": asset.get("serial_number")
         or props.get("serial_number")

--- a/app/templates/admin/tray/configuration_form.html
+++ b/app/templates/admin/tray/configuration_form.html
@@ -85,7 +85,7 @@
           {% endif %}
           <p class="form-help">
             Configure each row with the fields you need. Types: <code>label</code>, <code>app_version</code>, <code>link</code>, <code>submenu</code>,
-            <code>display_text</code>, <code>env_var</code>, <code>open_chat</code>, <code>submit_ticket</code>,
+            <code>display_text</code>, <code>env_var</code>, <code>open_chat</code>, <code>submit_ticket</code>, <code>submit_syncro_ticket</code>,
             <code>TRMM_Script</code>, <code>refresh_config</code>, <code>separator</code>, <code>quit</code>.
             Use <code>Level</code> to place nodes under the nearest preceding submenu. Add company visibility conditions to show a node only for selected company IDs or hide it from selected company IDs.
           </p>
@@ -137,6 +137,7 @@
         'env_var',
         'open_chat',
         'submit_ticket',
+        'submit_syncro_ticket',
         'TRMM_Script',
         'refresh_config',
         'separator',

--- a/tray/ui/ticket_windows.go
+++ b/tray/ui/ticket_windows.go
@@ -575,8 +575,16 @@ func parseTicketDialogOutput(output string) (ticketFormResult, error) {
 // Ticket WinForms dialog, persists prefill values to HKCU, and submits the
 // ticket to the portal.
 func openNewTicketDialog(cfg *api.ConfigResponse) {
+	openTicketDialogWithEndpoint(cfg, "/api/tray/submit-ticket", "Submit Ticket")
+}
+
+func openSyncroTicketDialog(cfg *api.ConfigResponse) {
+	openTicketDialogWithEndpoint(cfg, "/api/tray/submit-syncro-ticket", "Create Syncro Ticket")
+}
+
+func openTicketDialogWithEndpoint(cfg *api.ConfigResponse, submitPath string, notificationTitle string) {
 	if gPortalURL == "" {
-		showOSNotification("Submit Ticket", "Portal connection not yet established. Please try again shortly.")
+		showOSNotification(notificationTitle, "Portal connection not yet established. Please try again shortly.")
 		return
 	}
 
@@ -635,17 +643,17 @@ func openNewTicketDialog(cfg *api.ConfigResponse) {
 	}
 
 	if result.Name == "" || result.Email == "" || result.Subject == "" {
-		showOSNotification("Submit Ticket", "Name, email and subject are required.")
+		showOSNotification(notificationTitle, "Name, email and subject are required.")
 		return
 	}
 
-	if err := submitTicketToPortal(result); err != nil {
+	if err := submitTicketToPortal(result, submitPath); err != nil {
 		logger.Warn("openNewTicketDialog: submit: %v", err)
-		showOSNotification("Submit Ticket", fmt.Sprintf("Could not submit ticket: %v", err))
+		showOSNotification(notificationTitle, fmt.Sprintf("Could not submit ticket: %v", err))
 		return
 	}
 
-	showOSNotification("Submit Ticket", "Your ticket has been submitted. We will be in touch soon.")
+	showOSNotification(notificationTitle, "Your ticket has been submitted. We will be in touch soon.")
 }
 
 func newTicketDialogCommand(scriptPath string) *exec.Cmd {
@@ -699,8 +707,12 @@ func fetchTicketQuestions() []api.TicketQuestion {
 // pooling.  A 15-second timeout is sufficient for a simple JSON POST.
 var ticketHTTPClient = &http.Client{Timeout: 15 * time.Second}
 
-// submitTicketToPortal posts the ticket to POST /api/tray/submit-ticket.
-func submitTicketToPortal(result ticketFormResult) error {
+// submitTicketToPortal posts the ticket to the requested tray ticket endpoint.
+func submitTicketToPortal(result ticketFormResult, submitPaths ...string) error {
+	submitPath := "/api/tray/submit-ticket"
+	if len(submitPaths) > 0 {
+		submitPath = submitPaths[0]
+	}
 	type submitAnswer struct {
 		QuestionID int    `json:"question_id"`
 		Value      string `json:"value"`
@@ -742,7 +754,13 @@ func submitTicketToPortal(result ticketFormResult) error {
 		return fmt.Errorf("marshal: %w", err)
 	}
 
-	url := strings.TrimRight(gPortalURL, "/") + "/api/tray/submit-ticket"
+	if strings.TrimSpace(submitPath) == "" {
+		submitPath = "/api/tray/submit-ticket"
+	}
+	if !strings.HasPrefix(submitPath, "/") {
+		submitPath = "/" + submitPath
+	}
+	url := strings.TrimRight(gPortalURL, "/") + submitPath
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)

--- a/tray/ui/tray_nowebview_windows.go
+++ b/tray/ui/tray_nowebview_windows.go
@@ -281,6 +281,18 @@ func addNode(node api.MenuNode, cfg *api.ConfigResponse, parent *systray.MenuIte
 			}
 		}()
 
+	case "submit_syncro_ticket":
+		label := node.Label
+		if label == "" {
+			label = "Create Syncro Ticket"
+		}
+		item := addTrayMenuItem(parent, label, "Create a support ticket in Syncro")
+		go func() {
+			for range item.ClickedCh {
+				go openSyncroTicketDialog(cfg)
+			}
+		}()
+
 	case "TRMM_Script", "trmm_script":
 		label := node.Label
 		if label == "" {


### PR DESCRIPTION
### Motivation
- Provide a new tray icon action that lets devices install the tray ahead of migration while creating tickets directly in Syncro using the same Submit Ticket form.
- Ensure Syncro tickets are linked to the correct Syncro customer/contact by resolving the requester email against local staff/company mappings and the Syncro API, using the existing Syncro configuration (module settings and env vars).

### Description
- Added a device-facing endpoint `POST /api/tray/submit-syncro-ticket` that reuses the existing tray ticket payload, validates dynamic answers, composes the same ticket description, and creates a ticket in Syncro via the Syncro service. (`app/api/routes/tray.py`)
- Implemented Syncro helpers to locate contacts by email and to build/create Syncro ticket payloads, using the existing Syncro module settings / env vars and the webhook monitor for request logging. (`app/services/syncro.py`)
- Added `get_staff_by_email` to staff repository and resolution logic to prefer local company/staff Syncro IDs before falling back to a Syncro contact lookup. (`app/repositories/staff.py`, `app/api/routes/tray.py`)
- Updated the tray client to expose a new `submit_syncro_ticket` menu node that reuses the existing Submit Ticket WinForms dialog but posts to `/api/tray/submit-syncro-ticket` and shows an action-specific notification title, and added the new node type to the admin UI/schema helpers. (`tray/ui/ticket_windows.go`, `tray/ui/tray_nowebview_windows.go`, `app/schemas/tray.py`, `app/templates/admin/tray/configuration_form.html`)

### Testing
- Ran Python byte-compile checks with `python3 -m compileall app/api/routes/tray.py app/services/syncro.py app/repositories/staff.py app/schemas/tray.py` and they succeeded. (✅)
- Ran tray Go tests for the UI with webview-disabled tag via `cd tray && go test -tags nowebview ./ui ./internal/api` and they passed. (✅)
- Attempted the full `cd tray && go test ./...` which failed in this environment due to a missing native Linux tray dependency (`ayatana-appindicator3-0.1`) required by `systray` in the CI/container environment and not related to the logic changes. (⚠️)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39dfbf281c832d96ae75f7db24797f)