### PR TITLE
Show cached tray release on admin Tray devices page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5804,6 +5804,7 @@ async def admin_tray_devices_page(
         return RedirectResponse(url="/", status_code=303)
 
     from app.repositories import tray as tray_repo
+    from app.services import tray_installer as tray_installer_service
 
     devices = await tray_repo.list_devices(status=(status or None))
     if search:
@@ -5819,6 +5820,7 @@ async def admin_tray_devices_page(
         "devices": devices,
         "filters": {"search": search or "", "status": status or ""},
         "matrix_enabled": settings.matrix_enabled,
+        "tray_release": tray_installer_service.get_cached_latest_release_info(),
     }
     return await _render_template("admin/tray/devices.html", request, current_user, extra=extra)
 

--- a/app/services/tray_installer.py
+++ b/app/services/tray_installer.py
@@ -109,6 +109,67 @@ def _is_current(asset_name: str, metadata: dict[str, Any]) -> bool:
     )
 
 
+def _parse_release_version(tag_name: str | None) -> str | None:
+    """Return a display-friendly version from a GitHub release tag."""
+
+    if not tag_name:
+        return None
+    tag = str(tag_name).strip()
+    return tag[1:] if tag.lower().startswith("v") and len(tag) > 1 else tag
+
+
+def get_cached_latest_release_info() -> dict[str, Any]:
+    """Return metadata for the latest tray release currently cached on this server.
+
+    The server downloads installer assets from GitHub Releases and stores the
+    corresponding release metadata next to each asset.  This helper reads those
+    local metadata files only, so admin pages show the release actually loaded on
+    the MyPortal server instead of making an interactive GitHub request.
+    """
+
+    loaded_assets: list[dict[str, Any]] = []
+    latest: dict[str, Any] | None = None
+    for asset_name in _ASSET_NAMES:
+        metadata_file = _metadata_path(asset_name)
+        try:
+            metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        asset_path = _TRAY_STATIC_DIR / asset_name
+        if not asset_path.is_file():
+            continue
+
+        asset_info = {
+            "name": asset_name,
+            "size": metadata.get("asset_size"),
+            "updated_at": metadata.get("asset_updated_at"),
+            "download_url": metadata.get("download_url"),
+        }
+        loaded_assets.append(asset_info)
+
+        metadata_updated_at = str(metadata.get("asset_updated_at") or "")
+        latest_updated_at = str(latest.get("asset_updated_at") or "") if latest else ""
+        if latest is None or metadata_updated_at > latest_updated_at:
+            latest = metadata
+
+    if latest is None:
+        return {
+            "version": None,
+            "release_tag": None,
+            "loaded_assets": loaded_assets,
+        }
+
+    release_tag = latest.get("release_tag")
+    return {
+        "version": _parse_release_version(release_tag),
+        "release_tag": release_tag,
+        "release_id": latest.get("release_id"),
+        "asset_updated_at": latest.get("asset_updated_at"),
+        "loaded_assets": loaded_assets,
+    }
+
+
 async def fetch_latest_tray_installers(
     *,
     repo: str,

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -3186,6 +3186,33 @@ button.header-title-menu__link {
   margin: 1.5rem 0;
 }
 
+.info-grid {
+  display: grid;
+  gap: var(--space-gap-roomy);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.info-grid--compact {
+  margin: 0.85rem 0 1rem;
+}
+
+.info-grid__item {
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 0.85rem;
+  padding: 0.85rem 1rem;
+}
+
+.info-grid__label {
+  color: var(--text-muted, rgba(148, 163, 184, 0.85));
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.25rem;
+  text-transform: uppercase;
+}
+
 .filter-grid {
   display: grid;
   gap: var(--space-gap-roomy);

--- a/app/templates/admin/tray/devices.html
+++ b/app/templates/admin/tray/devices.html
@@ -16,6 +16,26 @@
   <section class="card card--panel">
     <header class="card__header card__header--stacked">
       <p class="card__lede">Endpoints that have enrolled with the MyPortal tray service. Use the menu configurations and install tokens pages to provision new fleets.</p>
+      <div class="info-grid info-grid--compact" aria-label="Tray release loaded on this server">
+        <div class="info-grid__item">
+          <span class="info-grid__label">Server tray app release</span>
+          <strong>{{ tray_release.version or 'Not loaded' }}</strong>
+          {% if tray_release.release_tag and tray_release.release_tag != tray_release.version %}
+            <span class="data-table__sub">GitHub tag {{ tray_release.release_tag }}</span>
+          {% endif %}
+        </div>
+        <div class="info-grid__item">
+          <span class="info-grid__label">Loaded installers</span>
+          <strong>{{ tray_release.loaded_assets|length }}</strong>
+          <span class="data-table__sub">
+            {% if tray_release.loaded_assets %}
+              {{ tray_release.loaded_assets | map(attribute='name') | join(', ') }}
+            {% else %}
+              No GitHub release assets are cached on this server yet.
+            {% endif %}
+          </span>
+        </div>
+      </div>
       <form method="get" class="filter-grid" id="tray-device-filter">
         <div class="form-field">
           <label class="form-label" for="filter-search">Search</label>

--- a/tests/test_tray_installer_cached_release.py
+++ b/tests/test_tray_installer_cached_release.py
@@ -1,0 +1,49 @@
+import json
+
+from app.services import tray_installer
+
+
+def test_get_cached_latest_release_info_reads_loaded_github_release(monkeypatch, tmp_path):
+    monkeypatch.setattr(tray_installer, "_TRAY_STATIC_DIR", tmp_path)
+
+    (tmp_path / "myportal-tray.msi").write_bytes(b"msi")
+    (tmp_path / "myportal-tray.msi.json").write_text(
+        json.dumps(
+            {
+                "release_id": 42,
+                "release_tag": "v1.2.3",
+                "asset_id": 101,
+                "asset_name": "myportal-tray.msi",
+                "asset_updated_at": "2026-06-23T01:02:03Z",
+                "asset_size": 3,
+                "download_url": "https://github.example/myportal-tray.msi",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    info = tray_installer.get_cached_latest_release_info()
+
+    assert info["version"] == "1.2.3"
+    assert info["release_tag"] == "v1.2.3"
+    assert info["release_id"] == 42
+    assert info["loaded_assets"] == [
+        {
+            "name": "myportal-tray.msi",
+            "size": 3,
+            "updated_at": "2026-06-23T01:02:03Z",
+            "download_url": "https://github.example/myportal-tray.msi",
+        }
+    ]
+
+
+def test_get_cached_latest_release_info_handles_no_loaded_assets(monkeypatch, tmp_path):
+    monkeypatch.setattr(tray_installer, "_TRAY_STATIC_DIR", tmp_path)
+
+    info = tray_installer.get_cached_latest_release_info()
+
+    assert info == {
+        "version": None,
+        "release_tag": None,
+        "loaded_assets": [],
+    }


### PR DESCRIPTION
### Motivation
- Admins need to see which Tray app release is actually loaded on the MyPortal server without performing live GitHub requests from the admin UI. 
- Displaying the locally cached release and assets improves transparency for rollout and avoids unnecessary external API calls.

### Description
- Added `get_cached_latest_release_info()` and `_parse_release_version()` in `app/services/tray_installer.py` to read local GitHub release metadata stored next to downloaded installer assets and compute a display-friendly version.
- Updated the admin route for `/admin/tray/devices` to include `tray_release` data from the new helper so pages show what the server has loaded.
- Rendered a compact responsive release summary on the Tray devices page showing the server-loaded release, GitHub tag, and cached installer asset names, and added shared `info-grid` CSS styles for the cards.
- Added a regression test `tests/test_tray_installer_cached_release.py` covering parsed release info and empty-cache handling.

### Testing
- Ran `pytest -q tests/test_tray_installer_cached_release.py tests/test_scheduler_tray_installer_update.py`, and both tests passed.
- Verified the new helper returns `None`/empty lists when no assets are cached and correctly parses a `vX.Y.Z` release tag into `X.Y.Z` when assets exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a7b376d60832da39cb1c83f48d1a9)