### PR TITLE
Apply tray branding to ticket forms and chat window title

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -38,6 +38,7 @@ from app.repositories import chat as chat_repo
 from app.repositories import companies as companies_repo
 from app.repositories import tray as tray_repo
 from app.repositories import tickets as tickets_repo
+from app.repositories import site_settings as site_settings_repo
 from app.repositories import users as users_repo
 from app.repositories import staff as staff_repo
 from app.schemas.tray import (
@@ -730,9 +731,12 @@ def _render_ticket_form(
     error: str | None = None,
     values: dict[str, str] | None = None,
     success: str | None = None,
+    branding_display_name: str | None = None,
+    branding_icon_url: str = "/tray/icon.ico",
 ) -> str:
     values = values or {}
     title = "Create Syncro Ticket" if mode == "syncro" else "Submit Ticket"
+    brand_name = (branding_display_name or "MyPortal Helpdesk").strip() or "MyPortal Helpdesk"
     intro = "Create a support ticket linked to this computer."
     fields = []
     for name, label, field_type, placeholder, required in [
@@ -824,19 +828,20 @@ def _render_ticket_form(
     meta_json = _html.escape(json.dumps(question_meta), quote=True)
     return f"""<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>{_html.escape(title)}</title>
+<title>{_html.escape(title)} - {_html.escape(brand_name)}</title>
+<link rel="icon" href="{_html.escape(branding_icon_url, quote=True)}" type="image/x-icon">
 <style>
 :root{{--primary:#0f8f8f;--ink:#1f2937;--muted:#64748b;--line:#e5e7eb;--bg:#f8fafc}}
 *{{box-sizing:border-box}}body{{margin:0;font-family:Segoe UI,Arial,sans-serif;background:var(--bg);color:var(--ink)}}
 .shell{{min-height:100vh;display:grid;grid-template-columns:220px 1fr;grid-template-rows:auto 1fr}}
-.nav{{grid-row:1/3;background:#0f172a;color:white;padding:24px}}.nav h1{{font-size:18px;margin:0 0 18px}}.nav p{{color:#cbd5e1;font-size:13px;line-height:1.5}}
+.nav{{grid-row:1/3;background:#0f172a;color:white;padding:24px}}.brand{{display:flex;align-items:center;gap:10px;margin-bottom:18px}}.brand img{{width:32px;height:32px;border-radius:8px;background:white;padding:4px}}.brand h1{{font-size:18px;margin:0}}.nav p{{color:#cbd5e1;font-size:13px;line-height:1.5}}
 .header{{background:white;border-bottom:1px solid var(--line);padding:20px 28px}}.header h2{{margin:0;font-size:24px}}.header p{{margin:6px 0 0;color:var(--muted)}}
 .main{{padding:28px;overflow:auto}}.card{{max-width:860px;background:white;border:1px solid var(--line);border-radius:16px;padding:24px;box-shadow:0 10px 30px rgba(15,23,42,.06)}}
 .field{{display:grid;gap:8px;margin-bottom:18px}}.field span{{font-weight:600}}input,textarea,select{{width:100%;border:1px solid #cbd5e1;border-radius:10px;padding:11px 12px;font:inherit}}textarea{{resize:vertical}}.check{{display:flex;gap:8px;align-items:center}}.check input{{width:auto}}
 .actions{{display:flex;justify-content:flex-end;gap:12px;margin-top:24px}}button{{border:0;border-radius:10px;padding:12px 18px;font-weight:700;cursor:pointer}}.primary{{background:var(--primary);color:white}}.secondary{{background:#e5e7eb;color:#111827}}
 .alert{{border-radius:12px;padding:12px 14px;margin-bottom:18px}}.alert-error{{background:#fef2f2;color:#991b1b;border:1px solid #fecaca}}.alert-success{{background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0}}
 @media(max-width:760px){{.shell{{display:block}}.nav{{padding:16px}}.main{{padding:16px}}}}
-</style></head><body><div class="shell"><aside class="nav"><h1>MyPortal</h1><p>This secure tray form is authenticated by your enrolled tray device and links the request to this computer.</p></aside><header class="header"><h2>{_html.escape(title)}</h2><p>{_html.escape(intro)}</p></header><main class="main"><form class="card" method="post" action="/api/tray/ticket-form"><input type="hidden" name="token" value="{_html.escape(token)}"><input type="hidden" name="csrf" value="{_html.escape(csrf)}"><input type="hidden" id="question-meta" value="{meta_json}">{notice}{done}{''.join(fields)}<div class="actions"><button type="button" class="secondary" onclick="window.close()">Cancel</button><button class="primary" type="submit"{disabled}>Send Request</button></div></form></main></div>
+</style></head><body><div class="shell"><aside class="nav"><div class="brand"><img src="{_html.escape(branding_icon_url, quote=True)}" alt=""><h1>{_html.escape(brand_name)}</h1></div><p>This secure tray form is authenticated by your enrolled tray device and links the request to this computer.</p></aside><header class="header"><h2>{_html.escape(title)}</h2><p>{_html.escape(intro)}</p></header><main class="main"><form class="card" method="post" action="/api/tray/ticket-form"><input type="hidden" name="token" value="{_html.escape(token)}"><input type="hidden" name="csrf" value="{_html.escape(csrf)}"><input type="hidden" id="question-meta" value="{meta_json}">{notice}{done}{''.join(fields)}<div class="actions"><button type="button" class="secondary" onclick="window.close()">Cancel</button><button class="primary" type="submit"{disabled}>Send Request</button></div></form></main></div>
 <script>
 const meta=JSON.parse(document.getElementById('question-meta').value||'[]');
 function valueFor(id){{const el=document.querySelector(`[data-question-input="${{id}}"]`);if(!el)return'';if(el.type==='checkbox')return el.checked?'Yes':'No';return (el.value||'').trim();}}
@@ -884,12 +889,14 @@ async def tray_ticket_form(token: str) -> HTMLResponse:
     if not device or device.get("status") == "revoked":
         raise HTTPException(status_code=403, detail="Device not found or revoked")
     questions = await tq_service.get_questions_for_company(device.get("company_id"))
+    branding_display_name = await site_settings_repo.get_tray_icon_tooltip_name()
     return HTMLResponse(
         _render_ticket_form(
             token=token,
             csrf=str(session["csrf"]),
             mode=str(session["mode"]),
             questions=questions,
+            branding_display_name=branding_display_name,
         )
     )
 
@@ -909,6 +916,7 @@ async def tray_ticket_form_submit(request: Request) -> HTMLResponse:
     if not device or device.get("status") == "revoked":
         raise HTTPException(status_code=403, detail="Device not found or revoked")
     questions = await tq_service.get_questions_for_company(device.get("company_id"))
+    branding_display_name = await site_settings_repo.get_tray_icon_tooltip_name()
     values = {
         k: str(v)
         for k, v in form.multi_items()
@@ -955,6 +963,7 @@ async def tray_ticket_form_submit(request: Request) -> HTMLResponse:
                 csrf=str(session["csrf"]),
                 mode=str(session["mode"]),
                 questions=questions,
+                branding_display_name=branding_display_name,
                 error=detail,
                 values=values,
             ),
@@ -974,6 +983,7 @@ async def tray_ticket_form_submit(request: Request) -> HTMLResponse:
             csrf=str(session["csrf"]),
             mode=str(session["mode"]),
             questions=questions,
+            branding_display_name=branding_display_name,
             success=success,
             values={},
         )

--- a/app/features/chat/routes.py
+++ b/app/features/chat/routes.py
@@ -16,6 +16,7 @@ from app.repositories import chat as chat_repo
 from app.repositories import companies as companies_repo
 from app.repositories import tray as tray_repo
 from app.repositories import user_companies as user_company_repo
+from app.repositories import site_settings as site_settings_repo
 from app.repositories import users as user_repo
 from app.security.encryption import decrypt_secret, encrypt_secret
 from app.security.session import SessionData
@@ -369,6 +370,7 @@ async def tray_chat_popup(
     # 4. Load initial messages and render the popup.
     # ------------------------------------------------------------------
     messages = await chat_repo.get_messages(final_room_id, limit=50)
+    branding_display_name = await site_settings_repo.get_tray_icon_tooltip_name()
 
     html_content = _render_popup(
         room=chat_room,
@@ -377,6 +379,7 @@ async def tray_chat_popup(
         room_id=final_room_id,
         device_id=device_id,
         hostname=device.get("hostname") or "Tray Device",
+        branding_display_name=branding_display_name,
     )
 
     resp = HTMLResponse(content=html_content)
@@ -400,6 +403,7 @@ def _render_popup(
     room_id: int,
     device_id: int,
     hostname: str,
+    branding_display_name: str | None = None,
 ) -> str:
     """Render the standalone popup HTML using the Jinja2 template."""
     from jinja2 import Environment, PackageLoader, select_autoescape
@@ -439,6 +443,7 @@ def _render_popup(
         room_id=room_id,
         device_id=device_id,
         hostname=hostname,
+        branding_display_name=(branding_display_name or "MyPortal Helpdesk"),
     )
 
 

--- a/app/templates/tray/chat_popup.html
+++ b/app/templates/tray/chat_popup.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="/tray/icon.ico" type="image/x-icon" />
-  <title>MyPortal Chat{% if room and room.subject %}: {{ room.subject }}{% endif %}</title>
+  <title>{{ branding_display_name }} Chat{% if room and room.subject %}: {{ room.subject }}{% endif %}</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     html, body {
@@ -154,7 +154,7 @@
 <body>
 <div id="chat-root">
   <header id="chat-header">
-    <h1>{% if room and room.subject %}{{ room.subject }}{% else %}MyPortal Chat{% endif %}</h1>
+    <h1>{% if room and room.subject %}{{ room.subject }}{% else %}{{ branding_display_name }} Chat{% endif %}</h1>
     <span id="chat-status-badge"{% if room and room.status == 'closed' %} class="closed"{% endif %}>
       {% if room and room.status == 'closed' %}Closed{% else %}Open{% endif %}
     </span>

--- a/tray/chat-shell/main.js
+++ b/tray/chat-shell/main.js
@@ -23,21 +23,24 @@ const { URL } = require('url');
 // Parse --url argument
 // ---------------------------------------------------------------------------
 
-function getChatURL() {
-  // In a packaged Electron app process.argv[0] is the executable and user
-  // arguments begin at index 1.  In development (electron .) argv[1] is the
-  // app entry point, so user arguments begin at index 2.
+function getLaunchArg(name) {
+  const prefix = `--${name}=`;
   const argv = process.argv.slice(app.isPackaged ? 1 : 2);
   for (const arg of argv) {
-    if (arg.startsWith('--url=')) {
-      const val = arg.slice('--url='.length).trim();
+    if (arg.startsWith(prefix)) {
+      const val = arg.slice(prefix.length).trim();
       return val || null;
     }
   }
   return null;
 }
 
+function getChatURL() {
+  return getLaunchArg('url');
+}
+
 const chatURL = getChatURL();
+let windowTitle = getLaunchArg('title') || 'MyPortal Chat';
 let launchURL = chatURL;
 let appReady = false;
 
@@ -50,6 +53,16 @@ let appReady = false;
 // session.
 const CHAT_PARTITION = 'persist:myportal-tray-chat';
 
+function escapeHTML(value) {
+  return String(value).replace(/[&<>"']/g, (ch) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[ch]);
+}
+
 // How long (ms) to display the informational window when the app is run without
 // a --url= argument (e.g. manually by a user).
 const INFO_WINDOW_DISPLAY_MS = 8000;
@@ -61,7 +74,7 @@ const INFO_WINDOW_DISPLAY_MS = 8000;
 // instance is launched with a different URL, focus the existing window and
 // navigate it to the new URL.
 
-const gotLock = app.requestSingleInstanceLock({ chatURL: chatURL || '' });
+const gotLock = app.requestSingleInstanceLock({ chatURL: chatURL || '', windowTitle });
 if (!gotLock) {
   app.quit();
   process.exit(0);
@@ -135,7 +148,7 @@ function createChatWindow(url) {
     height: 680,
     minWidth: 480,
     minHeight: 400,
-    title: 'MyPortal Chat',
+    title: windowTitle,
     autoHideMenuBar: true,
     backgroundColor: '#ffffff',
     webPreferences: {
@@ -171,6 +184,11 @@ function createChatWindow(url) {
 
 app.on('second-instance', (_event, _argv, _cwd, additionalData) => {
   const newURL = (additionalData && additionalData.chatURL) || null;
+  if (additionalData && additionalData.windowTitle) {
+    windowTitle = additionalData.windowTitle;
+    if (mainWindow && !mainWindow.isDestroyed()) mainWindow.setTitle(windowTitle);
+    if (infoWindow && !infoWindow.isDestroyed()) infoWindow.setTitle(windowTitle);
+  }
   if (newURL) {
     launchURL = newURL;
   }
@@ -212,7 +230,7 @@ app.whenReady().then(() => {
     infoWindow = new BrowserWindow({
       width: 480,
       height: 220,
-      title: 'MyPortal Chat',
+      title: windowTitle,
       autoHideMenuBar: true,
       resizable: false,
       webPreferences: {
@@ -226,7 +244,7 @@ app.whenReady().then(() => {
       'data:text/html,' +
         encodeURIComponent(
           '<!DOCTYPE html><html><body style="font-family:sans-serif;padding:24px;margin:0">' +
-            '<h3 style="margin-top:0">MyPortal Chat</h3>' +
+            '<h3 style="margin-top:0">' + escapeHTML(windowTitle) + '</h3>' +
             '<p>This application opens automatically when you click ' +
             '<strong>Support Chat</strong> in the MyPortal tray menu.</p>' +
             '<p style="color:#888;font-size:0.9em">This window will close in a few seconds.</p>' +

--- a/tray/ui/chat_shell_nowebview.go
+++ b/tray/ui/chat_shell_nowebview.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/bradhawkins85/myportal-tray/internal/api"
 	"github.com/bradhawkins85/myportal-tray/internal/logger"
 )
 
@@ -115,12 +116,12 @@ func findChatShell() string {
 // openWithChatShell launches the dedicated chat shell with chatURL as its
 // argument.  Returns true when the shell was found and the process started
 // successfully.
-func openWithChatShell(chatURL string) bool {
+func openWithChatShell(chatURL string, cfg *api.ConfigResponse) bool {
 	shellPath := findChatShell()
 	if shellPath == "" {
 		return false
 	}
-	cmd := exec.Command(shellPath, "--url="+chatURL)
+	cmd := exec.Command(shellPath, "--url="+chatURL, "--title="+trayDisplayName(cfg)+" Chat")
 	if err := cmd.Start(); err != nil {
 		logger.Warn("openWithChatShell: launch failed: %v", err)
 		return false

--- a/tray/ui/chat_shell_nowebview_test.go
+++ b/tray/ui/chat_shell_nowebview_test.go
@@ -147,7 +147,7 @@ func TestOpenWithChatShell_ReturnsFalseWhenAbsent(t *testing.T) {
 		t.Skipf("chat shell binary present at %s — skipping absence test", candidate)
 	}
 
-	result := openWithChatShell("https://example.com/tray/chat")
+	result := openWithChatShell("https://example.com/tray/chat", nil)
 	if result {
 		t.Error("expected false when chat shell is not installed, got true")
 	}

--- a/tray/ui/platform_darwin.go
+++ b/tray/ui/platform_darwin.go
@@ -34,7 +34,7 @@ func openChatWindow(chatURL string, cfg *api.ConfigResponse) {
 	}
 	w := webview.New(false)
 	defer w.Destroy()
-	w.SetTitle("MyPortal Chat")
+	w.SetTitle(trayDisplayName(cfg) + " Chat")
 	w.SetSize(900, 650, webview.HintNone)
 	w.Navigate(chatURL)
 	w.Run()

--- a/tray/ui/platform_nowebview_darwin.go
+++ b/tray/ui/platform_nowebview_darwin.go
@@ -36,7 +36,7 @@ func showTextWindow(title, text string) {
 
 // openChatWindow resolves the chat URL (requesting an auth token when needed)
 // then delegates to openChatAppWindow which handles the launch strategy.
-func openChatWindow(chatURL string, _ *api.ConfigResponse) {
+func openChatWindow(chatURL string, cfg *api.ConfigResponse) {
 	if chatURL == "" {
 		// Request a short-lived one-time auth token from the portal.  If the
 		// request fails (portal unreachable, device not enrolled, etc.) we do
@@ -61,7 +61,7 @@ func openChatWindow(chatURL string, _ *api.ConfigResponse) {
 		return
 	}
 
-	openChatAppWindow(chatURL)
+	openChatAppWindow(chatURL, cfg)
 }
 
 // findAppBrowser returns the full path to a Chromium-based browser binary that
@@ -96,12 +96,12 @@ func findAppBrowser() string {
 }
 
 // openChatAppWindow implements the three-tier launch strategy for macOS.
-func openChatAppWindow(chatURL string) {
+func openChatAppWindow(chatURL string, cfg *api.ConfigResponse) {
 	mode := chatClientMode()
 
 	// Tier 1: dedicated Electron chat shell.
 	if mode != "browser" {
-		if openWithChatShell(chatURL) {
+		if openWithChatShell(chatURL, cfg) {
 			return
 		}
 		if mode == "shell" {

--- a/tray/ui/platform_nowebview_windows.go
+++ b/tray/ui/platform_nowebview_windows.go
@@ -34,7 +34,7 @@ func showTextWindow(title, text string) {
 	fmt.Printf("[%s] %s\n", title, text)
 }
 
-func openChatWindow(chatURL string, _ *api.ConfigResponse) {
+func openChatWindow(chatURL string, cfg *api.ConfigResponse) {
 	if chatURL == "" {
 		// Request a short-lived one-time auth token from the portal.  If the
 		// request fails (portal unreachable, device not enrolled, etc.) we do
@@ -58,7 +58,7 @@ func openChatWindow(chatURL string, _ *api.ConfigResponse) {
 		return
 	}
 
-	openChatAppWindow(chatURL)
+	openChatAppWindow(chatURL, cfg)
 }
 
 // findAppBrowser returns the full path to an Edge or Chrome executable that
@@ -107,12 +107,12 @@ func findAppBrowser() string {
 	return ""
 }
 
-func openChatAppWindow(chatURL string) {
+func openChatAppWindow(chatURL string, cfg *api.ConfigResponse) {
 	mode := chatClientMode()
 
 	// Tier 1: dedicated Electron chat shell.
 	if mode != "browser" {
-		if openWithChatShell(chatURL) {
+		if openWithChatShell(chatURL, cfg) {
 			return
 		}
 		if mode == "shell" {
@@ -138,7 +138,7 @@ func openChatAppWindow(chatURL string) {
 			if gPortalURL != "" {
 				iconURL := strings.TrimRight(gPortalURL, "/") + "/tray/icon.ico"
 				edgeArgs = append(edgeArgs,
-					"--app-name=MyPortal Chat",
+					"--app-name="+trayDisplayName(cfg)+" Chat",
 					"--app-icon-url="+iconURL,
 				)
 			}

--- a/tray/ui/platform_windows.go
+++ b/tray/ui/platform_windows.go
@@ -37,7 +37,7 @@ func openChatWindow(chatURL string, cfg *api.ConfigResponse) {
 	}
 	w := webview.New(false)
 	defer w.Destroy()
-	w.SetTitle("MyPortal Chat")
+	w.SetTitle(trayDisplayName(cfg) + " Chat")
 	w.SetSize(900, 650, webview.HintNone)
 	w.Navigate(chatURL)
 	w.Run()


### PR DESCRIPTION
### Motivation
- Align the tray-authenticated Submit Ticket and Create Syncro Ticket pages with the tray branding configured at `/admin/tray/branding` so end-users see the same display name and icon as the tray tooltip. 
- Surface the same tooltip display name in tray chat windows so the window title matches the configured branding while keeping the icon behaviour unchanged.

### Description
- Load the current tray tooltip display name via `site_settings_repo.get_tray_icon_tooltip_name()` and pass it into the tray ticket form renderer for both the GET and POST paths, preserving it across error and success renderings. 
- Update `_render_ticket_form` to include the branding display name in the page title, show the branding icon (`/tray/icon.ico` by default) in the form sidebar, and render the brand heading in the form UI. 
- Make the tray chat popup use the branding display name in the HTML `<title>` and fallback header by passing `branding_display_name` into the chat popup render path and updating the template. 
- Propagate the display name into tray UI window launches by using `trayDisplayName(cfg)` for chat window titles and by passing a `--title` launch argument to the dedicated Electron chat shell; update the Electron shell to accept and safely escape `--title` and apply it to both info and chat windows. 
- Adjust tray UI helpers and tests to accept the display-name-aware signatures used when launching chat windows and the shell launch arguments; unchanged icon serving continues to use `/tray/icon.ico` so icons are not modified.

### Testing
- Ran Python static compilation with `python3 -m compileall app/api/routes/tray.py app/features/chat/routes.py`, which completed successfully. 
- Ran Go unit tests for the tray UI with `cd tray/ui && go test -tags nowebview ./...`, which passed. 
- Performed a Node syntax check on the Electron shell with `cd tray/chat-shell && node --check main.js`, which passed. 
- Rendered a preview of the ticket form via `_render_ticket_form(...)` and asserted the branding display name appears in the generated HTML; the assertion succeeded. 
- Attempted to capture a screenshot but no supported browser binary was available in the container, so UI screenshots were not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3dba98fa28832d8c279871093aa19e)