### PR TITLE
Add tray install token bulk purge

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -743,6 +743,17 @@ async def revoke_install_token(
     return JSONResponse({"status": "revoked"})
 
 
+@router.post(
+    "/admin/install-tokens/bulk-purge-revoked",
+    summary="Purge all revoked install tokens (admin)",
+)
+async def bulk_purge_revoked_install_tokens(
+    current_user: dict = Depends(require_super_admin),
+) -> JSONResponse:
+    deleted_count = await tray_repo.delete_revoked_install_tokens()
+    return JSONResponse({"status": "ok", "deleted_count": deleted_count})
+
+
 @router.get(
     "/admin/configs",
     summary="List tray menu configurations",

--- a/app/main.py
+++ b/app/main.py
@@ -6031,6 +6031,26 @@ async def admin_tray_revoke_install_token(token_id: int, request: Request):
     return RedirectResponse(url="/admin/tray/install-tokens", status_code=303)
 
 
+@app.post("/admin/tray/install-tokens/bulk-purge-revoked", response_class=HTMLResponse)
+async def admin_tray_bulk_purge_revoked_install_tokens(request: Request):
+    _current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+    from app.repositories import tray as tray_repo
+
+    deleted_count = await tray_repo.delete_revoked_install_tokens()
+    if deleted_count <= 0:
+        return flash_redirect(
+            "/admin/tray/install-tokens", "No revoked install tokens to purge.", "info"
+        )
+    suffix = "token" if deleted_count == 1 else "tokens"
+    return flash_redirect(
+        "/admin/tray/install-tokens",
+        f"Purged {deleted_count} revoked install {suffix}.",
+        "success",
+    )
+
+
 @app.post("/admin/tray/install-tokens/sync-tactical-rmm", response_class=HTMLResponse)
 async def admin_tray_sync_install_tokens_to_tactical_rmm(request: Request):
     current_user, redirect = await _require_super_admin_page(request)

--- a/app/repositories/tray.py
+++ b/app/repositories/tray.py
@@ -100,6 +100,16 @@ async def revoke_install_token(token_id: int) -> None:
     )
 
 
+async def delete_revoked_install_tokens() -> int:
+    rows = await db.fetch_all(
+        "SELECT id FROM tray_install_tokens WHERE revoked_at IS NOT NULL"
+    )
+    if not rows:
+        return 0
+    await db.execute("DELETE FROM tray_install_tokens WHERE revoked_at IS NOT NULL")
+    return len(rows)
+
+
 # ---------------------------------------------------------------------------
 # Devices
 # ---------------------------------------------------------------------------

--- a/app/templates/admin/tray/install_tokens.html
+++ b/app/templates/admin/tray/install_tokens.html
@@ -6,7 +6,8 @@
 {% block header_actions %}
   {{ page_header_actions([
     {"label": "Devices", "type": "link", "variant": "ghost", "href": "/admin/tray/devices"},
-    {"label": "Configurations", "type": "link", "variant": "ghost", "href": "/admin/tray/configurations"}
+    {"label": "Configurations", "type": "link", "variant": "ghost", "href": "/admin/tray/configurations"},
+    {"label": "Bulk purge revoked", "type": "form", "variant": "danger", "action": "/admin/tray/install-tokens/bulk-purge-revoked", "confirm": "Purge all revoked tray install tokens? This permanently deletes token audit rows and cannot be undone."}
   ]) }}
 {% endblock %}
 

--- a/tests/test_tray_app.py
+++ b/tests/test_tray_app.py
@@ -495,6 +495,54 @@ def test_device_create_update_revoke(tray_db, run):
     assert run(repo.delete_revoked_devices()) == 0
 
 
+def test_delete_revoked_install_tokens(tray_db, run):
+    from app.repositories import tray as repo
+    from app.services import tray as svc
+
+    active_raw = svc.generate_install_token()
+    revoked_one_raw = svc.generate_install_token()
+    revoked_two_raw = svc.generate_install_token()
+    active = run(
+        repo.create_install_token(
+            label="Active",
+            company_id=None,
+            token_hash=svc.hash_token(active_raw),
+            token_prefix=svc.token_prefix(active_raw),
+            created_by_user_id=None,
+        )
+    )
+    revoked_one = run(
+        repo.create_install_token(
+            label="Revoked 1",
+            company_id=None,
+            token_hash=svc.hash_token(revoked_one_raw),
+            token_prefix=svc.token_prefix(revoked_one_raw),
+            created_by_user_id=None,
+        )
+    )
+    revoked_two = run(
+        repo.create_install_token(
+            label="Revoked 2",
+            company_id=None,
+            token_hash=svc.hash_token(revoked_two_raw),
+            token_prefix=svc.token_prefix(revoked_two_raw),
+            created_by_user_id=None,
+        )
+    )
+
+    run(repo.revoke_install_token(int(revoked_one["id"])))
+    run(repo.revoke_install_token(int(revoked_two["id"])))
+
+    deleted_count = run(repo.delete_revoked_install_tokens())
+    assert deleted_count >= 2
+    tokens = run(repo.list_install_tokens())
+    token_ids = {int(token["id"]) for token in tokens}
+    assert int(active["id"]) in token_ids
+    assert int(revoked_one["id"]) not in token_ids
+    assert int(revoked_two["id"]) not in token_ids
+    assert run(repo.delete_revoked_install_tokens()) == 0
+
+
 def test_resolve_config_default_when_no_configs(tray_db, run):
     from app.services import tray as svc
 

--- a/tests/test_tray_install_tokens_page.py
+++ b/tests/test_tray_install_tokens_page.py
@@ -157,3 +157,22 @@ async def test_tray_install_tokens_snippet_prefers_configured_portal_url(monkeyp
     await main.admin_tray_install_tokens_page(_make_request(), new_token="abc")
 
     assert captured["extra"]["portal_url"] == "https://portal.example.com"
+
+
+@pytest.mark.anyio
+async def test_tray_bulk_purge_revoked_install_tokens_calls_repo(monkeypatch):
+    import app.repositories.tray as tray_repo
+
+    monkeypatch.setattr(
+        main, "_require_super_admin_page", AsyncMock(return_value=({"id": 1}, None))
+    )
+    delete_mock = AsyncMock(return_value=2)
+    monkeypatch.setattr(tray_repo, "delete_revoked_install_tokens", delete_mock)
+
+    response = await main.admin_tray_bulk_purge_revoked_install_tokens(
+        _make_request("/admin/tray/install-tokens/bulk-purge-revoked")
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/admin/tray/install-tokens"
+    delete_mock.assert_awaited_once()


### PR DESCRIPTION
### Motivation
- Provide administrators with a safe, single-action way to permanently remove all revoked Tray install tokens to keep the database and audit rows tidy.
- Expose the capability via both the admin UI and the API so operators and automation can purge revoked tokens when required.

### Description
- Added a header-level destructive action button to the Tray install tokens admin page that posts to `/admin/tray/install-tokens/bulk-purge-revoked`. (`app/templates/admin/tray/install_tokens.html`)
- Implemented a web handler `admin_tray_bulk_purge_revoked_install_tokens` that requires super-admin, calls the repository purge, and returns a flash message with the deleted count. (`app/main.py`)
- Added a repository function `delete_revoked_install_tokens()` which deletes rows where `revoked_at IS NOT NULL` and returns the number of purged rows. (`app/repositories/tray.py`)
- Exposed an API endpoint `POST /admin/install-tokens/bulk-purge-revoked` that returns JSON with the `deleted_count`. (`app/api/routes/tray.py`)
- Added regression tests for the repository purge and the admin page action: `test_delete_revoked_install_tokens` and `test_tray_bulk_purge_revoked_install_tokens_calls_repo`. (`tests/test_tray_app.py`, `tests/test_tray_install_tokens_page.py`)

### Testing
- Ran the targeted tests `pytest tests/test_tray_install_tokens_page.py tests/test_tray_app.py::test_delete_revoked_install_tokens` and the new page test, and they passed. (`tests/test_tray_install_tokens_page.py`, `tests/test_tray_app.py`) 
- A run of the broader tray test suite (`pytest tests/test_tray_install_tokens_page.py tests/test_tray_app.py -q`) surfaces pre-existing SQLite fixture/schema issues (missing `site_settings`) unrelated to this change, so only the targeted tests were relied on for validation and those succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b513bd2d0832d9004aa4d3961b83f)