### PR TITLE
Add Related panel to admin ticket detail (agent-powered scan)

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -19,6 +19,7 @@ Mirrors the routes that used to live in ``app/main.py``:
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from typing import Any
 from urllib.parse import urlsplit
@@ -34,8 +35,10 @@ from app.repositories import companies as company_repo
 from app.repositories import company_memberships as membership_repo
 from app.repositories import staff as staff_repo
 from app.repositories import ticket_statuses as ticket_status_repo
+from app.repositories import ticket_attachments as attachments_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import users as user_repo
+from app.services import agent as agent_service
 from app.services import labour_types as labour_types_service
 from app.services import ticket_attachments as attachments_service
 from app.services import tickets as tickets_service
@@ -53,6 +56,93 @@ def _main():
 
 
 
+
+
+def _strip_external_links(text: str) -> str:
+    return re.sub(r"https?://\S+|www\.\S+", " ", text or "")
+
+
+def _compact_ticket_text(value: Any, *, limit: int = 700) -> str:
+    sanitized = sanitize_rich_text(_strip_external_links(str(value or "")))
+    text = re.sub(r"\s+", " ", sanitized.text_content).strip()
+    return text[:limit]
+
+
+def _build_related_ticket_query(
+    ticket: dict[str, Any],
+    replies: Sequence[dict[str, Any]],
+    attachments: Sequence[dict[str, Any]],
+) -> str:
+    parts: list[str] = [
+        "Find useful related MyPortal records for this helpdesk ticket. "
+        "Prioritise exact error messages, product names, assets, users, companies, previous tickets, knowledge base articles, service status and known issues. "
+        "Ignore email signatures and do not use external links.",
+        f"Subject: {_compact_ticket_text(ticket.get('subject'), limit=220)}",
+        f"Description: {_compact_ticket_text(ticket.get('description'), limit=900)}",
+    ]
+    if ticket.get("category"):
+        parts.append(f"Category: {_compact_ticket_text(ticket.get('category'), limit=120)}")
+    for reply in replies[-8:]:
+        label = "Internal" if reply.get("is_internal") else "Public"
+        parts.append(f"{label} reply: {_compact_ticket_text(reply.get('body'), limit=600)}")
+    attachment_names = [
+        _compact_ticket_text(a.get("original_filename") or a.get("filename"), limit=160)
+        for a in attachments[:12]
+        if a.get("original_filename") or a.get("filename")
+    ]
+    if attachment_names:
+        parts.append("Attachment filenames: " + "; ".join(attachment_names))
+    return "\n".join(part for part in parts if part).strip()[:2000]
+
+
+def _source_url(source_type: str, item: dict[str, Any]) -> str | None:
+    if item.get("url"):
+        return str(item["url"])
+    identifier = item.get("id")
+    if source_type == "tickets" and identifier:
+        return f"/admin/tickets/{identifier}"
+    if source_type == "assets" and identifier:
+        return f"/admin/assets/{identifier}"
+    if source_type == "companies" and identifier:
+        return f"/admin/companies/{identifier}"
+    if source_type == "staff" and identifier:
+        return f"/admin/staff/{identifier}"
+    if source_type == "orders" and item.get("order_number"):
+        return f"/admin/orders/{item['order_number']}"
+    if source_type == "chats" and identifier:
+        return f"/chat/{identifier}"
+    if source_type == "issues" and identifier:
+        return f"/admin/issues/{identifier}"
+    return None
+
+
+def _related_items_from_agent_sources(sources: dict[str, Any], current_ticket_id: int) -> list[dict[str, str]]:
+    items: list[dict[str, str]] = []
+    for source_type, values in sources.items():
+        if source_type == "feature_packs" and isinstance(values, dict):
+            iterable = [(f"feature:{slug}", item) for slug, records in values.items() for item in (records or [])]
+        else:
+            iterable = [(source_type, item) for item in (values or [])]
+        for item_type, raw_item in iterable:
+            if not isinstance(raw_item, dict):
+                continue
+            if item_type == "tickets":
+                try:
+                    if int(raw_item.get("id")) == current_ticket_id:
+                        continue
+                except (TypeError, ValueError):
+                    pass
+            url = _source_url(item_type, raw_item)
+            if not url:
+                continue
+            label = (
+                raw_item.get("title") or raw_item.get("subject") or raw_item.get("name")
+                or raw_item.get("order_number") or raw_item.get("key") or f"{item_type.title()} {raw_item.get('id', '')}"
+            )
+            items.append({"type": item_type, "label": str(label).strip()[:180], "url": url})
+            if len(items) >= 12:
+                return items
+    return items
 
 def _parse_requester_value(raw: Any) -> tuple[str | None, int | None]:
     value = str(raw or "").strip()
