### PR TITLE
Throttle TacticalRMM API calls configurable via TACTICALRMM_CALLS_PER_SECOND

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -240,6 +240,8 @@ TACTICALRMM_BASE_URL=
 TACTICALRMM_BASE_RMM_URL=
 TACTICALRMM_API_KEY=
 TACTICALRMM_VERIFY_SSL=true
+# Maximum TacticalRMM API calls per second; defaults to 1 when unset or invalid.
+TACTICALRMM_CALLS_PER_SECOND=1
 # Tactical RMM client-level custom field used to store MyPortal tray enrolment tokens
 TRMM_CLIENT_TOKEN_FIELD=MyPortalToken
 NTFY_BASE_URL=https://ntfy.sh

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -41,6 +41,11 @@ REQUEST_TIMEOUT = httpx.Timeout(15.0, connect=5.0)
 
 _BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
 
+_TACTICALRMM_RATE_LIMIT_LOCK = asyncio.Lock()
+_TACTICALRMM_LAST_REQUEST_AT: float | None = None
+_TACTICALRMM_DEFAULT_CALLS_PER_SECOND = 1.0
+
+
 # Module slug constants
 XERO_MODULE_SLUG = "xero"
 
@@ -68,6 +73,53 @@ DEFAULT_CHATGPT_TOOLS = [
     "createTicketReply",
     "updateTicket",
 ]
+
+
+def _get_tacticalrmm_calls_per_second() -> float:
+    """Return the configured TacticalRMM request rate limit.
+
+    The value is intentionally loaded from the environment at call time so
+    operators can tune ``TACTICALRMM_CALLS_PER_SECOND`` via the ``.env`` file
+    without storing throttling configuration in the encrypted module settings.
+    Invalid, blank, or non-positive values safely fall back to one request per
+    second.
+    """
+    raw_value = os.getenv("TACTICALRMM_CALLS_PER_SECOND", "").strip()
+    if not raw_value:
+        return _TACTICALRMM_DEFAULT_CALLS_PER_SECOND
+    try:
+        calls_per_second = float(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid TACTICALRMM_CALLS_PER_SECOND value; using default",
+            value=raw_value,
+            default=_TACTICALRMM_DEFAULT_CALLS_PER_SECOND,
+        )
+        return _TACTICALRMM_DEFAULT_CALLS_PER_SECOND
+    if calls_per_second <= 0:
+        logger.warning(
+            "Non-positive TACTICALRMM_CALLS_PER_SECOND value; using default",
+            value=raw_value,
+            default=_TACTICALRMM_DEFAULT_CALLS_PER_SECOND,
+        )
+        return _TACTICALRMM_DEFAULT_CALLS_PER_SECOND
+    return calls_per_second
+
+
+async def _throttle_tacticalrmm_request() -> None:
+    """Serialize TacticalRMM API calls so they respect the configured rate."""
+    global _TACTICALRMM_LAST_REQUEST_AT
+    calls_per_second = _get_tacticalrmm_calls_per_second()
+    min_interval = 1.0 / calls_per_second
+    loop = asyncio.get_running_loop()
+    async with _TACTICALRMM_RATE_LIMIT_LOCK:
+        now = loop.time()
+        if _TACTICALRMM_LAST_REQUEST_AT is not None:
+            wait_seconds = (_TACTICALRMM_LAST_REQUEST_AT + min_interval) - now
+            if wait_seconds > 0:
+                await asyncio.sleep(wait_seconds)
+                now = loop.time()
+        _TACTICALRMM_LAST_REQUEST_AT = now
 
 
 def _hash_secret(secret: str) -> str:
@@ -2814,6 +2866,7 @@ async def _invoke_tacticalrmm(
         event_future.set_result(event_id)
     attempt_number = 1
     try:
+        await _throttle_tacticalrmm_request()
         async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT, verify=True) as client:
             response = await client.request(method, url, json=request_body, headers=headers)
         response.raise_for_status()

