### PR TITLE
Show invoice creation timestamps

### DIFF
--- a/app/features/invoices/routes.py
+++ b/app/features/invoices/routes.py
@@ -95,6 +95,14 @@ async def invoices_page(request: Request):
         if status_slug == "paid":
             paid_count += 1
         status_class = _STATUS_CLASS_MAP.get(status_slug, "status--invited" if status_slug else "")
+        created_value = record.get("created_at")
+        created_iso = ""
+        created_display = None
+        if isinstance(created_value, datetime):
+            if created_value.tzinfo is None:
+                created_value = created_value.replace(tzinfo=timezone.utc)
+            created_iso = created_value.astimezone(timezone.utc).isoformat()
+            created_display = created_iso
         due_value = record.get("due_date")
         if isinstance(due_value, datetime):
             due_value = due_value.date()
@@ -110,6 +118,9 @@ async def invoices_page(request: Request):
             | {
                 "amount": amount_decimal,
                 "amount_display": f"${amount_decimal:,.2f}",
+                "created_display": created_display,
+                "created_iso": created_iso,
+                "created_sort": created_iso,
                 "due_display": due_display,
                 "due_iso": due_iso,
                 "due_sort": due_iso,
@@ -158,6 +169,14 @@ async def invoice_detail_page(request: Request, invoice_id: int):
         status_slug = "xero"
         status_text_raw = "Xero"
     status_class = _STATUS_CLASS_MAP.get(status_slug, "status--invited" if status_slug else "")
+    created_value = invoice.get("created_at")
+    created_iso = ""
+    created_display = None
+    if isinstance(created_value, datetime):
+        if created_value.tzinfo is None:
+            created_value = created_value.replace(tzinfo=timezone.utc)
+        created_iso = created_value.astimezone(timezone.utc).isoformat()
+        created_display = created_iso
     due_value = invoice.get("due_date")
     if isinstance(due_value, datetime):
         due_value = due_value.date()
@@ -197,6 +216,8 @@ async def invoice_detail_page(request: Request, invoice_id: int):
         | {
             "amount": amount_decimal,
             "amount_display": f"${amount_decimal:,.2f}",
+            "created_display": created_display,
+            "created_iso": created_iso,
             "due_display": due_display,
             "status_display": status_text_raw.title() if status_text_raw else "—",
             "status_class": status_class,

--- a/app/repositories/invoices.py
+++ b/app/repositories/invoices.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Any, Optional
 
@@ -21,9 +21,13 @@ def _normalise_invoice(row: dict[str, Any]) -> dict[str, Any]:
         invoice["due_date"] = due_date.date()
     elif due_date is None or isinstance(due_date, date):
         invoice["due_date"] = due_date
-    synced_at = invoice.get("synced_to_xero_at")
-    if synced_at is not None and not isinstance(synced_at, datetime):
-        invoice["synced_to_xero_at"] = datetime.fromisoformat(str(synced_at))
+    for key in ("created_at", "synced_to_xero_at"):
+        value = invoice.get(key)
+        if value is not None and not isinstance(value, datetime):
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+            invoice[key] = parsed
+        if isinstance(invoice.get(key), datetime) and invoice[key].tzinfo is None:
+            invoice[key] = invoice[key].replace(tzinfo=timezone.utc)
     return invoice
 
 
@@ -64,10 +68,10 @@ async def create_invoice(
 ) -> dict[str, Any]:
     invoice_id = await db.execute_returning_lastrowid(
         """
-        INSERT INTO invoices (company_id, invoice_number, amount, due_date, status)
-        VALUES (%s, %s, %s, %s, %s)
+        INSERT INTO invoices (company_id, invoice_number, amount, due_date, status, created_at)
+        VALUES (%s, %s, %s, %s, %s, %s)
         """,
-        (company_id, invoice_number, amount, due_date, status),
+        (company_id, invoice_number, amount, due_date, status, datetime.now(timezone.utc)),
     )
     if not invoice_id:
         raise RuntimeError("Failed to create invoice")

--- a/app/schemas/invoices.py
+++ b/app/schemas/invoices.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 
 from pydantic import BaseModel, Field
@@ -43,5 +43,6 @@ class InvoiceResponse(BaseModel):
     amount: Decimal
     due_date: date | None = Field(default=None, alias="dueDate")
     status: str | None
+    created_at: datetime | None = Field(default=None, alias="createdAt")
 
     model_config = {"populate_by_name": True}

--- a/app/templates/invoices/detail.html
+++ b/app/templates/invoices/detail.html
@@ -19,7 +19,8 @@
         <h2 class="card__title">{{ invoice.invoice_number }}</h2>
         <p class="card__subtitle">
           {% if company %}{{ company.name }} · {% endif %}
-          {% if invoice.due_display %}Due {{ invoice.due_display }}{% else %}No due date{% endif %}
+          Created {% if invoice.created_display %}<span data-utc="{{ invoice.created_iso }}">{{ invoice.created_display }}</span>{% else %}unknown{% endif %}
+          · {% if invoice.due_display %}Due {{ invoice.due_display }}{% else %}No due date{% endif %}
         </p>
       </div>
       <div class="card__controls">

--- a/app/templates/invoices/index.html
+++ b/app/templates/invoices/index.html
@@ -49,6 +49,7 @@
           <tr>
             <th scope="col" data-sort="string" data-mobile-priority="essential">Invoice #</th>
             <th scope="col" data-sort="number" data-mobile-priority="essential">Amount</th>
+            <th scope="col" data-sort="date" data-mobile-priority="essential">Created</th>
             <th scope="col" data-sort="date" data-mobile-priority="essential">Due date</th>
             <th scope="col" data-sort="string" data-mobile-priority="essential">Status</th>
             {% if can_delete_invoices %}<th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>{% endif %}
@@ -61,6 +62,13 @@
               <a href="/invoices/{{ invoice.id }}" class="link">{{ invoice.invoice_number }}</a>
             </td>
             <td data-label="Amount" data-value="{{ invoice.amount }}">{{ invoice.amount_display }}</td>
+            <td data-label="Created" data-value="{{ invoice.created_sort }}" data-utc="{{ invoice.created_iso }}">
+              {% if invoice.created_display %}
+                {{ invoice.created_display }}
+              {% else %}
+                <span class="text-muted">Unknown</span>
+              {% endif %}
+            </td>
             <td data-label="Due date" data-value="{{ invoice.due_sort }}" data-utc="{{ invoice.due_iso }}">
               {% if invoice.due_display %}
                 {{ invoice.due_display }}

--- a/migrations/281_add_invoice_created_at.sql
+++ b/migrations/281_add_invoice_created_at.sql
@@ -1,0 +1,6 @@
+ALTER TABLE invoices
+    ADD COLUMN created_at DATETIME NULL;
+
+UPDATE invoices
+SET created_at = CURRENT_TIMESTAMP
+WHERE created_at IS NULL;


### PR DESCRIPTION
### Motivation
- The invoices list and detail pages must display when an invoice was created so users can see invoice timestamps.  
- Store and expose a UTC `created_at` timestamp from creation and render it client-side in local time using existing `data-utc` conversion logic.

### Description
- Add migration `migrations/281_add_invoice_created_at.sql` to add a nullable `created_at` column and backfill existing rows.  
- Persist `created_at` on new invoices in `app/repositories/invoices.py` and normalize/parses `created_at` as an aware UTC `datetime`.  
- Expose the field in the API by adding `createdAt` to `InvoiceResponse` in `app/schemas/invoices.py`.  
- Include `created_display`, `created_iso`, and `created_sort` in the invoices page and invoice detail context in `app/features/invoices/routes.py` and render the created timestamp in `app/templates/invoices/index.html` and `app/templates/invoices/detail.html` using the existing `data-utc` localiser.

### Testing
- Ran `python3 -m compileall app/repositories/invoices.py app/features/invoices/routes.py app/schemas/invoices.py` and compilation succeeded.  
- Validated the schema by instantiating `InvoiceResponse` with a UTC `created_at` and confirmed `createdAt` is returned (Pydantic validation succeeded).  
- Executed an in-memory SQLite script to apply `migrations/281_add_invoice_created_at.sql` and confirmed existing rows are backfilled (`sqlite` migration test succeeded).  
- Attempted to start the app with `uvicorn app.main:app` to capture a UI screenshot but the full app startup failed due to unrelated pre-existing migration compatibility issues in the local SQLite path, so the UI screenshot was not captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a432cb49078832daaa13d9bc9a88aca)