### PR TITLE
Fix Windows tray toast registration

### DIFF
--- a/tray/ui/platform_nowebview_windows.go
+++ b/tray/ui/platform_nowebview_windows.go
@@ -160,6 +160,7 @@ func openChatAppWindow(chatURL string) {
 }
 
 func showOSNotification(title, body string) {
+	ensureWindowsToastShortcut()
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsToastEncodedCommand(title, body))
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
 	_ = cmd.Start()

--- a/tray/ui/platform_windows.go
+++ b/tray/ui/platform_windows.go
@@ -48,6 +48,7 @@ func openNewTicketWindow(cfg *api.ConfigResponse) {
 }
 
 func showOSNotification(title, body string) {
+	ensureWindowsToastShortcut()
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsToastEncodedCommand(title, body))
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
 	_ = cmd.Start()

--- a/tray/ui/windows_notification.go
+++ b/tray/ui/windows_notification.go
@@ -4,21 +4,28 @@ package main
 
 import (
 	"encoding/base64"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"unicode/utf16"
 )
 
+const windowsToastAppID = "MyPortal.Tray"
+
+var ensureWindowsToastShortcutOnce sync.Once
+
 func windowsToastEncodedCommand(title, body string) string {
-	appName := windowsToastAppName()
-	script := windowsToastScript(title, body, "", appName, windowsToastIconURL(), true)
+	appID := windowsToastAppID
+	script := windowsToastScript(title, body, "", appID, windowsToastIconURL(), true)
 	return encodePowerShellCommand(script)
 }
 
 func windowsPersistentChatToastEncodedCommand(title, body, chatURL string) string {
-	appName := windowsToastAppName()
-	script := windowsToastScript(title, body, "reminder", appName, windowsToastIconURL(), false) + `
+	appID := windowsToastAppID
+	script := windowsToastScript(title, body, "reminder", appID, windowsToastIconURL(), false) + `
 $actions = $xml.CreateElement('actions')
 $open = $xml.CreateElement('action')
 $open.SetAttribute('content', 'Open chat')
@@ -48,17 +55,67 @@ $dismiss.SetAttribute('arguments', 'dismiss')
 $notification = [Windows.UI.Notifications.ToastNotification]::new($xml)
 $notification.Tag = 'myportal-chat'
 $notification.Group = 'myportal'
-[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + powershellSingleQuotedString(appName) + `').Show($notification)`
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + powershellSingleQuotedString(appID) + `').Show($notification)`
 	return encodePowerShellCommand(script)
 }
 
 func showChatSessionNotification(title, body, chatURL string) {
+	ensureWindowsToastShortcut()
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsPersistentChatToastEncodedCommand(title, body, chatURL))
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
 	_ = cmd.Start()
 }
 
