### PR TITLE
Fix shop product AI description refresh

### DIFF
--- a/app/services/product_descriptions.py
+++ b/app/services/product_descriptions.py
@@ -13,7 +13,7 @@ from app.services.sanitization import sanitize_rich_text
 _PROMPT = """Below is a product description, without modifying the specifications redesign the layout in a user-friendly and easily readable way.
 
 Return JSON only with this shape:
-{"description_html":"safe HTML using headings, lists and tables", "features":[{"name":"Feature name","value":"Feature value"}]}
+{{"description_html":"safe HTML using headings, lists and tables", "features":[{{"name":"Feature name","value":"Feature value"}}]}}
 
 Product description:
 {description}
@@ -128,7 +128,11 @@ async def improve_product_description(product_id: int) -> dict[str, Any] | None:
     description_html: str | None = None
     features: list[dict[str, Any]] = []
     try:
-        response = await modules_service.trigger_module("ollama", {"prompt": _PROMPT.format(description=original), "format": "json"})
+        response = await modules_service.trigger_module(
+            "ollama",
+            {"prompt": _PROMPT.format(description=original), "format": "json"},
+            background=False,
+        )
         status = str(response.get("status") or "") if isinstance(response, Mapping) else ""
         if status not in {"skipped", "error"}:
             description_html, features = _parse_ai_payload(response.get("response") if isinstance(response, Mapping) else response)

--- a/app/services/products.py
+++ b/app/services/products.py
@@ -706,7 +706,7 @@ async def import_product_by_vendor_sku(vendor_sku: str) -> bool:
         imported_product = await shop_repo.get_product_by_sku(
             cleaned_vendor_sku, include_archived=True
         )
-        if imported_product and not existing_product:
+        if imported_product and imported_product.get("id"):
             try:
                 await product_descriptions.improve_product_description(int(imported_product["id"]))
             except Exception as exc:  # pragma: no cover - AI/network/database safety

--- a/tests/test_product_descriptions.py
+++ b/tests/test_product_descriptions.py
@@ -32,3 +32,36 @@ def test_parse_ai_payload_sanitizes_html_and_features():
     assert "script" not in (html or "").lower()
     assert "Safe" in (html or "")
     assert features == [{"name": "Warranty", "value": "3 years", "position": 0}]
+
+import pytest
+from unittest.mock import AsyncMock
+
+
+@pytest.mark.anyio("asyncio")
+async def test_improve_product_description_invokes_ollama_synchronously(monkeypatch):
+    monkeypatch.setattr(
+        product_descriptions.shop_repo,
+        "get_product_by_id",
+        AsyncMock(return_value={"id": 10, "description": "CPU: Fast"}),
+    )
+    trigger = AsyncMock(
+        return_value={
+            "status": "success",
+            "response": '{"description_html":"<h3>Overview</h3><p>AI copy</p>","features":[{"name":"CPU","value":"Fast"}]}',
+        }
+    )
+    monkeypatch.setattr(product_descriptions.modules_service, "trigger_module", trigger)
+    update = AsyncMock(return_value={"description": "<h3>Overview</h3><p>AI copy</p>"})
+    monkeypatch.setattr(product_descriptions.shop_repo, "update_product_description", update)
+    replace = AsyncMock()
+    monkeypatch.setattr(product_descriptions.shop_repo, "replace_product_features", replace)
+
+    result = await product_descriptions.improve_product_description(10)
+
+    assert result == {
+        "description": "<h3>Overview</h3><p>AI copy</p>",
+        "features": [{"name": "CPU", "value": "Fast", "position": 0}],
+    }
+    trigger.assert_awaited_once()
+    assert trigger.await_args.args[0] == "ollama"
+    assert trigger.await_args.kwargs["background"] is False

--- a/tests/test_products_service.py
+++ b/tests/test_products_service.py
@@ -55,13 +55,37 @@ async def test_import_product_by_vendor_sku_processes_feed_item(monkeypatch):
 
     mock_process = AsyncMock(return_value=True)
     monkeypatch.setattr(products_service, "_process_feed_item", mock_process)
+    refresh = AsyncMock(return_value={"description": "AI", "features": []})
+    monkeypatch.setattr(products_service.product_descriptions, "improve_product_description", refresh)
 
     result = await products_service.import_product_by_vendor_sku("  ABC123  ")
 
     assert result is True
     mock_get_item.assert_awaited_once_with("ABC123")
-    mock_get_product.assert_awaited_once_with("ABC123", include_archived=True)
+    assert mock_get_product.await_args_list == [
+        call("ABC123", include_archived=True),
+        call("ABC123", include_archived=True),
+    ]
     mock_process.assert_awaited_once_with(item, existing_product)
+    refresh.assert_awaited_once_with(42)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_import_product_by_vendor_sku_refreshes_description_for_existing_product(monkeypatch):
+    item = {"sku": "ABC123"}
+    existing_product = {"id": 42}
+
+    monkeypatch.setattr(products_service.stock_feed_repo, "get_item_by_sku", AsyncMock(return_value=item))
+    get_product = AsyncMock(side_effect=[existing_product, existing_product])
+    monkeypatch.setattr(products_service.shop_repo, "get_product_by_sku", get_product)
+    monkeypatch.setattr(products_service, "_process_feed_item", AsyncMock(return_value=True))
+    refresh = AsyncMock(return_value={"description": "AI", "features": []})
+    monkeypatch.setattr(products_service.product_descriptions, "improve_product_description", refresh)
+
+    result = await products_service.import_product_by_vendor_sku("ABC123")
+
+    assert result is True
+    refresh.assert_awaited_once_with(42)
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation
- Product description formatting used a JSON example in the prompt that was interpreted by Python's `str.format`, which could break before the Ollama call runs.
- The Ollama trigger was being queued in the background so the service often fell back to local formatting before an AI response was available.
- Importing products from the stock feed did not reliably refresh AI descriptions for products with an ID after upsert.

### Description
- Escape the JSON example in the product-description prompt (`_PROMPT`) so `str.format(description=...)` no longer fails before calling the module (change in `app/services/product_descriptions.py`).
- Invoke the Ollama module synchronously by calling `modules_service.trigger_module("ollama", ..., background=False)` so the AI response is available before the fallback is applied (change in `app/services/product_descriptions.py`).
- Update the import flow to trigger description refresh for any successfully imported product that has an `id` (change in `app/services/products.py`).
- Add/adjust unit tests to cover synchronous Ollama invocation and the import-triggered description refresh behaviour (changes in `tests/test_product_descriptions.py` and `tests/test_products_service.py`).

### Testing
- Ran the focused test suite: `pytest -q tests/test_product_descriptions.py tests/test_products_service.py` and all tests passed.
- Verified no lint/format check errors with `git diff --check` (no reported issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b4e64c0f883329096116c3d1cd57e)