### PR TITLE
Fix requester names in generated invoice lines

### DIFF
--- a/app/services/invoice_generator.py
+++ b/app/services/invoice_generator.py
@@ -17,6 +17,7 @@ from app.repositories import invoice_lines as invoice_lines_repo
 from app.repositories import invoices as invoice_repo
 from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import tickets as tickets_repo
+from app.repositories import users as users_repo
 from app.services import modules as modules_service
 from app.services import xero as xero_service
 
@@ -68,6 +69,8 @@ def _build_ticket_line_description(
     *,
     billable_minutes: int,
     non_billable_minutes: int = 0,
+    requester_name: str = "",
+    requester_email: str = "",
 ) -> str:
     return xero_service._format_line_description(
         template,
@@ -76,7 +79,37 @@ def _build_ticket_line_description(
         minutes,
         billable_minutes=billable_minutes,
         non_billable_minutes=non_billable_minutes,
+        requester_name=requester_name,
+        requester_email=requester_email,
     )
+
+
+async def resolve_ticket_requester(ticket: dict[str, Any]) -> tuple[str, str]:
+    """Resolve requester display fields for invoice template substitutions."""
+
+    requester_name = str(ticket.get("requester_name") or "").strip()
+    requester_email = str(ticket.get("requester_email") or ticket.get("email") or "").strip()
+
+    if requester_name and requester_email:
+        return requester_name, requester_email
+
+    requester_id = ticket.get("requester_id")
+    try:
+        requester_id_int = int(requester_id) if requester_id is not None else 0
+    except (TypeError, ValueError):
+        requester_id_int = 0
+
+    if requester_id_int <= 0:
+        return requester_name, requester_email
+
+    requester = await users_repo.get_user_by_id(requester_id_int) or {}
+    if not requester_name:
+        first = str(requester.get("first_name") or "").strip()
+        last = str(requester.get("last_name") or "").strip()
+        requester_name = " ".join(part for part in (first, last) if part)
+    if not requester_email:
+        requester_email = str(requester.get("email") or "").strip()
+    return requester_name, requester_email
 
 
 async def _generate_invoice_number() -> str:
@@ -183,6 +216,7 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
             continue
 
         labour_groups = list(labour_map.values())
+        requester_name, requester_email = await resolve_ticket_requester(ticket)
         for group in labour_groups:
             group_minutes = int(group.get("minutes") or 0)
             if group_minutes <= 0:
@@ -196,6 +230,8 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
                 group,
                 group_minutes,
                 billable_minutes=billable_minutes,
+                requester_name=requester_name,
+                requester_email=requester_email,
             )
 
             local_rate = group.get("rate")
@@ -220,6 +256,8 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
                 "status": ticket.get("status"),
                 "billable_minutes": billable_minutes,
                 "labour_groups": labour_groups,
+                "requester_name": requester_name,
+                "requester_email": requester_email,
             }
         )
 

--- a/app/services/scheduled_task_preview.py
+++ b/app/services/scheduled_task_preview.py
@@ -129,6 +129,7 @@ async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any])
                 bucket = {"minutes": 0, "code": labour_code, "name": labour_name, "rate": labour_rate}
                 labour_map[key] = bucket
             bucket["minutes"] += reply_minutes
+        requester_name, requester_email = await invoice_generator_service.resolve_ticket_requester(dict(ticket))
         for group in labour_map.values():
             group_minutes = int(group.get("minutes") or 0)
             if group_minutes <= 0:
@@ -140,6 +141,8 @@ async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any])
                 group,
                 group_minutes,
                 billable_minutes=minutes,
+                requester_name=requester_name,
+                requester_email=requester_email,
             )
             unit_amount = invoice_generator_service._to_decimal(group.get("rate")) or Decimal("0")
             labour_code = str(group.get("code") or "").strip()

--- a/tests/test_invoice_generator.py
+++ b/tests/test_invoice_generator.py
@@ -231,6 +231,46 @@ def test_generate_invoice_billable_ticket_uses_hours_and_minutes(monkeypatch):
     assert created_lines[0]["description"] == "Ticket 55: VPN help · Remote (2 Hours 30 Mins)"
 
 
