### PR TITLE
Add super admin mailbox rules viewer

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3657,6 +3657,40 @@ async def enable_m365_user_archive(request: Request):
     return JSONResponse({"enabled": True})
 
 
+@app.get("/m365/mailboxes/rules", response_class=JSONResponse, tags=["Microsoft 365"])
+async def get_m365_mailbox_rules(request: Request, upn: str):
+    """Return inbox rules for a known mailbox. Super admins only."""
+    user, membership, company, company_id, redirect = await _load_license_context(request)
+    if redirect:
+        return JSONResponse({"error": "Authentication required"}, status_code=401)
+    if not user.get("is_super_admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Super admin privileges required",
+        )
+
+    user_mbs = await m365_service.get_user_mailboxes(company_id)
+    shared_mbs = await m365_service.get_shared_mailboxes(company_id)
+    known_upns = {
+        str(mb.get("user_principal_name") or "").strip().lower()
+        for mb in user_mbs + shared_mbs
+    }
+    if str(upn or "").strip().lower() not in known_upns:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Mailbox not found"
+        )
+
+    try:
+        rules = await m365_service.get_mailbox_rules(company_id, upn)
+        return JSONResponse({"rules": rules})
+    except m365_service.M365Error:
+        logger.exception("Failed to get inbox rules for UPN %s", upn)
+        return JSONResponse(
+            {"error": "Unable to retrieve mailbox rules at this time."},
+            status_code=503,
+        )
+
+
 @app.post("/m365/mailboxes/start-managed-folder-assistant", response_class=JSONResponse, tags=["Microsoft 365"])
 async def start_m365_managed_folder_assistant(request: Request):
     """Start Managed Folder Assistant for a specific mailbox."""

--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -5209,6 +5209,59 @@ async def enable_user_archive(company_id: int, upn: str) -> None:
     )
 
 
+def _normalise_inbox_rule(rule: dict[str, Any], index: int) -> dict[str, Any]:
+    """Convert an Exchange Online inbox rule response into UI-friendly fields."""
+    name = str(rule.get("Name") or rule.get("DisplayName") or "").strip()
+    if not name:
+        name = f"Rule {index + 1}"
+    return {
+        "id": str(
+            rule.get("Identity")
+            or rule.get("RuleIdentity")
+            or rule.get("Guid")
+            or name
+        ),
+        "title": name,
+        "enabled": bool(rule.get("Enabled", True)),
+        "priority": rule.get("Priority"),
+        "description": str(rule.get("Description") or "").strip(),
+        "raw": rule,
+    }
+
+
+async def get_mailbox_rules(company_id: int, upn: str) -> list[dict[str, Any]]:
+    """Return inbox rules configured for a mailbox using Exchange Online."""
+    normalised = str(upn or "").strip()
+    if not normalised:
+        raise M365Error("A user principal name is required", http_status=400)
+
+    exo_token, tenant_id = await _acquire_exo_access_token(company_id)
+    data = await _exo_invoke_command(
+        exo_token,
+        tenant_id,
+        "Get-InboxRule",
+        {"Mailbox": normalised},
+    )
+    rows = data.get("value") or []
+    if isinstance(rows, dict):
+        rows = [rows]
+    if not isinstance(rows, list):
+        rows = []
+    rules = [
+        _normalise_inbox_rule(row, index)
+        for index, row in enumerate(rows)
+        if isinstance(row, dict)
+    ]
+    rules.sort(
+        key=lambda r: (
+            r.get("priority") is None,
+            r.get("priority") or 0,
+            str(r.get("title") or "").lower(),
+        )
+    )
+    return rules
+
+
 async def start_managed_folder_assistant(company_id: int, upn: str) -> None:
     """Start Managed Folder Assistant for a specific mailbox ``upn``."""
     normalised = str(upn or "").strip()

