### PR TITLE
Enable auto-expanding archive when enabling mailbox archives

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3613,11 +3613,12 @@ async def sync_m365_mailboxes(request: Request):
 
 @app.post("/m365/mailboxes/enable-archive", response_class=JSONResponse, tags=["Microsoft 365"])
 async def enable_m365_user_archive(request: Request):
-    """Enable the in-place archive mailbox for a user via Exchange Online PowerShell.
+    """Enable in-place and auto-expanding archive for a user via Exchange Online PowerShell.
 
-    Issues ``Enable-Mailbox -Identity <upn> -Archive`` for the supplied UPN.  The
-    UPN must belong to a known user mailbox in this company; otherwise a 404 is
-    returned.  Requires super-admin privileges.
+    Issues ``Enable-Mailbox -Identity <upn> -Archive`` followed by
+    ``Enable-Mailbox -Identity <upn> -AutoExpandingArchive`` for the supplied
+    UPN. The UPN must belong to a known user mailbox in this company; otherwise
+    a 404 is returned. Requires mailbox write privileges.
     """
     user, membership, company, company_id, redirect = await _load_license_context(request)
     if redirect:
@@ -3649,10 +3650,10 @@ async def enable_m365_user_archive(request: Request):
     except m365_service.M365Error as exc:
         logger.exception("Failed to enable in-place archive for UPN %s", upn)
         return JSONResponse(
-            {"error": "Unable to enable in-place archive at this time."},
+            {"error": "Unable to enable in-place and auto-expanding archive at this time."},
             status_code=503,
         )
-    log_info("M365 in-place archive enable requested", company_id=company_id, user_id=user.get("id"), upn=upn)
+    log_info("M365 in-place and auto-expanding archive enable requested", company_id=company_id, user_id=user.get("id"), upn=upn)
     return JSONResponse({"enabled": True})
 
 

--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -5176,9 +5176,10 @@ async def convert_mailbox_to_shared(company_id: int, upn: str) -> None:
 async def enable_user_archive(company_id: int, upn: str) -> None:
     """Enable the in-place (online) archive mailbox for ``upn``.
 
-    Issues ``Enable-Mailbox -Identity <upn> -Archive`` via the Exchange Online
-    PowerShell REST ``InvokeCommand`` API and, on success, updates the cached
-    ``m365_mailboxes`` row so the UI reflects the new state immediately.
+    Issues ``Enable-Mailbox -Identity <upn> -Archive`` and then
+    ``Enable-Mailbox -Identity <upn> -AutoExpandingArchive`` via the Exchange
+    Online PowerShell REST ``InvokeCommand`` API. On success, updates the
+    cached ``m365_mailboxes`` row so the UI reflects the new state immediately.
 
     The caller is responsible for verifying that ``upn`` belongs to a known
     mailbox in the given company.
@@ -5194,9 +5195,15 @@ async def enable_user_archive(company_id: int, upn: str) -> None:
         "Enable-Mailbox",
         {"Identity": normalised, "Archive": True},
     )
+    await _exo_invoke_command(
+        exo_token,
+        tenant_id,
+        "Enable-Mailbox",
+        {"Identity": normalised, "AutoExpandingArchive": True},
+    )
     await m365_repo.set_mailbox_archive_enabled(company_id, normalised)
     log_info(
-        "M365 in-place archive enabled",
+        "M365 in-place archive and auto-expanding archive enabled",
         company_id=company_id,
         upn=normalised,
     )

--- a/tests/test_m365_mailboxes.py
+++ b/tests/test_m365_mailboxes.py
@@ -11,7 +11,7 @@ Covers:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -1902,6 +1902,48 @@ async def test_fetch_exo_archive_mailbox_sizes_short_circuits_on_403():
 
     assert result == {}
     assert call_count == 1
+
+
+@pytest.mark.anyio("asyncio")
+async def test_enable_user_archive_enables_auto_expanding_archive():
+    with (
+        patch.object(
+            m365_service,
+            "_acquire_exo_access_token",
+            AsyncMock(return_value=("exo-token", "tenant-1")),
+        ),
+        patch.object(m365_service, "_exo_invoke_command", AsyncMock()) as invoke_mock,
+        patch.object(
+            m365_service.m365_repo,
+            "set_mailbox_archive_enabled",
+            AsyncMock(),
+        ) as set_archive_mock,
+    ):
+        await m365_service.enable_user_archive(7, "user@example.com")
+
+    assert invoke_mock.await_args_list == [
+        call(
+            "exo-token",
+            "tenant-1",
+            "Enable-Mailbox",
+            {"Identity": "user@example.com", "Archive": True},
+        ),
+        call(
+            "exo-token",
+            "tenant-1",
+            "Enable-Mailbox",
+            {"Identity": "user@example.com", "AutoExpandingArchive": True},
+        ),
+    ]
+    set_archive_mock.assert_awaited_once_with(7, "user@example.com")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_enable_user_archive_requires_upn():
+    with pytest.raises(M365Error) as exc_info:
+        await m365_service.enable_user_archive(7, " ")
+
+    assert exc_info.value.http_status == 400
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation
- When enabling an Exchange Online in-place archive for a mailbox, the account should also have auto-expanding archive enabled to ensure additional storage is available as needed.

### Description
- Update `app/services/m365.py` so `enable_user_archive` issues `Enable-Mailbox -Archive` followed by `Enable-Mailbox -AutoExpandingArchive` via `_exo_invoke_command` and only then updates the cached mailbox state with `m365_repo.set_mailbox_archive_enabled`.
- Update the `/m365/mailboxes/enable-archive` endpoint in `app/main.py` to reflect both steps in the docstring, error message, and log message.
- Add unit tests in `tests/test_m365_mailboxes.py` that assert both Exchange Online commands are invoked in order and that a blank UPN argument is rejected; adjust imports to support `call` assertions.
- Files changed: `app/services/m365.py`, `app/main.py`, and `tests/test_m365_mailboxes.py`.

### Testing
- Ran `pytest tests/test_m365_mailboxes.py -q` which completed successfully with `52 passed` (test run produced warnings but no failures).
- Attempted `pytest tests/test_m365_enable_archive_endpoint.py -q` but the run did not complete within the available time window and was stopped; the endpoint behavior is otherwise exercised by the added service-level tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39f46b41ec83328363c5e9c1bd6308)