### PR TITLE
Fix macOS chat shell packaging

### DIFF
--- a/tray/Makefile
+++ b/tray/Makefile
@@ -111,11 +111,18 @@ build-chat-shell-mac:
 	@case "$(HOST_OS)" in \
 	    Darwin) \
 	        echo "Building chat shell for macOS (x64 + arm64)..."; \
-	        (cd chat-shell && npm ci && npm run build:mac); \
+	        (cd chat-shell && npm ci && CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac); \
 	        mkdir -p $(DIST)/darwin; \
-	        echo "Renaming .app bundle to myportal-tray-chat.app..."; \
+	        echo "Copying .app bundle to myportal-tray-chat.app..."; \
+	        app_bundle=$$(find chat-shell/dist -maxdepth 3 -type d -name "MyPortal Chat.app" | sort | head -n 1); \
+	        if [ -z "$$app_bundle" ]; then \
+	            echo "Error: electron-builder did not create MyPortal Chat.app under chat-shell/dist."; \
+	            echo "Available chat-shell/dist contents:"; \
+	            find chat-shell/dist -maxdepth 3 -print 2>/dev/null | sort; \
+	            exit 1; \
+	        fi; \
 	        rm -rf $(DIST)/darwin/myportal-tray-chat.app; \
-	        cp -R "chat-shell/dist/mac/MyPortal Chat.app" $(DIST)/darwin/myportal-tray-chat.app ;; \
+	        cp -R "$$app_bundle" $(DIST)/darwin/myportal-tray-chat.app ;; \
 	    *) \
 	        echo "Skipping macOS chat shell build: electron-builder --mac requires a macOS host (host: $(HOST_OS))."; \
 	        echo "Run 'make build-chat-shell-mac' on a macOS machine, or build via the GitHub Actions macos-latest runner."; \

--- a/tray/chat-shell/package.json
+++ b/tray/chat-shell/package.json
@@ -8,7 +8,7 @@
     "start": "electron .",
     "build": "electron-builder",
     "build:win": "electron-builder --win --x64",
-    "build:mac": "npm run build:icons:mac && electron-builder --mac --x64 --arm64",
+    "build:mac": "npm run build:icons:mac && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac --x64 --arm64",
     "build:icons:mac": "bash ../scripts/build-macos-icons.sh"
   },
   "build": {
@@ -44,7 +44,8 @@
       ],
       "category": "public.app-category.utilities",
       "darkModeSupport": true,
-      "icon": "build/icon.icns"
+      "icon": "build/icon.icns",
+      "identity": null
     },
     "portable": {
       "artifactName": "myportal-tray-chat.exe"


### PR DESCRIPTION
### Motivation
- Prevent macOS chat-shell packaging from failing or producing misleading warnings when no Developer ID signing identity is available in CI or unsigned builds.
- Make the Makefile robust against electron-builder output layout changes instead of assuming a fixed `dist/mac/MyPortal Chat.app` path.

### Description
- Disable electron-builder macOS code-sign auto-discovery by adding `CSC_IDENTITY_AUTO_DISCOVERY=false` to the `build:mac` npm script and Makefile invocation to avoid attempts to locate a Developer ID certificate when unsigned builds are expected (`tray/chat-shell/package.json` and `tray/Makefile`).
- Explicitly set the mac `identity` to `null` in `tray/chat-shell/package.json` to suppress identity-related warnings from electron-builder during unsigned packaging.
- Replace the hard-coded `chat-shell/dist/mac/MyPortal Chat.app` copy with a `find`-based lookup in `tray/Makefile` that locates the generated `.app` bundle under `chat-shell/dist`, prints diagnostic output if it is missing, and copies the discovered bundle into `$(DIST)/darwin/myportal-tray-chat.app`.

### Testing
- Ran `cd tray && make build-chat-shell-mac`, which correctly skips macOS packaging on a non-macOS host and exits with the documented message, demonstrating the host-check path is unchanged (skipped on Linux).
- Validated `tray/chat-shell/package.json` JSON parsing with `node -e "JSON.parse(require('fs').readFileSync('tray/chat-shell/package.json','utf8'))"`, which succeeded.
- Ran `git diff --check` to validate the patch format and whitespace, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39e6965afc832d8bc022a63d80677f)