### PR TITLE
Handle invalid XML feed items safely

### DIFF
--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -11,7 +11,6 @@ import aiomysql
 
 from app.core.database import db
 
-
 _FULLTEXT_MIN_SEARCH_LENGTH = 3
 
 
@@ -36,7 +35,9 @@ def _prepare_product_search_term(search: str | None) -> tuple[str | None, str | 
     return "prefix", f"{term}%"
 
 
-def _append_product_search_filter(conditions: list[str], params: list[Any], search: str | None) -> None:
+def _append_product_search_filter(
+    conditions: list[str], params: list[Any], search: str | None
+) -> None:
     mode, value = _prepare_product_search_term(search)
     if not mode or value is None:
         return
@@ -48,9 +49,7 @@ def _append_product_search_filter(conditions: list[str], params: list[Any], sear
         params.append(value)
         return
 
-    conditions.append(
-        "(p.name LIKE %s OR p.sku LIKE %s OR p.vendor_sku LIKE %s)"
-    )
+    conditions.append("(p.name LIKE %s OR p.sku LIKE %s OR p.vendor_sku LIKE %s)")
     params.extend([value, value, value])
 
 
@@ -74,51 +73,47 @@ class PackageFilters:
 
 
 async def list_categories() -> list[dict[str, Any]]:
-    rows = await db.fetch_all(
-        """
+    rows = await db.fetch_all("""
         SELECT id, name, parent_id, display_order 
         FROM shop_categories 
         ORDER BY name
-        """
-    )
+        """)
     categories = [
         {
-            "id": int(row["id"]), 
+            "id": int(row["id"]),
             "name": row["name"],
             "parent_id": _coerce_optional_int(row.get("parent_id")),
             "display_order": _coerce_int(row.get("display_order"), default=0),
         }
         for row in rows
     ]
-    
+
     # Build hierarchical structure
     parent_map: dict[int | None, list[dict[str, Any]]] = {}
     for category in categories:
         parent_id = category.get("parent_id")
         parent_map.setdefault(parent_id, []).append(category)
-    
+
     # Sort all children alphabetically by name
     for children_list in parent_map.values():
         children_list.sort(key=lambda c: c["name"].lower())
-    
+
     # Attach children to parents
     for category in categories:
         category_id = category["id"]
         category["children"] = parent_map.get(category_id, [])
-    
+
     # Return only top-level categories (those without parents), already sorted alphabetically
     return parent_map.get(None, [])
 
 
 async def _fetch_all_categories_raw() -> list[dict[str, Any]]:
     """Fetch all categories from the database as a flat list ordered by name."""
-    rows = await db.fetch_all(
-        """
+    rows = await db.fetch_all("""
         SELECT id, name, parent_id, display_order 
         FROM shop_categories 
         ORDER BY name
-        """
-    )
+        """)
     return [
         {
             "id": int(row["id"]),
@@ -132,24 +127,24 @@ async def _fetch_all_categories_raw() -> list[dict[str, Any]]:
 
 async def list_all_categories_flat() -> list[dict[str, Any]]:
     """List all categories in a flat structure for admin purposes.
-    
+
     Returns categories ordered alphabetically with children grouped under their parents.
     Parent categories are sorted alphabetically, and each parent's children are also
     sorted alphabetically and appear immediately after their parent. This handles
     all levels of nesting (grandchildren, great-grandchildren, etc.).
     """
     categories = await _fetch_all_categories_raw()
-    
+
     # Build parent-child map
     parent_map: dict[int | None, list[dict[str, Any]]] = {}
     for category in categories:
         parent_id = category.get("parent_id")
         parent_map.setdefault(parent_id, []).append(category)
-    
+
     # Sort all groups alphabetically by name
     for children_list in parent_map.values():
         children_list.sort(key=lambda c: c["name"].lower())
-    
+
     # Recursively build flat list: parent followed by all its descendants
     def add_category_and_descendants(cat_id: int, result: list[dict[str, Any]]) -> None:
         """Add a category and all its descendants to the result list."""
@@ -157,14 +152,14 @@ async def list_all_categories_flat() -> list[dict[str, Any]]:
             result.append(child)
             # Recursively add this child's children
             add_category_and_descendants(child["id"], result)
-    
+
     result: list[dict[str, Any]] = []
     # Start with top-level categories (no parent)
     for parent in parent_map.get(None, []):
         result.append(parent)
         # Add all descendants of this parent
         add_category_and_descendants(parent["id"], result)
-    
+
     return result
 
 
@@ -179,12 +174,12 @@ async def list_categories_with_products() -> list[dict[str, Any]]:
     all_categories = await _fetch_all_categories_raw()
 
     # Find category IDs that have at least one product
-    product_rows = await db.fetch_all(
-        """
+    product_rows = await db.fetch_all("""
         SELECT DISTINCT category_id FROM shop_products WHERE category_id IS NOT NULL
-        """
-    )
-    category_ids_with_products: set[int] = {int(row["category_id"]) for row in product_rows}
+        """)
+    category_ids_with_products: set[int] = {
+        int(row["category_id"]) for row in product_rows
+    }
 
     # Build parent-child map for all categories
     parent_map: dict[int | None, list[dict[str, Any]]] = {}
@@ -193,7 +188,9 @@ async def list_categories_with_products() -> list[dict[str, Any]]:
         parent_map.setdefault(parent_id, []).append(category)
 
     # Determine which category IDs to include: those with products plus their ancestors
-    def get_ancestor_ids(cat: dict[str, Any], cat_by_id: dict[int, dict[str, Any]]) -> list[int]:
+    def get_ancestor_ids(
+        cat: dict[str, Any], cat_by_id: dict[int, dict[str, Any]]
+    ) -> list[int]:
         """Return ancestor IDs for a category (not including itself)."""
         ancestors: list[int] = []
         current = cat
@@ -232,17 +229,15 @@ async def list_categories_with_products() -> list[dict[str, Any]]:
 
 async def get_category_descendants(category_id: int) -> list[int]:
     """Get all descendant category IDs for a given category.
-    
+
     Returns a list of category IDs including the category itself and all its descendants
     (children, grandchildren, etc.).
     """
-    rows = await db.fetch_all(
-        """
+    rows = await db.fetch_all("""
         SELECT id, parent_id 
         FROM shop_categories
-        """
-    )
-    
+        """)
+
     # Build parent-child map
     parent_map: dict[int, list[int]] = {}
     for row in rows:
@@ -250,11 +245,13 @@ async def get_category_descendants(category_id: int) -> list[int]:
         child_id = int(row["id"])
         if parent_id is not None:
             parent_map.setdefault(parent_id, []).append(child_id)
-    
+
     # Recursively collect all descendants with cycle detection
-    def collect_descendants(cat_id: int, result: set[int], visited: set[int], depth: int = 0) -> None:
+    def collect_descendants(
+        cat_id: int, result: set[int], visited: set[int], depth: int = 0
+    ) -> None:
         """Recursively add all descendants to the result set.
-        
+
         Args:
             cat_id: Category ID to process
             result: Set of all descendant IDs found
@@ -266,16 +263,16 @@ async def get_category_descendants(category_id: int) -> list[int]:
             return
         if cat_id in visited:  # Cycle detection
             return
-        
+
         visited.add(cat_id)
         for child_id in parent_map.get(cat_id, []):
             result.add(child_id)
             collect_descendants(child_id, result, visited, depth + 1)
         visited.remove(cat_id)
-    
+
     descendants: set[int] = {category_id}
     collect_descendants(category_id, descendants, set(), 0)
-    
+
     return list(descendants)
 
 
@@ -594,7 +591,9 @@ async def list_packages(filters: PackageFilters) -> list[dict[str, Any]]:
     if filters.search_term:
         search = f"%{filters.search_term.strip()}%"
         if search.strip("%"):
-            conditions.append("(pkg.name LIKE %s OR pkg.sku LIKE %s OR pkg.description LIKE %s)")
+            conditions.append(
+                "(pkg.name LIKE %s OR pkg.sku LIKE %s OR pkg.description LIKE %s)"
+            )
             params.extend([search, search, search])
     if conditions:
         query.append("WHERE " + " AND ".join(conditions))
@@ -605,7 +604,9 @@ async def list_packages(filters: PackageFilters) -> list[dict[str, Any]]:
     return [_normalise_package(row) for row in rows]
 
 
-async def get_package(package_id: int, *, include_archived: bool = False) -> dict[str, Any] | None:
+async def get_package(
+    package_id: int, *, include_archived: bool = False
+) -> dict[str, Any] | None:
     sql = [
         "SELECT",
         "    pkg.id,",
@@ -915,18 +916,20 @@ async def get_restricted_product_ids(
         """,
         tuple([company_id, *identifiers]),
     )
-    return {_coerce_int(row.get("product_id")) for row in rows if row.get("product_id") is not None}
+    return {
+        _coerce_int(row.get("product_id"))
+        for row in rows
+        if row.get("product_id") is not None
+    }
 
 
 async def list_product_restrictions() -> list[dict[str, Any]]:
-    rows = await db.fetch_all(
-        """
+    rows = await db.fetch_all("""
         SELECT e.product_id, e.company_id, c.name AS company_name
         FROM shop_product_exclusions AS e
         INNER JOIN companies AS c ON c.id = e.company_id
         ORDER BY c.name
-        """
-    )
+        """)
     restrictions: list[dict[str, Any]] = []
     for row in rows:
         restrictions.append(
@@ -939,7 +942,9 @@ async def list_product_restrictions() -> list[dict[str, Any]]:
     return restrictions
 
 
-async def list_product_restrictions_for_product(product_id: int) -> list[dict[str, Any]]:
+async def list_product_restrictions_for_product(
+    product_id: int,
+) -> list[dict[str, Any]]:
     rows = await db.fetch_all(
         """
         SELECT e.product_id, e.company_id, c.name AS company_name
@@ -970,8 +975,7 @@ async def list_optional_accessory_products() -> list[dict[str, Any]]:
     result includes the names and SKUs of the parent products that reference
     each accessory.
     """
-    rows = await db.fetch_all(
-        """
+    rows = await db.fetch_all("""
         SELECT
             p.id,
             p.name,
@@ -993,8 +997,7 @@ async def list_optional_accessory_products() -> list[dict[str, Any]]:
         GROUP BY p.id, p.name, p.sku, p.vendor_sku, p.image_url, p.price,
                  p.vip_price, p.stock, p.archived, p.category_id, c.name
         ORDER BY p.name ASC
-        """
-    )
+        """)
     return [_normalise_optional_accessory_product(row) for row in rows]
 
 
@@ -1040,8 +1043,7 @@ async def sync_pending_optional_accessories() -> int:
     Returns the number of rows inserted or updated.
     """
     # Fetch all stock-feed items that have opt_accessori populated
-    rows = await db.fetch_all(
-        """
+    rows = await db.fetch_all("""
         SELECT
             sf.sku AS parent_sku,
             sf.opt_accessori,
@@ -1059,8 +1061,7 @@ async def sync_pending_optional_accessories() -> int:
           AND NOT EXISTS (
               SELECT 1 FROM shop_products WHERE sku = sf2.sku AND archived = 0
           )
-        """
-    )
+        """)
 
     if not rows:
         return 0
@@ -1114,41 +1115,35 @@ async def sync_pending_optional_accessories() -> int:
         count += 1
 
     # Remove entries that have since been imported into shop_products
-    await db.execute(
-        """
+    await db.execute("""
         DELETE soa FROM shop_optional_accessories AS soa
         INNER JOIN shop_products AS sp ON sp.sku = soa.sku AND sp.archived = 0
-        """
-    )
+        """)
 
     return count
 
 
 async def list_pending_optional_accessories() -> list[dict[str, Any]]:
     """Return non-dismissed rows from the ``shop_optional_accessories`` staging table."""
-    rows = await db.fetch_all(
-        """
+    rows = await db.fetch_all("""
         SELECT id, sku, product_name, category_name, rrp, image_url,
                manufacturer, referenced_by_skus, discovered_at
         FROM shop_optional_accessories
         WHERE dismissed = 0
         ORDER BY product_name ASC, sku ASC
-        """
-    )
+        """)
     return [_normalise_pending_optional_accessory(row) for row in rows]
 
 
 async def list_dismissed_optional_accessories() -> list[dict[str, Any]]:
     """Return dismissed rows from the ``shop_optional_accessories`` staging table."""
-    rows = await db.fetch_all(
-        """
+    rows = await db.fetch_all("""
         SELECT id, sku, product_name, category_name, rrp, image_url,
                manufacturer, referenced_by_skus, discovered_at, dismissed_at
         FROM shop_optional_accessories
         WHERE dismissed = 1
         ORDER BY dismissed_at DESC, product_name ASC, sku ASC
-        """
-    )
+        """)
     return [_normalise_pending_optional_accessory(row) for row in rows]
 
 
@@ -1240,7 +1235,7 @@ async def get_category(category_id: int) -> dict[str, Any] | None:
     if not row:
         return None
     return {
-        "id": int(row["id"]), 
+        "id": int(row["id"]),
         "name": row["name"],
         "parent_id": _coerce_optional_int(row.get("parent_id")),
         "display_order": _coerce_int(row.get("display_order"), default=0),
@@ -1470,7 +1465,9 @@ async def create_order(
                 if row and row.get("stock") is not None:
                     previous_stock = int(row["stock"])
                     if previous_stock < quantity:
-                        raise ValueError("Insufficient stock available for this product")
+                        raise ValueError(
+                            "Insufficient stock available for this product"
+                        )
                     new_stock = previous_stock - quantity
                 await cursor.execute(
                     """
@@ -1542,7 +1539,9 @@ async def list_order_summaries(company_id: int) -> list[dict[str, Any]]:
     return [_normalise_order_summary(row) for row in rows]
 
 
-async def get_order_summary(order_number: str, company_id: int) -> dict[str, Any] | None:
+async def get_order_summary(
+    order_number: str, company_id: int
+) -> dict[str, Any] | None:
     row = await db.fetch_one(
         """
         SELECT
@@ -1647,14 +1646,16 @@ async def get_category_by_name(name: str) -> dict[str, Any] | None:
     if not row:
         return None
     return {
-        "id": int(row["id"]), 
+        "id": int(row["id"]),
         "name": row["name"],
         "parent_id": _coerce_optional_int(row.get("parent_id")),
         "display_order": _coerce_int(row.get("display_order"), default=0),
     }
 
 
-async def create_category(name: str, parent_id: int | None = None, display_order: int = 0) -> int:
+async def create_category(
+    name: str, parent_id: int | None = None, display_order: int = 0
+) -> int:
     async with db.acquire() as conn:
         async with conn.cursor(aiomysql.DictCursor) as cursor:
             await cursor.execute(
@@ -1665,7 +1666,9 @@ async def create_category(name: str, parent_id: int | None = None, display_order
     return category_id
 
 
-async def update_category(category_id: int, name: str, parent_id: int | None = None, display_order: int = 0) -> bool:
+async def update_category(
+    category_id: int, name: str, parent_id: int | None = None, display_order: int = 0
+) -> bool:
     async with db.acquire() as conn:
         async with conn.cursor(aiomysql.DictCursor) as cursor:
             await cursor.execute(
@@ -1685,7 +1688,9 @@ async def delete_category(category_id: int) -> bool:
             return cursor.rowcount > 0
 
 
-async def update_product_description(product_id: int, description: str | None) -> dict[str, Any] | None:
+async def update_product_description(
+    product_id: int, description: str | None
+) -> dict[str, Any] | None:
     async with db.acquire() as conn:
         async with conn.cursor(aiomysql.DictCursor) as cursor:
             await cursor.execute(
@@ -1803,12 +1808,20 @@ async def replace_product_recommendations(
     auto_linked: bool = False,
 ) -> None:
     cross_ids = (
-        sorted({int(pid) for pid in cross_sell_ids if int(pid) > 0 and int(pid) != product_id})
+        sorted(
+            {
+                int(pid)
+                for pid in cross_sell_ids
+                if int(pid) > 0 and int(pid) != product_id
+            }
+        )
         if cross_sell_ids is not None
         else None
     )
     upsell_ids_clean = (
-        sorted({int(pid) for pid in upsell_ids if int(pid) > 0 and int(pid) != product_id})
+        sorted(
+            {int(pid) for pid in upsell_ids if int(pid) > 0 and int(pid) != product_id}
+        )
         if upsell_ids is not None
         else None
     )
@@ -1852,7 +1865,10 @@ async def replace_product_recommendations(
                                 " (product_id, related_product_id, is_auto_linked)"
                                 " VALUES (%s, %s, 1)"
                                 " ON DUPLICATE KEY UPDATE is_auto_linked = is_auto_linked",
-                                [(product_id, related_id) for related_id in upsell_ids_clean],
+                                [
+                                    (product_id, related_id)
+                                    for related_id in upsell_ids_clean
+                                ],
                             )
                 else:
                     # Admin-driven replacement: replace all recommendations for the
@@ -1865,10 +1881,15 @@ async def replace_product_recommendations(
                     if cross_ids_for_insert:
                         await cursor.executemany(
                             "INSERT INTO shop_product_cross_sells (product_id, related_product_id) VALUES (%s, %s)",
-                            [(product_id, related_id) for related_id in cross_ids_for_insert],
+                            [
+                                (product_id, related_id)
+                                for related_id in cross_ids_for_insert
+                            ],
                         )
 
-                    upsell_ids_for_insert = upsell_ids_clean if upsell_ids_clean is not None else []
+                    upsell_ids_for_insert = (
+                        upsell_ids_clean if upsell_ids_clean is not None else []
+                    )
                     await cursor.execute(
                         "DELETE FROM shop_product_upsells WHERE product_id = %s",
                         (product_id,),
@@ -1876,7 +1897,10 @@ async def replace_product_recommendations(
                     if upsell_ids_for_insert:
                         await cursor.executemany(
                             "INSERT INTO shop_product_upsells (product_id, related_product_id) VALUES (%s, %s)",
-                            [(product_id, related_id) for related_id in upsell_ids_for_insert],
+                            [
+                                (product_id, related_id)
+                                for related_id in upsell_ids_for_insert
+                            ],
                         )
             except Exception:
                 await conn.rollback()
@@ -2048,9 +2072,9 @@ async def replace_product_exclusions(
                 await conn.commit()
 
 
-
-
-async def search_products_for_admin_lookup(term: str, *, limit: int = 10) -> list[dict[str, Any]]:
+async def search_products_for_admin_lookup(
+    term: str, *, limit: int = 10
+) -> list[dict[str, Any]]:
     cleaned_term = term.strip()
     if not cleaned_term or limit <= 0:
         return []
@@ -2113,6 +2137,27 @@ async def get_product_ids_by_skus(skus: Sequence[str]) -> list[int]:
     )
     rows = await db.fetch_all(sql, tuple(skus) * 2)
     return [_coerce_int(row["id"]) for row in rows if _coerce_int(row.get("id")) > 0]
+
+
+async def mark_product_out_of_stock_by_sku(sku: str) -> None:
+    """Set stock quantities to zero for products matching a feed SKU."""
+
+    cleaned_sku = sku.strip()
+    if not cleaned_sku:
+        return
+
+    await db.execute(
+        """
+        UPDATE shop_products
+        SET stock = 0,
+            stock_nsw = 0,
+            stock_qld = 0,
+            stock_vic = 0,
+            stock_sa = 0
+        WHERE sku = %s OR vendor_sku = %s
+        """,
+        (cleaned_sku, cleaned_sku),
+    )
 
 
 async def upsert_product_from_feed(
@@ -2196,13 +2241,17 @@ async def upsert_product_from_feed(
 
 
 async def _attach_features_to_products(
-    products: list[dict[str, Any]]
+    products: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     if not products:
         return products
 
     identifiers = sorted(
-        {int(product.get("id") or 0) for product in products if int(product.get("id") or 0) > 0}
+        {
+            int(product.get("id") or 0)
+            for product in products
+            if int(product.get("id") or 0) > 0
+        }
     )
     features_map: dict[int, list[dict[str, Any]]] = {}
     if identifiers:
@@ -2233,14 +2282,22 @@ def _normalise_product(row: dict[str, Any]) -> dict[str, Any]:
     normalised = dict(row)
     normalised["id"] = _coerce_int(row.get("id"))
     normalised["category_id"] = _coerce_optional_int(row.get("category_id"))
-    normalised["subscription_category_id"] = _coerce_optional_int(row.get("subscription_category_id"))
+    normalised["subscription_category_id"] = _coerce_optional_int(
+        row.get("subscription_category_id")
+    )
     normalised["commitment_type"] = row.get("commitment_type")
     normalised["payment_frequency"] = row.get("payment_frequency")
     normalised["price"] = _coerce_decimal(row.get("price"), default=0.0)
     normalised["vip_price"] = _coerce_optional_decimal(row.get("vip_price"))
-    normalised["price_monthly_commitment"] = _coerce_optional_decimal(row.get("price_monthly_commitment"))
-    normalised["price_annual_monthly_payment"] = _coerce_optional_decimal(row.get("price_annual_monthly_payment"))
-    normalised["price_annual_annual_payment"] = _coerce_optional_decimal(row.get("price_annual_annual_payment"))
+    normalised["price_monthly_commitment"] = _coerce_optional_decimal(
+        row.get("price_monthly_commitment")
+    )
+    normalised["price_annual_monthly_payment"] = _coerce_optional_decimal(
+        row.get("price_annual_monthly_payment")
+    )
+    normalised["price_annual_annual_payment"] = _coerce_optional_decimal(
+        row.get("price_annual_annual_payment")
+    )
     normalised["buy_price"] = _coerce_optional_decimal(row.get("buy_price"))
     normalised["weight"] = _coerce_optional_decimal(row.get("weight"))
     normalised["length"] = _coerce_optional_decimal(row.get("length"))
@@ -2278,7 +2335,9 @@ def _normalise_product_summary(row: dict[str, Any]) -> dict[str, Any]:
         "archived": bool(row.get("archived")),
         "category_id": _coerce_optional_int(row.get("category_id")),
         "category_name": row.get("category_name") or None,
-        "duplicate_sku_import": bool(_coerce_int(row.get("duplicate_sku_import"), default=0)),
+        "duplicate_sku_import": bool(
+            _coerce_int(row.get("duplicate_sku_import"), default=0)
+        ),
         "duplicate_sku_count": _coerce_int(row.get("duplicate_sku_count"), default=0),
     }
 
@@ -2572,7 +2631,9 @@ async def list_quote_summaries(company_id: int) -> list[dict[str, Any]]:
     return [_normalise_quote_summary(row) for row in rows]
 
 
-async def get_quote_summary(quote_number: str, company_id: int) -> dict[str, Any] | None:
+async def get_quote_summary(
+    quote_number: str, company_id: int
+) -> dict[str, Any] | None:
     row = await db.fetch_one(
         """
         SELECT
@@ -2637,12 +2698,12 @@ async def assign_quote(
     assigned_user_id: int | None,
 ) -> dict[str, Any] | None:
     """Assign or unassign a quote to a specific user.
-    
+
     Args:
         quote_number: The quote number to assign
         company_id: The company ID that owns the quote
         assigned_user_id: The user ID to assign the quote to, or None to unassign
-        
+
     Returns:
         Updated quote summary if successful, None if quote not found
     """

--- a/app/services/products.py
+++ b/app/services/products.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import html
 import socket
 from ipaddress import ip_address
 from datetime import date, datetime, timezone
@@ -139,9 +140,7 @@ def _normalise_name(feed_name: str, product: Mapping[str, Any] | None) -> str:
     existing_name = str(product.get("name") or "").strip()
     if not existing_name:
         return feed_name or ""
-    existing_sku = str(
-        product.get("vendor_sku") or product.get("sku") or ""
-    ).strip()
+    existing_sku = str(product.get("vendor_sku") or product.get("sku") or "").strip()
     if existing_sku and existing_name.lower() != existing_sku.lower():
         return existing_name
     return feed_name or existing_name or existing_sku or ""
@@ -164,7 +163,9 @@ async def _download_product_image(image_url: str) -> str | None:
 
     try:
         async with httpx.AsyncClient(timeout=20.0) as client:
-            async with client.stream("GET", candidate, follow_redirects=True) as response:
+            async with client.stream(
+                "GET", candidate, follow_redirects=True
+            ) as response:
                 if response.status_code != httpx.codes.OK:
                     log_error(
                         "Failed to download product image from feed",
@@ -304,9 +305,7 @@ def _parse_feed_item(element: Element) -> dict[str, Any] | None:
     manufacturer = _optional_text(
         _get_feed_value(element, "Manufacturer", "manufacturer")
     )
-    image_url = _optional_text(
-        _get_feed_value(element, "ImageUrl", "image_url")
-    )
+    image_url = _optional_text(_get_feed_value(element, "ImageUrl", "image_url"))
 
     pub_date_raw = _get_feed_value(element, "pubDate", "pub_date")
     pub_date = _parse_stock_date(pub_date_raw)
@@ -359,12 +358,70 @@ def _format_stock_feed_parse_error(exc: ParseError) -> str:
     return detail
 
 
-def _parse_stock_feed_xml(payload: str) -> list[dict[str, Any]]:
+def _extract_stock_code_from_item_xml(item_xml: str) -> str | None:
+    """Best-effort StockCode extraction for malformed feed items."""
+
+    match = re.search(
+        r"<\s*(?:[\w.-]+:)?(?:StockCode|stockcode|stock_code|sku)\b[^>]*>(.*?)</\s*(?:[\w.-]+:)?(?:StockCode|stockcode|stock_code|sku)\s*>",
+        item_xml,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    if not match:
+        return None
+    cleaned = re.sub(r"<[^>]+>", "", match.group(1)).strip()
+    if not cleaned:
+        return None
+    try:
+        cleaned = html.unescape(cleaned)
+    except Exception:
+        pass
+    return cleaned.strip() or None
+
+
+def _parse_stock_feed_xml_with_skipped(
+    payload: str,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    skipped_skus: list[str] = []
     try:
         root = fromstring(payload)
     except ParseError as exc:
         detail = _format_stock_feed_parse_error(exc)
-        raise ValueError(f"Invalid stock feed XML: {detail}") from exc
+        if "reference to invalid character number" not in detail.lower():
+            raise ValueError(f"Invalid stock feed XML: {detail}") from exc
+
+        items: list[dict[str, Any]] = []
+        item_matches = list(
+            re.finditer(
+                r"<\s*(?:[\w.-]+:)?item\b[^>]*>.*?</\s*(?:[\w.-]+:)?item\s*>",
+                payload,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+        )
+        if not item_matches:
+            raise ValueError(f"Invalid stock feed XML: {detail}") from exc
+
+        for match in item_matches:
+            item_xml = match.group(0)
+            try:
+                parsed = _parse_feed_item(fromstring(item_xml))
+            except ParseError as item_exc:
+                item_detail = _format_stock_feed_parse_error(item_exc)
+                if "reference to invalid character number" not in item_detail.lower():
+                    raise ValueError(
+                        f"Invalid stock feed XML: {item_detail}"
+                    ) from item_exc
+                skipped_sku = _extract_stock_code_from_item_xml(item_xml)
+                if skipped_sku:
+                    skipped_skus.append(skipped_sku)
+                log_error(
+                    "Skipped stock feed item with invalid XML character reference",
+                    sku=skipped_sku or "unknown",
+                    error=item_detail,
+                )
+                continue
+            if parsed:
+                items.append(parsed)
+        return items, skipped_skus
 
     items: list[dict[str, Any]] = []
     for element in root.iter():
@@ -379,10 +436,17 @@ def _parse_stock_feed_xml(payload: str) -> list[dict[str, Any]]:
             if parsed:
                 items.append(parsed)
 
+    return items, skipped_skus
+
+
+def _parse_stock_feed_xml(payload: str) -> list[dict[str, Any]]:
+    items, _skipped_skus = _parse_stock_feed_xml_with_skipped(payload)
     return items
 
 
-def _flag_duplicate_stock_feed_skus(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _flag_duplicate_stock_feed_skus(
+    items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
     """Return feed items with duplicate SKUs collapsed and flagged for review.
 
     The stock feed table is keyed by SKU, so duplicate XML records cannot all be
@@ -436,12 +500,21 @@ async def update_stock_feed() -> int:
         raise
 
     try:
-        items = _parse_stock_feed_xml(response.text)
+        items, skipped_skus = _parse_stock_feed_xml_with_skipped(response.text)
     except ValueError as exc:
         log_error("Failed to parse stock feed", error=str(exc))
         raise
 
     persisted_items = _flag_duplicate_stock_feed_skus(items)
+    for skipped_sku in skipped_skus:
+        try:
+            await shop_repo.mark_product_out_of_stock_by_sku(skipped_sku)
+        except Exception as exc:  # pragma: no cover - best-effort safety
+            log_error(
+                "Failed to mark skipped stock feed item out of stock",
+                sku=skipped_sku,
+                error=str(exc),
+            )
     await stock_feed_repo.replace_feed(persisted_items)
 
     # Record DBP price history for every unique item in the feed.
@@ -455,52 +528,56 @@ async def update_stock_feed() -> int:
         except Exception as exc:  # pragma: no cover - best-effort
             log_error("Failed to record price history", sku=sku, error=str(exc))
 
-    log_info("Stock feed updated", item_count=len(persisted_items), source_item_count=len(items))
+    log_info(
+        "Stock feed updated",
+        item_count=len(persisted_items),
+        source_item_count=len(items),
+    )
     return len(persisted_items)
 
 
 async def _get_or_create_category_hierarchy(category_path: str) -> int | None:
     """
     Parse a category path delimited by ' - ' and create/retrieve the hierarchy.
-    
+
     For example, "Electronics - Computers - Laptops" will:
     1. Create/get "Electronics" (parent)
     2. Create/get "Computers" as child of "Electronics"
     3. Create/get "Laptops" as child of "Computers"
     4. Return the ID of the final category ("Laptops")
-    
+
     Args:
         category_path: A string with category names separated by ' - '
-        
+
     Returns:
         The ID of the final (deepest) category in the hierarchy, or None if invalid
     """
     if not category_path or not category_path.strip():
         return None
-    
+
     # Split by ' - ' delimiter and clean up each part
     parts = [part.strip() for part in category_path.split(" - ")]
     parts = [part for part in parts if part]  # Remove empty parts
-    
+
     if not parts:
         return None
-    
+
     # Fetch all categories once to avoid N+1 queries
     all_categories = await shop_repo.list_all_categories_flat()
-    
+
     # Build lookup dictionary for O(1) access using (name, parent_id) as key
     category_lookup: dict[tuple[str, int | None], dict[str, Any]] = {}
     for cat in all_categories:
         key = (cat["name"], cat.get("parent_id"))
         category_lookup[key] = cat
-    
+
     parent_id: int | None = None
-    
+
     for category_name in parts:
         # Look up existing category with this name and parent
         lookup_key = (category_name, parent_id)
         matching_category = category_lookup.get(lookup_key)
-        
+
         if matching_category:
             # Found exact match (same name and parent)
             category_id = int(matching_category["id"])
@@ -508,9 +585,7 @@ async def _get_or_create_category_hierarchy(category_path: str) -> int | None:
             # Create new category with appropriate parent
             try:
                 category_id = await shop_repo.create_category(
-                    name=category_name,
-                    parent_id=parent_id,
-                    display_order=0
+                    name=category_name, parent_id=parent_id, display_order=0
                 )
                 # Add newly created category to our lookup dictionary
                 new_category = {
@@ -528,10 +603,10 @@ async def _get_or_create_category_hierarchy(category_path: str) -> int | None:
                     error=str(exc),
                 )
                 return None
-        
+
         # This category becomes the parent for the next level
         parent_id = category_id
-    
+
     return parent_id
 
 
@@ -611,9 +686,7 @@ async def _process_feed_item(
         name = code
 
     existing_image_url = (
-        str(current_product.get("image_url") or "").strip()
-        if current_product
-        else ""
+        str(current_product.get("image_url") or "").strip() if current_product else ""
     )
     feed_image_url = str(item.get("image_url") or "").strip()
     image_url: str | None = None
@@ -708,7 +781,9 @@ async def import_product_by_vendor_sku(vendor_sku: str) -> bool:
         )
         if imported_product and imported_product.get("id"):
             try:
-                await product_descriptions.improve_product_description(int(imported_product["id"]))
+                await product_descriptions.improve_product_description(
+                    int(imported_product["id"])
+                )
             except Exception as exc:  # pragma: no cover - AI/network/database safety
                 log_error(
                     "Failed to refresh imported product description",
@@ -764,7 +839,10 @@ async def update_products_from_feed() -> None:
             continue
         try:
             if await _process_feed_item(
-                item, existing_product, update_recommendations=False, download_image_if_new=False
+                item,
+                existing_product,
+                update_recommendations=False,
+                download_image_if_new=False,
             ):
                 processed += 1
         except Exception as exc:  # pragma: no cover - defensive logging
@@ -773,6 +851,14 @@ async def update_products_from_feed() -> None:
                 sku=code,
                 error=str(exc),
             )
+            try:
+                await shop_repo.mark_product_out_of_stock_by_sku(code)
+            except Exception as stock_exc:  # pragma: no cover - best-effort safety
+                log_error(
+                    "Failed to mark errored stock feed item out of stock",
+                    sku=code,
+                    error=str(stock_exc),
+                )
 
     # Second pass: set cross-sell associations for products that exist in-store.
     for item in feed_items:

--- a/tests/test_products_service.py
+++ b/tests/test_products_service.py
@@ -56,7 +56,9 @@ async def test_import_product_by_vendor_sku_processes_feed_item(monkeypatch):
     mock_process = AsyncMock(return_value=True)
     monkeypatch.setattr(products_service, "_process_feed_item", mock_process)
     refresh = AsyncMock(return_value={"description": "AI", "features": []})
-    monkeypatch.setattr(products_service.product_descriptions, "improve_product_description", refresh)
+    monkeypatch.setattr(
+        products_service.product_descriptions, "improve_product_description", refresh
+    )
 
     result = await products_service.import_product_by_vendor_sku("  ABC123  ")
 
@@ -71,16 +73,26 @@ async def test_import_product_by_vendor_sku_processes_feed_item(monkeypatch):
 
 
 @pytest.mark.anyio("asyncio")
-async def test_import_product_by_vendor_sku_refreshes_description_for_existing_product(monkeypatch):
+async def test_import_product_by_vendor_sku_refreshes_description_for_existing_product(
+    monkeypatch,
+):
     item = {"sku": "ABC123"}
     existing_product = {"id": 42}
 
-    monkeypatch.setattr(products_service.stock_feed_repo, "get_item_by_sku", AsyncMock(return_value=item))
+    monkeypatch.setattr(
+        products_service.stock_feed_repo,
+        "get_item_by_sku",
+        AsyncMock(return_value=item),
+    )
     get_product = AsyncMock(side_effect=[existing_product, existing_product])
     monkeypatch.setattr(products_service.shop_repo, "get_product_by_sku", get_product)
-    monkeypatch.setattr(products_service, "_process_feed_item", AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        products_service, "_process_feed_item", AsyncMock(return_value=True)
+    )
     refresh = AsyncMock(return_value={"description": "AI", "features": []})
-    monkeypatch.setattr(products_service.product_descriptions, "improve_product_description", refresh)
+    monkeypatch.setattr(
+        products_service.product_descriptions, "improve_product_description", refresh
+    )
 
     result = await products_service.import_product_by_vendor_sku("ABC123")
 
@@ -302,7 +314,9 @@ async def test_process_feed_item_links_cross_sells_from_opt_accessori(monkeypatc
         "opt_accessori": "ACC1, ACC2",
     }
 
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
+    monkeypatch.setattr(
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
+    )
     monkeypatch.setattr(
         products_service.shop_repo,
         "get_product_ids_by_skus",
@@ -319,7 +333,11 @@ async def test_process_feed_item_links_cross_sells_from_opt_accessori(monkeypatc
         "replace_product_recommendations",
         mock_replace,
     )
-    monkeypatch.setattr(products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
+    )
 
     result = await products_service._process_feed_item(item, None)
 
@@ -331,7 +349,9 @@ async def test_process_feed_item_links_cross_sells_from_opt_accessori(monkeypatc
 
 
 @pytest.mark.anyio("asyncio")
-async def test_process_feed_item_skips_cross_sells_when_opt_accessori_absent(monkeypatch):
+async def test_process_feed_item_skips_cross_sells_when_opt_accessori_absent(
+    monkeypatch,
+):
     """When opt_accessori is absent, cross-sells are not updated."""
     item = {
         "sku": "MAIN1",
@@ -355,21 +375,29 @@ async def test_process_feed_item_skips_cross_sells_when_opt_accessori_absent(mon
         "opt_accessori": None,
     }
 
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
+    monkeypatch.setattr(
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
+    )
     monkeypatch.setattr(
         products_service.shop_repo,
         "get_product_by_sku",
         AsyncMock(return_value={"id": 5, "image_url": ""}),
     )
     mock_get_ids = AsyncMock(return_value=[])
-    monkeypatch.setattr(products_service.shop_repo, "get_product_ids_by_skus", mock_get_ids)
+    monkeypatch.setattr(
+        products_service.shop_repo, "get_product_ids_by_skus", mock_get_ids
+    )
     mock_replace = AsyncMock()
     monkeypatch.setattr(
         products_service.shop_repo,
         "replace_product_recommendations",
         mock_replace,
     )
-    monkeypatch.setattr(products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
+    )
 
     result = await products_service._process_feed_item(item, None)
 
@@ -403,9 +431,13 @@ async def test_process_feed_item_empty_opt_accessori_preserves_cross_sells(monke
         "opt_accessori": "",
     }
 
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
+    monkeypatch.setattr(
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
+    )
     mock_get_ids = AsyncMock(return_value=[])
-    monkeypatch.setattr(products_service.shop_repo, "get_product_ids_by_skus", mock_get_ids)
+    monkeypatch.setattr(
+        products_service.shop_repo, "get_product_ids_by_skus", mock_get_ids
+    )
     monkeypatch.setattr(
         products_service.shop_repo,
         "get_product_by_sku",
@@ -417,7 +449,11 @@ async def test_process_feed_item_empty_opt_accessori_preserves_cross_sells(monke
         "replace_product_recommendations",
         mock_replace,
     )
-    monkeypatch.setattr(products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
+    )
 
     result = await products_service._process_feed_item(item, None)
 
@@ -521,7 +557,9 @@ async def test_update_products_from_feed_sets_cross_sells(monkeypatch):
         "get_product_by_sku",
         AsyncMock(return_value={"id": 1, "image_url": None}),
     )
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
+    monkeypatch.setattr(
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
+    )
     monkeypatch.setattr(
         products_service.shop_repo,
         "get_product_ids_by_skus",
@@ -534,13 +572,19 @@ async def test_update_products_from_feed_sets_cross_sells(monkeypatch):
         mock_replace,
     )
     monkeypatch.setattr(
-        products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None)
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "sync_pending_optional_accessories", AsyncMock(return_value=0)
+        products_service.shop_repo,
+        "sync_pending_optional_accessories",
+        AsyncMock(return_value=0),
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "list_pending_optional_accessories", AsyncMock(return_value=[])
+        products_service.shop_repo,
+        "list_pending_optional_accessories",
+        AsyncMock(return_value=[]),
     )
 
     await products_service.update_products_from_feed()
@@ -571,22 +615,32 @@ async def test_update_products_from_feed_upserts_only_existing_feed_items(monkey
             return {"id": 1, "image_url": None}
         return None
 
-    monkeypatch.setattr(products_service.shop_repo, "get_product_by_sku", fake_get_by_sku)
+    monkeypatch.setattr(
+        products_service.shop_repo, "get_product_by_sku", fake_get_by_sku
+    )
     mock_upsert = AsyncMock()
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", mock_upsert)
+    monkeypatch.setattr(
+        products_service.shop_repo, "upsert_product_from_feed", mock_upsert
+    )
     monkeypatch.setattr(
         products_service.shop_repo,
         "replace_product_recommendations",
         AsyncMock(),
     )
     monkeypatch.setattr(
-        products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None)
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "sync_pending_optional_accessories", AsyncMock(return_value=0)
+        products_service.shop_repo,
+        "sync_pending_optional_accessories",
+        AsyncMock(return_value=0),
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "list_pending_optional_accessories", AsyncMock(return_value=[])
+        products_service.shop_repo,
+        "list_pending_optional_accessories",
+        AsyncMock(return_value=[]),
     )
 
     await products_service.update_products_from_feed()
@@ -614,23 +668,35 @@ async def test_update_products_from_feed_cross_sells_resolved_for_existing_produ
         "list_all_items",
         AsyncMock(return_value=feed_items),
     )
-    monkeypatch.setattr(products_service.shop_repo, "get_product_by_sku", fake_get_by_sku)
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
     monkeypatch.setattr(
-        products_service.shop_repo, "get_product_ids_by_skus", AsyncMock(return_value=[99])
+        products_service.shop_repo, "get_product_by_sku", fake_get_by_sku
+    )
+    monkeypatch.setattr(
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
+    )
+    monkeypatch.setattr(
+        products_service.shop_repo,
+        "get_product_ids_by_skus",
+        AsyncMock(return_value=[99]),
     )
     mock_replace = AsyncMock()
     monkeypatch.setattr(
         products_service.shop_repo, "replace_product_recommendations", mock_replace
     )
     monkeypatch.setattr(
-        products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None)
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "sync_pending_optional_accessories", AsyncMock(return_value=0)
+        products_service.shop_repo,
+        "sync_pending_optional_accessories",
+        AsyncMock(return_value=0),
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "list_pending_optional_accessories", AsyncMock(return_value=[])
+        products_service.shop_repo,
+        "list_pending_optional_accessories",
+        AsyncMock(return_value=[]),
     )
 
     await products_service.update_products_from_feed()
@@ -655,7 +721,9 @@ async def test_update_products_from_feed_uses_vendor_sku_for_cross_sells(monkeyp
         "get_product_by_sku",
         AsyncMock(return_value={"id": 10, "image_url": None}),
     )
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
+    monkeypatch.setattr(
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
+    )
     monkeypatch.setattr(
         products_service.shop_repo,
         "get_product_ids_by_skus",
@@ -668,13 +736,19 @@ async def test_update_products_from_feed_uses_vendor_sku_for_cross_sells(monkeyp
         mock_replace,
     )
     monkeypatch.setattr(
-        products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None)
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "sync_pending_optional_accessories", AsyncMock(return_value=0)
+        products_service.shop_repo,
+        "sync_pending_optional_accessories",
+        AsyncMock(return_value=0),
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "list_pending_optional_accessories", AsyncMock(return_value=[])
+        products_service.shop_repo,
+        "list_pending_optional_accessories",
+        AsyncMock(return_value=[]),
     )
 
     await products_service.update_products_from_feed()
@@ -690,7 +764,10 @@ async def test_update_products_from_feed_does_not_download_images_for_new_produc
     monkeypatch,
 ):
     """Images must not be downloaded for products that do not yet exist in the store."""
-    feed_item = {**_make_feed_item("NEW-SKU"), "image_url": "https://example.com/img.jpg"}
+    feed_item = {
+        **_make_feed_item("NEW-SKU"),
+        "image_url": "https://example.com/img.jpg",
+    }
 
     monkeypatch.setattr(
         products_service.stock_feed_repo,
@@ -702,16 +779,26 @@ async def test_update_products_from_feed_does_not_download_images_for_new_produc
         "get_product_by_sku",
         AsyncMock(return_value=None),
     )
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
-    monkeypatch.setattr(products_service.shop_repo, "replace_product_recommendations", AsyncMock())
     monkeypatch.setattr(
-        products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None)
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "sync_pending_optional_accessories", AsyncMock(return_value=0)
+        products_service.shop_repo, "replace_product_recommendations", AsyncMock()
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "list_pending_optional_accessories", AsyncMock(return_value=[])
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        products_service.shop_repo,
+        "sync_pending_optional_accessories",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        products_service.shop_repo,
+        "list_pending_optional_accessories",
+        AsyncMock(return_value=[]),
     )
 
     mock_download = AsyncMock(return_value="/uploads/shop/some.jpg")
@@ -727,7 +814,10 @@ async def test_update_products_from_feed_downloads_image_for_existing_product_wi
     monkeypatch,
 ):
     """Images should be downloaded for store products that do not yet have an image."""
-    feed_item = {**_make_feed_item("EXISTING-SKU"), "image_url": "https://example.com/img.jpg"}
+    feed_item = {
+        **_make_feed_item("EXISTING-SKU"),
+        "image_url": "https://example.com/img.jpg",
+    }
 
     monkeypatch.setattr(
         products_service.stock_feed_repo,
@@ -739,16 +829,26 @@ async def test_update_products_from_feed_downloads_image_for_existing_product_wi
         "get_product_by_sku",
         AsyncMock(return_value={"id": 7, "image_url": None}),
     )
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
-    monkeypatch.setattr(products_service.shop_repo, "replace_product_recommendations", AsyncMock())
     monkeypatch.setattr(
-        products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None)
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "sync_pending_optional_accessories", AsyncMock(return_value=0)
+        products_service.shop_repo, "replace_product_recommendations", AsyncMock()
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "list_pending_optional_accessories", AsyncMock(return_value=[])
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        products_service.shop_repo,
+        "sync_pending_optional_accessories",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        products_service.shop_repo,
+        "list_pending_optional_accessories",
+        AsyncMock(return_value=[]),
     )
 
     mock_download = AsyncMock(return_value="/uploads/shop/downloaded.jpg")
@@ -766,14 +866,18 @@ async def test_process_feed_item_skips_image_download_for_new_product_when_disab
     """_process_feed_item with download_image_if_new=False must not download images for new products."""
     item = {**_make_feed_item("NEW-SKU"), "image_url": "https://example.com/img.jpg"}
 
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
+    monkeypatch.setattr(
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
+    )
     monkeypatch.setattr(
         products_service.shop_repo,
         "get_product_by_sku",
         AsyncMock(return_value=None),
     )
     monkeypatch.setattr(
-        products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None)
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
     )
 
     mock_download = AsyncMock(return_value="/uploads/shop/some.jpg")
@@ -794,14 +898,18 @@ async def test_process_feed_item_downloads_image_for_new_product_when_enabled(
     """_process_feed_item with download_image_if_new=True (default) downloads images for new products."""
     item = {**_make_feed_item("NEW-SKU"), "image_url": "https://example.com/img.jpg"}
 
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
+    monkeypatch.setattr(
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
+    )
     monkeypatch.setattr(
         products_service.shop_repo,
         "get_product_by_sku",
         AsyncMock(return_value=None),
     )
     monkeypatch.setattr(
-        products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None)
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
     )
 
     mock_download = AsyncMock(return_value="/uploads/shop/some.jpg")
@@ -907,7 +1015,9 @@ async def test_download_pending_accessory_images_skips_when_no_url(monkeypatch):
 
 
 @pytest.mark.anyio("asyncio")
-async def test_download_pending_accessory_images_skips_update_when_download_fails(monkeypatch):
+async def test_download_pending_accessory_images_skips_update_when_download_fails(
+    monkeypatch,
+):
     """If the image download fails (returns None), the DB record is not updated."""
     accessories = [
         {
@@ -928,7 +1038,9 @@ async def test_download_pending_accessory_images_skips_update_when_download_fail
         "update_pending_accessory_image_url",
         mock_update,
     )
-    monkeypatch.setattr(products_service, "_download_product_image", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        products_service, "_download_product_image", AsyncMock(return_value=None)
+    )
 
     await products_service._download_pending_accessory_images()
 
@@ -936,7 +1048,9 @@ async def test_download_pending_accessory_images_skips_update_when_download_fail
 
 
 @pytest.mark.anyio("asyncio")
-async def test_update_products_from_feed_downloads_pending_accessory_images(monkeypatch):
+async def test_update_products_from_feed_downloads_pending_accessory_images(
+    monkeypatch,
+):
     """update_products_from_feed downloads images for pending accessories with external URLs."""
     feed_item = _make_feed_item("EXISTING-SKU")
     monkeypatch.setattr(
@@ -949,13 +1063,21 @@ async def test_update_products_from_feed_downloads_pending_accessory_images(monk
         "get_product_by_sku",
         AsyncMock(return_value={"id": 1, "image_url": None}),
     )
-    monkeypatch.setattr(products_service.shop_repo, "upsert_product_from_feed", AsyncMock())
-    monkeypatch.setattr(products_service.shop_repo, "replace_product_recommendations", AsyncMock())
     monkeypatch.setattr(
-        products_service, "_get_or_create_category_hierarchy", AsyncMock(return_value=None)
+        products_service.shop_repo, "upsert_product_from_feed", AsyncMock()
     )
     monkeypatch.setattr(
-        products_service.shop_repo, "sync_pending_optional_accessories", AsyncMock(return_value=1)
+        products_service.shop_repo, "replace_product_recommendations", AsyncMock()
+    )
+    monkeypatch.setattr(
+        products_service,
+        "_get_or_create_category_hierarchy",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        products_service.shop_repo,
+        "sync_pending_optional_accessories",
+        AsyncMock(return_value=1),
     )
     pending = [
         {
@@ -1013,7 +1135,115 @@ async def test_download_product_image_rejects_non_public_url(monkeypatch):
     mock_client = AsyncMock()
     monkeypatch.setattr(products_service.httpx, "AsyncClient", mock_client)
 
-    result = await products_service._download_product_image("http://127.0.0.1/internal.png")
+    result = await products_service._download_product_image(
+        "http://127.0.0.1/internal.png"
+    )
 
     assert result is None
     mock_client.assert_not_called()
+
+
+def test_parse_stock_feed_xml_skips_item_with_invalid_character_reference():
+    xml_payload = """
+        <rss><channel>
+            <item><StockCode>GOOD1</StockCode><ProductName>Good</ProductName></item>
+            <item><StockCode>BAD1</StockCode><ProductName>Bad &#0; Name</ProductName></item>
+            <item><StockCode>GOOD2</StockCode><ProductName>Also Good</ProductName></item>
+        </channel></rss>
+    """
+
+    items, skipped_skus = products_service._parse_stock_feed_xml_with_skipped(
+        xml_payload
+    )
+
+    assert [item["sku"] for item in items] == ["GOOD1", "GOOD2"]
+    assert skipped_skus == ["BAD1"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_update_stock_feed_marks_skipped_invalid_xml_item_out_of_stock(
+    monkeypatch,
+):
+    xml_payload = """
+        <rss><channel>
+            <item><StockCode>GOOD1</StockCode><ProductName>Good</ProductName></item>
+            <item><StockCode>BAD1</StockCode><ProductName>Bad &#0; Name</ProductName></item>
+        </channel></rss>
+    """
+
+    class DummyResponse:
+        text = xml_payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class DummyClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "DummyClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:  # type: ignore[override]
+            return False
+
+        async def get(self, url: str, follow_redirects: bool = True) -> DummyResponse:
+            return DummyResponse()
+
+    monkeypatch.setattr(products_service.httpx, "AsyncClient", DummyClient)
+    monkeypatch.setattr(
+        products_service,
+        "get_settings",
+        lambda: SimpleNamespace(stock_feed_url="https://example.com/feed.xml"),
+    )
+    mock_replace = AsyncMock()
+    mock_mark_out = AsyncMock()
+    monkeypatch.setattr(products_service.stock_feed_repo, "replace_feed", mock_replace)
+    monkeypatch.setattr(
+        products_service.shop_repo, "mark_product_out_of_stock_by_sku", mock_mark_out
+    )
+    monkeypatch.setattr(
+        products_service.stock_feed_repo, "record_price_if_changed", AsyncMock()
+    )
+
+    count = await products_service.update_stock_feed()
+
+    assert count == 1
+    assert [item["sku"] for item in mock_replace.await_args.args[0]] == ["GOOD1"]
+    mock_mark_out.assert_awaited_once_with("BAD1")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_update_products_from_feed_marks_failed_item_out_of_stock(monkeypatch):
+    feed_items = [_make_feed_item("FAIL-SKU")]
+    monkeypatch.setattr(
+        products_service.stock_feed_repo,
+        "list_all_items",
+        AsyncMock(return_value=feed_items),
+    )
+    monkeypatch.setattr(
+        products_service.shop_repo,
+        "get_product_by_sku",
+        AsyncMock(return_value={"id": 12, "sku": "FAIL-SKU"}),
+    )
+    monkeypatch.setattr(
+        products_service,
+        "_process_feed_item",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    )
+    mock_mark_out = AsyncMock()
+    monkeypatch.setattr(
+        products_service.shop_repo, "mark_product_out_of_stock_by_sku", mock_mark_out
+    )
+    monkeypatch.setattr(
+        products_service.shop_repo,
+        "sync_pending_optional_accessories",
+        AsyncMock(return_value=0),
+    )
+    monkeypatch.setattr(
+        products_service, "_download_pending_accessory_images", AsyncMock()
+    )
+
+    await products_service.update_products_from_feed()
+
+    mock_mark_out.assert_awaited_once_with("FAIL-SKU")


### PR DESCRIPTION
### Motivation
- Stock feed imports should not abort when a vendor-provided XML item contains an illegal character reference; such items should be skipped instead of failing the whole import.
- Any items that cannot be parsed or that fail during processing must be marked out of stock to avoid exposing stale inventory to customers.

### Description
- Add a resilient parser `_parse_stock_feed_xml_with_skipped` and helper `_extract_stock_code_from_item_xml` that detect "reference to invalid character number" parse errors, parse valid `<item>` blocks individually, log the bad item, and return a list of skipped SKUs. (app/services/products.py)
- Call the new parser from `update_stock_feed`, persist the remaining valid items, and mark each skipped SKU out of stock by invoking `shop_repo.mark_product_out_of_stock_by_sku`. (app/services/products.py)
- Add `mark_product_out_of_stock_by_sku` to the shop repository to zero total and per-location stock for matching `sku` or `vendor_sku`. (app/repositories/shop.py)
- Best-effort safety: when processing a feed item in `update_products_from_feed` raises an exception, mark that SKU out of stock so customers are not sold potentially incorrect inventory. (app/services/products.py)
- Add regression tests for skipping malformed feed items, marking skipped items out of stock during `update_stock_feed`, and marking failed per-item imports out of stock during `update_products_from_feed`. (tests/test_products_service.py)

### Testing
- Ran formatting checks with `python3 -m black --check --target-version py312 app/services/products.py app/repositories/shop.py tests/test_products_service.py` which succeeded.
- Executed the modified test suites with `pytest -q tests/test_products_service.py tests/test_stock_feed_price_history.py` and the test runs covering the changes passed (`32 passed`, tests emitted warnings only).
- Confirmed the new regression tests for malformed XML item skipping and out-of-stock marking were executed and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b50bd0938832db30a515728f2004a)