### PR TITLE
Fix RAG relationship response parsing

### DIFF
--- a/app/services/rag_relationships.py
+++ b/app/services/rag_relationships.py
@@ -116,12 +116,48 @@ Return JSON only:
 {{"relationship":"DIRECT_MATCH","confidence":0.94,"score":0.93,"reason":"...","supporting_excerpt":"..."}}"""
 
 
+def _extract_json_object(text: str) -> str:
+    stripped = text.strip()
+    if not stripped:
+        raise ValueError("Relationship evaluator returned an empty response")
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].lstrip().startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]
+        stripped = "\n".join(lines).strip()
+    if stripped.startswith("{"):
+        return stripped
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start >= 0 and end > start:
+        return stripped[start : end + 1]
+    raise ValueError("Relationship evaluator did not return a JSON object")
+
+
+def _relationship_response_payload(response: Any) -> Any:
+    if not isinstance(response, Mapping):
+        return response
+    raw = response.get("payload")
+    if raw is None:
+        raw = response.get("response")
+    if raw is None:
+        raw = response.get("message")
+    if isinstance(raw, Mapping):
+        for key in ("response", "message", "text"):
+            nested = raw.get(key)
+            if nested is not None:
+                return nested
+    return raw
+
+
 def parse_relationship_response(value: Any, *, min_score: float) -> dict[str, Any]:
     if isinstance(value, Mapping):
         payload = value
     else:
         text = str(value or "").strip()
-        payload = json.loads(text)
+        payload = json.loads(_extract_json_object(text))
     relationship = str(payload.get("relationship") or payload.get("relationship_type") or "NOT_RELEVANT").strip().upper()
     try:
         relationship_type = RelationshipType(relationship)
@@ -166,9 +202,10 @@ async def evaluate_next_batch(*, limit: int | None = None) -> int:
                     {"prompt": _prompt(source, target), "format": "json", "model": settings.rag_relationship_model},
                     background=False,
                 )
-                raw = response.get("payload") if isinstance(response, Mapping) else response
-                if isinstance(raw, Mapping):
-                    raw = raw.get("response") or raw.get("message") or raw
+                if isinstance(response, Mapping) and str(response.get("status") or "").lower() in {"error", "failed", "skipped"}:
+                    reason = response.get("last_error") or response.get("error") or response.get("reason") or "module did not complete"
+                    raise RuntimeError(f"Relationship evaluator unavailable: {reason}")
+                raw = _relationship_response_payload(response)
                 parsed = parse_relationship_response(raw, min_score=settings.rag_relationship_min_score)
                 await rel_repo.store_relationship(
                     int(source["id"]), int(target["id"]), parsed,

--- a/tests/test_rag_relationships.py
+++ b/tests/test_rag_relationships.py
@@ -1,4 +1,4 @@
-from app.services.rag_relationships import parse_relationship_response
+from app.services.rag_relationships import _relationship_response_payload, parse_relationship_response
 
 
 def test_parse_relationship_response_stores_positive_match():
@@ -21,3 +21,38 @@ def test_parse_relationship_response_stores_negative_no_match():
 
     assert parsed["relationship_type"] == "NOT_RELEVANT"
     assert parsed["match_status"] == "NO_MATCH"
+
+
+def test_parse_relationship_response_accepts_fenced_json():
+    parsed = parse_relationship_response(
+        '```json\n{"relationship":"RELATED","confidence":0.8,"score":0.75}\n```',
+        min_score=0.55,
+    )
+
+    assert parsed["relationship_type"] == "RELATED"
+    assert parsed["match_status"] == "MATCH"
+
+
+def test_relationship_response_payload_reads_module_response_key():
+    raw = _relationship_response_payload(
+        {
+            "status": "succeeded",
+            "response": {
+                "response": '{"relationship":"DUPLICATE","confidence":0.9,"score":0.88}'
+            },
+        }
+    )
+
+    parsed = parse_relationship_response(raw, min_score=0.55)
+
+    assert parsed["relationship_type"] == "DUPLICATE"
+    assert parsed["match_status"] == "MATCH"
+
+
+def test_parse_relationship_response_empty_error_is_actionable():
+    try:
+        parse_relationship_response("", min_score=0.55)
+    except ValueError as exc:
+        assert "empty response" in str(exc)
+    else:  # pragma: no cover - assertion guard
+        raise AssertionError("Expected empty relationship responses to fail with a clear message")


### PR DESCRIPTION
### Motivation
- Background RAG relationship worker was encountering JSON parse errors (`Expecting value: line 1 column 1 (char 0)`) when LLM/module responses were empty, fenced, or wrapped in provider-specific fields, producing noisy/unclear queue failures.
- The intent is to make the relationship evaluator resilient to common LLM formatting and module response shapes and to produce actionable failure reasons when the evaluator did not complete.

### Description
- Added `_extract_json_object` to robustly unwrap fenced code blocks, surrounding text, or prefixed JSON and surface a JSON object string for parsing.
- Added `_relationship_response_payload` to extract nested payloads from module responses, reading `payload`, `response`, or `message` and handling nested `response`/`message`/`text` keys.
- Updated `parse_relationship_response` to use the JSON extractor so it tolerates fenced/prefixed JSON and returns a clear error for genuinely empty/non-JSON responses.
- Updated `evaluate_next_batch` to detect module results with status `error`/`failed`/`skipped` and raise a clear runtime error (so the queue records an actionable failure) before attempting JSON parsing.
- Added regression tests covering fenced JSON, nested module `response` extraction, and the empty-response error case in `tests/test_rag_relationships.py`.

### Testing
- Ran `pytest tests/test_rag_relationships.py -q` and the rag relationship tests all passed (5 passed).
- Ran `python -m compileall app/services/rag_relationships.py` to ensure the module compiles successfully and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3ce8f097f0832d8acb675a9243261c)