### PR TITLE
Format invoice billable time as hours and minutes

### DIFF
--- a/app/services/billing_time.py
+++ b/app/services/billing_time.py
@@ -1,0 +1,20 @@
+"""Helpers for formatting billable time on invoice descriptions."""
+from __future__ import annotations
+
+
+def format_billable_minutes(minutes: int) -> str:
+    """Return a human-readable invoice duration for whole billable minutes.
+
+    Examples:
+        30 -> "30 Mins"
+        150 -> "2 Hours 30 Mins"
+    """
+    total_minutes = max(0, int(minutes))
+    hours, remaining_minutes = divmod(total_minutes, 60)
+
+    parts: list[str] = []
+    if hours:
+        parts.append(f"{hours} {'Hour' if hours == 1 else 'Hours'}")
+    if remaining_minutes or not parts:
+        parts.append(f"{remaining_minutes} {'Min' if remaining_minutes == 1 else 'Mins'}")
+    return " ".join(parts)

--- a/app/services/invoice_generator.py
+++ b/app/services/invoice_generator.py
@@ -16,6 +16,7 @@ from app.repositories import invoice_lines as invoice_lines_repo
 from app.repositories import invoices as invoice_repo
 from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import tickets as tickets_repo
+from app.services.billing_time import format_billable_minutes
 from app.services import xero as xero_service
 
 
@@ -148,13 +149,14 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
             if group_minutes <= 0:
                 continue
             hours_decimal = _minutes_to_hours(group_minutes)
+            duration_text = format_billable_minutes(group_minutes)
             labour_name = str(group.get("name") or "").strip()
             labour_code = str(group.get("code") or "").strip()
 
             if labour_name:
-                description = f"Ticket #{ticket_id}: {ticket_subject} — {labour_name} ({hours_decimal}h)"
+                description = f"Ticket #{ticket_id}: {ticket_subject} — {labour_name} ({duration_text})"
             else:
-                description = f"Ticket #{ticket_id}: {ticket_subject} ({hours_decimal}h)"
+                description = f"Ticket #{ticket_id}: {ticket_subject} ({duration_text})"
 
             local_rate = group.get("rate")
             rate: Decimal

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -557,7 +557,7 @@ def _default_xero_settings() -> dict[str, Any]:
         "reference_prefix": _clean_env("XERO_REFERENCE_PREFIX") or "Support",
         "billable_statuses": _normalise_statuses(_clean_env("XERO_BILLABLE_STATUSES")),
         "line_item_description_template": _clean_env("XERO_LINE_ITEM_TEMPLATE")
-        or "Ticket {ticket_id}: {ticket_subject}{labour_suffix}",
+        or "Ticket {ticket_id}: {ticket_subject}{labour_suffix} ({labour_duration})",
         "auto_create_products": _ensure_bool(os.getenv("XERO_AUTO_CREATE_PRODUCTS"), True),
     }
 
@@ -1483,7 +1483,7 @@ def _coerce_settings(
                 "line_item_description_template": str(
                     merged.get("line_item_description_template", "")
                 ).strip()
-                or "Ticket {ticket_id}: {ticket_subject}{labour_suffix}",
+                or "Ticket {ticket_id}: {ticket_subject}{labour_suffix} ({labour_duration})",
                 "auto_create_products": _ensure_bool(merged.get("auto_create_products"), True),
             }
         )

--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -20,6 +20,7 @@ from app.repositories import invoices as invoice_repo
 from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import users as users_repo
+from app.services.billing_time import format_billable_minutes
 from app.services import modules as modules_service
 from app.services import webhook_monitor
 
