### PR TITLE
Expose RAG maintenance commands in Scheduled Tasks UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5693,6 +5693,11 @@ async def admin_scheduled_tasks(
         {"value": "queue_transcriptions", "label": "Queue transcriptions"},
         {"value": "process_transcription", "label": "Process transcription"},
         {"value": "update_tray_icon_installer", "label": "Update Tray Icon Installer"},
+        {"value": "rag_index_start", "label": "RAG start indexing"},
+        {"value": "rag_index_stop", "label": "RAG stop indexing"},
+        {"value": "rag_matching_pause", "label": "RAG pause matching"},
+        {"value": "rag_matching_resume", "label": "RAG resume matching"},
+        {"value": "rag_cleanup_stale_matches", "label": "RAG cleanup stale matches"},
     ]
     command_options = [o for o in command_options if o["value"] not in disabled_commands_global]
     existing_commands = {task.get("command") for task in tasks if task.get("command")}

--- a/tests/test_admin_scheduled_tasks_page.py
+++ b/tests/test_admin_scheduled_tasks_page.py
@@ -186,6 +186,33 @@ def test_scheduled_tasks_page_renders_tasks(super_admin_context, monkeypatch):
     assert 'data-task-create' in header_html
 
 
+def test_scheduled_tasks_page_offers_rag_control_commands(super_admin_context, monkeypatch):
+    """The create/edit modal exposes optional RAG maintenance commands even when no task exists yet."""
+
+    async def fake_list_tasks(include_inactive=False):
+        return []
+
+    async def fake_list_companies():
+        return []
+
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "list_tasks", fake_list_tasks)
+    monkeypatch.setattr(main_module.company_repo, "list_companies", fake_list_companies)
+
+    with TestClient(app) as client:
+        response = client.get("/admin/scheduled-tasks")
+
+    assert response.status_code == 200
+    html = response.text
+    for value, label in [
+        ("rag_index_start", "RAG start indexing"),
+        ("rag_index_stop", "RAG stop indexing"),
+        ("rag_matching_pause", "RAG pause matching"),
+        ("rag_matching_resume", "RAG resume matching"),
+        ("rag_cleanup_stale_matches", "RAG cleanup stale matches"),
+    ]:
+        assert f'<option value="{value}">{label}</option>' in html
+
+
 def test_scheduled_tasks_page_empty(super_admin_context, monkeypatch):
     """Test that the page shows an empty state when no tasks are configured."""
 


### PR DESCRIPTION
### Motivation
- Administrators need the ability to optionally schedule RAG maintenance (start/stop indexing, pause/resume matching, cleanup stale matches) from the Scheduled Tasks UI even when the corresponding seeded tasks are inactive or not present.
- Make the create/edit scheduled-task modal list these RAG control commands so admins can create their own schedules without requiring DB-seeded task records to be active first.

### Description
- Added the RAG maintenance command options (`rag_index_start`, `rag_index_stop`, `rag_matching_pause`, `rag_matching_resume`, `rag_cleanup_stale_matches`) to the scheduled task `command_options` shown on the admin scheduled tasks page in `app/main.py`.
- Added a regression test `test_scheduled_tasks_page_offers_rag_control_commands` to `tests/test_admin_scheduled_tasks_page.py` to assert the modal exposes these options even when `scheduled_tasks` is empty.
- This change is UI/templating only and leverages existing scheduler command handling; no scheduler runtime logic was modified.

### Testing
- Ran `python -m compileall app/main.py` to ensure syntax validity for the modified module, and it succeeded.
- Ran the focused regression `pytest -q tests/test_admin_scheduled_tasks_page.py::test_scheduled_tasks_page_offers_rag_control_commands -q` and it passed.
- A broader run of `pytest -q tests/test_admin_scheduled_tasks_page.py -q` was attempted but produced unrelated/startup environment failures (database pool and startup side-effects); those failures are pre-existing and not caused by these UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3df03e7a80832db532c5d8f00e9872)