### PR TITLE
Fix Windows tray toast fallback

### DIFF
--- a/tray/ui/platform_nowebview_windows.go
+++ b/tray/ui/platform_nowebview_windows.go
@@ -161,7 +161,7 @@ func openChatAppWindow(chatURL string) {
 
 func showOSNotification(title, body string) {
 	ensureWindowsToastShortcut()
-	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsToastEncodedCommand(title, body))
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-STA", "-WindowStyle", "Hidden", "-EncodedCommand", windowsToastEncodedCommand(title, body))
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
 	_ = cmd.Start()
 }

--- a/tray/ui/platform_windows.go
+++ b/tray/ui/platform_windows.go
@@ -49,7 +49,7 @@ func openNewTicketWindow(cfg *api.ConfigResponse) {
 
 func showOSNotification(title, body string) {
 	ensureWindowsToastShortcut()
-	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsToastEncodedCommand(title, body))
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-STA", "-WindowStyle", "Hidden", "-EncodedCommand", windowsToastEncodedCommand(title, body))
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
 	_ = cmd.Start()
 }

--- a/tray/ui/windows_notification.go
+++ b/tray/ui/windows_notification.go
@@ -61,7 +61,7 @@ $notification.Group = 'myportal'
 
 func showChatSessionNotification(title, body, chatURL string) {
 	ensureWindowsToastShortcut()
-	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", windowsPersistentChatToastEncodedCommand(title, body, chatURL))
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-STA", "-WindowStyle", "Hidden", "-EncodedCommand", windowsPersistentChatToastEncodedCommand(title, body, chatURL))
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
 	_ = cmd.Start()
 }
@@ -74,7 +74,7 @@ func ensureWindowsToastShortcut() {
 		}
 		shortcut := filepath.Join(os.Getenv("APPDATA"), "Microsoft", "Windows", "Start Menu", "Programs", "MyPortal Tray.lnk")
 		script := windowsToastShortcutScript(exe, shortcut, windowsToastAppID, trayDisplayName(gConfig), windowsToastIconPath())
-		cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", encodePowerShellCommand(script))
+		cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-STA", "-WindowStyle", "Hidden", "-EncodedCommand", encodePowerShellCommand(script))
 		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: 0x08000000 /* CREATE_NO_WINDOW */}
 		_ = cmd.Run()
 	})
@@ -138,9 +138,27 @@ $toast = $xml.GetElementsByTagName('toast')[0]
 [void]$textNodes.Item(1).AppendChild($xml.CreateTextNode('` + powershellSingleQuotedString(body) + `'))`
 	if show {
 		script += `
-[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + powershellSingleQuotedString(appID) + `').Show([Windows.UI.Notifications.ToastNotification]::new($xml))`
+try {
+    [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('` + powershellSingleQuotedString(appID) + `').Show([Windows.UI.Notifications.ToastNotification]::new($xml))
+} catch {
+` + windowsFormsBalloonFallbackScript(title, body) + `
+}`
 	}
 	return script
+}
+
+func windowsFormsBalloonFallbackScript(title, body string) string {
+	return `    Add-Type -AssemblyName System.Windows.Forms
+    Add-Type -AssemblyName System.Drawing
+    $notify = New-Object System.Windows.Forms.NotifyIcon
+    $notify.Icon = [System.Drawing.SystemIcons]::Information
+    $notify.BalloonTipIcon = [System.Windows.Forms.ToolTipIcon]::Info
+    $notify.BalloonTipTitle = '` + powershellSingleQuotedString(title) + `'
+    $notify.BalloonTipText = '` + powershellSingleQuotedString(body) + `'
+    $notify.Visible = $true
+    $notify.ShowBalloonTip(10000)
+    Start-Sleep -Seconds 11
+    $notify.Dispose()`
 }
 
 func windowsToastIconURL() string {

--- a/tray/ui/windows_notification_test.go
+++ b/tray/ui/windows_notification_test.go
@@ -38,6 +38,9 @@ func TestWindowsToastEncodedCommandAppendsTextNodes(t *testing.T) {
 		"AppendChild($xml.CreateTextNode('Script scheduled'))",
 		"AppendChild($xml.CreateTextNode('The requested automation has been scheduled and will run in the background shortly.'))",
 		"CreateToastNotifier('MyPortal.Tray').Show",
+		"catch {",
+		"System.Windows.Forms.NotifyIcon",
+		"ShowBalloonTip(10000)",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("encoded script missing %q:\n%s", want, script)


### PR DESCRIPTION
### Motivation
- Ensure desktop toast notifications are shown on Windows even when the WinRT/Toast API path fails.
- Make PowerShell-based notification launches reliable for COM/WinForms code paths by running PowerShell in STA mode.

### Description
- Run PowerShell invocations with `-STA` when launching encoded notification scripts in `platform_windows.go`, `platform_nowebview_windows.go`, and `windows_notification.go` to support COM/WinForms usage. 
- Wrap WinRT toast creation in a `try { ... } catch { ... }` and fall back to a `System.Windows.Forms.NotifyIcon` balloon-tip script when toast creation fails in `tray/ui/windows_notification.go`.
- Add a helper `windowsFormsBalloonFallbackScript` that returns the Windows Forms fallback PowerShell snippet in `tray/ui/windows_notification.go`.
- Extend `windows_notification` tests in `tray/ui/windows_notification_test.go` to assert the generated PowerShell script contains the fallback path.

### Testing
- Ran `cd tray && go test -tags nowebview ./...` which passed all tested packages under the `nowebview` build tag.
- Built the `nowebview` UI package with `cd tray && GOOS=windows GOARCH=amd64 go test -tags nowebview -c ./ui` which succeeded.
- Running the full test set `cd tray && go test ./...` failed in this Linux environment due to missing native `ayatana-appindicator3-0.1` for `systray` (expected CI/build-machine platform dependency), so full native UI tests were not executed here.
- Attempted `cd tray && GOOS=windows GOARCH=amd64 go test -c ./ui` without `nowebview` which failed due to `webview_go` not containing cross-compile files for this environment (expected for cross-compile).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a01c431a883328753ae2af67181d4)