### PR TITLE
Expand agent /search to include companies and issues

### DIFF
--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -78,6 +78,28 @@ class AgentSourceAsset(BaseModel):
     last_sync: Optional[str] = None
 
 
+class AgentSourceCompany(BaseModel):
+    id: int
+    name: str
+    syncro_company_id: Optional[str] = None
+
+
+class AgentSourceIssueAssignment(BaseModel):
+    company_id: Optional[int] = None
+    company_name: Optional[str] = None
+    status: Optional[str] = None
+    status_label: Optional[str] = None
+
+
+class AgentSourceIssue(BaseModel):
+    id: int
+    name: str
+    slug: Optional[str] = None
+    description: Optional[str] = None
+    updated_at: Optional[str] = None
+    assignments: list[AgentSourceIssueAssignment] = Field(default_factory=list)
+
+
 class AgentSourceFeaturePackItem(BaseModel):
     title: str
     summary: Optional[str] = None
@@ -94,6 +116,8 @@ class AgentSources(BaseModel):
     chats: list[AgentSourceChat] = Field(default_factory=list)
     orders: list[AgentSourceOrder] = Field(default_factory=list)
     assets: list[AgentSourceAsset] = Field(default_factory=list)
+    companies: list[AgentSourceCompany] = Field(default_factory=list)
+    issues: list[AgentSourceIssue] = Field(default_factory=list)
     feature_packs: dict[str, list[AgentSourceFeaturePackItem]] = Field(
         default_factory=dict
     )

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -100,6 +100,46 @@ class AgentSourceIssue(BaseModel):
     assignments: list[AgentSourceIssueAssignment] = Field(default_factory=list)
 
 
+class AgentSourceServiceStatus(BaseModel):
+    id: int
+    name: str
+    status: Optional[str] = None
+    status_message: Optional[str] = None
+    description: Optional[str] = None
+
+
+class AgentSourceBackupJob(BaseModel):
+    id: int
+    company_id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    latest_status: Optional[str] = None
+    today_status: Optional[str] = None
+
+
+class AgentSourceReport(BaseModel):
+    key: str
+    title: str
+    description: Optional[str] = None
+    source_type: Optional[str] = None
+
+
+class AgentSourceMailbox(BaseModel):
+    user_principal_name: str
+    display_name: str
+    mailbox_type: Optional[str] = None
+    company_id: Optional[int] = None
+    storage_used_bytes: Optional[int] = None
+
+
+class AgentSourceBestPractice(BaseModel):
+    check_id: str
+    check_name: str
+    status: Optional[str] = None
+    details: Optional[str] = None
+    company_id: Optional[int] = None
+
+
 class AgentSourceFeaturePackItem(BaseModel):
     title: str
     summary: Optional[str] = None
@@ -118,6 +158,11 @@ class AgentSources(BaseModel):
     assets: list[AgentSourceAsset] = Field(default_factory=list)
     companies: list[AgentSourceCompany] = Field(default_factory=list)
     issues: list[AgentSourceIssue] = Field(default_factory=list)
+    service_status: list[AgentSourceServiceStatus] = Field(default_factory=list)
+    backup_jobs: list[AgentSourceBackupJob] = Field(default_factory=list)
+    reports: list[AgentSourceReport] = Field(default_factory=list)
+    mailboxes: list[AgentSourceMailbox] = Field(default_factory=list)
+    best_practices: list[AgentSourceBestPractice] = Field(default_factory=list)
     feature_packs: dict[str, list[AgentSourceFeaturePackItem]] = Field(
         default_factory=dict
     )

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -11,6 +11,7 @@ from app.core.logging import log_error
 from app.repositories import shop as shop_repo
 from app.repositories import tickets as tickets_repo
 from app.services import company_access
+from app.services import issues as issues_service
 from app.services import knowledge_base as knowledge_base_service
 from app.services import modules as modules_service
 
@@ -22,6 +23,8 @@ _CHAT_RESULT_LIMIT = 5
 _ORDER_RESULT_LIMIT = 5
 _ASSET_RESULT_LIMIT = 5
 _FEATURE_PACK_RESULT_LIMIT = 5
+_COMPANY_RESULT_LIMIT = 5
+_ISSUE_RESULT_LIMIT = 5
 _MAX_SNIPPET_LENGTH = 320
 
 
@@ -123,6 +126,76 @@ def _coerce_user_id(user: Mapping[str, Any]) -> int:
         return int(user.get("id") or 0)
     except (TypeError, ValueError):
         return 0
