### PR TITLE
Fix chat room bulk delete refresh notification

### DIFF
--- a/app/api/routes/chat.py
+++ b/app/api/routes/chat.py
@@ -193,9 +193,10 @@ async def bulk_delete_rooms(
         },
     )
 
-    await refresh_notifier.publish(
+    await refresh_notifier.broadcast_refresh(
+        reason="chat_rooms_deleted",
         topics=["chat:rooms"],
-        payload={"type": "chat_rooms_deleted", "room_ids": sorted(found_ids)},
+        data={"room_ids": sorted(found_ids)},
     )
     return JSONResponse({"deleted": deleted_count, "room_ids": sorted(found_ids), "missing_room_ids": missing_ids})
 

--- a/tests/test_chat_bulk_delete.py
+++ b/tests/test_chat_bulk_delete.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import asyncio
+
+from app.api.routes import chat as chat_routes
+
+
+def test_bulk_delete_rooms_broadcasts_refresh_after_delete(monkeypatch):
+    async def run_test():
+        monkeypatch.setattr(chat_routes._settings, "matrix_enabled", True)
+        rooms = [
+            {"id": 2, "subject": "Second"},
+            {"id": 5, "subject": "Fifth"},
+        ]
+        deleted_ids = []
+        audit_payload = {}
+        broadcasts = []
+
+        async def fake_list_rooms_by_ids(room_ids):
+            assert room_ids == [2, 5, 9]
+            return rooms
+
+        async def fake_delete_rooms(room_ids):
+            deleted_ids.extend(room_ids)
+            return len(room_ids)
+
+        async def fake_log_action(**kwargs):
+            audit_payload.update(kwargs)
+
+        async def fake_broadcast_refresh(**kwargs):
+            broadcasts.append(kwargs)
+
+        monkeypatch.setattr(chat_routes.chat_repo, "list_rooms_by_ids", fake_list_rooms_by_ids)
+        monkeypatch.setattr(chat_routes.chat_repo, "delete_rooms", fake_delete_rooms)
+        monkeypatch.setattr(chat_routes.audit_service, "log_action", fake_log_action)
+        monkeypatch.setattr(chat_routes.refresh_notifier, "broadcast_refresh", fake_broadcast_refresh)
+
+        response = await chat_routes.bulk_delete_rooms(
+            body=chat_routes.ChatRoomBulkDelete(room_ids=[5, 2, 2, 9]),
+            current_user={"id": 7, "is_super_admin": True},
+        )
+
+        assert response.status_code == 200
+        assert deleted_ids == [2, 5]
+        assert audit_payload["action"] == "bulk_delete"
+        assert audit_payload["previous_value"]["missing_room_ids"] == [9]
+        assert broadcasts == [
+            {
+                "reason": "chat_rooms_deleted",
+                "topics": ["chat:rooms"],
+                "data": {"room_ids": [2, 5]},
+            }
+        ]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
### Motivation
- Deleting chat rooms caused an internal server error because the routes used a non-existent `RefreshNotifier.publish` method, though rooms were deleted; this change prevents the 500 and preserves client notifications.

### Description
- Replace the invalid `refresh_notifier.publish(...)` call with `refresh_notifier.broadcast_refresh(...)` in `app/api/routes/chat.py`, passing `reason="chat_rooms_deleted"` and `data` containing the deleted `room_ids`.
- Add a regression test `tests/test_chat_bulk_delete.py` that verifies request normalization, repository deletion behavior, audit metadata for missing IDs, and the expected refresh broadcast payload.

### Testing
- Ran `pytest tests/test_chat_bulk_delete.py -q` and the new test passed.
- Verified syntax/compilation with `python -m py_compile app/api/routes/chat.py tests/test_chat_bulk_delete.py` with no errors.
- Ran `git diff --check` to ensure no formatting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3dbd5364a4832dbbf9cb58809d4588)