### PR TITLE
Show Xero line item format in invoice preview

### DIFF
--- a/app/services/invoice_generator.py
+++ b/app/services/invoice_generator.py
@@ -16,7 +16,7 @@ from app.repositories import invoice_lines as invoice_lines_repo
 from app.repositories import invoices as invoice_repo
 from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import tickets as tickets_repo
-from app.services.billing_time import format_billable_minutes
+from app.services import modules as modules_service
 from app.services import xero as xero_service
 
 
@@ -38,6 +38,33 @@ def _to_decimal(value: Any) -> Decimal | None:
         return Decimal(str(value))
     except (InvalidOperation, TypeError, ValueError):
         return None
+
+
+async def _get_xero_line_item_template() -> str:
+    try:
+        settings = await modules_service.get_module_settings("xero") or {}
+    except RuntimeError:
+        return "Ticket {ticket_id}: {ticket_subject}{labour_suffix} ({labour_duration})"
+    return str(settings.get("line_item_description_template") or "").strip()
+
+
+def _build_ticket_line_description(
+    template: str,
+    ticket: dict[str, Any],
+    labour_group: dict[str, Any],
+    minutes: int,
+    *,
+    billable_minutes: int,
+    non_billable_minutes: int = 0,
+) -> str:
+    return xero_service._format_line_description(
+        template,
+        ticket,
+        labour_group,
+        minutes,
+        billable_minutes=billable_minutes,
+        non_billable_minutes=non_billable_minutes,
+    )
 
 
 async def _generate_invoice_number() -> str:
@@ -81,6 +108,8 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
         tax_type=None,
         context=context,
     )
+
+    line_item_template = await _get_xero_line_item_template()
 
     # Build ticket line items for billable tickets
     ticket_line_items: list[dict[str, Any]] = []
@@ -142,21 +171,20 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
             continue
 
         labour_groups = list(labour_map.values())
-        ticket_subject = str(ticket.get("subject") or "").strip()
-
         for group in labour_groups:
             group_minutes = int(group.get("minutes") or 0)
             if group_minutes <= 0:
                 continue
             hours_decimal = _minutes_to_hours(group_minutes)
-            duration_text = format_billable_minutes(group_minutes)
             labour_name = str(group.get("name") or "").strip()
             labour_code = str(group.get("code") or "").strip()
-
-            if labour_name:
-                description = f"Ticket #{ticket_id}: {ticket_subject} — {labour_name} ({duration_text})"
-            else:
-                description = f"Ticket #{ticket_id}: {ticket_subject} ({duration_text})"
+            description = _build_ticket_line_description(
+                line_item_template,
+                ticket,
+                group,
+                group_minutes,
+                billable_minutes=billable_minutes,
+            )
 
             local_rate = group.get("rate")
             rate: Decimal

--- a/app/services/scheduled_task_preview.py
+++ b/app/services/scheduled_task_preview.py
@@ -9,6 +9,7 @@ from app.repositories import invoices as invoice_repo
 from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import tickets as tickets_repo
 from app.services import invoice_generator as invoice_generator_service
+from app.services import modules as modules_service
 from app.services import subscription_price_changes
 from app.services import xero as xero_service
 
@@ -94,6 +95,11 @@ async def _preview_sync_to_xero(company_id: int, company: Mapping[str, Any], *, 
 
 
 async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        settings = await modules_service.get_module_settings("xero") or {}
+    except RuntimeError:
+        settings = {}
+    line_item_template = str(settings.get("line_item_description_template") or "").strip()
     context = await xero_service.build_invoice_context(company_id)
     recurring_items = await xero_service.build_recurring_invoice_items(company_id, tax_type=None, context=context)
     tickets = await tickets_repo.list_tickets(company_id=company_id, limit=1000)
@@ -111,14 +117,53 @@ async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any])
         if minutes <= 0:
             continue
         billable_reply_count += len([r for r in replies if r.get("id") in unbilled_ids and r.get("is_billable")])
