### PR TITLE
Include Staff in AI agent search; use staff repo and collapse source sections

### DIFF
--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -91,6 +91,11 @@ class AgentSourceStaff(BaseModel):
     email: Optional[str] = None
     job_title: Optional[str] = None
     department: Optional[str] = None
+    mobile_phone: Optional[str] = None
+    org_company: Optional[str] = None
+    manager_name: Optional[str] = None
+    account_action: Optional[str] = None
+    custom_fields: dict[str, Any] = Field(default_factory=dict)
     enabled: bool = True
     is_ex_staff: bool = False
     onboarding_status: Optional[str] = None

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -84,6 +84,19 @@ class AgentSourceCompany(BaseModel):
     syncro_company_id: Optional[str] = None
 
 
+class AgentSourceStaff(BaseModel):
+    id: int
+    company_id: Optional[int] = None
+    name: str
+    email: Optional[str] = None
+    job_title: Optional[str] = None
+    department: Optional[str] = None
+    enabled: bool = True
+    is_ex_staff: bool = False
+    onboarding_status: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
 class AgentSourceIssueAssignment(BaseModel):
     company_id: Optional[int] = None
     company_name: Optional[str] = None
@@ -157,6 +170,7 @@ class AgentSources(BaseModel):
     orders: list[AgentSourceOrder] = Field(default_factory=list)
     assets: list[AgentSourceAsset] = Field(default_factory=list)
     companies: list[AgentSourceCompany] = Field(default_factory=list)
+    staff: list[AgentSourceStaff] = Field(default_factory=list)
     issues: list[AgentSourceIssue] = Field(default_factory=list)
     service_status: list[AgentSourceServiceStatus] = Field(default_factory=list)
     backup_jobs: list[AgentSourceBackupJob] = Field(default_factory=list)

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -12,6 +12,7 @@ from app.repositories import m365_best_practices as m365_bp_repo
 from app.repositories import reporting as reporting_repo
 from app.repositories import shop as shop_repo
 from app.repositories import staff as staff_repo
+from app.repositories import staff_custom_fields as staff_custom_fields_repo
 from app.repositories import tickets as tickets_repo
 from app.services import company_access
 from app.services import backup_jobs as backup_jobs_service
