### PR TITLE
Fix tray UI restart single-instance race

### DIFF
--- a/tray/ui/single_instance_windows.go
+++ b/tray/ui/single_instance_windows.go
@@ -3,7 +3,9 @@
 package main
 
 import (
+	"os"
 	"strings"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
@@ -21,19 +23,34 @@ func acquireSingleInstanceLock() (bool, error) {
 		return false, err
 	}
 
-	handle, err := windows.CreateMutex(nil, true, namePtr)
-	if err == windows.ERROR_ALREADY_EXISTS {
-		if handle != 0 {
-			_ = windows.CloseHandle(handle)
-		}
-		return false, nil
-	}
-	if err != nil {
-		return false, err
+	// During a deliberate self-restart the replacement process can start before
+	// the old process has fully unwound systray.Run and released its mutex. Treat
+	// that narrow overlap as expected and wait briefly instead of exiting as a
+	// duplicate, otherwise a config/icon refresh can leave no UI process running.
+	deadline := time.Now()
+	if os.Getenv("MYPORTAL_TRAY_RESTART") == "1" {
+		deadline = deadline.Add(10 * time.Second)
 	}
 
-	singleInstanceMutex = handle
-	return true, nil
+	for {
+		handle, err := windows.CreateMutex(nil, true, namePtr)
+		if err == windows.ERROR_ALREADY_EXISTS {
+			if handle != 0 {
+				_ = windows.CloseHandle(handle)
+			}
+			if time.Now().Before(deadline) {
+				time.Sleep(200 * time.Millisecond)
+				continue
+			}
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+
+		singleInstanceMutex = handle
+		return true, nil
+	}
 }
 
 func releaseSingleInstanceLock() {

--- a/tray/ui/tray_nowebview_windows.go
+++ b/tray/ui/tray_nowebview_windows.go
@@ -146,6 +146,7 @@ func handleConfigChanged(cfg *api.ConfigResponse) {
 			return
 		}
 		cmd := exec.Command(exe, os.Args[1:]...)
+		cmd.Env = append(os.Environ(), "MYPORTAL_TRAY_RESTART=1")
 		if startErr := cmd.Start(); startErr != nil {
 			logger.Warn("config_changed restart: Start: %v", startErr)
 			return


### PR DESCRIPTION
### Motivation
- Restarting the tray UI to refresh icon/menu can start a replacement process while the old process is still releasing the per-user single-instance mutex, causing the replacement to exit as a duplicate and leaving no UI process running. 
- Make deliberate self-restarts tolerant of this narrow overlap while preserving the normal duplicate-instance protection for unrelated launches.

### Description
- Add a restart-aware retry loop to `acquireSingleInstanceLock()` so a process started with the restart marker will wait briefly for the existing mutex to be released instead of immediately exiting, implemented in `tray/ui/single_instance_windows.go`.
- Use the environment marker `MYPORTAL_TRAY_RESTART=1` to enable the temporary wait window and keep normal duplicate launches exiting immediately.
- Mark config-change self-restarts with `MYPORTAL_TRAY_RESTART=1` when spawning the replacement UI process, implemented in `tray/ui/tray_nowebview_windows.go`.

### Testing
- Ran `go test ./...` across packages which succeeded for many internal packages but failed for the UI build on Linux due to system pkg-config dependency `ayatana-appindicator3-0.1` required by `github.com/getlantern/systray` (expected in this environment). 
- Built a Windows UI test binary with `GOOS=windows GOARCH=amd64 go test -c -tags nowebview ./ui -o /tmp/myportal-ui.test.exe` which completed successfully, demonstrating the modified code compiles for the Windows nowebview target. 
- Attempted `GOOS=windows GOARCH=amd64 go test ./ui` which cannot run on the Linux CI host because the produced Windows test binary is not executable here (expected constraint).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a38639660832d8a0c8249b995ad1d)