+
+
+def _search_company_sources(
+    query: str, memberships: Sequence[Mapping[str, Any]]
+) -> list[dict[str, Any]]:
+    needle = query.casefold()
+    matches: list[dict[str, Any]] = []
+    for membership in memberships:
+        try:
+            company_id = int(membership.get("company_id") or membership.get("id"))
+        except (TypeError, ValueError):
+            continue
+        name = str(
+            membership.get("company_name") or membership.get("name") or ""
+        ).strip()
+        syncro_id = str(membership.get("syncro_company_id") or "").strip()
+        searchable = " ".join(
+            part for part in (name, syncro_id, str(company_id)) if part
+        ).casefold()
+        if needle not in searchable:
+            continue
+        matches.append(
+            {
+                "id": company_id,
+                "name": name or f"Company #{company_id}",
+                "syncro_company_id": syncro_id or None,
+            }
+        )
+        if len(matches) >= _COMPANY_RESULT_LIMIT:
+            break
+    return matches
+
+
+async def _search_issue_sources(
+    query: str,
+    *,
+    memberships: Sequence[Mapping[str, Any]],
+    company_ids: Sequence[int],
+    is_super_admin: bool,
+) -> list[dict[str, Any]]:
+    if not _has_membership_flag(
+        memberships, "can_manage_issues", is_super_admin=is_super_admin
+    ):
+        return []
+    overviews = await issues_service.build_issue_overview(
+        search=query.strip().lower(),
+        company_ids=company_ids or None,
+    )
+    sources: list[dict[str, Any]] = []
+    for overview in overviews[:_ISSUE_RESULT_LIMIT]:
+        assignments = [
+            {
+                "company_id": assignment.company_id,
+                "company_name": assignment.company_name,
+                "status": assignment.status,
+                "status_label": assignment.status_label,
+            }
+            for assignment in overview.assignments[:3]
+        ]
+        sources.append(
+            {
+                "id": overview.issue_id,
+                "name": overview.name,
+                "slug": overview.slug,
+                "description": _truncate(overview.description),
+                "updated_at": overview.updated_at_iso,
+                "assignments": assignments,
+            }
+        )
+    return sources
 
 
 async def _search_chat_sources(
@@ -367,6 +440,8 @@ async def execute_agent_query(
                 "chats": [],
                 "orders": [],
                 "assets": [],
+                "companies": [],
+                "issues": [],
                 "feature_packs": {},
             },
             "context": {"companies": []},
@@ -456,6 +531,10 @@ async def execute_agent_query(
     chat_sources: list[dict[str, Any]] = []
     order_sources: list[dict[str, Any]] = []
     asset_sources: list[dict[str, Any]] = []
+    company_sources: list[dict[str, Any]] = _search_company_sources(
+        query_text, resolved_memberships
+    )
+    issue_sources: list[dict[str, Any]] = []
     feature_pack_sources: dict[str, list[dict[str, Any]]] = {}
     include_products = _can_access_shop(
         resolved_memberships, is_super_admin=is_super_admin
@@ -615,6 +694,17 @@ async def execute_agent_query(
                 }
             )
 
+    try:
+        issue_sources = await _search_issue_sources(
+            query_text,
+            memberships=resolved_memberships,
+            company_ids=accessible_company_ids,
+            is_super_admin=is_super_admin,
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        log_error("Agent issue lookup failed", error=str(exc))
+        issue_sources = []
+
     feature_pack_sources = await _search_feature_pack_sources(
         query_text,
         user=user,
@@ -633,6 +723,8 @@ async def execute_agent_query(
         or chat_sources
         or order_sources
         or asset_sources
+        or company_sources
+        or issue_sources
         or any(feature_pack_sources.values())
     )
 
@@ -642,7 +734,7 @@ async def execute_agent_query(
         "explicitly state that you don't have that specific information available and suggest creating a support ticket.",
         "Do NOT suggest unrelated articles or products - only reference sources that directly answer the question.",
         "Never reference systems, data, or permissions outside the provided information.",
-        "Use Markdown and cite sources inline with [KB:slug], [Ticket:#id], [Product:SKU], [Chat:#id], [Order:number], or [Asset:#id].",
+        "Use Markdown and cite sources inline with [KB:slug], [Ticket:#id], [Product:SKU], [Chat:#id], [Order:number], [Asset:#id], [Company:#id], or [Issue:#id].",
         f"User query: {query_text}",
         "",
     ]
@@ -713,6 +805,33 @@ async def execute_agent_query(
             ):
                 if asset.get(key):
                     parts.append(f"{label}: {asset[key]}")
+            context_sections.append("- " + " — ".join(parts))
+        context_sections.append("")
+
+    if company_sources:
+        context_sections.append("Companies accessible to the user:")
+        for company in company_sources:
+            parts = [f"[Company:#{company['id']}] {company['name']}"]
+            if company.get("syncro_company_id"):
+                parts.append(f"Syncro ID: {company['syncro_company_id']}")
+            context_sections.append("- " + " — ".join(parts))
+        context_sections.append("")
+
+    if issue_sources:
+        context_sections.append("Issues accessible to the user:")
+        for issue in issue_sources:
+            parts = [f"[Issue:#{issue['id']}] {issue['name']}"]
+            if issue.get("description"):
+                parts.append(issue["description"])
+            assignment_labels = [
+                (
+                    f"{assignment.get('company_name') or assignment.get('company_id')}: "
+                    f"{assignment.get('status_label') or assignment.get('status')}"
+                )
+                for assignment in issue.get("assignments", [])
+            ]
+            if assignment_labels:
+                parts.append("Assignments: " + ", ".join(assignment_labels))
             context_sections.append("- " + " — ".join(parts))
         context_sections.append("")
 
@@ -836,6 +955,8 @@ async def execute_agent_query(
             "chats": chat_sources,
             "orders": order_sources,
             "assets": asset_sources,
+            "companies": company_sources,
+            "issues": issue_sources,
             "feature_packs": feature_pack_sources,
         },
         "context": {"companies": company_context},

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -8,10 +8,14 @@ from typing import Any, Mapping, Sequence
 from app.core.database import db
 from app.core.features import get_registry, module_name_for_slug
 from app.core.logging import log_error
+from app.repositories import m365_best_practices as m365_bp_repo
+from app.repositories import reporting as reporting_repo
 from app.repositories import shop as shop_repo
 from app.repositories import tickets as tickets_repo
 from app.services import company_access
+from app.services import backup_jobs as backup_jobs_service
 from app.services import issues as issues_service
+from app.services import reports as reports_service
 from app.services import knowledge_base as knowledge_base_service
 from app.services import modules as modules_service
 
@@ -25,6 +29,7 @@ _ASSET_RESULT_LIMIT = 5
 _FEATURE_PACK_RESULT_LIMIT = 5
 _COMPANY_RESULT_LIMIT = 5
 _ISSUE_RESULT_LIMIT = 5
+_SYSTEM_RESULT_LIMIT = 5
 _MAX_SNIPPET_LENGTH = 320
 
 
@@ -195,6 +200,229 @@ async def _search_issue_sources(
                 "assignments": assignments,
             }
         )
+    return sources
+
+
+def _matches_query(query: str, *values: Any) -> bool:
+    needle = query.casefold()
+    return needle in " ".join(str(value or "") for value in values).casefold()
+
+
+async def _search_service_status_sources(
+    query: str, *, company_ids: Sequence[int], is_super_admin: bool
+) -> list[dict[str, Any]]:
+    if not is_super_admin and not company_ids:
+        return []
+    rows = await db.fetch_all(
+        """
+        SELECT s.id, s.name, s.description, s.status, s.status_message, s.updated_at
+        FROM service_status_services s
+        WHERE s.is_active = 1
+          AND (
+              ? = 1
+              OR NOT EXISTS (
+                  SELECT 1 FROM service_status_service_companies sc
+                  WHERE sc.service_id = s.id
+              )
+              OR EXISTS (
+                  SELECT 1 FROM service_status_service_companies sc
+                  WHERE sc.service_id = s.id AND sc.company_id IN ({placeholders})
+              )
+          )
+          AND (s.name LIKE ? OR s.description LIKE ? OR s.status LIKE ? OR s.status_message LIKE ?)
+        ORDER BY s.display_order ASC, s.name ASC
+        LIMIT ?
+        """.format(placeholders=", ".join(["?"] * len(company_ids)) or "NULL"),
+        (
+            1 if is_super_admin else 0,
+            *company_ids,
+            f"%{query}%",
+            f"%{query}%",
+            f"%{query}%",
+            f"%{query}%",
+            _SYSTEM_RESULT_LIMIT,
+        ),
+    )
+    return [
+        {
+            "id": row.get("id"),
+            "name": row.get("name") or f"Service #{row.get('id')}",
+            "description": _truncate(row.get("description")),
+            "status": row.get("status"),
+            "status_message": _truncate(row.get("status_message")),
+        }
+        for row in rows or []
+    ]
+
+
+async def _search_backup_job_sources(
+    query: str, *, company_ids: Sequence[int], is_super_admin: bool
+) -> list[dict[str, Any]]:
+    sources: list[dict[str, Any]] = []
+    scoped_ids: Sequence[int | None]
+    if company_ids:
+        scoped_ids = company_ids
+    elif is_super_admin:
+        scoped_ids = [None]
+    else:
+        return []
+    for company_id in scoped_ids:
+        jobs = await backup_jobs_service.list_jobs_with_latest(
+            company_id=company_id, include_inactive=is_super_admin
+        )
+        for job in jobs:
+            if not _matches_query(
+                query,
+                job.get("name"),
+                job.get("description"),
+                job.get("latest_status"),
+                job.get("today_status"),
+            ):
+                continue
+            sources.append(
+                {
+                    "id": job.get("id"),
+                    "company_id": job.get("company_id"),
+                    "name": job.get("name") or f"Backup job #{job.get('id')}",
+                    "description": _truncate(job.get("description")),
+                    "latest_status": job.get("latest_status"),
+                    "today_status": job.get("today_status"),
+                }
+            )
+            if len(sources) >= _SYSTEM_RESULT_LIMIT:
+                return sources
+    return sources
+
+
+def _search_company_report_sources(query: str) -> list[dict[str, Any]]:
+    sources: list[dict[str, Any]] = []
+    for section in reports_service.REPORT_SECTIONS:
+        if not _matches_query(query, section.key, section.label, section.description):
+            continue
+        sources.append(
+            {
+                "key": section.key,
+                "title": section.label,
+                "description": _truncate(section.description),
+                "source_type": "company_report_section",
+            }
+        )
+        if len(sources) >= _SYSTEM_RESULT_LIMIT:
+            break
+    return sources
+
+
+async def _search_reporting_query_sources(
+    query: str, *, user: Mapping[str, Any], is_super_admin: bool
+) -> list[dict[str, Any]]:
+    user_id = _coerce_user_id(user)
+    if not is_super_admin and user_id <= 0:
+        return []
+    queries = await reporting_repo.list_queries_for_user(
+        user_id, include_all=is_super_admin
+    )
+    sources: list[dict[str, Any]] = []
+    for report in queries:
+        if not _matches_query(
+            query, report.get("name"), report.get("slug"), report.get("description")
+        ):
+            continue
+        sources.append(
+            {
+                "key": str(report.get("slug") or report.get("id")),
+                "title": report.get("name") or f"Report #{report.get('id')}",
+                "description": _truncate(report.get("description")),
+                "source_type": "reporting_query",
+            }
+        )
+        if len(sources) >= _SYSTEM_RESULT_LIMIT:
+            break
+    return sources
+
+
+async def _search_mailbox_sources(
+    query: str, *, memberships: Sequence[Mapping[str, Any]], company_ids: Sequence[int], is_super_admin: bool
+) -> list[dict[str, Any]]:
+    can_user = _has_membership_flag(
+        memberships, "can_view_m365_user_mailboxes", is_super_admin=is_super_admin
+    )
+    can_shared = _has_membership_flag(
+        memberships, "can_view_m365_shared_mailboxes", is_super_admin=is_super_admin
+    )
+    if (not can_user and not can_shared) or not company_ids:
+        return []
+    mailbox_types = []
+    if can_user:
+        mailbox_types.append("UserMailbox")
+    if can_shared:
+        mailbox_types.append("SharedMailbox")
+    placeholders_companies = ", ".join(["?"] * len(company_ids)) or "NULL"
+    placeholders_types = ", ".join(["?"] * len(mailbox_types))
+    rows = await db.fetch_all(
+        f"""
+        SELECT company_id, user_principal_name, display_name, mailbox_type, storage_used_bytes
+        FROM m365_mailboxes
+        WHERE company_id IN ({placeholders_companies})
+          AND mailbox_type IN ({placeholders_types})
+          AND (user_principal_name LIKE ? OR display_name LIKE ? OR mailbox_type LIKE ?)
+        ORDER BY display_name ASC
+        LIMIT ?
+        """,
+        (
+            *company_ids,
+            *mailbox_types,
+            f"%{query}%",
+            f"%{query}%",
+            f"%{query}%",
+            _SYSTEM_RESULT_LIMIT,
+        ),
+    )
+    return [
+        {
+            "company_id": row.get("company_id"),
+            "user_principal_name": row.get("user_principal_name"),
+            "display_name": row.get("display_name") or row.get("user_principal_name"),
+            "mailbox_type": row.get("mailbox_type"),
+            "storage_used_bytes": row.get("storage_used_bytes"),
+        }
+        for row in rows or []
+        if row.get("user_principal_name")
+    ]
+
+
+async def _search_best_practice_sources(
+    query: str, *, memberships: Sequence[Mapping[str, Any]], company_ids: Sequence[int], is_super_admin: bool
+) -> list[dict[str, Any]]:
+    if (
+        not _has_membership_flag(
+            memberships, "can_view_m365_best_practices", is_super_admin=is_super_admin
+        )
+        or not company_ids
+    ):
+        return []
+    sources: list[dict[str, Any]] = []
+    for company_id in company_ids:
+        results = await m365_bp_repo.list_results(company_id)
+        for result in results:
+            if not _matches_query(
+                query,
+                result.get("check_id"),
+                result.get("check_name"),
+                result.get("status"),
+                result.get("details"),
+            ):
+                continue
+            sources.append(
+                {
+                    "company_id": company_id,
+                    "check_id": result.get("check_id"),
+                    "check_name": result.get("check_name") or result.get("check_id"),
+                    "status": result.get("status"),
+                    "details": _truncate(result.get("details")),
+                }
+            )
+            if len(sources) >= _SYSTEM_RESULT_LIMIT:
+                return sources
     return sources
 
 
@@ -442,6 +670,11 @@ async def execute_agent_query(
                 "assets": [],
                 "companies": [],
                 "issues": [],
+                "service_status": [],
+                "backup_jobs": [],
+                "reports": [],
+                "mailboxes": [],
+                "best_practices": [],
                 "feature_packs": {},
             },
             "context": {"companies": []},
@@ -535,6 +768,11 @@ async def execute_agent_query(
         query_text, resolved_memberships
     )
     issue_sources: list[dict[str, Any]] = []
+    service_status_sources: list[dict[str, Any]] = []
+    backup_job_sources: list[dict[str, Any]] = []
+    report_sources: list[dict[str, Any]] = []
+    mailbox_sources: list[dict[str, Any]] = []
+    best_practice_sources: list[dict[str, Any]] = []
     feature_pack_sources: dict[str, list[dict[str, Any]]] = {}
     include_products = _can_access_shop(
         resolved_memberships, is_super_admin=is_super_admin
@@ -705,6 +943,63 @@ async def execute_agent_query(
         log_error("Agent issue lookup failed", error=str(exc))
         issue_sources = []
 
+    for label, lookup in (
+        (
+            "service status",
+            lambda: _search_service_status_sources(
+                query_text, company_ids=accessible_company_ids, is_super_admin=is_super_admin
+            ),
+        ),
+        (
+            "backup job",
+            lambda: _search_backup_job_sources(
+                query_text, company_ids=accessible_company_ids, is_super_admin=is_super_admin
+            ),
+        ),
+        (
+            "mailbox",
+            lambda: _search_mailbox_sources(
+                query_text,
+                memberships=resolved_memberships,
+                company_ids=accessible_company_ids,
+                is_super_admin=is_super_admin,
+            ),
+        ),
+        (
+            "best practice",
+            lambda: _search_best_practice_sources(
+                query_text,
+                memberships=resolved_memberships,
+                company_ids=accessible_company_ids,
+                is_super_admin=is_super_admin,
+            ),
+        ),
+    ):
+        try:
+            result = await lookup()
+        except Exception as exc:  # pragma: no cover - defensive guard
+            log_error(f"Agent {label} lookup failed", error=str(exc))
+            result = []
+        if label == "service status":
+            service_status_sources = result
+        elif label == "backup job":
+            backup_job_sources = result
+        elif label == "mailbox":
+            mailbox_sources = result
+        elif label == "best practice":
+            best_practice_sources = result
+
+    try:
+        report_sources = _search_company_report_sources(
+            query_text
+        ) + await _search_reporting_query_sources(
+            query_text, user=user, is_super_admin=is_super_admin
+        )
+        report_sources = report_sources[:_SYSTEM_RESULT_LIMIT]
+    except Exception as exc:  # pragma: no cover - defensive guard
+        log_error("Agent report lookup failed", error=str(exc))
+        report_sources = []
+
     feature_pack_sources = await _search_feature_pack_sources(
         query_text,
         user=user,
@@ -725,6 +1020,11 @@ async def execute_agent_query(
         or asset_sources
         or company_sources
         or issue_sources
+        or service_status_sources
+        or backup_job_sources
+        or report_sources
+        or mailbox_sources
+        or best_practice_sources
         or any(feature_pack_sources.values())
     )
 
@@ -734,7 +1034,7 @@ async def execute_agent_query(
         "explicitly state that you don't have that specific information available and suggest creating a support ticket.",
         "Do NOT suggest unrelated articles or products - only reference sources that directly answer the question.",
         "Never reference systems, data, or permissions outside the provided information.",
-        "Use Markdown and cite sources inline with [KB:slug], [Ticket:#id], [Product:SKU], [Chat:#id], [Order:number], [Asset:#id], [Company:#id], or [Issue:#id].",
+        "Use Markdown and cite sources inline with [KB:slug], [Ticket:#id], [Product:SKU], [Chat:#id], [Order:number], [Asset:#id], [Company:#id], [Issue:#id], [ServiceStatus:#id], [BackupJob:#id], [Report:key], [Mailbox:upn], or [BestPractice:check_id].",
         f"User query: {query_text}",
         "",
     ]
@@ -832,6 +1132,65 @@ async def execute_agent_query(
             ]
             if assignment_labels:
                 parts.append("Assignments: " + ", ".join(assignment_labels))
+            context_sections.append("- " + " — ".join(parts))
+        context_sections.append("")
+
+    if service_status_sources:
+        context_sections.append("Service statuses accessible to the user:")
+        for service in service_status_sources:
+            parts = [f"[ServiceStatus:#{service['id']}] {service['name']}"]
+            if service.get("status"):
+                parts.append(f"status: {service['status']}")
+            if service.get("status_message"):
+                parts.append(service["status_message"])
+            elif service.get("description"):
+                parts.append(service["description"])
+            context_sections.append("- " + " — ".join(parts))
+        context_sections.append("")
+
+    if backup_job_sources:
+        context_sections.append("Backup summary jobs accessible to the user:")
+        for job in backup_job_sources:
+            parts = [f"[BackupJob:#{job['id']}] {job['name']}"]
+            if job.get("today_status"):
+                parts.append(f"today: {job['today_status']}")
+            if job.get("latest_status"):
+                parts.append(f"latest: {job['latest_status']}")
+            if job.get("description"):
+                parts.append(job["description"])
+            context_sections.append("- " + " — ".join(parts))
+        context_sections.append("")
+
+    if report_sources:
+        context_sections.append("Reports accessible to the user:")
+        for report in report_sources:
+            parts = [f"[Report:{report['key']}] {report['title']}"]
+            if report.get("source_type"):
+                parts.append(f"type: {report['source_type']}")
+            if report.get("description"):
+                parts.append(report["description"])
+            context_sections.append("- " + " — ".join(parts))
+        context_sections.append("")
+
+    if mailbox_sources:
+        context_sections.append("Office 365 mailboxes accessible to the user:")
+        for mailbox in mailbox_sources:
+            parts = [f"[Mailbox:{mailbox['user_principal_name']}] {mailbox['display_name']}"]
+            if mailbox.get("mailbox_type"):
+                parts.append(f"type: {mailbox['mailbox_type']}")
+            if mailbox.get("storage_used_bytes") is not None:
+                parts.append(f"storage bytes: {mailbox['storage_used_bytes']}")
+            context_sections.append("- " + " — ".join(parts))
+        context_sections.append("")
+
+    if best_practice_sources:
+        context_sections.append("Microsoft 365 best practices accessible to the user:")
+        for check in best_practice_sources:
+            parts = [f"[BestPractice:{check['check_id']}] {check['check_name']}"]
+            if check.get("status"):
+                parts.append(f"status: {check['status']}")
+            if check.get("details"):
+                parts.append(check["details"])
             context_sections.append("- " + " — ".join(parts))
         context_sections.append("")
 
@@ -957,6 +1316,11 @@ async def execute_agent_query(
             "assets": asset_sources,
             "companies": company_sources,
             "issues": issue_sources,
+            "service_status": service_status_sources,
+            "backup_jobs": backup_job_sources,
+            "reports": report_sources,
+            "mailboxes": mailbox_sources,
+            "best_practices": best_practice_sources,
             "feature_packs": feature_pack_sources,
         },
         "context": {"companies": company_context},

--- a/app/static/js/agent.js
+++ b/app/static/js/agent.js
@@ -168,6 +168,41 @@
     return `[#${id}] ${name}${meta ? `<div class="agent-sources__meta">${meta}</div>` : ''}`;
   }
 
+  function formatServiceStatusSource(item) {
+    const id = escapeHtml(item.id);
+    const name = escapeHtml(item.name || `Service #${item.id}`);
+    const meta = [item.status ? `Status: ${escapeHtml(item.status)}` : null, item.status_message || item.description ? escapeHtml(item.status_message || item.description) : null].filter(Boolean).join('<br />');
+    return `[#${id}] ${name}${meta ? `<div class="agent-sources__meta">${meta}</div>` : ''}`;
+  }
+
+  function formatBackupJobSource(item) {
+    const id = escapeHtml(item.id);
+    const name = escapeHtml(item.name || `Backup job #${item.id}`);
+    const meta = [item.today_status ? `Today: ${escapeHtml(item.today_status)}` : null, item.latest_status ? `Latest: ${escapeHtml(item.latest_status)}` : null, item.description ? escapeHtml(item.description) : null].filter(Boolean).join(' • ');
+    return `[#${id}] ${name}${meta ? `<div class="agent-sources__meta">${meta}</div>` : ''}`;
+  }
+
+  function formatReportSource(item) {
+    const key = escapeHtml(item.key || 'report');
+    const title = escapeHtml(item.title || key);
+    const meta = [item.source_type ? `Type: ${escapeHtml(item.source_type)}` : null, item.description ? escapeHtml(item.description) : null].filter(Boolean).join('<br />');
+    return `[${key}] ${title}${meta ? `<div class="agent-sources__meta">${meta}</div>` : ''}`;
+  }
+
+  function formatMailboxSource(item) {
+    const upn = escapeHtml(item.user_principal_name || 'mailbox');
+    const name = escapeHtml(item.display_name || item.user_principal_name || 'Mailbox');
+    const meta = [item.mailbox_type ? `Type: ${escapeHtml(item.mailbox_type)}` : null, item.storage_used_bytes != null ? `Storage: ${escapeHtml(item.storage_used_bytes)} bytes` : null].filter(Boolean).join(' • ');
+    return `[${upn}] ${name}${meta ? `<div class="agent-sources__meta">${meta}</div>` : ''}`;
+  }
+
+  function formatBestPracticeSource(item) {
+    const id = escapeHtml(item.check_id || 'check');
+    const name = escapeHtml(item.check_name || item.check_id || 'Best practice');
+    const meta = [item.status ? `Status: ${escapeHtml(item.status)}` : null, item.details ? escapeHtml(item.details) : null].filter(Boolean).join('<br />');
+    return `[${id}] ${name}${meta ? `<div class="agent-sources__meta">${meta}</div>` : ''}`;
+  }
+
   function formatFeaturePackTitle(slug) {
     return String(slug || 'feature pack')
       .replace(/[_-]+/g, ' ')
@@ -222,6 +257,21 @@
     }
     if (Array.isArray(sources.issues)) {
       groups.push(createSourceList('Issues', sources.issues, formatIssueSource));
+    }
+    if (Array.isArray(sources.service_status)) {
+      groups.push(createSourceList('Service status', sources.service_status, formatServiceStatusSource));
+    }
+    if (Array.isArray(sources.backup_jobs)) {
+      groups.push(createSourceList('Backup summary', sources.backup_jobs, formatBackupJobSource));
+    }
+    if (Array.isArray(sources.reports)) {
+      groups.push(createSourceList('Reports', sources.reports, formatReportSource));
+    }
+    if (Array.isArray(sources.mailboxes)) {
+      groups.push(createSourceList('Office 365 mailboxes', sources.mailboxes, formatMailboxSource));
+    }
+    if (Array.isArray(sources.best_practices)) {
+      groups.push(createSourceList('Best practices', sources.best_practices, formatBestPracticeSource));
     }
     if (sources.feature_packs && typeof sources.feature_packs === 'object') {
       Object.keys(sources.feature_packs).sort().forEach((slug) => {

--- a/app/static/js/agent.js
+++ b/app/static/js/agent.js
@@ -146,6 +146,28 @@
   }
 
 
+  function formatCompanySource(item) {
+    const id = escapeHtml(item.id);
+    const name = escapeHtml(item.name || `Company #${item.id}`);
+    const syncro = item.syncro_company_id ? `<div class="agent-sources__meta">Syncro ID: ${escapeHtml(item.syncro_company_id)}</div>` : '';
+    return `[#${id}] ${name}${syncro}`;
+  }
+
+  function formatIssueSource(item) {
+    const id = escapeHtml(item.id);
+    const name = escapeHtml(item.name || `Issue #${item.id}`);
+    const description = item.description ? escapeHtml(item.description) : '';
+    const assignments = Array.isArray(item.assignments) && item.assignments.length
+      ? item.assignments.map((assignment) => {
+          const company = assignment.company_name || assignment.company_id || 'Company';
+          const status = assignment.status_label || assignment.status || 'unknown';
+          return `${escapeHtml(company)}: ${escapeHtml(status)}`;
+        }).join(', ')
+      : '';
+    const meta = [description, assignments ? `Assignments: ${assignments}` : null].filter(Boolean).join('<br />');
+    return `[#${id}] ${name}${meta ? `<div class="agent-sources__meta">${meta}</div>` : ''}`;
+  }
+
   function formatFeaturePackTitle(slug) {
     return String(slug || 'feature pack')
       .replace(/[_-]+/g, ' ')
@@ -194,6 +216,12 @@
     }
     if (Array.isArray(sources.packages)) {
       groups.push(createSourceList('Packages', sources.packages, formatPackageSource));
+    }
+    if (Array.isArray(sources.companies)) {
+      groups.push(createSourceList('Companies', sources.companies, formatCompanySource));
+    }
+    if (Array.isArray(sources.issues)) {
+      groups.push(createSourceList('Issues', sources.issues, formatIssueSource));
     }
     if (sources.feature_packs && typeof sources.feature_packs === 'object') {
       Object.keys(sources.feature_packs).sort().forEach((slug) => {

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -262,6 +262,8 @@ async def test_execute_agent_query_includes_chat_order_and_asset_sources(monkeyp
             "can_access_orders": True,
             "can_manage_assets": True,
             "can_manage_issues": True,
+            "can_view_m365_user_mailboxes": True,
+            "can_view_m365_best_practices": True,
         }
     ]
 
@@ -280,6 +282,26 @@ async def test_execute_agent_query_includes_chat_order_and_asset_sources(monkeyp
     )
 
     async def fake_fetch_all(sql, params):
+        if "FROM service_status_services" in sql:
+            return [
+                {
+                    "id": 8,
+                    "name": "VPN Service",
+                    "description": "Remote access platform",
+                    "status": "degraded",
+                    "status_message": "VPN logins are delayed",
+                }
+            ]
+        if "FROM m365_mailboxes" in sql:
+            return [
+                {
+                    "company_id": 1,
+                    "user_principal_name": "vpn.user@example.com",
+                    "display_name": "VPN User",
+                    "mailbox_type": "UserMailbox",
+                    "storage_used_bytes": 1234,
+                }
+            ]
         if "FROM chat_rooms" in sql:
             return [
                 {
@@ -330,6 +352,11 @@ async def test_execute_agent_query_includes_chat_order_and_asset_sources(monkeyp
         assert "Chats accessible" in prompt
         assert "Orders accessible" in prompt
         assert "Assets accessible" in prompt
+        assert "Service statuses accessible" in prompt
+        assert "Backup summary jobs accessible" in prompt
+        assert "Reports accessible" in prompt
+        assert "Office 365 mailboxes accessible" in prompt
+        assert "Microsoft 365 best practices accessible" in prompt
         return {
             "status": "succeeded",
             "model": "llama3",
@@ -358,6 +385,50 @@ async def test_execute_agent_query_includes_chat_order_and_asset_sources(monkeyp
         "build_issue_overview",
         AsyncMock(return_value=issue_overviews),
     )
+    monkeypatch.setattr(
+        agent_service.backup_jobs_service,
+        "list_jobs_with_latest",
+        AsyncMock(
+            return_value=[
+                {
+                    "id": 44,
+                    "company_id": 1,
+                    "name": "VPN Config Backup",
+                    "description": "Backs up VPN configuration",
+                    "latest_status": "pass",
+                    "today_status": "pass",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        agent_service.reporting_repo,
+        "list_queries_for_user",
+        AsyncMock(
+            return_value=[
+                {
+                    "id": 55,
+                    "slug": "vpn-report",
+                    "name": "VPN Report",
+                    "description": "Reports VPN usage",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        agent_service.m365_bp_repo,
+        "list_results",
+        AsyncMock(
+            return_value=[
+                {
+                    "check_id": "vpn-mfa",
+                    "check_name": "VPN MFA Best Practice",
+                    "status": "pass",
+                    "details": "VPN users require MFA",
+                }
+            ]
+        ),
+    )
 
     monkeypatch.setattr(agent_service.modules_service, "trigger_module", fake_trigger)
 
@@ -370,6 +441,11 @@ async def test_execute_agent_query_includes_chat_order_and_asset_sources(monkeyp
     assert result["sources"]["chats"][0]["id"] == 11
     assert result["sources"]["orders"][0]["order_number"] == "ORD-100"
     assert result["sources"]["assets"][0]["id"] == 33
+    assert result["sources"]["service_status"][0]["id"] == 8
+    assert result["sources"]["backup_jobs"][0]["id"] == 44
+    assert result["sources"]["reports"][0]["key"] == "vpn-report"
+    assert result["sources"]["mailboxes"][0]["user_principal_name"] == "vpn.user@example.com"
+    assert result["sources"]["best_practices"][0]["check_id"] == "vpn-mfa"
     assert result["has_relevant_sources"] is True
 
 

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -255,11 +256,12 @@ async def test_execute_agent_query_includes_chat_order_and_asset_sources(monkeyp
     memberships = [
         {
             "company_id": 1,
-            "company_name": "Contoso",
+            "company_name": "VPN Co",
             "can_access_shop": False,
             "can_access_chat": True,
             "can_access_orders": True,
             "can_manage_assets": True,
+            "can_manage_issues": True,
         }
     ]
 
@@ -334,12 +336,37 @@ async def test_execute_agent_query_includes_chat_order_and_asset_sources(monkeyp
             "response": {"response": "Found sources"},
         }
 
+    issue_overviews = [
+        SimpleNamespace(
+            issue_id=22,
+            name="VPN rollout",
+            slug="vpn-rollout",
+            description="Track VPN deployment issues",
+            updated_at_iso="2025-01-10T10:00:00+00:00",
+            assignments=[
+                SimpleNamespace(
+                    company_id=1,
+                    company_name="VPN Co",
+                    status="investigating",
+                    status_label="Investigating",
+                )
+            ],
+        )
+    ]
+    monkeypatch.setattr(
+        agent_service.issues_service,
+        "build_issue_overview",
+        AsyncMock(return_value=issue_overviews),
+    )
+
     monkeypatch.setattr(agent_service.modules_service, "trigger_module", fake_trigger)
 
     result = await agent_service.execute_agent_query(
         "VPN", user, active_company_id=1, memberships=memberships
     )
 
+    assert result["sources"]["companies"][0]["name"] == "VPN Co"
+    assert result["sources"]["issues"][0]["id"] == 22
     assert result["sources"]["chats"][0]["id"] == 11
     assert result["sources"]["orders"][0]["order_number"] == "ORD-100"
     assert result["sources"]["assets"][0]["id"] == 33


### PR DESCRIPTION
### Motivation
- The agent-backed `/search` UI only surfaced knowledge-base results and missed other permitted portal context like company records and issue-tracker entries, reducing usefulness of queries. 
- Provide the assistant with a broader, permission-aware context so answers can cite non-KB records and suggest relevant portal items.

### Description
- Add company and issue result types to the agent response schema in `app/schemas/agent.py` so the API can return `companies` and `issues` sources. 
- Implement permission-aware company and issue lookups in `app/services/agent.py` (new `_search_company_sources` and `_search_issue_sources`) and include those sources in the assembled prompt, `sources` payload, and `has_relevant_sources` logic. 
- Extend the agent prompt and inline citation guidance to include `[Company:#id]` and `[Issue:#id]` so generated answers may reference these records. 
- Render Companies and Issues groups in the search UI by updating `app/static/js/agent.js`, and extend `tests/test_agent_service.py` to cover the new sources.

### Testing
- Ran static compile checks with `python -m py_compile app/services/agent.py app/schemas/agent.py` which succeeded. 
- Ran unit tests `pytest -q tests/test_agent_service.py` and observed `6 passed` (with warnings) validating the new company and issue source handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b1c37d7008332ad2c75037c327296)