### PR TITLE
Auto-resume paused staff webhook tasks

### DIFF
--- a/app/repositories/webhook_events.py
+++ b/app/repositories/webhook_events.py
@@ -57,6 +57,7 @@ def _normalise_event(row: dict[str, Any]) -> dict[str, Any]:
             data[key] = int(data[key])
     data["headers"] = _deserialise(data.get("headers"))
     data["payload"] = _deserialise(data.get("payload"))
+    data["metadata"] = _deserialise(data.get("metadata"))
     if data.get("created_at"):
         data["created_at"] = _make_aware(data["created_at"])
     if data.get("updated_at"):
@@ -97,12 +98,13 @@ async def create_event(
     backoff_seconds: int = 300,
     direction: str = "outgoing",
     source_url: str | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     event_id = await db.execute_returning_lastrowid(
         """
         INSERT INTO webhook_events
-            (name, target_url, headers, payload, max_attempts, backoff_seconds, direction, source_url)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            (name, target_url, headers, payload, max_attempts, backoff_seconds, direction, source_url, metadata)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
         """,
         (
             name,
@@ -113,6 +115,7 @@ async def create_event(
             max(1, backoff_seconds),
             direction,
             source_url,
+            _serialise(metadata),
         ),
     )
     if not event_id:

--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -29,6 +29,7 @@ from app.services import m365 as m365_service
 from app.services.m365 import M365Error
 from app.services import notifications as notifications_service
 from app.services import system_variables
+from app.services import webhook_monitor
 from app.services import tickets as tickets_service
 from app.security.api_keys import hash_api_key
 
@@ -1082,6 +1083,8 @@ async def _execute_policy_step(
     staff: dict[str, Any],
     policy_config: dict[str, Any],
     vars_map: dict[str, Any],
+    execution_id: int | None = None,
+    step_name: str | None = None,
 ) -> dict[str, Any]:
     async def _resolve_step_user_id() -> str:
         configured_user_id = str(
@@ -1132,6 +1135,35 @@ async def _execute_policy_step(
             parsed_body = _parse_json_text(body)
             if parsed_body is not None:
                 body = parsed_body
+        failure_policy = _resolve_step_failure_policy(step)
+        use_monitor = method == "POST" and failure_policy["mode"] == "pause" and execution_id is not None
+        if use_monitor:
+            event = await webhook_monitor.enqueue_event(
+                name=f"Staff workflow webhook: {step_name or step.get('name') or 'http_post'}",
+                target_url=url,
+                payload=body,
+                headers={str(k): str(v) for k, v in headers.items()},
+                max_attempts=_resolve_step_max_retries(step, default_max_retries=3),
+                backoff_seconds=max(1, int(step.get("backoff_seconds") or 300)),
+                attempt_immediately=False,
+                metadata={
+                    "resume_source": "staff_workflow_http_post",
+                    "execution_id": int(execution_id),
+                    "step_name": str(step_name or step.get("name") or "http_post"),
+                },
+            )
+            if str(event.get("status") or "").lower() == "succeeded":
+                return {
+                    "status_code": event.get("response_status"),
+                    "body": _normalize_plain_text_payload(str(event.get("response_body") or "")),
+                    "webhook_event_id": event.get("id"),
+                }
+            return {
+                "pause": True,
+                "reason": "webhook_delivery_pending",
+                "webhook_event_id": event.get("id"),
+                "webhook_status": event.get("status"),
+            }
         timeout_seconds = max(1, int(step.get("timeout_seconds") or 30))
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:
             response = await client.request(
@@ -2666,6 +2698,8 @@ async def _execute_policy_steps(
                     staff=staff,
                     policy_config=policy_config,
                     vars_map=vars_map,
+                    execution_id=execution_id,
+                    step_name=step_name,
                 ),
             )
         except WorkflowStepError as exc:

--- a/app/services/webhook_monitor.py
+++ b/app/services/webhook_monitor.py
@@ -8,6 +8,8 @@ import httpx
 from app.core.logging import log_error, log_info
 from app.repositories import webhook_events as webhook_repo
 
+_STAFF_WORKFLOW_RESUME_SOURCE = "staff_workflow_http_post"
+
 _MAX_BACKOFF_SECONDS = 3600
 _SENSITIVE_HEADERS = {
     "authorization",
@@ -60,6 +62,7 @@ async def enqueue_event(
     max_attempts: int = 3,
     backoff_seconds: int = 300,
     attempt_immediately: bool = True,
+    metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     event = await webhook_repo.create_event(
         name=name,
@@ -69,6 +72,7 @@ async def enqueue_event(
         max_attempts=max_attempts,
         backoff_seconds=backoff_seconds,
         direction="outgoing",
+        metadata=metadata,
     )
     if attempt_immediately and event.get("id"):
         event_id = int(event["id"])
@@ -397,6 +401,7 @@ async def _attempt_event(event: dict[str, Any]) -> None:
                 response_body=response_body,
             )
             log_info("Webhook delivered", event_id=event_id, status=response_status)
+            await _resume_staff_workflow_after_delivery(event_id=event_id, event=event)
             return
         error_message = f"Unexpected status {response.status_code}"
     except Exception as exc:  # pragma: no cover - network safety
@@ -445,3 +450,23 @@ async def _attempt_event(event: dict[str, Any]) -> None:
 def _calculate_next_attempt(backoff_seconds: int, attempt: int) -> datetime:
     delay = min(backoff_seconds * (2 ** (attempt - 1)), _MAX_BACKOFF_SECONDS)
     return datetime.now(timezone.utc) + timedelta(seconds=delay)
+
+
+async def _resume_staff_workflow_after_delivery(*, event_id: int, event: dict[str, Any]) -> None:
+    metadata = event.get("metadata") if isinstance(event.get("metadata"), dict) else {}
+    if metadata.get("resume_source") != _STAFF_WORKFLOW_RESUME_SOURCE:
+        return
+    try:
+        from app.services import staff_onboarding_workflows as workflow_service
+
+        await workflow_service.resume_paused_workflow_execution(
+            execution_id=int(metadata["execution_id"]),
+            initiated_by_user_id=None,
+        )
+    except Exception as exc:  # pragma: no cover - defensive scheduler safety
+        log_error(
+            "Failed to resume staff workflow after webhook delivery",
+            event_id=event_id,
+            execution_id=metadata.get("execution_id"),
+            error=str(exc),
+        )

--- a/migrations/275_webhook_event_metadata.sql
+++ b/migrations/275_webhook_event_metadata.sql
@@ -1,0 +1,6 @@
+-- Migration 275: internal webhook event metadata.
+-- Stores non-delivered scheduler metadata used to resume paused workflow tasks
+-- after monitored outbound webhook delivery succeeds.
+
+ALTER TABLE webhook_events
+    ADD COLUMN IF NOT EXISTS metadata TEXT NULL;

--- a/tests/test_staff_workflow_webhook_resume.py
+++ b/tests/test_staff_workflow_webhook_resume.py
@@ -1,0 +1,46 @@
+import pytest
+
+from app.services import webhook_monitor
+
+
+@pytest.mark.anyio
+async def test_staff_workflow_webhook_delivery_resumes_paused_execution(monkeypatch):
+    calls = []
+
+    async def fake_resume_paused_workflow_execution(*, execution_id, initiated_by_user_id):
+        calls.append({"execution_id": execution_id, "initiated_by_user_id": initiated_by_user_id})
+        return {"execution_id": execution_id, "state": "completed"}
+
+    from app.services import staff_onboarding_workflows
+
+    monkeypatch.setattr(
+        staff_onboarding_workflows,
+        "resume_paused_workflow_execution",
+        fake_resume_paused_workflow_execution,
+    )
+
+    await webhook_monitor._resume_staff_workflow_after_delivery(
+        event_id=123,
+        event={"metadata": {"resume_source": "staff_workflow_http_post", "execution_id": 456}},
+    )
+
+    assert calls == [{"execution_id": 456, "initiated_by_user_id": None}]
+
+
+@pytest.mark.anyio
+async def test_non_staff_workflow_webhook_delivery_does_not_resume(monkeypatch):
+    async def fail_resume_paused_workflow_execution(**_kwargs):
+        raise AssertionError("resume should not be called")
+
+    from app.services import staff_onboarding_workflows
+
+    monkeypatch.setattr(
+        staff_onboarding_workflows,
+        "resume_paused_workflow_execution",
+        fail_resume_paused_workflow_execution,
+    )
+
+    await webhook_monitor._resume_staff_workflow_after_delivery(
+        event_id=123,
+        event={"metadata": {"resume_source": "other", "execution_id": 456}},
+    )


### PR DESCRIPTION
### Motivation
- Ensure staff onboarding/offboarding workflows that pause waiting for an outbound HTTP POST (webhook) automatically resume when the webhook delivery completes successfully. 
- Allow monitored outbound webhook deliveries to be retried via the existing webhook monitor and persist resume context without leaking it into the external payload.

### Description
- When a workflow step is an HTTP POST with a `pause` failure policy, enqueue the request through the webhook monitor instead of performing the immediate POST, and return a paused response if delivery is pending. (`app/services/staff_onboarding_workflows.py`)
- Pass execution context (`execution_id`, `step_name`) into policy-step execution so resumed work can map back to the paused workflow execution. (`app/services/staff_onboarding_workflows.py`)
- Add a `metadata` column to `webhook_events` and persist internal metadata (not sent to external targets) so resume context is stored with the webhook event. (`app/repositories/webhook_events.py`, `migrations/275_webhook_event_metadata.sql`)
- Extend `webhook_monitor.enqueue_event`/event handling to accept and store `metadata`, and automatically invoke a resume helper after a successful webhook delivery for events marked as staff-workflow resume candidates. (`app/services/webhook_monitor.py`)
- Add regression tests that verify the monitor resumes a paused staff workflow when event metadata indicates a staff-workflow resume, and that non-matching metadata does not trigger a resume. (`tests/test_staff_workflow_webhook_resume.py`)

### Testing
- Compiled modified modules with `python -m py_compile app/repositories/webhook_events.py app/services/webhook_monitor.py app/services/staff_onboarding_workflows.py tests/test_staff_workflow_webhook_resume.py` (success).
- Ran the new unit tests with `pytest -q tests/test_staff_workflow_webhook_resume.py` (2 tests passed).
- Ran broader packs/tests `pytest -q tests/test_staff_feature_pack.py tests/test_syncro_service.py`; these failed with unrelated pre-existing issues (staff route manifest mismatch and Syncro test expecting `syncro.module_repo` that is not present) and are not caused by the webhook resume changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39e1290af0832db8990ee3f0aea190)