### PR TITLE
Add super-admin RAG Index dashboard and indexing trigger

### DIFF
--- a/app/api/routes/agent.py
+++ b/app/api/routes/agent.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, status
 
-from app.api.dependencies.auth import get_current_user
+from app.api.dependencies.auth import get_current_user, require_super_admin
 from app.schemas.agent import AgentQueryRequest, AgentQueryResponse
 from app.services import agent as agent_service
 from app.repositories import rag_index as rag_index_repo
@@ -30,5 +30,63 @@ async def query_agent(
 @router.get("/rag/health")
 async def rag_health(current_user: dict = Depends(get_current_user)) -> dict:
     if not bool(current_user.get("is_super_admin")):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not permitted")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not permitted"
+        )
     return await rag_index_repo.health()
+
+
+async def _run_rag_index_job(
+    job_id: int,
+    current_user: dict,
+    *,
+    active_company_id: int | None = None,
+    memberships: list[dict] | None = None,
+) -> None:
+    await rag_index_repo.update_job(
+        job_id, status="running", message="Indexing started.", started=True
+    )
+    try:
+        result = await agent_service.execute_agent_query(
+            "",
+            current_user,
+            active_company_id=active_company_id,
+            memberships=memberships,
+        )
+        indexed = 0
+        for value in result.get("sources", {}).values():
+            if isinstance(value, list):
+                indexed += len(value)
+            elif isinstance(value, dict):
+                indexed += sum(
+                    len(rows or []) for rows in value.values() if isinstance(rows, list)
+                )
+        await rag_index_repo.update_job(
+            job_id,
+            status="completed",
+            message=f"Indexing completed. Refreshed up to {indexed} source records.",
+            finished=True,
+        )
+    except Exception as exc:  # pragma: no cover - defensive background job guard
+        await rag_index_repo.update_job(
+            job_id, status="failed", message=str(exc), finished=True
+        )
+
+
+@router.post("/rag/index")
+async def trigger_rag_index(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    current_user: dict = Depends(require_super_admin),
+) -> dict:
+    job_id = await rag_index_repo.create_job(source_type="all")
+    active_company_id = getattr(request.state, "active_company_id", None)
+    memberships = getattr(request.state, "available_companies", None)
+    background_tasks.add_task(
+        _run_rag_index_job,
+        job_id,
+        dict(current_user),
+        active_company_id=active_company_id,
+        memberships=[dict(item) for item in memberships or []],
+    )
+    return {"job_id": job_id, "status": "queued"}

--- a/app/main.py
+++ b/app/main.py
@@ -5445,6 +5445,19 @@ async def admin_profile_page(request: Request):
     return templates.TemplateResponse(context["request"], "admin/profile.html", context)
 
 
