### PR TITLE
Default ticket time entries to configured default labour type

### DIFF
--- a/app/repositories/call_recordings.py
+++ b/app/repositories/call_recordings.py
@@ -7,6 +7,24 @@ from app.core.database import db
 from app.core.phone_utils import normalize_to_e164
 
 
+async def _get_default_labour_type_id() -> int | None:
+    row = await db.fetch_one(
+        """
+        SELECT id
+        FROM ticket_labour_types
+        WHERE is_default = 1
+        LIMIT 1
+        """,
+        (),
+    )
+    if not row:
+        return None
+    try:
+        return int(row.get("id"))
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
 def _ensure_utc(value: datetime | None) -> datetime | None:
     if value is None:
         return None
@@ -367,6 +385,11 @@ async def update_call_recording(
     if labour_type_id is not None:
         updates.append("labour_type_id = %s")
         params.append(labour_type_id)
+    elif minutes_spent is not None and minutes_spent > 0:
+        default_labour_type_id = await _get_default_labour_type_id()
+        if default_labour_type_id is not None:
+            updates.append("labour_type_id = %s")
+            params.append(default_labour_type_id)
     
     if not updates:
         # No updates to perform

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -14,6 +14,35 @@ _UNSET = object()
 _FULLTEXT_MIN_SEARCH_LENGTH = 3
 
 
+async def _get_default_labour_type_id() -> int | None:
+    row = await db.fetch_one(
+        """
+        SELECT id
+        FROM ticket_labour_types
+        WHERE is_default = 1
+        LIMIT 1
+        """,
+        (),
+    )
+    if not row:
+        return None
+    try:
+        return int(row.get("id"))
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+async def _default_labour_type_for_time_entry(
+    minutes_spent: int | None,
+    labour_type_id: int | None,
+) -> int | None:
+    if labour_type_id is not None:
+        return labour_type_id
+    if minutes_spent is None or minutes_spent <= 0:
+        return None
+    return await _get_default_labour_type_id()
+
+
 def _prepare_ticket_search_term(search: str | None) -> tuple[str | None, str | None]:
     term = (search or "").strip()
     if not term:
@@ -1054,6 +1083,8 @@ async def create_reply(
     created_at: datetime | None = None,
     labour_type_id: int | None = None,
 ) -> TicketRecord:
+    labour_type_id = await _default_labour_type_for_time_entry(minutes_spent, labour_type_id)
+
     log_info(
         "Creating ticket reply",
         ticket_id=ticket_id,
@@ -1299,13 +1330,32 @@ async def update_reply(
     if is_billable is not _UNSET:
         updates.append("is_billable = %s")
         params.append(1 if bool(is_billable) else 0)
-    if labour_type_id is not _UNSET:
-        if labour_type_id is None:
-            updates.append("labour_type_id = NULL")
-        else:
-            updates.append("labour_type_id = %s")
-            params.append(int(labour_type_id))
+    if labour_type_id is not _UNSET and labour_type_id is not None:
+        updates.append("labour_type_id = %s")
+        params.append(int(labour_type_id))
     if updates:
+        effective_minutes = minutes_spent
+        effective_labour_type_id = labour_type_id
+        if effective_minutes is _UNSET or effective_labour_type_id is _UNSET:
+            current = await get_reply_by_id(reply_id)
+            if effective_minutes is _UNSET:
+                current_minutes = current.get("minutes_spent") if current else None
+                effective_minutes = current_minutes if isinstance(current_minutes, int) else None
+            if effective_labour_type_id is _UNSET:
+                current_labour_type_id = current.get("labour_type_id") if current else None
+                effective_labour_type_id = (
+                    current_labour_type_id if isinstance(current_labour_type_id, int) else None
+                )
+        default_labour_type_id = await _default_labour_type_for_time_entry(
+            effective_minutes if isinstance(effective_minutes, int) else None,
+            effective_labour_type_id if isinstance(effective_labour_type_id, int) else None,
+        )
+        if effective_labour_type_id is None:
+            if default_labour_type_id is not None:
+                updates.append("labour_type_id = %s")
+                params.append(default_labour_type_id)
+            elif labour_type_id is None:
+                updates.append("labour_type_id = NULL")
         params.append(reply_id)
         await db.execute(
             f"""

--- a/tests/test_call_recordings_billing.py
+++ b/tests/test_call_recordings_billing.py
@@ -176,3 +176,36 @@ async def test_call_recording_schema_validation():
     assert response_schema.labour_type_id == 5
     assert response_schema.labour_type_name == "Remote Support"
     assert response_schema.labour_type_code == "RS"
+
+
+@pytest.mark.anyio
+async def test_update_call_recording_defaults_labour_type_for_time_entry():
+    """Call recording time entries use the selected default labour type when omitted."""
+    from app.repositories import call_recordings as repo
+
+    recording_id = 1
+    updated_recording = {
+        "id": recording_id,
+        "minutes_spent": 45,
+        "is_billable": True,
+        "labour_type_id": 9,
+    }
+
+    with patch.object(repo.db, "execute", new_callable=AsyncMock) as mock_execute, \
+         patch.object(repo.db, "fetch_one", new_callable=AsyncMock) as mock_fetch_one, \
+         patch.object(repo, "get_call_recording_by_id", new_callable=AsyncMock) as mock_get:
+        mock_fetch_one.return_value = {"id": 9}
+        mock_get.return_value = updated_recording
+
+        result = await repo.update_call_recording(
+            recording_id,
+            minutes_spent=45,
+            is_billable=True,
+            labour_type_id=None,
+        )
+
+        assert result["labour_type_id"] == 9
+        mock_fetch_one.assert_called_once()
+        sql, params = mock_execute.call_args[0]
+        assert "labour_type_id = %s" in sql
+        assert params == (45, 1, 9, recording_id)

--- a/tests/test_tickets_repository.py
+++ b/tests/test_tickets_repository.py
@@ -360,6 +360,7 @@ async def test_update_reply_updates_minutes_and_billable(monkeypatch):
         "is_internal": 0,
         "minutes_spent": 15,
         "is_billable": 1,
+        "labour_type_id": 6,
         "created_at": None,
     }
     dummy_db = _UpdateTicketDB(fetched)
@@ -572,3 +573,78 @@ def test_prepare_ticket_search_term_uses_fulltext_for_mysql(monkeypatch):
 
     assert mode == "fulltext"
     assert value == "+wireless* +mouse*"
+
+
+@pytest.mark.anyio
+async def test_create_reply_defaults_labour_type_for_time_entry(monkeypatch):
+    class _DefaultLabourDB(_DummyTicketDB):
+        async def fetch_one(self, sql, params=()):
+            sql_clean = sql.strip()
+            if "FROM ticket_labour_types" in sql_clean:
+                return {"id": 12}
+            self.fetch_sql = sql_clean
+            self.fetch_params = params
+            return self._fetched_row
+
+    fetched = {
+        "id": 42,
+        "ticket_id": 3,
+        "author_id": 4,
+        "body": "Reply",
+        "is_internal": 0,
+        "minutes_spent": 15,
+        "is_billable": 1,
+        "labour_type_id": 12,
+        "created_at": None,
+    }
+    dummy_db = _DefaultLabourDB(fetched)
+    monkeypatch.setattr(tickets, "db", dummy_db)
+
+    record = await tickets.create_reply(
+        ticket_id=3,
+        author_id=4,
+        body="Reply",
+        is_internal=False,
+        minutes_spent=15,
+        is_billable=True,
+        labour_type_id=None,
+    )
+
+    assert "labour_type_id" in dummy_db.insert_sql
+    assert dummy_db.insert_params == (3, 4, "Reply", 0, 1, 15, 12)
+    assert record["labour_type_id"] == 12
+
+
+@pytest.mark.anyio
+async def test_update_reply_defaults_labour_type_when_time_entry_has_none(monkeypatch):
+    class _DefaultLabourUpdateDB(_UpdateTicketDB):
+        def __init__(self):
+            super().__init__(
+                {
+                    "id": 7,
+                    "ticket_id": 3,
+                    "author_id": 4,
+                    "body": "Reply",
+                    "is_internal": 0,
+                    "minutes_spent": 15,
+                    "is_billable": 1,
+                    "labour_type_id": None,
+                    "created_at": None,
+                }
+            )
+
+        async def fetch_one(self, sql, params=()):
+            sql_clean = sql.strip()
+            if "FROM ticket_labour_types" in sql_clean:
+                return {"id": 12}
+            self.fetch_sql = sql_clean
+            self.fetch_params = params
+            return self._row
+
+    dummy_db = _DefaultLabourUpdateDB()
+    monkeypatch.setattr(tickets, "db", dummy_db)
+
+    await tickets.update_reply(7, minutes_spent=15, is_billable=True)
+
+    assert "labour_type_id = %s" in dummy_db.execute_sql
+    assert dummy_db.execute_params == (15, 1, 12, 7)


### PR DESCRIPTION
### Motivation
- Prevent ticket time entries from ending up with "No labour type" when minutes are recorded without an explicit labour type. 
- Ensure consistency across all sources of time entries (ticket replies and call recordings) by assigning the configured default labour type when appropriate. 
- Reduce manual fixes and improve billing correctness by automatically using the system default labour type for positive minute entries.

### Description
- Add `_get_default_labour_type_id` and `_default_labour_type_for_time_entry` helpers and use them to resolve a default labour type when minutes are present and none is specified in `app/repositories/tickets.py`. 
- Set the default labour type before inserting replies in `create_reply` and enhance `update_reply` to compute effective minutes/labour and apply the default (or NULL) as needed. 
- Apply the same defaulting behavior to call recording billing updates in `app/repositories/call_recordings.py` by setting the default labour type when `minutes_spent` is positive and `labour_type_id` is omitted. 
- Add regression tests covering reply creation, reply updates, and call recording updates without an explicit labour type in `tests/test_tickets_repository.py` and `tests/test_call_recordings_billing.py`.

### Testing
- Ran `pytest` for the modified test files including `tests/test_tickets_repository.py` and `tests/test_call_recordings_billing.py::test_update_call_recording_defaults_labour_type_for_time_entry`, and the tests passed. 
- Executed `python -m compileall app/repositories/tickets.py app/repositories/call_recordings.py` to verify modules compile cleanly. 
- Added and ran the new regression tests which validated defaulting behavior for `create_reply`, `update_reply`, and `update_call_recording` (all passing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4330e1a5f0832dbcc014b93950efe6)