### PR TITLE
Download and track all tray installer assets (MSI/DMG/PKG) from GitHub Releases

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2704,7 +2704,7 @@ async def on_startup() -> None:
     async def _fetch_tray_msi() -> None:
         from app.services import tray_installer as tray_installer_service
 
-        await tray_installer_service.fetch_latest_tray_msi(
+        await tray_installer_service.fetch_latest_tray_installers(
             repo=settings.github_tray_msi_repo,
             github_token=settings.github_token,
         )

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -796,15 +796,15 @@ class SchedulerService:
                         details = output
                 elif command == "update_tray_icon_installer":
                     settings = get_settings()
-                    updated = await tray_installer_service.fetch_latest_tray_msi(
+                    updated_assets = await tray_installer_service.fetch_latest_tray_installers(
                         repo=settings.github_tray_msi_repo,
                         github_token=settings.github_token,
                     )
                     details = json.dumps(
                         {
                             "repo": settings.github_tray_msi_repo,
-                            "asset": "myportal-tray.msi",
-                            "updated": updated,
+                            "assets": updated_assets,
+                            "updated": any(updated_assets.values()),
                         },
                         default=str,
                     )

--- a/app/services/tray_installer.py
+++ b/app/services/tray_installer.py
@@ -1,24 +1,25 @@
-"""Service for fetching the latest MyPortal Tray MSI from GitHub Releases.
+"""Service for fetching the latest MyPortal Tray installers from GitHub Releases.
 
-On startup (and optionally on demand) the app calls :func:`fetch_latest_tray_msi`
+On startup (and optionally on demand) the app calls :func:`fetch_latest_tray_installers`
 which:
 
 1. Queries the GitHub Releases API for the latest release of the configured
    repository.
-2. Finds the ``myportal-tray.msi`` release asset.
-3. Downloads the asset to ``app/static/tray/myportal-tray.msi`` so it is
-   immediately served by the existing ``/static`` mount used by ``install.ps1``.
+2. Finds the supported tray installer release assets.
+3. Downloads those assets to ``app/static/tray`` so they are immediately served
+   by the existing ``/static`` mount.
 
-The download is skipped when:
-* The GitHub API returns no release or no MSI asset.
-* The remote ``ETag`` / ``Last-Modified`` header matches the cached value stored
-  alongside the file, meaning the file is already current.
+The download is skipped per asset when:
+* The GitHub API returns no release or no matching installer asset.
+* The release asset metadata matches the cached metadata stored alongside the
+  file, meaning the file is already current.
 * Any network or I/O error occurs — failures are logged but never fatal.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 
@@ -27,11 +28,8 @@ import httpx
 from app.core.logging import log_error, log_info, log_warning
 
 _GITHUB_API_BASE = "https://api.github.com"
-_ASSET_NAME = "myportal-tray.msi"
+_ASSET_NAMES = ("myportal-tray.msi", "myportal-tray.dmg", "myportal-tray.pkg")
 _TRAY_STATIC_DIR = Path(__file__).resolve().parent.parent / "static" / "tray"
-_DEST_PATH = _TRAY_STATIC_DIR / _ASSET_NAME
-_ETAG_PATH = _TRAY_STATIC_DIR / f"{_ASSET_NAME}.etag"
-
 _DOWNLOAD_LOCK = asyncio.Lock()
 _DOWNLOAD_CHUNK_SIZE = 65536
 
@@ -56,11 +54,11 @@ async def _get_latest_release(
     try:
         resp = await client.get(url, headers=headers, timeout=15.0)
         if resp.status_code == 404:
-            log_warning("No releases found for tray MSI repo", repo=repo)
+            log_warning("No releases found for tray installer repo", repo=repo)
             return None
         if resp.status_code in (403, 429):
             log_warning(
-                "GitHub API rate-limited or forbidden when checking tray MSI",
+                "GitHub API rate-limited or forbidden when checking tray installers",
                 status=resp.status_code,
                 repo=repo,
             )
@@ -72,11 +70,55 @@ async def _get_latest_release(
         return None
 
 
-def _find_msi_asset(release: dict[str, Any]) -> dict[str, Any] | None:
+def _find_assets(release: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    assets: dict[str, dict[str, Any]] = {}
     for asset in release.get("assets") or []:
-        if asset.get("name") == _ASSET_NAME:
-            return asset
-    return None
+        name = asset.get("name")
+        if name in _ASSET_NAMES:
+            assets[name] = asset
+    return assets
+
+
+def _asset_metadata(release: dict[str, Any], asset: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "release_id": release.get("id"),
+        "release_tag": release.get("tag_name"),
+        "asset_id": asset.get("id"),
+        "asset_name": asset.get("name"),
+        "asset_updated_at": asset.get("updated_at"),
+        "asset_size": asset.get("size"),
+        "download_url": asset.get("browser_download_url"),
+    }
+
+
+def _metadata_path(asset_name: str) -> Path:
+    return _TRAY_STATIC_DIR / f"{asset_name}.json"
+
+
+def _is_current(asset_name: str, metadata: dict[str, Any]) -> bool:
+    dest_path = _TRAY_STATIC_DIR / asset_name
+    if not dest_path.is_file():
+        return False
+    try:
+        cached = json.loads(_metadata_path(asset_name).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return all(
+        cached.get(key) == metadata.get(key)
+        for key in ("release_id", "asset_id", "asset_updated_at", "asset_size")
+    )
+
+
+async def fetch_latest_tray_installers(
+    *,
+    repo: str,
+    github_token: str | None = None,
+    force: bool = False,
+) -> dict[str, bool]:
+    """Download the latest supported tray installers from GitHub Releases."""
+
+    async with _DOWNLOAD_LOCK:
+        return await _fetch(repo=repo, github_token=github_token, force=force)
 
 
 async def fetch_latest_tray_msi(
@@ -85,26 +127,14 @@ async def fetch_latest_tray_msi(
     github_token: str | None = None,
     force: bool = False,
 ) -> bool:
-    """Download the latest ``myportal-tray.msi`` from GitHub Releases.
+    """Backward-compatible wrapper that returns whether the MSI was updated."""
 
-    Parameters
-    ----------
-    repo:
-        GitHub repository in ``owner/name`` format.
-    github_token:
-        Optional personal-access token or fine-grained token with
-        ``contents:read`` permission. Required for private repositories.
-    force:
-        When ``True``, re-download even if the local file appears current.
-
-    Returns
-    -------
-    bool
-        ``True`` when a (new) file was written to disk, ``False`` otherwise.
-    """
-
-    async with _DOWNLOAD_LOCK:
-        return await _fetch(repo=repo, github_token=github_token, force=force)
+    results = await fetch_latest_tray_installers(
+        repo=repo,
+        github_token=github_token,
+        force=force,
+    )
+    return results.get("myportal-tray.msi", False)
 
 
 async def _fetch(
@@ -112,92 +142,119 @@ async def _fetch(
     repo: str,
     github_token: str | None,
     force: bool,
-) -> bool:
+) -> dict[str, bool]:
     _TRAY_STATIC_DIR.mkdir(parents=True, exist_ok=True)
     headers = _build_headers(github_token)
+    results = {asset_name: False for asset_name in _ASSET_NAMES}
 
     async with httpx.AsyncClient(follow_redirects=True) as client:
         release = await _get_latest_release(client, repo, headers)
         if release is None:
-            return False
-
-        asset = _find_msi_asset(release)
-        if asset is None:
-            log_warning(
-                "Latest release does not contain myportal-tray.msi",
-                repo=repo,
-                release=release.get("tag_name"),
-            )
-            return False
-
-        download_url: str = asset.get("browser_download_url", "")
-        if not download_url:
-            log_error("MSI asset has no download URL", repo=repo)
-            return False
+            return results
 
         tag_name: str = release.get("tag_name", "unknown")
-
-        # Check ETag to skip unnecessary re-downloads.
-        cached_etag: str | None = None
-        if not force and _ETAG_PATH.is_file() and _DEST_PATH.is_file():
-            try:
-                cached_etag = _ETAG_PATH.read_text(encoding="utf-8").strip()
-            except OSError:
-                cached_etag = None
-
-        download_headers = dict(headers)
-        download_headers["Accept"] = "application/octet-stream"
-        if cached_etag:
-            download_headers["If-None-Match"] = cached_etag
-
-        try:
-            async with client.stream(
-                "GET", download_url, headers=download_headers, timeout=120.0
-            ) as resp:
-                if resp.status_code == 304:
-                    log_info(
-                        "Tray MSI is already current (304 Not Modified)",
-                        repo=repo,
-                        release=tag_name,
-                    )
-                    return False
-                resp.raise_for_status()
-                tmp_path = _DEST_PATH.with_suffix(".msi.tmp")
-                try:
-                    with tmp_path.open("wb") as fh:
-                        async for chunk in resp.aiter_bytes(chunk_size=_DOWNLOAD_CHUNK_SIZE):
-                            fh.write(chunk)
-                    tmp_path.replace(_DEST_PATH)
-                except Exception:
-                    tmp_path.unlink(missing_ok=True)
-                    raise
-                new_etag = resp.headers.get("etag", "")
-                if new_etag:
-                    try:
-                        _ETAG_PATH.write_text(new_etag, encoding="utf-8")
-                    except OSError:
-                        pass
-        except httpx.HTTPStatusError as exc:
-            log_error(
-                "Failed to download tray MSI",
+        assets = _find_assets(release)
+        missing_assets = [
+            asset_name for asset_name in _ASSET_NAMES if asset_name not in assets
+        ]
+        if missing_assets:
+            log_warning(
+                "Latest release does not contain all tray installer assets",
                 repo=repo,
                 release=tag_name,
-                status=exc.response.status_code,
-                error=str(exc),
+                missing=missing_assets,
             )
-            return False
-        except Exception as exc:
-            log_error(
-                "Unexpected error downloading tray MSI",
+
+        for asset_name, asset in assets.items():
+            results[asset_name] = await _download_asset(
+                client=client,
                 repo=repo,
-                error=str(exc),
+                headers=headers,
+                release=release,
+                asset=asset,
+                asset_name=asset_name,
+                force=force,
             )
-            return False
+
+    return results
+
+
+async def _download_asset(
+    *,
+    client: httpx.AsyncClient,
+    repo: str,
+    headers: dict[str, str],
+    release: dict[str, Any],
+    asset: dict[str, Any],
+    asset_name: str,
+    force: bool,
+) -> bool:
+    download_url: str = asset.get("browser_download_url", "")
+    tag_name: str = release.get("tag_name", "unknown")
+    if not download_url:
+        log_error(
+            "Tray installer asset has no download URL", repo=repo, asset=asset_name
+        )
+        return False
+
+    metadata = _asset_metadata(release, asset)
+    dest_path = _TRAY_STATIC_DIR / asset_name
+    if not force and _is_current(asset_name, metadata):
+        log_info(
+            "Tray installer is already current",
+            repo=repo,
+            release=tag_name,
+            asset=asset_name,
+        )
+        return False
+
+    download_headers = dict(headers)
+    download_headers["Accept"] = "application/octet-stream"
+
+    try:
+        async with client.stream(
+            "GET", download_url, headers=download_headers, timeout=120.0
+        ) as resp:
+            resp.raise_for_status()
+            tmp_path = dest_path.with_name(f"{asset_name}.tmp")
+            try:
+                with tmp_path.open("wb") as fh:
+                    async for chunk in resp.aiter_bytes(
+                        chunk_size=_DOWNLOAD_CHUNK_SIZE
+                    ):
+                        fh.write(chunk)
+                tmp_path.replace(dest_path)
+                metadata["etag"] = resp.headers.get("etag")
+                _metadata_path(asset_name).write_text(
+                    json.dumps(metadata, sort_keys=True), encoding="utf-8"
+                )
+            except Exception:
+                tmp_path.unlink(missing_ok=True)
+                raise
+    except httpx.HTTPStatusError as exc:
+        log_error(
+            "Failed to download tray installer",
+            repo=repo,
+            release=tag_name,
+            asset=asset_name,
+            status=exc.response.status_code,
+            error=str(exc),
+        )
+        return False
+    except Exception as exc:
+        log_error(
+            "Unexpected error downloading tray installer",
+            repo=repo,
+            asset=asset_name,
+            error=str(exc),
+        )
+        return False
 
     log_info(
-        "Tray MSI updated",
+        "Tray installer updated",
         repo=repo,
         release=tag_name,
-        path=str(_DEST_PATH),
+        asset=asset_name,
+        path=str(dest_path),
     )
     return True

--- a/tests/test_scheduler_tray_installer_update.py
+++ b/tests/test_scheduler_tray_installer_update.py
@@ -7,28 +7,37 @@ from unittest.mock import AsyncMock, patch
 from app.services.scheduler import SchedulerService
 
 
-def test_update_tray_icon_installer_fetches_latest_msi(monkeypatch):
+def test_update_tray_icon_installer_fetches_latest_installers(monkeypatch):
     task = {"id": 101, "command": "update_tray_icon_installer"}
     scheduler = SchedulerService()
     fetched: dict[str, str | None] = {}
 
-    async def fake_fetch_latest_tray_msi(*, repo: str, github_token: str | None = None, force: bool = False):
+    async def fake_fetch_latest_tray_installers(
+        *, repo: str, github_token: str | None = None, force: bool = False
+    ):
         fetched["repo"] = repo
         fetched["github_token"] = github_token
         fetched["force"] = str(force)
-        return True
+        return {
+            "myportal-tray.msi": True,
+            "myportal-tray.dmg": True,
+            "myportal-tray.pkg": False,
+        }
 
     monkeypatch.setattr(
-        "app.services.scheduler.tray_installer_service.fetch_latest_tray_msi",
-        fake_fetch_latest_tray_msi,
+        "app.services.scheduler.tray_installer_service.fetch_latest_tray_installers",
+        fake_fetch_latest_tray_installers,
     )
 
-    with patch(
-        "app.services.scheduler.scheduled_tasks_repo.record_task_run",
-        new_callable=AsyncMock,
-    ) as record_task_run, patch(
-        "app.services.scheduler.db.acquire_lock",
-    ) as mock_lock:
+    with (
+        patch(
+            "app.services.scheduler.scheduled_tasks_repo.record_task_run",
+            new_callable=AsyncMock,
+        ) as record_task_run,
+        patch(
+            "app.services.scheduler.db.acquire_lock",
+        ) as mock_lock,
+    ):
         mock_lock.return_value.__aenter__.return_value = True
 
         asyncio.run(scheduler._run_task(task))
@@ -38,6 +47,10 @@ def test_update_tray_icon_installer_fetches_latest_msi(monkeypatch):
     details = json.loads(record_task_run.await_args.kwargs["details"])
     assert details == {
         "repo": "bradhawkins85/MyPortal",
-        "asset": "myportal-tray.msi",
+        "assets": {
+            "myportal-tray.msi": True,
+            "myportal-tray.dmg": True,
+            "myportal-tray.pkg": False,
+        },
         "updated": True,
     }


### PR DESCRIPTION
### Motivation
- The existing code only fetched a single `myportal-tray.msi` and used an ETag-only freshness check, causing the server to miss updated releases and report `updated: false` in task history. The server should also obtain the macOS installers (`.dmg` and `.pkg`) from the same repo.

### Description
- Introduce `fetch_latest_tray_installers` in `app/services/tray_installer.py` to discover and download multiple assets (`myportal-tray.msi`, `myportal-tray.dmg`, `myportal-tray.pkg`) from the configured GitHub Releases repo and return a per-asset result map.
- Replace fragile ETag-only logic with per-asset cached metadata files (JSON) to detect updates by `release_id`, `asset_id`, `asset_updated_at`, and `asset_size` before downloading.
- Keep `fetch_latest_tray_msi` as a backward-compatible wrapper that returns the MSI result from the new multi-asset function.
- Update calls to use the new function: startup (`app/main.py`) and scheduled task handling (`app/services/scheduler.py`) now call `fetch_latest_tray_installers` and record `assets` (map) plus an aggregate `updated` flag in task details.
- Update test `tests/test_scheduler_tray_installer_update.py` to assert the new multi-asset behavior and task details format.

### Testing
- Ran `pytest tests/test_scheduler_tray_installer_update.py -q` which passed (1 test, all assertions OK). 
- Verified Python syntax by running `python -m py_compile app/services/tray_installer.py app/services/scheduler.py app/main.py`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39fe352ec08332b817b93332bbcf39)