### PR TITLE
Honor Xero line item template from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -342,7 +342,7 @@ XERO_TAX_TYPE=
 XERO_LINE_AMOUNT_TYPE=Exclusive
 XERO_REFERENCE_PREFIX=Support
 XERO_BILLABLE_STATUSES=resolved, closed
-XERO_LINE_ITEM_TEMPLATE=Ticket #{ticket_id} - {ticket_subject} - {labour_name}
+XERO_LINE_ITEM_TEMPLATE=Ticket {ticket_id}: {ticket_subject} {labour_suffix} {requester_name} ({labour_duration})
 XERO_AUTO_CREATE_PRODUCTS=true
 
 # ChatGPT MCP integration

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -1039,6 +1039,10 @@ def _resolve_module_settings_for_runtime(
 
     raw_settings = _parse_module_settings((module or {}).get("settings"))
     resolved = _coerce_settings(slug, raw_settings, module)
+    if slug == "xero":
+        env_line_item_template = str(os.getenv("XERO_LINE_ITEM_TEMPLATE", "")).strip()
+        if env_line_item_template:
+            resolved["line_item_description_template"] = env_line_item_template
     if not _force_env_module_settings():
         return resolved
     env_only = _coerce_settings(slug, {}, None)

--- a/tests/test_xero_module.py
+++ b/tests/test_xero_module.py
@@ -1124,3 +1124,24 @@ async def test_acquire_xero_access_token_rechecks_cache_after_refresh_lock(monke
     assert token == "fresh-access-token"
     assert calls == 2
     refresh.assert_not_awaited()
+
+
+def test_xero_line_item_template_env_overrides_stored_settings(monkeypatch):
+    monkeypatch.setenv(
+        "XERO_LINE_ITEM_TEMPLATE",
+        "Ticket {ticket_id}: {ticket_subject} {labour_suffix} {requester_name} ({labour_duration})",
+    )
+    module = {
+        "slug": "xero",
+        "settings": {
+            "line_item_description_template": "Ticket {ticket_id}: {ticket_subject}{labour_suffix} ({labour_duration})",
+            "account_code": "400",
+            "line_amount_type": "Exclusive",
+        },
+    }
+
+    result = modules_service._resolve_module_settings_for_runtime("xero", module)
+
+    assert result["line_item_description_template"] == (
+        "Ticket {ticket_id}: {ticket_subject} {labour_suffix} {requester_name} ({labour_duration})"
+    )


### PR DESCRIPTION
### Motivation
- Preview and Xero sync paths were using the stored/default Xero line item template instead of a custom `XERO_LINE_ITEM_TEMPLATE` set in the environment, preventing expected custom formatting from appearing in previews and invoices.

### Description
- When resolving module settings at runtime, read `XERO_LINE_ITEM_TEMPLATE` from the environment and, if present, set `line_item_description_template` on the resolved Xero settings in `app/services/modules.py` so env config takes precedence.
- Update `.env.example` to show the requested template format with `{requester_name}` and `{labour_duration}` placeholders.
- Add a regression test `test_xero_line_item_template_env_overrides_stored_settings` in `tests/test_xero_module.py` that asserts the env variable overrides the stored/default template.
- The override is applied only when the env var is non-empty and occurs before honoring `FORCE_ENV_MODULE_SETTINGS` logic so runtime consumers (previews/sync) see the env-provided template.

### Testing
- Ran the targeted pytest commands `pytest tests/test_xero_module.py::test_xero_line_item_template_env_overrides_stored_settings tests/test_scheduled_task_preview.py::test_generate_invoice_preview_uses_xero_line_item_template -q` and both tests passed.
- Verified syntax with `python -m py_compile app/services/modules.py app/services/xero.py app/services/scheduled_task_preview.py app/services/invoice_generator.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a434e53ca28832d85588f289aefdda3)