### PR TITLE
Constrain company edit form field widths

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -8976,6 +8976,11 @@ a.service-card__ai-icon:hover {
   max-width: 90%;
 }
 
+.company-edit-page .form-input,
+.company-edit-page .form-textarea {
+  max-width: 85%;
+}
+
 .ticket-reply-form .form-input,
 .ticket-reply-form .form-textarea,
 .ticket-reply-form .rich-text-editor {

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -10,7 +10,7 @@
   ]) }}
 {% endblock %}
 {% block content %}
-  <div data-company-id="{{ company.id }}">
+  <div class="company-edit-page" data-company-id="{{ company.id }}">
   <div class="admin-grid admin-grid--columns">
     <section class="card card--panel admin-grid__full">
       <header class="card__header card__header--actions">


### PR DESCRIPTION
### Motivation
- Limit the visual width of input controls on the company edit page so long fields do not stretch the layout (targeting `/admin/companies/*/edit`).

### Description
- Add `company-edit-page` to the root wrapper in `app/templates/admin/company_edit.html` to scope page-specific styles.
- Add a scoped rule in `app/static/css/app.css`: `.company-edit-page .form-input, .company-edit-page .form-textarea { max-width: 85%; }` so inputs/textareas on this page are constrained.

### Testing
- Ran `git diff --check` which passed.
- Ran `pytest -q tests/test_companies_feature_pack.py` which failed with unrelated route/manifest assertions (tray ticket question routes expectations), so the CSS/template change itself did not introduce test failures but the test suite did not fully pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3ba210f8b08332a1ce90b5b5622474)