### PR TITLE
Render sanitized HTML product descriptions in shop details

### DIFF
--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -16,6 +16,7 @@ from fastapi import File, Form, HTTPException, Query, Request, UploadFile, statu
 from fastapi.responses import JSONResponse, RedirectResponse
 
 from app.security.flash import flash_redirect
+from app.services.sanitization import sanitize_rich_text
 
 
 def _main():
@@ -406,11 +407,13 @@ async def shop_product_detail_api(request: Request, product_id: int):
 
 
 def _public_shop_product_payload(product: Mapping[str, Any], *, is_vip: bool) -> dict[str, Any]:
+    sanitized_description = sanitize_rich_text(str(product.get("description") or ""))
     payload = {
         "id": product.get("id"),
         "name": product.get("name"),
         "sku": product.get("sku"),
         "description": product.get("description"),
+        "description_html": sanitized_description.html,
         "image_url": product.get("image_url"),
         "price": product.get("price"),
         "vip_price": product.get("vip_price"),

--- a/app/main.py
+++ b/app/main.py
@@ -8958,3 +8958,11 @@ async def readiness_probe() -> JSONResponse:
 # at ``app/features/chat/``.  They are loaded on startup via the
 # ``FEATURE_PACKS`` setting and can be hot-reloaded without restarting
 # the application.
+
+
+def _public_shop_product_payload(product: Mapping[str, Any], *, is_vip: bool) -> dict[str, Any]:
+    """Compatibility wrapper for the shop feature-pack public payload helper."""
+
+    from app.features.shop.handlers import _public_shop_product_payload as shop_payload
+
+    return shop_payload(product, is_vip=is_vip)

--- a/app/static/js/shop.js
+++ b/app/static/js/shop.js
@@ -134,17 +134,6 @@
     return row;
   }
 
-  function appendPlainTextWithLineBreaks(container, text) {
-    const lines = String(text).split(/\r?\n/);
-    lines.forEach((line, index) => {
-      if (index > 0) {
-        container.appendChild(document.createElement('br'));
-      }
-      container.appendChild(document.createTextNode(line));
-    });
-  }
-
-
   async function fetchProductDetails(productId) {
     const response = await fetch(`/api/shop/products/${productId}`, {
       headers: {
@@ -183,15 +172,21 @@
     container.appendChild(createDetailRow('Price', `$${Number(product.price || 0).toFixed(2)}`));
     container.appendChild(createDetailRow('Availability', describeStockStatus(product.stock)));
 
-    if (product.description) {
+    const descriptionHtml = typeof product.description_html === 'string' ? product.description_html.trim() : '';
+    const descriptionText = typeof product.description === 'string' ? product.description.trim() : '';
+    if (descriptionHtml || descriptionText) {
       const descriptionTitle = document.createElement('h3');
       descriptionTitle.className = 'modal__subtitle';
       descriptionTitle.textContent = 'Description';
       container.appendChild(descriptionTitle);
 
       const descriptionDiv = document.createElement('div');
-      descriptionDiv.className = 'modal__description';
-      appendPlainTextWithLineBreaks(descriptionDiv, product.description);
+      descriptionDiv.className = 'modal__description rich-text-viewer';
+      if (descriptionHtml) {
+        descriptionDiv.innerHTML = descriptionHtml;
+      } else {
+        descriptionDiv.textContent = descriptionText;
+      }
       container.appendChild(descriptionDiv);
     }
   }

--- a/tests/test_shop_product_public_payload.py
+++ b/tests/test_shop_product_public_payload.py
@@ -53,3 +53,20 @@ def test_public_shop_product_payload_uses_vip_price_for_vip_company() -> None:
     payload = main._public_shop_product_payload(product, is_vip=True)
 
     assert payload["price"] == 22.0
+
+
+def test_public_shop_product_payload_includes_sanitized_description_html() -> None:
+    product = {
+        "id": 12,
+        "name": "Firewall",
+        "description": '<h3>Overview</h3><script>alert(1)</script><p onclick="evil()">Safe</p>',
+        "price": 99.0,
+    }
+
+    payload = main._public_shop_product_payload(product, is_vip=False)
+
+    assert payload["description"] == product["description"]
+    assert "<h3>Overview</h3>" in payload["description_html"]
+    assert "<p>Safe</p>" in payload["description_html"]
+    assert "script" not in payload["description_html"].lower()
+    assert "onclick" not in payload["description_html"].lower()


### PR DESCRIPTION
### Motivation

- Allow product descriptions to include safe rich HTML in the shop product details modal while preventing XSS and preserving existing plain-text compatibility.

### Description

- Sanitize server-side description content with `sanitize_rich_text` and expose a new `description_html` field in the public product payload returned by `/_api/shop/products/{product_id}` while keeping the original `description` unchanged. (`app/features/shop/handlers.py`)
- Render the sanitized HTML in the product details modal by using `innerHTML` when `description_html` is present and falling back to plain-text when not, and apply the `rich-text-viewer` styling class. (`app/static/js/shop.js`)
- Add a compatibility wrapper ` _public_shop_product_payload` in `app/main.py` to maintain existing import paths used by tests and other modules. (`app/main.py`)
- Add regression test coverage that verifies unsafe tags and attributes are stripped from `description_html`. (`tests/test_shop_product_public_payload.py`)

### Testing

- Ran `pytest tests/test_shop_product_public_payload.py tests/test_product_descriptions.py -q`, and the suite passed (all tests succeeded).
- Compiled changed modules with `python -m compileall app/features/shop/handlers.py app/main.py` with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b54a2d1dc832d99a56f50627b28b1)