### PR TITLE
Improve Syncro ticket import feedback

### DIFF
--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -279,6 +279,9 @@ class SyncroTicketImportSummary(BaseModel):
     created: int = Field(default=0, ge=0)
     updated: int = Field(default=0, ge=0)
     skipped: int = Field(default=0, ge=0)
+    skipped_reasons: list[str] = Field(default_factory=list, alias="skippedReasons")
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class TicketTaskCreate(BaseModel):

--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -71,14 +71,24 @@ class TicketImportSummary:
     created: int = 0
     updated: int = 0
     skipped: int = 0
+    skipped_reasons: list[str] | None = None
 
-    def record(self, outcome: str) -> None:
+    def record_skip(self, reason: str) -> None:
+        self.skipped += 1
+        reason_text = _clean_text(reason) or "Unknown reason"
+        if self.skipped_reasons is None:
+            self.skipped_reasons = []
+        self.skipped_reasons.append(reason_text)
+
+    def record(self, outcome: str, reason: str | None = None) -> None:
         if outcome == "created":
             self.created += 1
         elif outcome == "updated":
             self.updated += 1
         else:
-            self.skipped += 1
+            if reason is None and outcome.startswith("skipped:"):
+                reason = outcome.split(":", 1)[1].strip()
+            self.record_skip(reason or "Ticket could not be imported")
 
     def as_dict(self) -> dict[str, Any]:
         return {
@@ -87,6 +97,7 @@ class TicketImportSummary:
             "created": self.created,
             "updated": self.updated,
             "skipped": self.skipped,
+            "skipped_reasons": self.skipped_reasons or [],
         }
 _HTML_NEWLINE_TAGS = re.compile(
     r"<\s*(?:br\s*/?|/(?:p|div|li|tr|table|thead|tbody|tfoot|section|article|header|footer|h[1-6]))\b[^>]*>",
@@ -1128,7 +1139,7 @@ async def _upsert_ticket(
     status_choices = set(allowed_statuses)
     syncro_id = ticket.get("id")
     if syncro_id is None:
-        return "skipped"
+        return "skipped: Syncro ticket payload did not include an id"
     external_reference = str(syncro_id)
     subject = _clean_text(ticket.get("subject") or ticket.get("title") or ticket.get("summary"))
     if not subject:
@@ -1269,8 +1280,8 @@ async def import_ticket_by_id(
     log_info("Starting Syncro ticket import", mode="single", ticket_id=ticket_id)
     ticket = await syncro.get_ticket(ticket_id, rate_limiter=limiter)
     if not ticket:
-        summary.skipped += 1
-        log_info("Syncro ticket import completed", mode="single", fetched=summary.fetched, created=0, updated=0, skipped=1)
+        summary.record_skip(f"Syncro ticket {ticket_id} was not returned by the Syncro API")
+        log_info("Syncro ticket import completed", mode="single", fetched=summary.fetched, created=0, updated=0, skipped=1, skipped_reasons=summary.skipped_reasons)
         return summary
     summary.fetched = 1
     allowed_statuses, default_status, status_mappings = await _get_status_context()
@@ -1300,7 +1311,7 @@ async def import_ticket_range(
     for identifier in range(start_id, end_id + 1):
         ticket = await syncro.get_ticket(identifier, rate_limiter=limiter)
         if not ticket:
-            summary.skipped += 1
+            summary.record_skip(f"Syncro ticket {identifier} was not returned by the Syncro API")
             continue
         summary.fetched += 1
         outcome = await _upsert_ticket(ticket, allowed_statuses, default_status, status_mappings)
@@ -1349,8 +1360,9 @@ async def import_all_tickets(
             try:
                 outcome = await _upsert_ticket(ticket, allowed_statuses, default_status, status_mappings)
             except Exception as exc:  # pragma: no cover - defensive logging
+                reason = f"Syncro ticket {ticket.get('id') or 'unknown'} failed to import: {exc}"
                 log_error("Failed to import Syncro ticket", syncro_id=ticket.get("id"), error=str(exc))
-                summary.skipped += 1
+                summary.record_skip(reason)
                 continue
             summary.record(outcome)
         if total_pages is None:

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -498,7 +498,22 @@
       const alertBox = document.createElement('div');
       alertBox.className = isError ? 'alert alert--error' : 'alert';
       alertBox.setAttribute('role', isError ? 'alert' : 'status');
-      alertBox.textContent = message;
+      if (Array.isArray(message)) {
+        const [summary, ...details] = message;
+        alertBox.appendChild(document.createTextNode(summary || 'Import completed.'));
+        if (details.length) {
+          const list = document.createElement('ul');
+          list.className = 'list list--compact';
+          details.forEach((detail) => {
+            const item = document.createElement('li');
+            item.textContent = detail;
+            list.appendChild(item);
+          });
+          alertBox.appendChild(list);
+        }
+      } else {
+        alertBox.textContent = message;
+      }
       statusRegion.appendChild(alertBox);
       statusRegion.hidden = false;
     };
@@ -542,10 +557,11 @@
           const created = Number(response?.created ?? 0);
           const updated = Number(response?.updated ?? 0);
           const skipped = Number(response?.skipped ?? 0);
-          renderStatus(
-            `Imported ${fetched} ticket${fetched === 1 ? '' : 's'} (created ${created}, updated ${updated}, skipped ${skipped}).`,
-            false,
-          );
+          const summaryMessage = `Imported ${fetched} ticket${fetched === 1 ? '' : 's'} (created ${created}, updated ${updated}, skipped ${skipped}).`;
+          const skippedReasons = Array.isArray(response?.skipped_reasons)
+            ? response.skipped_reasons
+            : (Array.isArray(response?.skippedReasons) ? response.skippedReasons : []);
+          renderStatus(skippedReasons.length ? [summaryMessage, ...skippedReasons] : summaryMessage, false);
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unable to import tickets.';
           renderStatus(message, true);
@@ -556,6 +572,48 @@
         }
       });
     });
