### PR TITLE
Fix Tactical RMM tray token sync (use PUT)

### DIFF
--- a/app/services/tray.py
+++ b/app/services/tray.py
@@ -217,9 +217,13 @@ async def update_trmm_client_token_field(
         # name-based fallback so the sync still works on APIs that accept names.
         custom_field_payload = {"name": custom_field_name, "string_value": token}
 
-    body = {"custom_fields": [custom_field_payload]}
+    # Tactical RMM's client update API is implemented as ``put`` (not
+    # ``patch``) and expects a top-level ``client`` object even when only
+    # custom fields are being updated.  Sending PATCH here causes TRMM to
+    # return HTTP 405: ``Method \"PATCH\" not allowed.``
+    body = {"client": {}, "custom_fields": [custom_field_payload]}
     return await tacticalrmm_service._call_endpoint(
-        f"/clients/{client_id}/", method="PATCH", body=body
+        f"/clients/{client_id}/", method="PUT", body=body
     )
 
 

--- a/tests/test_tray_trmm_token_sync.py
+++ b/tests/test_tray_trmm_token_sync.py
@@ -1,0 +1,69 @@
+import asyncio
+
+from app.services import tray
+
+
+def test_update_trmm_client_token_field_uses_trmm_put_payload(monkeypatch):
+    calls = []
+
+    async def fake_call_endpoint(endpoint, *, method="GET", body=None):
+        calls.append({"endpoint": endpoint, "method": method, "body": body})
+        if method == "GET":
+            return {
+                "id": 42,
+                "name": "Acme",
+                "custom_fields": [
+                    {"field": 7, "name": "MyPortalToken", "string_value": "old"}
+                ],
+            }
+        return {"status": "ok"}
+
+    from app.services import tacticalrmm
+
+    monkeypatch.setattr(tacticalrmm, "_call_endpoint", fake_call_endpoint)
+
+    result = asyncio.run(
+        tray.update_trmm_client_token_field(trmm_client_id=42, token="new-token")
+    )
+
+    assert result == {"status": "ok"}
+    assert calls == [
+        {"endpoint": "/clients/42/", "method": "GET", "body": None},
+        {
+            "endpoint": "/clients/42/",
+            "method": "PUT",
+            "body": {
+                "client": {},
+                "custom_fields": [{"field": 7, "string_value": "new-token"}],
+            },
+        },
+    ]
+
+
+def test_update_trmm_client_token_field_put_payload_allows_name_fallback(monkeypatch):
+    calls = []
+
+    async def fake_call_endpoint(endpoint, *, method="GET", body=None):
+        calls.append({"endpoint": endpoint, "method": method, "body": body})
+        if method == "GET":
+            return {"id": 42, "name": "Acme", "custom_fields": []}
+        return {"status": "ok"}
+
+    from app.services import tacticalrmm
+
+    monkeypatch.setattr(tacticalrmm, "_call_endpoint", fake_call_endpoint)
+
+    asyncio.run(
+        tray.update_trmm_client_token_field(
+            trmm_client_id="42", token="new-token", field_name="Portal Token"
+        )
+    )
+
+    assert calls[-1] == {
+        "endpoint": "/clients/42/",
+        "method": "PUT",
+        "body": {
+            "client": {},
+            "custom_fields": [{"name": "Portal Token", "string_value": "new-token"}],
+        },
+    }


### PR DESCRIPTION
### Motivation
- Tactical RMM rejects `PATCH` updates to the client resource with HTTP 405 (`Method "PATCH" not allowed`) when updating client custom fields, and its API expects a top-level `client` object even when only custom fields change.

### Description
- Change the Tactical RMM client update call in `app/services/tray.py` to send a payload containing `{"client": {}, "custom_fields": [...]}` and use `method="PUT"` instead of `PATCH`.
- Preserve the existing fallback behaviour which writes either a custom field `id` (`{"field": id, "string_value": token}`) or a name-based payload (`{"name": field_name, "string_value": token}`).
- Add regression tests in `tests/test_tray_trmm_token_sync.py` that assert the `GET` then `PUT` sequence and validate both the custom-field-id and name-fallback payloads.

### Testing
- Ran `pytest -q tests/test_tray_trmm_token_sync.py`, which executed the two new tests and they passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b1715f5d88332aab4bfedbd030c96)