+def test_generate_invoice_resolves_requester_name_for_template(monkeypatch):
+    created_lines: list[dict[str, Any]] = []
+
+    async def fake_create_invoice(**kwargs):
+        return {"id": 303, **kwargs}
+
+    async def fake_create_line(**kwargs):
+        created_lines.append(kwargs)
+        return {"id": len(created_lines), **kwargs}
+
+    monkeypatch.setenv("XERO_LINE_ITEM_TEMPLATE", "Ticket {ticket_id}: {ticket_subject} - {requester_name}")
+    monkeypatch.setattr(invoice_generator.company_repo, "get_company_by_id", AsyncMock(return_value=_make_company()))
+    monkeypatch.setattr(invoice_generator.xero_service, "build_invoice_context", AsyncMock(return_value={}))
+    monkeypatch.setattr(invoice_generator.xero_service, "build_recurring_invoice_items", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        invoice_generator.tickets_repo,
+        "list_tickets",
+        AsyncMock(return_value=[{"id": 55, "subject": "VPN help", "requester_id": 99}]),
+    )
+    monkeypatch.setattr(
+        invoice_generator.users_repo,
+        "get_user_by_id",
+        AsyncMock(return_value={"id": 99, "first_name": "Jane", "last_name": "Requester", "email": "jane@example.com"}),
+    )
+    monkeypatch.setattr(invoice_generator.billed_time_repo, "get_unbilled_reply_ids", AsyncMock(return_value=[1]))
+    monkeypatch.setattr(invoice_generator.tickets_repo, "list_replies", AsyncMock(return_value=[
+        {"id": 1, "minutes_spent": 60, "is_billable": True, "labour_type_name": "Remote", "labour_type_code": "REMOTE", "labour_type_rate": "100"},
+    ]))
+    monkeypatch.setattr(invoice_generator.invoice_repo, "create_invoice", fake_create_invoice)
+    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0))
+    monkeypatch.setattr(invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line)
+    monkeypatch.setattr(invoice_generator.billed_time_repo, "create_billed_time_entry", AsyncMock())
+    monkeypatch.setattr(invoice_generator.tickets_repo, "update_ticket", AsyncMock())
+
+    result = asyncio.run(invoice_generator.generate_invoice(1))
+
+    assert result["status"] == "succeeded"
+    assert created_lines[0]["description"] == "Ticket 55: VPN help - Jane Requester"
+
+
 # ---------------------------------------------------------------------------
 # get_max_invoice_seq helper in repository
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduled_task_preview.py
+++ b/tests/test_scheduled_task_preview.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import AsyncMock
 
 from app.services import scheduled_task_preview
 
@@ -147,3 +148,50 @@ def test_generate_invoice_preview_prefers_env_xero_line_item_template(monkeypatc
     assert preview["items"][0]["xeroDescription"] == (
         "Ticket 42: Broken printer  · Remote Support Jane Requester (1 Hour 30 Mins)"
     )
+
+
+def test_generate_invoice_preview_resolves_requester_name_for_template(monkeypatch):
+    async def fake_company(company_id):
+        return {"id": company_id, "name": "Acme"}
+
+    async def fake_context(company_id):
+        return {}
+
+    async def fake_recurring(company_id, *, tax_type, context):
+        return []
+
+    async def fake_tickets(company_id, limit):
+        return [{"id": 42, "subject": "Broken printer", "status": "Resolved", "requester_id": 99}]
+
+    async def fake_unbilled(ticket_id):
+        return [100]
+
+    async def fake_replies(ticket_id, include_internal):
+        return [
+            {
+                "id": 100,
+                "is_billable": True,
+                "minutes_spent": 90,
+                "labour_type_code": "LAB",
+                "labour_type_name": "Remote Support",
+                "labour_type_rate": "125.50",
+            }
+        ]
+
+    monkeypatch.setenv("XERO_LINE_ITEM_TEMPLATE", "Ticket {ticket_id}: {ticket_subject} - {requester_name}")
+    monkeypatch.setattr(scheduled_task_preview.company_repo, "get_company_by_id", fake_company)
+    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_invoice_context", fake_context)
+    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_recurring_invoice_items", fake_recurring)
+    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_tickets", fake_tickets)
+    monkeypatch.setattr(scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled)
+    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_replies", fake_replies)
+    monkeypatch.setattr(
+        scheduled_task_preview.invoice_generator_service.users_repo,
+        "get_user_by_id",
+        AsyncMock(return_value={"id": 99, "first_name": "Jane", "last_name": "Requester", "email": "jane@example.com"}),
+    )
+
+    preview = asyncio.run(scheduled_task_preview.preview_task({"command": "generate_invoice", "company_id": 1}))
+
+    assert preview["status"] == "ready"
+    assert preview["items"][0]["xeroDescription"] == "Ticket 42: Broken printer - Jane Requester"


### PR DESCRIPTION
### Motivation
- Invoice line descriptions using `{requester_name}` were empty when tickets only included a `requester_id`, so generated Xero/local invoice lines and previews could miss requester information.
- The goal is to resolve requester display fields from the users repository and ensure templates receive `requester_name`/`requester_email` for substitution.

### Description
- Added `resolve_ticket_requester` to `app/services/invoice_generator.py` and imported `users` repo to resolve requester name/email from `requester_id` when needed.
- Extended `_build_ticket_line_description` to accept `requester_name` and `requester_email` and pass those through to `xero_service._format_line_description`.
- Called `resolve_ticket_requester` in `generate_invoice` and wired the resolved `requester_name`/`requester_email` into generated ticket line descriptions and invoice context items.
- Updated `app/services/scheduled_task_preview.py` to reuse `invoice_generator.resolve_ticket_requester` so previews also show resolved requester names, and added regression tests in `tests/test_invoice_generator.py` and `tests/test_scheduled_task_preview.py` to cover the template behavior.

### Testing
- Ran `pytest tests/test_invoice_generator.py tests/test_scheduled_task_preview.py -q` and all relevant tests passed (`15 passed` for the targeted test run).
- Ran `git diff --check` with no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4355f8885483329cae8c3817b846dd)