### PR TITLE
Add rotating application file logging with feature-pack field

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,12 +183,16 @@ SWAGGER_UI_URL=/docs
 # be downgraded to GET by the proxy's HTTP→HTTPS redirect.
 PUBLIC_BASE_URL=
 OPNFORM_BASE_URL=
+# Main application log file. Receives INFO-and-above server events in addition
+# to journald/stdout, one entry per line, including the feature pack field for filtering.
+# Set empty to disable the file sink.
+APP_LOG_PATH=/var/log/myportal/myportal.log
 FAIL2BAN_LOG_PATH=
-# Loguru rotation policy for the disk log file (size, interval, or clock time).
-# Examples: "50 MB", "1 day", "00:00". Set empty to disable rotation.
-LOG_ROTATION=50 MB
-# How long rotated log files are kept. Examples: "30 days", "4 weeks". Set empty to keep indefinitely.
-LOG_RETENTION=30 days
+# Loguru rotation policy for disk log files (size, interval, or clock time).
+# Defaults to daily rotation at midnight. Examples: "50 MB", "1 day", "00:00". Set empty to disable rotation.
+LOG_ROTATION=00:00
+# How long rotated log files are kept. Defaults to 7 days. Examples: "30 days", "4 weeks". Set empty to keep indefinitely.
+LOG_RETENTION=7 days
 # Compression format applied to rotated log files. Examples: "gz", "zip", "bz2". Set empty to keep uncompressed.
 LOG_COMPRESSION=gz
 # Optional dedicated log file that receives WARNING and above only. Useful for tailing

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -219,20 +219,30 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("OPNFORM_BASE_URL", "OPNFORM_URL"),
     )
