### PR TITLE
Add scheduled task to update tray installer from GitHub

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -489,6 +489,7 @@ TASK_COMMAND_LABELS: dict[str, str] = {
     "queue_transcriptions": "Queue transcriptions",
     "process_transcription": "Process transcription",
     "sync_huntress": "Sync Huntress data",
+    "update_tray_icon_installer": "Update Tray Icon Installer",
 }
 
 app = FastAPI(
@@ -5635,6 +5636,7 @@ async def admin_scheduled_tasks(
         {"value": "sync_unifi_talk_recordings", "label": "Sync Unifi Talk recordings"},
         {"value": "queue_transcriptions", "label": "Queue transcriptions"},
         {"value": "process_transcription", "label": "Process transcription"},
+        {"value": "update_tray_icon_installer", "label": "Update Tray Icon Installer"},
     ]
     command_options = [o for o in command_options if o["value"] not in disabled_commands_global]
     existing_commands = {task.get("command") for task in tasks if task.get("command")}

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -29,6 +29,7 @@ from app.services import staff_onboarding_workflows as staff_onboarding_workflow
 from app.services import subscription_price_changes
 from app.services import subscription_renewals
 from app.services import tickets as tickets_service
+from app.services import tray_installer as tray_installer_service
 from app.services import value_templates
 from app.services import webhook_monitor
 from app.services import xero as xero_service
@@ -793,6 +794,20 @@ class SchedulerService:
                     output = await self.run_system_update(force_restart=force_restart)
                     if output:
                         details = output
+                elif command == "update_tray_icon_installer":
+                    settings = get_settings()
+                    updated = await tray_installer_service.fetch_latest_tray_msi(
+                        repo=settings.github_tray_msi_repo,
+                        github_token=settings.github_token,
+                    )
+                    details = json.dumps(
+                        {
+                            "repo": settings.github_tray_msi_repo,
+                            "asset": "myportal-tray.msi",
+                            "updated": updated,
+                        },
+                        default=str,
+                    )
                 elif command == "create_scheduled_ticket":
                     # Parse JSON payload from task description
                     task_description = task.get("description") or ""

--- a/migrations/255_update_tray_icon_installer_task.sql
+++ b/migrations/255_update_tray_icon_installer_task.sql
@@ -1,0 +1,13 @@
+-- Add scheduled task for keeping the tray icon installer current from GitHub Releases.
+INSERT INTO scheduled_tasks (name, command, cron, active, description, max_retries, retry_backoff_seconds)
+SELECT
+  'Update Tray Icon Installer',
+  'update_tray_icon_installer',
+  '*/30 * * * *',
+  1,
+  'Download the latest MyPortal tray app MSI from GitHub Releases so clients receive the newest tray app without requiring a server restart.',
+  12,
+  300
+WHERE NOT EXISTS (
+  SELECT 1 FROM scheduled_tasks WHERE command = 'update_tray_icon_installer'
+);

--- a/tests/test_scheduler_tray_installer_update.py
+++ b/tests/test_scheduler_tray_installer_update.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+from app.services.scheduler import SchedulerService
+
+
+def test_update_tray_icon_installer_fetches_latest_msi(monkeypatch):
+    task = {"id": 101, "command": "update_tray_icon_installer"}
+    scheduler = SchedulerService()
+    fetched: dict[str, str | None] = {}
+
+    async def fake_fetch_latest_tray_msi(*, repo: str, github_token: str | None = None, force: bool = False):
+        fetched["repo"] = repo
+        fetched["github_token"] = github_token
+        fetched["force"] = str(force)
+        return True
+
+    monkeypatch.setattr(
+        "app.services.scheduler.tray_installer_service.fetch_latest_tray_msi",
+        fake_fetch_latest_tray_msi,
+    )
+
+    with patch(
+        "app.services.scheduler.scheduled_tasks_repo.record_task_run",
+        new_callable=AsyncMock,
+    ) as record_task_run, patch(
+        "app.services.scheduler.db.acquire_lock",
+    ) as mock_lock:
+        mock_lock.return_value.__aenter__.return_value = True
+
+        asyncio.run(scheduler._run_task(task))
+
+    assert fetched["repo"] == "bradhawkins85/MyPortal"
+    assert fetched["force"] == "False"
+    details = json.loads(record_task_run.await_args.kwargs["details"])
+    assert details == {
+        "repo": "bradhawkins85/MyPortal",
+        "asset": "myportal-tray.msi",
+        "updated": True,
+    }


### PR DESCRIPTION
### Motivation
- Ensure the MyPortal tray app installer (`myportal-tray.msi`) is kept current by periodically fetching the latest release from GitHub so clients receive updates even when the server process is not restarted.

### Description
- Added a new scheduled command handler `update_tray_icon_installer` in `app/services/scheduler.py` that calls `tray_installer.fetch_latest_tray_msi` using `get_settings()` to read `github_tray_msi_repo` and `github_token` and records a JSON details payload for the run.
- Exposed the command label and admin UI option as `"Update Tray Icon Installer"` in `app/main.py` so admins can create/manage the task from the Scheduled Tasks UI.
- Added a migration `migrations/255_update_tray_icon_installer_task.sql` that seeds a default, active scheduled task running every 30 minutes (`*/30 * * * *`) without duplicating existing entries.
- Added `tests/test_scheduler_tray_installer_update.py` to cover the scheduler handler and verify the fetch is invoked and run details are recorded.

### Testing
- Ran the new unit test with `pytest tests/test_scheduler_tray_installer_update.py`, which passed.
- Performed a Python compile check with `python -m compileall app/services/scheduler.py app/main.py tests/test_scheduler_tray_installer_update.py`, which completed successfully.
- Confirmed the new scheduler handler uses the existing `tray_installer.fetch_latest_tray_msi` implementation and returns a JSON details payload indicating repo, asset, and whether an update occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39fa31def08332bc1bec0806d1a821)