@@ -113,6 +203,35 @@ async def admin_ticket_detail(
         ticket_id=ticket_id,
     )
 
+
+
+@router.post("/admin/tickets/{ticket_id:int}/related/rescan", response_class=JSONResponse)
+async def admin_rescan_ticket_related(ticket_id: int, request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not permitted")
+    ticket = await tickets_repo.get_ticket(ticket_id)
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
+
+    replies = await tickets_repo.list_replies(ticket_id, include_internal=True)
+    attachments = await attachments_repo.list_attachments(ticket_id)
+    query = _build_related_ticket_query(ticket, replies, attachments)
+    result = await agent_service.execute_agent_query(
+        query,
+        current_user,
+        active_company_id=getattr(request.state, "active_company_id", None),
+        memberships=getattr(request.state, "available_companies", None),
+    )
+    items = _related_items_from_agent_sources(dict(result.get("sources") or {}), ticket_id)
+    return JSONResponse({
+        "items": items,
+        "scanned": True,
+        "skipped": False,
+        "message": result.get("message"),
+        "generated_at": result.get("generated_at"),
+    })
 
 @router.post("/admin/tickets", response_class=HTMLResponse)
 async def admin_create_ticket(request: Request):

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -95,9 +95,22 @@ def _build_related_ticket_query(
     return "\n".join(part for part in parts if part).strip()[:2000]
 
 
+def _safe_related_url(url: str | None) -> str | None:
+    candidate = str(url or "").strip()
+    if not candidate:
+        return None
+    parsed = urlsplit(candidate)
+    if parsed.scheme or parsed.netloc:
+        return None
+    if not candidate.startswith("/") or candidate.startswith("//"):
+        return None
+    return candidate
+
+
 def _source_url(source_type: str, item: dict[str, Any]) -> str | None:
-    if item.get("url"):
-        return str(item["url"])
+    supplied_url = _safe_related_url(item.get("url"))
+    if supplied_url:
+        return supplied_url
     identifier = item.get("id")
     if source_type == "tickets" and identifier:
         return f"/admin/tickets/{identifier}"
@@ -229,7 +242,6 @@ async def admin_rescan_ticket_related(ticket_id: int, request: Request):
         "items": items,
         "scanned": True,
         "skipped": False,
-        "message": result.get("message"),
         "generated_at": result.get("generated_at"),
     })
 

--- a/app/main.py
+++ b/app/main.py
@@ -8633,6 +8633,13 @@ async def _render_ticket_detail(
         "ticket_call_recordings": enriched_recordings,
         "ticket_watchers": enriched_watchers,
         "ticket_attachments": formatted_attachments,
+        "ticket_related_auto_scan": not (
+            str(ticket.get("module_slug") or "").lower() == "syncro"
+            or (
+                str(ticket.get("external_reference") or "").isdigit()
+                and bool(ticket.get("ticket_number"))
+            )
+        ),
         "ticket_labour_types": labour_types,
         "ticket_billable_minutes": total_billable_minutes,
         "ticket_non_billable_minutes": total_non_billable_minutes,

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10543,3 +10543,40 @@ a.stat-strip__stat:focus-visible {
     margin: 0;
   }
 }
