### PR TITLE
Add device/company/console-user columns and column picker to chat list

### DIFF
--- a/app/repositories/chat.py
+++ b/app/repositories/chat.py
@@ -80,9 +80,15 @@ async def list_rooms(
     rows = await db.fetch_all(
         f"""SELECT r.*,
                (SELECT COUNT(*) FROM chat_room_participants p WHERE p.room_id = r.id AND p.role IN ('technician','admin')) AS tech_participant_count,
-               CONCAT(COALESCE(u.first_name, ''), ' ', COALESCE(u.last_name, '')) AS assigned_tech_display_name
+               CONCAT(COALESCE(u.first_name, ''), ' ', COALESCE(u.last_name, '')) AS assigned_tech_display_name,
+               COALESCE(NULLIF(a.name, ''), NULLIF(td.hostname, ''), td.device_uid) AS device_name,
+               c.name AS company_name,
+               td.console_user AS console_user
             FROM chat_rooms r
             LEFT JOIN users u ON u.id = r.assigned_tech_user_id
+            LEFT JOIN tray_devices td ON td.id = r.tray_device_id
+            LEFT JOIN assets a ON a.id = td.asset_id
+            LEFT JOIN companies c ON c.id = r.company_id
             {unattended_join}
             WHERE {where}
             ORDER BY r.updated_at DESC LIMIT %s OFFSET %s""",

--- a/app/static/js/chat_columns.js
+++ b/app/static/js/chat_columns.js
@@ -1,0 +1,125 @@
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'portal.chat.columns';
+  const REQUIRED_COLUMN = 'subject';
+
+  function loadVisibleColumns(defaultColumns) {
+    try {
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      if (Array.isArray(stored) && stored.every((item) => typeof item === 'string')) {
+        return stored;
+      }
+    } catch (err) {
+      console.warn('Failed to read stored chat column preferences', err);
+    }
+    return defaultColumns;
+  }
+
+  function saveVisibleColumns(columns) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(columns));
+    } catch (err) {
+      console.warn('Failed to persist chat column preferences', err);
+    }
+  }
+
+  function setColumnVisibility(table, column, visible) {
+    if (!table || !column) {
+      return;
+    }
+    table.querySelectorAll(`[data-column="${column}"]`).forEach((element) => {
+      element.style.display = visible ? '' : 'none';
+    });
+  }
+
+  function initialiseColumnControls() {
+    const table = document.getElementById('chat-rooms-table');
+    const container = document.querySelector('[data-chat-columns]');
+    if (!table || !container) {
+      return;
+    }
+
+    const toggleButton = container.querySelector('[data-columns-toggle]');
+    const panel = container.querySelector('[data-columns-panel]');
+    const toggles = Array.from(container.querySelectorAll('.chat-column-toggle'));
+    if (!toggleButton || !panel || toggles.length === 0) {
+      return;
+    }
+
+    function openPanel() {
+      container.classList.add('ticket-columns--open');
+      panel.hidden = false;
+      toggleButton.setAttribute('aria-expanded', 'true');
+    }
+
+    function closePanel() {
+      container.classList.remove('ticket-columns--open');
+      panel.hidden = true;
+      toggleButton.setAttribute('aria-expanded', 'false');
+    }
+
+    toggleButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (container.classList.contains('ticket-columns--open')) {
+        closePanel();
+      } else {
+        openPanel();
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!container.contains(event.target)) {
+        closePanel();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closePanel();
+        toggleButton.focus();
+      }
+    });
+
+    const defaultColumns = toggles.filter((input) => input.checked).map((input) => input.dataset.column).filter(Boolean);
+    const visibleColumns = loadVisibleColumns(defaultColumns);
+    if (!visibleColumns.includes(REQUIRED_COLUMN)) {
+      visibleColumns.push(REQUIRED_COLUMN);
+    }
+
+    toggles.forEach((input) => {
+      const column = input.dataset.column;
+      if (!column) {
+        return;
+      }
+      const shouldShow = column === REQUIRED_COLUMN || visibleColumns.includes(column);
+      input.checked = shouldShow;
+      setColumnVisibility(table, column, shouldShow);
+    });
+
+    toggles.forEach((input) => {
+      input.addEventListener('change', () => {
+        const column = input.dataset.column;
+        if (!column) {
+          return;
+        }
+        if (column === REQUIRED_COLUMN) {
+          input.checked = true;
+          return;
+        }
+        const selected = toggles
+          .filter((toggle) => (toggle.checked && !toggle.disabled) || toggle.dataset.column === REQUIRED_COLUMN)
+          .map((toggle) => toggle.dataset.column)
+          .filter(Boolean);
+        if (!selected.includes(REQUIRED_COLUMN)) {
+          selected.push(REQUIRED_COLUMN);
+        }
+        saveVisibleColumns(selected);
+        setColumnVisibility(table, column, input.checked);
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', initialiseColumnControls);
+})();

--- a/app/templates/chat/index.html
+++ b/app/templates/chat/index.html
@@ -41,7 +41,70 @@
           </select>
         </div>
         {% endif %}
+        <div class="tickets-toolbar__field">
+          <label class="form-label" for="chat-table-filter">Filter chats</label>
+          <input
+            id="chat-table-filter"
+            type="search"
+            class="form-input"
+            placeholder="Filter chats…"
+            data-table-filter="chat-rooms-table"
+          />
+        </div>
       </form>
+      <div class="ticket-columns" data-chat-columns>
+        <button type="button" class="button button--ghost ticket-columns__toggle" data-columns-toggle aria-haspopup="true" aria-expanded="false">
+          Columns
+          <span class="ticket-columns__chevron" aria-hidden="true">▾</span>
+        </button>
+        <div class="ticket-columns__panel" data-columns-panel hidden>
+          <p class="ticket-columns__title">Toggle columns</p>
+          <div class="ticket-columns__options">
+            <label class="ticket-columns__option">
+              <input type="checkbox" class="chat-column-toggle" data-column="id" checked />
+              <span>ID</span>
+            </label>
+            <label class="ticket-columns__option">
+              <input type="checkbox" class="chat-column-toggle" data-column="subject" checked disabled />
+              <span>Subject</span>
+            </label>
+            <label class="ticket-columns__option">
+              <input type="checkbox" class="chat-column-toggle" data-column="device" checked />
+              <span>Device</span>
+            </label>
+            <label class="ticket-columns__option">
+              <input type="checkbox" class="chat-column-toggle" data-column="company" checked />
+              <span>Company</span>
+            </label>
+            <label class="ticket-columns__option">
+              <input type="checkbox" class="chat-column-toggle" data-column="console-user" checked />
+              <span>Console user</span>
+            </label>
+            <label class="ticket-columns__option">
+              <input type="checkbox" class="chat-column-toggle" data-column="status" checked />
+              <span>Status</span>
+            </label>
+            {% if is_staff %}
+            <label class="ticket-columns__option">
+              <input type="checkbox" class="chat-column-toggle" data-column="assigned" checked />
+              <span>Assigned to</span>
+            </label>
+            {% endif %}
+            <label class="ticket-columns__option">
+              <input type="checkbox" class="chat-column-toggle" data-column="created" checked />
+              <span>Created</span>
+            </label>
+            <label class="ticket-columns__option">
+              <input type="checkbox" class="chat-column-toggle" data-column="last-message" checked />
+              <span>Last message</span>
+            </label>
+            <label class="ticket-columns__option">
+              <input type="checkbox" class="chat-column-toggle" data-column="actions" checked />
+              <span>Actions</span>
+            </label>
+          </div>
+        </div>
+      </div>
     </div>
   </header>
   {% if not rooms %}
@@ -51,34 +114,40 @@
     <table class="table" id="chat-rooms-table" data-table>
       <thead>
         <tr>
-          <th scope="col" data-sort="int">ID</th>
-          <th scope="col" data-sort="string">Subject</th>
-          <th scope="col" data-sort="string">Status</th>
+          <th scope="col" data-column="id" data-sort="int">ID</th>
+          <th scope="col" data-column="subject" data-sort="string">Subject</th>
+          <th scope="col" data-column="device" data-sort="string">Device</th>
+          <th scope="col" data-column="company" data-sort="string">Company</th>
+          <th scope="col" data-column="console-user" data-sort="string">Console user</th>
+          <th scope="col" data-column="status" data-sort="string">Status</th>
           {% if is_staff %}
-          <th scope="col" data-sort="string">Assigned to</th>
+          <th scope="col" data-column="assigned" data-sort="string">Assigned to</th>
           {% endif %}
-          <th scope="col" data-sort="date">Created</th>
-          <th scope="col" data-sort="date">Last message</th>
-          <th scope="col">Actions</th>
+          <th scope="col" data-column="created" data-sort="date">Created</th>
+          <th scope="col" data-column="last-message" data-sort="date">Last message</th>
+          <th scope="col" data-column="actions">Actions</th>
         </tr>
       </thead>
       <tbody>
         {% for room in rooms %}
         <tr>
-          <td>{{ room.id }}</td>
-          <td>
+          <td data-column="id" data-label="ID">{{ room.id }}</td>
+          <td data-column="subject" data-label="Subject">
             <a href="/chat/{{ room.id }}">{{ room.subject | e }}</a>
             {% if is_staff and room.status == 'open' and (room.tech_participant_count is not defined or room.tech_participant_count == 0) %}
               <span class="badge badge--warning" title="No technician has joined this chat">Unattended</span>
             {% endif %}
           </td>
-          <td>
+          <td data-column="device" data-label="Device">{{ room.device_name or '—' }}</td>
+          <td data-column="company" data-label="Company">{{ room.company_name or '—' }}</td>
+          <td data-column="console-user" data-label="Console user">{{ room.console_user or '—' }}</td>
+          <td data-column="status" data-label="Status">
             <span class="badge badge--{% if room.status == 'open' %}operational{% else %}neutral{% endif %}">
               {{ room.status | capitalize }}
             </span>
           </td>
           {% if is_staff %}
-          <td>
+          <td data-column="assigned" data-label="Assigned to">
             {% if room.assigned_tech_display_name %}
               {{ room.assigned_tech_display_name | e }}
             {% elif room.assigned_tech_user_id %}
@@ -88,9 +157,9 @@
             {% endif %}
           </td>
           {% endif %}
-          <td>{{ room.created_at | default('—') }}</td>
-          <td>{{ room.last_message_at | default('—') }}</td>
-          <td class="table-actions">
+          <td data-column="created" data-label="Created">{{ room.created_at | default('—') }}</td>
+          <td data-column="last-message" data-label="Last message">{{ room.last_message_at | default('—') }}</td>
+          <td class="table-actions" data-column="actions" data-label="Actions">
             <a href="/chat/{{ room.id }}" class="button button--sm">Open</a>
             {% if is_staff and room.status == 'open' %}
               <button class="button button--sm button--secondary btn-assign-join"
@@ -134,6 +203,7 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="{{ url_for('static', path='js/chat_columns.js') }}" defer></script>
 <script>
 (function () {
   const openBtn = document.querySelector('[data-create-chat-modal-open]');

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -114,3 +114,22 @@ async def test_chat_index_show_closed_filter_includes_closed(monkeypatch):
     assert list_rooms.await_args.kwargs["status"] is None
     assert captured["template"] == "chat/index.html"
     assert captured["extra"]["show_closed_filter"] is True
+
+
+def test_chat_index_template_exposes_device_company_console_user_columns():
+    source = __import__('pathlib').Path('app/templates/chat/index.html').read_text()
+
+    assert 'data-column="device"' in source
+    assert 'data-column="company"' in source
+    assert 'data-column="console-user"' in source
+    assert 'data-chat-columns' in source
+    assert "js/chat_columns.js" in source
+
+
+def test_chat_room_list_query_includes_device_company_console_user_metadata():
+    source = __import__('pathlib').Path('app/repositories/chat.py').read_text()
+
+    assert 'AS device_name' in source
+    assert 'c.name AS company_name' in source
+    assert 'td.console_user AS console_user' in source
+    assert 'LEFT JOIN tray_devices td ON td.id = r.tray_device_id' in source


### PR DESCRIPTION
### Motivation
- Surface device, company and console-user metadata in the `/chat` room list so agents can see originating device and company context at a glance.
- Allow users to customise which chat columns are visible and persist those preferences in the browser.
- Provide an inline filter for the chat table to improve discoverability of sessions.

### Description
- Updated `app/repositories/chat.py` to include `device_name`, `company_name` and `console_user` in the `list_rooms` query and added `LEFT JOIN` clauses for `tray_devices`, `assets` and `companies` so room rows carry the new metadata.
- Updated `app/templates/chat/index.html` to add sortable `Device`, `Company`, and `Console user` columns, annotated table cells with `data-column`/`data-label` attributes, added a table filter input, and added a column-picker UI (wrapped in `data-chat-columns`), and included the new column script.
- Added `app/static/js/chat_columns.js`, a small client-side module that manages the column picker and persists visible column selections to `localStorage` under `portal.chat.columns`.
- Added regression assertions in `tests/test_chat_routes.py` to verify the template exposes the new `data-column` attributes and that the repository query contains the expected `AS device_name`, `c.name AS company_name`, `td.console_user AS console_user` and join for `tray_devices`.

### Testing
- Ran `pytest -q tests/test_chat_routes.py` and the tests passed (`4 passed`, with warnings only).
- Verified `python3 -m py_compile app/repositories/chat.py` to ensure no syntax errors, which succeeded.
- Ran `git diff --check` to confirm there are no whitespace/diff issues, which produced no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a79ca735c832da45761727988151d)