### PR TITLE
Add 'Update' action to Admin Tray Devices to trigger tray auto-update check

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5787,6 +5787,47 @@ async def admin_tray_devices_page(
     return await _render_template("admin/tray/devices.html", request, current_user, extra=extra)
 
 
+@app.post("/admin/tray/devices/{device_id}/update", response_class=HTMLResponse)
+async def admin_tray_update_device(device_id: int, request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+    from app.repositories import tray as tray_repo
+    from app.services import tray as tray_service
+
+    device = await tray_repo.get_device_by_id(device_id)
+    if not device:
+        return flash_redirect("/admin/tray/devices", "Tray device not found.", "error")
+    if device.get("status") == "revoked":
+        return flash_redirect(
+            "/admin/tray/devices",
+            "Revoked tray devices cannot receive update commands.",
+            "error",
+        )
+
+    payload = {"type": "update"}
+    device_uid = str(device.get("device_uid") or "").strip()
+    delivered = await tray_service.send_to_device(device_uid, payload) if device_uid else False
+    await tray_repo.log_command(
+        device_id=int(device["id"]),
+        command="update",
+        payload_json=json.dumps(payload),
+        initiated_by_user_id=current_user.get("id") if current_user else None,
+        status="delivered" if delivered else "queued",
+    )
+    if delivered:
+        return flash_redirect(
+            "/admin/tray/devices",
+            "Update command sent to tray device.",
+            "success",
+        )
+    return flash_redirect(
+        "/admin/tray/devices",
+        "Update command queued; the tray device is not currently connected to this server process.",
+        "info",
+    )
+
+
 @app.post("/admin/tray/devices/{device_id}/revoke", response_class=HTMLResponse)
 async def admin_tray_revoke_device(device_id: int, request: Request):
     current_user, redirect = await _require_super_admin_page(request)

--- a/app/templates/admin/tray/devices.html
+++ b/app/templates/admin/tray/devices.html
@@ -78,6 +78,10 @@
                 <td>{{ device.agent_version or '—' }}</td>
                 <td class="data-table__col--actions">
                   {% if device.status != 'revoked' %}
+                    <form method="post" action="/admin/tray/devices/{{ device.id }}/update" class="inline-form">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+                      <button type="submit" class="button button--small button--primary" data-confirm="Signal this tray device to check the server for an updated tray app installer?">Update</button>
+                    </form>
                     <form method="post" action="/admin/tray/devices/{{ device.id }}/revoke" class="inline-form">
                       <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                       <button type="submit" class="button button--small button--danger" data-confirm="Revoke this tray device? It will need to re-enrol to reconnect.">Revoke</button>

--- a/tray/internal/updater/updater.go
+++ b/tray/internal/updater/updater.go
@@ -105,7 +105,13 @@ func (c *Checker) Run(ctx context.Context) {
 }
 
 func (c *Checker) check(ctx context.Context) {
-	if !c.autoUpdate {
+	c.CheckNow(ctx, false)
+}
+
+// CheckNow runs an immediate update check. When force is true, the check runs
+// even if automatic updates are disabled in the tray configuration.
+func (c *Checker) CheckNow(ctx context.Context, force bool) {
+	if !force && !c.autoUpdate {
 		return
 	}
 	resp, err := c.client.GetVersion(ctx)

--- a/tray/service/main.go
+++ b/tray/service/main.go
@@ -103,10 +103,11 @@ func saveState(s persistedState) {
 // -----------------------------------------------------------------
 
 type daemon struct {
-	cfg    *config.Config
-	client *api.Client
-	ipcSrv *ipc.Server
-	stopCh chan struct{}
+	cfg     *config.Config
+	client  *api.Client
+	updater *updater.Checker
+	ipcSrv  *ipc.Server
+	stopCh  chan struct{}
 
 	pendingUIMu      sync.Mutex
 	pendingUIMessage *ipc.Message
@@ -179,8 +180,8 @@ func (d *daemon) run() {
 	// Auto-update checker.
 	updateCtx, cancelUpdate := context.WithCancel(context.Background())
 	defer cancelUpdate()
-	checker := updater.New(d.client, d.cfg.AutoUpdate)
-	go checker.Run(updateCtx)
+	d.updater = updater.New(d.client, d.cfg.AutoUpdate)
+	go d.updater.Run(updateCtx)
 
 	// Main WS + heartbeat loop.
 	go d.wsLoop()
@@ -319,6 +320,12 @@ func (d *daemon) dispatchWSMessage(msgType string, msg map[string]json.RawMessag
 			Type:    "chat_message",
 			Payload: json.RawMessage(rawPayload),
 		})
+	case "update":
+		logger.Info("update command received — checking for tray update")
+		if d.updater == nil {
+			d.updater = updater.New(d.client, d.cfg.AutoUpdate)
+		}
+		go d.updater.CheckNow(context.Background(), true)
 	case "show_notification":
 		if d.ipcSrv != nil {
 			payload := msg["payload"]


### PR DESCRIPTION
### Motivation
- Provide an admin action to signal an enrolled Tray device that a new tray installer may be available so the Tray service/UI can fetch and install it on demand.
- Allow operators to trigger an immediate, forced update check for a single device without waiting for the periodic auto-update cycle.

### Description
- Added a new admin POST route `POST /admin/tray/devices/{device_id}/update` which validates the device, prevents sending to revoked devices, sends a `{"type": "update"}` payload to the device via `app.services.tray.send_to_device`, and logs the command via `tray_repo.log_command` (file: `app/main.py`).
- Added an `Update` button to the Tray Devices admin table which posts to the new route for non-revoked devices (file: `app/templates/admin/tray/devices.html`).
- Exposed an immediate check entrypoint `CheckNow(ctx, force bool)` in the tray updater and refactored `check` to call it, enabling forced checks even when auto-update is disabled (file: `tray/internal/updater/updater.go`).
- Modified the tray service to keep an `updater` instance, run the updater loop on startup, and handle a new `update` WebSocket message by invoking `CheckNow(..., true)` to perform a forced, immediate version check/download (file: `tray/service/main.go`).

### Testing
- Ran `git diff --check` with no issues reported.
- Compiled Python sources with `python -m compileall app/main.py` which succeeded.
- Ran Go tests with `cd tray && go test ./...`; non-UI packages passed but the UI package failed to build in this environment due to a missing system pkg-config dependency (`ayatana-appindicator3-0.1`), so full integration could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39f86886b48332b9ad6e489bc0a634)