### PR TITLE
Fix tray ticket form CSRF exemption

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -750,6 +750,7 @@ app.add_middleware(
         "/api/backup-status",
         "/api/tray/enrol",
         "/api/tray/popup-chat",
+        "/api/tray/ticket-form",
         # Public Wait For Webhook callbacks authenticate with an unguessable
         # webhook URL plus the per-step post key in the JSON payload, not a
         # browser session. Requiring CSRF here blocks legitimate automation.

--- a/tests/test_csrf_middleware.py
+++ b/tests/test_csrf_middleware.py
@@ -126,4 +126,5 @@ def test_main_app_exempts_public_callback_paths():
     assert csrf_middleware is not None
     exempt_paths = csrf_middleware.kwargs.get("exempt_paths", ())
     assert "/api/tray/popup-chat" in exempt_paths
+    assert "/api/tray/ticket-form" in exempt_paths
     assert "/api/staff/workflow-webhooks" in exempt_paths


### PR DESCRIPTION
### Motivation
- The tray-issued ticket form was being blocked by the global CSRF middleware because it relies on its own short-lived signed token and per-form validation rather than a browser session-based CSRF token.

### Description
- Add `/api/tray/ticket-form` to the `CSRFMiddleware` `exempt_paths` in `app/main.py` and add an assertion in `tests/test_csrf_middleware.py` to ensure the exemption is maintained.

### Testing
- Ran `pytest tests/test_csrf_middleware.py -q` which passed (6 tests passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3cb1c0f0808332a4bcf1eb69ebb10f)