### PR TITLE
Improve stock feed XML parse errors

### DIFF
--- a/app/services/products.py
+++ b/app/services/products.py
@@ -346,11 +346,25 @@ def _parse_feed_item(element: Element) -> dict[str, Any] | None:
     }
 
 
+def _format_stock_feed_parse_error(exc: ParseError) -> str:
+    """Return a safe, actionable description of an XML parse failure."""
+
+    detail = str(exc).strip() or exc.__class__.__name__
+    position = getattr(exc, "position", None)
+    if position:
+        line, column = position
+        location = f"line {line}, column {column}"
+        if location not in detail:
+            detail = f"{detail} at {location}"
+    return detail
+
+
 def _parse_stock_feed_xml(payload: str) -> list[dict[str, Any]]:
     try:
         root = fromstring(payload)
     except ParseError as exc:
-        raise ValueError("Invalid stock feed XML") from exc
+        detail = _format_stock_feed_parse_error(exc)
+        raise ValueError(f"Invalid stock feed XML: {detail}") from exc
 
     items: list[dict[str, Any]] = []
     for element in root.iter():

--- a/tests/test_products_service.py
+++ b/tests/test_products_service.py
@@ -205,6 +205,17 @@ async def test_update_stock_feed_requires_config(monkeypatch):
         await products_service.update_stock_feed()
 
 
+def test_parse_stock_feed_xml_reports_parse_error_details():
+    with pytest.raises(ValueError) as exc_info:
+        products_service._parse_stock_feed_xml("<rss><channel></rss>")
+
+    message = str(exc_info.value)
+    assert message.startswith("Invalid stock feed XML: ")
+    assert "mismatched tag" in message
+    assert "line 1" in message
+    assert "column" in message
+
+
 @pytest.mark.anyio("asyncio")
 async def test_parse_feed_item_includes_opt_accessori():
     """OptAccessori in XML feed is parsed into the opt_accessori key."""


### PR DESCRIPTION
### Motivation
- The `update_stock_feed` XML parser raised `ValueError("Invalid stock feed XML")` with no actionable details, making it hard to diagnose malformed feeds.

### Description
- Added `_format_stock_feed_parse_error(exc: ParseError) -> str` to extract the parser message and include `line`/`column` when available.
- Updated `_parse_stock_feed_xml` to include the formatted parse detail in the raised `ValueError` (e.g. `Invalid stock feed XML: ...`).
- Added regression test `test_parse_stock_feed_xml_reports_parse_error_details` to assert the error message contains the parse cause and position.

### Testing
- Ran `pytest tests/test_products_service.py::test_parse_stock_feed_xml_reports_parse_error_details -q` and it passed.
- Ran `pytest tests/test_products_service.py -q` where the new regression passed but the run reported one unrelated pre-existing test failure in `test_import_product_by_vendor_sku_processes_feed_item`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b48aab088832d94ba07724fbb683b)