+@app.get("/admin/rag", response_class=HTMLResponse)
+async def admin_rag_page(request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+    return await _render_template(
+        "admin/rag.html",
+        request,
+        current_user,
+        extra={"title": "RAG Index"},
+    )
+
+
 @app.get("/admin/impersonation", response_class=HTMLResponse)
 async def admin_impersonation_page(
     request: Request,

--- a/app/repositories/rag_index.py
+++ b/app/repositories/rag_index.py
@@ -41,15 +41,23 @@ async def upsert_document(record: dict[str, Any]) -> int:
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
         """,
         (
-            record["source_type"], record["source_id"], record.get("company_id"),
-            record["title"], record.get("url"), record.get("permission_scope_json"),
-            record.get("metadata_json"), record["content_hash"], record["embedding_model"],
+            record["source_type"],
+            record["source_id"],
+            record.get("company_id"),
+            record["title"],
+            record.get("url"),
+            record.get("permission_scope_json"),
+            record.get("metadata_json"),
+            record["content_hash"],
+            record["embedding_model"],
         ),
     )
 
 
 async def replace_chunks(document_id: int, chunks: Sequence[dict[str, Any]]) -> None:
-    await db.execute("UPDATE rag_chunks SET is_active = 0 WHERE document_id = ?", (document_id,))
+    await db.execute(
+        "UPDATE rag_chunks SET is_active = 0 WHERE document_id = ?", (document_id,)
+    )
     for chunk in chunks:
         existing = await db.fetch_one(
             """
@@ -59,8 +67,11 @@ async def replace_chunks(document_id: int, chunks: Sequence[dict[str, Any]]) -> 
             (document_id, chunk["chunk_index"], chunk["embedding_model"]),
         )
         params = (
-            chunk["chunk_text"], chunk["chunk_hash"], chunk["embedding_json"],
-            int(chunk.get("token_count") or 0), 1,
+            chunk["chunk_text"],
+            chunk["chunk_hash"],
+            chunk["embedding_json"],
+            int(chunk.get("token_count") or 0),
+            1,
         )
         if existing:
             await db.execute(
@@ -81,13 +92,20 @@ async def replace_chunks(document_id: int, chunks: Sequence[dict[str, Any]]) -> 
                 VALUES (?, ?, ?, ?, ?, ?, ?, 1)
                 """,
                 (
-                    document_id, chunk["chunk_index"], chunk["chunk_text"], chunk["chunk_hash"],
-                    chunk["embedding_json"], chunk["embedding_model"], int(chunk.get("token_count") or 0),
+                    document_id,
+                    chunk["chunk_index"],
+                    chunk["chunk_text"],
+                    chunk["chunk_hash"],
+                    chunk["embedding_json"],
+                    chunk["embedding_model"],
+                    int(chunk.get("token_count") or 0),
                 ),
             )
 
 
-async def list_active_chunks(*, embedding_model: str, source_types: Sequence[str] | None = None) -> list[dict[str, Any]]:
+async def list_active_chunks(
+    *, embedding_model: str, source_types: Sequence[str] | None = None
+) -> list[dict[str, Any]]:
     params: list[Any] = [embedding_model]
     where = ["d.is_active = 1", "c.is_active = 1", "c.embedding_model = ?"]
     if source_types:
@@ -100,7 +118,7 @@ async def list_active_chunks(*, embedding_model: str, source_types: Sequence[str
                d.title, d.url, d.permission_scope_json, d.metadata_json, d.indexed_at
         FROM rag_chunks c
         JOIN rag_documents d ON d.id = c.document_id
-        WHERE {' AND '.join(where)}
+        WHERE {" AND ".join(where)}
         ORDER BY d.indexed_at DESC, c.id DESC
         LIMIT 2000
         """,
@@ -109,15 +127,98 @@ async def list_active_chunks(*, embedding_model: str, source_types: Sequence[str
 
 
 async def health() -> dict[str, Any]:
-    docs = await db.fetch_one("SELECT COUNT(*) AS count FROM rag_documents WHERE is_active = 1")
-    chunks = await db.fetch_one("SELECT COUNT(*) AS count FROM rag_chunks WHERE is_active = 1")
-    stale = await db.fetch_one("SELECT COUNT(*) AS count FROM rag_chunks WHERE is_active = 0")
+    docs = await db.fetch_one(
+        "SELECT COUNT(*) AS count FROM rag_documents WHERE is_active = 1"
+    )
+    inactive_docs = await db.fetch_one(
+        "SELECT COUNT(*) AS count FROM rag_documents WHERE is_active = 0"
+    )
+    chunks = await db.fetch_one(
+        "SELECT COUNT(*) AS count FROM rag_chunks WHERE is_active = 1"
+    )
+    stale = await db.fetch_one(
+        "SELECT COUNT(*) AS count FROM rag_chunks WHERE is_active = 0"
+    )
+    token_stats = await db.fetch_one(
+        """
+        SELECT COALESCE(SUM(token_count), 0) AS token_count,
+               COALESCE(AVG(token_count), 0) AS avg_tokens,
+               COALESCE(MAX(token_count), 0) AS max_tokens
+        FROM rag_chunks WHERE is_active = 1
+        """
+    )
+    doc_stats = await db.fetch_one(
+        """
+        SELECT MIN(indexed_at) AS first_indexed_at, MAX(indexed_at) AS last_indexed_at,
+               COUNT(DISTINCT company_id) AS company_count, COUNT(DISTINCT embedding_model) AS model_count
+        FROM rag_documents WHERE is_active = 1
+        """
+    )
     by_source = await db.fetch_all(
-        "SELECT source_type, COUNT(*) AS count, MAX(indexed_at) AS last_indexed_at FROM rag_documents WHERE is_active = 1 GROUP BY source_type ORDER BY source_type"
+        """
+        SELECT d.source_type, COUNT(DISTINCT d.id) AS count, COUNT(c.id) AS chunk_count,
+               COALESCE(SUM(c.token_count), 0) AS token_count, MAX(d.indexed_at) AS last_indexed_at
+        FROM rag_documents d
+        LEFT JOIN rag_chunks c ON c.document_id = d.id AND c.is_active = 1
+        WHERE d.is_active = 1
+        GROUP BY d.source_type ORDER BY d.source_type
+        """
+    )
+    recent_documents = await db.fetch_all(
+        """
+        SELECT id, source_type, source_id, company_id, title, embedding_model, indexed_at
+        FROM rag_documents WHERE is_active = 1 ORDER BY indexed_at DESC, id DESC LIMIT 10
+        """
+    )
+    recent_jobs = await db.fetch_all(
+        """
+        SELECT id, source_type, source_id, status, message, started_at, finished_at, created_at
+        FROM rag_index_jobs ORDER BY created_at DESC, id DESC LIMIT 10
+        """
     )
     return {
         "documents": int((docs or {}).get("count") or 0),
+        "inactive_documents": int((inactive_docs or {}).get("count") or 0),
         "chunks": int((chunks or {}).get("count") or 0),
         "stale_chunks": int((stale or {}).get("count") or 0),
+        "token_count": int((token_stats or {}).get("token_count") or 0),
+        "avg_tokens_per_chunk": float((token_stats or {}).get("avg_tokens") or 0),
+        "max_tokens_per_chunk": int((token_stats or {}).get("max_tokens") or 0),
+        "first_indexed_at": (doc_stats or {}).get("first_indexed_at"),
+        "last_indexed_at": (doc_stats or {}).get("last_indexed_at"),
+        "company_count": int((doc_stats or {}).get("company_count") or 0),
+        "model_count": int((doc_stats or {}).get("model_count") or 0),
         "sources": by_source or [],
+        "recent_documents": recent_documents or [],
+        "recent_jobs": recent_jobs or [],
     }
+
+
+async def create_job(
+    source_type: str | None = None, source_id: str | None = None
+) -> int:
+    return await db.execute_returning_lastrowid(
+        "INSERT INTO rag_index_jobs (source_type, source_id, status) VALUES (?, ?, 'queued')",
+        (source_type, source_id),
+    )
+
+
+async def update_job(
+    job_id: int,
+    *,
+    status: str,
+    message: str | None = None,
+    started: bool = False,
+    finished: bool = False,
+) -> None:
+    assignments = ["status = ?", "message = ?"]
+    params: list[Any] = [status, message]
+    if started:
+        assignments.append("started_at = CURRENT_TIMESTAMP")
+    if finished:
+        assignments.append("finished_at = CURRENT_TIMESTAMP")
+    params.append(job_id)
+    await db.execute(
+        f"UPDATE rag_index_jobs SET {', '.join(assignments)} WHERE id = ?",
+        tuple(params),
+    )

--- a/app/templates/admin/rag.html
+++ b/app/templates/admin/rag.html
@@ -1,0 +1,106 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="page-header">
+  <div>
+    <p class="eyebrow">Administration</p>
+    <h1>RAG Index</h1>
+    <p class="page-description">Monitor retrieval-augmented generation coverage and refresh the searchable index.</p>
+  </div>
+  <button type="button" class="button" data-rag-index-trigger>Trigger indexing</button>
+</section>
+
+<div class="card card--panel" data-rag-dashboard>
+  <div class="card__header">
+    <div>
+      <h2 class="card__title">Index health</h2>
+      <p class="card__description" data-rag-status>Loading RAG statistics…</p>
+    </div>
+    <button type="button" class="button button--ghost" data-rag-refresh>Refresh</button>
+  </div>
+  <div class="card__body">
+    <div class="stats-grid" data-rag-summary></div>
+
+    <div class="grid grid--2" style="margin-top: 1.5rem; gap: 1rem;">
+      <section>
+        <h3>Sources</h3>
+        <div class="table-responsive">
+          <table class="table">
+            <thead><tr><th>Source</th><th>Documents</th><th>Chunks</th><th>Tokens</th><th>Last indexed</th></tr></thead>
+            <tbody data-rag-sources></tbody>
+          </table>
+        </div>
+      </section>
+      <section>
+        <h3>Recent indexing jobs</h3>
+        <div class="table-responsive">
+          <table class="table">
+            <thead><tr><th>ID</th><th>Status</th><th>Message</th><th>Finished</th></tr></thead>
+            <tbody data-rag-jobs></tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+
+    <section style="margin-top: 1.5rem;">
+      <h3>Recently indexed documents</h3>
+      <div class="table-responsive">
+        <table class="table">
+          <thead><tr><th>Title</th><th>Source</th><th>Company</th><th>Model</th><th>Indexed</th></tr></thead>
+          <tbody data-rag-documents></tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+(() => {
+  const root = document.querySelector('[data-rag-dashboard]');
+  if (!root) return;
+  const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
+  const summary = root.querySelector('[data-rag-summary]');
+  const sourcesBody = root.querySelector('[data-rag-sources]');
+  const docsBody = root.querySelector('[data-rag-documents]');
+  const jobsBody = root.querySelector('[data-rag-jobs]');
+  const status = root.querySelector('[data-rag-status]');
+  const fmt = (value) => value === null || value === undefined || value === '' ? '—' : value;
+  const number = (value) => Number(value || 0).toLocaleString();
+  const date = (value) => value ? new Date(value).toLocaleString() : '—';
+  const esc = (value) => String(fmt(value)).replace(/[&<>"]/g, (c) => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+  function metric(label, value, hint) {
+    return `<article class="stat-card"><span class="stat-card__label">${esc(label)}</span><strong class="stat-card__value">${esc(value)}</strong><span class="stat-card__hint">${esc(hint)}</span></article>`;
+  }
+  function emptyRow(cols, text) { return `<tr><td colspan="${cols}" class="table__empty">${esc(text)}</td></tr>`; }
+  async function loadHealth() {
+    status.textContent = 'Loading RAG statistics…';
+    const res = await fetch('/api/agent/rag/health', {headers: {'Accept': 'application/json'}});
+    if (!res.ok) throw new Error('Unable to load RAG health');
+    const data = await res.json();
+    summary.innerHTML = [
+      metric('Active documents', number(data.documents), `${number(data.inactive_documents)} inactive`),
+      metric('Active chunks', number(data.chunks), `${number(data.stale_chunks)} stale chunks`),
+      metric('Indexed tokens', number(data.token_count), `${Number(data.avg_tokens_per_chunk || 0).toFixed(1)} avg/chunk`),
+      metric('Companies covered', number(data.company_count), `${number(data.model_count)} embedding model(s)`),
+      metric('First indexed', date(data.first_indexed_at), 'Oldest active document'),
+      metric('Last indexed', date(data.last_indexed_at), 'Newest active document'),
+    ].join('');
+    sourcesBody.innerHTML = (data.sources || []).map((row) => `<tr><td>${esc(row.source_type)}</td><td>${number(row.count)}</td><td>${number(row.chunk_count)}</td><td>${number(row.token_count)}</td><td>${date(row.last_indexed_at)}</td></tr>`).join('') || emptyRow(5, 'No indexed sources yet.');
+    docsBody.innerHTML = (data.recent_documents || []).map((row) => `<tr><td>${esc(row.title)}</td><td>${esc(row.source_type)}:${esc(row.source_id)}</td><td>${esc(row.company_id)}</td><td>${esc(row.embedding_model)}</td><td>${date(row.indexed_at)}</td></tr>`).join('') || emptyRow(5, 'No recent documents.');
+    jobsBody.innerHTML = (data.recent_jobs || []).map((row) => `<tr><td>#${esc(row.id)}</td><td><span class="badge">${esc(row.status)}</span></td><td>${esc(row.message)}</td><td>${date(row.finished_at || row.created_at)}</td></tr>`).join('') || emptyRow(4, 'No indexing jobs yet.');
+    status.textContent = `Last refreshed ${new Date().toLocaleTimeString()}`;
+  }
+  async function triggerIndex() {
+    status.textContent = 'Queueing indexing job…';
+    const res = await fetch('/api/agent/rag/index', {method: 'POST', headers: {'Accept': 'application/json', 'X-CSRF-Token': csrf}});
+    if (!res.ok) throw new Error('Unable to trigger indexing');
+    const data = await res.json();
+    status.textContent = `Indexing job #${data.job_id} queued.`;
+    setTimeout(loadHealth, 1500);
+  }
+  root.querySelector('[data-rag-refresh]')?.addEventListener('click', () => loadHealth().catch(err => status.textContent = err.message));
+  document.querySelector('[data-rag-index-trigger]')?.addEventListener('click', () => triggerIndex().catch(err => status.textContent = err.message));
+  loadHealth().catch(err => status.textContent = err.message);
+})();
+</script>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -512,6 +512,14 @@
                 </a>
               </li>
               <li class="menu__item">
+                <a href="/admin/rag" {% if current_path.startswith('/admin/rag') %}aria-current="page"{% endif %}>
+                  <span class="menu__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false"><path d="M12 2a8 8 0 0 1 8 8c0 5.25-8 12-8 12S4 15.25 4 10a8 8 0 0 1 8-8zm0 2a6 6 0 0 0-6 6c0 2.94 3.68 7.1 6 9.36 2.32-2.26 6-6.42 6-9.36a6 6 0 0 0-6-6zm-2 5h4v2h-4zm0 3h4v2h-4z"/></svg>
+                  </span>
+                  <span class="menu__label">RAG Index</span>
+                </a>
+              </li>
+              <li class="menu__item">
                 <a href="/admin/chat/ai-tag-synonyms" {% if current_path.startswith('/admin/chat/ai-tag-synonyms') or current_path.startswith('/chat/configuration') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" focusable="false"><path d="M4 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-5l-5 5v-5H6a2 2 0 0 1-2-2V4zm4 4v2h8V8H8zm0 4v2h5v-2H8z"/></svg>


### PR DESCRIPTION
### Motivation

- Provide super administrators with an operational view of the RAG (retrieval-augmented generation) index and a safe way to trigger re-indexing from the UI.  

### Description

- Added a new admin page template `app/templates/admin/rag.html` and a route `GET /admin/rag` (rendered via `_render_template`) to surface RAG metrics and controls.  
- Exposed a left-sidebar admin menu link for super admins in `app/templates/base.html` that navigates to the new RAG Index page.  
- Extended repository health reporting in `app/repositories/rag_index.py::health()` to return expanded statistics including active/inactive documents, chunk counts, token aggregates (`token_count`, `avg_tokens_per_chunk`, `max_tokens_per_chunk`), per-source counts (documents/chunks/tokens), recent documents, and recent indexing jobs.  
- Added job helpers `create_job()` and `update_job()` to `app/repositories/rag_index.py` and a background indexing trigger in `app/api/routes/agent.py` (`POST /api/agent/rag/index`) which queues a job and runs `_run_rag_index_job` to call the existing agent indexing flow and update job status.  
- Implemented client-side UI logic in the new template to fetch `/api/agent/rag/health`, render metrics, and call the new index trigger endpoint; the trigger is restricted to super admins via `require_super_admin`.  

### Testing

- Ran Python compilation checks: `python -m py_compile app/repositories/rag_index.py app/api/routes/agent.py app/main.py` and they passed.  
- Verified Jinja templates load with a lightweight `jinja2` template parse check (`Environment.get_template`) and it succeeded.  
- Formatted code with `ruff` and re-compiled to ensure syntax; `git diff --check` produced no issues.  
- Confirmed templates and endpoints are wired into the existing admin flow (`/admin/rag` route added and sidebar link shown only for super admins).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c7e66ed6c8332b4c5d264debfaac7)