### PR TITLE
Fix cart Decimal JSON serialization

### DIFF
--- a/app/templates/shop/cart.html
+++ b/app/templates/shop/cart.html
@@ -394,7 +394,7 @@
   <script src="{{ static_url('/static/js/cart.js') }}" defer></script>
   <script>
     (function () {
-      var freightTotal = {{ freight_total | tojson }};
+      var freightTotal = {{ (freight_total | float) | tojson }};
       var subtotalEl = document.getElementById('cart-subtotal-amount');
       var cartSubtotal = subtotalEl ? parseFloat(subtotalEl.dataset.value || '0') : 0;
 

--- a/tests/test_cart_template_decimal.py
+++ b/tests/test_cart_template_decimal.py
@@ -1,0 +1,15 @@
+from decimal import Decimal
+from pathlib import Path
+
+from jinja2 import Environment
+
+
+def test_cart_template_serializes_decimal_freight_total_for_javascript():
+    template_text = Path("app/templates/shop/cart.html").read_text()
+    assert "{{ (freight_total | float) | tojson }}" in template_text
+
+    rendered = Environment(autoescape=True).from_string(
+        "var freightTotal = {{ (freight_total | float) | tojson }};"
+    ).render(freight_total=Decimal("12.34"))
+
+    assert rendered == "var freightTotal = 12.34;"


### PR DESCRIPTION
### Motivation
- Prevent the "Object of type Decimal is not JSON serializable" error when the cart page embeds `freight_total` (a `Decimal`) into client-side JavaScript.

### Description
- Convert `freight_total` to a float before passing it to Jinja's `tojson` filter in `app/templates/shop/cart.html`, and add a regression test `tests/test_cart_template_decimal.py` that verifies the template uses Decimal-safe JSON serialization.

### Testing
- Ran focused tests: `pytest -q tests/test_cart_template_decimal.py` (passed) and `pytest -q tests/test_company_require_po.py::test_cart_view_accepts_integer_catalog_prices` (passed); `pytest -q tests/test_cart_feature_pack.py::test_cart_pack_loads_and_reloads_cleanly` failed due to an existing feature-pack route registration assertion that appears unrelated to this Decimal serialization fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b3b046fb48332805dc5955fa68f26)