### PR TITLE
Update macOS installer enrolment flow

### DIFF
--- a/tray/installer/macos/build-dmg.sh
+++ b/tray/installer/macos/build-dmg.sh
@@ -29,17 +29,69 @@ if [ ! -f "$PKG_PATH" ]; then
 fi
 
 cp "$PKG_PATH" "$STAGING_DIR/myportal-tray.pkg"
+cat > "$STAGING_DIR/silent-install.sh" <<'SILENT'
+#!/bin/bash
+# MyPortal Tray silent installer for the package included in this DMG.
+#
+# Usage (as root, from the mounted DMG):
+#   MYPORTAL_URL='https://portal.example.com' ENROL_TOKEN='TOKEN' ./silent-install.sh
+#
+# Or edit the values below before running the script:
+MYPORTAL_URL="${MYPORTAL_URL:-}"
+ENROL_TOKEN="${ENROL_TOKEN:-}"
+AUTO_UPDATE="${AUTO_UPDATE:-true}"
+
+set -euo pipefail
+
+: "${MYPORTAL_URL:?Set MYPORTAL_URL to your portal URL, for example https://portal.example.com}"
+: "${ENROL_TOKEN:?Set ENROL_TOKEN to the enrolment token from MyPortal}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_PATH="$SCRIPT_DIR/myportal-tray.pkg"
+ENV_FILE="/Library/Preferences/io.myportal.tray.env"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This installer must be run as root. Re-run with sudo." >&2
+    exit 1
+fi
+
+if [ ! -f "$PKG_PATH" ]; then
+    echo "Package not found next to this script: $PKG_PATH" >&2
+    exit 1
+fi
+
+echo "Writing MyPortal Tray configuration to $ENV_FILE ..."
+umask 077
+cat > "$ENV_FILE" <<EOF
+MYPORTAL_URL=${MYPORTAL_URL}
+ENROL_TOKEN=${ENROL_TOKEN}
+AUTO_UPDATE=${AUTO_UPDATE}
+EOF
+chmod 600 "$ENV_FILE"
+
+echo "Installing $PKG_PATH ..."
+installer -pkg "$PKG_PATH" -target /
+
+echo "MyPortal Tray installed successfully."
+SILENT
+chmod +x "$STAGING_DIR/silent-install.sh"
+
 cat > "$STAGING_DIR/README.txt" <<README
 MyPortal Tray Installer
 
 Open myportal-tray.pkg to install the MyPortal tray service and user agent.
+The installer prompts for the portal URL and enrolment token when configuration
+has not already been written to /Library/Preferences/io.myportal.tray.env.
 
 The package installs an uninstaller at:
   /Library/MyPortal/Tray/uninstall.sh
 Run it with sudo, optionally adding --purge to remove configuration, state, and logs.
 
-For RMM deployment, use installer/macos/install.sh from the source repository
-or download the package directly from your MyPortal server:
+For silent local deployment from this DMG, run the included script as root:
+  sudo MYPORTAL_URL="https://portal.example.com" ENROL_TOKEN="TOKEN" ./silent-install.sh
+
+For RMM deployment that downloads the latest package, use installer/macos/install.sh
+from the source repository or download the package directly from your MyPortal server:
   /static/tray/myportal-tray.pkg
 README
 

--- a/tray/installer/macos/postinstall
+++ b/tray/installer/macos/postinstall
@@ -8,9 +8,78 @@ DAEMON_PLIST="/Library/LaunchDaemons/io.myportal.tray.service.plist"
 AGENT_PLIST="/Library/LaunchAgents/io.myportal.tray.agent.plist"
 LOG_DIR="/Library/Logs/MyPortal/tray"
 STATE_DIR="/Library/Application Support/MyPortal/Tray"
