### PR TITLE
Add saved column filters to admin Webhook Monitor

### DIFF
--- a/app/static/js/tables.js
+++ b/app/static/js/tables.js
@@ -81,8 +81,11 @@
       this.tbody = table.tBodies[0] || null;
       this.rows = this.tbody ? Array.from(this.tbody.querySelectorAll('tr')) : [];
       this.filterInputs = new Set();
+      this.columnFilterInputs = new Set();
       this.filterTerm = '';
       this.filterInputValue = '';
+      this.columnFilters = {};
+      this.persistedFilterState = this.loadPersistedFilterState();
       this.page = 0;
       this.pageSize = 0;
       const maxPageSizeAttr = table.getAttribute('data-page-size-max');
@@ -136,6 +139,7 @@
         }
       }
 
+      this.restorePersistedFilters();
       this.updateFilterState();
       if (this.paginationElement) {
         this.paginationElement.classList.add('table-pagination--active');
@@ -214,6 +218,87 @@
       });
     }
 
+    getStorageKey() {
+      const tableId = this.table ? (this.table.getAttribute('data-table-id') || this.table.id) : '';
+      return tableId ? `myportal.tableFilters.${tableId}` : '';
+    }
+
+    loadPersistedFilterState() {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        return {};
+      }
+      const key = this.getStorageKey();
+      if (!key) {
+        return {};
+      }
+      try {
+        const value = window.localStorage.getItem(key);
+        return value ? JSON.parse(value) : {};
+      } catch (error) {
+        return {};
+      }
+    }
+
+    persistFilterState() {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        return;
+      }
+      const key = this.getStorageKey();
+      if (!key) {
+        return;
+      }
+      const state = {
+        global: this.filterInputValue || '',
+        columns: this.columnFilters || {},
+      };
+      const hasColumns = Object.values(state.columns).some((value) => Boolean(value));
+      try {
+        if (state.global || hasColumns) {
+          window.localStorage.setItem(key, JSON.stringify(state));
+        } else {
+          window.localStorage.removeItem(key);
+        }
+      } catch (error) {
+        /* Ignore storage failures so table filtering remains usable. */
+      }
+    }
+
+    restorePersistedFilters() {
+      const state = this.persistedFilterState || {};
+      if (typeof state.global === 'string' && state.global) {
+        this.filterInputValue = state.global;
+        this.filterTerm = state.global.trim().toLowerCase();
+      }
+      if (state.columns && typeof state.columns === 'object') {
+        this.columnFilters = Object.entries(state.columns).reduce((filters, [key, value]) => {
+          if (typeof value === 'string' && value) {
+            filters[key] = value.trim().toLowerCase();
+          }
+          return filters;
+        }, {});
+      }
+    }
+
+    getColumnCellValue(row, columnKey) {
+      if (!row || !columnKey) {
+        return '';
+      }
+      const escapedKey = window.CSS && typeof window.CSS.escape === 'function'
+        ? window.CSS.escape(columnKey)
+        : columnKey.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      const cell = row.querySelector(`[data-column-key="${escapedKey}"]`);
+      return cell ? (cell.getAttribute('data-value') || cell.textContent || '').trim().toLowerCase() : '';
+    }
+
+    rowMatchesColumnFilters(row) {
+      return Object.entries(this.columnFilters).every(([columnKey, term]) => {
+        if (!term) {
+          return true;
+        }
+        return this.getColumnCellValue(row, columnKey).includes(term);
+      });
+    }
+
     updateFilterState() {
       if (!this.rows.length) {
         return;
@@ -223,12 +308,10 @@
         if (!row) {
           return;
         }
-        if (!term) {
-          delete row.dataset.filterHidden;
-          return;
-        }
         const text = (row.textContent || '').toLowerCase();
-        if (text.includes(term)) {
+        const matchesGlobal = !term || text.includes(term);
+        const matchesColumns = this.rowMatchesColumnFilters(row);
+        if (matchesGlobal && matchesColumns) {
           delete row.dataset.filterHidden;
         } else {
           row.dataset.filterHidden = 'true';
@@ -278,7 +361,41 @@
       this.syncFilterInputs(source);
       this.page = 0;
       this.updateFilterState();
+      this.persistFilterState();
       this.render();
+    }
+
+    bindColumnFilterInput(input) {
+      if (!input) {
+        return;
+      }
+      const columnKey = input.getAttribute('data-table-column-filter');
+      if (!columnKey) {
+        return;
+      }
+      this.columnFilterInputs.add(input);
+      const persistedValue = this.persistedFilterState?.columns?.[columnKey];
+      if (typeof persistedValue === 'string' && !input.value) {
+        input.value = persistedValue;
+      }
+      const applyValue = () => {
+        const rawValue = input.value || '';
+        const normalised = rawValue.trim().toLowerCase();
+        if (normalised) {
+          this.columnFilters[columnKey] = normalised;
+        } else {
+          delete this.columnFilters[columnKey];
+        }
+        this.page = 0;
+        this.updateFilterState();
+        this.persistFilterState();
+        this.render();
+      };
+      input.addEventListener('input', applyValue);
+      input.addEventListener('change', applyValue);
+      if (input.value) {
+        applyValue();
+      }
     }
 
     refreshRows() {
@@ -570,6 +687,16 @@
           }
         });
       });
+    });
+    document.querySelectorAll('[data-table-column-filter]').forEach((input) => {
+      const tableId = input.getAttribute('data-table-column-filter-table') || input.getAttribute('data-table-filter');
+      if (!tableId) {
+        return;
+      }
+      const controller = controllers.get(tableId);
+      if (controller) {
+        controller.bindColumnFilterInput(input);
+      }
     });
   }
 

