### PR TITLE
Sync tray enrolment tokens to Tactical RMM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -240,6 +240,8 @@ TACTICALRMM_BASE_URL=
 TACTICALRMM_BASE_RMM_URL=
 TACTICALRMM_API_KEY=
 TACTICALRMM_VERIFY_SSL=true
+# Tactical RMM client-level custom field used to store MyPortal tray enrolment tokens
+TRMM_CLIENT_TOKEN_FIELD=MyPortalToken
 NTFY_BASE_URL=https://ntfy.sh
 NTFY_TOPIC=
 NTFY_AUTH_TOKEN=

--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -711,6 +711,21 @@ async def create_install_token(
         created_by_user_id=int(current_user["id"]),
         expires_at=payload.expires_at,
     )
+    if payload.company_id is not None:
+        company = await companies_repo.get_company_by_id(int(payload.company_id))
+        trmm_client_id = str((company or {}).get("tacticalrmm_client_id") or "").strip()
+        if trmm_client_id:
+            try:
+                await tray_service.update_trmm_client_token_field(
+                    trmm_client_id=trmm_client_id,
+                    token=raw_token,
+                )
+            except Exception as exc:  # pragma: no cover - external integration
+                log_error(
+                    "Failed to publish tray install token to Tactical RMM",
+                    company_id=payload.company_id,
+                    error=str(exc),
+                )
     response = _serialise_token(record)
     response["token"] = raw_token
     return TrayInstallTokenResponse(**response)

--- a/app/features/companies/handlers.py
+++ b/app/features/companies/handlers.py
@@ -2382,6 +2382,21 @@ async def admin_company_tray_create_token(company_id: int, request: Request):
         token_prefix=tray_service.token_prefix(raw_token),
         created_by_user_id=int(current_user["id"]),
     )
