### PR TITLE
Fix TRMM client tray token custom field sync

### DIFF
--- a/app/services/tray.py
+++ b/app/services/tray.py
@@ -175,9 +175,42 @@ def _extract_trmm_custom_field_id(
     for field in client.get("custom_fields") or []:
         if not isinstance(field, dict):
             continue
-        if str(field.get("name") or "").strip() != field_name:
+        if str(field.get("name") or "").strip().casefold() != field_name.casefold():
             continue
         raw_id = field.get("field") or field.get("id") or field.get("pk")
+        try:
+            return int(raw_id)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _iter_trmm_custom_field_definitions(response: Any) -> Iterable[dict[str, Any]]:
+    if isinstance(response, list):
+        for item in response:
+            if isinstance(item, dict):
+                yield item
+        return
+    if isinstance(response, dict):
+        for key in ("results", "custom_fields", "items", "data"):
+            value = response.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        yield item
+                return
+
+
+def _extract_trmm_client_custom_field_definition_id(
+    response: Any, field_name: str
+) -> int | None:
+    target_name = field_name.strip().casefold()
+    for field in _iter_trmm_custom_field_definitions(response):
+        name = str(field.get("name") or "").strip().casefold()
+        model = str(field.get("model") or "").strip().casefold()
+        if name != target_name or model != "client":
+            continue
+        raw_id = field.get("id") or field.get("pk") or field.get("field")
         try:
             return int(raw_id)
         except (TypeError, ValueError):
@@ -208,20 +241,25 @@ async def update_trmm_client_token_field(
     if not isinstance(client, dict):
         client = {}
     field_id = _extract_trmm_custom_field_id(client, custom_field_name)
+    if field_id is None:
+        definitions = await tacticalrmm_service._call_endpoint(
+            "/core/customfields/", method="GET"
+        )
+        field_id = _extract_trmm_client_custom_field_definition_id(
+            definitions, custom_field_name
+        )
+    if field_id is None:
+        raise ValueError(
+            f'Tactical RMM client custom field "{custom_field_name}" was not found'
+        )
 
-    custom_field_payload: dict[str, Any]
-    if field_id is not None:
-        custom_field_payload = {"field": field_id, "string_value": token}
-    else:
-        # Recent TRMM builds expose the field ID in the client response. Keep a
-        # name-based fallback so the sync still works on APIs that accept names.
-        custom_field_payload = {"name": custom_field_name, "string_value": token}
+    custom_field_payload = {"field": field_id, "string_value": token}
 
-    # Tactical RMM's client update API is implemented as ``put`` (not
-    # ``patch``) and expects a top-level ``client`` object even when only
-    # custom fields are being updated.  Sending PATCH here causes TRMM to
-    # return HTTP 405: ``Method \"PATCH\" not allowed.``
-    body = {"client": {}, "custom_fields": [custom_field_payload]}
+    # Tactical RMM's custom-field update examples use ``PUT`` with only the
+    # ``custom_fields`` array in the request body.  Keeping the payload scoped
+    # to the client endpoint ensures we update the client-level value, not an
+    # agent or site field.
+    body = {"custom_fields": [custom_field_payload]}
     return await tacticalrmm_service._call_endpoint(
         f"/clients/{client_id}/", method="PUT", body=body
     )

--- a/tests/test_tray_trmm_token_sync.py
+++ b/tests/test_tray_trmm_token_sync.py
@@ -33,20 +33,24 @@ def test_update_trmm_client_token_field_uses_trmm_put_payload(monkeypatch):
             "endpoint": "/clients/42/",
             "method": "PUT",
             "body": {
-                "client": {},
                 "custom_fields": [{"field": 7, "string_value": "new-token"}],
             },
         },
     ]
 
 
-def test_update_trmm_client_token_field_put_payload_allows_name_fallback(monkeypatch):
+def test_update_trmm_client_token_field_resolves_client_field_definition(monkeypatch):
     calls = []
 
     async def fake_call_endpoint(endpoint, *, method="GET", body=None):
         calls.append({"endpoint": endpoint, "method": method, "body": body})
-        if method == "GET":
+        if endpoint == "/clients/42/" and method == "GET":
             return {"id": 42, "name": "Acme", "custom_fields": []}
+        if endpoint == "/core/customfields/" and method == "GET":
+            return [
+                {"id": 3, "model": "agent", "name": "Portal Token"},
+                {"id": 9, "model": "client", "name": "Portal Token"},
+            ]
         return {"status": "ok"}
 
     from app.services import tacticalrmm
@@ -59,11 +63,14 @@ def test_update_trmm_client_token_field_put_payload_allows_name_fallback(monkeyp
         )
     )
 
-    assert calls[-1] == {
-        "endpoint": "/clients/42/",
-        "method": "PUT",
-        "body": {
-            "client": {},
-            "custom_fields": [{"name": "Portal Token", "string_value": "new-token"}],
+    assert calls == [
+        {"endpoint": "/clients/42/", "method": "GET", "body": None},
+        {"endpoint": "/core/customfields/", "method": "GET", "body": None},
+        {
+            "endpoint": "/clients/42/",
+            "method": "PUT",
+            "body": {
+                "custom_fields": [{"field": 9, "string_value": "new-token"}],
+            },
         },
-    }
+    ]


### PR DESCRIPTION
### Motivation

- The tray enrolment token was being sent in a payload that could target the wrong scope (agent/site) or rely on a name-based fallback when the client response did not contain a populated custom field; this prevented per-client token values from being set in Tactical RMM. 

### Description

- Make name-matching case-insensitive in `_extract_trmm_custom_field_id` to avoid miss-matches for field names.  
- Add helpers `_iter_trmm_custom_field_definitions` and `_extract_trmm_client_custom_field_definition_id` and, when the client response has no populated custom field, fetch `/core/customfields/` and resolve the client-scoped field ID (`model == "client"`).
- Always update using the resolved field ID and send the client update payload as `PUT /clients/{id}/` with `{"custom_fields": [...]}` (no top-level `client` wrapper), ensuring the update is applied per-client.
- Update `tests/test_tray_trmm_token_sync.py` to assert the new behaviour (use of resolved client field definition and new PUT payload shape).

### Testing

- Ran `pytest tests/test_tray_trmm_token_sync.py -q` and the test suite for this file passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b2018815c8332b02163f94f464bbb)