+  }
+
+  function bindSyncroStatusMappingRows() {
+    const tbody = document.querySelector('[data-syncro-status-mapping-rows]');
+    if (!tbody) {
+      return;
+    }
+
+    const rowHasValue = (row) => Array.from(row.querySelectorAll('input, select')).some((field) => String(field.value || '').trim());
+
+    const cloneBlankRow = () => {
+      const template = Array.from(tbody.querySelectorAll('[data-syncro-status-mapping-row]')).find((row) => !rowHasValue(row));
+      if (!template) {
+        return null;
+      }
+      const clone = template.cloneNode(true);
+      clone.querySelectorAll('input, select').forEach((field) => {
+        field.value = '';
+      });
+      return clone;
+    };
+
+    const ensureOneBlankRow = () => {
+      const rows = Array.from(tbody.querySelectorAll('[data-syncro-status-mapping-row]'));
+      const blankRows = rows.filter((row) => !rowHasValue(row));
+      if (blankRows.length === 0) {
+        const row = cloneBlankRow() || rows[rows.length - 1]?.cloneNode(true);
+        if (!row) {
+          return;
+        }
+        row.querySelectorAll('input, select').forEach((field) => {
+          field.value = '';
+        });
+        tbody.appendChild(row);
+      } else if (blankRows.length > 1) {
+        blankRows.slice(1).forEach((row) => row.remove());
+      }
+    };
+
+    tbody.addEventListener('input', ensureOneBlankRow);
+    tbody.addEventListener('change', ensureOneBlankRow);
+    ensureOneBlankRow();
   }
 
   function bindSyncroCompanyImportForm() {
@@ -3423,6 +3481,7 @@
 
   document.addEventListener('DOMContentLoaded', () => {
     bindSyncroTicketImportForms();
+    bindSyncroStatusMappingRows();
     bindSyncroCompanyImportForm();
     bindTicketBulkDelete();
     bindTicketStatusAutoSubmit();

--- a/app/templates/admin/syncro_ticket_import.html
+++ b/app/templates/admin/syncro_ticket_import.html
@@ -56,13 +56,13 @@
 
 
 
-        <article class="card card--panel">
-          <header class="card__header">
+        <details class="card card--panel" data-syncro-status-mappings>
+          <summary class="card__header">
             <div>
               <h2 class="card__title">Status mappings</h2>
               <p class="card__subtitle">List each Syncro ticket status and choose the MyPortal status that imported tickets should use when the names do not match exactly.</p>
             </div>
-          </header>
+          </summary>
           <form class="card__form" action="/admin/tickets/syncro-import/status-mappings" method="post">
             {% include "partials/csrf.html" %}
             <div class="table-wrapper">
@@ -73,10 +73,10 @@
                     <th scope="col">MyPortal status</th>
                   </tr>
                 </thead>
-                <tbody>
+                <tbody data-syncro-status-mapping-rows>
                   {% set mappings = syncro_module.ticket_status_mappings or [] %}
                   {% for mapping in mappings %}
-                    <tr>
+                    <tr data-syncro-status-mapping-row>
                       <td data-label="Syncro status">
                         <input name="syncroStatus" class="form-input" maxlength="128" value="{{ mapping.syncro_status }}" placeholder="e.g. Waiting on Customer" />
                       </td>
@@ -89,21 +89,19 @@
                       </td>
                     </tr>
                   {% endfor %}
-                  {% for index in range(3) %}
-                    <tr>
-                      <td data-label="Syncro status">
-                        <input name="syncroStatus" class="form-input" maxlength="128" placeholder="e.g. {{ 'New' if index == 0 else 'In Progress' if index == 1 else 'Customer Reply' }}" />
-                      </td>
-                      <td data-label="MyPortal status">
-                        <select name="myportalStatus" class="form-input">
-                          <option value="">Select a MyPortal status</option>
-                          {% for status_option in ticket_status_definitions %}
-                            <option value="{{ status_option.tech_status }}">{{ status_option.tech_label }}</option>
-                          {% endfor %}
-                        </select>
-                      </td>
-                    </tr>
-                  {% endfor %}
+                  <tr data-syncro-status-mapping-row>
+                    <td data-label="Syncro status">
+                      <input name="syncroStatus" class="form-input" maxlength="128" placeholder="e.g. Waiting on Customer" />
+                    </td>
+                    <td data-label="MyPortal status">
+                      <select name="myportalStatus" class="form-input">
+                        <option value="">Select a MyPortal status</option>
+                        {% for status_option in ticket_status_definitions %}
+                          <option value="{{ status_option.tech_status }}">{{ status_option.tech_label }}</option>
+                        {% endfor %}
+                      </select>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </div>
@@ -112,7 +110,7 @@
               <button type="submit" class="button button--primary">Save status mappings</button>
             </div>
           </form>
-        </article>
+        </details>
 
         <article class="card card--panel">
           <header class="card__header">

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -246,6 +246,36 @@ async def test_import_ticket_range_handles_missing(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_import_ticket_by_id_reports_skip_reason_when_missing(monkeypatch):
+    async def fake_get_ticket(ticket_id, rate_limiter=None):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+
+    summary = await ticket_importer.import_ticket_by_id(404, rate_limiter=None)
+
+    assert summary.skipped == 1
+    assert summary.as_dict()["skipped_reasons"] == ["Syncro ticket 404 was not returned by the Syncro API"]
+
+
+@pytest.mark.anyio
+async def test_upsert_ticket_reports_missing_id_skip_reason(monkeypatch):
+    allowed = {"open", "closed"}
+
+    outcome = await ticket_importer._upsert_ticket(
+        {"subject": "No Syncro id"},
+        allowed,
+        "open",
+        {},
+    )
+    summary = ticket_importer.TicketImportSummary(mode="single", fetched=1)
+    summary.record(outcome)
+
+    assert summary.skipped == 1
+    assert summary.as_dict()["skipped_reasons"] == ["Syncro ticket payload did not include an id"]
+
+
+@pytest.mark.anyio
 async def test_resolve_company_creates_company_when_missing(monkeypatch):
     created_payload: dict[str, Any] = {}
 


### PR DESCRIPTION
### Motivation
- Make Syncro ticket imports actionable by surfacing why tickets are skipped instead of only returning counts. 
- Improve the admin UX for Status mappings by collapsing the section by default and keeping a single blank mapping row that grows as needed.

### Description
- Add `skipped_reasons` to the import summary schema (`app/schemas/tickets.py`) and include it in the JSON payload returned by imports.  
- Track per-ticket skip reasons in the import workflow by extending `TicketImportSummary` with `record_skip` and plumbing concrete reasons from `_upsert_ticket`, `import_ticket_by_id`, `import_ticket_range`, and `import_all_tickets` (`app/services/ticket_importer.py`).  
- Return descriptive skip tokens from `_upsert_ticket` (e.g. `"skipped: ..."`) so `record` can capture legacy skip outcomes as reasons.  
- Update admin UI code to display skipped reasons beneath the import summary (`app/static/js/admin.js`) and to read either `skipped_reasons` or `skippedReasons` from the response.  
- Collapse the Status mappings card by default and reduce the initial blank rows to a single row, adding client-side logic to ensure exactly one blank row is available as users fill mappings (`app/templates/admin/syncro_ticket_import.html` and new `bindSyncroStatusMappingRows` in `app/static/js/admin.js`).  
- Add regression tests that assert skip reasons are recorded and surfaced (`tests/test_ticket_importer.py`).

### Testing
- Ran `pytest -q tests/test_ticket_importer.py -q` and the test suite for that file passed.  
- Performed a JavaScript syntax check with `node --check app/static/js/admin.js` which succeeded.  
- All automated checks executed during development completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b7b4b11e48332988a0eb46d3351ae)