### PR TITLE
Use root ticket fields for Syncro payloads and add friendly tray ticket submission messages/errors

### DIFF
--- a/app/services/syncro.py
+++ b/app/services/syncro.py
@@ -438,6 +438,18 @@ async def find_contact_by_email(email: str) -> dict[str, Any] | None:
     return None
 
 
+def _coerce_int_id(value: str | int | None) -> int | None:
+    """Return a positive integer ID for Syncro payloads, or ``None``."""
+
+    if value in (None, ""):
+        return None
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return None
+    return coerced if coerced > 0 else None
+
+
 def build_ticket_payload(
     *,
     subject: str,
@@ -447,24 +459,37 @@ def build_ticket_payload(
     requester_email: str | None = None,
     requester_name: str | None = None,
 ) -> dict[str, Any]:
-    """Build a Syncro ticket create payload while omitting empty values."""
+    """Build a Syncro ticket create payload while omitting empty values.
 
-    ticket: dict[str, Any] = {
+    Syncro's ticket create endpoint accepts ticket fields at the JSON root, not
+    inside a nested ``ticket`` object. Keeping ``customer_id`` at the root is
+    required for Syncro to associate the new ticket with a customer.
+    """
+
+    payload: dict[str, Any] = {
         "subject": subject,
         "problem_type": "Other",
         "status": "New",
     }
+    customer_id_value = _coerce_int_id(customer_id)
+    contact_id_value = _coerce_int_id(contact_id)
+    if customer_id_value is not None:
+        payload["customer_id"] = customer_id_value
+    if contact_id_value is not None:
+        payload["contact_id"] = contact_id_value
     if description:
-        ticket["description"] = description
-    if customer_id:
-        ticket["customer_id"] = customer_id
-    if contact_id:
-        ticket["contact_id"] = contact_id
+        payload["comments_attributes"] = [
+            {
+                "subject": subject,
+                "body": description,
+                "hidden": False,
+            }
+        ]
     if requester_email:
-        ticket["email"] = requester_email
+        payload["email"] = requester_email
     if requester_name:
-        ticket["name"] = requester_name
-    return {"ticket": ticket}
+        payload["name"] = requester_name
+    return payload
 
 
 async def create_ticket(payload: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_syncro_service.py
+++ b/tests/test_syncro_service.py
@@ -22,7 +22,7 @@ def reset_syncro_caches(monkeypatch):
 async def test_syncro_request_records_webhook_success(reset_syncro_caches):
     recorded: dict[str, list[dict[str, object]] | dict[str, object]] = {"success": []}
 
-    async def fake_get_module(slug: str):
+    async def fake_get_module(slug: str, **_kwargs):
         assert slug == "syncro"
         return {
             "enabled": True,
@@ -110,7 +110,7 @@ async def test_syncro_request_records_webhook_success(reset_syncro_caches):
             }
             return DummyResponse()
 
-    reset_syncro_caches.setattr(syncro.module_repo, "get_module", fake_get_module)
+    reset_syncro_caches.setattr(syncro.modules_service, "get_module", fake_get_module)
     reset_syncro_caches.setattr(syncro.webhook_monitor, "create_manual_event", fake_manual_event)
     reset_syncro_caches.setattr(syncro.webhook_monitor, "record_manual_success", fake_record_success)
     reset_syncro_caches.setattr(syncro.webhook_monitor, "record_manual_failure", fake_record_failure)
@@ -131,7 +131,7 @@ async def test_syncro_request_records_webhook_success(reset_syncro_caches):
 async def test_syncro_request_records_webhook_failure(reset_syncro_caches):
     recorded: dict[str, list[dict[str, object]] | dict[str, object]] = {}
 
-    async def fake_get_module(slug: str):
+    async def fake_get_module(slug: str, **_kwargs):
         return {
             "enabled": True,
             "settings": {
@@ -183,7 +183,7 @@ async def test_syncro_request_records_webhook_failure(reset_syncro_caches):
         async def request(self, method, url, headers=None, params=None, json=None):
             raise httpx.HTTPError("boom")
 
-    reset_syncro_caches.setattr(syncro.module_repo, "get_module", fake_get_module)
+    reset_syncro_caches.setattr(syncro.modules_service, "get_module", fake_get_module)
     reset_syncro_caches.setattr(syncro.webhook_monitor, "create_manual_event", fake_manual_event)
     reset_syncro_caches.setattr(syncro.webhook_monitor, "record_manual_failure", fake_record_failure)
     reset_syncro_caches.setattr(syncro.webhook_monitor, "record_manual_success", fake_record_success)
@@ -196,3 +196,41 @@ async def test_syncro_request_records_webhook_failure(reset_syncro_caches):
     assert recorded["failure"][0]["event_id"] == 654
     assert recorded["failure"][0]["status"] == "error"
     assert recorded["failure"][0]["error_message"] == "boom"
+
+
+def test_build_ticket_payload_uses_syncro_root_ticket_fields():
+    payload = syncro.build_ticket_payload(
+        subject="Need help",
+        description="The workstation is offline",
+        customer_id="123",
+        contact_id="456",
+    )
+
+    assert payload["customer_id"] == 123
+    assert payload["contact_id"] == 456
+    assert payload["subject"] == "Need help"
+    assert "ticket" not in payload
+    assert payload["comments_attributes"] == [
+        {
+            "subject": "Need help",
+            "body": "The workstation is offline",
+            "hidden": False,
+        }
+    ]
+
+
+def test_build_ticket_payload_omits_invalid_optional_ids():
+    payload = syncro.build_ticket_payload(
+        subject="Need help",
+        description=None,
+        customer_id="not-an-id",
+        contact_id=0,
+        requester_email="person@example.com",
+        requester_name="Person Example",
+    )
+
+    assert "customer_id" not in payload
+    assert "contact_id" not in payload
+    assert "comments_attributes" not in payload
+    assert payload["email"] == "person@example.com"
+    assert payload["name"] == "Person Example"

--- a/tray/ui/ticket_windows.go
+++ b/tray/ui/ticket_windows.go
@@ -647,13 +647,14 @@ func openTicketDialogWithEndpoint(cfg *api.ConfigResponse, submitPath string, no
 		return
 	}
 
-	if err := submitTicketToPortal(result, submitPath); err != nil {
+	submission, err := submitTicketToPortal(result, submitPath)
+	if err != nil {
 		logger.Warn("openNewTicketDialog: submit: %v", err)
-		showOSNotification(notificationTitle, fmt.Sprintf("Could not submit ticket: %v", err))
+		showOSNotification(notificationTitle, err.Error())
 		return
 	}
 
-	showOSNotification(notificationTitle, "Your ticket has been submitted. We will be in touch soon.")
+	showOSNotification(notificationTitle, submission.SuccessMessage())
 }
 
 func newTicketDialogCommand(scriptPath string) *exec.Cmd {
@@ -707,8 +708,86 @@ func fetchTicketQuestions() []api.TicketQuestion {
 // pooling.  A 15-second timeout is sufficient for a simple JSON POST.
 var ticketHTTPClient = &http.Client{Timeout: 15 * time.Second}
 
+type ticketSubmissionResponse struct {
+	TicketID     int    `json:"ticket_id"`
+	TicketNumber string `json:"ticket_number"`
+}
+
+func (r ticketSubmissionResponse) SuccessMessage() string {
+	ticketNumber := strings.TrimSpace(r.TicketNumber)
+	if ticketNumber != "" {
+		return fmt.Sprintf("Your ticket %s has been submitted. We will be in touch soon.", ticketNumber)
+	}
+	if r.TicketID > 0 {
+		return fmt.Sprintf("Your ticket #%d has been submitted. We will be in touch soon.", r.TicketID)
+	}
+	return "Your ticket has been submitted. We will be in touch soon."
+}
+
+type apiErrorResponse struct {
+	Detail any `json:"detail"`
+	Error  any `json:"error"`
+}
+
+func friendlyTicketSubmitError(statusCode int, body []byte) error {
+	message := extractAPIErrorMessage(body)
+	if message != "" {
+		return fmt.Errorf("Ticket submission failed: %s", message)
+	}
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("Ticket submission failed because this device is not authorised. Please contact support.")
+	case http.StatusNotFound:
+		return fmt.Errorf("Ticket submission failed because this device is not registered. Please contact support.")
+	case http.StatusUnprocessableEntity, http.StatusBadRequest:
+		return fmt.Errorf("Ticket submission failed because some required information is missing or invalid. Please review the form and try again.")
+	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return fmt.Errorf("Ticket submission failed because the ticket system is temporarily unavailable. Please try again shortly.")
+	default:
+		return fmt.Errorf("Ticket submission failed. Please try again shortly or contact support.")
+	}
+}
+
+func extractAPIErrorMessage(body []byte) string {
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return ""
+	}
+	var payload apiErrorResponse
+	if err := json.Unmarshal(body, &payload); err == nil {
+		for _, candidate := range []any{payload.Detail, payload.Error} {
+			if msg := stringifyAPIErrorValue(candidate); msg != "" {
+				return msg
+			}
+		}
+	}
+	return ""
+}
+
+func stringifyAPIErrorValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			if msg := stringifyAPIErrorValue(item); msg != "" {
+				parts = append(parts, msg)
+			}
+		}
+		return strings.Join(parts, "; ")
+	case map[string]any:
+		for _, key := range []string{"msg", "message", "detail", "error"} {
+			if msg := stringifyAPIErrorValue(v[key]); msg != "" {
+				return msg
+			}
+		}
+	}
+	return ""
+}
+
 // submitTicketToPortal posts the ticket to the requested tray ticket endpoint.
-func submitTicketToPortal(result ticketFormResult, submitPaths ...string) error {
+func submitTicketToPortal(result ticketFormResult, submitPaths ...string) (ticketSubmissionResponse, error) {
 	submitPath := "/api/tray/submit-ticket"
 	if len(submitPaths) > 0 {
 		submitPath = submitPaths[0]
@@ -738,7 +817,7 @@ func submitTicketToPortal(result ticketFormResult, submitPaths ...string) error 
 		deviceUID = strings.TrimSpace(gDeviceUID)
 	}
 	if deviceUID == "" && strings.TrimSpace(gAuthToken) == "" {
-		return fmt.Errorf("device UID or auth token is not available yet")
+		return ticketSubmissionResponse{}, fmt.Errorf("Ticket submission failed because the device is not ready yet. Please try again shortly.")
 	}
 
 	body, err := json.Marshal(submitRequest{
@@ -751,7 +830,7 @@ func submitTicketToPortal(result ticketFormResult, submitPaths ...string) error 
 		Answers:     answers,
 	})
 	if err != nil {
-		return fmt.Errorf("marshal: %w", err)
+		return ticketSubmissionResponse{}, fmt.Errorf("Ticket submission failed before it could be sent. Please try again.")
 	}
 
 	if strings.TrimSpace(submitPath) == "" {
@@ -763,7 +842,7 @@ func submitTicketToPortal(result ticketFormResult, submitPaths ...string) error 
 	url := strings.TrimRight(gPortalURL, "/") + submitPath
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
+		return ticketSubmissionResponse{}, fmt.Errorf("Ticket submission failed before it could be sent. Please try again.")
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if gAuthToken != "" {
@@ -771,17 +850,17 @@ func submitTicketToPortal(result ticketFormResult, submitPaths ...string) error 
 	}
 	resp, err := ticketHTTPClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("post: %w", err)
+		return ticketSubmissionResponse{}, fmt.Errorf("Ticket submission failed because the portal could not be reached. Please check your connection and try again.")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		msg := strings.TrimSpace(string(b))
-		if len(b) == 512 {
-			msg += "…"
-		}
-		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, msg)
+		return ticketSubmissionResponse{}, friendlyTicketSubmitError(resp.StatusCode, b)
+	}
+	var submission ticketSubmissionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&submission); err != nil && err != io.EOF {
+		logger.Debug("submitTicketToPortal: could not decode success response: %v", err)
 	}
 	logger.Info("Tray ticket submitted (HTTP %d)", resp.StatusCode)
-	return nil
+	return submission, nil
 }

