### PR TITLE
Fix Xero token refresh race

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -45,6 +45,9 @@ _TACTICALRMM_RATE_LIMIT_LOCK = asyncio.Lock()
 _TACTICALRMM_LAST_REQUEST_AT: float | None = None
 _TACTICALRMM_DEFAULT_CALLS_PER_SECOND = 1.0
 
+_XERO_TOKEN_REFRESH_LOCK = asyncio.Lock()
+_XERO_TOKEN_EXPIRY_BUFFER = timedelta(minutes=5)
+
 
 # Module slug constants
 XERO_MODULE_SLUG = "xero"
@@ -292,6 +295,24 @@ async def refresh_xero_access_token() -> str:
     return access_token
 
 
+def _xero_cached_access_token(credentials: Mapping[str, Any] | None) -> str | None:
+    """Return the cached Xero access token when it is safely reusable."""
+    if not credentials:
+        return None
+
+    access_token = str(credentials.get("access_token", "")).strip()
+    token_expires_at = credentials.get("token_expires_at")
+    if not (access_token and isinstance(token_expires_at, datetime)):
+        return None
+
+    if token_expires_at.tzinfo is None:
+        token_expires_at = token_expires_at.replace(tzinfo=timezone.utc)
+
+    if datetime.now(timezone.utc) + _XERO_TOKEN_EXPIRY_BUFFER < token_expires_at:
+        return access_token
+    return None
+
+
 async def acquire_xero_access_token() -> str:
     """Get a valid Xero access token, refreshing if necessary.
     
@@ -304,26 +325,25 @@ async def acquire_xero_access_token() -> str:
     credentials = await get_xero_credentials()
     if not credentials:
         raise RuntimeError("Xero credentials not configured")
-    
-    access_token = credentials.get("access_token", "").strip()
-    token_expires_at = credentials.get("token_expires_at")
-    
-    # Check if we have a valid token
-    if access_token and token_expires_at:
-        # Add 5 minute buffer before expiry
-        now = datetime.now(timezone.utc)
-        buffer_time = timedelta(minutes=5)
-        
-        # Ensure token_expires_at is timezone-aware
-        if token_expires_at.tzinfo is None:
-            token_expires_at = token_expires_at.replace(tzinfo=timezone.utc)
-        
-        if now + buffer_time < token_expires_at:
-            # Token is still valid
-            return access_token
-    
-    # Token is missing or expired, refresh it
-    return await refresh_xero_access_token()
+
+    cached_token = _xero_cached_access_token(credentials)
+    if cached_token:
+        return cached_token
+
+    # Xero rotates refresh tokens. Serialise refreshes and re-read the token
+    # after waiting so a concurrent request does not reuse an already-rotated
+    # refresh token and poison the integration with intermittent invalid_grant
+    # failures.
+    async with _XERO_TOKEN_REFRESH_LOCK:
+        refreshed_credentials = await get_xero_credentials()
+        if not refreshed_credentials:
+            raise RuntimeError("Xero credentials not configured")
+
+        cached_token = _xero_cached_access_token(refreshed_credentials)
+        if cached_token:
+            return cached_token
+
+        return await refresh_xero_access_token()
 
 
 def _merge_settings(defaults: Mapping[str, Any], overrides: Mapping[str, Any] | None) -> dict[str, Any]:

--- a/tests/test_xero_module.py
+++ b/tests/test_xero_module.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1084,3 +1084,43 @@ async def test_sync_company_uses_existing_contact_when_xero_id_missing():
     posted_body = post_call[1]["json"] if "json" in post_call[1] else post_call[0][1]
     invoice = posted_body["Invoices"][0]
     assert invoice["Contact"].get("ContactID") == "xero-contact-abc"
+
+@pytest.mark.anyio("asyncio")
+async def test_acquire_xero_access_token_rechecks_cache_after_refresh_lock(monkeypatch):
+    """Waiting requests must not reuse a Xero refresh token rotated by another request."""
+    expired_credentials = {
+        "access_token": "expired-access-token",
+        "token_expires_at": datetime(2026, 6, 30, tzinfo=timezone.utc),
+    }
+    valid_credentials = {
+        "access_token": "fresh-access-token",
+        "token_expires_at": (
+            datetime.now(timezone.utc)
+            + modules_service._XERO_TOKEN_EXPIRY_BUFFER
+            + timedelta(minutes=10)
+        ),
+    }
+    calls = 0
+
+    async def fake_get_xero_credentials():
+        nonlocal calls
+        calls += 1
+        return expired_credentials if calls == 1 else valid_credentials
+
+    refresh = AsyncMock(return_value="should-not-be-used")
+    lock = modules_service.asyncio.Lock()
+    await lock.acquire()
+
+    monkeypatch.setattr(modules_service, "get_xero_credentials", fake_get_xero_credentials)
+    monkeypatch.setattr(modules_service, "refresh_xero_access_token", refresh)
+    monkeypatch.setattr(modules_service, "_XERO_TOKEN_REFRESH_LOCK", lock)
+
+    task = modules_service.asyncio.create_task(modules_service.acquire_xero_access_token())
+    await modules_service.asyncio.sleep(0)
+    lock.release()
+
+    token = await task
+
+    assert token == "fresh-access-token"
+    assert calls == 2
+    refresh.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Concurrent requests could trigger Xero refresh-token rotation races where multiple callers try to exchange the same refresh token, causing intermittent `invalid_grant` failures and broken integration. 
- Ensure waiting callers can pick up a freshly-stored access token instead of attempting a redundant refresh with an already-rotated refresh token.

### Description
- Added a module-level lock ` _XERO_TOKEN_REFRESH_LOCK` and expiry buffer ` _XERO_TOKEN_EXPIRY_BUFFER` to serialize refresh attempts and define a safe reuse window for access tokens. 
- Introduced helper ` _xero_cached_access_token(credentials)` to centralise cached-token validity checks using the expiry buffer. 
- Updated `acquire_xero_access_token()` to return a cached token when valid, to acquire the refresh lock for serialising refreshes, and to re-read credentials after acquiring the lock so waiting callers reuse a newly-stored token instead of calling the refresh flow. 
- Added regression test `test_acquire_xero_access_token_rechecks_cache_after_refresh_lock` in `tests/test_xero_module.py` to verify waiting requests re-check the cache and do not call `refresh_xero_access_token` if a fresh token was stored.

### Testing
- Ran `pytest -q tests/test_xero_module.py -q` and the test suite for that file completed successfully. 
- Executed the new focused test `pytest -q tests/test_xero_module.py::test_acquire_xero_access_token_rechecks_cache_after_refresh_lock -q` and it passed. 
- Verified Python syntax with `python -m py_compile app/services/modules.py tests/test_xero_module.py` which succeeded. 
- Checked there were no whitespace/format issues with `git diff --check` (no problems reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a432c1513bc832d9d9449a8348015d0)