### PR TITLE
Prevent staff admin field inputs from overlapping

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10383,3 +10383,108 @@ a.stat-strip__stat:focus-visible {
   background: rgba(56, 189, 248, 0.16);
   outline: none;
 }
+
+/* Staff admin field configuration tables need enough intrinsic width for
+ * labels, inputs, textareas, and action buttons. Keep them inside the card's
+ * horizontal scroller instead of letting controls visually overlap. */
+.staff-field-config-table,
+.staff-custom-fields-table {
+  table-layout: fixed;
+}
+
+.staff-field-config-table {
+  min-width: 980px;
+}
+
+.staff-custom-fields-table {
+  min-width: 1680px;
+}
+
+.staff-field-config-table th,
+.staff-field-config-table td,
+.staff-custom-fields-table th,
+.staff-custom-fields-table td {
+  vertical-align: top;
+}
+
+.staff-field-config-table .form-input,
+.staff-custom-fields-table .form-input {
+  min-width: 0;
+}
+
+.staff-field-config-table td:nth-child(1) {
+  width: 18%;
+}
+
+.staff-field-config-table td:nth-child(2) {
+  width: 14%;
+}
+
+.staff-field-config-table td:nth-child(5) {
+  width: 9rem;
+}
+
+.staff-custom-fields-table th:nth-child(1),
+.staff-custom-fields-table td:nth-child(1) {
+  width: 9rem;
+}
+
+.staff-custom-fields-table th:nth-child(2),
+.staff-custom-fields-table td:nth-child(2),
+.staff-custom-fields-table th:nth-child(3),
+.staff-custom-fields-table td:nth-child(3),
+.staff-custom-fields-table th:nth-child(5),
+.staff-custom-fields-table td:nth-child(5),
+.staff-custom-fields-table th:nth-child(9),
+.staff-custom-fields-table td:nth-child(9),
+.staff-custom-fields-table th:nth-child(10),
+.staff-custom-fields-table td:nth-child(10) {
+  width: 12rem;
+}
+
+.staff-custom-fields-table th:nth-child(4),
+.staff-custom-fields-table td:nth-child(4) {
+  width: 9rem;
+}
+
+.staff-custom-fields-table th:nth-child(6),
+.staff-custom-fields-table td:nth-child(6) {
+  width: 7rem;
+}
+
+.staff-custom-fields-table th:nth-child(7),
+.staff-custom-fields-table td:nth-child(7) {
+  width: 5rem;
+  text-align: center;
+}
+
+.staff-custom-fields-table th:nth-child(8),
+.staff-custom-fields-table td:nth-child(8) {
+  width: 16rem;
+}
+
+.staff-custom-fields-table th:nth-child(11),
+.staff-custom-fields-table td:nth-child(11) {
+  width: 9rem;
+}
+
+.staff-custom-fields-table .form-field {
+  gap: 0.35rem;
+  margin: 0 0 var(--space-gap-tight);
+}
+
+.staff-custom-fields-table .form-field:last-child {
+  margin-bottom: 0;
+}
+
+.staff-custom-fields-table .table__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-gap-tight);
+}
+
+.staff-custom-fields-table .table__actions .inline-form,
+.staff-custom-fields-table .table__actions .button {
+  width: 100%;
+}

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -397,7 +397,7 @@
           <form action="/admin/companies/{{ company.id }}/staff-fields" method="post" class="form">
             {% include "partials/csrf.html" %}
             <div class="table-wrapper">
-              <table class="table">
+              <table class="table staff-field-config-table">
                 <thead>
                   <tr>
                     <th scope="col">Field</th>
@@ -569,7 +569,7 @@
           </form>
 
           <div class="table-wrapper">
-            <table class="table">
+            <table class="table staff-custom-fields-table">
               <thead>
                 <tr>
                   <th>Key</th>


### PR DESCRIPTION
### Motivation
- Staff intake and staff custom field admin pages contained dense controls that could visually overlap in narrow containers, reducing usability and making configuration error-prone.
- The admin tables need predictable intrinsic widths so inputs, selects, textareas, and action buttons stay separated inside the existing horizontal scroller rather than overlapping.

### Description
- Added scoped table classes `staff-field-config-table` and `staff-custom-fields-table` to the staff intake and staff custom fields tables in `app/templates/admin/company_edit.html`.
- Added CSS rules in `app/static/css/app.css` to use `table-layout: fixed`, set `min-width` for each table, and apply column sizing and `vertical-align: top` to keep controls aligned and prevent visual overlap.
- Adjusted action column styles so per-row action buttons stack and expand to full width inside the actions cell to avoid cramped side-by-side controls.
- Ensured form inputs in the scoped tables use `min-width: 0` so they shrink correctly inside the table cells without overflowing.

### Testing
- Ran `git diff --check` to validate no whitespace/format issues (passed).
- Executed `python -m pytest tests/test_staff_email_optional_intake.py tests/test_staff_request_permissions.py tests/test_staff_permissions_ui.py`; `tests/test_staff_email_optional_intake.py` failed in this environment because async tests require an async pytest plugin, while `tests/test_staff_request_permissions.py` and `tests/test_staff_permissions_ui.py` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a387e2184832daa03a453dd1027b1)