+
+.ticket-related__summary .button {
+  position: relative;
+  z-index: 1;
+}
+
+.ticket-related__actions {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.ticket-related__refresh.is-loading {
+  opacity: 0.65;
+  pointer-events: none;
+}
+
+.ticket-related__status {
+  color: var(--color-text-muted, #64748b);
+  font-size: 0.9rem;
+}
+
+.ticket-related__list {
+  display: grid;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.ticket-related__link {
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
+  overflow: hidden;
+  text-decoration: none;
+}

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -155,6 +155,107 @@
     return getCookie('myportal_session_csrf');
   }
 
+
+  function initTicketRelated() {
+    const panel = document.querySelector('[data-ticket-related]');
+    if (!panel) {
+      return;
+    }
+    const ticketId = panel.getAttribute('data-ticket-id');
+    const autoScan = panel.getAttribute('data-auto-scan') === 'true';
+    const refreshButton = panel.querySelector('[data-ticket-related-refresh]');
+    const status = panel.querySelector('[data-ticket-related-status]');
+    const list = panel.querySelector('[data-ticket-related-list]');
+    let hasScanned = false;
+    let isScanning = false;
+
+    function setStatus(message) {
+      if (status) {
+        status.textContent = message || '';
+        status.hidden = !message;
+      }
+    }
+
+    function renderItems(items) {
+      if (!list) {
+        return;
+      }
+      list.innerHTML = '';
+      if (!Array.isArray(items) || items.length === 0) {
+        list.hidden = true;
+        setStatus('No related MyPortal content was found for this ticket.');
+        return;
+      }
+      items.forEach((item) => {
+        const li = document.createElement('li');
+        li.className = 'ticket-related__item';
+        const link = document.createElement('a');
+        link.className = 'ticket-related__link';
+        link.href = item.url || '#';
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.textContent = item.label || item.url || 'Related item';
+        link.title = link.textContent;
+        li.appendChild(link);
+        list.appendChild(li);
+      });
+      list.hidden = false;
+      setStatus('');
+    }
+
+    async function scanRelated() {
+      if (!ticketId || isScanning) {
+        return;
+      }
+      isScanning = true;
+      hasScanned = true;
+      if (refreshButton) {
+        refreshButton.disabled = true;
+        refreshButton.classList.add('is-loading');
+      }
+      setStatus('Scanning this ticket for related MyPortal content…');
+      try {
+        const headers = { Accept: 'application/json' };
+        const csrfToken = getCsrfToken();
+        if (csrfToken) {
+          headers['X-CSRF-Token'] = csrfToken;
+        }
+        const response = await fetch(`/admin/tickets/${encodeURIComponent(ticketId)}/related/rescan`, {
+          method: 'POST',
+          headers,
+        });
+        if (!response.ok) {
+          throw new Error(`Scan failed (${response.status})`);
+        }
+        const payload = await response.json();
+        renderItems(payload.items || []);
+      } catch (error) {
+        console.error('Failed to scan ticket related content:', error);
+        setStatus(error.message || 'Failed to scan related content.');
+      } finally {
+        isScanning = false;
+        if (refreshButton) {
+          refreshButton.disabled = false;
+          refreshButton.classList.remove('is-loading');
+        }
+      }
+    }
+
+    if (refreshButton) {
+      refreshButton.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        scanRelated();
+      });
+    }
+
+    panel.addEventListener('toggle', () => {
+      if (panel.open && autoScan && !hasScanned) {
+        scanRelated();
+      }
+    });
+  }
+
   function parseMinutesValue(value) {
     if (typeof value !== 'string' || value.trim() === '') {
       return null;
@@ -2114,6 +2215,7 @@
     initialiseTaskManagement();
     initialiseWatcherManagement();
     initialiseAttachmentActions();
+    initTicketRelated();
     convertUtcElements();
     initialiseBookingModal();
   }

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -213,7 +213,7 @@
         refreshButton.disabled = true;
         refreshButton.classList.add('is-loading');
       }
