### PR TITLE
Fix RAG matching state key quoting

### DIFF
--- a/app/repositories/rag_relationships.py
+++ b/app/repositories/rag_relationships.py
@@ -266,7 +266,7 @@ async def metrics() -> dict[str, Any]:
 
 async def matching_paused() -> bool:
     row = await db.fetch_one(
-        "SELECT value FROM rag_matching_state WHERE key = 'paused'",
+        "SELECT value FROM rag_matching_state WHERE `key` = 'paused'",
         (),
     )
     return str((row or {}).get("value") or "0").lower() in {"1", "true", "yes"}
@@ -277,9 +277,9 @@ async def set_matching_paused(paused: bool) -> None:
     if db.is_sqlite():
         await db.execute(
             """
-            INSERT INTO rag_matching_state (key, value, updated_at)
+            INSERT INTO rag_matching_state (`key`, value, updated_at)
             VALUES ('paused', ?, CURRENT_TIMESTAMP)
-            ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP
+            ON CONFLICT(`key`) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP
             """,
             (value,),
         )

--- a/tests/test_rag_relationships.py
+++ b/tests/test_rag_relationships.py
@@ -1,3 +1,6 @@
+import pytest
+
+from app.repositories import rag_relationships as rag_relationships_repo
 from app.services.rag_relationships import (
     _relationship_response_payload,
     parse_relationship_response,
@@ -122,3 +125,40 @@ def test_relationship_queue_priority_prefers_ticket_pairs():
     assert _relationship_queue_priority(ticket, article) > _relationship_queue_priority(
         asset, article
     )
+
+
+@pytest.mark.anyio
+async def test_matching_paused_quotes_reserved_key_column(monkeypatch):
+    executed: list[tuple[str, tuple]] = []
+
+    async def fake_fetch_one(query, params=()):
+        executed.append((query, params))
+        return {"value": "1"}
+
+    monkeypatch.setattr(rag_relationships_repo.db, "fetch_one", fake_fetch_one)
+
+    assert await rag_relationships_repo.matching_paused() is True
+    query, params = executed[0]
+    assert "WHERE `key` = 'paused'" in query
+    assert "WHERE key = 'paused'" not in query
+    assert params == ()
+
+
+@pytest.mark.anyio
+async def test_set_matching_paused_quotes_reserved_key_column_for_sqlite(monkeypatch):
+    executed: list[tuple[str, tuple]] = []
+
+    def fake_is_sqlite():
+        return True
+
+    async def fake_execute(query, params=()):
+        executed.append((query, params))
+
+    monkeypatch.setattr(rag_relationships_repo.db, "is_sqlite", fake_is_sqlite)
+    monkeypatch.setattr(rag_relationships_repo.db, "execute", fake_execute)
+
+    await rag_relationships_repo.set_matching_paused(True)
+    query, params = executed[0]
+    assert "INSERT INTO rag_matching_state (`key`, value, updated_at)" in query
+    assert "ON CONFLICT(`key`)" in query
+    assert params == ("1",)


### PR DESCRIPTION
### Motivation
- MariaDB treated the unquoted identifier `key` in the `rag_matching_state` queries as reserved SQL syntax which caused a syntax error when loading RAG admin data.

### Description
- Quote the reserved column name in the repository by changing the read/upsert SQL to use `` `key` `` and add regression tests that assert the queries include the quoted identifier in `tests/test_rag_relationships.py`.

### Testing
- Ran `pytest -q tests/test_rag_relationships.py` which passed (10 tests passed) and verified `git diff --check` showed no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3dd0645ce8832d8a498a4f1468bd94)