--- a/app/templates/m365/shared_mailboxes.html
+++ b/app/templates/m365/shared_mailboxes.html
@@ -74,6 +74,20 @@
                       aria-controls="mailbox-perm-modal"
                     >Mailbox Permissions</button>
                   </li>
+                  {% if is_super_admin %}
+                  <li class="header-title-menu__item" role="none">
+                    <button
+                      type="button"
+                      class="header-title-menu__link"
+                      role="menuitem"
+                      data-rules-btn
+                      data-upn="{{ mb.user_principal_name }}"
+                      data-display-name="{{ mb.display_name or mb.user_principal_name }}"
+                      aria-haspopup="dialog"
+                      aria-controls="mailbox-rules-modal"
+                    >View Rules</button>
+                  </li>
+                  {% endif %}
                   <li class="header-title-menu__item" role="none">
                     <button
                       type="button"
@@ -147,6 +161,31 @@
       </div>
     </div>
   </div>
+
+  {% if is_super_admin %}
+  <div
+    class="modal"
+    id="mailbox-rules-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="mailbox-rules-title"
+    aria-hidden="true"
+    hidden
+  >
+    <div class="modal__content" role="document">
+      <button type="button" class="modal__close" data-rules-modal-close>
+        <span class="visually-hidden">Close mailbox rules</span>
+        &times;
+      </button>
+      <h2 class="modal__title" id="mailbox-rules-title">Mailbox Rules</h2>
+      <div class="modal__body">
+        <p id="rules-loading" style="display:none">Loading&hellip;</p>
+        <p id="rules-error" class="alert alert--error" role="alert" style="display:none"></p>
+        <div id="rules-content" style="display:none"></div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
 {% endblock %}
 
 {% block scripts %}
@@ -515,4 +554,119 @@
     });
   }());
   </script>