+ENV_FILE="/Library/Preferences/io.myportal.tray.env"
 
 warn() {
     echo "Warning: $*" >&2
+}
+
+prompt_console_user() {
+    local prompt="$1"
+    local default_answer="${2:-}"
+    local hidden="${3:-false}"
+    local uid
+    uid="$(stat -f '%u' /dev/console 2>/dev/null || echo "")"
+
+    if ! [[ "$uid" =~ ^[0-9]+$ ]] || [ "$uid" -lt 500 ]; then
+        return 1
+    fi
+
+    if [ "$hidden" = "true" ]; then
+        launchctl asuser "$uid" osascript - "$prompt" "$default_answer" 2>/dev/null <<'APPLESCRIPT'
+on run argv
+    set dialogResult to display dialog (item 1 of argv) default answer (item 2 of argv) with title "MyPortal Tray Setup" buttons {"Cancel", "Continue"} default button "Continue" with hidden answer
+    return text returned of dialogResult
+end run
+APPLESCRIPT
+    else
+        launchctl asuser "$uid" osascript - "$prompt" "$default_answer" 2>/dev/null <<'APPLESCRIPT'
+on run argv
+    set dialogResult to display dialog (item 1 of argv) default answer (item 2 of argv) with title "MyPortal Tray Setup" buttons {"Cancel", "Continue"} default button "Continue"
+    return text returned of dialogResult
+end run
+APPLESCRIPT
+    fi
+}
+
+write_env_file() {
+    local portal_url="$1"
+    local enrol_token="$2"
+    local auto_update="${3:-true}"
+
+    umask 077
+    cat > "$ENV_FILE" <<EOF_ENV
+MYPORTAL_URL=${portal_url}
+ENROL_TOKEN=${enrol_token}
+AUTO_UPDATE=${auto_update}
+EOF_ENV
+    chmod 600 "$ENV_FILE" 2>/dev/null || true
+}
+
+ensure_configuration() {
+    # Silent/RMM installs should pre-create ENV_FILE (for example with the DMG's
+    # silent-install.sh). If a deployment system exports these variables into the
+    # package environment, persist them before launchd starts the service.
+    if [ -n "${MYPORTAL_URL:-}" ] && [ -n "${ENROL_TOKEN:-}" ]; then
+        write_env_file "$MYPORTAL_URL" "$ENROL_TOKEN" "${AUTO_UPDATE:-true}"
+        return 0
+    fi
+
+    if [ -s "$ENV_FILE" ] && grep -q '^MYPORTAL_URL=' "$ENV_FILE" && grep -q '^ENROL_TOKEN=' "$ENV_FILE"; then
+        return 0
+    fi
+
+    echo "MyPortal Tray configuration is missing; prompting for manual install settings."
+    local portal_url enrol_token
+    portal_url="$(prompt_console_user 'Enter the MyPortal portal URL, for example https://portal.example.com:' 'https://' 'false' || true)"
+    enrol_token="$(prompt_console_user 'Enter the MyPortal enrolment token:' '' 'true' || true)"
+
+    if [ -z "$portal_url" ] || [ -z "$enrol_token" ]; then
+        warn "MYPORTAL_URL and ENROL_TOKEN are required. Install completed, but the tray service will not be configured until $ENV_FILE is created."
+        return 0
+    fi
+
+    write_env_file "$portal_url" "$enrol_token" "${AUTO_UPDATE:-true}"
 }
 
 # Create service-owned directories before launchd evaluates stdio paths or the
@@ -19,6 +88,8 @@ warn() {
 mkdir -p "$LOG_DIR" "$STATE_DIR" || warn "failed to create support directories"
 chmod 755 "/Library/Logs/MyPortal" "$LOG_DIR" 2>/dev/null || true
 chmod 755 "/Library/Application Support/MyPortal" "$STATE_DIR" 2>/dev/null || true
+
+ensure_configuration
 
 # Make payload executables runnable.
 chmod +x "$BIN_DIR/myportal-tray-service" "$BIN_DIR/myportal-tray-ui" "$BIN_DIR/uninstall.sh" 2>/dev/null || true


### PR DESCRIPTION
### Motivation
- Ensure the tray service is configured during manual macOS installs by prompting the active console user for `MYPORTAL_URL` and `ENROL_TOKEN` when configuration is missing. 
- Provide a DMG-contained silent installer for scripted/RMM deployments that can pre-populate the required variables and install the package without interactive prompts. 
- Persist configuration before `launchd` starts the service so the tray can start with correct settings.

### Description
- Added interactive prompting in the package postinstall (`tray/installer/macos/postinstall`) using `osascript` via `launchctl asuser` to ask the active console user for the portal URL and enrolment token, and a `write_env_file` helper to persist values to `/Library/Preferences/io.myportal.tray.env`.
- Added `ensure_configuration` invocation in the postinstall to prefer environment-provided values or the existing env file, otherwise prompt and then write the file before bootstrapping launchd jobs.
- Updated the DMG builder (`tray/installer/macos/build-dmg.sh`) to include a `silent-install.sh` script in the DMG that accepts `MYPORTAL_URL`, `ENROL_TOKEN`, and optional `AUTO_UPDATE`, writes `/Library/Preferences/io.myportal.tray.env` with safe permissions, and installs the bundled `.pkg`.
- Updated the DMG `README.txt` content generated by `build-dmg.sh` to document the interactive prompt behaviour and the DMG-bundled silent install workflow.

### Testing
- Ran a syntax / smoke check with `bash -n tray/installer/macos/build-dmg.sh tray/installer/macos/postinstall`, which completed successfully. 
- Ran `git diff --check` to verify no whitespace/patch issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a04e2ea288332a00f5393cdc30125)