### PR TITLE
Record automation action history and expose it in admin UI

### DIFF
--- a/app/features/automations/handlers.py
+++ b/app/features/automations/handlers.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse
 from starlette.datastructures import FormData
 
 from app.security.flash import flash_redirect
@@ -643,3 +644,29 @@ async def admin_delete_automation(automation_id: int, request: Request):
 
     message = f"Automation {automation_id} deleted."
     return flash_redirect("/admin/automations", message, "success")
+
+
+async def admin_automation_history(automation_id: int, request: Request, limit: int = Query(default=200, ge=1, le=1000)):
+    from app.repositories import automations as automation_repo
+
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return JSONResponse({"detail": "Authentication required"}, status_code=status.HTTP_401_UNAUTHORIZED)
+    automation = await automation_repo.get_automation(automation_id)
+    if not automation:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+    rows = await automation_repo.list_history(automation_id, limit=limit)
+
+    def encode(value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.astimezone(timezone.utc).isoformat()
+        if isinstance(value, Mapping):
+            return {str(k): encode(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [encode(item) for item in value]
+        return value
+
+    return JSONResponse({
+        "automation": {"id": automation_id, "name": automation.get("name")},
+        "history": [encode(row) for row in rows],
+    })

--- a/app/features/automations/routes.py
+++ b/app/features/automations/routes.py
@@ -58,6 +58,11 @@ router.add_api_route(
     response_class=HTMLResponse,
 )
 router.add_api_route(
+    "/admin/automations/{automation_id}/history",
+    handlers.admin_automation_history,
+    methods=["GET"],
+)
+router.add_api_route(
     "/admin/automations/{automation_id}/execute",
     handlers.admin_execute_automation,
     methods=["POST"],

--- a/app/repositories/automations.py
+++ b/app/repositories/automations.py
@@ -10,6 +10,7 @@ from app.core.database import db
 
 AutomationRecord = dict[str, Any]
 AutomationRunRecord = dict[str, Any]
+AutomationHistoryRecord = dict[str, Any]
 
 
 async def _ensure_connection() -> None:
@@ -77,6 +78,17 @@ def _normalise_automation(row: dict[str, Any]) -> AutomationRecord:
             record[key] = bool(record[key])
     record["trigger_filters"] = _deserialise(record.get("trigger_filters"))
     record["action_payload"] = _deserialise(record.get("action_payload"))
+    return record
+
+
+def _normalise_history(row: dict[str, Any]) -> AutomationHistoryRecord:
+    record = dict(row)
+    for key in ("id", "automation_id", "automation_run_id", "ticket_id"):
+        if key in record and record[key] is not None:
+            record[key] = int(record[key])
+    record["occurred_at"] = _make_aware(record.get("occurred_at"))
+    record["previous_values"] = _deserialise(record.get("previous_values"))
+    record["result_payload"] = _deserialise(record.get("result_payload"))
     return record
 
 
@@ -372,3 +384,67 @@ async def list_event_automations(
         params.append(limit)
     rows = await db.fetch_all(query, tuple(params))
     return [_normalise_automation(row) for row in rows]
+
+
+async def record_history(
+    *,
+    automation_id: int,
+    automation_run_id: int | None = None,
+    occurred_at: datetime | None = None,
+    action_name: str,
+    action_module: str | None,
+    ticket_id: int | None,
+    ticket_number: str | None,
+    status: str,
+    previous_values: Any = None,
+    result_payload: Any = None,
+    error_message: str | None = None,
+) -> AutomationHistoryRecord:
+    await _ensure_connection()
+    history_id = await db.execute_returning_lastrowid(
+        """
+        INSERT INTO automation_history (
+            automation_id, automation_run_id, occurred_at, action_name, action_module,
+            ticket_id, ticket_number, status, previous_values, result_payload, error_message
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            automation_id,
+            automation_run_id,
+            _prepare_for_storage(occurred_at or datetime.now(timezone.utc)),
+            action_name,
+            action_module,
+            ticket_id,
+            ticket_number,
+            status,
+            _serialise(previous_values),
+            _serialise(result_payload),
+            error_message,
+        ),
+    )
+    row = await db.fetch_one("SELECT * FROM automation_history WHERE id = %s", (history_id,))
+    if not row:
+        row = {
+            "id": history_id, "automation_id": automation_id, "automation_run_id": automation_run_id,
+            "occurred_at": occurred_at or datetime.now(timezone.utc), "action_name": action_name,
+            "action_module": action_module, "ticket_id": ticket_id, "ticket_number": ticket_number,
+            "status": status, "previous_values": previous_values, "result_payload": result_payload,
+            "error_message": error_message,
+        }
+    return _normalise_history(row)
+
+
+async def list_history(automation_id: int, *, limit: int = 200) -> list[AutomationHistoryRecord]:
+    await _ensure_connection()
+    rows = await db.fetch_all(
+        """
+        SELECT *
+        FROM automation_history
+        WHERE automation_id = %s
+        ORDER BY occurred_at DESC, id DESC
+        LIMIT %s
+        """,
+        (automation_id, limit),
+    )
+    return [_normalise_history(row) for row in rows]

--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -103,6 +103,74 @@ def _claim_reply_event_execution(
     return True
 
 
+
+def _context_ticket_identity(context: Mapping[str, Any] | None, result: Any = None) -> tuple[int | None, str | None]:
+    ticket_id: int | None = None
+    ticket_number: str | None = None
+    if isinstance(result, Mapping):
+        raw_ticket_id = result.get("ticket_id")
+        if raw_ticket_id is not None:
+            try:
+                ticket_id = int(raw_ticket_id)
+            except (TypeError, ValueError):
+                ticket_id = None
+        raw_number = result.get("ticket_number") or result.get("number")
+        if raw_number is not None:
+            ticket_number = str(raw_number)
+    if isinstance(context, Mapping):
+        ticket = context.get("ticket")
+        if isinstance(ticket, Mapping):
+            if ticket_id is None and ticket.get("id") is not None:
+                try:
+                    ticket_id = int(ticket.get("id"))
+                except (TypeError, ValueError):
+                    ticket_id = None
+            if ticket_number is None:
+                raw_number = ticket.get("ticket_number") or ticket.get("number")
+                if raw_number is not None:
+                    ticket_number = str(raw_number)
+    return ticket_id, ticket_number
+
+
+def _previous_values_from_result(result: Any) -> Any:
+    if not isinstance(result, Mapping):
+        return None
+    previous = result.get("previous_values")
+    if previous is not None:
+        return previous
+    nested = result.get("result")
+    if isinstance(nested, Mapping):
+        return nested.get("previous_values")
+    return None
+
+
+async def _record_action_history(
+    automation: Mapping[str, Any],
+    *,
+    action_name: str,
+    action_module: str | None,
+    status: str,
+    result: Any,
+    error_message: str | None,
+    context: Mapping[str, Any] | None,
+) -> None:
+    automation_id = int(automation.get("id"))
+    ticket_id, ticket_number = _context_ticket_identity(context, result)
+    try:
+        await automation_repo.record_history(
+            automation_id=automation_id,
+            action_name=action_name,
+            action_module=action_module,
+            ticket_id=ticket_id,
+            ticket_number=ticket_number,
+            status=status,
+            previous_values=_previous_values_from_result(result),
+            result_payload=result,
+            error_message=error_message,
+        )
+    except Exception as exc:  # pragma: no cover - history must not break automations
+        logger.warning("Failed to record automation history", automation_id=automation_id, error=str(exc))
+
 def _normalise_actions(actions: Any) -> list[dict[str, Any]]:
     normalised: list[dict[str, Any]] = []
     if not isinstance(actions, list):
@@ -557,7 +625,17 @@ async def _invoke_automation_actions_for_context(
                 exc_message = str(exc)
                 if not first_error:
                     first_error = exc_message
-                results.append({"module": module_slug, "status": "failed", "error": exc_message})
+                failure_entry = {"module": module_slug, "status": "failed", "error": exc_message}
+                results.append(failure_entry)
+                await _record_action_history(
+                    automation,
+                    action_name=action.get("note") or module_slug,
+                    action_module=module_slug,
+                    status="failed",
+                    result=failure_entry,
+                    error_message=exc_message,
+                    context=context,
+                )
                 continue
 
             action_status_raw = action_result.get("status") if isinstance(action_result, Mapping) else None
@@ -578,6 +656,16 @@ async def _invoke_automation_actions_for_context(
             if action_reason:
                 result_entry["reason"] = action_reason
             results.append(result_entry)
+            history_status = "failed" if action_status in {"failed", "error"} or (action_status == "unknown" and action_error) else "succeeded"
+            await _record_action_history(
+                automation,
+                action_name=action.get("note") or module_slug,
+                action_module=module_slug,
+                status=history_status,
+                result=result_entry,
+                error_message=str(action_error) if action_error else None,
+                context=context,
+            )
             if action_status in {"failed", "error"} or (action_status == "unknown" and action_error):
                 if not first_error:
                     first_error = str(action_error or "Module action failed")
@@ -591,11 +679,33 @@ async def _invoke_automation_actions_for_context(
         if context:
             module_payload.setdefault("context", context)
         result = await modules_service.trigger_module(str(module_slug), module_payload, background=False)
+        history_error = None
+        history_status = "succeeded"
         if isinstance(result, Mapping):
             result_status = str(result.get("status") or result.get("event_status") or "").strip().lower()
             result_error = result.get("error") or result.get("last_error") or None
             if result_status in {"failed", "error"} or result_error:
-                return result, str(result_error or "Module action failed")
+                history_status = "failed"
+                history_error = str(result_error or "Module action failed")
+                await _record_action_history(
+                    automation,
+                    action_name=str(module_slug),
+                    action_module=str(module_slug),
+                    status=history_status,
+                    result=result,
+                    error_message=history_error,
+                    context=context,
+                )
+                return result, history_error
+        await _record_action_history(
+            automation,
+            action_name=str(module_slug),
+            action_module=str(module_slug),
+            status=history_status,
+            result=result,
+            error_message=history_error,
+            context=context,
+        )
         return result, None
     return {"status": "skipped", "reason": "No action module configured"}, None
 
@@ -801,8 +911,16 @@ async def _execute_automation(
                         status = "failed"
                         if not error_message:
                             error_message = exc_message
-                        results.append(
-                            {"module": module_slug, "status": "failed", "error": exc_message}
+                        failure_entry = {"module": module_slug, "status": "failed", "error": exc_message}
+                        results.append(failure_entry)
+                        await _record_action_history(
+                            automation,
+                            action_name=action.get("note") or module_slug,
+                            action_module=module_slug,
+                            status="failed",
+                            result=failure_entry,
+                            error_message=exc_message,
+                            context=context,
                         )
                         logger.error(
                             "Automation action failed",
@@ -837,6 +955,16 @@ async def _execute_automation(
                     if action_reason:
                         result_entry["reason"] = action_reason
                     results.append(result_entry)
+                    history_status = "failed" if action_status in {"failed", "error"} or (action_status == "unknown" and action_error) else "succeeded"
+                    await _record_action_history(
+                        automation,
+                        action_name=action.get("note") or module_slug,
+                        action_module=module_slug,
+                        status=history_status,
+                        result=result_entry,
+                        error_message=str(action_error) if action_error else None,
+                        context=context,
+                    )
 
                     if action_status in {"failed", "error"} or (
                         action_status == "unknown" and action_error
@@ -857,6 +985,24 @@ async def _execute_automation(
                         module_payload.setdefault("context", context)
                     result_payload = await modules_service.trigger_module(
                         str(module_slug), module_payload, background=False
+                    )
+                    action_status = "succeeded"
+                    action_error = None
+                    if isinstance(result_payload, Mapping):
+                        raw_status = str(result_payload.get("status") or result_payload.get("event_status") or "").strip().lower()
+                        action_error = result_payload.get("error") or result_payload.get("last_error") or None
+                        if raw_status in {"failed", "error"} or action_error:
+                            action_status = "failed"
+                            status = "failed"
+                            error_message = str(action_error or "Module action failed")
+                    await _record_action_history(
+                        automation,
+                        action_name=str(module_slug),
+                        action_module=str(module_slug),
+                        status=action_status,
+                        result=result_payload,
+                        error_message=str(action_error) if action_error else None,
+                        context=context,
                     )
                 else:
                     result_payload = {"status": "skipped", "reason": "No action module configured"}

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -3428,6 +3428,12 @@ async def _invoke_create_ticket(
     if external_reference is not None:
         external_reference = str(external_reference).strip() or None
     
+    try:
+        existing = await tickets_repo.get_ticket(ticket_id_int)
+    except RuntimeError:
+        existing = None
+    previous_description = existing.get("description") if existing else None
+
     # Create webhook event for tracking
     event = await webhook_monitor.create_manual_event(
         name="module.create-ticket.create",
@@ -4736,9 +4742,11 @@ async def _invoke_update_ticket(
             extra={"ticket_id": ticket_id_int},
         )
     
+    previous_values = {field: existing.get(field) for field in update_fields.keys()}
     response_body = json.dumps({
         "ticket_id": ticket_id_int,
         "updated_fields": list(update_fields.keys()),
+        "previous_values": previous_values,
     })
     updated_event = await _record_success(
         event_id,
@@ -4751,6 +4759,7 @@ async def _invoke_update_ticket(
         extra={
             "ticket_id": ticket_id_int,
             "updated_fields": list(update_fields.keys()),
+            "previous_values": previous_values,
         },
     )
 
@@ -4793,6 +4802,13 @@ async def _invoke_update_ticket_description(
     description = payload.get("description")
     if description is not None:
         description = str(description)
+
+    from app.repositories import tickets as tickets_repo
+    try:
+        existing = await tickets_repo.get_ticket(ticket_id_int)
+    except RuntimeError:
+        existing = None
+    previous_description = existing.get("description") if existing else None
     
     # Create webhook event for tracking
     event = await webhook_monitor.create_manual_event(
@@ -4842,7 +4858,12 @@ async def _invoke_update_ticket_description(
     )
     return _build_event_result(
         updated_event,
-        extra={"ticket_id": ticket_id_int, "description_updated": True},
+        extra={
+            "ticket_id": ticket_id_int,
+            "description_updated": True,
+            "previous_values": {"description": previous_description},
+            "updated_fields": ["description"],
+        },
     )
 
 

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -2590,3 +2590,87 @@
     initialiseAutomationUI();
   }
 })();
+
+(function () {
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function formatDate(value) {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return escapeHtml(value);
+    return date.toLocaleString();
+  }
+
+  function formatJson(value) {
+    if (value === null || value === undefined || value === '') return '—';
+    try {
+      return escapeHtml(JSON.stringify(value));
+    } catch (error) {
+      return escapeHtml(value);
+    }
+  }
+
+  function renderRows(tbody, rows) {
+    if (!tbody) return;
+    if (!Array.isArray(rows) || rows.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="6" class="table__empty">No history recorded for this automation yet.</td></tr>';
+      return;
+    }
+    tbody.innerHTML = rows.map((item) => {
+      const ticket = item.ticket_number || item.ticket_id || '—';
+      const action = item.action_name || item.action_module || '—';
+      const details = item.error_message || item.result_payload || null;
+      return `
+        <tr>
+          <td data-label="When" data-column-key="occurred_at">${formatDate(item.occurred_at)}</td>
+          <td data-label="Ticket" data-column-key="ticket">${escapeHtml(ticket)}</td>
+          <td data-label="Action" data-column-key="action">${escapeHtml(action)}</td>
+          <td data-label="Status" data-column-key="status">${escapeHtml(item.status || 'unknown')}</td>
+          <td data-label="Previous values" data-column-key="previous"><code>${formatJson(item.previous_values)}</code></td>
+          <td data-label="Details" data-column-key="details"><code>${formatJson(details)}</code></td>
+        </tr>`;
+    }).join('');
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const modal = document.getElementById('automation-history-modal');
+    const title = document.getElementById('automation-history-title');
+    const tbody = document.querySelector('[data-automation-history-rows]');
+    if (!modal || !tbody) return;
+
+    function openModal() { modal.hidden = false; }
+    function closeModal() { modal.hidden = true; }
+
+    document.querySelectorAll('[data-automation-history-close]').forEach((button) => {
+      button.addEventListener('click', closeModal);
+    });
+
+    document.querySelectorAll('[data-automation-history-open]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const automationId = button.getAttribute('data-automation-id');
+        const automationName = button.getAttribute('data-automation-name') || `#${automationId}`;
+        title.textContent = `Automation history: ${automationName}`;
+        tbody.innerHTML = '<tr><td colspan="6" class="table__empty">Loading history…</td></tr>';
+        openModal();
+        try {
+          const response = await fetch(`/admin/automations/${encodeURIComponent(automationId)}/history`, {
+            headers: { Accept: 'application/json' },
+            credentials: 'same-origin',
+          });
+          if (!response.ok) throw new Error(`Request failed with ${response.status}`);
+          const payload = await response.json();
+          renderRows(tbody, payload.history || []);
+        } catch (error) {
+          tbody.innerHTML = `<tr><td colspan="6" class="table__empty">Unable to load history: ${escapeHtml(error.message)}</td></tr>`;
+        }
+      });
+    });
+  });
+}());

--- a/app/templates/admin/automations.html
+++ b/app/templates/admin/automations.html
@@ -118,6 +118,9 @@
                           <li class="header-title-menu__item" role="none">
                             <a class="header-title-menu__link" role="menuitem" href="/admin/automations/{{ automation.id }}/edit">Edit</a>
                           </li>
+                          <li class="header-title-menu__item" role="none">
+                            <button type="button" class="header-title-menu__link" role="menuitem" data-automation-history-open data-automation-id="{{ automation.id }}" data-automation-name="{{ automation.name }}">History</button>
+                          </li>
                           {% if automation.kind == 'scheduled' %}
                           <li class="header-title-menu__item" role="none">
                             <a class="header-title-menu__link" role="menuitem" href="/admin/automations/{{ automation.id }}/preview">Preview tickets</a>
@@ -157,6 +160,44 @@
         </div>
       </div>
     </section>
+  </div>
+{% endblock %}
+
+
+{% block modals %}
+  {{ super() }}
+  <div class="modal" id="automation-history-modal" role="dialog" aria-modal="true" aria-labelledby="automation-history-title" hidden>
+    <div class="modal__backdrop" data-automation-history-close></div>
+    <div class="modal__panel modal__panel--wide">
+      <header class="modal__header">
+        <h2 class="modal__title" id="automation-history-title">Automation history</h2>
+        <button type="button" class="modal__close" data-automation-history-close aria-label="Close">×</button>
+      </header>
+      <div class="modal__body">
+        <div class="management__toolbar">
+          <div class="management__toolbar-search">
+            <input type="search" class="form-input" placeholder="Filter history" aria-label="Filter automation history" data-table-filter="automation-history-table" />
+          </div>
+        </div>
+        <div class="table-wrapper">
+          <table class="table" id="automation-history-table" data-table data-table-id="automation-history">
+            <thead>
+              <tr>
+                <th scope="col" data-sort="string" data-column-key="occurred_at">When</th>
+                <th scope="col" data-sort="string" data-column-key="ticket">Ticket</th>
+                <th scope="col" data-sort="string" data-column-key="action">Action</th>
+                <th scope="col" data-sort="string" data-column-key="status">Status</th>
+                <th scope="col" data-sort="string" data-column-key="previous">Previous values</th>
+                <th scope="col" data-sort="string" data-column-key="details">Details</th>
+              </tr>
+            </thead>
+            <tbody data-automation-history-rows>
+              <tr><td colspan="6" class="table__empty">Choose History from an automation action menu.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
   </div>
 {% endblock %}
 

--- a/migrations/270_automation_history.sql
+++ b/migrations/270_automation_history.sql
@@ -1,0 +1,22 @@
+-- Automation action history
+-- Stores one row per action/ticket change performed by automations.
+
+CREATE TABLE IF NOT EXISTS automation_history (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    automation_id INT NOT NULL,
+    automation_run_id INT NULL,
+    occurred_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    action_name VARCHAR(255) NOT NULL,
+    action_module VARCHAR(64) NULL,
+    ticket_id INT NULL,
+    ticket_number VARCHAR(64) NULL,
+    status VARCHAR(32) NOT NULL,
+    previous_values JSON NULL,
+    result_payload JSON NULL,
+    error_message TEXT NULL,
+    CONSTRAINT fk_automation_history_automation FOREIGN KEY (automation_id) REFERENCES automations(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_automation_history_automation_time ON automation_history (automation_id, occurred_at);
+CREATE INDEX IF NOT EXISTS idx_automation_history_ticket ON automation_history (ticket_id);
+CREATE INDEX IF NOT EXISTS idx_automation_history_status ON automation_history (status);


### PR DESCRIPTION
### Motivation
- Persist a detailed audit trail for every action performed by automations so admins can inspect what was done, when, and whether it succeeded. 
- Surface that history directly from the Automations action menu in the admin UI to make investigation and troubleshooting straightforward. 
- Capture useful context for ticket-related actions (ticket id/number, previous field values, module/result payload, error) to aid operators and avoid blind updates.

### Description
- Added a new migration `migrations/270_automation_history.sql` to create the `automation_history` table storing `occurred_at`, `action_name`, `action_module`, `ticket_id`/`ticket_number`, `status`, `previous_values`, `result_payload`, and `error_message`.
- Implemented repository helpers `record_history`, `list_history`, and `_normalise_history` in `app/repositories/automations.py` to persist and read history rows.
- Instrumented automation execution paths in `app/services/automations.py` by adding `_context_ticket_identity`, `_previous_values_from_result`, and `_record_action_history`, and calling these from both the multi-action and single-module execution flows so each action produces a history row (success or failure).
- Extended ticket-related module handlers in `app/services/modules.py` to include `previous_values` in results for update actions and to expose previous description for description edits so history contains previous field values.
- Exposed a new authenticated JSON endpoint `GET /admin/automations/{automation_id}/history` implemented in `app/features/automations/handlers.py` and registered in routes so the UI can load history for a specific automation.
- Added a `History` item to each automation row action menu and a modal in `app/templates/admin/automations.html` that shows one history item per row in a sortable/filterable table.
- Implemented client-side modal loading and rendering logic in `app/static/js/automation.js` with safe HTML escaping and local-time date formatting, and reused existing table filtering/sorting (`tables.js`).

### Testing
- Ran static compile checks with `python -m py_compile app/repositories/automations.py app/services/automations.py app/services/modules.py app/features/automations/handlers.py` and they succeeded.
- Ran the focused test suite `python -m pytest tests/test_ticket_automation_actions.py -q` and it passed (`15 passed`).
- Attempted to run the full test suite with `python -m pytest tests -q`, which aborted during collection due to unrelated pre-existing test/environment issues (a syntax error in `tests/test_companies_members_endpoint.py`, missing `respx` package, and missing imports in `app.main`), so full-suite verification could not be completed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3dbea9ed1c832d8309b517d219439d)