### PR TITLE
Add AI Search workspace and left-menu Search entry

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2953,6 +2953,19 @@ async def _extract_switch_company_payload(request: Request) -> dict[str, Any]:
     return data
 
 
+@app.get("/search", response_class=HTMLResponse)
+async def ai_search_page(request: Request):
+    user, redirect = await _require_authenticated_user(request)
+    if redirect:
+        return redirect
+    return await _render_template(
+        "search.html",
+        request,
+        user,
+        extra={"title": "AI Search"},
+    )
+
+
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
     user, redirect = await _require_authenticated_user(request)

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10488,3 +10488,21 @@ a.stat-strip__stat:focus-visible {
 .staff-custom-fields-table .table__actions .button {
   width: 100%;
 }
+
+.search-workspace {
+  max-width: 1100px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.search-workspace__textarea {
+  min-height: 8rem;
+  resize: vertical;
+  line-height: 1.5;
+}
+
+@media (max-width: 720px) {
+  .search-workspace {
+    margin: 0;
+  }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -156,6 +156,16 @@
             </a>
           </li>
           {% endif %}
+          {% if has_authenticated_user %}
+          <li class="menu__item">
+            <a href="/search" {% if current_path.startswith('/search') %}aria-current="page"{% endif %}>
+              <span class="menu__icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" focusable="false"><path d="M10.5 3a7.5 7.5 0 0 1 5.96 12.06l4.24 4.24a1 1 0 0 1-1.4 1.4l-4.24-4.24A7.5 7.5 0 1 1 10.5 3Zm0 2a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11Zm.88 2.52.52 1.58 1.58.52a.5.5 0 0 1 0 .96l-1.58.52-.52 1.58a.5.5 0 0 1-.96 0l-.52-1.58-1.58-.52a.5.5 0 0 1 0-.96l1.58-.52.52-1.58a.5.5 0 0 1 .96 0Z"/></svg>
+              </span>
+              <span class="menu__label">Search</span>
+            </a>
+          </li>
+          {% endif %}
           {% if can_access_service_status %}
           <li class="menu__item">
             <a href="/service-status" {% if current_path.startswith('/service-status') %}aria-current="page"{% endif %}>

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+{% from "macros/header.html" import page_header_actions %}
+
+{% block title %}AI Search{% endblock %}
+
+{% block header_title %}
+  <div class="header__title-content header__title-content--stacked">
+    <span class="header__title-text">AI Search</span>
+    <span class="header__title-meta">Search permitted portal content using natural language.</span>
+  </div>
+{% endblock %}
+
+{% block header_actions %}
+  {{ page_header_actions([
+    {"label": "Create ticket", "type": "link", "href": "/tickets", "variant": "ghost"},
+    {"label": "Knowledge base", "type": "link", "href": "/knowledge-base", "variant": "ghost"}
+  ]) }}
+{% endblock %}
+
+{% block content %}
+<section class="dashboard__section dashboard__section--agent search-workspace" aria-labelledby="ai-search-heading">
+  <article class="card card--panel agent-panel" data-agent-panel>
+    <header class="agent-panel__header">
+      <h2 id="ai-search-heading" class="agent-panel__title">Search accessible content</h2>
+      <p class="agent-panel__subtitle">
+        Ask a question in plain English. The assistant only searches records already permitted for your account,
+        such as visible knowledge base articles, your accessible tickets, and shop content available to your company.
+      </p>
+    </header>
+
+    <form class="agent-panel__form" data-agent-form>
+      <label class="agent-panel__label" for="agent-search-query">What are you looking for?</label>
+      <div class="agent-panel__controls">
+        <textarea
+          id="agent-search-query"
+          class="agent-panel__input search-workspace__textarea"
+          name="query"
+          rows="4"
+          maxlength="2000"
+          placeholder="For example: show me recent VPN tickets, password reset guidance, or available laptop bundles"
+          required
+          data-agent-input
+        ></textarea>
+        <button class="button button--primary agent-panel__submit" type="submit" data-agent-submit>
+          Search
+        </button>
+      </div>
+      <p class="agent-panel__hint">
+        Results are generated through the configured Ollama, llama.cpp, or OpenAI-compatible integration and include the source records used.
+      </p>
+    </form>
+
+    <div class="agent-panel__status" role="status" aria-live="polite" data-agent-status></div>
+
+    <section class="agent-panel__results" hidden data-agent-results>
+      <article class="agent-answer" hidden data-agent-answer>
+        <h3 class="agent-answer__heading">Answer</h3>
+        <div class="agent-answer__body" data-agent-answer-body></div>
+      </article>
+
+      <article class="agent-sources" hidden data-agent-sources>
+        <h3 class="agent-sources__heading">Permitted sources searched</h3>
+        <div class="agent-sources__lists" data-agent-source-lists></div>
+      </article>
+
+      <div class="agent-panel__actions">
+        <a class="button button--ghost" href="/tickets" hidden data-agent-create-ticket>Create a support ticket</a>
+      </div>
+    </section>
+  </article>
+</section>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ static_url('/static/js/agent.js') }}" defer></script>
+{% endblock %}

--- a/docs/wiki/administration/Agent Setup.md
+++ b/docs/wiki/administration/Agent Setup.md
@@ -20,7 +20,7 @@ The MyPortal agent provides a permission-aware assistant that searches knowledge
 
 ## Using the agent
 
-- The dashboard now includes an **Agent** panel above the existing overview cards. Enter a question such as _"How do I reset the VPN appliance?"_ to search for matching knowledge base articles, your own tickets, and relevant product recommendations.
+- The left menu includes **Search**, which opens the AI Search workspace at `/search`. Enter a question such as _"How do I reset the VPN appliance?"_ to search for matching knowledge base articles, your own accessible tickets, and relevant product recommendations.
 - Results show a structured answer (rendered in Markdown-style text) followed by cited sources. Source identifiers use `[KB:slug]`, `[Ticket:#id]`, or `[Product:SKU]` markers.
 - The agent only operates on data available to the current user:
   - Knowledge base visibility is enforced through the existing permission scopes.

--- a/wiki/Agent.md
+++ b/wiki/Agent.md
@@ -23,7 +23,7 @@ The MyPortal agent provides a permission-aware assistant that searches knowledge
 
 ## Using the agent
 
-- The dashboard now includes an **Agent** panel above the existing overview cards. Enter a question such as _"How do I reset the VPN appliance?"_ to search for matching knowledge base articles, your own tickets, and relevant product recommendations.
+- The left menu includes **Search**, which opens the AI Search workspace at `/search`. Enter a question such as _"How do I reset the VPN appliance?"_ to search for matching knowledge base articles, your own accessible tickets, and relevant product recommendations.
 - Results show a structured answer (rendered in Markdown-style text) followed by cited sources. Source identifiers use `[KB:slug]`, `[Ticket:#id]`, or `[Product:SKU]` markers.
 - The agent only operates on data available to the current user:
   - Knowledge base visibility is enforced through the existing permission scopes.


### PR DESCRIPTION
### Motivation
- Provide users with a permission-aware, natural-language search workspace that leverages the existing Ollama/OpenAI/llama.cpp integrations to surface only records they are permitted to see.
- Surface the feature in the standard 3-part layout by adding a left-menu entry so authenticated users can easily open the AI Search workspace.

### Description
- Added an authenticated page at `GET /search` which renders `app/templates/search.html` and reuses the existing `agent.js` frontend to call the existing `/api/agent/query` API. 
- Inserted a left-menu `Search` item visible to signed-in users in `app/templates/base.html` and included an SVG icon and active-route highlighting for `/search`.
- Created `app/templates/search.html` implementing the three-part layout panel, input textarea, results/answers/sources areas and a create-ticket action tied to the agent UI.
- Added responsive CSS rules in `app/static/css/app.css` for the search workspace and textarea, and updated agent documentation in `wiki/Agent.md` and `docs/wiki/administration/Agent Setup.md` to reference the new workspace.

### Testing
- Verified Python syntax by running `python -m py_compile app/main.py app/api/routes/agent.py app/services/agent.py`, which succeeded. 
- Ran `pytest -q tests/services/test_service_status_ai_lookup.py` to ensure agent/service-status related behaviors remain intact, and the test suite passed. 
- Ran `pytest -q tests/services/test_service_status_ai_lookup.py tests/test_section_permissions.py` where `tests/test_section_permissions.py::test_build_base_context_includes_cart_permission` previously surfaced an unrelated `Database pool not initialised` failure during a run; this appears unrelated to the changes made here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a7aad64d0832d840f01ae25dba303)