### PR TITLE
Add bulk shop description refresh action

### DIFF
--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -2443,6 +2443,67 @@ async def admin_update_shop_product(
     return RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
 
 
+async def admin_bulk_refresh_shop_product_descriptions(request: Request):
+    from app.services import audit as audit_service
+    from app.services import product_descriptions
+    from app.repositories import shop as shop_repo
+
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    form = await request.form()
+    include_archived = _form_bool(form, "include_archived")
+    products = await shop_repo.list_products_summary(
+        shop_repo.ProductFilters(include_archived=include_archived, sort="name_asc")
+    )
+
+    refreshed_count = 0
+    failed_count = 0
+    for product in products:
+        product_id = int(product["id"])
+        try:
+            result = await product_descriptions.improve_product_description(product_id)
+        except Exception as exc:  # pragma: no cover - defensive per-item isolation
+            failed_count += 1
+            _main().log_error(
+                "Bulk shop product description refresh failed for product",
+                product_id=product_id,
+                error=str(exc),
+            )
+            continue
+        if result is None:
+            failed_count += 1
+        else:
+            refreshed_count += 1
+
+    await audit_service.record(
+        action="shop.product.description_bulk_refresh",
+        request=request,
+        entity_type="shop.product",
+        metadata={
+            "include_archived": include_archived,
+            "requested_count": len(products),
+            "refreshed_count": refreshed_count,
+            "failed_count": failed_count,
+        },
+    )
+    _main().log_info(
+        "Bulk shop product descriptions refreshed",
+        requested_count=len(products),
+        refreshed_count=refreshed_count,
+        failed_count=failed_count,
+        include_archived=include_archived,
+        refreshed_by=current_user["id"] if current_user else None,
+    )
+
+    level = "warning" if failed_count else "success"
+    message = f"Refreshed {refreshed_count} product description{'s' if refreshed_count != 1 else ''}."
+    if failed_count:
+        message += f" {failed_count} product{'s' if failed_count != 1 else ''} could not be refreshed."
+    return flash_redirect("/admin/shop", message, level)
+
+
 async def admin_refresh_shop_product_description(request: Request, product_id: int):
     from app.services import audit as audit_service
     from app.services import product_descriptions

--- a/app/features/shop/routes.py
+++ b/app/features/shop/routes.py
@@ -221,6 +221,14 @@ _add(
     status_code=303,
 )
 _add(
+    "/shop/admin/products/bulk-refresh-descriptions",
+    handlers.admin_bulk_refresh_shop_product_descriptions,
+    ["POST"],
+    status_code=303,
+    summary="Refresh descriptions and comparison features for shop products in bulk",
+    tags=["Shop"],
+)
+_add(
     "/shop/admin/product/{product_id}/refresh-description",
     handlers.admin_refresh_shop_product_description,
     ["POST"],

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1327,6 +1327,10 @@ html {
   list-style: none;
 }
 
+.header-title-menu__form {
+  display: contents;
+}
+
 .header-title-menu__link {
   display: flex;
   align-items: center;
@@ -1349,7 +1353,8 @@ html {
   appearance: none;
 }
 
-button.header-title-menu__link {
+button.header-title-menu__link,
+.header-title-menu__form .header-title-menu__link {
   width: 100%;
 }
 

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -36,6 +36,19 @@
           <a href="/admin/shop/products/new" class="header-title-menu__link" role="menuitem">Add product</a>
         </li>
         <li class="header-title-menu__item" role="none">
+          <form
+            action="/shop/admin/products/bulk-refresh-descriptions"
+            method="post"
+            class="header-title-menu__form"
+            data-confirm="Refresh descriptions for all {{ 'visible active and archived' if show_archived else 'active' }} products? This may take several minutes."
+            onsubmit="return confirm('Refresh descriptions for all {{ 'visible active and archived' if show_archived else 'active' }} products? This may take several minutes.');"
+          >
+            {% if csrf_token %}<input type="hidden" name="_csrf" value="{{ csrf_token }}" />{% endif %}
+            {% if show_archived %}<input type="hidden" name="include_archived" value="1" />{% endif %}
+            <button type="submit" class="header-title-menu__link" role="menuitem">Bulk Refresh Descriptions</button>
+          </form>
+        </li>
+        <li class="header-title-menu__item" role="none">
           <button
             type="button"
             class="header-title-menu__link"

--- a/tests/test_product_descriptions.py
+++ b/tests/test_product_descriptions.py
@@ -65,3 +65,62 @@ async def test_improve_product_description_invokes_ollama_synchronously(monkeypa
     trigger.assert_awaited_once()
     assert trigger.await_args.args[0] == "ollama"
     assert trigger.await_args.kwargs["background"] is False
+
+
+@pytest.mark.anyio("asyncio")
+async def test_bulk_refresh_shop_product_descriptions_refreshes_active_products(monkeypatch):
+    from app import main as app_main
+    from app.features.shop import handlers
+
+    async def _fake_require_super_admin_page(request):
+        return ({"id": 9, "is_super_admin": True}, None)
+
+    monkeypatch.setattr(
+        app_main, "_require_super_admin_page", _fake_require_super_admin_page
+    )
+
+    captured_filters = []
+
+    async def _list_products_summary(filters):
+        captured_filters.append(filters)
+        return [{"id": 1}, {"id": 2}]
+
+    monkeypatch.setattr(
+        product_descriptions.shop_repo, "list_products_summary", _list_products_summary
+    )
+    refresh = AsyncMock(
+        side_effect=[
+            {"description": "one", "features": []},
+            {"description": "two", "features": []},
+        ]
+    )
+    monkeypatch.setattr(product_descriptions, "improve_product_description", refresh)
+
+    audit_record = AsyncMock()
+    monkeypatch.setattr("app.services.audit.record", audit_record)
+
+    class _Request:
+        headers = {}
+        client = None
+
+        class _State:
+            pass
+
+        state = _State()
+
+        async def form(self):
+            return {}
+
+    response = await handlers.admin_bulk_refresh_shop_product_descriptions(_Request())
+
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/admin/shop")
+    assert captured_filters[0].include_archived is False
+    assert refresh.await_count == 2
+    assert [call.args[0] for call in refresh.await_args_list] == [1, 2]
+    audit_record.assert_awaited_once()
+    assert (
+        audit_record.await_args.kwargs["action"]
+        == "shop.product.description_bulk_refresh"
+    )
+    assert audit_record.await_args.kwargs["metadata"]["refreshed_count"] == 2


### PR DESCRIPTION
### Motivation
- Provide a Shop Tools action to refresh product descriptions in bulk so admins can regenerate descriptions and extracted features for many products at once. 
- Support running across active or archived products and surface per-product failures without aborting the whole run. 

### Description
- Added a `Bulk Refresh Descriptions` form action to the Shop Tools menu (`app/templates/admin/shop.html`) that posts to `/shop/admin/products/bulk-refresh-descriptions` and includes CSRF and `include_archived` when applicable. 
- Implemented `admin_bulk_refresh_shop_product_descriptions` in `app/features/shop/handlers.py` which enumerates products via `shop_repo.list_products_summary`, calls `product_descriptions.improve_product_description` per product with per-item failure isolation, and records an audit via `audit.record`. 
- Registered the new POST route in `app/features/shop/routes.py` with OpenAPI metadata. 
- Updated header menu form styling in `app/static/css/app.css` so form-backed menu items match existing menu links, and added a regression test in `tests/test_product_descriptions.py`. 

### Testing
- Ran `pytest -q tests/test_product_descriptions.py` and the tests passed (4 passed). 
- Compiled key modules with `python -m py_compile app/features/shop/handlers.py app/features/shop/routes.py app/services/product_descriptions.py` which succeeded. 
- Ran repository checks including `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b5505eb90832db5024212806e3bb6)