### PR TITLE
Fix mac chat shell app bundle lookup

### DIFF
--- a/tray/Makefile
+++ b/tray/Makefile
@@ -114,9 +114,11 @@ build-chat-shell-mac:
 	        (cd chat-shell && npm ci && CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac); \
 	        mkdir -p $(DIST)/darwin; \
 	        echo "Copying .app bundle to myportal-tray-chat.app..."; \
-	        app_bundle=$$(find chat-shell/dist -maxdepth 3 -type d -name "MyPortal Chat.app" | sort | head -n 1); \
+	        app_bundle=$$(find chat-shell/dist -maxdepth 3 -type d \
+	            \( -name "myportal-tray-chat.app" -o -name "MyPortal Chat.app" \) \
+	            | sort | head -n 1); \
 	        if [ -z "$$app_bundle" ]; then \
-	            echo "Error: electron-builder did not create MyPortal Chat.app under chat-shell/dist."; \
+	            echo "Error: electron-builder did not create a macOS chat shell .app under chat-shell/dist."; \
 	            echo "Available chat-shell/dist contents:"; \
 	            find chat-shell/dist -maxdepth 3 -print 2>/dev/null | sort; \
 	            exit 1; \


### PR DESCRIPTION
### Motivation
- The macOS chat shell build failed when electron-builder emitted `myportal-tray-chat.app` but the Makefile only looked for `MyPortal Chat.app`, causing the copy step to error. 
- The failure message referenced only the legacy name and was misleading when electron-builder produced the executable-name-based bundle.

### Description
- Update the `build-chat-shell-mac` `find` call to accept either `myportal-tray-chat.app` or `MyPortal Chat.app` when locating the .app bundle. 
- Generalize the missing-bundle error text to indicate a missing macOS chat shell `.app` under `chat-shell/dist`.
- Change is limited to `tray/Makefile` and does not affect other build logic.

### Testing
- Ran `make -C tray -n build-chat-shell-mac HOST_OS=Darwin` to verify the target logic in dry-run mode and it succeeded. 
- Performed a `find` fixture check using a temporary directory containing `myportal-tray-chat.app` and confirmed the updated `find` expression locates the bundle. 
- Ran `make -C tray build-chat-shell-mac HOST_OS=Linux` and observed the expected host-skip message, indicating non-macOS hosts still skip the macOS build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39fa583c1883329a08ca4b9f3e8ff2)