### PR TITLE
Fix macOS tray package postinstall and bundle uninstaller

### DIFF
--- a/tray/README.md
+++ b/tray/README.md
@@ -187,6 +187,19 @@ See [docs/tray_app.md](../docs/tray_app.md) for the full architecture document.
 MYPORTAL_URL='https://portal.example.com' ENROL_TOKEN='TOKEN' bash installer/macos/install.sh
 ```
 
+
+### macOS uninstaller
+
+The macOS package bundles an uninstaller at `/Library/MyPortal/Tray/uninstall.sh`:
+
+```bash
+sudo /Library/MyPortal/Tray/uninstall.sh
+# Remove config, enrolment state, and logs as well:
+sudo /Library/MyPortal/Tray/uninstall.sh --purge
+```
+
+The default uninstall stops launchd jobs and removes installed binaries/plists while preserving configuration, state, and logs for troubleshooting or reinstall.
+
 ## Security model
 
 - The install token is **single-company** and **rotatable** from the admin UI.

--- a/tray/installer/macos/build-dmg.sh
+++ b/tray/installer/macos/build-dmg.sh
@@ -34,6 +34,10 @@ MyPortal Tray Installer
 
 Open myportal-tray.pkg to install the MyPortal tray service and user agent.
 
+The package installs an uninstaller at:
+  /Library/MyPortal/Tray/uninstall.sh
+Run it with sudo, optionally adding --purge to remove configuration, state, and logs.
+
 For RMM deployment, use installer/macos/install.sh from the source repository
 or download the package directly from your MyPortal server:
   /static/tray/myportal-tray.pkg

--- a/tray/installer/macos/build-pkg.sh
+++ b/tray/installer/macos/build-pkg.sh
@@ -19,6 +19,7 @@ mkdir -p "$PAYLOAD_DIR/Library/LaunchAgents"
 # Binaries (cross-compiled by Makefile).
 cp ../../dist/darwin/myportal-tray-service "$PAYLOAD_DIR$INSTALL_LOCATION/"
 cp ../../dist/darwin/myportal-tray-ui     "$PAYLOAD_DIR$INSTALL_LOCATION/"
+cp uninstall.sh "$PAYLOAD_DIR$INSTALL_LOCATION/"
 
 # Dedicated chat shell: an Electron .app bundle pre-built on a macOS runner.
 # The tray UI launches the binary inside this bundle directly for an isolated
@@ -31,6 +32,8 @@ else
     echo "Warning: dist/darwin/myportal-tray-chat.app not found; chat shell will not be included in this package." >&2
     echo "  Run 'make build-chat-shell-mac' on a macOS host first, or download the chat-shell-darwin CI artifact." >&2
 fi
+
+chmod +x "$PAYLOAD_DIR$INSTALL_LOCATION/uninstall.sh"
 
 # Plists.
 cp io.myportal.tray.service.plist "$PAYLOAD_DIR/Library/LaunchDaemons/"

--- a/tray/installer/macos/postinstall
+++ b/tray/installer/macos/postinstall
@@ -1,32 +1,51 @@
 #!/bin/bash
 # Package postinstall script — runs as root after the pkg payload is extracted.
-# Loads the LaunchDaemon and registers the LaunchAgent for all current users.
-set -euo pipefail
+# Loads the LaunchDaemon and registers the LaunchAgent for current users.
+set -u
 
 BIN_DIR="/Library/MyPortal/Tray"
 DAEMON_PLIST="/Library/LaunchDaemons/io.myportal.tray.service.plist"
 AGENT_PLIST="/Library/LaunchAgents/io.myportal.tray.agent.plist"
 LOG_DIR="/Library/Logs/MyPortal/tray"
+STATE_DIR="/Library/Application Support/MyPortal/Tray"
 
-# Create log directory.
-mkdir -p "$LOG_DIR"
-chmod 755 "$LOG_DIR"
+warn() {
+    echo "Warning: $*" >&2
+}
 
-# Make binaries executable.
-chmod +x "$BIN_DIR/myportal-tray-service" "$BIN_DIR/myportal-tray-ui"
+# Create service-owned directories before launchd evaluates stdio paths or the
+# daemon tries to write its state. Missing parent directories can make a pkg look
+# like it failed even though the payload was installed.
+mkdir -p "$LOG_DIR" "$STATE_DIR" || warn "failed to create support directories"
+chmod 755 "/Library/Logs/MyPortal" "$LOG_DIR" 2>/dev/null || true
+chmod 755 "/Library/Application Support/MyPortal" "$STATE_DIR" 2>/dev/null || true
 
-# Load the daemon (stops and reloads if already running).
-if launchctl list io.myportal.tray.service &>/dev/null; then
-    launchctl unload "$DAEMON_PLIST" 2>/dev/null || true
+# Make payload executables runnable.
+chmod +x "$BIN_DIR/myportal-tray-service" "$BIN_DIR/myportal-tray-ui" "$BIN_DIR/uninstall.sh" 2>/dev/null || true
+
+# Stop any existing jobs before bootstrapping the newly installed plists. Prefer
+# modern launchctl verbs and fall back to load/unload for older macOS releases.
+launchctl bootout system "$DAEMON_PLIST" 2>/dev/null || launchctl unload "$DAEMON_PLIST" 2>/dev/null || true
+if ! launchctl bootstrap system "$DAEMON_PLIST" 2>/dev/null; then
+    if ! launchctl load -w "$DAEMON_PLIST" 2>/dev/null; then
+        warn "failed to load $DAEMON_PLIST; the service should start after reboot or can be loaded manually"
+    fi
 fi
-launchctl load -w "$DAEMON_PLIST"
+launchctl enable system/io.myportal.tray.service 2>/dev/null || true
+launchctl kickstart -k system/io.myportal.tray.service 2>/dev/null || true
 
-# Register the agent for all currently logged-in users.
-# New user sessions will pick it up automatically from /Library/LaunchAgents.
-for uid in $(ps -axo uid= -c Aqua 2>/dev/null | sort -u); do
-    if [[ "$uid" -ge 500 ]]; then
-        launchctl asuser "$uid" launchctl load -w "$AGENT_PLIST" 2>/dev/null || true
+# Register the agent for the active console user and any other GUI sessions.
+# New sessions will also pick it up automatically from /Library/LaunchAgents.
+for uid in $(stat -f '%u' /dev/console 2>/dev/null; ps -axo uid= 2>/dev/null | sort -u); do
+    if [[ "$uid" =~ ^[0-9]+$ && "$uid" -ge 500 ]]; then
+        launchctl bootout "gui/$uid" "$AGENT_PLIST" 2>/dev/null || launchctl asuser "$uid" launchctl unload "$AGENT_PLIST" 2>/dev/null || true
+        if ! launchctl bootstrap "gui/$uid" "$AGENT_PLIST" 2>/dev/null; then
+            launchctl asuser "$uid" launchctl load -w "$AGENT_PLIST" 2>/dev/null || true
+        fi
+        launchctl enable "gui/$uid/io.myportal.tray.agent" 2>/dev/null || true
+        launchctl kickstart -k "gui/$uid/io.myportal.tray.agent" 2>/dev/null || true
     fi
 done
 
 echo "MyPortal Tray postinstall complete."
+exit 0

--- a/tray/installer/macos/uninstall.sh
+++ b/tray/installer/macos/uninstall.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# MyPortal Tray — macOS uninstaller
+# Usage: sudo /Library/MyPortal/Tray/uninstall.sh [--purge]
+#
+# By default this removes installed binaries and launchd jobs while preserving
+# device state, preferences, and logs. Pass --purge to also remove local config,
+# enrolment state, and logs.
+set -u
+
+PURGE=false
+if [[ "${1:-}" == "--purge" ]]; then
+    PURGE=true
+elif [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    sed -n '1,8p' "$0"
+    exit 0
+elif [[ -n "${1:-}" ]]; then
+    echo "Unknown argument: $1" >&2
+    echo "Usage: sudo $0 [--purge]" >&2
+    exit 2
+fi
+
+if [[ "$(id -u)" -ne 0 ]]; then
+    echo "This uninstaller must be run as root. Try: sudo $0 ${1:-}" >&2
+    exit 1
+fi
+
+BIN_DIR="/Library/MyPortal/Tray"
+DAEMON_PLIST="/Library/LaunchDaemons/io.myportal.tray.service.plist"
+AGENT_PLIST="/Library/LaunchAgents/io.myportal.tray.agent.plist"
+ENV_FILE="/Library/Preferences/io.myportal.tray.env"
+STATE_DIR="/Library/Application Support/MyPortal/Tray"
+LOG_DIR="/Library/Logs/MyPortal/tray"
+
+# Stop currently running per-user agents first so they do not reconnect while
+# the daemon is being removed. Ignore all launchctl errors because labels may
+# not be loaded in every user session or on every macOS version.
+for uid in $(/usr/bin/stat -f '%u' /dev/console 2>/dev/null; /bin/ps -axo uid= 2>/dev/null | /usr/bin/sort -u); do
+    if [[ "$uid" =~ ^[0-9]+$ && "$uid" -ge 500 ]]; then
+        /bin/launchctl bootout "gui/$uid" "$AGENT_PLIST" 2>/dev/null || true
+        /bin/launchctl asuser "$uid" /bin/launchctl unload -w "$AGENT_PLIST" 2>/dev/null || true
+    fi
+done
+
+/bin/launchctl bootout system "$DAEMON_PLIST" 2>/dev/null || true
+/bin/launchctl unload -w "$DAEMON_PLIST" 2>/dev/null || true
+
+/bin/rm -f "$DAEMON_PLIST" "$AGENT_PLIST"
+/bin/rm -rf "$BIN_DIR"
+
+# Remove empty parent directories left by the package payload.
+/bin/rmdir /Library/MyPortal 2>/dev/null || true
+
+if [[ "$PURGE" == "true" ]]; then
+    /bin/rm -f "$ENV_FILE"
+    /bin/rm -rf "$STATE_DIR" "$LOG_DIR"
+    /bin/rmdir "/Library/Application Support/MyPortal" 2>/dev/null || true
+    /bin/rmdir "/Library/Logs/MyPortal" 2>/dev/null || true
+fi
+
+echo "MyPortal Tray uninstalled."
+if [[ "$PURGE" != "true" ]]; then
+    echo "Configuration, state, and logs were preserved. Re-run with --purge to remove them."
+fi


### PR DESCRIPTION
### Motivation

- The macOS installer could appear to fail when required log/state directories were absent or when `launchd` bootstrap/load isn't available during postinstall, and there was no packaged way to remove the installed files or purge local state.
- Provide an easy, supported uninstall path so admins can remove the tray, optionally purging configuration, enrolment state, and logs.

### Description

- Add a macOS uninstaller `tray/installer/macos/uninstall.sh` that stops per-user agents and the system daemon, removes installed binaries and plists, and supports `--purge` to also remove `io.myportal.tray.env`, state, and logs.
- Harden `tray/installer/macos/postinstall` to create service-owned directories (`/Library/Logs/MyPortal/tray` and `/Library/Application Support/MyPortal/Tray`), make payload executables (including the new `uninstall.sh`) runnable, and use modern `launchctl` verbs (`bootstrap`/`bootout`, `enable`, `kickstart`) with fallbacks for older macOS releases.
- Bundle the uninstaller into the pkg payload by updating `tray/installer/macos/build-pkg.sh` to copy and mark `uninstall.sh` executable, and update `tray/installer/macos/build-dmg.sh` and `tray/README.md` to document the installed uninstaller and how to run it.

### Testing

- Static script checks: ran `bash -n` on `tray/installer/macos/postinstall`, `tray/installer/macos/uninstall.sh`, `tray/installer/macos/build-pkg.sh`, and `tray/installer/macos/build-dmg.sh` and they passed.
- Build/test: ran `go test ./...` in the `tray` module where non-UI packages passed and the UI package failed to build in this Linux CI environment due to a missing system pkg-config dependency (`ayatana-appindicator3-0.1`) required by `github.com/getlantern/systray` (this is an environment/system dependency, not a change regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39ff4466408332a20f5993fad99e38)