+    trmm_client_id = str(company.get("tacticalrmm_client_id") or "").strip()
+    if trmm_client_id:
+        try:
+            await tray_service.update_trmm_client_token_field(
+                trmm_client_id=trmm_client_id,
+                token=raw_token,
+            )
+        except Exception as exc:
+            from app.core.logging import log_error
+
+            log_error(
+                "Failed to publish company tray token to Tactical RMM",
+                company_id=company_id,
+                error=str(exc),
+            )
     cid = int(company_id)
     return RedirectResponse(
         url=f"/admin/companies/{cid}/tray?" + urlencode({"new_token": raw_token}),

--- a/app/features/tacticalrmm/__init__.py
+++ b/app/features/tacticalrmm/__init__.py
@@ -3,6 +3,7 @@
 This pack owns TacticalRMM-specific admin synchronisation routes:
   - POST /admin/modules/tacticalrmm/push-companies
   - POST /admin/modules/tacticalrmm/pull-companies
+  - POST /admin/modules/tacticalrmm/sync-tray-tokens
 """
 
 from __future__ import annotations
@@ -10,7 +11,6 @@ from __future__ import annotations
 from app.core.features import FeaturePack
 
 from .routes import router as tacticalrmm_router
-
 
 PACK = FeaturePack(
     slug="tacticalrmm",

--- a/app/features/tacticalrmm/handlers.py
+++ b/app/features/tacticalrmm/handlers.py
@@ -104,7 +104,9 @@ async def admin_push_companies_to_tactical_rmm(request: Request):
         request_path=str(request.url),
     )
 
-    success_message = f"Tactical RMM company synchronisation queued. Task ID: {task_id[:8]}"
+    success_message = (
+        f"Tactical RMM company synchronisation queued. Task ID: {task_id[:8]}"
+    )
     query = f"success={quote(success_message)}"
     redirect_url = f"/admin/modules?{query}" if query else "/admin/modules"
 
@@ -196,3 +198,59 @@ async def admin_pull_companies_from_tactical_rmm(request: Request):
     redirect_url = f"/admin/modules?{query}" if query else "/admin/modules"
 
     return RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
+
+
+async def admin_sync_tray_tokens_to_tactical_rmm(request: Request):
+    from app.core.logging import log_error, log_info
+    from app.services import background as background_tasks
+    from app.services import modules as modules_service
+    from app.services import tray as tray_service
+
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    try:
+        await modules_service.ensure_tacticalrmm_ready()
+    except ValueError as exc:
+        log_error("Unable to sync tray tokens to Tactical RMM", error=str(exc))
+        return await _main()._render_modules_dashboard(
+            request,
+            current_user,
+            error_message=str(exc),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    task_id = uuid4().hex
+
+    async def _on_success(summary: Mapping[str, Any]) -> None:
+        log_info(
+            "Tactical RMM tray token sync completed",
+            task_id=task_id,
+            processed=summary.get("processed"),
+            updated=summary.get("updated"),
+            skipped=len(summary.get("skipped") or []),
+            errors=len(summary.get("errors") or []),
+        )
+
+    async def _on_error(exc: Exception) -> None:
+        log_error(
+            "Tactical RMM tray token sync failed", task_id=task_id, error=str(exc)
+        )
+
+    user_id = int(current_user["id"]) if current_user.get("id") is not None else None
+    background_tasks.queue_background_task(
+        lambda: tray_service.sync_all_company_trmm_tray_tokens(
+            created_by_user_id=user_id
+        ),
+        task_id=task_id,
+        description="tacticalrmm-tray-token-sync",
+        on_complete=_on_success,
+        on_error=_on_error,
+    )
+
+    success_message = f"Tactical RMM tray token sync queued. Task ID: {task_id[:8]}"
+    return RedirectResponse(
+        url=f"/admin/modules?success={quote(success_message)}",
+        status_code=status.HTTP_303_SEE_OTHER,
+    )

--- a/app/features/tacticalrmm/routes.py
+++ b/app/features/tacticalrmm/routes.py
@@ -21,6 +21,12 @@ router.add_api_route(
     methods=["POST"],
     response_class=HTMLResponse,
 )
+router.add_api_route(
+    "/admin/modules/tacticalrmm/sync-tray-tokens",
+    handlers.admin_sync_tray_tokens_to_tactical_rmm,
+    methods=["POST"],
+    response_class=HTMLResponse,
+)
 
 
 __all__ = ["router"]

--- a/app/services/tray.py
+++ b/app/services/tray.py
@@ -16,13 +16,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import secrets
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Iterable
 
 from app.core.config import get_settings
-from app.core.logging import log_info, log_warning
+from app.core.logging import log_error, log_info, log_warning
 from app.repositories import assets as assets_repo
 from app.repositories import companies as companies_repo
 from app.repositories import site_settings as site_settings_repo
@@ -115,6 +116,193 @@ async def find_matching_asset(
         except (TypeError, ValueError):
             return None
     return None
+
+
+# ---------------------------------------------------------------------------
+# Tactical RMM enrolment-token synchronisation
+# ---------------------------------------------------------------------------
+
+
+def trmm_client_token_field_name() -> str:
+    """Return the TRMM client custom field name that stores tray install tokens."""
+
+    return (
+        os.getenv("TRMM_CLIENT_TOKEN_FIELD", "MyPortalToken").strip() or "MyPortalToken"
+    )[:128]
+
+
+async def ensure_company_install_token(
+    *,
+    company_id: int,
+    created_by_user_id: int | None = None,
+    label: str | None = None,
+) -> tuple[dict[str, Any], str | None]:
+    """Return an active company install-token row, creating one when needed.
+
+    The raw token can only be returned when a new token is created. Existing
+    token values are intentionally unrecoverable because only HMAC hashes are
+    stored at rest.
+    """
+
+    tokens = await tray_repo.list_install_tokens(company_id=int(company_id))
+    for token in tokens:
+        if token.get("revoked_at"):
+            continue
+        expires_at = token.get("expires_at")
+        if isinstance(expires_at, datetime):
+            aware = expires_at.replace(tzinfo=expires_at.tzinfo or timezone.utc)
+            if aware < datetime.now(timezone.utc):
+                continue
+        return token, None
+
+    company = await companies_repo.get_company_by_id(int(company_id))
+    raw_token = generate_install_token()
+    record = await tray_repo.create_install_token(
+        label=(label or f"{(company or {}).get('name') or 'Company'} TRMM tray token")[
+            :150
+        ],
+        company_id=int(company_id),
+        token_hash=hash_token(raw_token),
+        token_prefix=token_prefix(raw_token),
+        created_by_user_id=created_by_user_id,
+    )
+    return record, raw_token
+
+
+def _extract_trmm_custom_field_id(
+    client: dict[str, Any], field_name: str
+) -> int | None:
+    for field in client.get("custom_fields") or []:
+        if not isinstance(field, dict):
+            continue
+        if str(field.get("name") or "").strip() != field_name:
+            continue
+        raw_id = field.get("field") or field.get("id") or field.get("pk")
+        try:
+            return int(raw_id)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+async def update_trmm_client_token_field(
+    *,
+    trmm_client_id: str | int,
+    token: str,
+    field_name: str | None = None,
+) -> dict[str, Any]:
+    """Write a tray enrolment token into a Tactical RMM client custom field."""
+
+    from app.services import tacticalrmm as tacticalrmm_service
+
+    client_id = str(trmm_client_id or "").strip()
+    if not client_id:
+        raise ValueError("Tactical RMM client ID is required")
+    custom_field_name = (field_name or trmm_client_token_field_name()).strip()
+    if not custom_field_name:
+        raise ValueError("Tactical RMM custom field name is required")
+
+    client = await tacticalrmm_service._call_endpoint(
+        f"/clients/{client_id}/", method="GET"
+    )
+    if not isinstance(client, dict):
+        client = {}
+    field_id = _extract_trmm_custom_field_id(client, custom_field_name)
+
+    custom_field_payload: dict[str, Any]
+    if field_id is not None:
+        custom_field_payload = {"field": field_id, "string_value": token}
+    else:
+        # Recent TRMM builds expose the field ID in the client response. Keep a
+        # name-based fallback so the sync still works on APIs that accept names.
+        custom_field_payload = {"name": custom_field_name, "string_value": token}
+
+    body = {"custom_fields": [custom_field_payload]}
+    return await tacticalrmm_service._call_endpoint(
+        f"/clients/{client_id}/", method="PATCH", body=body
+    )
+
+
+async def sync_company_trmm_tray_token(
+    *,
+    company_id: int,
+    created_by_user_id: int | None = None,
+) -> dict[str, Any]:
+    """Ensure a MyPortal tray token exists and publish it to TRMM for a company."""
+
+    company = await companies_repo.get_company_by_id(int(company_id))
+    if not company:
+        return {
+            "status": "skipped",
+            "reason": "company_not_found",
+            "company_id": company_id,
+        }
+    trmm_client_id = str(company.get("tacticalrmm_client_id") or "").strip()
+    if not trmm_client_id:
+        return {
+            "status": "skipped",
+            "reason": "missing_tacticalrmm_client_id",
+            "company_id": company_id,
+        }
+
+    token_record, raw_token = await ensure_company_install_token(
+        company_id=int(company_id), created_by_user_id=created_by_user_id
+    )
+    if raw_token is None:
+        return {
+            "status": "skipped",
+            "reason": "existing_token_value_not_recoverable",
+            "company_id": company_id,
+            "token_id": token_record.get("id"),
+        }
+
+    await update_trmm_client_token_field(trmm_client_id=trmm_client_id, token=raw_token)
+    log_info(
+        "Published tray enrolment token to Tactical RMM client custom field",
+        company_id=company_id,
+        trmm_client_id=trmm_client_id,
+        field=trmm_client_token_field_name(),
+    )
+    return {
+        "status": "updated",
+        "company_id": company_id,
+        "token_id": token_record.get("id"),
+    }
+
+
+async def sync_all_company_trmm_tray_tokens(
+    *, created_by_user_id: int | None = None
+) -> dict[str, Any]:
+    """Create missing tray enrolment tokens and publish new values to TRMM."""
+
+    companies = await companies_repo.list_companies()
+    summary: dict[str, Any] = {
+        "processed": 0,
+        "updated": 0,
+        "skipped": [],
+        "errors": [],
+    }
+    for company in companies:
+        company_id = int(company.get("id") or 0)
+        if company_id <= 0:
+            continue
+        summary["processed"] += 1
+        try:
+            result = await sync_company_trmm_tray_token(
+                company_id=company_id, created_by_user_id=created_by_user_id
+            )
+            if result.get("status") == "updated":
+                summary["updated"] += 1
+            else:
+                summary["skipped"].append(result)
+        except Exception as exc:  # pragma: no cover - defensive integration logging
+            log_error(
+                "Failed to sync tray token to Tactical RMM",
+                company_id=company_id,
+                error=str(exc),
+            )
+            summary["errors"].append({"company_id": company_id, "error": str(exc)})
+    return summary
 
 
 # ---------------------------------------------------------------------------
@@ -242,11 +430,7 @@ async def resolve_config_for_device(device: dict[str, Any]) -> dict[str, Any]:
         display_text = chosen.get("display_text")
         branding_icon_url = chosen.get("branding_icon_url")
         raw_allow = chosen.get("env_allowlist") or ""
-        env_allowlist = [
-            v.strip()
-            for v in str(raw_allow).split(",")
-            if v.strip()
-        ]
+        env_allowlist = [v.strip() for v in str(raw_allow).split(",") if v.strip()]
         version = int(chosen.get("version") or 1)
     else:
         payload = list(_DEFAULT_MENU)
@@ -346,7 +530,9 @@ async def push_notification_to_company_devices(
     if not company or not company.get("tray_notifications_enabled"):
         return {"targeted": 0, "delivered": 0, "queued": 0}
 
-    active_devices = await tray_repo.list_devices(company_id=int(company_id), status="active")
+    active_devices = await tray_repo.list_devices(
+        company_id=int(company_id), status="active"
+    )
     allowed_asset_ids = {
         int(asset_id)
         for asset_id in (asset_ids or [])
@@ -355,7 +541,8 @@ async def push_notification_to_company_devices(
     target_devices = [
         device
         for device in active_devices
-        if not allowed_asset_ids or int(device.get("asset_id") or 0) in allowed_asset_ids
+        if not allowed_asset_ids
+        or int(device.get("asset_id") or 0) in allowed_asset_ids
     ]
     if not target_devices:
         return {"targeted": 0, "delivered": 0, "queued": 0}
@@ -400,7 +587,9 @@ async def push_notification_to_company_devices(
 # ---------------------------------------------------------------------------
 
 
-def technician_can_initiate(user: dict[str, Any], company: dict[str, Any] | None) -> bool:
+def technician_can_initiate(
+    user: dict[str, Any], company: dict[str, Any] | None
+) -> bool:
     """Return True when ``user`` is allowed to push a chat to a device.
 
     The per-company toggle ``tray_chat_enabled`` is the primary gate; super


### PR DESCRIPTION
### Motivation

- Ensure MyPortal automatically creates company-scoped tray enrolment tokens and publishes them into Tactical RMM client custom fields so tray icons can be deployed from TRMM.
- Make the TRMM custom field name configurable via environment and provide an admin-facing bulk sync to populate missing values.

### Description

- Added TRMM sync helpers in `app/services/tray.py`: `trmm_client_token_field_name`, `ensure_company_install_token`, `_extract_trmm_custom_field_id`, `update_trmm_client_token_field`, `sync_company_trmm_tray_token`, and `sync_all_company_trmm_tray_tokens` to create tokens and write them to a Tactical RMM client custom field.
- When an install token is created via the Tray API (`POST /api/tray/admin/install-tokens` in `app/api/routes/tray.py`), attempt to publish the newly-generated raw token to the company’s `tacticalrmm_client_id` custom field (logged on integration failure).
- When an admin creates a token via the company tray settings page (`app/features/companies/handlers.py`), attempt the same publish and log any failures without leaking secrets.
- Added an admin TacticalRMM route `/admin/modules/tacticalrmm/sync-tray-tokens` and handler (`app/features/tacticalrmm/handlers.py` + `routes.py`) that queues a background job to create/publish tokens for all companies by calling `tray_service.sync_all_company_trmm_tray_tokens`.
- Introduced environment variable `TRMM_CLIENT_TOKEN_FIELD` (documented in `.env.example`) to control which TRMM client custom field stores the token (default `MyPortalToken`).
- Minor logging/import adjustments and formatting cleanup.

### Testing

- Ran code formatting (`black`) and bytecode compilation (`python -m compileall`) on modified modules; these completed successfully (Black emitted a Python-version warning unrelated to functional changes).
- Ran unit tests focused on the TacticalRMM/tray surface: `pytest tests/test_tacticalrmm_scripts.py` passed.
- Ran the company tray settings tests (`pytest tests/test_company_tray_settings_page.py`) during validation and observed failures caused by an uninitialised database pool in the test environment (this is an environment/test harness issue, not a regression in the TRMM sync logic).
- Verified repository integrity with `git diff --check` (no whitespace errors).

If you want, I can: add a small integration test stub that mocks the TacticalRMM API, wire the new sync route into the admin UI, or add a migration/DB change if you prefer storing any metadata for sync tracking.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a68e19a70832d8442610e429fd5ac)