@@ -164,6 +165,16 @@ async def _search_staff_sources(
             continue
         try:
             staff_rows = await staff_repo.list_staff(company_id, page_size=500)
+            staff_ids = [
+                int(staff_member["id"])
+                for staff_member in staff_rows
+                if staff_member.get("id") is not None
+            ]
+            custom_field_values = (
+                await staff_custom_fields_repo.get_all_staff_field_values(
+                    company_id, staff_ids
+                )
+            )
         except Exception as exc:  # pragma: no cover - defensive guard
             log_error(
                 "Agent staff lookup failed", company_id=company_id, error=str(exc)
@@ -178,7 +189,11 @@ async def _search_staff_sources(
                 staff_member.get("job_title"),
                 staff_member.get("department"),
                 staff_member.get("mobile_phone"),
+                staff_member.get("org_company"),
+                staff_member.get("manager_name"),
+                staff_member.get("account_action"),
                 staff_member.get("onboarding_status"),
+                custom_field_values.get(int(staff_member.get("id") or 0), {}),
             ):
                 continue
             full_name = " ".join(
@@ -189,6 +204,8 @@ async def _search_staff_sources(
                 )
                 if str(part or "").strip()
             ).strip()
+            staff_id = int(staff_member.get("id") or 0)
+            custom_fields = custom_field_values.get(staff_id, {})
             sources.append(
                 {
                     "id": staff_member.get("id"),
@@ -199,6 +216,11 @@ async def _search_staff_sources(
                     "email": staff_member.get("email"),
                     "job_title": staff_member.get("job_title"),
                     "department": staff_member.get("department"),
+                    "mobile_phone": staff_member.get("mobile_phone"),
+                    "org_company": staff_member.get("org_company"),
+                    "manager_name": staff_member.get("manager_name"),
+                    "account_action": staff_member.get("account_action"),
+                    "custom_fields": dict(custom_fields),
                     "enabled": bool(staff_member.get("enabled")),
                     "is_ex_staff": bool(staff_member.get("is_ex_staff")),
                     "onboarding_status": staff_member.get("onboarding_status"),
@@ -1238,6 +1260,23 @@ async def execute_agent_query(
                 parts.append(f"title: {staff_member['job_title']}")
             if staff_member.get("department"):
                 parts.append(f"department: {staff_member['department']}")
+            if staff_member.get("mobile_phone"):
+                parts.append(f"mobile: {staff_member['mobile_phone']}")
+            if staff_member.get("org_company"):
+                parts.append(f"organisation: {staff_member['org_company']}")
+            if staff_member.get("manager_name"):
+                parts.append(f"manager: {staff_member['manager_name']}")
+            if staff_member.get("account_action"):
+                parts.append(f"account action: {staff_member['account_action']}")
+            custom_field_parts = [
+                f"{key}: {value}"
+                for key, value in sorted(
+                    (staff_member.get("custom_fields") or {}).items()
+                )
+                if value not in (None, "", [], {})
+            ]
+            if custom_field_parts:
+                parts.append("custom fields: " + ", ".join(custom_field_parts[:5]))
             if staff_member.get("onboarding_status"):
                 parts.append(f"status: {staff_member['onboarding_status']}")
             context_sections.append("- " + " — ".join(parts))

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -11,6 +11,7 @@ from app.core.logging import log_error
 from app.repositories import m365_best_practices as m365_bp_repo
 from app.repositories import reporting as reporting_repo
 from app.repositories import shop as shop_repo
+from app.repositories import staff as staff_repo
 from app.repositories import tickets as tickets_repo
 from app.services import company_access
 from app.services import backup_jobs as backup_jobs_service
@@ -28,6 +29,7 @@ _ORDER_RESULT_LIMIT = 5
 _ASSET_RESULT_LIMIT = 5
 _FEATURE_PACK_RESULT_LIMIT = 5
 _COMPANY_RESULT_LIMIT = 5
+_STAFF_RESULT_LIMIT = 5
 _ISSUE_RESULT_LIMIT = 5
 _SYSTEM_RESULT_LIMIT = 5
 _MAX_SNIPPET_LENGTH = 320
@@ -131,6 +133,81 @@ def _coerce_user_id(user: Mapping[str, Any]) -> int:
         return int(user.get("id") or 0)
     except (TypeError, ValueError):
         return 0
+
+
+def _can_access_staff(
+    memberships: Sequence[Mapping[str, Any]], *, is_super_admin: bool
+) -> bool:
+    if is_super_admin:
+        return True
+    for membership in memberships:
+        try:
+            staff_permission = int(membership.get("staff_permission") or 0)
+        except (TypeError, ValueError):
+            staff_permission = 0
+        if staff_permission > 0 or bool(membership.get("can_manage_staff")):
+            return True
+    return False
+
+
+async def _search_staff_sources(
+    query: str, *, memberships: Sequence[Mapping[str, Any]], is_super_admin: bool
+) -> list[dict[str, Any]]:
+    if not _can_access_staff(memberships, is_super_admin=is_super_admin):
+        return []
+
+    sources: list[dict[str, Any]] = []
+    for membership in memberships:
+        try:
+            company_id = int(membership.get("company_id"))
+        except (TypeError, ValueError):
+            continue
+        try:
+            staff_rows = await staff_repo.list_staff(company_id, page_size=500)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            log_error(
+                "Agent staff lookup failed", company_id=company_id, error=str(exc)
+            )
+            continue
+        for staff_member in staff_rows:
+            if not _matches_query(
+                query,
+                staff_member.get("first_name"),
+                staff_member.get("last_name"),
+                staff_member.get("email"),
+                staff_member.get("job_title"),
+                staff_member.get("department"),
+                staff_member.get("mobile_phone"),
+                staff_member.get("onboarding_status"),
+            ):
+                continue
+            full_name = " ".join(
+                part
+                for part in (
+                    staff_member.get("first_name"),
+                    staff_member.get("last_name"),
+                )
+                if str(part or "").strip()
+            ).strip()
+            sources.append(
+                {
+                    "id": staff_member.get("id"),
+                    "company_id": staff_member.get("company_id"),
+                    "name": full_name
+                    or staff_member.get("email")
+                    or f"Staff #{staff_member.get('id')}",
+                    "email": staff_member.get("email"),
+                    "job_title": staff_member.get("job_title"),
+                    "department": staff_member.get("department"),
+                    "enabled": bool(staff_member.get("enabled")),
+                    "is_ex_staff": bool(staff_member.get("is_ex_staff")),
+                    "onboarding_status": staff_member.get("onboarding_status"),
+                    "updated_at": staff_member.get("updated_at"),
+                }
+            )
+            if len(sources) >= _STAFF_RESULT_LIMIT:
+                return sources
+    return sources
 
 
 def _search_company_sources(
@@ -406,7 +483,11 @@ async def _search_mailbox_sources(
 
 
 async def _search_best_practice_sources(
-    query: str, *, memberships: Sequence[Mapping[str, Any]], company_ids: Sequence[int], is_super_admin: bool
+    query: str,
+    *,
+    memberships: Sequence[Mapping[str, Any]],
+    company_ids: Sequence[int],
+    is_super_admin: bool,
 ) -> list[dict[str, Any]]:
     if (
         not _has_membership_flag(
@@ -684,6 +765,7 @@ async def execute_agent_query(
                 "orders": [],
                 "assets": [],
                 "companies": [],
+                "staff": [],
                 "issues": [],
                 "service_status": [],
                 "backup_jobs": [],
@@ -782,6 +864,7 @@ async def execute_agent_query(
     company_sources: list[dict[str, Any]] = _search_company_sources(
         query_text, resolved_memberships
     )
+    staff_sources: list[dict[str, Any]] = []
     issue_sources: list[dict[str, Any]] = []
     service_status_sources: list[dict[str, Any]] = []
     backup_job_sources: list[dict[str, Any]] = []
@@ -948,6 +1031,14 @@ async def execute_agent_query(
             )
 
     try:
+        staff_sources = await _search_staff_sources(
+            query_text, memberships=resolved_memberships, is_super_admin=is_super_admin
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        log_error("Agent staff lookup failed", error=str(exc))
+        staff_sources = []
+
+    try:
         issue_sources = await _search_issue_sources(
             query_text,
             memberships=resolved_memberships,
@@ -962,13 +1053,17 @@ async def execute_agent_query(
         (
             "service status",
             lambda: _search_service_status_sources(
-                query_text, company_ids=accessible_company_ids, is_super_admin=is_super_admin
+                query_text,
+                company_ids=accessible_company_ids,
+                is_super_admin=is_super_admin,
             ),
         ),
         (
             "backup job",
             lambda: _search_backup_job_sources(
-                query_text, company_ids=accessible_company_ids, is_super_admin=is_super_admin
+                query_text,
+                company_ids=accessible_company_ids,
+                is_super_admin=is_super_admin,
             ),
         ),
         (
@@ -1034,6 +1129,7 @@ async def execute_agent_query(
         or order_sources
         or asset_sources
         or company_sources
+        or staff_sources
         or issue_sources
         or service_status_sources
         or backup_job_sources
@@ -1049,7 +1145,7 @@ async def execute_agent_query(
         "explicitly state that you don't have that specific information available and suggest creating a support ticket.",
         "Do NOT suggest unrelated articles or products - only reference sources that directly answer the question.",
         "Never reference systems, data, or permissions outside the provided information.",
-        "Use Markdown and cite sources inline with [KB:slug], [Ticket:#id], [Product:SKU], [Chat:#id], [Order:number], [Asset:#id], [Company:#id], [Issue:#id], [ServiceStatus:#id], [BackupJob:#id], [Report:key], [Mailbox:upn], or [BestPractice:check_id].",
+        "Use Markdown and cite sources inline with [KB:slug], [Ticket:#id], [Product:SKU], [Chat:#id], [Order:number], [Asset:#id], [Company:#id], [Staff:#id], [Issue:#id], [ServiceStatus:#id], [BackupJob:#id], [Report:key], [Mailbox:upn], or [BestPractice:check_id].",
         f"User query: {query_text}",
         "",
     ]
@@ -1132,6 +1228,21 @@ async def execute_agent_query(
             context_sections.append("- " + " — ".join(parts))
         context_sections.append("")
 
+    if staff_sources:
+        context_sections.append("Staff accessible to the user:")
+        for staff_member in staff_sources:
+            parts = [f"[Staff:#{staff_member['id']}] {staff_member['name']}"]
+            if staff_member.get("email"):
+                parts.append(f"email: {staff_member['email']}")
+            if staff_member.get("job_title"):
+                parts.append(f"title: {staff_member['job_title']}")
+            if staff_member.get("department"):
+                parts.append(f"department: {staff_member['department']}")
+            if staff_member.get("onboarding_status"):
+                parts.append(f"status: {staff_member['onboarding_status']}")
+            context_sections.append("- " + " — ".join(parts))
+        context_sections.append("")
+
     if issue_sources:
         context_sections.append("Issues accessible to the user:")
         for issue in issue_sources:
@@ -1190,7 +1301,9 @@ async def execute_agent_query(
     if mailbox_sources:
         context_sections.append("Office 365 mailboxes accessible to the user:")
         for mailbox in mailbox_sources:
-            parts = [f"[Mailbox:{mailbox['user_principal_name']}] {mailbox['display_name']}"]
+            parts = [
+                f"[Mailbox:{mailbox['user_principal_name']}] {mailbox['display_name']}"
+            ]
             if mailbox.get("mailbox_type"):
                 parts.append(f"type: {mailbox['mailbox_type']}")
             if mailbox.get("storage_used_bytes") is not None:
@@ -1330,6 +1443,7 @@ async def execute_agent_query(
             "orders": order_sources,
             "assets": asset_sources,
             "companies": company_sources,
+            "staff": staff_sources,
             "issues": issue_sources,
             "service_status": service_status_sources,
             "backup_jobs": backup_job_sources,

--- a/app/static/js/agent.js
+++ b/app/static/js/agent.js
@@ -160,6 +160,21 @@
     if (item.email) metaParts.push(`Email: ${escapeHtml(item.email)}`);
     if (item.job_title) metaParts.push(`Title: ${escapeHtml(item.job_title)}`);
     if (item.department) metaParts.push(`Department: ${escapeHtml(item.department)}`);
+    if (item.mobile_phone) metaParts.push(`Mobile: ${escapeHtml(item.mobile_phone)}`);
+    if (item.org_company) metaParts.push(`Organisation: ${escapeHtml(item.org_company)}`);
+    if (item.manager_name) metaParts.push(`Manager: ${escapeHtml(item.manager_name)}`);
+    if (item.account_action) metaParts.push(`Account action: ${escapeHtml(item.account_action)}`);
+    if (item.custom_fields && typeof item.custom_fields === 'object') {
+      const customValues = Object.keys(item.custom_fields)
+        .sort()
+        .filter((key) => {
+          const value = item.custom_fields[key];
+          return value != null && value !== '' && !(Array.isArray(value) && value.length === 0);
+        })
+        .slice(0, 5)
+        .map((key) => `${escapeHtml(key)}: ${escapeHtml(item.custom_fields[key])}`);
+      if (customValues.length) metaParts.push(`Custom fields: ${customValues.join(', ')}`);
+    }
     if (item.onboarding_status) metaParts.push(`Status: ${escapeHtml(item.onboarding_status)}`);
     if (item.is_ex_staff) metaParts.push('Ex-staff');
     else if (item.enabled === false) metaParts.push('Disabled');

--- a/app/static/js/agent.js
+++ b/app/static/js/agent.js
@@ -33,11 +33,11 @@
     if (!items || items.length === 0) {
       return null;
     }
-    const section = document.createElement('section');
+    const section = document.createElement('details');
     section.className = 'agent-sources__group';
-    const heading = document.createElement('h4');
+    const heading = document.createElement('summary');
     heading.className = 'agent-sources__title';
-    heading.textContent = title;
+    heading.textContent = `${title} (${items.length})`;
     section.appendChild(heading);
 
     const list = document.createElement('ul');
@@ -153,6 +153,20 @@
     return `[#${id}] ${name}${syncro}`;
   }
 
+  function formatStaffSource(item) {
+    const id = escapeHtml(item.id);
+    const name = escapeHtml(item.name || `Staff #${item.id}`);
+    const metaParts = [];
+    if (item.email) metaParts.push(`Email: ${escapeHtml(item.email)}`);
+    if (item.job_title) metaParts.push(`Title: ${escapeHtml(item.job_title)}`);
+    if (item.department) metaParts.push(`Department: ${escapeHtml(item.department)}`);
+    if (item.onboarding_status) metaParts.push(`Status: ${escapeHtml(item.onboarding_status)}`);
+    if (item.is_ex_staff) metaParts.push('Ex-staff');
+    else if (item.enabled === false) metaParts.push('Disabled');
+    const meta = metaParts.length ? `<div class="agent-sources__meta">${metaParts.join(' • ')}</div>` : '';
+    return `[#${id}] ${name}${meta}`;
+  }
+
   function formatIssueSource(item) {
     const id = escapeHtml(item.id);
     const name = escapeHtml(item.name || `Issue #${item.id}`);
@@ -254,6 +268,9 @@
     }
     if (Array.isArray(sources.companies)) {
       groups.push(createSourceList('Companies', sources.companies, formatCompanySource));
+    }
+    if (Array.isArray(sources.staff)) {
+      groups.push(createSourceList('Staff', sources.staff, formatStaffSource));
     }
     if (Array.isArray(sources.issues)) {
       groups.push(createSourceList('Issues', sources.issues, formatIssueSource));

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -509,3 +509,60 @@ async def test_execute_agent_query_includes_generic_feature_pack_sources(monkeyp
     assert provider_calls[0]["company_ids"] == [1]
     assert result["sources"]["feature_packs"]["backups"][0]["title"] == "Backups policy"
     assert result["has_relevant_sources"] is True
+
+
+@pytest.mark.anyio
+async def test_search_staff_sources_matches_mobile_org_and_custom_fields(monkeypatch):
+    memberships = [
+        {
+            "company_id": 1,
+            "company_name": "Contoso",
+            "can_manage_staff": True,
+            "staff_permission": 3,
+        }
+    ]
+    staff_rows = [
+        {
+            "id": 101,
+            "company_id": 1,
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "email": "ada@example.com",
+            "mobile_phone": "+61 400 555 123",
+            "department": "Engineering",
+            "job_title": "Principal Analyst",
+            "org_company": "Research Org",
+            "manager_name": "Grace Hopper",
+            "account_action": "create",
+            "enabled": True,
+            "is_ex_staff": False,
+            "onboarding_status": "pending",
+            "updated_at": "2026-01-02T03:04:05+00:00",
+        }
+    ]
+
+    monkeypatch.setattr(
+        agent_service.staff_repo, "list_staff", AsyncMock(return_value=staff_rows)
+    )
+    monkeypatch.setattr(
+        agent_service.staff_custom_fields_repo,
+        "get_all_staff_field_values",
+        AsyncMock(return_value={101: {"employment_type": "Contractor", "site": "HQ"}}),
+    )
+
+    mobile_matches = await agent_service._search_staff_sources(
+        "555 123", memberships=memberships, is_super_admin=False
+    )
+    org_matches = await agent_service._search_staff_sources(
+        "Research Org", memberships=memberships, is_super_admin=False
+    )
+    custom_matches = await agent_service._search_staff_sources(
+        "Contractor", memberships=memberships, is_super_admin=False
+    )
+
+    assert mobile_matches[0]["mobile_phone"] == "+61 400 555 123"
+    assert org_matches[0]["org_company"] == "Research Org"
+    assert custom_matches[0]["custom_fields"] == {
+        "employment_type": "Contractor",
+        "site": "HQ",
+    }


### PR DESCRIPTION
### Motivation
- Extend the AI agent search to return Staff records alongside existing sources so staff can be found by name, email, role, department, and onboarding status.
- Avoid constructing ad-hoc/dynamic SQL or using f-string SQL interpolation in the agent search path by reusing the existing `staff` repository, addressing SQL injection / unsafe query concerns.
- Improve UX of search results by rendering each source group as a collapsed section that shows the title and count of items.

### Description
- Added a new `AgentSourceStaff` schema and included a `staff` list in the `AgentSources` payload so staff records are returned in agent responses (`app/schemas/agent.py`).
- Implemented permission-aware staff lookup using `staff_repo.list_staff(...)` with a `_can_access_staff` guard and `_search_staff_sources` helper; results are capped with `_STAFF_RESULT_LIMIT` and normalized for the agent prompt (`app/services/agent.py`).
- Integrated staff results into relevance detection, the agent prompt context (so the model may cite `[Staff:#id]`), and the final response `sources` payload (`app/services/agent.py`).
- Updated the frontend source renderer to show each source group as a collapsed `<details>` section with a title that includes the item count and added formatting for Staff items (`app/static/js/agent.js`).

### Testing
- Compiled modified Python modules with `python -m py_compile app/services/agent.py app/schemas/agent.py` and the compile succeeded.
- Checked JS syntax with `node --check app/static/js/agent.js` and the check succeeded.
- Validated the new schema by instantiating `AgentSources(staff=[])` under appropriate env vars and the check passed (`AgentSources staff schema ok`).
- Ran code formatting with `black` on the service file as part of the edit (no functional regressions observed from formatting).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b2273c41c8332bbe632303c3487ba)