### PR TITLE
Add permission-scoped RAG indexing and retrieval for agent and ticket related searches

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,6 +174,18 @@ FORCE_ENV_MODULE_SETTINGS=false
 # Prevent caching by proxy servers and CDNs. When true, adds no-cache headers to responses.
 # Static files are exempt from this restriction.
 DISABLE_CACHING=true
+
+# Retrieval-augmented generation (RAG) indexing/search controls.
+# RAG_EMBEDDING_MODEL is stored with each indexed chunk; change it when
+# switching embedding implementations or dimensions so old vectors do not mix
+# with new vectors. The default uses MyPortal's deterministic local hash
+# embedding and does not require an external API key.
+RAG_EMBEDDING_MODEL=myportal-hash-embedding-v1
+RAG_EMBEDDING_DIMENSIONS=256
+RAG_CHUNK_WORDS=180
+RAG_CHUNK_OVERLAP_WORDS=35
+RAG_CANDIDATE_LIMIT=8
+RAG_MIN_SCORE=0.12
 SWAGGER_UI_URL=/docs
 # Public base URL of this MyPortal instance (e.g. "https://portal.example.com").
 # Used to build callback URLs registered with external services such as Trello

--- a/app/api/routes/agent.py
+++ b/app/api/routes/agent.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from app.api.dependencies.auth import get_current_user
 from app.schemas.agent import AgentQueryRequest, AgentQueryResponse
 from app.services import agent as agent_service
+from app.repositories import rag_index as rag_index_repo
 
 router = APIRouter(prefix="/api/agent", tags=["Agent"])
 
@@ -24,3 +25,10 @@ async def query_agent(
         memberships=memberships,
     )
     return AgentQueryResponse(**result)
+
+
+@router.get("/rag/health")
+async def rag_health(current_user: dict = Depends(get_current_user)) -> dict:
+    if not bool(current_user.get("is_super_admin")):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not permitted")
+    return await rag_index_repo.health()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -203,6 +203,30 @@ class Settings(BaseSettings):
     disable_caching: bool = Field(
         default=True, validation_alias="DISABLE_CACHING"
     )
+    rag_embedding_model: str = Field(
+        default="myportal-hash-embedding-v1",
+        validation_alias="RAG_EMBEDDING_MODEL",
+        description=(
+            "Embedding model/version identifier stored with RAG chunks. Change this "
+            "when switching embedding providers or dimensions so new vectors are "
+            "indexed separately from old vectors."
+        ),
+    )
+    rag_embedding_dimensions: int = Field(
+        default=256, validation_alias="RAG_EMBEDDING_DIMENSIONS", ge=16, le=4096
+    )
+    rag_chunk_words: int = Field(
+        default=180, validation_alias="RAG_CHUNK_WORDS", ge=50, le=2000
+    )
+    rag_chunk_overlap_words: int = Field(
+        default=35, validation_alias="RAG_CHUNK_OVERLAP_WORDS", ge=0, le=500
+    )
+    rag_candidate_limit: int = Field(
+        default=8, validation_alias="RAG_CANDIDATE_LIMIT", ge=1, le=50
+    )
+    rag_min_score: float = Field(
+        default=0.12, validation_alias="RAG_MIN_SCORE", ge=0.0, le=1.0
+    )
     swagger_ui_url: str = Field(default="/docs", validation_alias="SWAGGER_UI_URL")
     public_base_url: str | None = Field(
         default=None,

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -41,6 +41,7 @@ from app.repositories import users as user_repo
 from app.services import agent as agent_service
 from app.services import labour_types as labour_types_service
 from app.services import ticket_attachments as attachments_service
+from app.services import rag_retrieval
 from app.services import tickets as tickets_service
 from app.services import tray as tray_service
 from app.services.sanitization import sanitize_rich_text
@@ -296,11 +297,50 @@ async def admin_rescan_ticket_related(ticket_id: int, request: Request):
         active_company_id=getattr(request.state, "active_company_id", None),
         memberships=getattr(request.state, "available_companies", None),
     )
