### PR TITLE
Fix tray update command delivery

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -970,6 +970,7 @@ async def tray_device_socket(websocket: WebSocket, device_uid: str) -> None:
 
     await websocket.accept()
     tray_service.register_connection(device_uid, websocket)
+    await tray_service.deliver_queued_commands(device)
     try:
         while True:
             try:
@@ -5857,15 +5858,18 @@ async def admin_tray_update_device(device_id: int, request: Request):
         )
 
     payload = {"type": "update"}
-    device_uid = str(device.get("device_uid") or "").strip()
-    delivered = await tray_service.send_to_device(device_uid, payload) if device_uid else False
-    await tray_repo.log_command(
+    command_id = await tray_repo.log_command(
         device_id=int(device["id"]),
         command="update",
         payload_json=json.dumps(payload),
         initiated_by_user_id=current_user.get("id") if current_user else None,
-        status="delivered" if delivered else "queued",
+        status="queued",
     )
+    payload["command_id"] = command_id
+    device_uid = str(device.get("device_uid") or "").strip()
+    delivered = await tray_service.send_to_device(device_uid, payload) if device_uid else False
+    if delivered:
+        await tray_repo.mark_command_delivered(command_id)
     if delivered:
         return flash_redirect(
             "/admin/tray/devices",

--- a/app/repositories/tray.py
+++ b/app/repositories/tray.py
@@ -453,6 +453,25 @@ async def log_command(
     return int(last_id) if last_id else 0
 
 
+async def get_queued_commands_for_device(device_id: int, *, limit: int = 50) -> list[dict[str, Any]]:
+    """Return queued commands for a device in creation order.
+
+    Commands may be queued when an admin action targets a device whose
+    websocket is connected to a different app process or is offline.  The
+    websocket handler drains this queue when the device reconnects so admin
+    actions are not silently lost.
+    """
+
+    placeholder = "?" if db.is_sqlite() else "%s"
+    rows = await db.fetch_all(
+        f"SELECT * FROM tray_command_log "
+        f"WHERE device_id = {placeholder} AND status = 'queued' "
+        f"ORDER BY created_at ASC, id ASC LIMIT {int(limit)}",
+        (device_id,),
+    )
+    return [dict(row) for row in rows]
+
+
 async def mark_command_delivered(command_id: int, *, error: str | None = None) -> None:
     placeholder = "?" if db.is_sqlite() else "%s"
     now = datetime.now(timezone.utc).replace(tzinfo=None)

--- a/app/services/tray.py
+++ b/app/services/tray.py
@@ -600,6 +600,54 @@ async def send_to_device(
         return False
 
 
+async def deliver_queued_commands(device: dict[str, Any]) -> dict[str, int]:
+    """Send queued commands to a freshly connected device.
+
+    The admin device page logs commands as ``queued`` before attempting live
+    websocket delivery.  If live delivery is impossible (for example the tray
+    is offline or connected to another web worker), this reconnect drain is
+    the reliable path that ensures the tray service eventually receives the
+    command.
+    """
+
+    device_uid = str(device.get("device_uid") or "").strip()
+    if not device_uid:
+        return {"delivered": 0, "failed": 0}
+
+    delivered = 0
+    failed = 0
+    commands = await tray_repo.get_queued_commands_for_device(int(device["id"]))
+    for command in commands:
+        payload: dict[str, Any]
+        raw_payload = command.get("payload_json")
+        if raw_payload:
+            try:
+                parsed = json.loads(raw_payload)
+                payload = parsed if isinstance(parsed, dict) else {}
+            except json.JSONDecodeError:
+                payload = {}
+        else:
+            payload = {}
+        payload.setdefault("type", command.get("command"))
+        payload.setdefault("command_id", command.get("id"))
+
+        if await send_to_device(device_uid, payload):
+            await tray_repo.mark_command_delivered(int(command["id"]))
+            delivered += 1
+        else:
+            failed += 1
+            break
+
+    if delivered or failed:
+        log_info(
+            "Tray queued command delivery complete",
+            device_uid=device_uid,
+            delivered=delivered,
+            failed=failed,
+        )
+    return {"delivered": delivered, "failed": failed}
+
+
 async def push_notification_to_company_devices(
     *,
     company_id: int | None,


### PR DESCRIPTION
### Motivation
- Admin UI reported update commands as delivered or queued even when the tray agent never received them, causing silent failures when devices were offline or connected to a different worker.

### Description
- Change admin update flow to always persist the command first by calling `log_command(..., status='queued')`, include the returned `command_id` in the payload, then attempt live delivery and mark as delivered only on success in `app/main.py`.
- Add `get_queued_commands_for_device` repository function to read queued entries in creation order in `app/repositories/tray.py`.
- Add `deliver_queued_commands` service function in `app/services/tray.py` that deserializes queued payloads, sends them via `send_to_device`, and marks individual commands delivered with `mark_command_delivered` on success.
- Invoke `deliver_queued_commands` when a tray websocket connection is accepted so queued commands are drained to the freshly connected device in `app/main.py`.

### Testing
- Compiled modified modules with `python3 -m compileall app/repositories/tray.py app/services/tray.py app/main.py` and the compile succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b7fb581d48332b673ada07a36a363)