### PR TITLE
Fix TRMM tray token custom field sync

### DIFF
--- a/app/services/tray.py
+++ b/app/services/tray.py
@@ -185,6 +185,14 @@ def _extract_trmm_custom_field_id(
     return None
 
 
+def _coerce_positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
 def _iter_trmm_custom_field_definitions(response: Any) -> Iterable[dict[str, Any]]:
     if isinstance(response, list):
         for item in response:
@@ -210,12 +218,49 @@ def _extract_trmm_client_custom_field_definition_id(
         model = str(field.get("model") or "").strip().casefold()
         if name != target_name or model != "client":
             continue
-        raw_id = field.get("id") or field.get("pk") or field.get("field")
-        try:
-            return int(raw_id)
-        except (TypeError, ValueError):
-            return None
+        field_id = _coerce_positive_int(
+            field.get("id") or field.get("pk") or field.get("field")
+        )
+        if field_id is not None:
+            return field_id
     return None
+
+
+def _build_trmm_client_custom_field_payload(
+    client: dict[str, Any], field_id: int, token: str
+) -> list[dict[str, Any]]:
+    """Return TRMM client custom-field values preserving unrelated fields.
+
+    Tactical RMM client responses identify custom-field values by numeric
+    definition IDs in the ``field`` property rather than by field name. When
+    updating a single client field, include the existing field value ``id`` (if
+    present) and keep the rest of the custom-field array intact so the PUT does
+    not accidentally clear unrelated client custom fields.
+    """
+
+    payload: list[dict[str, Any]] = []
+    found_target = False
+    for existing in client.get("custom_fields") or []:
+        if not isinstance(existing, dict):
+            continue
+        existing_field_id = _coerce_positive_int(existing.get("field"))
+        if existing_field_id is None:
+            continue
+        item: dict[str, Any] = {
+            "field": existing_field_id,
+            "value": existing.get("value"),
+        }
+        value_id = _coerce_positive_int(existing.get("id") or existing.get("pk"))
+        if value_id is not None:
+            item["id"] = value_id
+        if existing_field_id == field_id:
+            item["value"] = token
+            found_target = True
+        payload.append(item)
+
+    if not found_target:
+        payload.append({"field": field_id, "value": token})
+    return payload
 
 
 async def update_trmm_client_token_field(
@@ -253,13 +298,15 @@ async def update_trmm_client_token_field(
             f'Tactical RMM client custom field "{custom_field_name}" was not found'
         )
 
-    custom_field_payload = {"field": field_id, "string_value": token}
+    custom_field_payload = _build_trmm_client_custom_field_payload(
+        client, field_id, token
+    )
 
-    # Tactical RMM's custom-field update examples use ``PUT`` with only the
-    # ``custom_fields`` array in the request body.  Keeping the payload scoped
-    # to the client endpoint ensures we update the client-level value, not an
-    # agent or site field.
-    body = {"custom_fields": [custom_field_payload]}
+    # Tactical RMM returns client custom-field values as ``{"field": <id>,
+    # "value": ...}`` entries, often without the field name.  Send the same
+    # value shape back and preserve unrelated fields so updating the tray token
+    # does not clear other client-level custom fields.
+    body = {"custom_fields": custom_field_payload}
     return await tacticalrmm_service._call_endpoint(
         f"/clients/{client_id}/", method="PUT", body=body
     )

--- a/tests/test_tray_trmm_token_sync.py
+++ b/tests/test_tray_trmm_token_sync.py
@@ -13,7 +13,7 @@ def test_update_trmm_client_token_field_uses_trmm_put_payload(monkeypatch):
                 "id": 42,
                 "name": "Acme",
                 "custom_fields": [
-                    {"field": 7, "name": "MyPortalToken", "string_value": "old"}
+                    {"id": 11, "field": 7, "name": "MyPortalToken", "value": "old"}
                 ],
             }
         return {"status": "ok"}
@@ -33,7 +33,7 @@ def test_update_trmm_client_token_field_uses_trmm_put_payload(monkeypatch):
             "endpoint": "/clients/42/",
             "method": "PUT",
             "body": {
-                "custom_fields": [{"field": 7, "string_value": "new-token"}],
+                "custom_fields": [{"field": 7, "value": "new-token", "id": 11}],
             },
         },
     ]