--- a/tray/ui/ticket_windows_test.go
+++ b/tray/ui/ticket_windows_test.go
@@ -268,8 +268,12 @@ func TestSubmitTicketToPortalPostsJSONWithAuth(t *testing.T) {
 	ticketHTTPClient = server.Client()
 	ticketHTTPClient.Timeout = 5 * time.Second
 
-	if err := submitTicketToPortal(ticketFormResult{Name: "Jane", Email: "jane@example.com", Subject: "Help"}); err != nil {
+	submission, err := submitTicketToPortal(ticketFormResult{Name: "Jane", Email: "jane@example.com", Subject: "Help"})
+	if err != nil {
 		t.Fatalf("submit ticket: %v", err)
+	}
+	if submission.TicketID != 42 {
+		t.Fatalf("unexpected ticket id: %d", submission.TicketID)
 	}
 }
 
@@ -305,7 +309,7 @@ func TestSubmitTicketToPortalCanUseAuthTokenWithoutDeviceUID(t *testing.T) {
 	ticketHTTPClient = server.Client()
 	ticketHTTPClient.Timeout = 5 * time.Second
 
-	if err := submitTicketToPortal(ticketFormResult{Name: "Jane", Email: "jane@example.com", Subject: "Help"}); err != nil {
+	if _, err := submitTicketToPortal(ticketFormResult{Name: "Jane", Email: "jane@example.com", Subject: "Help"}); err != nil {
 		t.Fatalf("submit ticket with auth token only: %v", err)
 	}
 }
@@ -321,8 +325,49 @@ func TestSubmitTicketToPortalRequiresDeviceUIDOrAuthToken(t *testing.T) {
 	gDeviceUID = ""
 	gAuthToken = ""
 
-	err := submitTicketToPortal(ticketFormResult{Name: "Jane", Email: "jane@example.com", Subject: "Help"})
-	if err == nil || !strings.Contains(err.Error(), "device UID or auth token") {
-		t.Fatalf("expected device UID/auth token error, got %v", err)
+	_, err := submitTicketToPortal(ticketFormResult{Name: "Jane", Email: "jane@example.com", Subject: "Help"})
+	if err == nil || !strings.Contains(err.Error(), "device is not ready") {
+		t.Fatalf("expected device readiness error, got %v", err)
+	}
+}
+
+func TestSubmitTicketToPortalReturnsFriendlyServerError(t *testing.T) {
+	oldPortalURL, oldDeviceUID, oldAuthToken, oldClient := gPortalURL, gDeviceUID, gAuthToken, ticketHTTPClient
+	defer func() {
+		gPortalURL = oldPortalURL
+		gDeviceUID = oldDeviceUID
+		gAuthToken = oldAuthToken
+		ticketHTTPClient = oldClient
+	}()
+
+	gDeviceUID = "device-123"
+	gAuthToken = "token-abc"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"detail":"Syncro ticket system is unavailable"}`))
+	}))
+	defer server.Close()
+
+	gPortalURL = server.URL
+	ticketHTTPClient = server.Client()
+	ticketHTTPClient.Timeout = 5 * time.Second
+
+	_, err := submitTicketToPortal(ticketFormResult{Name: "Jane", Email: "jane@example.com", Subject: "Help"})
+	if err == nil {
+		t.Fatal("expected friendly submission error")
+	}
+	if strings.Contains(err.Error(), "HTTP") || strings.Contains(err.Error(), "502") {
+		t.Fatalf("error should not expose HTTP status codes: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Ticket submission failed: Syncro ticket system is unavailable") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTicketSubmissionResponseSuccessMessageIncludesTicketNumber(t *testing.T) {
+	message := (ticketSubmissionResponse{TicketID: 42, TicketNumber: "T-42"}).SuccessMessage()
+	if !strings.Contains(message, "T-42") || strings.Contains(message, "HTTP") {
+		t.Fatalf("unexpected success message: %q", message)
 	}
 }


### PR DESCRIPTION
### Motivation
- Ensure tickets created via the Syncro service use Syncro's expected root-level fields and accept numeric IDs supplied as strings.
- Improve user-facing success and error messages for Tray ticket submissions and avoid exposing raw HTTP details to end users.
- Update tests and mocks to reflect API and function signature changes.

### Description
- Add `_coerce_int_id` and change `build_ticket_payload` to emit root-level Syncro fields (`customer_id`, `contact_id`, `email`, `name`) and use `comments_attributes` for ticket description while omitting invalid IDs.
- Update tests to use `modules_service.get_module` in place of the previous import location and add unit tests for `build_ticket_payload` behavior in `tests/test_syncro_service.py`.
- In the tray UI, introduce `ticketSubmissionResponse` and `apiErrorResponse` types plus `SuccessMessage`, `friendlyTicketSubmitError`, `extractAPIErrorMessage`, and `stringifyAPIErrorValue` helpers to parse responses and produce friendly messages.
- Change `submitTicketToPortal` to return `(ticketSubmissionResponse, error)` and to return friendly, non-technical errors for various failure modes while decoding successful responses and logging appropriately.
- Update UI flow to show the submission's `SuccessMessage()` and adjust tests in `tray/ui/ticket_windows_test.go` to match the new return value and friendly error behavior.

### Testing
- Ran `pytest tests/test_syncro_service.py` which exercised the Syncro request recording and the new `build_ticket_payload` tests and completed successfully.
- Ran `go test ./tray/ui` which covered `submitTicketToPortal` behavior and new friendly error/success message tests and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39e97542e4832dab5d4be56533e5b6)