-      setStatus('Scanning this ticket for related MyPortal content…');
+      setStatus('Scanning this ticket for related MyPortal content...');
       try {
         const headers = { Accept: 'application/json' };
         const csrfToken = getCsrfToken();

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -550,7 +550,7 @@
                   data-ticket-related-refresh
                   title="Re-scan this ticket for related MyPortal content"
                   aria-label="Re-scan related content"
-                >↻</button>
+                >Refresh</button>
                 <span class="card__toggle-icon" aria-hidden="true"></span>
               </div>
             </summary>

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -476,11 +476,15 @@
             </article>
           {% endif %}
 
-          <article class="card card--panel">
-            <header class="card__header">
+          <details class="card card--panel card-collapsible" {% if not ticket_attachments %}open{% endif %}>
+            <summary class="card__header card__header--collapsible">
               <h2 class="card__title">Attachments</h2>
-            </header>
-            <div class="card__body">
+              <div class="card__collapsible-meta">
+                {% if ticket_attachments %}<span class="badge badge--muted">{{ ticket_attachments|length }}</span>{% endif %}
+                <span class="card__toggle-icon" aria-hidden="true"></span>
+              </div>
+            </summary>
+            <div class="card-collapsible__content card__body">
               <div
                 class="attachments-grid"
                 data-attachments-grid
@@ -529,7 +533,38 @@
                 No attachments have been added yet.
               </p>
             </div>
-          </article>
+          </details>
+
+          <details
+            class="card card--panel card-collapsible ticket-related"
+            data-ticket-related
+            data-ticket-id="{{ ticket.id }}"
+            data-auto-scan="{{ 'true' if ticket_related_auto_scan else 'false' }}"
+          >
+            <summary class="card__header card__header--collapsible ticket-related__summary">
+              <h2 class="card__title">Related</h2>
+              <div class="card__collapsible-meta ticket-related__actions">
+                <button
+                  type="button"
+                  class="button button--ghost button--small ticket-related__refresh"
+                  data-ticket-related-refresh
+                  title="Re-scan this ticket for related MyPortal content"
+                  aria-label="Re-scan related content"
+                >↻</button>
+                <span class="card__toggle-icon" aria-hidden="true"></span>
+              </div>
+            </summary>
+            <div class="card-collapsible__content card__body">
+              <div class="ticket-related__status" data-ticket-related-status>
+                {% if ticket_related_auto_scan %}
+                  Open this section or use refresh to scan the ticket for related MyPortal content.
+                {% else %}
+                  Syncro-imported tickets are not scanned automatically. Use refresh to scan this ticket manually.
+                {% endif %}
+              </div>
+              <ul class="ticket-related__list" data-ticket-related-list hidden></ul>
+            </div>
+          </details>
 
           {% if ticket.xero_invoice_number %}
             <article class="card card--panel">


### PR DESCRIPTION
### Motivation
- Provide technicians a concise, permission-scoped "Related" section on the admin ticket detail that surfaces other internal MyPortal records related to the ticket using the existing agent/search pipeline. 
- Allow manual rescans (including for Syncro-imported tickets) via a refresh control and avoid auto-scanning Syncro imports by default to respect import semantics. 
- Reduce initial vertical space by making the Attachments area collapsible when attachments exist. 

### Description
- Added a POST endpoint `POST /admin/tickets/{ticket_id}/related/rescan` that builds a sanitized ticket query (subject, description, last replies, attachment filenames), calls `agent_service.execute_agent_query`, and returns linkable related sources; implemented in `app/features/tickets/admin_routes.py` (helpers: `_strip_external_links`, `_compact_ticket_text`, `_build_related_ticket_query`, `_source_url`, `_related_items_from_agent_sources`).
- Templating changes in `app/templates/admin/ticket_detail.html` to make the Attachments panel collapsible and to add a new `Related` collapsible section below Attachments with a refresh button and `data-` attributes for JS-driven behavior. 
- Client-side code in `app/static/js/ticket_detail.js` adds `initTicketRelated()` to auto-scan when opened (for non-Syncro tickets), to call the rescan endpoint with CSRF protection, and to render results as links that open in a new tab. 
- Pass `ticket_related_auto_scan` flag into the ticket detail context in `app/main.py` to disable automatic scanning for Syncro-imported tickets. 
- Added UI styles in `app/static/css/app.css` to keep Related links to two lines and style the refresh action. 

### Testing
- Ran `python -m compileall app/features/tickets/admin_routes.py app/main.py` and it completed successfully. 
- Ran `node --check app/static/js/ticket_detail.js` and it completed successfully. 
- Ran `git diff --check` with no issues reported. 
- Ran `pytest tests/test_ticket_watchers_api.py -q` and observed failures unrelated to this change (existing test mocks for watcher functions have signature mismatches); these failures pre-existed and are not caused by the Related feature.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c697d0f048332895bb148bd066878)