+    app_log_path: Path | None = Field(
+        default=Path("/var/log/myportal/myportal.log"),
+        validation_alias="APP_LOG_PATH",
+        description=(
+            "Main application log file. Receives the same INFO-and-above server "
+            "events sent to journald/stdout, with one entry per line and the "
+            "feature pack field included for filtering. Set empty to disable."
+        ),
+    )
     fail2ban_log_path: Path | None = Field(
         default=None,
         validation_alias="FAIL2BAN_LOG_PATH",
     )
     log_rotation: str | None = Field(
-        default="50 MB",
+        default="00:00",
         validation_alias="LOG_ROTATION",
         description=(
-            "Loguru rotation policy for the disk log sink. Accepts a size (e.g. '50 MB'), "
-            "an interval (e.g. '1 day'), or a clock time (e.g. '00:00'). Set empty to disable."
+            "Loguru rotation policy for disk log sinks. Defaults to midnight daily. "
+            "Accepts a size (e.g. '50 MB'), an interval (e.g. '1 day'), or a clock "
+            "time (e.g. '00:00'). Set empty to disable."
         ),
     )
     log_retention: str | None = Field(
-        default="30 days",
+        default="7 days",
         validation_alias="LOG_RETENTION",
         description=(
             "Loguru retention policy controlling how long old rotated log files are kept "
@@ -484,6 +494,21 @@ class Settings(BaseSettings):
         if isinstance(value, str):
             # Split on '#' and take the first part, then strip whitespace
             value = value.split("#")[0].strip()
+        return value
+
+
+    @field_validator(
+        "app_log_path",
+        "fail2ban_log_path",
+        "error_log_path",
+        mode="before",
+    )
+    @classmethod
+    def _empty_string_to_none_for_paths(cls, value: Path | str | None) -> Path | str | None:
+        """Coerce blank path environment variables to ``None`` so file sinks can be disabled."""
+
+        if isinstance(value, str) and value.strip() == "":
+            return None
         return value
 
     @field_validator(

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -81,27 +81,76 @@ def get_request_context() -> dict[str, Any]:
     return snapshot
 
 
+def _infer_feature_from_record(record: dict[str, Any]) -> str:
+    """Best-effort feature pack name for logs emitted from app.features modules."""
+
+    module_name = str(record.get("name") or "")
+    prefix = "app.features."
+    if module_name.startswith(prefix):
+        remainder = module_name[len(prefix) :]
+        feature = remainder.split(".", 1)[0].strip()
+        if feature:
+            return feature
+    return "-"
+
+
 def configure_logging() -> None:
     from app.core.config import get_settings
 
     logger.remove()
-    log_format = (
+    console_log_format = (
         "{time:YYYY-MM-DDTHH:mm:ss.SSSZ} | {level} | "
-        "{extra[request_id]} | {extra[user_id]} | {message}\n{exception}"
+        "{extra[request_id]} | {extra[user_id]} | {extra[feature]} | {message}\n{exception}"
+    )
+    file_log_format = (
+        "{time:YYYY-MM-DDTHH:mm:ss.SSSZ} | {level} | "
+        "{extra[request_id]} | {extra[user_id]} | {extra[feature]} | {message}"
     )
 
     # Default extras keep the format string safe even when context is missing.
-    logger.configure(extra={"request_id": "-", "user_id": "-"})
+    logger.configure(extra={"request_id": "-", "user_id": "-", "feature": "-"})
 
-    def _format_record(record: dict[str, Any]) -> str:  # pragma: no cover - thin shim
+    def _prepare_record(record: dict[str, Any]) -> None:
         record.setdefault("extra", {})
         record["extra"].setdefault("request_id", "-")
         record["extra"].setdefault("user_id", "-")
-        return log_format
+        if record["extra"].get("feature") in (None, "", "-"):
+            record["extra"]["feature"] = _infer_feature_from_record(record)
 
-    logger.add(sink=lambda msg: print(msg, end=""), format=_format_record)
+    def _format_console_record(record: dict[str, Any]) -> str:  # pragma: no cover - thin shim
+        _prepare_record(record)
+        return console_log_format
+
+    def _format_file_record(record: dict[str, Any]) -> str:  # pragma: no cover - thin shim
+        _prepare_record(record)
+        record["message"] = str(record["message"]).replace("\r", "\\r").replace("\n", "\\n")
+        return file_log_format + "\n"
+
+    logger.add(sink=lambda msg: print(msg, end=""), format=_format_console_record)
 
     settings = get_settings()
+    app_log_path = getattr(settings, "app_log_path", None)
+    if app_log_path:
+        app_log_path = app_log_path.expanduser()
+        if _ensure_log_path(app_log_path):
+            try:
+                rotation = _coerce_optional(getattr(settings, "log_rotation", None))
+                retention = _coerce_optional(getattr(settings, "log_retention", None))
+                compression = _coerce_optional(getattr(settings, "log_compression", None))
+                logger.add(
+                    str(app_log_path),
+                    format=_format_file_record,
+                    level="INFO",
+                    encoding="utf-8",
+                    enqueue=True,
+                    rotation=rotation,
+                    retention=retention,
+                    compression=compression,
+                )
+            except Exception as exc:  # pragma: no cover - defensive logging setup
+                logger.warning(
+                    f"APP LOG FILE DISABLED - unable to open file path={app_log_path} error={exc}"
+                )
     log_path = settings.fail2ban_log_path
     if log_path:
         log_path = log_path.expanduser()
@@ -112,7 +161,7 @@ def configure_logging() -> None:
                 compression = _coerce_optional(getattr(settings, "log_compression", None))
                 logger.add(
                     str(log_path),
-                    format=_format_record,
+                    format=_format_file_record,
                     level="INFO",
                     encoding="utf-8",
                     enqueue=True,
@@ -135,7 +184,7 @@ def configure_logging() -> None:
                 compression = _coerce_optional(getattr(settings, "log_compression", None))
                 logger.add(
                     str(error_log_path),
-                    format=_format_record,
+                    format=_format_file_record,
                     level="WARNING",
                     encoding="utf-8",
                     enqueue=True,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,12 @@
 """Tests for logging functionality."""
 
+import os
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
-from app.core.logging import log_debug, log_error, log_info, log_warning
+from loguru import logger
+from app.core.logging import configure_logging, log_debug, log_error, log_info, log_warning
 
 
 def test_log_info_without_metadata():
@@ -42,3 +47,70 @@ def test_log_debug_without_metadata():
 def test_log_debug_with_metadata():
     """Test log_debug works with metadata."""
     log_debug("Test debug message with metadata", query="SELECT *", duration_ms=25.5)
+
+
+def test_configure_logging_writes_application_log_one_line_per_entry(tmp_path):
+    """Application log file includes feature field and escapes embedded newlines."""
+    log_path = tmp_path / "myportal.log"
+
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
+    with patch.dict(
+        os.environ,
+        {
+            "SESSION_SECRET": "test-secret",
+            "TOTP_ENCRYPTION_KEY": "test-totp-key",
+            "APP_LOG_PATH": str(log_path),
+            "LOG_ROTATION": "",
+            "LOG_RETENTION": "",
+            "LOG_COMPRESSION": "",
+        },
+    ):
+        configure_logging()
+        logger.bind(feature="tickets").info("first line\nsecond line")
+        logger.complete()
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert "| INFO | - | - | tickets |" in lines[0]
+    assert "first line\\nsecond line" in lines[0]
+    get_settings.cache_clear()
+    logger.remove()
+
+
+def test_default_application_log_rotation_and_retention():
+    """Main file log defaults to daily rotation and seven-day retention."""
+    from app.core.config import Settings
+
+    with patch.dict(
+        os.environ,
+        {
+            "SESSION_SECRET": "test-secret",
+            "TOTP_ENCRYPTION_KEY": "test-totp-key",
+        },
+        clear=True,
+    ):
+        settings = Settings()
+
+    assert settings.app_log_path == Path("/var/log/myportal/myportal.log")
+    assert settings.log_rotation == "00:00"
+    assert settings.log_retention == "7 days"
+
+
+def test_blank_application_log_path_disables_file_sink():
+    """APP_LOG_PATH can be set empty in .env to disable the main file log."""
+    from app.core.config import Settings
+
+    with patch.dict(
+        os.environ,
+        {
+            "SESSION_SECRET": "test-secret",
+            "TOTP_ENCRYPTION_KEY": "test-totp-key",
+            "APP_LOG_PATH": "",
+        },
+        clear=True,
+    ):
+        settings = Settings()
+
+    assert settings.app_log_path is None


### PR DESCRIPTION
### Motivation
- Mirror the live server log output (what `journalctl -fu myportal` shows) to a disk file so post-mortem debugging is possible.  
- Ensure on-disk logs are one entry per line, auto-rotate daily by default, and retain a limited history to avoid unbounded disk usage.  
- Make it easy to filter logs by the feature pack that emitted the entry by adding a `feature` field to each log line.

### Description
- Introduce a new `app_log_path` setting (env `APP_LOG_PATH`) with a default of `/var/log/myportal/myportal.log`, and add a `@field_validator` to treat blank path env values as `None` to disable the file sink.  
- Change default `LOG_ROTATION` to `00:00` (daily at midnight) and `LOG_RETENTION` to `7 days`, while keeping `LOG_COMPRESSION` and override env vars intact.  
- Extend logging formatting to include an explicit `feature` extra, add `_infer_feature_from_record()` to best-effort infer a feature pack from `app.features.<pack>` module names, and prefer an explicitly bound `feature` when present.  
- Add an application file sink that writes INFO-and-above events to `APP_LOG_PATH` using the configured rotation/retention/compression, and escape embedded newlines so each file entry is a single line; apply the same one-line formatting to the existing fail2ban/error file sinks.  
- Update `.env.example` documentation and add/extend tests in `tests/test_logging.py` to validate one-line file output, feature field output, default rotation/retention, and blank `APP_LOG_PATH` handling.

### Testing
- Ran `pytest -q tests/test_logging.py`, which passed.  
- Ran `pytest -q tests/test_config_allowed_origins.py`, which passed.  
- Verified the modules compile with `python -m py_compile app/core/config.py app/core/logging.py` and ran `git diff --check`; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39f55b132c833294743a1792a43ea5)