### PR TITLE
Add super-admin bulk chat deletion (API + UI)

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -16,6 +16,7 @@ from app.repositories import matrix_ai_tag_synonyms as synonyms_repo
 from app.schemas.chat import (
     ChatMessageCreate,
     ChatRoomCreate,
+    ChatRoomBulkDelete,
     ChatRoomRename,
     ExternalInviteCreate,
     AiTagSynonymGroupCreate,
@@ -160,6 +161,43 @@ async def list_rooms(
         rooms = await chat_repo.list_rooms(user_id=user_id, company_id=company_id, status=status)
 
     return JSONResponse(_serialize([dict(r) for r in rooms]))
+
+
+@router.delete("/rooms", summary="Bulk delete chat rooms (super admin)")
+async def bulk_delete_rooms(
+    body: ChatRoomBulkDelete,
+    current_user: dict = Depends(require_super_admin),
+) -> JSONResponse:
+    _require_matrix_enabled()
+    room_ids = sorted({int(room_id) for room_id in body.room_ids if int(room_id) > 0})
+    if not room_ids:
+        raise HTTPException(status_code=422, detail="Select at least one chat to delete")
+
+    rooms = await chat_repo.list_rooms_by_ids(room_ids)
+    if not rooms:
+        raise HTTPException(status_code=404, detail="No matching chat rooms found")
+
+    found_ids = {int(room["id"]) for room in rooms}
+    missing_ids = [room_id for room_id in room_ids if room_id not in found_ids]
+    deleted_count = await chat_repo.delete_rooms(sorted(found_ids))
+
+    await audit_service.log_action(
+        action="bulk_delete",
+        entity_type="chat_room",
+        entity_id=None,
+        user_id=current_user["id"],
+        previous_value={
+            "room_ids": sorted(found_ids),
+            "missing_room_ids": missing_ids,
+            "subjects": {str(room["id"]): room.get("subject") for room in rooms},
+        },
+    )
+
+    await refresh_notifier.publish(
+        topics=["chat:rooms"],
+        payload={"type": "chat_rooms_deleted", "room_ids": sorted(found_ids)},
+    )
+    return JSONResponse({"deleted": deleted_count, "room_ids": sorted(found_ids), "missing_room_ids": missing_ids})
 
 
 @router.post("/rooms", summary="Create a chat room")
@@ -385,7 +423,7 @@ async def rename_room(
         entity_type="chat_room",
         entity_id=room_id,
         user_id=current_user["id"],
-        old_value={"subject": old_subject},
+        previous_value={"subject": old_subject},
         new_value={"subject": new_subject},
     )
 

--- a/app/repositories/chat.py
+++ b/app/repositories/chat.py
@@ -97,6 +97,33 @@ async def list_rooms(
     return [dict(r) for r in rows]
 
 
+def _placeholders(count: int) -> str:
+    return ", ".join(["%s"] * count)
+
+
+async def list_rooms_by_ids(room_ids: list[int]) -> list[dict[str, Any]]:
+    if not room_ids:
+        return []
+    rows = await db.fetch_all(
+        f"SELECT * FROM chat_rooms WHERE id IN ({_placeholders(len(room_ids))})",
+        tuple(room_ids),
+    )
+    return [dict(r) for r in rows]
+
+
+async def delete_rooms(room_ids: list[int]) -> int:
+    if not room_ids:
+        return 0
+    placeholders = _placeholders(len(room_ids))
+    params = tuple(room_ids)
+    await db.execute(f"DELETE FROM chat_ticket_reply_links WHERE room_id IN ({placeholders})", params)
+    await db.execute(f"DELETE FROM matrix_ai_analysis_queue WHERE chat_room_id IN ({placeholders})", params)
+    await db.execute(f"DELETE FROM chat_invites WHERE room_id IN ({placeholders})", params)
+    await db.execute(f"DELETE FROM chat_room_participants WHERE room_id IN ({placeholders})", params)
+    await db.execute(f"DELETE FROM chat_messages WHERE room_id IN ({placeholders})", params)
+    return await db.execute_rowcount(f"DELETE FROM chat_rooms WHERE id IN ({placeholders})", params)
+
+
 async def create_room(
     *,
     subject: str,

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -62,6 +62,10 @@ class ChatRoomRename(BaseModel):
     subject: str = Field(..., min_length=1, max_length=500)
 
 
+class ChatRoomBulkDelete(BaseModel):
+    room_ids: list[int] = Field(..., min_length=1, max_length=100)
+
+
 class ChatMessageResponse(BaseModel):
     id: int
     room_id: int

--- a/app/templates/chat/index.html
+++ b/app/templates/chat/index.html
@@ -11,11 +11,15 @@
   {% if is_super_admin | default(false) %}
     {% set chat_actions = chat_actions + [{"label": "AI tag synonyms", "type": "link", "href": "/admin/chat/ai-tag-synonyms"}, {"label": "Auto-assign rules", "type": "link", "href": "/chat/auto-assign"}] %}
   {% endif %}
+  {% if is_super_admin | default(false) %}
+    {% set chat_actions = chat_actions + [{"label": "Delete selected", "variant": "danger", "type": "button", "attrs": {"id": "bulk-delete-chats", "disabled": "disabled"}}] %}
+  {% endif %}
   {{ page_header_actions(chat_actions) }}
 {% endblock %}
 
 {% block content %}
 <section class="card card--panel">
+  {% if csrf_token %}<input type="hidden" id="chat-csrf-token" value="{{ csrf_token }}" />{% endif %}
   <header class="card__header">
     <div class="card__controls">
       <form method="get" autocomplete="off" class="tickets-toolbar__form" id="chat-filter-form">
@@ -114,6 +118,9 @@
     <table class="table" id="chat-rooms-table" data-table>
       <thead>
         <tr>
+          {% if is_super_admin | default(false) %}
+          <th scope="col" data-column="select"><span class="sr-only">Select</span><input type="checkbox" id="select-all-chats" aria-label="Select all chats" /></th>
+          {% endif %}
           <th scope="col" data-column="id" data-sort="int">ID</th>
           <th scope="col" data-column="subject" data-sort="string">Subject</th>
           <th scope="col" data-column="device" data-sort="string">Device</th>
@@ -131,6 +138,9 @@
       <tbody>
         {% for room in rooms %}
         <tr>
+          {% if is_super_admin | default(false) %}
+          <td data-column="select" data-label="Select"><input type="checkbox" class="chat-bulk-select" value="{{ room.id }}" aria-label="Select chat {{ room.id }}" /></td>
+          {% endif %}
           <td data-column="id" data-label="ID">{{ room.id }}</td>
           <td data-column="subject" data-label="Subject">
             <a href="/chat/{{ room.id }}">{{ room.subject | e }}</a>
@@ -248,8 +258,63 @@
     el.addEventListener('change', () => document.getElementById('chat-filter-form').submit());
   });
 
+  // Bulk delete controls for super admins
+  const csrf = document.getElementById('chat-csrf-token')?.value || document.querySelector('[name="_csrf"]')?.value || '';
+  const bulkDeleteButton = document.getElementById('bulk-delete-chats');
+  const selectAllChats = document.getElementById('select-all-chats');
+  const chatSelectBoxes = Array.from(document.querySelectorAll('.chat-bulk-select'));
+
+  function selectedChatIds() {
+    return chatSelectBoxes.filter(box => box.checked).map(box => Number(box.value));
+  }
+
+  function refreshBulkDeleteState() {
+    const selectedCount = selectedChatIds().length;
+    if (bulkDeleteButton) {
+      bulkDeleteButton.disabled = selectedCount === 0;
+      bulkDeleteButton.textContent = selectedCount ? `Delete selected (${selectedCount})` : 'Delete selected';
+    }
+    if (selectAllChats) {
+      selectAllChats.checked = selectedCount > 0 && selectedCount === chatSelectBoxes.length;
+      selectAllChats.indeterminate = selectedCount > 0 && selectedCount < chatSelectBoxes.length;
+    }
+  }
+
+  selectAllChats?.addEventListener('change', function() {
+    chatSelectBoxes.forEach(box => { box.checked = this.checked; });
+    refreshBulkDeleteState();
+  });
+
+  chatSelectBoxes.forEach(box => box.addEventListener('change', refreshBulkDeleteState));
+
+  bulkDeleteButton?.addEventListener('click', async function() {
+    const roomIds = selectedChatIds();
+    if (!roomIds.length) return;
+    const plural = roomIds.length === 1 ? 'chat' : 'chats';
+    if (!confirm(`Permanently delete ${roomIds.length} selected ${plural}? This removes messages, participants, invites, and sync links.`)) return;
+    this.disabled = true;
+    try {
+      const resp = await fetch('/api/chat/rooms', {
+        method: 'DELETE',
+        headers: {'Content-Type': 'application/json', 'X-CSRF-Token': csrf},
+        body: JSON.stringify({room_ids: roomIds}),
+      });
+      if (resp.ok) {
+        window.location.reload();
+      } else {
+        const err = await resp.json();
+        alert(err.detail || 'Failed to delete selected chats');
+        refreshBulkDeleteState();
+      }
+    } catch(err) {
+      alert('Network error: ' + err.message);
+      refreshBulkDeleteState();
+    }
+  });
+
+  refreshBulkDeleteState();
+
   // Assign & Join buttons
-  const csrf = document.querySelector('[name="_csrf"]')?.value || '';
   document.querySelectorAll('.btn-assign-join').forEach(btn => {
     btn.addEventListener('click', async function() {
       const roomId = this.dataset.roomId;


### PR DESCRIPTION
### Motivation
- Provide super admins a safe way to delete multiple chat rooms from the `/chat` UI and via the API, ensuring related data is removed and actions are auditable. 
- Ensure deletes remove dependent data (messages, participants, invites, ticket sync links, AI queue items) and notify clients to refresh chat lists.

### Description
- Added a bounded request schema `ChatRoomBulkDelete` to `app/schemas/chat.py` to accept up to 100 room IDs.
- Implemented repository helpers `list_rooms_by_ids` and `delete_rooms` in `app/repositories/chat.py` that remove dependent rows (ticket links, AI queue, invites, participants, messages) before deleting `chat_rooms`.
- Added a super-admin-only endpoint `DELETE /api/chat/rooms` in `app/api/routes/chat.py` that validates IDs, calls the repo helper, writes an audit entry, and publishes a `chat:rooms` refresh notification.
- Updated the `/chat` view (`app/templates/chat/index.html`) to show selection checkboxes for super admins, a disabled-by-default "Delete selected" header action, CSRF token handling, confirmation prompt, and client-side JavaScript to submit selected IDs to the new API.
- Small audit-field naming consistency fix to use `previous_value` when renaming a chat subject.

### Testing
- Run-time checks: `python -m py_compile app/api/routes/chat.py app/repositories/chat.py app/schemas/chat.py` succeeded.
- Unit tests: `python -m pytest tests/test_agent_service.py` passed (13 tests, all green).
- Integration tests: running `python -m pytest tests/test_tray_app.py tests/test_agent_service.py` in this environment showed failures in `tests/test_tray_app.py` due to the fixture SQLite test database missing pre-existing `site_settings` table (environment/test setup issue), while the agent service tests passed; this appears unrelated to the new chat changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3cb319d4808332ae6484b80da93020)