-        ticket_items.append({
-            "type": "ticket",
-            "id": int(ticket_id),
-            "label": f"Ticket #{ticket_id}: {ticket.get('subject') or ''}".strip(),
-            "minutes": minutes,
-            "hours": str(invoice_generator_service._minutes_to_hours(minutes)),
-            "action": "Add billable ticket time to the generated invoice",
-        })
+        labour_map: dict[tuple[str | None, str | None], dict[str, Any]] = {}
+        for reply in replies:
+            if reply.get("id") not in unbilled_ids or not reply.get("is_billable"):
+                continue
+            reply_minutes = invoice_generator_service._coerce_minutes(reply.get("minutes_spent"))
+            if reply_minutes <= 0:
+                continue
+            labour_code = str(reply.get("labour_type_code") or "").strip() or None
+            labour_name = str(reply.get("labour_type_name") or "").strip() or None
+            labour_rate = reply.get("labour_type_rate")
+            key = (labour_code, labour_name)
+            bucket = labour_map.get(key)
+            if not bucket:
+                bucket = {"minutes": 0, "code": labour_code, "name": labour_name, "rate": labour_rate}
+                labour_map[key] = bucket
+            bucket["minutes"] += reply_minutes
+        for group in labour_map.values():
+            group_minutes = int(group.get("minutes") or 0)
+            if group_minutes <= 0:
+                continue
+            hours = invoice_generator_service._minutes_to_hours(group_minutes)
+            description = invoice_generator_service._build_ticket_line_description(
+                line_item_template,
+                ticket,
+                group,
+                group_minutes,
+                billable_minutes=minutes,
+            )
+            unit_amount = invoice_generator_service._to_decimal(group.get("rate")) or Decimal("0")
+            xero_line_item: dict[str, Any] = {
+                "Description": description,
+                "Quantity": float(hours),
+                "UnitAmount": float(unit_amount),
+            }
+            labour_code = str(group.get("code") or "").strip()
+            if labour_code:
+                xero_line_item["ItemCode"] = labour_code
+            ticket_items.append({
+                "type": "ticket",
+                "id": int(ticket_id),
+                "label": description,
+                "minutes": group_minutes,
+                "hours": str(hours),
+                "xeroLineItemTemplate": line_item_template or "Ticket {ticket_id}: {ticket_subject}{labour_suffix}",
+                "xeroLineItem": xero_line_item,
+                "action": "Add billable ticket time using this Xero line item format",
+            })
     recurring_total = sum(Decimal(str(i.get("Quantity") or 0)) * Decimal(str(i.get("UnitAmount") or 0)) for i in recurring_items)
     return {
         "status": "ready" if recurring_items or ticket_items else "skipped",
@@ -126,7 +171,7 @@ async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any])
         "company_id": company_id,
         "company_name": company.get("name") or f"Company #{company_id}",
         "summary": "A draft MyPortal invoice will be generated." if recurring_items or ticket_items else "No active recurring invoice items or billable tickets were found.",
-        "totals": {"recurringLineCount": len(recurring_items), "ticketCount": len(ticket_items), "billableReplyCount": billable_reply_count, "recurringAmount": _money(recurring_total)},
+        "totals": {"recurringLineCount": len(recurring_items), "ticketLineCount": len(ticket_items), "billableReplyCount": billable_reply_count, "recurringAmount": _money(recurring_total)},
         "items": [{"type": "recurring", "label": i.get("Description") or i.get("ItemCode") or "Recurring item", "amount": _money(Decimal(str(i.get("Quantity") or 0)) * Decimal(str(i.get("UnitAmount") or 0))), "action": "Add recurring line to the generated invoice"} for i in recurring_items] + ticket_items,
     }
 

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -1112,6 +1112,28 @@
   }
 
 
