### PR TITLE
Allow technicians to rename chat rooms (PATCH /api/chat/rooms/{room_id})

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -15,6 +15,7 @@ from app.repositories import matrix_ai_tag_synonyms as synonyms_repo
 from app.schemas.chat import (
     ChatMessageCreate,
     ChatRoomCreate,
+    ChatRoomRename,
     ExternalInviteCreate,
     AiTagSynonymGroupCreate,
     AiTagSynonymGroupUpdate,
@@ -338,6 +339,51 @@ async def send_message(
     )
 
     return JSONResponse(msg_data, status_code=201)
+
+
+@router.patch("/rooms/{room_id}", summary="Rename a chat room (technician/admin)")
+async def rename_room(
+    room_id: int,
+    request: Request,
+    body: ChatRoomRename,
+    current_user: dict = Depends(get_current_user),
+) -> JSONResponse:
+    _require_matrix_enabled()
+    if not (current_user.get("is_super_admin") or current_user.get("is_helpdesk_technician")):
+        raise HTTPException(status_code=403, detail="Only technicians or admins can rename chats")
+
+    room = await chat_repo.get_room(room_id)
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    new_subject = body.subject.strip()
+    if not new_subject:
+        raise HTTPException(status_code=422, detail="Chat subject cannot be blank")
+
+    old_subject = room.get("subject")
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    await chat_repo.update_room(room_id, subject=new_subject, updated_at=now)
+
+    try:
+        await matrix_service.set_room_name(room["matrix_room_id"], new_subject)
+    except Exception as exc:
+        log_error("Failed to rename Matrix room", room_id=room_id, error=str(exc))
+
+    await audit_service.log_action(
+        action="rename",
+        entity_type="chat_room",
+        entity_id=room_id,
+        user_id=current_user["id"],
+        old_value={"subject": old_subject},
+        new_value={"subject": new_subject},
+    )
+
+    updated = await chat_repo.get_room(room_id) or {**dict(room), "subject": new_subject, "updated_at": now}
+    await refresh_notifier.broadcast_refresh(
+        topics=[f"chat:room:{room_id}", "chat:rooms"],
+        data={"room_id": room_id, "subject": new_subject},
+    )
+    return JSONResponse(_serialize(dict(updated)))
 
 
 @router.post("/rooms/{room_id}/ticket", summary="Create or return a ticket linked to a chat room")

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -58,6 +58,10 @@ class ChatMessageCreate(BaseModel):
     body: str = Field(..., min_length=1, max_length=65535)
 
 
+class ChatRoomRename(BaseModel):
+    subject: str = Field(..., min_length=1, max_length=500)
+
+
 class ChatMessageResponse(BaseModel):
     id: int
     room_id: int

--- a/app/services/matrix.py
+++ b/app/services/matrix.py
@@ -128,6 +128,16 @@ async def create_room(
     return await _request("POST", "/_matrix/client/v3/createRoom", headers=_bot_headers(), json=body)
 
 
+async def set_room_name(room_id: str, name: str) -> dict[str, Any]:
+    """Set the Matrix room display name using the bot token."""
+    return await _request(
+        "PUT",
+        f"/_matrix/client/v3/rooms/{room_id}/state/m.room.name/",
+        headers=_bot_headers(),
+        json={"name": name},
+    )
+
+
 async def invite_user(room_id: str, user_id: str) -> dict[str, Any]:
     """Invite a user to a room."""
     return await _request(

--- a/app/templates/chat/room.html
+++ b/app/templates/chat/room.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block header_title %}Chat: {{ room.subject | e }}{% endblock %}
+{% block header_title %}Chat: <span id="chat-room-title">{{ room.subject | e }}</span>{% endblock %}
 {% from "macros/header.html" import page_header_actions %}
 
 {% block header_actions %}
@@ -12,6 +12,7 @@
         {% else %}
           <button class="button button--sm button--primary" id="btn-create-ticket" data-room-id="{{ room.id }}">Chat to Ticket</button>
         {% endif %}
+        <button class="button button--sm" id="btn-rename-room" data-room-id="{{ room.id }}" aria-haspopup="dialog" aria-controls="rename-modal">Rename chat</button>
         <button class="button button--sm" id="btn-join-room" data-room-id="{{ room.id }}">Join room</button>
         <button class="button button--sm button--secondary" id="btn-assign-room" data-room-id="{{ room.id }}"
                 data-assigned="{{ room.assigned_tech_user_id | default('') }}"
@@ -39,7 +40,7 @@
   {% if room.subject %}
   <span class="chat-meta-bar__item">
     <strong>Subject:</strong>
-    {{ room.subject | e }}
+    <span id="chat-room-subject">{{ room.subject | e }}</span>
   </span>
   {% endif %}
   {% if room.creator_display_name %}
@@ -151,6 +152,33 @@
   <div class="alert alert--info">This chat is closed and no longer accepting messages.</div>
   {% endif %}
 </div>
+
+
+{% if is_staff %}
+<!-- Rename chat modal -->
+<div id="rename-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="rename-modal-title" hidden>
+  <div class="modal__backdrop" data-rename-modal-close></div>
+  <div class="modal__panel">
+    <header class="modal__header">
+      <h2 id="rename-modal-title" class="modal__title">Rename chat</h2>
+      <button type="button" class="modal__close" data-rename-modal-close aria-label="Close">×</button>
+    </header>
+    <form id="rename-form" class="modal__body">
+      {% if csrf_token %}
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+      {% endif %}
+      <div class="form-group">
+        <label class="form-label required" for="rename-subject">Chat name</label>
+        <input type="text" id="rename-subject" name="subject" class="form-input" value="{{ room.subject | e }}" required maxlength="500" />
+      </div>
+      <footer class="modal__footer">
+        <button type="submit" class="button button--primary" id="rename-submit-btn">Save name</button>
+        <button type="button" class="button button--ghost" data-rename-modal-close>Cancel</button>
+      </footer>
+    </form>
+  </div>
+</div>
+{% endif %}
 
 {% if matrix_is_self_hosted and is_staff %}
 <!-- Invite to Matrix modal -->
@@ -459,6 +487,50 @@
       }
     } catch {}
   }, 5000);