@@ -70,7 +70,53 @@ def test_update_trmm_client_token_field_resolves_client_field_definition(monkeyp
             "endpoint": "/clients/42/",
             "method": "PUT",
             "body": {
-                "custom_fields": [{"field": 9, "string_value": "new-token"}],
+                "custom_fields": [{"field": 9, "value": "new-token"}],
             },
         },
     ]
+
+
+def test_update_trmm_client_token_field_preserves_id_only_custom_fields(monkeypatch):
+    calls = []
+
+    async def fake_call_endpoint(endpoint, *, method="GET", body=None):
+        calls.append({"endpoint": endpoint, "method": method, "body": body})
+        if endpoint == "/clients/86/" and method == "GET":
+            return {
+                "id": 86,
+                "name": "Forgate Contracting",
+                "custom_fields": [
+                    {"id": 12, "field": 12, "client": 86, "value": "forgate"},
+                    {"id": 13, "field": 4, "client": 86, "value": None},
+                    {"id": 14, "field": 5, "client": 86, "value": None},
+                ],
+            }
+        if endpoint == "/core/customfields/" and method == "GET":
+            return {
+                "results": [
+                    {"id": 12, "model": "client", "name": "Company Slug"},
+                    {"id": 4, "model": "client", "name": "MyPortalToken"},
+                    {"id": 5, "model": "client", "name": "Other"},
+                ]
+            }
+        return {"status": "ok"}
+
+    from app.services import tacticalrmm
+
+    monkeypatch.setattr(tacticalrmm, "_call_endpoint", fake_call_endpoint)
+
+    asyncio.run(
+        tray.update_trmm_client_token_field(trmm_client_id=86, token="new-token")
+    )
+
+    assert calls[-1] == {
+        "endpoint": "/clients/86/",
+        "method": "PUT",
+        "body": {
+            "custom_fields": [
+                {"field": 12, "value": "forgate", "id": 12},
+                {"field": 4, "value": "new-token", "id": 13},
+                {"field": 5, "value": None, "id": 14},
+            ]
+        },
+    }


### PR DESCRIPTION
### Motivation
- Tactical RMM client responses sometimes expose `custom_fields` using numeric IDs and `value` fields instead of names and `string_value`, which caused tray enrolment tokens not to be written back to TRMM and risked clearing unrelated client custom fields.
- Preserve existing TRMM client custom-field entries and include existing value IDs when updating to avoid accidentally removing other client-level custom fields.

### Description
- Add `_coerce_positive_int` helper to robustly parse numeric IDs from TRMM responses and use it when resolving field definitions via `id|pk|field`.
- Implement `_build_trmm_client_custom_field_payload` to construct an update payload that preserves unrelated custom-fields and existing value `id`s while writing the tray token into the target field.
- Replace the previous single-field `string_value` payload with a preserved `custom_fields` array shaped like TRMM returns (using `field`/`value` and `id` when present) and send that in the `PUT /clients/{id}/` call.
- Add a regression test `test_update_trmm_client_token_field_preserves_id_only_custom_fields` and update existing TRMM token tests to cover ID-only and `value`-shaped responses, and run code formatting with `black` on the touched files.

### Testing
- Ran code formatting with `python -m black app/services/tray.py tests/test_tray_trmm_token_sync.py` which completed successfully.
- Ran `pytest tests/test_tray_trmm_token_sync.py -q` and all tests passed (`3 passed`) with warnings reported; tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b47bb2a68832d9c17df5a94b3b560)