+  {% if is_super_admin %}
+  <script>
+  (function () {
+    var modal = document.getElementById('mailbox-rules-modal');
+    if (!modal) return;
+    var closeBtn = modal.querySelector('[data-rules-modal-close]');
+    var titleEl = document.getElementById('mailbox-rules-title');
+    var loadingEl = document.getElementById('rules-loading');
+    var errorEl = document.getElementById('rules-error');
+    var contentEl = document.getElementById('rules-content');
+    var activeTrigger = null;
+
+    function escapeHtml(str) {
+      var div = document.createElement('div');
+      div.appendChild(document.createTextNode(String(str == null ? '' : str)));
+      return div.innerHTML;
+    }
+    function handleKeydown(e) { if (e.key === 'Escape') { e.preventDefault(); closeModal(); } }
+    function openModal(trigger) {
+      activeTrigger = trigger || null;
+      modal.hidden = false;
+      modal.classList.add('is-visible');
+      modal.setAttribute('aria-hidden', 'false');
+      document.addEventListener('keydown', handleKeydown);
+      if (closeBtn) closeBtn.focus();
+    }
+    function closeModal() {
+      modal.classList.remove('is-visible');
+      modal.hidden = true;
+      modal.setAttribute('aria-hidden', 'true');
+      document.removeEventListener('keydown', handleKeydown);
+      if (activeTrigger && typeof activeTrigger.focus === 'function') activeTrigger.focus();
+      activeTrigger = null;
+    }
+    function formatRawValue(value) {
+      if (value === null || value === undefined || value === '') return '<span class="text-muted">—</span>';
+      if (Array.isArray(value)) return escapeHtml(value.join(', '));
+      if (typeof value === 'object') return '<pre style="white-space:pre-wrap;margin:0">' + escapeHtml(JSON.stringify(value, null, 2)) + '</pre>';
+      return escapeHtml(value);
+    }
+    function buildRule(rule, index) {
+      var details = document.createElement('details');
+      details.className = 'panel';
+      details.style.margin = '0 0 .75rem';
+      var title = rule.title || ('Rule ' + (index + 1));
+      var summary = document.createElement('summary');
+      summary.style.cursor = 'pointer';
+      summary.style.padding = '.75rem 1rem';
+      summary.innerHTML = '<strong>' + escapeHtml(title) + '</strong>' +
+        (rule.enabled === false ? ' <span class="badge badge--warning">Disabled</span>' : '') +
+        (rule.priority !== null && rule.priority !== undefined ? ' <small class="text-muted">Priority ' + escapeHtml(rule.priority) + '</small>' : '');
+      details.appendChild(summary);
+      var body = document.createElement('div');
+      body.style.padding = '0 1rem 1rem';
+      var html = '';
+      if (rule.description) html += '<p>' + escapeHtml(rule.description) + '</p>';
+      var raw = rule.raw || {};
+      var keys = Object.keys(raw).sort();
+      if (keys.length) {
+        html += '<dl class="definition-list">';
+        keys.forEach(function (key) {
+          html += '<dt>' + escapeHtml(key) + '</dt><dd>' + formatRawValue(raw[key]) + '</dd>';
+        });
+        html += '</dl>';
+      }
+      body.innerHTML = html || '<p class="text-muted">No rule details returned.</p>';
+      details.appendChild(body);
+      return details;
+    }
+    function renderRules(rules) {
+      contentEl.innerHTML = '';
+      if (!rules || !rules.length) {
+        var empty = document.createElement('p');
+        empty.className = 'text-muted';
+        empty.textContent = 'No mailbox rules found.';
+        contentEl.appendChild(empty);
+        return;
+      }
+      rules.forEach(function (rule, index) { contentEl.appendChild(buildRule(rule, index)); });
+    }
+
+    if (closeBtn) closeBtn.addEventListener('click', closeModal);
+    modal.addEventListener('click', function (e) { if (e.target === modal) closeModal(); });
+    document.querySelectorAll('[data-rules-btn]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var upn = btn.getAttribute('data-upn');
+        var displayName = btn.getAttribute('data-display-name') || upn;
+        titleEl.textContent = 'Mailbox Rules — ' + displayName;
+        loadingEl.style.display = 'block';
+        errorEl.style.display = 'none';
+        contentEl.style.display = 'none';
+        contentEl.innerHTML = '';
+        openModal(btn);
+        fetch('/m365/mailboxes/rules?upn=' + encodeURIComponent(upn))
+          .then(function (resp) { return resp.json().then(function (data) { return { ok: resp.ok, data: data }; }); })
+          .then(function (result) {
+            loadingEl.style.display = 'none';
+            if (!result.ok || (result.data && result.data.error)) {
+              errorEl.textContent = (result.data && result.data.error) || 'Failed to load mailbox rules.';
+              errorEl.style.display = 'block';
+              return;
+            }
+            renderRules(result.data.rules || []);
+            contentEl.style.display = 'block';
+          })
+          .catch(function () {
+            loadingEl.style.display = 'none';
+            errorEl.textContent = 'Failed to load mailbox rules. Please try again.';
+            errorEl.style.display = 'block';
+          });
+      });
+    });
+  }());
+  </script>
+  {% endif %}
 {% endblock %}

--- a/app/templates/m365/user_mailboxes.html
+++ b/app/templates/m365/user_mailboxes.html
@@ -82,6 +82,20 @@
                       aria-controls="mailbox-perm-modal"
                     >Mailbox Permissions</button>
                   </li>
+                  {% if is_super_admin %}
+                  <li class="header-title-menu__item" role="none">
+                    <button
+                      type="button"
+                      class="header-title-menu__link"
+                      role="menuitem"
+                      data-rules-btn
+                      data-upn="{{ mb.user_principal_name }}"
+                      data-display-name="{{ mb.display_name or mb.user_principal_name }}"
+                      aria-haspopup="dialog"
+                      aria-controls="mailbox-rules-modal"
+                    >View Rules</button>
+                  </li>
+                  {% endif %}
                   <li class="header-title-menu__item" role="none">
                     <button
                       type="button"