-func windowsToastScript(title, body, scenario, appName, iconURL string, show bool) string {
+func ensureWindowsToastShortcut() {
+	ensureWindowsToastShortcutOnce.Do(func() {
+		exe, err := os.Executable()
+		if err != nil {
+			return
+		}
+		shortcut := filepath.Join(os.Getenv("APPDATA"), "Microsoft", "Windows", "Start Menu", "Programs", "MyPortal Tray.lnk")
+		script := windowsToastShortcutScript(exe, shortcut, windowsToastAppID, trayDisplayName(gConfig), windowsToastIconPath())
+		cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", encodePowerShellCommand(script))
+		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
+		_ = cmd.Run()
+	})
+}
+
+func windowsToastShortcutScript(exePath, shortcutPath, appID, appName, iconPath string) string {
+	iconScript := ""
+	if iconPath != "" {
+		iconScript = `$shortcut.IconLocation = '` + powershellSingleQuotedString(iconPath) + `'
+`
+	}
+	return `$shortcutPath = '` + powershellSingleQuotedString(shortcutPath) + `'
+$shortcutDir = Split-Path -Parent $shortcutPath
+if (-not (Test-Path -LiteralPath $shortcutDir)) { [void](New-Item -ItemType Directory -Path $shortcutDir -Force) }
+$shell = New-Object -ComObject WScript.Shell
+$shortcut = $shell.CreateShortcut($shortcutPath)
+$shortcut.TargetPath = '` + powershellSingleQuotedString(exePath) + `'
+$shortcut.WorkingDirectory = '` + powershellSingleQuotedString(filepath.Dir(exePath)) + `'
+$shortcut.Description = '` + powershellSingleQuotedString(appName) + `'
+` + iconScript + `$shortcut.Save()
+$code = @'
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+[ComImport, Guid("00021401-0000-0000-C000-000000000046")] class CShellLink {}
+[ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("000214F9-0000-0000-C000-000000000046")]
+interface IShellLinkW { void GetPath(IntPtr pszFile, int cchMaxPath, IntPtr pfd, uint fFlags); void GetIDList(out IntPtr ppidl); void SetIDList(IntPtr pidl); void GetDescription(IntPtr pszName, int cchMaxName); void SetDescription(string pszName); void GetWorkingDirectory(IntPtr pszDir, int cchMaxPath); void SetWorkingDirectory(string pszDir); void GetArguments(IntPtr pszArgs, int cchMaxPath); void SetArguments(string pszArgs); void GetHotkey(out short pwHotkey); void SetHotkey(short wHotkey); void GetShowCmd(out int piShowCmd); void SetShowCmd(int iShowCmd); void GetIconLocation(IntPtr pszIconPath, int cchIconPath, out int piIcon); void SetIconLocation(string pszIconPath, int iIcon); void SetRelativePath(string pszPathRel, uint dwReserved); void Resolve(IntPtr hwnd, uint fFlags); void SetPath(string pszFile); }
+[ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("0000010b-0000-0000-C000-000000000046")]
+interface IPersistFile { void GetClassID(out Guid pClassID); void IsDirty(); void Load([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, uint dwMode); void Save([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, bool fRemember); void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string pszFileName); void GetCurFile([MarshalAs(UnmanagedType.LPWStr)] out string ppszFileName); }
+[ComImport, InterfaceType(ComInterfaceType.InterfaceIsIUnknown), Guid("00000138-0000-0000-C000-000000000046")]
+interface IPropertyStore { void GetCount(out uint cProps); void GetAt(uint iProp, out PROPERTYKEY pkey); void GetValue(ref PROPERTYKEY key, out PROPVARIANT pv); void SetValue(ref PROPERTYKEY key, ref PROPVARIANT pv); void Commit(); }
+[StructLayout(LayoutKind.Sequential, Pack=4)] struct PROPERTYKEY { public Guid fmtid; public uint pid; }
+[StructLayout(LayoutKind.Sequential)] struct PROPVARIANT { public ushort vt; public ushort w1; public ushort w2; public ushort w3; public IntPtr p; public int p2; }
+public static class ToastShortcut { public static void SetAppId(string path, string appId) { var link=(IShellLinkW)new CShellLink(); ((IPersistFile)link).Load(path, 0); var store=(IPropertyStore)link; var key=new PROPERTYKEY{fmtid=new Guid("9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3"), pid=5}; var pv=new PROPVARIANT{vt=31, p=Marshal.StringToCoTaskMemUni(appId)}; try { store.SetValue(ref key, ref pv); store.Commit(); ((IPersistFile)link).Save(path, true); } finally { Marshal.FreeCoTaskMem(pv.p); } } }
+'@
+Add-Type -TypeDefinition $code -ErrorAction Stop
+[ToastShortcut]::SetAppId($shortcutPath, '` + powershellSingleQuotedString(appID) + `')
+`
+}
+
+func windowsToastScript(title, body, scenario, appID, iconURL string, show bool) string {
 	scenarioScript := ""
 	if scenario != "" {
 		scenarioScript = `$toast.SetAttribute('scenario', '` + powershellSingleQuotedString(scenario) + `')
@@ -81,13 +138,9 @@ $toast = $xml.GetElementsByTagName('toast')[0]
 [void]$textNodes.Item(1).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(body) + `'))`
 	if show {
 		script += `
-[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + powershellSingleQuotedString(appName) + `').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + powershellSingleQuotedString(appID) + `').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
 	}
 	return script
-}
-
-func windowsToastAppName() string {
-	return trayDisplayName(gConfig)
 }
 
 func windowsToastIconURL() string {
@@ -96,6 +149,14 @@ func windowsToastIconURL() string {
 		return ""
 	}
 	return strings.TrimRight(portalURL, "/") + "/tray/icon.ico"
+}
+
+func windowsToastIconPath() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return exe
 }
 
 func powershellSingleQuotedString(value string) string {

--- a/tray/ui/windows_notification_test.go
+++ b/tray/ui/windows_notification_test.go
@@ -37,7 +37,7 @@ func TestWindowsToastEncodedCommandAppendsTextNodes(t *testing.T) {
 		"$appLogo.SetAttribute('src', 'https://portal.example.test/tray/icon.ico')",
 		"AppendChild($xml.CreateTextNode('Script scheduled'))",
 		"AppendChild($xml.CreateTextNode('The requested automation has been scheduled and will run in the background shortly.'))",
-		"CreateToastNotifier('Acme Support').Show",
+		"CreateToastNotifier('MyPortal.Tray').Show",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("encoded script missing %q:\n%s", want, script)
@@ -45,5 +45,20 @@ func TestWindowsToastEncodedCommandAppendsTextNodes(t *testing.T) {
 	}
 	if strings.Contains(script, ".InnerText =") {
 		t.Fatalf("encoded script should not use InnerText assignment:\n%s", script)
+	}
+}
+
+func TestWindowsToastShortcutScriptSetsAppUserModelID(t *testing.T) {
+	script := windowsToastShortcutScript(`C:\\Program Files\\MyPortal\\tray.exe`, `C:\\Users\\me\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\MyPortal Tray.lnk`, windowsToastAppID, "MyPortal", `C:\\Program Files\\MyPortal\\tray.exe`)
+	for _, want := range []string{
+		"ToastShortcut",
+		"IPropertyStore",
+		"9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3",
+		"[ToastShortcut]::SetAppId",
+		"MyPortal.Tray",
+	} {
+		if !strings.Contains(script, want) {
+			t.Fatalf("shortcut script missing %q:\n%s", want, script)
+		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Unpackaged Windows tray toasts were unreliable because notifications used the mutable branded display name and the app lacked a Start Menu shortcut/AppUserModelID registration required for WinRT toasts. 

### Description
- Use a stable AppUserModelID constant `MyPortal.Tray` when building PowerShell toast payloads instead of the branded display name by switching `windowsToast*` callers to the new ID.  
- Create a one-time `ensureWindowsToastShortcut()` that builds a Start Menu shortcut and tags it with the AppUserModelID via a PowerShell script which calls a small `Add-Type` C# helper that writes the `System.AppUserModel.ID` property through `IPropertyStore`.  
- Ensure both notification entry points call `ensureWindowsToastShortcut()` before sending regular or persistent chat toasts by updating `platform_windows.go` and `platform_nowebview_windows.go`.  
- Add a unit test `TestWindowsToastShortcutScriptSetsAppUserModelID` and update the existing toast test to assert the stable notifier ID and presence of the shortcut/AppUserModelID script content.  

### Testing
- Ran `cd tray && go test -tags nowebview ./ui ./internal/notify`, which passed.  
- Built Windows-target tests with `cd tray && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -tags nowebview ./ui`, which succeeded (compile/test binary produced).  
- Attempting the full non-`nowebview` UI `go test ./ui ./internal/notify` failed in this Linux environment due to a missing native dependency (`ayatana-appindicator3-0.1`) required for the non-nowebview systray build, so that platform-specific test could not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39fb2c541c8332897532dbc9622011)