### PR TITLE
Show stored RAG-related items in ticket detail and disable auto-scan

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -134,6 +134,8 @@ from app.repositories import staff_onboarding_workflows as staff_workflow_repo
 from app.repositories import staff_requests as staff_requests_repo
 from app.repositories import pending_staff_access as pending_staff_access_repo
 from app.repositories import tickets as tickets_repo
+from app.repositories import rag_index as rag_index_repo
+from app.repositories import rag_relationships as rag_relationship_repo
 from app.repositories import ticket_attachments as attachments_repo
 from app.repositories import ticket_views as ticket_views_repo
 from app.repositories import ticket_statuses as ticket_status_repo
@@ -192,6 +194,7 @@ from app.services import staff_onboarding_workflows as staff_onboarding_workflow
 from app.services import labour_types as labour_types_service
 from app.services import subscription_shop_integration
 from app.services import tickets as tickets_service
+from app.services import rag_index as rag_index_service
 from app.services import ticket_attachments as attachments_service
 from app.services import template_variables
 from app.services import webhook_monitor
@@ -8212,6 +8215,74 @@ async def _render_tickets_dashboard(
     return response
 
 
+def _ticket_related_safe_url(url: Any) -> str | None:
+    candidate = str(url or "").strip()
+    if not candidate:
+        return None
+    parsed = urlsplit(candidate)
+    if parsed.scheme or parsed.netloc:
+        return None
+    if not candidate.startswith("/") or candidate.startswith("//"):
+        return None
+    return candidate
+
+
+def _ticket_related_fallback_url(source_type: str, source_id: Any) -> str | None:
+    identifier = str(source_id or "").strip()
+    if not identifier:
+        return None
+    if source_type == "tickets":
+        return f"/admin/tickets/{quote(identifier, safe='')}"
+    if source_type == "assets":
+        return f"/admin/assets/{quote(identifier, safe='')}"
+    if source_type == "companies":
+        return f"/admin/companies/{quote(identifier, safe='')}"
+    if source_type == "staff":
+        return f"/admin/staff/{quote(identifier, safe='')}"
+    if source_type == "chats":
+        return f"/chat/{quote(identifier, safe='')}"
+    if source_type == "issues":
+        return f"/admin/issues/{quote(identifier, safe='')}"
+    return None
+
+
+async def _load_ticket_stored_related_items(ticket_id: int, *, limit: int = 12) -> list[dict[str, str]]:
+    try:
+        document = await rag_index_repo.get_document_by_source(
+            "tickets",
+            str(ticket_id),
+            rag_index_service.embedding_model(),
+        )
+        if not document:
+            return []
+        evidence_rows = await rag_relationship_repo.list_relationship_evidence(
+            int(document["id"]),
+            limit=limit,
+        )
+    except Exception as exc:  # pragma: no cover - defensive UI fallback
+        log_error("Failed to load stored ticket related content", ticket_id=ticket_id, error=str(exc))
+        return []
+
+    items: list[dict[str, str]] = []
+    seen_urls: set[str] = set()
+    for row in evidence_rows:
+        source_type = str(row.get("source_type") or "").strip()
+        source_id = row.get("source_id")
+        if source_type == "tickets":
+            try:
+                if int(source_id) == ticket_id:
+                    continue
+            except (TypeError, ValueError):
+                pass
+        url = _ticket_related_safe_url(row.get("url")) or _ticket_related_fallback_url(source_type, source_id)
+        if not url or url in seen_urls:
+            continue
+        seen_urls.add(url)
+        label = str(row.get("title") or f"{source_type.title()} {source_id}").strip()[:180]
+        items.append({"type": source_type, "label": label, "url": url})
+    return items
+
+
 async def _render_ticket_detail(
     request: Request,
     user: dict[str, Any],
@@ -8625,6 +8696,8 @@ async def _render_ticket_detail(
 
     asset_options.sort(key=lambda option: option["label"].lower())
 
+    ticket_related_items = await _load_ticket_stored_related_items(ticket_id)
+
     # Find relevant knowledge base articles based on AI tag matching
     relevant_articles: list[dict[str, Any]] = []
     ticket_ai_tags = ticket.get("ai_tags") or []
@@ -8667,13 +8740,8 @@ async def _render_ticket_detail(
         "ticket_call_recordings": enriched_recordings,
         "ticket_watchers": enriched_watchers,
         "ticket_attachments": formatted_attachments,
-        "ticket_related_auto_scan": not (
-            str(ticket.get("module_slug") or "").lower() == "syncro"
-            or (
-                str(ticket.get("external_reference") or "").isdigit()
-                and bool(ticket.get("ticket_number"))
-            )
-        ),
+        "ticket_related_auto_scan": False,
+        "ticket_related_items": ticket_related_items,
         "ticket_labour_types": labour_types,
         "ticket_billable_minutes": total_billable_minutes,
         "ticket_non_billable_minutes": total_non_billable_minutes,

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -539,7 +539,7 @@
             class="card card--panel card-collapsible ticket-related"
             data-ticket-related
             data-ticket-id="{{ ticket.id }}"
-            data-auto-scan="{{ 'true' if ticket_related_auto_scan else 'false' }}"
+            data-auto-scan="false"
           >
             <summary class="card__header card__header--collapsible ticket-related__summary">
               <h2 class="card__title">Related</h2>
@@ -555,14 +555,30 @@
               </div>
             </summary>
             <div class="card-collapsible__content card__body">
-              <div class="ticket-related__status" data-ticket-related-status>
-                {% if ticket_related_auto_scan %}
-                  Open this section or use refresh to scan the ticket for related MyPortal content.
-                {% else %}
-                  Syncro-imported tickets are not scanned automatically. Use refresh to scan this ticket manually.
-                {% endif %}
+              <div
+                class="ticket-related__status"
+                data-ticket-related-status
+                {% if ticket_related_items %}hidden{% endif %}
+              >
+                No pre-discovered related MyPortal content is available yet. Use refresh to scan this ticket manually.
               </div>
-              <ul class="ticket-related__list" data-ticket-related-list hidden></ul>
+              <ul
+                class="ticket-related__list"
+                data-ticket-related-list
+                {% if not ticket_related_items %}hidden{% endif %}
+              >
+                {% for item in ticket_related_items %}
+                  <li class="ticket-related__item">
+                    <a
+                      class="ticket-related__link"
+                      href="{{ item.url }}"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title="{{ item.label }}"
+                    >{{ item.label }}</a>
+                  </li>
+                {% endfor %}
+              </ul>
             </div>
           </details>
 


### PR DESCRIPTION
### Motivation
- The Related panel on ticket detail currently triggers a live re-scan when expanded instead of showing already-discovered related content, causing unnecessary realtime queries and poor UX.

### Description
- Load precomputed RAG relationship evidence using `rag_index` and `rag_relationships` and expose the results via a new helper `async def _load_ticket_stored_related_items(ticket_id, *, limit=12)` in `app/main.py`.
- Add safe-local URL handling with `_ticket_related_safe_url` and fallback path generation with `_ticket_related_fallback_url` to avoid rendering external URLs in the Related list in `app/main.py`.
- Pass `ticket_related_items` into the ticket detail template and explicitly set `ticket_related_auto_scan` to `False` in `app/main.py` so the panel shows stored items by default and does not auto-trigger a scan.
- Update `app/templates/admin/ticket_detail.html` to render `ticket_related_items` when present, hide the scanning status when items exist, and keep the manual `Refresh` button available to perform an explicit re-scan.

### Testing
- `python -m py_compile app/main.py app/features/tickets/admin_routes.py` completed successfully.
- `git diff --check` returned clean results.
- `pytest tests/test_admin_ticket_detail.py` passed (tests covering admin ticket detail rendering).
- Running the combined `pytest tests/test_admin_ticket_detail.py tests/test_ticket_booking_link.py` initially produced 2 failures in `tests/test_ticket_booking_link.py` because the test helper expected `app.main.call_recordings_repo` to be exposed (an existing test fixture expectation), and the admin ticket detail tests passed when re-run individually.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3ce2fb2664832d91ae2c82073a2a8c)