@@ -167,6 +181,31 @@
       </div>
     </div>
   </div>
+
+  {% if is_super_admin %}
+  <div
+    class="modal"
+    id="mailbox-rules-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="mailbox-rules-title"
+    aria-hidden="true"
+    hidden
+  >
+    <div class="modal__content" role="document">
+      <button type="button" class="modal__close" data-rules-modal-close>
+        <span class="visually-hidden">Close mailbox rules</span>
+        &times;
+      </button>
+      <h2 class="modal__title" id="mailbox-rules-title">Mailbox Rules</h2>
+      <div class="modal__body">
+        <p id="rules-loading" style="display:none">Loading&hellip;</p>
+        <p id="rules-error" class="alert alert--error" role="alert" style="display:none"></p>
+        <div id="rules-content" style="display:none"></div>
+      </div>
+    </div>
+  </div>
+  {% endif %}
 {% endblock %}
 
 {% block scripts %}
@@ -582,4 +621,119 @@
     });
   }());
   </script>
+  {% if is_super_admin %}
+  <script>
+  (function () {
+    var modal = document.getElementById('mailbox-rules-modal');
+    if (!modal) return;
+    var closeBtn = modal.querySelector('[data-rules-modal-close]');
+    var titleEl = document.getElementById('mailbox-rules-title');
+    var loadingEl = document.getElementById('rules-loading');
+    var errorEl = document.getElementById('rules-error');
+    var contentEl = document.getElementById('rules-content');
+    var activeTrigger = null;
+
+    function escapeHtml(str) {
+      var div = document.createElement('div');
+      div.appendChild(document.createTextNode(String(str == null ? '' : str)));
+      return div.innerHTML;
+    }
+    function handleKeydown(e) { if (e.key === 'Escape') { e.preventDefault(); closeModal(); } }
+    function openModal(trigger) {
+      activeTrigger = trigger || null;
+      modal.hidden = false;
+      modal.classList.add('is-visible');
+      modal.setAttribute('aria-hidden', 'false');
+      document.addEventListener('keydown', handleKeydown);
+      if (closeBtn) closeBtn.focus();
+    }
+    function closeModal() {
+      modal.classList.remove('is-visible');
+      modal.hidden = true;
+      modal.setAttribute('aria-hidden', 'true');
+      document.removeEventListener('keydown', handleKeydown);
+      if (activeTrigger && typeof activeTrigger.focus === 'function') activeTrigger.focus();
+      activeTrigger = null;
+    }
+    function formatRawValue(value) {
+      if (value === null || value === undefined || value === '') return '<span class="text-muted">—</span>';
+      if (Array.isArray(value)) return escapeHtml(value.join(', '));
+      if (typeof value === 'object') return '<pre style="white-space:pre-wrap;margin:0">' + escapeHtml(JSON.stringify(value, null, 2)) + '</pre>';
+      return escapeHtml(value);
+    }
+    function buildRule(rule, index) {
+      var details = document.createElement('details');
+      details.className = 'panel';
+      details.style.margin = '0 0 .75rem';
+      var title = rule.title || ('Rule ' + (index + 1));
+      var summary = document.createElement('summary');
+      summary.style.cursor = 'pointer';
+      summary.style.padding = '.75rem 1rem';
+      summary.innerHTML = '<strong>' + escapeHtml(title) + '</strong>' +
+        (rule.enabled === false ? ' <span class="badge badge--warning">Disabled</span>' : '') +
+        (rule.priority !== null && rule.priority !== undefined ? ' <small class="text-muted">Priority ' + escapeHtml(rule.priority) + '</small>' : '');
+      details.appendChild(summary);
+      var body = document.createElement('div');
+      body.style.padding = '0 1rem 1rem';
+      var html = '';
+      if (rule.description) html += '<p>' + escapeHtml(rule.description) + '</p>';
+      var raw = rule.raw || {};
+      var keys = Object.keys(raw).sort();
+      if (keys.length) {
+        html += '<dl class="definition-list">';
+        keys.forEach(function (key) {
+          html += '<dt>' + escapeHtml(key) + '</dt><dd>' + formatRawValue(raw[key]) + '</dd>';
+        });
+        html += '</dl>';
+      }
+      body.innerHTML = html || '<p class="text-muted">No rule details returned.</p>';
+      details.appendChild(body);
+      return details;
+    }
+    function renderRules(rules) {
+      contentEl.innerHTML = '';
+      if (!rules || !rules.length) {
+        var empty = document.createElement('p');
+        empty.className = 'text-muted';
+        empty.textContent = 'No mailbox rules found.';
+        contentEl.appendChild(empty);
+        return;
+      }
+      rules.forEach(function (rule, index) { contentEl.appendChild(buildRule(rule, index)); });
+    }
+
+    if (closeBtn) closeBtn.addEventListener('click', closeModal);
+    modal.addEventListener('click', function (e) { if (e.target === modal) closeModal(); });
+    document.querySelectorAll('[data-rules-btn]').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var upn = btn.getAttribute('data-upn');
+        var displayName = btn.getAttribute('data-display-name') || upn;
+        titleEl.textContent = 'Mailbox Rules — ' + displayName;
+        loadingEl.style.display = 'block';
+        errorEl.style.display = 'none';
+        contentEl.style.display = 'none';
+        contentEl.innerHTML = '';
+        openModal(btn);
+        fetch('/m365/mailboxes/rules?upn=' + encodeURIComponent(upn))
+          .then(function (resp) { return resp.json().then(function (data) { return { ok: resp.ok, data: data }; }); })
+          .then(function (result) {
+            loadingEl.style.display = 'none';
+            if (!result.ok || (result.data && result.data.error)) {
+              errorEl.textContent = (result.data && result.data.error) || 'Failed to load mailbox rules.';
+              errorEl.style.display = 'block';
+              return;
+            }
+            renderRules(result.data.rules || []);
+            contentEl.style.display = 'block';
+          })
+          .catch(function () {
+            loadingEl.style.display = 'none';
+            errorEl.textContent = 'Failed to load mailbox rules. Please try again.';
+            errorEl.style.display = 'block';
+          });
+      });
+    });
+  }());
+  </script>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Provide Super Admins a way to inspect users' inbox rules for auditing and troubleshooting.
- Restrict access to mailbox rule retrieval to super admins and validate the mailbox belongs to the active company to avoid arbitrary Graph/EXO queries.

### Description
- Add a new endpoint `GET /m365/mailboxes/rules` in `app/main.py` that requires super-admin privileges and verifies the requested UPN belongs to the current company before returning rules.
- Implement `get_mailbox_rules` and helper `_normalise_inbox_rule` in `app/services/m365.py` which call Exchange Online `Get-InboxRule` via the existing `_exo_invoke_command` and normalise rules to include `id`, `title`, `enabled`, `priority`, `description`, and raw payload.
- Update `app/templates/m365/user_mailboxes.html` and `app/templates/m365/shared_mailboxes.html` to add a Super Admin-only `View Rules` row action, modal markup, and client-side JS that fetches `/m365/mailboxes/rules` and renders each rule as a collapsed `<details>` panel showing the rule title and details.
- Ensure client-side rendering shows readable fields (enabled state, priority, description) and raw rule JSON for deeper inspection.

### Testing
- Ran `python -m py_compile app/services/m365.py app/main.py` and the files compiled successfully.
- Parsed templates via Jinja2 (`env.get_template`) for `m365/user_mailboxes.html` and `m365/shared_mailboxes.html` and both templates loaded successfully.
- Ran `git diff --check` to verify no whitespace/merge issues and found no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39f7db667083328bb6c3e940528099)