### PR TITLE
Add AI-backed product description processor and manual refresh

### DIFF
--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -2443,6 +2443,41 @@ async def admin_update_shop_product(
     return RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
 
 
+async def admin_refresh_shop_product_description(request: Request, product_id: int):
+    from app.services import audit as audit_service
+    from app.services import product_descriptions
+    from app.repositories import shop as shop_repo
+
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    product = await shop_repo.get_product_by_id(product_id, include_archived=True)
+    if not product:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+
+    result = await product_descriptions.improve_product_description(product_id)
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Product not found")
+
+    refreshed = await shop_repo.get_product_by_id(product_id, include_archived=True)
+    await audit_service.record(
+        action="shop.product.description_refresh",
+        request=request,
+        entity_type="shop.product",
+        entity_id=product_id,
+        before=product,
+        after=refreshed or result,
+        sensitive_extra_keys=("buy_price",),
+    )
+    _main().log_info(
+        "Shop product description refreshed",
+        product_id=product_id,
+        refreshed_by=current_user["id"] if current_user else None,
+    )
+    return RedirectResponse(url="/admin/shop", status_code=status.HTTP_303_SEE_OTHER)
+
+
 async def _handle_shop_product_archive(
     request: Request,
     product_id: int,

--- a/app/features/shop/routes.py
+++ b/app/features/shop/routes.py
@@ -221,6 +221,15 @@ _add(
     status_code=303,
 )
 _add(
+    "/shop/admin/product/{product_id}/refresh-description",
+    handlers.admin_refresh_shop_product_description,
+    ["POST"],
+    status_code=303,
+    summary="Refresh a shop product description and comparison features",
+    tags=["Shop"],
+)
+
+_add(
     "/shop/admin/product/{product_id}/archive",
     handlers.admin_archive_shop_product,
     ["POST"],

--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -1685,6 +1685,16 @@ async def delete_category(category_id: int) -> bool:
             return cursor.rowcount > 0
 
 
+async def update_product_description(product_id: int, description: str | None) -> dict[str, Any] | None:
+    async with db.acquire() as conn:
+        async with conn.cursor(aiomysql.DictCursor) as cursor:
+            await cursor.execute(
+                "UPDATE shop_products SET description = %s WHERE id = %s",
+                (description, product_id),
+            )
+    return await get_product_by_id(product_id, include_archived=True)
+
+
 async def update_product(
     product_id: int,
     *,

--- a/app/services/product_descriptions.py
+++ b/app/services/product_descriptions.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import html
+import json
+import re
+from typing import Any, Mapping
+
+from app.core.logging import log_error, log_info
+from app.repositories import shop as shop_repo
+from app.services import modules as modules_service
+from app.services.sanitization import sanitize_rich_text
+
+_PROMPT = """Below is a product description, without modifying the specifications redesign the layout in a user-friendly and easily readable way.
+
+Return JSON only with this shape:
+{"description_html":"safe HTML using headings, lists and tables", "features":[{"name":"Feature name","value":"Feature value"}]}
+
+Product description:
+{description}
+"""
+
+_KEY_VALUE_RE = re.compile(r"^\s*([^:\-–—|]{2,80})\s*[:\-–—|]\s*(.{1,300})\s*$")
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _plain_text(value: str | None) -> str:
+    sanitized = sanitize_rich_text(value or "")
+    text = re.sub(r"<br\s*/?>", "\n", sanitized.html, flags=re.IGNORECASE)
+    text = re.sub(r"</(p|div|li|tr|td|th|h[1-6])>", "\n", text, flags=re.IGNORECASE)
+    text = _TAG_RE.sub("", text)
+    return html.unescape(text).replace("\xa0", " ").strip()
+
+
+def _normalise_feature_name(name: str) -> str:
+    name = re.sub(r"[_\s]+", " ", name).strip(" -:|\t\r\n")
+    return name[:255]
+
+
+def extract_features(description: str | None, *, limit: int = 30) -> list[dict[str, Any]]:
+    text = _plain_text(description)
+    features: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw_line in re.split(r"[\r\n]+| {2,}|;\s*", text):
+        line = raw_line.strip(" •-*\t")
+        if not line or len(line) > 360:
+            continue
+        match = _KEY_VALUE_RE.match(line)
+        if not match:
+            continue
+        name = _normalise_feature_name(match.group(1))
+        value = match.group(2).strip()
+        if not name or not value:
+            continue
+        key = name.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        features.append({"name": name, "value": value, "position": len(features)})
+        if len(features) >= limit:
+            break
+    return features
+
+
+def _fallback_layout(description: str | None) -> str | None:
+    text = _plain_text(description)
+    if not text:
+        return None
+    features = extract_features(text)
+    remaining = []
+    feature_keys = {f"{f['name'].lower()}:{str(f.get('value') or '').lower()}" for f in features}
+    for line in [part.strip(" •-*\t") for part in re.split(r"[\r\n]+", text)]:
+        match = _KEY_VALUE_RE.match(line)
+        if match:
+            key = f"{_normalise_feature_name(match.group(1)).lower()}:{match.group(2).strip().lower()}"
+            if key in feature_keys:
+                continue
+        if line:
+            remaining.append(line)
+    parts: list[str] = []
+    if remaining:
+        parts.append("<h3>Overview</h3>")
+        parts.extend(f"<p>{html.escape(line)}</p>" for line in remaining[:8])
+    if features:
+        parts.append("<h3>Specifications</h3><dl>")
+        for feature in features:
+            parts.append(f"<dt>{html.escape(str(feature['name']))}</dt><dd>{html.escape(str(feature.get('value') or ''))}</dd>")
+        parts.append("</dl>")
+    return sanitize_rich_text("\n".join(parts)).html or None
+
+
+def _parse_ai_payload(payload: Any) -> tuple[str | None, list[dict[str, Any]]]:
+    if isinstance(payload, Mapping):
+        text = payload.get("response") or payload.get("text") or payload.get("content") or payload
+    else:
+        text = payload
+    if isinstance(text, Mapping):
+        data = dict(text)
+    else:
+        raw = str(text or "").strip()
+        raw = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw, flags=re.IGNORECASE | re.DOTALL).strip()
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return sanitize_rich_text(raw).html if raw else None, []
+    desc = data.get("description_html") or data.get("description") or data.get("html")
+    raw_features = data.get("features") or []
+    features: list[dict[str, Any]] = []
+    if isinstance(raw_features, list):
+        for item in raw_features:
+            if not isinstance(item, Mapping):
+                continue
+            name = _normalise_feature_name(str(item.get("name") or item.get("feature") or ""))
+            value = str(item.get("value") or item.get("specification") or "").strip()
+            if name and value:
+                features.append({"name": name, "value": value, "position": len(features)})
+    return sanitize_rich_text(str(desc)).html if desc else None, features
+
+
+async def improve_product_description(product_id: int) -> dict[str, Any] | None:
+    product = await shop_repo.get_product_by_id(product_id, include_archived=True)
+    if not product:
+        return None
+    original = str(product.get("description") or "").strip()
+    if not original:
+        await shop_repo.replace_product_features(product_id, [])
+        return {"description": None, "features": []}
+
+    description_html: str | None = None
+    features: list[dict[str, Any]] = []
+    try:
+        response = await modules_service.trigger_module("ollama", {"prompt": _PROMPT.format(description=original), "format": "json"})
+        status = str(response.get("status") or "") if isinstance(response, Mapping) else ""
+        if status not in {"skipped", "error"}:
+            description_html, features = _parse_ai_payload(response.get("response") if isinstance(response, Mapping) else response)
+    except ValueError:
+        pass
+    except Exception as exc:  # pragma: no cover - external AI/network failures
+        log_error("Product description AI refresh failed; using local formatting", product_id=product_id, error=str(exc))
+
+    if not description_html:
+        description_html = _fallback_layout(original)
+    if not features:
+        features = extract_features(original)
+
+    updated = await shop_repo.update_product_description(product_id, description_html)
+    await shop_repo.replace_product_features(product_id, features)
+    log_info("Product description refreshed", product_id=product_id, feature_count=len(features), ai_used=bool(description_html))
+    return {"description": updated.get("description") if updated else description_html, "features": features}

--- a/app/services/products.py
+++ b/app/services/products.py
@@ -20,6 +20,7 @@ from app.core.config import get_settings
 from app.core.logging import log_error, log_info
 from app.repositories import shop as shop_repo
 from app.repositories import stock_feed as stock_feed_repo
+from app.services import product_descriptions
 
 
 class _ImageTooLargeError(Exception):
@@ -688,6 +689,19 @@ async def import_product_by_vendor_sku(vendor_sku: str) -> bool:
                 existing_id = int(existing_product["id"])
             except (TypeError, ValueError):  # pragma: no cover - defensive
                 existing_id = None
+        imported_product = await shop_repo.get_product_by_sku(
+            cleaned_vendor_sku, include_archived=True
+        )
+        if imported_product and not existing_product:
+            try:
+                await product_descriptions.improve_product_description(int(imported_product["id"]))
+            except Exception as exc:  # pragma: no cover - AI/network/database safety
+                log_error(
+                    "Failed to refresh imported product description",
+                    vendor_sku=cleaned_vendor_sku,
+                    product_id=imported_product.get("id"),
+                    error=str(exc),
+                )
         log_info(
             "Imported product from stock feed",
             vendor_sku=cleaned_vendor_sku,

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -258,6 +258,10 @@
                     <button type="button" class="header-menu__item" role="menuitem" data-product-edit="{{ product.id }}">Edit</button>
                     <button type="button" class="header-menu__item" role="menuitem" data-product-visibility="{{ product.id }}">Visibility</button>
                     <button type="button" class="header-menu__item" role="menuitem" data-product-price-history="{{ product.id }}" data-product-sku="{{ product.vendor_sku or product.sku }}">Price History</button>
+                    <form action="/shop/admin/product/{{ product.id }}/refresh-description" method="post" class="header-menu__form">
+                      {% if csrf_token %}<input type="hidden" name="_csrf" value="{{ csrf_token }}" />{% endif %}
+                      <button type="submit" class="header-menu__item" role="menuitem">Refresh description</button>
+                    </form>
                     <form action="/shop/admin/product/{{ product.id }}/{{ 'unarchive' if product.archived else 'archive' }}" method="post" class="header-menu__form">
                       {% if csrf_token %}<input type="hidden" name="_csrf" value="{{ csrf_token }}" />{% endif %}
                       <button type="submit" class="header-menu__item" role="menuitem">{{ 'Unarchive' if product.archived else 'Archive' }}</button>

--- a/tests/test_product_descriptions.py
+++ b/tests/test_product_descriptions.py
@@ -1,0 +1,34 @@
+from app.services import product_descriptions
+
+
+def test_extract_features_from_key_value_lines():
+    description = """
+    CPU: Intel Core i7
+    Memory - 16GB DDR5
+    Storage | 512GB SSD
+    Marketing paragraph without a separator.
+    """
+
+    features = product_descriptions.extract_features(description)
+
+    assert features == [
+        {"name": "CPU", "value": "Intel Core i7", "position": 0},
+        {"name": "Memory", "value": "16GB DDR5", "position": 1},
+        {"name": "Storage", "value": "512GB SSD", "position": 2},
+    ]
+
+
+def test_parse_ai_payload_sanitizes_html_and_features():
+    html, features = product_descriptions._parse_ai_payload(
+        {
+            "description_html": "<h3>Specs</h3><script>alert(1)</script><p>Safe</p>",
+            "features": [
+                {"name": "Warranty", "value": "3 years"},
+                {"name": "", "value": "ignored"},
+            ],
+        }
+    )
+
+    assert "script" not in (html or "").lower()
+    assert "Safe" in (html or "")
+    assert features == [{"name": "Warranty", "value": "3 years", "position": 0}]


### PR DESCRIPTION
### Motivation
- Improve readability of shop product descriptions imported from vendor feeds by reformatting them into user-friendly HTML. 
- Persist useful key/value specifications into the existing `shop_product_features` table to enable future product comparison. 
- Provide both automatic processing for newly imported products and a manual admin action to refresh descriptions on demand. 

### Description
- Add a new service `app/services/product_descriptions.py` that calls the configured AI module via `modules_service.trigger_module` with a prompt to return sanitized HTML and a `features` list, and falls back to a local formatting and key/value feature extraction routine when AI is unavailable. 
- Persist extracted features using the existing `replace_product_features` flow and update product description via a new repository helper `update_product_description` in `app/repositories/shop.py`. 
- Automatically invoke description processing for newly imported stock-feed products in `app/services/products.py` after successful import. 
- Add a super-admin handler `admin_refresh_shop_product_description` and route `/shop/admin/product/{product_id}/refresh-description` plus a UI action in `app/templates/admin/shop.html` to allow manual refreshes, and wire in auditing of the refresh. 
- Add unit tests `tests/test_product_descriptions.py` covering feature extraction and AI payload sanitization. 

### Testing
- Ran Python syntax checks with `python -m py_compile` on changed modules which completed successfully. 
- Ensured repository integrity with `git diff --check` which reported no issues. 
- Executed the new tests with `pytest -q tests/test_product_descriptions.py`, which passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b424cf7c4832da3e6c51584b4d805)