--- a/app/templates/admin/webhooks.html
+++ b/app/templates/admin/webhooks.html
@@ -48,6 +48,60 @@
         aria-label="Filter webhook events"
         data-table-filter="webhooks-table"
       />
+      <select
+        class="form-input"
+        aria-label="Filter webhooks by direction"
+        data-table-column-filter="direction"
+        data-table-column-filter-table="webhooks-table"
+      >
+        <option value="">All directions</option>
+        <option value="incoming">Incoming</option>
+        <option value="outgoing">Outgoing</option>
+      </select>
+      <input
+        type="search"
+        class="form-input"
+        placeholder="Name"
+        aria-label="Filter webhooks by name"
+        data-table-column-filter="name"
+        data-table-column-filter-table="webhooks-table"
+      />
+      <input
+        type="search"
+        class="form-input"
+        placeholder="Target"
+        aria-label="Filter webhooks by target"
+        data-table-column-filter="target"
+        data-table-column-filter-table="webhooks-table"
+      />
+      <select
+        class="form-input"
+        aria-label="Filter webhooks by status"
+        data-table-column-filter="status"
+        data-table-column-filter-table="webhooks-table"
+      >
+        <option value="">All statuses</option>
+        <option value="pending">Pending</option>
+        <option value="in_progress">In progress</option>
+        <option value="succeeded">Succeeded</option>
+        <option value="failed">Failed</option>
+      </select>
+      <input
+        type="search"
+        class="form-input"
+        placeholder="Attempts"
+        aria-label="Filter webhooks by attempts"
+        data-table-column-filter="attempts"
+        data-table-column-filter-table="webhooks-table"
+      />
+      <input
+        type="search"
+        class="form-input"
+        placeholder="Last error"
+        aria-label="Filter webhooks by last error"
+        data-table-column-filter="last_error"
+        data-table-column-filter-table="webhooks-table"
+      />
     </div>
   </header>
   <div class="table-wrapper">
@@ -74,16 +128,16 @@
             data-event-status="{{ event.status }}"
             data-event-direction="{{ event.direction or 'outgoing' }}"
           >
-            <td data-label="Direction" data-column-key="direction">
+            <td data-label="Direction" data-value="{{ event.direction or 'outgoing' }}" data-column-key="direction">
               {% if event.direction == 'incoming' %}
                 <span class="badge badge--info">⬇ Incoming</span>
               {% else %}
                 <span class="badge badge--primary">⬆ Outgoing</span>
               {% endif %}
             </td>
-            <td data-label="Name" data-column-key="name">{{ event.name }}</td>
-            <td data-label="Target" class="table__col--truncate" title="{{ event.target_url or '' }}" data-column-key="target">{{ event.target_url }}</td>
-            <td data-label="Status" data-column-key="status">{{ event.status }}</td>
+            <td data-label="Name" data-value="{{ event.name }}" data-column-key="name">{{ event.name }}</td>
+            <td data-label="Target" class="table__col--truncate" title="{{ event.target_url or '' }}" data-value="{{ event.target_url or '' }}" data-column-key="target">{{ event.target_url }}</td>
+            <td data-label="Status" data-value="{{ event.status }}" data-column-key="status">{{ event.status }}</td>
             <td data-label="Attempts" data-value="{{ event.attempt_count }}" data-column-key="attempts">
               {{ event.attempt_count }}/{{ event.max_attempts }}
             </td>
@@ -94,7 +148,7 @@
                 <span class="text-muted">—</span>
               {% endif %}
             </td>
-            <td data-label="Last error" data-column-key="last_error">{{ event.last_error or '—' }}</td>
+            <td data-label="Last error" data-value="{{ event.last_error or '' }}" data-column-key="last_error">{{ event.last_error or '—' }}</td>
             <td data-label="Updated" data-value="{{ event.updated_iso or '' }}" data-column-key="updated">
               {% if event.updated_iso %}
                 <span data-utc="{{ event.updated_iso }}"></span>


### PR DESCRIPTION
### Motivation
- Improve the webhook monitor's usability by allowing column-specific filtering for common fields and persisting those filters across sessions.
- Ensure filters are applied reliably even when cell display content uses badges or formatted text by normalising column values.

### Description
- Added per-column filter controls (Direction, Name, Target, Status, Attempts, Last Error) to the Webhook Monitor header and wired them to the table controller. (files: `app/templates/admin/webhooks.html`)
- Extended the shared table controller to support column filters, combine global and per-column filtering, and persist/restore filter state in `localStorage` keyed per table. (file: `app/static/js/tables.js`)
- Added explicit `data-value` attributes to webhook table cells for Direction, Name, Target, Status, Attempts, and Last Error so filters match normalized values rather than rendered badge/text. (file: `app/templates/admin/webhooks.html`)
- Column filter inputs are bound to the controller and automatically persist state whenever a filter is applied or changed so users do not need to manually save filters.

### Testing
- Checked JavaScript syntax with `node --check app/static/js/tables.js` which succeeded. 
- Checked other JS with `node --check app/static/js/webhooks.js` which succeeded. 
- Ensured Python modules compile with `python3 -m compileall app/features/webhooks app/api/routes/scheduler.py` which succeeded. 
- Attempted to start the app in a development environment (`ENVIRONMENT=development SESSION_SECRET=dev-secret TOTP_ENCRYPTION_KEY=dev-totp python3 -m uvicorn app.main:app`) to capture a screenshot, and the server started but produced many SQLite migration warnings/errors in this sandboxed environment so a reliable authenticated screenshot was not captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c8e189f10832dbc5b2f9aaef6b04a)