### PR TITLE
Debounce scheduled tasks to prevent duplicate runs and add run-history check with tests

### DIFF
--- a/app/repositories/scheduled_tasks.py
+++ b/app/repositories/scheduled_tasks.py
@@ -215,6 +215,21 @@ async def set_task_active(task_id: int, active: bool) -> dict[str, Any] | None:
     return await get_task(task_id)
 
 
+async def has_run_since(task_id: int, since: datetime) -> bool:
+    """Return whether *task_id* has a recorded run at or after *since*."""
+    row = await db.fetch_one(
+        """
+        SELECT id
+        FROM scheduled_task_runs
+        WHERE task_id = %s AND started_at >= %s
+        ORDER BY started_at DESC
+        LIMIT 1
+        """,
+        (task_id, since.replace(tzinfo=None)),
+    )
+    return bool(row)
+
+
 async def record_task_run(
     task_id: int,
     *,

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -5,7 +5,7 @@ import json
 import os
 import re
 from asyncio.subprocess import PIPE
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -582,6 +582,28 @@ class SchedulerService:
             if not lock_acquired:
                 # Another worker is already executing this task, skip silently
                 return
+
+            if not force_restart:
+                debounce_cutoff = datetime.now(timezone.utc) - timedelta(seconds=55)
+                try:
+                    recently_ran = await scheduled_tasks_repo.has_run_since(
+                        int(task_id), debounce_cutoff
+                    )
+                except Exception as exc:  # pragma: no cover - keep scheduler resilient
+                    recently_ran = False
+                    log_error(
+                        "Scheduled task duplicate-run check failed",
+                        task_id=task_id,
+                        command=command,
+                        error=str(exc),
+                    )
+                if recently_ran:
+                    log_info(
+                        "Skipping duplicate scheduled task fire",
+                        task_id=task_id,
+                        command=command,
+                    )
+                    return
 
             log_info("Running scheduled task", task_id=task_id, command=command)
             started_at = datetime.now(timezone.utc)

--- a/tests/test_scheduler_duplicate_runs.py
+++ b/tests/test_scheduler_duplicate_runs.py
@@ -1,0 +1,71 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+DUPLICATE_GUARDED_COMMANDS = [
+    (
+        "generate_invoice",
+        "app.services.scheduler.invoice_generator_service.generate_invoice",
+    ),
+    (
+        "sync_to_xero",
+        "app.services.scheduler.xero_service.sync_company",
+    ),
+    (
+        "sync_to_xero_auto_send",
+        "app.services.scheduler.xero_service.sync_company",
+    ),
+]
+
+
+@pytest.mark.parametrize(("command", "service_path"), DUPLICATE_GUARDED_COMMANDS)
+def test_scheduled_task_skips_duplicate_fire_within_same_minute(command, service_path):
+    asyncio.run(_run_duplicate_skip_case(command, service_path))
+
+
+async def _run_duplicate_skip_case(command, service_path):
+    from app.services.scheduler import SchedulerService
+
+    scheduler = SchedulerService()
+    task = {"id": 123, "command": command, "company_id": 86, "cron": "6 2 * * *"}
+
+    with (
+        patch("app.services.scheduler.db.acquire_lock") as mock_lock,
+        patch("app.services.scheduler.scheduled_tasks_repo.has_run_since", new_callable=AsyncMock, return_value=True) as mock_has_run_since,
+        patch(service_path, new_callable=AsyncMock) as mock_service,
+        patch("app.services.scheduler.scheduled_tasks_repo.record_task_run", new_callable=AsyncMock) as mock_record,
+    ):
+        mock_lock.return_value.__aenter__.return_value = True
+
+        await scheduler._run_task(task)
+
+    mock_has_run_since.assert_awaited_once()
+    mock_service.assert_not_awaited()
+    mock_record.assert_not_awaited()
+
+
+def test_run_now_bypasses_duplicate_fire_debounce():
+    asyncio.run(_run_force_restart_case())
+
+
+async def _run_force_restart_case():
+    from app.services.scheduler import SchedulerService
+
+    scheduler = SchedulerService()
+    task = {"id": 123, "command": "generate_invoice", "company_id": 86, "cron": "6 2 * * *"}
+
+    with (
+        patch("app.services.scheduler.db.acquire_lock") as mock_lock,
+        patch("app.services.scheduler.scheduled_tasks_repo.has_run_since", new_callable=AsyncMock, return_value=True) as mock_has_run_since,
+        patch("app.services.scheduler.invoice_generator_service.generate_invoice", new_callable=AsyncMock, return_value={"status": "skipped"}) as mock_generate,
+        patch("app.services.scheduler.scheduled_tasks_repo.record_task_run", new_callable=AsyncMock) as mock_record,
+    ):
+        mock_lock.return_value.__aenter__.return_value = True
+
+        await scheduler._run_task(task, force_restart=True)
+
+    mock_has_run_since.assert_not_awaited()
+    mock_generate.assert_awaited_once_with(86)
+    mock_record.assert_awaited_once()


### PR DESCRIPTION
### Motivation
- Prevent the scheduler from executing the same scheduled task multiple times in rapid succession when multiple workers or triggers fire around the same time.

### Description
- Added `has_run_since(task_id: int, since: datetime) -> bool` to `app/repositories/scheduled_tasks.py` to check whether a task has a recorded run at or after a given timestamp.
- Added debounce logic in `SchedulerService._run_task` to skip execution if `has_run_since` indicates the task ran within the last 55 seconds, while preserving a `force_restart` bypass.
- Updated imports in `app/services/scheduler.py` to include `timedelta` and adjusted the duplicate-check to use `datetime.now(timezone.utc) - timedelta(seconds=55)`.
- Added `tests/test_scheduler_duplicate_runs.py` which verifies that duplicate guarded commands are skipped when recently run and that `force_restart=True` bypasses the debounce.

### Testing
- Ran the new test module with `pytest tests/test_scheduler_duplicate_runs.py`; all tests passed (duplicate-skip case and force-restart bypass succeeded).
- The tests exercise the `has_run_since` call, ensure guarded services are not invoked when a recent run exists, and ensure `record_task_run` is not called on skipped runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a432c837a04832db8cad0d50fa7f04c)