+
+
+  const renameBtn = document.getElementById('btn-rename-room');
+  const renameModal = document.getElementById('rename-modal');
+  const renameForm = document.getElementById('rename-form');
+  const renameInput = document.getElementById('rename-subject');
+  const renameCloseBtns = renameModal?.querySelectorAll('[data-rename-modal-close]') || [];
+  renameBtn?.addEventListener('click', () => {
+    if (!renameModal) return;
+    renameModal.hidden = false;
+    renameInput?.focus();
+    renameInput?.select();
+  });
+  renameCloseBtns.forEach((button) => button.addEventListener('click', () => { if (renameModal) renameModal.hidden = true; }));
+  renameForm?.addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const subject = (renameInput?.value || '').trim();
+    if (!subject) { showPortalToast('Chat name is required.', 'error'); return; }
+    const btn = document.getElementById('rename-submit-btn');
+    btn.disabled = true;
+    try {
+      const resp = await fetch(`/api/chat/rooms/${roomId}`, {
+        method: 'PATCH',
+        headers: {'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken},
+        body: JSON.stringify({subject}),
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        const updatedSubject = data.subject || subject;
+        document.getElementById('chat-room-title').textContent = updatedSubject;
+        document.getElementById('chat-room-subject').textContent = updatedSubject;
+        document.title = document.title.replace(originalTitle, `Chat: ${updatedSubject}`);
+        if (renameModal) renameModal.hidden = true;
+        showPortalToast('Chat renamed.', 'success');
+      } else {
+        const err = await resp.json();
+        showPortalToast(err.detail || 'Failed to rename chat', 'error');
+      }
+    } catch(err) {
+      showPortalToast('Network error: ' + err.message, 'error');
+    } finally {
+      btn.disabled = false;
+    }
+  });
 
   document.getElementById('btn-create-ticket')?.addEventListener('click', async function() {
     if (!confirm('Create a ticket from this chat transcript? Public replies will sync while the chat remains open.')) return;

--- a/tests/test_chat_rename.py
+++ b/tests/test_chat_rename.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routes import chat as chat_routes
+
+
+def test_rename_room_allows_technician_and_updates_subject(monkeypatch):
+    async def run_test():
+        monkeypatch.setattr(chat_routes._settings, "matrix_enabled", True)
+        room = {
+            "id": 42,
+            "subject": "Old subject",
+            "matrix_room_id": "!room:example.com",
+            "updated_at": datetime.now(timezone.utc).replace(tzinfo=None),
+        }
+        updated_fields = {}
+        audit_payload = {}
+        matrix_names = []
+        broadcasts = []
+
+        async def fake_get_room(room_id: int):
+            assert room_id == 42
+            return {**room, **updated_fields}
+
+        async def fake_update_room(room_id: int, **fields):
+            assert room_id == 42
+            updated_fields.update(fields)
+
+        async def fake_set_room_name(room_id: str, name: str):
+            matrix_names.append((room_id, name))
+            return {}
+
+        async def fake_log_action(**kwargs):
+            audit_payload.update(kwargs)
+
+        async def fake_broadcast_refresh(**kwargs):
+            broadcasts.append(kwargs)
+
+        monkeypatch.setattr(chat_routes.chat_repo, "get_room", fake_get_room)
+        monkeypatch.setattr(chat_routes.chat_repo, "update_room", fake_update_room)
+        monkeypatch.setattr(chat_routes.matrix_service, "set_room_name", fake_set_room_name)
+        monkeypatch.setattr(chat_routes.audit_service, "log_action", fake_log_action)
+        monkeypatch.setattr(chat_routes.refresh_notifier, "broadcast_refresh", fake_broadcast_refresh)
+
+        response = await chat_routes.rename_room(
+            42,
+            request=None,
+            body=chat_routes.ChatRoomRename(subject="  New subject  "),
+            current_user={"id": 7, "is_helpdesk_technician": True},
+        )
+
+        assert response.status_code == 200
+        assert updated_fields["subject"] == "New subject"
+        assert matrix_names == [("!room:example.com", "New subject")]
+        assert audit_payload["action"] == "rename"
+        assert audit_payload["old_value"] == {"subject": "Old subject"}
+        assert audit_payload["new_value"] == {"subject": "New subject"}
+        assert broadcasts[0]["topics"] == ["chat:room:42", "chat:rooms"]
+
+    asyncio.run(run_test())
+
+
+def test_rename_room_rejects_non_staff(monkeypatch):
+    async def run_test():
+        monkeypatch.setattr(chat_routes._settings, "matrix_enabled", True)
+
+        with pytest.raises(HTTPException) as exc:
+            await chat_routes.rename_room(
+                42,
+                request=None,
+                body=chat_routes.ChatRoomRename(subject="New subject"),
+                current_user={"id": 8, "is_helpdesk_technician": False, "is_super_admin": False},
+            )
+
+        assert exc.value.status_code == 403
+
+    asyncio.run(run_test())

--- a/tests/test_matrix_chat.py
+++ b/tests/test_matrix_chat.py
@@ -69,6 +69,7 @@ whoami = _matrix.whoami
 sanitize_localpart = _matrix.sanitize_localpart
 set_user_power_level = _matrix.set_user_power_level
 get_power_levels = _matrix.get_power_levels
+set_room_name = _matrix.set_room_name
 
 
 # ---------------------------------------------------------------------------
@@ -335,3 +336,20 @@ def test_set_power_level_function_exists():
     """matrix service must expose set_user_power_level."""
     assert callable(set_user_power_level), "set_user_power_level must be callable"
     assert callable(get_power_levels), "get_power_levels must be callable"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_set_room_name_success(monkeypatch):
+    monkeypatch.setattr(_matrix._settings, "matrix_homeserver_url", "https://matrix.example.com")
+    monkeypatch.setattr(_matrix._settings, "matrix_bot_access_token", "test_token")
+
+    route = respx.put(
+        "https://matrix.example.com/_matrix/client/v3/rooms/!abc123:example.com/state/m.room.name/"
+    ).mock(return_value=httpx.Response(200, json={}))
+
+    result = await set_room_name("!abc123:example.com", "Renamed chat")
+
+    assert result == {}
+    assert route.called
+    assert route.calls.last.request.content == b'{"name":"Renamed chat"}'


### PR DESCRIPTION
### Motivation
- Provide technicians and admins with the ability to rename support chat rooms from the UI and API so room titles are meaningful and kept in sync with the Matrix homeserver. 
- Ensure renames are validated, audited, and propagated to realtime clients and Matrix where possible.

### Description
- Added a new request schema `ChatRoomRename` in `app/schemas/chat.py` for subject validation. 
- Implemented `PATCH /api/chat/rooms/{room_id}` in `app/api/routes/chat.py` which requires technician/admin privileges, trims/validates the subject, updates `chat_rooms`, logs an audit record, and broadcasts refresh topics. 
- Added `set_room_name` to `app/services/matrix.py` to attempt best-effort synchronization of the room name with Matrix and log failures without blocking the API. 
- Updated `app/templates/chat/room.html` to include a `Rename chat` button, a CSRF-protected modal, and client-side JS to submit the `PATCH` request and update the in-page title/subject without a full reload. 
- Added regression tests: `tests/test_chat_rename.py` (technician success and non-staff rejection) and extended `tests/test_matrix_chat.py` with `test_set_room_name_success` for Matrix call coverage. 

### Testing
- Ran `pytest tests/test_chat_rename.py -q` and the new rename tests passed locally (2 passed). 
- Ran `python -m py_compile app/api/routes/chat.py app/schemas/chat.py app/services/matrix.py` and compilation succeeded. 
- Attempted to run `pytest tests/test_chat_rename.py tests/test_matrix_chat.py -q` but the combined run is blocked in this environment due to a missing optional test dependency `respx` required by the Matrix tests; the Matrix test added is otherwise valid and targets the new `set_room_name` behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a749e3f4c832db2b27e04313767aa)