+  function humanizePreviewKey(key) {
+    return String(key || '')
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/^./, (char) => char.toUpperCase());
+  }
+
+  function formatPreviewValue(value) {
+    if (value === null || value === undefined || value === '') {
+      return '';
+    }
+    if (Array.isArray(value)) {
+      return value.map(formatPreviewValue).filter(Boolean).join(', ');
+    }
+    if (typeof value === 'object') {
+      return Object.entries(value)
+        .filter(([, nestedValue]) => nestedValue !== null && nestedValue !== undefined && nestedValue !== '')
+        .map(([nestedKey, nestedValue]) => `${humanizePreviewKey(nestedKey)}: ${formatPreviewValue(nestedValue)}`)
+        .join('; ');
+    }
+    return String(value);
+  }
+
   function formatPreviewDetails(item) {
     if (!item || typeof item !== 'object') {
       return '—';
@@ -1119,7 +1141,8 @@
     const hidden = new Set(['type', 'id', 'label', 'action']);
     return Object.entries(item)
       .filter(([key, value]) => !hidden.has(key) && value !== null && value !== undefined && value !== '')
-      .map(([key, value]) => `${key}: ${value}`)
+      .map(([key, value]) => `${humanizePreviewKey(key)}: ${formatPreviewValue(value)}`)
+      .filter(Boolean)
       .join(' · ') || '—';
   }
 
@@ -1138,7 +1161,7 @@
         item.className = 'detail-grid__item';
         const label = document.createElement('span');
         label.className = 'detail-grid__label';
-        label.textContent = key.replace(/([A-Z])/g, ' $1').replace(/^./, (char) => char.toUpperCase());
+        label.textContent = humanizePreviewKey(key);
         const data = document.createElement('strong');
         data.className = 'detail-grid__value';
         data.textContent = String(value);

--- a/tests/test_invoice_generator.py
+++ b/tests/test_invoice_generator.py
@@ -228,7 +228,7 @@ def test_generate_invoice_billable_ticket_uses_hours_and_minutes(monkeypatch):
     result = asyncio.run(invoice_generator.generate_invoice(1))
 
     assert result["status"] == "succeeded"
-    assert created_lines[0]["description"] == "Ticket #55: VPN help — Remote (2 Hours 30 Mins)"
+    assert created_lines[0]["description"] == "Ticket 55: VPN help · Remote (2 Hours 30 Mins)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduled_task_preview.py
+++ b/tests/test_scheduled_task_preview.py
@@ -40,3 +40,55 @@ def test_preview_price_change_notifications(monkeypatch):
     assert preview["status"] == "ready"
     assert preview["totals"]["productCount"] == 1
     assert preview["items"][0]["label"] == "Managed Seat"
+
+
+def test_generate_invoice_preview_uses_xero_line_item_template(monkeypatch):
+    async def fake_company(company_id):
+        return {"id": company_id, "name": "Acme"}
+
+    async def fake_settings(slug):
+        return {
+            "line_item_description_template": "Ticket #{ticket_id} - {ticket_subject} - {labour_name} - {labour_duration}"
+        }
+
+    async def fake_context(company_id):
+        return {}
+
+    async def fake_recurring(company_id, *, tax_type, context):
+        return []
+
+    async def fake_tickets(company_id, limit):
+        return [{"id": 42, "subject": "Broken printer", "status": "Resolved"}]
+
+    async def fake_unbilled(ticket_id):
+        return [100]
+
+    async def fake_replies(ticket_id, include_internal):
+        return [
+            {
+                "id": 100,
+                "is_billable": True,
+                "minutes_spent": 90,
+                "labour_type_code": "LAB",
+                "labour_type_name": "Remote Support",
+                "labour_type_rate": "125.50",
+            }
+        ]
+
+    monkeypatch.setattr(scheduled_task_preview.company_repo, "get_company_by_id", fake_company)
+    monkeypatch.setattr(scheduled_task_preview.modules_service, "get_module_settings", fake_settings)
+    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_invoice_context", fake_context)
+    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_recurring_invoice_items", fake_recurring)
+    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_tickets", fake_tickets)
+    monkeypatch.setattr(scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled)
+    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_replies", fake_replies)
+
+    preview = asyncio.run(scheduled_task_preview.preview_task({"command": "generate_invoice", "company_id": 1}))
+
+    assert preview["status"] == "ready"
+    assert preview["totals"]["ticketLineCount"] == 1
+    line = preview["items"][0]["xeroLineItem"]
+    assert line["Description"] == "Ticket #42 - Broken printer - Remote Support - 1 Hour 30 Mins"
+    assert line["Quantity"] == 1.5
+    assert line["UnitAmount"] == 125.5
+    assert line["ItemCode"] == "LAB"


### PR DESCRIPTION
### Motivation
- Provide a preview that reflects the exact Xero line item format used when sending invoices so generated local invoices match what will be uploaded to Xero.
- Improve scheduled task preview UX so nested payloads like Xero line items are readable in the modal.
- Make template usage resilient when module settings (DB) are not available.

### Description
- Use the configured Xero `line_item_description_template` when building ticket line descriptions in `invoice_generator` and fall back to a safe template if module settings cannot be loaded. (`app/services/invoice_generator.py`)
- Extend the Generate Invoice scheduled task preview to group billable ticket time by labour type and include a preview of the constructed Xero line item payload (`Description`, `Quantity`, `UnitAmount`, `ItemCode`) along with the template used. Totals now include `ticketLineCount`. (`app/services/scheduled_task_preview.py`)
- Improve preview rendering in the scheduled task modal so nested objects are displayed as human-readable key/value strings and keys are humanised. (`app/static/js/automation.js`)
- Add/adjust regression tests to validate template-driven invoice descriptions and the preview Xero line item payload, and update invoice-generator expectations. (`tests/test_scheduled_task_preview.py`, `tests/test_invoice_generator.py`)

### Testing
- Ran unit tests: `pytest -q tests/test_scheduled_task_preview.py tests/test_invoice_generator.py` and all tests passed. 
- Performed bytecode/compile check: `python3 -m compileall -q app/services/invoice_generator.py app/services/scheduled_task_preview.py` which succeeded. 
- Ran `git diff --check` to ensure no whitespace/errors; no issues found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a434666c1a0832db96419330a6648de)