@@ -118,6 +119,7 @@ def _format_line_description(
     labour_code = str((labour or {}).get("code") or "").strip()
     labour_minutes = max(0, int(minutes))
     labour_hours_decimal = _minutes_to_hours(labour_minutes) if labour_minutes else Decimal("0")
+    labour_duration = format_billable_minutes(labour_minutes)
     values = _TemplateValues(
         ticket_id=ticket.get("id"),
         ticket_subject=subject,
@@ -126,6 +128,7 @@ def _format_line_description(
         labour_code=labour_code,
         labour_minutes=labour_minutes,
         labour_hours=float(_quantize(labour_hours_decimal)) if labour_minutes else 0.0,
+        labour_duration=labour_duration,
         labour_suffix=f" · {labour_name}" if labour_name else "",
         requester_name=requester_name,
         requester_email=requester_email,

--- a/docs/wiki/integrations/Xero Billable Tickets.md
+++ b/docs/wiki/integrations/Xero Billable Tickets.md
@@ -71,11 +71,12 @@ Available template variables:
 - `{labour_code}` - Code of the labour type
 - `{labour_minutes}` - Minutes spent on this labour type
 - `{labour_hours}` - Hours spent (decimal format)
+- `{labour_duration}` - Hours and minutes spent, for example `30 Mins` or `2 Hours 30 Mins`
 - `{labour_suffix}` - " · Labour Type Name" if present, empty otherwise
 
-Default template: `Ticket {ticket_id}: {ticket_subject}{labour_suffix}`
+Default template: `Ticket {ticket_id}: {ticket_subject}{labour_suffix} ({labour_duration})`
 
-Example custom template: `#{ticket_id} - {ticket_subject} - {labour_name} ({labour_hours}h)`
+Example custom template: `#{ticket_id} - {ticket_subject} - {labour_name} ({labour_duration})`
 
 ## How It Works
 

--- a/docs/wiki/integrations/Xero Integration.md
+++ b/docs/wiki/integrations/Xero Integration.md
@@ -65,16 +65,17 @@ extra line items instead of creating duplicate invoices. This keeps batched
 ticket runs grouped together without manual reconciliation.
 
 Each line item description is generated from a configurable template. The
-default mirrors the previous behaviour (`Ticket {ticket_id}: {ticket_subject}`),
+default includes the labour duration in hours and minutes
+(`Ticket {ticket_id}: {ticket_subject}{labour_suffix} ({labour_duration})`),
 and additional placeholders are available for labour-specific information:
 
 - `{ticket_id}`, `{ticket_subject}`, `{ticket_status}`
-- `{labour_name}`, `{labour_code}`, `{labour_minutes}`, `{labour_hours}`
+- `{labour_name}`, `{labour_code}`, `{labour_minutes}`, `{labour_hours}`, `{labour_duration}`
 - `{labour_suffix}` – resolves to ` · {labour_name}` when a labour type exists
 
 For example, setting the template to `Ticket #{ticket_id} - {ticket_subject} -
-{labour_name}` produces descriptions such as `Ticket #123 - Fix Computer -
-Remote`.
+{labour_name} ({labour_duration})` produces descriptions such as
+`Ticket #123 - Fix Computer - Remote (30 Mins)`.
 
 ## Quote sync
 

--- a/tests/test_invoice_generator.py
+++ b/tests/test_invoice_generator.py
@@ -200,6 +200,37 @@ def test_generate_invoice_recurring_items_only(monkeypatch):
     assert created_invoices[0]["company_id"] == 1
 
 
+def test_generate_invoice_billable_ticket_uses_hours_and_minutes(monkeypatch):
+    created_lines: list[dict[str, Any]] = []
+
+    async def fake_create_invoice(**kwargs):
+        return {"id": 202, **kwargs}
+
+    async def fake_create_line(**kwargs):
+        created_lines.append(kwargs)
+        return {"id": len(created_lines), **kwargs}
+
+    monkeypatch.setattr(invoice_generator.company_repo, "get_company_by_id", AsyncMock(return_value=_make_company()))
+    monkeypatch.setattr(invoice_generator.xero_service, "build_invoice_context", AsyncMock(return_value={}))
+    monkeypatch.setattr(invoice_generator.xero_service, "build_recurring_invoice_items", AsyncMock(return_value=[]))
+    monkeypatch.setattr(invoice_generator.tickets_repo, "list_tickets", AsyncMock(return_value=[{"id": 55, "subject": "VPN help"}]))
+    monkeypatch.setattr(invoice_generator.billed_time_repo, "get_unbilled_reply_ids", AsyncMock(return_value=[1, 2]))
+    monkeypatch.setattr(invoice_generator.tickets_repo, "list_replies", AsyncMock(return_value=[
+        {"id": 1, "minutes_spent": 120, "is_billable": True, "labour_type_name": "Remote", "labour_type_code": "REMOTE", "labour_type_rate": "100"},
+        {"id": 2, "minutes_spent": 30, "is_billable": True, "labour_type_name": "Remote", "labour_type_code": "REMOTE", "labour_type_rate": "100"},
+    ]))
+    monkeypatch.setattr(invoice_generator.invoice_repo, "create_invoice", fake_create_invoice)
+    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0))
+    monkeypatch.setattr(invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line)
+    monkeypatch.setattr(invoice_generator.billed_time_repo, "create_billed_time_entry", AsyncMock())
+    monkeypatch.setattr(invoice_generator.tickets_repo, "update_ticket", AsyncMock())
+
+    result = asyncio.run(invoice_generator.generate_invoice(1))
+
+    assert result["status"] == "succeeded"
+    assert created_lines[0]["description"] == "Ticket #55: VPN help — Remote (2 Hours 30 Mins)"
+
+
 # ---------------------------------------------------------------------------
 # get_max_invoice_seq helper in repository
 # ---------------------------------------------------------------------------

--- a/tests/test_xero_billable_tickets.py
+++ b/tests/test_xero_billable_tickets.py
@@ -268,7 +268,7 @@ async def test_build_ticket_invoices_uses_template():
     async def fake_fetch_company(company_id: int):
         return {"id": company_id, "name": "Test Corp", "xero_id": "xero-456"}
 
-    template = "#{ticket_id} - {ticket_subject} - {labour_name} ({labour_hours}h)"
+    template = "#{ticket_id} - {ticket_subject} - {labour_name} ({labour_duration})"
     
     invoices = await xero_service.build_ticket_invoices(
         [1],
@@ -286,11 +286,11 @@ async def test_build_ticket_invoices_uses_template():
     assert len(invoices) == 1
     line_item = invoices[0]["line_items"][0]
     
-    # Verify template was applied (45 min = 0.75 hr)
+    # Verify template was applied (45 min = 45 Mins)
     assert "#1" in line_item["Description"]
     assert "Email not working" in line_item["Description"]
     assert "Remote Support" in line_item["Description"]
-    assert "0.75" in line_item["Description"]
+    assert "45 Mins" in line_item["Description"]
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation
- Replace decimal-hour display (e.g. `(0.50h)`) on invoice line descriptions with a human-friendly Hours and Minutes format (e.g. `(30 Mins)` / `(2 Hours 30 Mins)`).
- Make the new formatted duration available to configurable Xero line item templates.

### Description
- Add `app/services/billing_time.py` with `format_billable_minutes(minutes: int) -> str` to render minutes as `30 Mins`, `2 Hours 30 Mins`, etc.
- Use `format_billable_minutes` when generating local invoice ticket line descriptions in `app/services/invoice_generator.py` so descriptions show `({labour_duration})` while leaving `Quantity` (decimal hours) unchanged for calculations.
- Add `labour_duration` to Xero template context in `app/services/xero.py` and update the default Xero description template in `app/services/modules.py` to include `({labour_duration})`.
- Update documentation (`docs/wiki/integrations/Xero Integration.md` and `docs/wiki/integrations/Xero Billable Tickets.md`) to document the new `{labour_duration}` placeholder and example templates.
- Add / update regression tests in `tests/test_invoice_generator.py` and `tests/test_xero_billable_tickets.py` to assert the new hours/minutes text appears in generated line descriptions.

### Testing
- Ran `pytest tests/test_invoice_generator.py tests/test_xero_billable_tickets.py -q` and all tests passed (`15 passed` for the affected suites). 
- Verified Python compilation with `python -m py_compile app/services/billing_time.py app/services/invoice_generator.py app/services/xero.py app/services/modules.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4336a7a9f4832da1cb3f223594a0bf)