### PR TITLE
Show app logo in Windows toast notifications

### DIFF
--- a/tray/ui/windows_notification.go
+++ b/tray/ui/windows_notification.go
@@ -12,40 +12,13 @@ import (
 
 func windowsToastEncodedCommand(title, body string) string {
 	appName := windowsToastAppName()
-	iconURL := windowsToastIconURL()
-	template := "ToastText02"
-	imageScript := ""
-	if iconURL != "" {
-		template = "ToastImageAndText02"
-		imageScript = `$xml.GetElementsByTagName('image')[0].SetAttribute('src', '` + powershellSingleQuotedString(iconURL) + `')
-`
-	}
-	script := `[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
-$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::` + template + `)
-` + imageScript + `$textNodes = $xml.GetElementsByTagName('text')
-[void]$textNodes.Item(0).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(title) + `'))
-[void]$textNodes.Item(1).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(body) + `'))
-[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + powershellSingleQuotedString(appName) + `').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
+	script := windowsToastScript(title, body, "", appName, windowsToastIconURL(), true)
 	return encodePowerShellCommand(script)
 }
 
 func windowsPersistentChatToastEncodedCommand(title, body, chatURL string) string {
 	appName := windowsToastAppName()
-	iconURL := windowsToastIconURL()
-	template := "ToastText02"
-	imageScript := ""
-	if iconURL != "" {
-		template = "ToastImageAndText02"
-		imageScript = `$xml.GetElementsByTagName('image')[0].SetAttribute('src', '` + powershellSingleQuotedString(iconURL) + `')
-`
-	}
-	script := `[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
-$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::` + template + `)
-` + imageScript + `$toast = $xml.GetElementsByTagName('toast')[0]
-$toast.SetAttribute('scenario', 'reminder')
-$textNodes = $xml.GetElementsByTagName('text')
-[void]$textNodes.Item(0).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(title) + `'))
-[void]$textNodes.Item(1).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(body) + `'))
+	script := windowsToastScript(title, body, "reminder", appName, windowsToastIconURL(), false) + `
 $actions = $xml.CreateElement('actions')
 $open = $xml.CreateElement('action')
 $open.SetAttribute('content', 'Open chat')
@@ -83,6 +56,34 @@ func showChatSessionNotification(title, body, chatURL string) {
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsPersistentChatToastEncodedCommand(title, body, chatURL))
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
 	_ = cmd.Start()
+}
+
+func windowsToastScript(title, body, scenario, appName, iconURL string, show bool) string {
+	scenarioScript := ""
+	if scenario != "" {
+		scenarioScript = `$toast.SetAttribute('scenario', '` + powershellSingleQuotedString(scenario) + `')
+`
+	}
+	logoScript := ""
+	if iconURL != "" {
+		logoScript = `$binding = $xml.GetElementsByTagName('binding').Item(0)
+$appLogo = $xml.CreateElement('image')
+$appLogo.SetAttribute('placement', 'appLogoOverride')
+$appLogo.SetAttribute('src', '` + powershellSingleQuotedString(iconURL) + `')
+[void]$binding.InsertBefore($appLogo, $binding.FirstChild)
+`
+	}
+	script := `[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+$xml = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastGeneric)
+$toast = $xml.GetElementsByTagName('toast')[0]
+` + scenarioScript + logoScript + `$textNodes = $xml.GetElementsByTagName('text')
+[void]$textNodes.Item(0).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(title) + `'))
+[void]$textNodes.Item(1).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(body) + `'))`
+	if show {
+		script += `
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + powershellSingleQuotedString(appName) + `').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
+	}
+	return script
 }
 
 func windowsToastAppName() string {

--- a/tray/ui/windows_notification_test.go
+++ b/tray/ui/windows_notification_test.go
@@ -33,7 +33,8 @@ func TestWindowsToastEncodedCommandAppendsTextNodes(t *testing.T) {
 	script := string(utf16.Decode(units))
 	for _, want := range []string{
 		"$textNodes = $xml.GetElementsByTagName('text')",
-		"$xml.GetElementsByTagName('image')[0].SetAttribute('src', 'https://portal.example.test/tray/icon.ico')",
+		"$appLogo.SetAttribute('placement', 'appLogoOverride')",
+		"$appLogo.SetAttribute('src', 'https://portal.example.test/tray/icon.ico')",
 		"AppendChild($xml.CreateTextNode('Script scheduled'))",
 		"AppendChild($xml.CreateTextNode('The requested automation has been scheduled and will run in the background shortly.'))",
 		"CreateToastNotifier('Acme Support').Show",


### PR DESCRIPTION
### Motivation
- Desktop toast notifications should display the app/logo in the left app-icon slot so the notification matches the tray branding and the screenshot indicator. 
- Windows toast XML needs to use a template that supports an `appLogoOverride` element to place the branded icon.

### Description
- Switch Windows toast generation to use the `ToastGeneric` template and a shared builder function `windowsToastScript` that produces the toast XML. 
- Inject the portal tray icon as an `appLogoOverride` image by inserting an `<image placement='appLogoOverride' src='...'>` element into the toast `binding` so the branded icon appears in the left logo slot. 
- Reuse the new builder for both standard notifications (`windowsToastEncodedCommand`) and persistent chat notifications (`windowsPersistentChatToastEncodedCommand`). 
- Update the unit test `TestWindowsToastEncodedCommandAppendsTextNodes` to assert the generated PowerShell script includes the `appLogoOverride` image and the portal `/tray/icon.ico` URL.

### Testing
- Ran `cd tray && go test -tags nowebview ./ui` and it passed (`ok`).
- Compiled Windows UI tests with `cd tray && GOOS=windows go test -tags nowebview -c ./ui -o /tmp/myportal-tray-ui.test.exe` and ran repository unit tests `go test ./internal/notify ./internal/config`, which succeeded; the compiled Windows test binary was removed afterwards. 
- Adjusted test expectations in `tray/ui/windows_notification_test.go` and executed the tray UI tests with `cd tray && go test -tags nowebview ./ui` which passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39f23174048332ab8d4af5e241238f)