### PR TITLE
Include tray contact details in Syncro ticket comments

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -636,7 +636,7 @@ async def tray_submit_syncro_ticket(
     full_description = _compose_ticket_description(
         payload=payload,
         normalised_email=normalised_email,
-        include_contact_block=syncro_contact_id is None,
+        include_contact_block=True,
         questions=questions,
         submitted_answers=submitted_answers,
     )

--- a/tests/test_tray_submit_ticket_auth.py
+++ b/tests/test_tray_submit_ticket_auth.py
@@ -42,7 +42,9 @@ async def test_tray_submit_ticket_uses_bearer_token_without_device_uid(monkeypat
         "get_device_by_auth_hash",
         fake_get_device_by_auth_hash,
     )
-    monkeypatch.setattr(tray_routes.users_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        tray_routes.users_repo, "get_user_by_email", fake_get_user_by_email
+    )
     monkeypatch.setattr(
         tray_routes.tq_service,
         "get_questions_for_company",
@@ -53,7 +55,9 @@ async def test_tray_submit_ticket_uses_bearer_token_without_device_uid(monkeypat
         "resolve_status_or_default",
         fake_resolve_status_or_default,
     )
-    monkeypatch.setattr(tray_routes.tickets_service, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(
+        tray_routes.tickets_service, "create_ticket", fake_create_ticket
+    )
 
     request = SimpleNamespace(headers={"Authorization": "Bearer token-abc"})
     payload = TrayTicketSubmitRequest(
@@ -70,3 +74,77 @@ async def test_tray_submit_ticket_uses_bearer_token_without_device_uid(monkeypat
     assert created["company_id"] == 456
     assert created["requester_email"] == "jane@example.com"
     assert created["questions_company_id"] == 456
+
+
+@pytest.mark.anyio
+async def test_tray_submit_syncro_ticket_keeps_contact_details_when_contact_matches(
+    monkeypatch,
+):
+    from app.api.routes import tray as tray_routes
+    from app.schemas.tray import TrayTicketSubmitRequest
+
+    created_payload: dict[str, object] = {}
+
+    async def fake_get_device_by_uid(device_uid: str):
+        return {
+            "id": 123,
+            "uid": device_uid,
+            "status": "active",
+            "company_id": 456,
+            "asset_id": None,
+        }
+
+    async def fake_get_questions_for_company(company_id: int | None):
+        return []
+
+    async def fake_get_company_by_id(company_id: int):
+        return {"id": company_id, "syncro_company_id": "789"}
+
+    async def fake_get_staff_by_company_and_email(company_id: int, email: str):
+        return {"id": 321, "syncro_contact_id": "654"}
+
+    async def fake_create_ticket(payload: dict[str, object]):
+        created_payload.update(payload)
+        return {"id": 987, "number": "S-987"}
+
+    monkeypatch.setattr(
+        tray_routes.tray_repo, "get_device_by_uid", fake_get_device_by_uid
+    )
+    monkeypatch.setattr(
+        tray_routes.tq_service,
+        "get_questions_for_company",
+        fake_get_questions_for_company,
+    )
+    monkeypatch.setattr(
+        tray_routes.companies_repo,
+        "get_company_by_id",
+        fake_get_company_by_id,
+    )
+    monkeypatch.setattr(
+        tray_routes.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
+    )
+    monkeypatch.setattr(tray_routes.syncro_service, "create_ticket", fake_create_ticket)
+
+    request = SimpleNamespace(headers={})
+    payload = TrayTicketSubmitRequest(
+        device_uid="device-abc",
+        name="Jane Contact",
+        email="JANE@EXAMPLE.COM",
+        phone="555-0100",
+        subject="Help",
+        description="Broken",
+    )
+
+    response = await tray_routes.tray_submit_syncro_ticket(payload, request)  # type: ignore[arg-type]
+
+    assert response.ticket_id == 987
+    assert created_payload["customer_id"] == 789
+    assert created_payload["contact_id"] == 654
+    assert "email" not in created_payload
+    comment = created_payload["comments_attributes"][0]["body"]  # type: ignore[index]
+    assert "**Name:** Jane Contact" in comment
+    assert "**Phone:** 555-0100" in comment
+    assert "**Email:** jane@example.com" in comment
+    assert "Broken" in comment


### PR DESCRIPTION
### Motivation
- Ensure the tray-submitted user's name, email and phone are always included in the Syncro ticket description so technicians have the original contact details even when the email resolves to an existing Syncro contact.

### Description
- Always include the tray contact block when composing Syncro ticket descriptions by setting `include_contact_block=True` in `tray_submit_syncro_ticket` (`app/api/routes/tray.py`).
- Add a regression test `test_tray_submit_syncro_ticket_keeps_contact_details_when_contact_matches` to `tests/test_tray_submit_ticket_auth.py` that verifies a matched Syncro contact still results in a linked ticket while preserving submitted name, phone, email and description in the ticket comment.

### Testing
- Ran `pytest -q tests/test_tray_submit_ticket_auth.py` and the test suite in that file passed (`2 passed`).
- Ran code formatting check with `python -m black --target-version py312 --check app/api/routes/tray.py tests/test_tray_submit_ticket_auth.py` and formatting was applied/verified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39f37ca4248332881f51f8bd4cef06)