### PR TITLE
Prioritize ticket relationships, normalize evaluator ordering, expand matching metrics, and fix hash ordering

### DIFF
--- a/app/repositories/rag_relationships.py
+++ b/app/repositories/rag_relationships.py
@@ -10,7 +10,9 @@ def _pair(source_id: int, target_id: int) -> tuple[int, int]:
 
 
 async def get_document(document_id: int) -> dict[str, Any] | None:
-    return await db.fetch_one("SELECT * FROM rag_documents WHERE id = ? AND is_active = 1", (document_id,))
+    return await db.fetch_one(
+        "SELECT * FROM rag_documents WHERE id = ? AND is_active = 1", (document_id,)
+    )
 
 
 async def get_document_with_content(document_id: int) -> dict[str, Any] | None:
@@ -27,9 +29,14 @@ async def get_document_with_content(document_id: int) -> dict[str, Any] | None:
     return row
 
 
-async def list_compatible_targets(document_id: int, *, include_tickets: bool) -> list[dict[str, Any]]:
+async def list_compatible_targets(
+    document_id: int, *, include_tickets: bool
+) -> list[dict[str, Any]]:
     if include_tickets:
-        return await db.fetch_all("SELECT * FROM rag_documents WHERE id <> ? AND is_active = 1", (document_id,))
+        return await db.fetch_all(
+            "SELECT * FROM rag_documents WHERE id <> ? AND is_active = 1",
+            (document_id,),
+        )
     return await db.fetch_all(
         "SELECT * FROM rag_documents WHERE id <> ? AND is_active = 1 AND source_type <> 'tickets'",
         (document_id,),
@@ -100,9 +107,34 @@ async def claim_jobs(limit: int) -> list[dict[str, Any]]:
     return jobs
 
 
-async def store_relationship(source_id: int, target_id: int, parsed: Mapping[str, Any], *, evaluated_model: str, source_hash: str, target_hash: str, duration_ms: int) -> None:
+async def store_relationship(
+    source_id: int,
+    target_id: int,
+    parsed: Mapping[str, Any],
+    *,
+    evaluated_model: str,
+    source_hash: str,
+    target_hash: str,
+    duration_ms: int,
+) -> None:
     left, right = _pair(source_id, target_id)
-    params = (left, right, parsed["relationship_type"], parsed["match_status"], parsed["relevance_score"], parsed["confidence"], parsed.get("reason"), parsed.get("supporting_excerpt"), evaluated_model, source_hash, target_hash, duration_ms)
+    left_hash, right_hash = (
+        (source_hash, target_hash) if left == source_id else (target_hash, source_hash)
+    )
+    params = (
+        left,
+        right,
+        parsed["relationship_type"],
+        parsed["match_status"],
+        parsed["relevance_score"],
+        parsed["confidence"],
+        parsed.get("reason"),
+        parsed.get("supporting_excerpt"),
+        evaluated_model,
+        left_hash,
+        right_hash,
+        duration_ms,
+    )
     if db.is_sqlite():
         await db.execute(
             """
@@ -147,7 +179,12 @@ async def complete_queue_item(queue_id: int, status: str) -> None:
 
 
 async def fail_queue_item(queue_id: int, error: str, *, max_retries: int) -> None:
-    row = await db.fetch_one("SELECT retry_count FROM rag_relationship_queue WHERE id = ?", (queue_id,)) or {}
+    row = (
+        await db.fetch_one(
+            "SELECT retry_count FROM rag_relationship_queue WHERE id = ?", (queue_id,)
+        )
+        or {}
+    )
     retry_count = int(row.get("retry_count") or 0) + 1
     status = "FAILED" if retry_count >= max_retries else "PENDING"
     await db.execute(
@@ -156,7 +193,9 @@ async def fail_queue_item(queue_id: int, error: str, *, max_retries: int) -> Non
     )
 
 
-async def list_relationship_evidence(document_id: int, *, limit: int) -> list[dict[str, Any]]:
+async def list_relationship_evidence(
+    document_id: int, *, limit: int
+) -> list[dict[str, Any]]:
     return await db.fetch_all(
         """
         SELECT r.*, d.source_type, d.source_id, d.title, d.url, GROUP_CONCAT(c.chunk_text, '\n') AS content
@@ -175,8 +214,50 @@ async def list_relationship_evidence(document_id: int, *, limit: int) -> list[di
 
 
 async def metrics() -> dict[str, Any]:
-    queue = await db.fetch_all("SELECT status, COUNT(*) AS count FROM rag_relationship_queue GROUP BY status")
-    rels = await db.fetch_all("SELECT match_status, COUNT(*) AS count FROM rag_relationships GROUP BY match_status")
-    avg = await db.fetch_one("SELECT COALESCE(AVG(evaluation_duration_ms),0) AS avg_ms FROM rag_relationships")
+    queue = await db.fetch_all(
+        "SELECT status, COUNT(*) AS count FROM rag_relationship_queue GROUP BY status"
+    )
+    rels = await db.fetch_all(
+        "SELECT match_status, COUNT(*) AS count FROM rag_relationships GROUP BY match_status"
+    )
+    avg = await db.fetch_one(
+        "SELECT COALESCE(AVG(evaluation_duration_ms),0) AS avg_ms FROM rag_relationships"
+    )
     total = await db.fetch_one("SELECT COUNT(*) AS count FROM rag_relationships")
-    return {"queue": queue, "relationships": rels, "average_evaluation_duration_ms": float((avg or {}).get("avg_ms") or 0), "total_stored_relationships": int((total or {}).get("count") or 0)}
+    matched_documents = await db.fetch_one("""
+        SELECT COUNT(DISTINCT document_id) AS count
+        FROM (
+            SELECT source_document_id AS document_id
+            FROM rag_relationships
+            WHERE match_status = 'MATCH'
+            UNION
+            SELECT target_document_id AS document_id
+            FROM rag_relationships
+            WHERE match_status = 'MATCH'
+        ) matched
+        """)
+    positive_matches = await db.fetch_one(
+        "SELECT COUNT(*) AS count FROM rag_relationships WHERE match_status = 'MATCH'"
+    )
+    stale_matches = await db.fetch_one(
+        "SELECT COUNT(*) AS count FROM rag_relationships WHERE match_status = 'STALE'"
+    )
+    pending_matches = await db.fetch_one("""
+        SELECT COUNT(*) AS count
+        FROM rag_relationship_queue
+        WHERE status IN ('PENDING', 'PROCESSING')
+        """)
+    failed_lookups = await db.fetch_one(
+        "SELECT COUNT(*) AS count FROM rag_relationship_queue WHERE status = 'FAILED'"
+    )
+    return {
+        "queue": queue,
+        "relationships": rels,
+        "average_evaluation_duration_ms": float((avg or {}).get("avg_ms") or 0),
+        "total_stored_relationships": int((total or {}).get("count") or 0),
+        "matched_documents": int((matched_documents or {}).get("count") or 0),
+        "positive_matches": int((positive_matches or {}).get("count") or 0),
+        "pending_matches": int((pending_matches or {}).get("count") or 0),
+        "failed_lookups": int((failed_lookups or {}).get("count") or 0),
+        "stale_matches": int((stale_matches or {}).get("count") or 0),
+    }

--- a/app/services/rag_relationships.py
+++ b/app/services/rag_relationships.py
@@ -80,15 +80,25 @@ async def enqueue_relationships_for_document(document_id: int) -> int:
             continue
         if await rel_repo.relationship_current(document_id, int(target["id"])):
             continue
-        if await rel_repo.enqueue(document_id, int(target["id"]), priority=1000):
+        if await rel_repo.enqueue(
+            document_id,
+            int(target["id"]),
+            priority=_relationship_queue_priority(source, target),
+        ):
             queued += 1
     return queued
 
 
-def _skip_pair(source: Mapping[str, Any], target: Mapping[str, Any], include_tickets: bool) -> bool:
+def _skip_pair(
+    source: Mapping[str, Any], target: Mapping[str, Any], include_tickets: bool
+) -> bool:
     if int(source["id"]) == int(target["id"]):
         return True
-    if source.get("company_id") and target.get("company_id") and int(source["company_id"]) != int(target["company_id"]):
+    if (
+        source.get("company_id")
+        and target.get("company_id")
+        and int(source["company_id"]) != int(target["company_id"])
+    ):
         return True
     source_type = str(source.get("source_type") or "")
     target_type = str(target.get("source_type") or "")
@@ -97,7 +107,38 @@ def _skip_pair(source: Mapping[str, Any], target: Mapping[str, Any], include_tic
     return False
 
 
+def _relationship_queue_priority(
+    source: Mapping[str, Any], target: Mapping[str, Any]
+) -> int:
+    """Return queue priority for a relationship candidate pair."""
+
+    source_type = str(source.get("source_type") or "")
+    target_type = str(target.get("source_type") or "")
+    if source_type == "tickets" or target_type == "tickets":
+        return 1100
+    return 1000
+
+
+def _evaluation_document_order(
+    source: Mapping[str, Any], target: Mapping[str, Any]
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    """Return the source/target order to present to the relationship evaluator.
+
+    Tickets should be the anchor document whenever a ticket is compared with
+    another document type so relationship prompts consistently present the
+    support request as Document A. Ticket-to-ticket and non-ticket pairs retain
+    their queued order.
+    """
+
+    source_type = str(source.get("source_type") or "")
+    target_type = str(target.get("source_type") or "")
+    if source_type != "tickets" and target_type == "tickets":
+        return target, source
+    return source, target
+
+
 def _prompt(source: Mapping[str, Any], target: Mapping[str, Any]) -> str:
+    source, target = _evaluation_document_order(source, target)
     return f"""You evaluate MyPortal RAG document relationships. Return JSON only.
 
 Document A
@@ -158,14 +199,29 @@ def parse_relationship_response(value: Any, *, min_score: float) -> dict[str, An
     else:
         text = str(value or "").strip()
         payload = json.loads(_extract_json_object(text))
-    relationship = str(payload.get("relationship") or payload.get("relationship_type") or "NOT_RELEVANT").strip().upper()
+    relationship = (
+        str(
+            payload.get("relationship")
+            or payload.get("relationship_type")
+            or "NOT_RELEVANT"
+        )
+        .strip()
+        .upper()
+    )
     try:
         relationship_type = RelationshipType(relationship)
     except ValueError:
         relationship_type = RelationshipType.NOT_RELEVANT
-    score = max(0.0, min(1.0, float(payload.get("score") or payload.get("relevance_score") or 0.0)))
+    score = max(
+        0.0,
+        min(1.0, float(payload.get("score") or payload.get("relevance_score") or 0.0)),
+    )
     confidence = max(0.0, min(1.0, float(payload.get("confidence") or 0.0)))
-    match_status = MatchStatus.MATCH if relationship_type in _POSITIVE_TYPES and score >= min_score else MatchStatus.NO_MATCH
+    match_status = (
+        MatchStatus.MATCH
+        if relationship_type in _POSITIVE_TYPES and score >= min_score
+        else MatchStatus.NO_MATCH
+    )
     if match_status is MatchStatus.NO_MATCH:
         relationship_type = RelationshipType.NOT_RELEVANT
     return {
@@ -185,30 +241,52 @@ async def evaluate_next_batch(*, limit: int | None = None) -> int:
     jobs = await rel_repo.claim_jobs(limit or settings.rag_relationship_batch_size)
     processed = 0
     semaphore = asyncio.Semaphore(max(1, int(settings.rag_relationship_max_concurrent)))
+
     async def _one(job: Mapping[str, Any]) -> None:
         nonlocal processed
         async with semaphore:
             started = time.perf_counter()
             try:
-                source = await rel_repo.get_document_with_content(int(job["source_document_id"]))
-                target = await rel_repo.get_document_with_content(int(job["target_document_id"]))
+                source = await rel_repo.get_document_with_content(
+                    int(job["source_document_id"])
+                )
+                target = await rel_repo.get_document_with_content(
+                    int(job["target_document_id"])
+                )
                 if not source or not target:
                     raise RuntimeError("Source or target document no longer exists")
-                if await rel_repo.relationship_current(int(source["id"]), int(target["id"])):
+                if await rel_repo.relationship_current(
+                    int(source["id"]), int(target["id"])
+                ):
                     await rel_repo.complete_queue_item(int(job["id"]), "skipped")
                     return
                 response = await modules_service.trigger_module(
                     "ollama",
-                    {"prompt": _prompt(source, target), "format": "json", "model": settings.rag_relationship_model},
+                    {
+                        "prompt": _prompt(source, target),
+                        "format": "json",
+                        "model": settings.rag_relationship_model,
+                    },
                     background=False,
                 )
-                if isinstance(response, Mapping) and str(response.get("status") or "").lower() in {"error", "failed", "skipped"}:
-                    reason = response.get("last_error") or response.get("error") or response.get("reason") or "module did not complete"
+                if isinstance(response, Mapping) and str(
+                    response.get("status") or ""
+                ).lower() in {"error", "failed", "skipped"}:
+                    reason = (
+                        response.get("last_error")
+                        or response.get("error")
+                        or response.get("reason")
+                        or "module did not complete"
+                    )
                     raise RuntimeError(f"Relationship evaluator unavailable: {reason}")
                 raw = _relationship_response_payload(response)
-                parsed = parse_relationship_response(raw, min_score=settings.rag_relationship_min_score)
+                parsed = parse_relationship_response(
+                    raw, min_score=settings.rag_relationship_min_score
+                )
                 await rel_repo.store_relationship(
-                    int(source["id"]), int(target["id"]), parsed,
+                    int(source["id"]),
+                    int(target["id"]),
+                    parsed,
                     evaluated_model=settings.rag_relationship_model,
                     source_hash=str(source.get("content_hash") or ""),
                     target_hash=str(target.get("content_hash") or ""),
@@ -219,6 +297,7 @@ async def evaluate_next_batch(*, limit: int | None = None) -> int:
             except Exception as exc:
                 await rel_repo.fail_queue_item(int(job["id"]), str(exc), max_retries=5)
                 logger.warning("RAG relationship job failed: {}", exc)
+
     await asyncio.gather(*(_one(job) for job in jobs))
     return processed
 
@@ -228,9 +307,19 @@ async def relationship_worker(stop_event: asyncio.Event) -> None:
     while not stop_event.is_set():
         processed = await evaluate_next_batch()
         if not processed:
-            await asyncio.sleep(max(0.1, settings.rag_relationship_idle_delay_ms / 1000))
+            await asyncio.sleep(
+                max(0.1, settings.rag_relationship_idle_delay_ms / 1000)
+            )
 
 
-async def load_evidence_for_document(document_id: int, *, limit: int = 12) -> list[dict[str, Any]]:
+async def load_evidence_for_document(
+    document_id: int, *, limit: int = 12
+) -> list[dict[str, Any]]:
     rows = await rel_repo.list_relationship_evidence(document_id, limit=limit)
-    return sorted(rows, key=lambda r: (_MATCH_ORDER.get(str(r.get("relationship_type")), 99), -float(r.get("relevance_score") or 0)))
+    return sorted(
+        rows,
+        key=lambda r: (
+            _MATCH_ORDER.get(str(r.get("relationship_type")), 99),
+            -float(r.get("relevance_score") or 0),
+        ),
+    )

--- a/app/templates/admin/rag.html
+++ b/app/templates/admin/rag.html
@@ -20,6 +20,16 @@
   <div class="card__body">
     <div class="stat-strip rag-stat-strip" data-rag-summary></div>
 
+    <section style="margin-top: 1.5rem;">
+      <div class="section-heading">
+        <div>
+          <h3>Matching Statistics</h3>
+          <p class="section-description">Relationship lookup status for matched, queued, and failed RAG document comparisons.</p>
+        </div>
+      </div>
+      <div class="stat-strip rag-stat-strip" data-rag-matching-summary></div>
+    </section>
+
     <div class="grid grid--2" style="margin-top: 1.5rem; gap: 1rem;">
       <section>
         <h3>Sources</h3>
@@ -60,6 +70,7 @@
   if (!root) return;
   const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
   const summary = root.querySelector('[data-rag-summary]');
+  const matchingSummary = root.querySelector('[data-rag-matching-summary]');
   const sourcesBody = root.querySelector('[data-rag-sources]');
   const docsBody = root.querySelector('[data-rag-documents]');
   const jobsBody = root.querySelector('[data-rag-jobs]');
@@ -74,9 +85,14 @@
   function emptyRow(cols, text) { return `<tr><td colspan="${cols}" class="table__empty">${esc(text)}</td></tr>`; }
   async function loadHealth() {
     status.textContent = 'Loading RAG statistics…';
-    const res = await fetch('/api/agent/rag/health', {headers: {'Accept': 'application/json'}});
-    if (!res.ok) throw new Error('Unable to load RAG health');
-    const data = await res.json();
+    const [healthRes, matchingRes] = await Promise.all([
+      fetch('/api/agent/rag/health', {headers: {'Accept': 'application/json'}}),
+      fetch('/api/rag/relationships/metrics', {headers: {'Accept': 'application/json'}}),
+    ]);
+    if (!healthRes.ok) throw new Error('Unable to load RAG health');
+    if (!matchingRes.ok) throw new Error('Unable to load matching statistics');
+    const data = await healthRes.json();
+    const matching = await matchingRes.json();
     summary.innerHTML = [
       metric('Active documents', number(data.documents), `${number(data.inactive_documents)} inactive`, 'total'),
       metric('Active chunks', number(data.chunks), `${number(data.stale_chunks)} stale chunks`, 'success'),
@@ -84,6 +100,13 @@
       metric('Companies covered', number(data.company_count), `${number(data.model_count)} embedding model(s)`, 'neutral'),
       metric('First indexed', date(data.first_indexed_at), 'Oldest active document', 'warning'),
       metric('Last indexed', date(data.last_indexed_at), 'Newest active document', 'success'),
+    ].join('');
+    matchingSummary.innerHTML = [
+      metric('Matched documents', number(matching.matched_documents), `${number(matching.positive_matches)} successful match(es)`, 'success'),
+      metric('Pending matches', number(matching.pending_matches), 'Queued or currently processing', 'warning'),
+      metric('Failed lookups', number(matching.failed_lookups), 'Exhausted retries and still failed', matching.failed_lookups ? 'danger' : 'neutral'),
+      metric('Stored decisions', number(matching.total_stored_relationships), `${number(matching.stale_matches)} stale decision(s)`, 'info'),
+      metric('Avg lookup time', `${Number(matching.average_evaluation_duration_ms || 0).toFixed(0)} ms`, 'Relationship evaluator runtime', 'neutral'),
     ].join('');
     sourcesBody.innerHTML = (data.sources || []).map((row) => `<tr><td>${esc(row.source_type)}</td><td>${number(row.count)}</td><td>${number(row.chunk_count)}</td><td>${number(row.token_count)}</td><td>${date(row.last_indexed_at)}</td></tr>`).join('') || emptyRow(5, 'No indexed sources yet.');
     docsBody.innerHTML = (data.recent_documents || []).map((row) => `<tr><td>${esc(row.title)}</td><td>${esc(row.source_type)}:${esc(row.source_id)}</td><td>${esc(row.company_id)}</td><td>${esc(row.embedding_model)}</td><td>${date(row.indexed_at)}</td></tr>`).join('') || emptyRow(5, 'No recent documents.');

--- a/tests/test_rag_relationships.py
+++ b/tests/test_rag_relationships.py
@@ -1,4 +1,7 @@
-from app.services.rag_relationships import _relationship_response_payload, parse_relationship_response
+from app.services.rag_relationships import (
+    _relationship_response_payload,
+    parse_relationship_response,
+)
 
 
 def test_parse_relationship_response_stores_positive_match():
@@ -55,4 +58,67 @@ def test_parse_relationship_response_empty_error_is_actionable():
     except ValueError as exc:
         assert "empty response" in str(exc)
     else:  # pragma: no cover - assertion guard
-        raise AssertionError("Expected empty relationship responses to fail with a clear message")
+        raise AssertionError(
+            "Expected empty relationship responses to fail with a clear message"
+        )
+
+
+def test_relationship_prompt_prefers_ticket_as_document_a_for_mixed_pair():
+    from app.services.rag_relationships import _prompt
+
+    asset = {
+        "source_type": "assets",
+        "source_id": 42,
+        "title": "Laptop Asset",
+        "content": "Device inventory details",
+    }
+    ticket = {
+        "source_type": "tickets",
+        "source_id": 1001,
+        "title": "Laptop will not boot",
+        "content": "Customer reports startup failure",
+    }
+
+    prompt = _prompt(asset, ticket)
+
+    document_a = prompt.split("----------------------------", 1)[0]
+    document_b = prompt.split("----------------------------", 1)[1]
+    assert "Document A\ntickets #1001" in document_a
+    assert "Document B\nassets #42" in document_b
+
+
+def test_relationship_prompt_keeps_non_ticket_order():
+    from app.services.rag_relationships import _prompt
+
+    asset = {
+        "source_type": "assets",
+        "source_id": 42,
+        "title": "Laptop Asset",
+        "content": "",
+    }
+    article = {
+        "source_type": "knowledge_base",
+        "source_id": 9,
+        "title": "Boot guide",
+        "content": "",
+    }
+
+    prompt = _prompt(asset, article)
+
+    document_a = prompt.split("----------------------------", 1)[0]
+    assert "Document A\nassets #42" in document_a
+
+
+def test_relationship_queue_priority_prefers_ticket_pairs():
+    from app.services.rag_relationships import _relationship_queue_priority
+
+    ticket = {"source_type": "tickets"}
+    asset = {"source_type": "assets"}
+    article = {"source_type": "knowledge_base"}
+
+    assert _relationship_queue_priority(asset, ticket) > _relationship_queue_priority(
+        asset, article
+    )
+    assert _relationship_queue_priority(ticket, article) > _relationship_queue_priority(
+        asset, article
+    )


### PR DESCRIPTION
### Motivation
- Improve relationship evaluation quality by prioritizing tickets and consistently presenting tickets as Document A in prompts so evaluators see the support request first.
- Fix storage ordering of `source_hash` / `target_hash` so hashes align with canonical document ordering and avoid mismatches on re-evaluation.
- Provide richer operational visibility by exposing matching statistics (queued, failed, matched, stale, avg lookup time) to the admin UI.

### Description
- Added `_relationship_queue_priority` to bump ticket-involving pairs and used it when calling `enqueue` to prioritize ticket comparisons over other pairs.
- Added `_evaluation_document_order` and updated `_prompt` to ensure tickets are presented as Document A when comparing a ticket with another document type, while preserving original ordering for other pairs.
- Adjusted `store_relationship` to compute and persist `source_hash`/`target_hash` according to the canonical left/right ordering determined by `_pair` to avoid swapped hashes.
- Extended `metrics()` in `rag_relationships.py` and updated admin template `admin/rag.html` and its client-side script to surface matching stats by fetching `/api/rag/relationships/metrics` and rendering new metrics; various formatting and small refactors across service and repository modules were applied for consistency.

### Testing
- Ran the updated unit tests in `tests/test_rag_relationships.py` using `pytest`, which exercised parsing, prompt ordering, and priority behavior, and they all passed.
- Existing relationship parsing tests including fenced JSON handling and payload extraction were executed via `pytest` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3db758415c832dabd9f5f3c339df69)