### PR TITLE
Add bulk Tactical RMM sync UI for Tray install tokens

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5963,6 +5963,7 @@ async def admin_tray_install_tokens_page(
 
     from app.repositories import tray as tray_repo
     from app.repositories import companies as companies_repo
+    from app.services import tray as tray_service
 
     tokens = await tray_repo.list_install_tokens()
     hidden_revoked_count = 0
@@ -5984,6 +5985,7 @@ async def admin_tray_install_tokens_page(
         "new_token": new_token,
         "now_iso": datetime.now(timezone.utc).isoformat(),
         "portal_url": portal_url,
+        "trmm_token_field_name": tray_service.trmm_client_token_field_name(),
     }
     return await _render_template(
         "admin/tray/install_tokens.html", request, current_user, extra=extra
@@ -6027,6 +6029,54 @@ async def admin_tray_revoke_install_token(token_id: int, request: Request):
 
     await tray_repo.revoke_install_token(token_id)
     return RedirectResponse(url="/admin/tray/install-tokens", status_code=303)
+
+
+@app.post("/admin/tray/install-tokens/sync-tactical-rmm", response_class=HTMLResponse)
+async def admin_tray_sync_install_tokens_to_tactical_rmm(request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    from app.services import modules as modules_service
+    from app.services import tray as tray_service
+
+    try:
+        await modules_service.ensure_tacticalrmm_ready()
+    except ValueError as exc:
+        log_error("Unable to sync tray tokens to Tactical RMM", error=str(exc))
+        return flash_redirect("/admin/tray/install-tokens", str(exc), "error")
+
+    task_id = uuid4().hex
+
+    async def _on_success(summary: Mapping[str, Any]) -> None:
+        log_info(
+            "Tactical RMM tray token sync completed",
+            task_id=task_id,
+            processed=summary.get("processed"),
+            updated=summary.get("updated"),
+            skipped=len(summary.get("skipped") or []),
+            errors=len(summary.get("errors") or []),
+        )
+
+    async def _on_error(exc: Exception) -> None:
+        log_error("Tactical RMM tray token sync failed", task_id=task_id, error=str(exc))
+
+    user_id = int(current_user["id"]) if current_user.get("id") is not None else None
+    background_tasks.queue_background_task(
+        lambda: tray_service.sync_all_company_trmm_tray_tokens(
+            created_by_user_id=user_id
+        ),
+        task_id=task_id,
+        description="tacticalrmm-tray-token-sync",
+        on_complete=_on_success,
+        on_error=_on_error,
+    )
+
+    return flash_redirect(
+        "/admin/tray/install-tokens",
+        f"Tactical RMM tray token sync queued. Task ID: {task_id[:8]}",
+        "success",
+    )
 
 
 @app.get("/admin/tray/configurations", response_class=HTMLResponse)

--- a/app/templates/admin/tray/install_tokens.html
+++ b/app/templates/admin/tray/install_tokens.html
@@ -61,6 +61,15 @@ sudo installer -pkg /tmp/myportal-tray.pkg -target /</code></pre>
           </div>
         </div>
       </form>
+
+      <div class="callout callout--info">
+        <h2 class="callout__title">Bulk Tactical RMM sync</h2>
+        <p>Generate missing company-scoped tray install tokens and publish the new token values to the Tactical RMM client custom field <code>{{ trmm_token_field_name }}</code>. Companies without a Tactical RMM client ID are skipped, and existing token values are not re-sent because MyPortal only stores their hashes.</p>
+        <form method="post" action="/admin/tray/install-tokens/sync-tactical-rmm" class="inline-form">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+          <button type="submit" class="button button--secondary" data-confirm="Generate missing tray install tokens and sync them to Tactical RMM?">Generate missing tokens and sync to Tactical RMM</button>
+        </form>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
### Motivation
- Provide super-admins a way to bulk-generate missing company-scoped Tray install tokens and publish them into Tactical RMM client custom fields without manual per-company work. 
- Surface the configured Tactical RMM custom-field name in the Tray install tokens UI so admins know which field is written.

### Description
- Added a POST admin endpoint `/admin/tray/install-tokens/sync-tactical-rmm` that validates Tactical RMM module readiness, queues the existing `tray_service.sync_all_company_trmm_tray_tokens` background job, and logs completion/errors; the route enforces super-admin access via `_require_super_admin_page` (file: `app/main.py`).
- Injected the Tactical RMM client token custom-field name into the Tray install tokens template context via `tray_service.trmm_client_token_field_name()` so the UI displays the configured field name (file: `app/main.py`).
- Added a callout and an inline form/button to the Tray install tokens admin page that triggers the new POST endpoint and includes a confirmation prompt (file: `app/templates/admin/tray/install_tokens.html`).
- The endpoint returns user-visible flash messages on success/error and records a short background task ID for reference.

### Testing
- Ran `python -m py_compile app/main.py` which succeeded without syntax errors.
- Ran `git diff --check` which reported no whitespace/patch issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b14e15aa48332bbd1cba5652261f9)