--- a/tests/test_modules_service.py
+++ b/tests/test_modules_service.py
@@ -677,6 +677,51 @@ def test_invoke_smtp_records_failure(monkeypatch):
     assert result.get("email_event_id") is None
 
 
+def test_tacticalrmm_calls_per_second_defaults_to_one(monkeypatch):
+    monkeypatch.delenv("TACTICALRMM_CALLS_PER_SECOND", raising=False)
+    assert modules._get_tacticalrmm_calls_per_second() == 1.0
+
+
+@pytest.mark.parametrize("raw_value", ["", "0", "-1", "not-a-number"])
+def test_tacticalrmm_calls_per_second_rejects_invalid_values(monkeypatch, raw_value):
+    monkeypatch.setenv("TACTICALRMM_CALLS_PER_SECOND", raw_value)
+    assert modules._get_tacticalrmm_calls_per_second() == 1.0
+
+
+def test_tacticalrmm_calls_per_second_uses_env_value(monkeypatch):
+    monkeypatch.setenv("TACTICALRMM_CALLS_PER_SECOND", "2.5")
+    assert modules._get_tacticalrmm_calls_per_second() == 2.5
+
+
+def test_tacticalrmm_throttle_waits_between_calls(monkeypatch):
+    sleep_calls: list[float] = []
+    current_time = 100.0
+
+    class FakeLoop:
+        def time(self):
+            return current_time
+
+    async def fake_sleep(delay):
+        nonlocal current_time
+        sleep_calls.append(delay)
+        current_time += delay
+
+    monkeypatch.setenv("TACTICALRMM_CALLS_PER_SECOND", "2")
+    monkeypatch.setattr(modules.asyncio, "get_running_loop", lambda: FakeLoop())
+    monkeypatch.setattr(modules.asyncio, "sleep", fake_sleep)
+    modules._TACTICALRMM_LAST_REQUEST_AT = None
+
+    async def run_throttle_twice():
+        await modules._throttle_tacticalrmm_request()
+        await modules._throttle_tacticalrmm_request()
+
+    try:
+        asyncio.run(run_throttle_twice())
+    finally:
+        modules._TACTICALRMM_LAST_REQUEST_AT = None
+
+    assert sleep_calls == [0.5]
+
 def test_invoke_tacticalrmm_records_success(monkeypatch):
     captured_event: dict[str, object] = {}
 


### PR DESCRIPTION
### Motivation
- Prevent bursts of outbound TacticalRMM/TRMM API requests by serializing calls and making the rate tunable via environment configuration.
- Provide a safe default of 1 call/second and defensive parsing so invalid or blank env values do not disable throttling.

### Description
- Added a process-wide async throttle in `app/services/modules.py` using an `asyncio.Lock`, a last-request timestamp, and `_throttle_tacticalrmm_request()` to enforce minimum inter-call intervals.  
- Implemented `_get_tacticalrmm_calls_per_second()` which reads and validates `TACTICALRMM_CALLS_PER_SECOND` from the environment and falls back to `1.0` on invalid/blank/non-positive values, logging warnings when appropriate.  
- Applied the throttle immediately before outbound TacticalRMM HTTP requests in `_invoke_tacticalrmm()` so all module-driven TRMM calls are rate-limited.  
- Documented the new env var in `.env.example` and added regression tests to `tests/test_modules_service.py` covering default, invalid, custom values and that the throttle enforces delays between calls.

### Testing
- Ran the new/related unit tests with `pytest -q tests/test_modules_service.py -k 'tacticalrmm_calls_per_second or tacticalrmm_throttle or invoke_tacticalrmm_records_success'` and the broader tactical-related tests with `pytest -q tests/test_tacticalrmm_scripts.py tests/test_modules_service.py -k 'tacticalrmm'`, and all targeted tests passed.  
- Full targeted run output: the tactical-related test selection completed with all relevant tests passing (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b5104c840832db1f5b98b1c9cbcca)