-    items = _related_items_from_agent_sources(
-        dict(result.get("sources") or {}),
-        ticket_id,
-        search_terms=search_terms,
-    )
+    try:
+        rag_candidates = await rag_retrieval.retrieve_candidates(
+            query,
+            current_user,
+            active_company_id=getattr(request.state, "active_company_id", None),
+            memberships=getattr(request.state, "available_companies", None),
+            limit=12,
+            min_score=0.08,
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        log_error("Ticket related RAG retrieval failed", ticket_id=ticket_id, error=str(exc))
+        rag_candidates = []
+
+    items: list[dict[str, str]] = []
+    for candidate in rag_candidates:
+        source_type = str(candidate.get("source_type") or "")
+        source_id = candidate.get("source_id")
+        if source_type == "tickets":
+            try:
+                if int(source_id) == ticket_id:
+                    continue
+            except (TypeError, ValueError):
+                pass
+        url = _safe_related_url(candidate.get("url"))
+        if not url:
+            url = _source_url(source_type, {"id": source_id, "url": candidate.get("url")})
+        if not url:
+            continue
+        label = str(candidate.get("title") or f"{source_type.title()} {source_id}").strip()[:180]
+        items.append({
+            "type": source_type,
+            "label": label,
+            "url": url,
+            "score": str(candidate.get("score") or ""),
+        })
+        if len(items) >= 12:
+            break
+
+    if not items:
+        items = _related_items_from_agent_sources(
+            dict(result.get("sources") or {}),
+            ticket_id,
+            search_terms=search_terms,
+        )
     return JSONResponse({
         "items": items,
         "scanned": True,

--- a/app/repositories/rag_index.py
+++ b/app/repositories/rag_index.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from app.core.database import db
+
+
+async def upsert_document(record: dict[str, Any]) -> int:
+    existing = await db.fetch_one(
+        """
+        SELECT id FROM rag_documents
+        WHERE source_type = ? AND source_id = ? AND embedding_model = ?
+        """,
+        (record["source_type"], record["source_id"], record["embedding_model"]),
+    )
+    params = (
+        record.get("company_id"),
+        record["title"],
+        record.get("url"),
+        record.get("permission_scope_json"),
+        record.get("metadata_json"),
+        record["content_hash"],
+        1,
+    )
+    if existing:
+        await db.execute(
+            """
+            UPDATE rag_documents
+            SET company_id = ?, title = ?, url = ?, permission_scope_json = ?,
+                metadata_json = ?, content_hash = ?, is_active = ?, indexed_at = CURRENT_TIMESTAMP
+            WHERE id = ?
+            """,
+            (*params, existing["id"]),
+        )
+        return int(existing["id"])
+    return await db.execute_returning_lastrowid(
+        """
+        INSERT INTO rag_documents
+            (source_type, source_id, company_id, title, url, permission_scope_json,
+             metadata_json, content_hash, embedding_model, is_active)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+        """,
+        (
+            record["source_type"], record["source_id"], record.get("company_id"),
+            record["title"], record.get("url"), record.get("permission_scope_json"),
+            record.get("metadata_json"), record["content_hash"], record["embedding_model"],
+        ),
+    )
+
+
+async def replace_chunks(document_id: int, chunks: Sequence[dict[str, Any]]) -> None:
+    await db.execute("UPDATE rag_chunks SET is_active = 0 WHERE document_id = ?", (document_id,))
+    for chunk in chunks:
+        existing = await db.fetch_one(
+            """
+            SELECT id FROM rag_chunks
+            WHERE document_id = ? AND chunk_index = ? AND embedding_model = ?
+            """,
+            (document_id, chunk["chunk_index"], chunk["embedding_model"]),
+        )
+        params = (
+            chunk["chunk_text"], chunk["chunk_hash"], chunk["embedding_json"],
+            int(chunk.get("token_count") or 0), 1,
+        )
+        if existing:
+            await db.execute(
+                """
+                UPDATE rag_chunks
+                SET chunk_text = ?, chunk_hash = ?, embedding_json = ?, token_count = ?,
+                    is_active = ?, indexed_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """,
+                (*params, existing["id"]),
+            )
+        else:
+            await db.execute(
+                """
+                INSERT INTO rag_chunks
+                    (document_id, chunk_index, chunk_text, chunk_hash, embedding_json,
+                     embedding_model, token_count, is_active)
+                VALUES (?, ?, ?, ?, ?, ?, ?, 1)
+                """,
+                (
+                    document_id, chunk["chunk_index"], chunk["chunk_text"], chunk["chunk_hash"],
+                    chunk["embedding_json"], chunk["embedding_model"], int(chunk.get("token_count") or 0),
+                ),
+            )
+
+
+async def list_active_chunks(*, embedding_model: str, source_types: Sequence[str] | None = None) -> list[dict[str, Any]]:
+    params: list[Any] = [embedding_model]
+    where = ["d.is_active = 1", "c.is_active = 1", "c.embedding_model = ?"]
+    if source_types:
+        where.append("d.source_type IN (" + ",".join("?" for _ in source_types) + ")")
+        params.extend(source_types)
+    return await db.fetch_all(
+        f"""
+        SELECT c.id AS chunk_id, c.chunk_index, c.chunk_text, c.embedding_json,
+               d.id AS document_id, d.source_type, d.source_id, d.company_id,
+               d.title, d.url, d.permission_scope_json, d.metadata_json, d.indexed_at
+        FROM rag_chunks c
+        JOIN rag_documents d ON d.id = c.document_id
+        WHERE {' AND '.join(where)}
+        ORDER BY d.indexed_at DESC, c.id DESC
+        LIMIT 2000
+        """,
+        tuple(params),
+    )
+
+
+async def health() -> dict[str, Any]:
+    docs = await db.fetch_one("SELECT COUNT(*) AS count FROM rag_documents WHERE is_active = 1")
+    chunks = await db.fetch_one("SELECT COUNT(*) AS count FROM rag_chunks WHERE is_active = 1")
+    stale = await db.fetch_one("SELECT COUNT(*) AS count FROM rag_chunks WHERE is_active = 0")
+    by_source = await db.fetch_all(
+        "SELECT source_type, COUNT(*) AS count, MAX(indexed_at) AS last_indexed_at FROM rag_documents WHERE is_active = 1 GROUP BY source_type ORDER BY source_type"
+    )
+    return {
+        "documents": int((docs or {}).get("count") or 0),
+        "chunks": int((chunks or {}).get("count") or 0),
+        "stale_chunks": int((stale or {}).get("count") or 0),
+        "sources": by_source or [],
+    }

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -192,8 +192,18 @@ class AgentContextCompany(BaseModel):
     company_name: str
 
 
+class AgentContextRagCandidate(BaseModel):
+    source_type: str | None = None
+    source_id: str | None = None
+    title: str | None = None
+    url: str | None = None
+    excerpt: str | None = None
+    score: float | None = None
+
+
 class AgentContext(BaseModel):
     companies: list[AgentContextCompany] = Field(default_factory=list)
+    rag_candidates: list[AgentContextRagCandidate] = Field(default_factory=list)
 
 
 class AgentQueryRequest(BaseModel):

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -20,6 +20,8 @@ from app.services import issues as issues_service
 from app.services import reports as reports_service
 from app.services import knowledge_base as knowledge_base_service
 from app.services import modules as modules_service
+from app.services import rag_index as rag_index_service
+from app.services import rag_retrieval
 
 _KB_RESULT_LIMIT = 5
 _TICKET_RESULT_LIMIT = 5
@@ -1141,6 +1143,36 @@ async def execute_agent_query(
         is_super_admin=is_super_admin,
     )
 
+    assembled_sources = {
+        "knowledge_base": knowledge_base_sources,
+        "tickets": ticket_sources,
+        "products": product_sources,
+        "packages": package_sources,
+        "chats": chat_sources,
+        "orders": order_sources,
+        "assets": asset_sources,
+        "companies": company_sources,
+        "staff": staff_sources,
+        "issues": issue_sources,
+        "service_status": service_status_sources,
+        "backup_jobs": backup_job_sources,
+        "reports": report_sources,
+        "mailboxes": mailbox_sources,
+        "best_practices": best_practice_sources,
+        "feature_packs": feature_pack_sources,
+    }
+    try:
+        await rag_index_service.index_agent_sources(assembled_sources)
+        rag_candidates = await rag_retrieval.retrieve_candidates(
+            query_text,
+            user,
+            active_company_id=active_company_id,
+            memberships=resolved_memberships,
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        log_error("Agent RAG retrieval failed", error=str(exc))
+        rag_candidates = []
+
     # Check if we have any relevant sources
     has_relevant_sources = bool(
         knowledge_base_sources
@@ -1184,6 +1216,22 @@ async def execute_agent_query(
                 "",
             ]
         )
+
+    if rag_candidates:
+        context_sections.append("High-confidence RAG candidates:")
+        for index, candidate in enumerate(rag_candidates, start=1):
+            source_type = candidate.get("source_type") or "source"
+            source_id = candidate.get("source_id") or candidate.get("document_id")
+            title = candidate.get("title") or f"{source_type} {source_id}"
+            excerpt = _truncate(candidate.get("excerpt"), 420) or "No excerpt available"
+            score = candidate.get("score")
+            context_sections.append(
+                f"- [RAG:{source_type}:{source_id}] #{index} score={score}: {title}: {excerpt}"
+            )
+        context_sections.append(
+            "Summarize and rank these RAG candidates first. Only use lower-confidence source lists below as fallback context."
+        )
+        context_sections.append("")
 
     if knowledge_base_sources:
         context_sections.append("Knowledge base articles:")
@@ -1491,5 +1539,5 @@ async def execute_agent_query(
             "best_practices": best_practice_sources,
             "feature_packs": feature_pack_sources,
         },
-        "context": {"companies": company_context},
+        "context": {"companies": company_context, "rag_candidates": rag_candidates},
     }

--- a/app/services/rag_index.py
+++ b/app/services/rag_index.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from app.core.config import get_settings
+from app.repositories import rag_index as rag_repo
+from app.services.sanitization import sanitize_rich_text
+
+
+def embedding_model() -> str:
+    return get_settings().rag_embedding_model
+
+
+def embedding_dimensions() -> int:
+    return int(get_settings().rag_embedding_dimensions)
+
+
+def _chunk_words() -> int:
+    return int(get_settings().rag_chunk_words)
+
+
+def _chunk_overlap_words() -> int:
+    overlap = int(get_settings().rag_chunk_overlap_words)
+    return min(overlap, max(0, _chunk_words() - 1))
+
+
+@dataclass(slots=True)
+class RagDocument:
+    source_type: str
+    source_id: str
+    title: str
+    text: str
+    url: str | None = None
+    company_id: int | None = None
+    permission_scope: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+
+
+def normalise_text(value: Any) -> str:
+    sanitized = sanitize_rich_text(str(value or ""))
+    return re.sub(r"\s+", " ", sanitized.text_content).strip()
+
+
+def content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def embed_text(text: str) -> list[float]:
+    vector_size = embedding_dimensions()
+    vector = [0.0] * vector_size
+    tokens = re.findall(r"[a-z0-9][a-z0-9_.:-]{1,}", normalise_text(text).casefold())
+    for token in tokens:
+        digest = hashlib.blake2b(token.encode("utf-8"), digest_size=8).digest()
+        bucket = int.from_bytes(digest[:4], "big") % vector_size
+        sign = 1.0 if digest[4] & 1 else -1.0
+        vector[bucket] += sign
+    magnitude = math.sqrt(sum(value * value for value in vector))
+    if not magnitude:
+        return vector
+    return [value / magnitude for value in vector]
+
+
+def cosine_similarity(left: Sequence[float], right: Sequence[float]) -> float:
+    return float(sum(a * b for a, b in zip(left, right)))
+
+
+def chunk_text(text: str) -> list[str]:
+    words = normalise_text(text).split()
+    if not words:
+        return []
+    chunks: list[str] = []
+    chunk_words = _chunk_words()
+    step = max(1, chunk_words - _chunk_overlap_words())
+    for start in range(0, len(words), step):
+        segment = words[start : start + chunk_words]
+        if not segment:
+            break
+        chunks.append(" ".join(segment))
+        if start + chunk_words >= len(words):
+            break
+    return chunks
+
+
+def document_from_source(source_type: str, item: Mapping[str, Any]) -> RagDocument | None:
+    source_id = item.get("id") or item.get("slug") or item.get("order_number") or item.get("key") or item.get("check_id") or item.get("user_principal_name")
+    if source_id is None:
+        return None
+    title = str(item.get("title") or item.get("subject") or item.get("name") or item.get("order_number") or item.get("key") or item.get("check_name") or source_id).strip()
+    body_parts = [title]
+    for key in ("summary", "excerpt", "description", "status", "priority", "serial_number", "os_name", "last_user", "details"):
+        if item.get(key):
+            body_parts.append(str(item[key]))
+    text = normalise_text("\n".join(body_parts))
+    if not text:
+        return None
+    company_id = item.get("company_id")
+    try:
+        company_id = int(company_id) if company_id is not None else None
+    except (TypeError, ValueError):
+        company_id = None
+    metadata = {key: value for key, value in item.items() if key not in {"permission_scope"}}
+    return RagDocument(
+        source_type=source_type,
+        source_id=str(source_id),
+        title=title[:500],
+        text=text,
+        url=item.get("url"),
+        company_id=company_id,
+        permission_scope=dict(item.get("permission_scope") or {}),
+        metadata=metadata,
+    )
+
+
+async def index_document(document: RagDocument) -> int:
+    chunks = chunk_text(document.text)
+    if not chunks:
+        chunks = [normalise_text(document.title)]
+    doc_id = await rag_repo.upsert_document(
+        {
+            "source_type": document.source_type,
+            "source_id": document.source_id,
+            "company_id": document.company_id,
+            "title": document.title,
+            "url": document.url,
+            "permission_scope_json": json.dumps(document.permission_scope or {}, ensure_ascii=False),
+            "metadata_json": json.dumps(document.metadata or {}, ensure_ascii=False, default=str),
+            "content_hash": content_hash(document.text),
+            "embedding_model": embedding_model(),
+        }
+    )
+    await rag_repo.replace_chunks(
+        doc_id,
+        [
+            {
+                "chunk_index": index,
+                "chunk_text": chunk,
+                "chunk_hash": content_hash(chunk),
+                "embedding_json": json.dumps(embed_text(chunk)),
+                "embedding_model": embedding_model(),
+                "token_count": len(chunk.split()),
+            }
+            for index, chunk in enumerate(chunks)
+        ],
+    )
+    return doc_id
+
+
+async def index_agent_sources(sources: Mapping[str, Any]) -> int:
+    indexed = 0
+    for source_type, values in sources.items():
+        if source_type == "feature_packs" and isinstance(values, Mapping):
+            iterable = ((f"feature:{slug}", item) for slug, rows in values.items() for item in (rows or []))
+        else:
+            iterable = ((source_type, item) for item in (values or []))
+        for normalised_type, item in iterable:
+            if not isinstance(item, Mapping):
+                continue
+            document = document_from_source(normalised_type, item)
+            if document is None:
+                continue
+            await index_document(document)
+            indexed += 1
+    return indexed
+
+
+def candidate_to_source(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    metadata = candidate.get("metadata") if isinstance(candidate.get("metadata"), Mapping) else {}
+    item = dict(metadata)
+    item.setdefault("id", candidate.get("source_id"))
+    item.setdefault("title", candidate.get("title"))
+    item.setdefault("summary", candidate.get("excerpt"))
+    item.setdefault("url", candidate.get("url"))
+    item.setdefault("rag_score", candidate.get("score"))
+    return item

--- a/app/services/rag_permissions.py
+++ b/app/services/rag_permissions.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+
+
+def _company_ids(memberships: Sequence[Mapping[str, Any]]) -> set[int]:
+    ids: set[int] = set()
+    for membership in memberships:
+        try:
+            ids.add(int(membership.get("company_id") or membership.get("id")))
+        except (TypeError, ValueError):
+            continue
+    return ids
+
+
+def _has_flag(memberships: Sequence[Mapping[str, Any]], flag: str) -> bool:
+    return any(bool(membership.get(flag)) for membership in memberships)
+
+
+def can_access_candidate(candidate: Mapping[str, Any], *, user: Mapping[str, Any], memberships: Sequence[Mapping[str, Any]]) -> bool:
+    if bool(user.get("is_super_admin")):
+        return True
+    source_type = str(candidate.get("source_type") or "")
+    company_id = candidate.get("company_id")
+    company_ids = _company_ids(memberships)
+    if company_id is not None:
+        try:
+            if int(company_id) not in company_ids:
+                return False
+        except (TypeError, ValueError):
+            return False
+    if source_type in {"products", "packages"}:
+        return any(bool(m.get(flag)) for m in memberships for flag in ("can_access_shop", "can_access_orders", "can_access_cart"))
+    if source_type == "chats":
+        return _has_flag(memberships, "can_access_chat")
+    if source_type == "orders":
+        return _has_flag(memberships, "can_access_orders")
+    if source_type == "assets":
+        return _has_flag(memberships, "can_manage_assets")
+    if source_type == "staff":
+        return any(bool(m.get("can_manage_staff")) or int(m.get("staff_permission") or 0) > 0 for m in memberships)
+    if source_type == "issues":
+        return _has_flag(memberships, "can_manage_issues")
+    if source_type == "mailboxes":
+        return _has_flag(memberships, "can_view_m365_user_mailboxes") or _has_flag(memberships, "can_view_m365_shared_mailboxes")
+    if source_type == "best_practices":
+        return _has_flag(memberships, "can_view_m365_best_practices")
+    return True

--- a/app/services/rag_retrieval.py
+++ b/app/services/rag_retrieval.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Mapping, Sequence
+
+from app.core.config import get_settings
+from app.repositories import rag_index as rag_repo
+from app.services import company_access
+from app.services.rag_index import cosine_similarity, embed_text, embedding_model
+from app.services.rag_permissions import can_access_candidate
+
+def _loads(value: Any, fallback: Any) -> Any:
+    if not value:
+        return fallback
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(str(value))
+    except json.JSONDecodeError:
+        return fallback
+
+
+def _lexical_bonus(query: str, row: Mapping[str, Any]) -> float:
+    tokens = {token for token in re.findall(r"[a-z0-9][a-z0-9_.:-]{2,}", query.casefold()) if len(token) >= 3}
+    if not tokens:
+        return 0.0
+    haystack = " ".join(str(row.get(key) or "") for key in ("title", "source_id", "chunk_text")).casefold()
+    hits = sum(1 for token in tokens if token in haystack)
+    return min(0.25, hits * 0.04)
+
+
+async def retrieve_candidates(
+    query: str,
+    user: Mapping[str, Any],
+    *,
+    active_company_id: int | None = None,
+    memberships: Sequence[Mapping[str, Any]] | None = None,
+    source_filters: Sequence[str] | None = None,
+    limit: int | None = None,
+    min_score: float | None = None,
+) -> list[dict[str, Any]]:
+    query_text = (query or "").strip()
+    if not query_text:
+        return []
+    resolved_memberships = list(memberships or [])
+    if not resolved_memberships:
+        resolved_memberships = await company_access.list_accessible_companies(user)
+    settings = get_settings()
+    resolved_limit = int(limit if limit is not None else settings.rag_candidate_limit)
+    resolved_min_score = float(min_score if min_score is not None else settings.rag_min_score)
+    query_embedding = embed_text(query_text)
+    rows = await rag_repo.list_active_chunks(embedding_model=embedding_model(), source_types=source_filters)
+    candidates_by_doc: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        embedding = _loads(row.get("embedding_json"), [])
+        if not isinstance(embedding, list):
+            continue
+        score = cosine_similarity(query_embedding, [float(value) for value in embedding]) + _lexical_bonus(query_text, row)
+        if score < resolved_min_score:
+            continue
+        metadata = _loads(row.get("metadata_json"), {})
+        candidate = {
+            "document_id": row.get("document_id"),
+            "chunk_id": row.get("chunk_id"),
+            "source_type": row.get("source_type"),
+            "source_id": row.get("source_id"),
+            "company_id": row.get("company_id"),
+            "title": row.get("title"),
+            "url": row.get("url"),
+            "excerpt": row.get("chunk_text"),
+            "score": round(score, 4),
+            "permission_scope": _loads(row.get("permission_scope_json"), {}),
+            "metadata": metadata if isinstance(metadata, dict) else {},
+        }
+        if not can_access_candidate(candidate, user=user, memberships=resolved_memberships):
+            continue
+        doc_id = int(row.get("document_id") or 0)
+        if doc_id not in candidates_by_doc or score > candidates_by_doc[doc_id]["score"]:
+            candidates_by_doc[doc_id] = candidate
+    candidates = sorted(candidates_by_doc.values(), key=lambda item: item["score"], reverse=True)
+    if active_company_id:
+        try:
+            active_id = int(active_company_id)
+        except (TypeError, ValueError):
+            active_id = None
+        if active_id is not None:
+            candidates.sort(key=lambda item: (item.get("company_id") != active_id, -float(item.get("score") or 0)))
+    return candidates[: max(1, resolved_limit)]

--- a/changes/485fad32-55bd-46f7-b9c8-bc7a8643bf95.json
+++ b/changes/485fad32-55bd-46f7-b9c8-bc7a8643bf95.json
@@ -1,0 +1,7 @@
+{
+  "guid": "485fad32-55bd-46f7-b9c8-bc7a8643bf95",
+  "occurred_at": "2026-06-25T00:44:13.773087+00:00",
+  "change_type": "feature",
+  "summary": "Added permission-scoped RAG indexing and retrieval for MyPortal agent, search, and related content.",
+  "content_hash": "4a84c73c6a1e6d18bd5c124cef83c2bfbd8953ce1b17f598b3ec4dcd72e724da"
+}

--- a/migrations/278_rag_index.sql
+++ b/migrations/278_rag_index.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS rag_documents (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    source_type VARCHAR(64) NOT NULL,
+    source_id VARCHAR(191) NOT NULL,
+    company_id INT NULL,
+    title VARCHAR(500) NOT NULL,
+    url VARCHAR(1000) NULL,
+    permission_scope_json LONGTEXT NULL,
+    metadata_json LONGTEXT NULL,
+    content_hash VARCHAR(64) NOT NULL,
+    embedding_model VARCHAR(128) NOT NULL,
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    indexed_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    CONSTRAINT uq_rag_document_source UNIQUE (source_type, source_id, embedding_model)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS rag_chunks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    document_id INT NOT NULL,
+    chunk_index INT NOT NULL,
+    chunk_text LONGTEXT NOT NULL,
+    chunk_hash VARCHAR(64) NOT NULL,
+    embedding_json LONGTEXT NOT NULL,
+    embedding_model VARCHAR(128) NOT NULL,
+    token_count INT NOT NULL DEFAULT 0,
+    is_active TINYINT(1) NOT NULL DEFAULT 1,
+    indexed_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    CONSTRAINT fk_rag_chunks_document FOREIGN KEY (document_id) REFERENCES rag_documents(id) ON DELETE CASCADE,
+    CONSTRAINT uq_rag_chunk_document_index UNIQUE (document_id, chunk_index, embedding_model)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS rag_index_jobs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    source_type VARCHAR(64) NULL,
+    source_id VARCHAR(191) NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'queued',
+    message TEXT NULL,
+    started_at DATETIME(6) NULL,
+    finished_at DATETIME(6) NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX IF NOT EXISTS idx_rag_documents_source ON rag_documents (source_type, source_id);
+CREATE INDEX IF NOT EXISTS idx_rag_documents_company_active ON rag_documents (company_id, is_active);
+CREATE INDEX IF NOT EXISTS idx_rag_documents_indexed_at ON rag_documents (indexed_at);
+CREATE INDEX IF NOT EXISTS idx_rag_chunks_active_model ON rag_chunks (is_active, embedding_model);
+CREATE INDEX IF NOT EXISTS idx_rag_chunks_hash ON rag_chunks (chunk_hash);
+CREATE INDEX IF NOT EXISTS idx_rag_jobs_status_created ON rag_index_jobs (status, created_at);
+CREATE INDEX IF NOT EXISTS idx_rag_jobs_source ON rag_index_jobs (source_type, source_id);


### PR DESCRIPTION
### Motivation
- Provide retrieval-augmented generation (RAG) support so the Agent and ticket-related features can surface high-confidence, permission-scoped candidate sources. 
- Store and manage embedding vectors and chunks locally with a deterministic hash-based embedding to avoid external API dependency by default. 
- Expose a lightweight health endpoint and configuration knobs for tuning indexing and retrieval behavior.

### Description
- Introduces database schema and migration `migrations/278_rag_index.sql` to create `rag_documents`, `rag_chunks`, and `rag_index_jobs` tables and indexes. 
- Adds repository `app/repositories/rag_index.py` for upsert/list/health operations and service `app/services/rag_index.py` to normalize, chunk, hash, embed (local hash embedding), and index documents. 
- Adds retrieval service `app/services/rag_retrieval.py` that loads active chunks, scores candidates using cosine similarity + lexical bonus, enforces permission checks via `app/services/rag_permissions.py`, and returns ranked candidates. 
- Integrates indexing and retrieval into the agent flow (`app/services/agent.py`) to index assembled sources and include `rag_candidates` in the agent context; also uses RAG retrieval in ticket related rescans (`app/features/tickets/admin_routes.py`) as a first-pass candidate source with a fallback to the original agent sources. 
- Adds API endpoint `/api/agent/rag/health` in `app/api/routes/agent.py` to expose index health to super-admins. 
- Extends configuration (`app/core/config.py`) and environment example (`.env.example`) with RAG tuning settings such as `RAG_EMBEDDING_MODEL`, `RAG_EMBEDDING_DIMENSIONS`, `RAG_CHUNK_WORDS`, `RAG_CHUNK_OVERLAP_WORDS`, `RAG_CANDIDATE_LIMIT`, and `RAG_MIN_SCORE`. 
- Extends agent schema (`app/schemas/agent.py`) to include `rag_candidates` in the `AgentContext` and includes defensive error handling and permission-aware filtering in retrieval and indexing paths.

### Testing
- Ran the existing test suite with `pytest` against the modified codebase and the suite passed (no failures observed). 
- Verified migration SQL applies to a test database and the new tables and indexes are created successfully. 
- Exercised the agent query and ticket rescan paths in a local dev instance to confirm indexing and retrieval code paths execute and fall back gracefully on errors. 
- Exercised the new `/api/agent/rag/health` endpoint as a super-admin to confirm it returns document/chunk counts and source summaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c784e24548332a90fc69dbe0ce1aa)