### PR TITLE
Resolve ticket requester fields for invoice templates and previews

### DIFF
--- a/app/services/invoice_generator.py
+++ b/app/services/invoice_generator.py
@@ -68,6 +68,8 @@ def _build_ticket_line_description(
     *,
     billable_minutes: int,
     non_billable_minutes: int = 0,
+    requester_name: str = "",
+    requester_email: str = "",
 ) -> str:
     return xero_service._format_line_description(
         template,
@@ -76,7 +78,15 @@ def _build_ticket_line_description(
         minutes,
         billable_minutes=billable_minutes,
         non_billable_minutes=non_billable_minutes,
+        requester_name=requester_name,
+        requester_email=requester_email,
     )
+
+
+async def resolve_ticket_requester(ticket: dict[str, Any]) -> tuple[str, str]:
+    """Resolve requester display fields for invoice template substitutions."""
+
+    return await xero_service.resolve_ticket_requester(ticket)
 
 
 async def _generate_invoice_number() -> str:
@@ -183,6 +193,7 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
             continue
 
         labour_groups = list(labour_map.values())
+        requester_name, requester_email = await resolve_ticket_requester(ticket)
         for group in labour_groups:
             group_minutes = int(group.get("minutes") or 0)
             if group_minutes <= 0:
@@ -196,6 +207,8 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
                 group,
                 group_minutes,
                 billable_minutes=billable_minutes,
+                requester_name=requester_name,
+                requester_email=requester_email,
             )
 
             local_rate = group.get("rate")
@@ -220,6 +233,8 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
                 "status": ticket.get("status"),
                 "billable_minutes": billable_minutes,
                 "labour_groups": labour_groups,
+                "requester_name": requester_name,
+                "requester_email": requester_email,
             }
         )
 

--- a/app/services/scheduled_task_preview.py
+++ b/app/services/scheduled_task_preview.py
@@ -129,6 +129,7 @@ async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any])
                 bucket = {"minutes": 0, "code": labour_code, "name": labour_name, "rate": labour_rate}
                 labour_map[key] = bucket
             bucket["minutes"] += reply_minutes
+        requester_name, requester_email = await invoice_generator_service.resolve_ticket_requester(dict(ticket))
         for group in labour_map.values():
             group_minutes = int(group.get("minutes") or 0)
             if group_minutes <= 0:
@@ -140,6 +141,8 @@ async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any])
                 group,
                 group_minutes,
                 billable_minutes=minutes,
+                requester_name=requester_name,
+                requester_email=requester_email,
             )
             unit_amount = invoice_generator_service._to_decimal(group.get("rate")) or Decimal("0")
             labour_code = str(group.get("code") or "").strip()

--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -16,6 +16,7 @@ from app.repositories import asset_custom_fields as asset_custom_fields_repo
 from app.repositories import companies as company_repo
 from app.repositories import company_recurring_invoice_items as recurring_items_repo
 from app.repositories import invoice_lines as invoice_lines_repo
+from app.repositories import staff as staff_repo
 from app.repositories import invoices as invoice_repo
 from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import tickets as tickets_repo
@@ -39,6 +40,94 @@ _XERO_INVOICE_NUMBER_SUFFIX_RE = re.compile(r"^(.*)(\d+)$")
 class _TemplateValues(dict[str, Any]):
     def __missing__(self, key: str) -> str:
         return ""
+
+
+def _requester_display_name(record: Mapping[str, Any] | None) -> str:
+    if not isinstance(record, Mapping):
+        return ""
+    first = str(record.get("first_name") or "").strip()
+    last = str(record.get("last_name") or "").strip()
+    full_name = " ".join(part for part in (first, last) if part)
+    return (
+        full_name
+        or str(record.get("display_name") or "").strip()
+        or str(record.get("name") or "").strip()
+        or str(record.get("email") or "").strip()
+    )
+
+
+def _ticket_requester_name(ticket: Mapping[str, Any]) -> str:
+    for key in ("requester_name", "requester_display_name", "requester_label", "contact_name", "name"):
+        value = str(ticket.get(key) or "").strip()
+        if value:
+            return value
+    requester = ticket.get("requester")
+    if isinstance(requester, Mapping):
+        return _requester_display_name(requester)
+    return ""
+
+
+def _ticket_requester_email(ticket: Mapping[str, Any]) -> str:
+    for key in ("requester_email", "email", "contact_email"):
+        value = str(ticket.get(key) or "").strip()
+        if value:
+            return value
+    requester = ticket.get("requester")
+    if isinstance(requester, Mapping):
+        return str(requester.get("email") or "").strip()
+    return ""
+
+
+async def resolve_ticket_requester(
+    ticket: Mapping[str, Any],
+    *,
+    requester_cache: MutableMapping[int, Mapping[str, Any]] | None = None,
+    staff_requester_cache: MutableMapping[int, Mapping[str, Any]] | None = None,
+) -> tuple[str, str]:
+    """Resolve requester display fields for invoice template substitutions."""
+
+    requester_name = _ticket_requester_name(ticket)
+    requester_email = _ticket_requester_email(ticket)
+
+    if not requester_name or not requester_email:
+        requester_id = ticket.get("requester_id")
+        try:
+            requester_id_int = int(requester_id) if requester_id is not None else 0
+        except (TypeError, ValueError):
+            requester_id_int = 0
+        if requester_id_int > 0:
+            requester: Mapping[str, Any] | None
+            if requester_cache is not None and requester_id_int in requester_cache:
+                requester = requester_cache[requester_id_int]
+            else:
+                requester = await users_repo.get_user_by_id(requester_id_int) or {}
+                if requester_cache is not None:
+                    requester_cache[requester_id_int] = requester
+            if not requester_name:
+                requester_name = _requester_display_name(requester)
+            if not requester_email:
+                requester_email = str((requester or {}).get("email") or "").strip()
+
+    if not requester_name or not requester_email:
+        requester_staff_id = ticket.get("requester_staff_id")
+        try:
+            requester_staff_id_int = int(requester_staff_id) if requester_staff_id is not None else 0
+        except (TypeError, ValueError):
+            requester_staff_id_int = 0
+        if requester_staff_id_int > 0:
+            staff_requester: Mapping[str, Any] | None
+            if staff_requester_cache is not None and requester_staff_id_int in staff_requester_cache:
+                staff_requester = staff_requester_cache[requester_staff_id_int]
+            else:
+                staff_requester = await staff_repo.get_staff_by_id(requester_staff_id_int) or {}
+                if staff_requester_cache is not None:
+                    staff_requester_cache[requester_staff_id_int] = staff_requester
+            if not requester_name:
+                requester_name = _requester_display_name(staff_requester)
+            if not requester_email:
+                requester_email = str((staff_requester or {}).get("email") or "").strip()
+
+    return requester_name, requester_email
 
 
 def _normalise_status_filter(
@@ -130,8 +219,8 @@ def _format_line_description(
         labour_hours=float(_quantize(labour_hours_decimal)) if labour_minutes else 0.0,
         labour_duration=labour_duration,
         labour_suffix=f" · {labour_name}" if labour_name else "",
-        requester_name=requester_name or str(ticket.get("requester_name") or "").strip(),
-        requester_email=requester_email or str(ticket.get("requester_email") or "").strip(),
+        requester_name=requester_name or _ticket_requester_name(ticket),
+        requester_email=requester_email or _ticket_requester_email(ticket),
         ticket_created_date=ticket_created_date,
         ticket_resolved_date=ticket_resolved_date,
         billable_minutes=billable_minutes,
@@ -895,7 +984,8 @@ async def build_ticket_invoices(
         return []
 
     tickets_by_company: dict[int, list[dict[str, Any]]] = {}
-    requester_cache: dict[int, dict[str, Any]] = {}
+    requester_cache: dict[int, Mapping[str, Any]] = {}
+    staff_requester_cache: dict[int, Mapping[str, Any]] = {}
     for ticket_id in unique_ticket_ids:
         ticket = await fetch_ticket(ticket_id)
         if not ticket:
@@ -962,28 +1052,11 @@ async def build_ticket_invoices(
             non_billable_minutes = int(item.get("non_billable_minutes") or 0)
             total_minutes += ticket_minutes
             labour_groups = item.get("labour_groups") or []
-            requester_name = str(ticket.get("requester_name") or "").strip()
-            requester_email = str(
-                ticket.get("requester_email") or ticket.get("email") or ""
-            ).strip()
-
-            if not requester_name or not requester_email:
-                requester_id = ticket.get("requester_id")
-                try:
-                    requester_id_int = int(requester_id) if requester_id is not None else 0
-                except (TypeError, ValueError):
-                    requester_id_int = 0
-                if requester_id_int > 0:
-                    requester = requester_cache.get(requester_id_int)
-                    if requester is None:
-                        requester = await users_repo.get_user_by_id(requester_id_int) or {}
-                        requester_cache[requester_id_int] = requester
-                    if not requester_name:
-                        first = str(requester.get("first_name") or "").strip()
-                        last = str(requester.get("last_name") or "").strip()
-                        requester_name = " ".join(part for part in (first, last) if part)
-                    if not requester_email:
-                        requester_email = str(requester.get("email") or "").strip()
+            requester_name, requester_email = await resolve_ticket_requester(
+                ticket,
+                requester_cache=requester_cache,
+                staff_requester_cache=staff_requester_cache,
+            )
 
             ticket_created_date = _format_date_value(ticket.get("created_at"))
             ticket_resolved_date = _format_date_value(ticket.get("closed_at"))

--- a/tests/test_invoice_generator.py
+++ b/tests/test_invoice_generator.py
@@ -231,6 +231,46 @@ def test_generate_invoice_billable_ticket_uses_hours_and_minutes(monkeypatch):
     assert created_lines[0]["description"] == "Ticket 55: VPN help · Remote (2 Hours 30 Mins)"
 
 
+def test_generate_invoice_resolves_requester_name_for_template(monkeypatch):
+    created_lines: list[dict[str, Any]] = []
+
+    async def fake_create_invoice(**kwargs):
+        return {"id": 303, **kwargs}
+
+    async def fake_create_line(**kwargs):
+        created_lines.append(kwargs)
+        return {"id": len(created_lines), **kwargs}
+
+    monkeypatch.setenv("XERO_LINE_ITEM_TEMPLATE", "Ticket {ticket_id}: {ticket_subject} - {requester_name}")
+    monkeypatch.setattr(invoice_generator.company_repo, "get_company_by_id", AsyncMock(return_value=_make_company()))
+    monkeypatch.setattr(invoice_generator.xero_service, "build_invoice_context", AsyncMock(return_value={}))
+    monkeypatch.setattr(invoice_generator.xero_service, "build_recurring_invoice_items", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        invoice_generator.tickets_repo,
+        "list_tickets",
+        AsyncMock(return_value=[{"id": 55, "subject": "VPN help", "requester_id": 99}]),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service.users_repo,
+        "get_user_by_id",
+        AsyncMock(return_value={"id": 99, "first_name": "Jane", "last_name": "Requester", "email": "jane@example.com"}),
+    )
+    monkeypatch.setattr(invoice_generator.billed_time_repo, "get_unbilled_reply_ids", AsyncMock(return_value=[1]))
+    monkeypatch.setattr(invoice_generator.tickets_repo, "list_replies", AsyncMock(return_value=[
+        {"id": 1, "minutes_spent": 60, "is_billable": True, "labour_type_name": "Remote", "labour_type_code": "REMOTE", "labour_type_rate": "100"},
+    ]))
+    monkeypatch.setattr(invoice_generator.invoice_repo, "create_invoice", fake_create_invoice)
+    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0))
+    monkeypatch.setattr(invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line)
+    monkeypatch.setattr(invoice_generator.billed_time_repo, "create_billed_time_entry", AsyncMock())
+    monkeypatch.setattr(invoice_generator.tickets_repo, "update_ticket", AsyncMock())
+
+    result = asyncio.run(invoice_generator.generate_invoice(1))
+
+    assert result["status"] == "succeeded"
+    assert created_lines[0]["description"] == "Ticket 55: VPN help - Jane Requester"
+
+
 # ---------------------------------------------------------------------------
 # get_max_invoice_seq helper in repository
 # ---------------------------------------------------------------------------

--- a/tests/test_scheduled_task_preview.py
+++ b/tests/test_scheduled_task_preview.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import AsyncMock
 
 from app.services import scheduled_task_preview
 
@@ -147,3 +148,50 @@ def test_generate_invoice_preview_prefers_env_xero_line_item_template(monkeypatc
     assert preview["items"][0]["xeroDescription"] == (
         "Ticket 42: Broken printer  · Remote Support Jane Requester (1 Hour 30 Mins)"
     )
+
+
+def test_generate_invoice_preview_resolves_requester_name_for_template(monkeypatch):
+    async def fake_company(company_id):
+        return {"id": company_id, "name": "Acme"}
+
+    async def fake_context(company_id):
+        return {}
+
+    async def fake_recurring(company_id, *, tax_type, context):
+        return []
+
+    async def fake_tickets(company_id, limit):
+        return [{"id": 42, "subject": "Broken printer", "status": "Resolved", "requester_id": 99}]
+
+    async def fake_unbilled(ticket_id):
+        return [100]
+
+    async def fake_replies(ticket_id, include_internal):
+        return [
+            {
+                "id": 100,
+                "is_billable": True,
+                "minutes_spent": 90,
+                "labour_type_code": "LAB",
+                "labour_type_name": "Remote Support",
+                "labour_type_rate": "125.50",
+            }
+        ]
+
+    monkeypatch.setenv("XERO_LINE_ITEM_TEMPLATE", "Ticket {ticket_id}: {ticket_subject} - {requester_name}")
+    monkeypatch.setattr(scheduled_task_preview.company_repo, "get_company_by_id", fake_company)
+    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_invoice_context", fake_context)
+    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_recurring_invoice_items", fake_recurring)
+    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_tickets", fake_tickets)
+    monkeypatch.setattr(scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled)
+    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_replies", fake_replies)
+    monkeypatch.setattr(
+        scheduled_task_preview.invoice_generator_service.xero_service.users_repo,
+        "get_user_by_id",
+        AsyncMock(return_value={"id": 99, "first_name": "Jane", "last_name": "Requester", "email": "jane@example.com"}),
+    )
+
+    preview = asyncio.run(scheduled_task_preview.preview_task({"command": "generate_invoice", "company_id": 1}))
+
+    assert preview["status"] == "ready"
+    assert preview["items"][0]["xeroDescription"] == "Ticket 42: Broken printer - Jane Requester"

--- a/tests/test_xero_module.py
+++ b/tests/test_xero_module.py
@@ -237,6 +237,51 @@ async def test_build_ticket_invoices_supports_extended_template_placeholders():
 
 
 @pytest.mark.anyio("asyncio")
+async def test_build_ticket_invoices_resolves_staff_requester_for_template():
+    async def fake_fetch_ticket(ticket_id: int):
+        return {
+            "id": ticket_id,
+            "company_id": 10,
+            "subject": "Printer jam",
+            "status": "resolved",
+            "requester_staff_id": 77,
+        }
+
+    async def fake_fetch_replies(ticket_id: int):
+        return [{"id": 1, "minutes_spent": 60, "is_billable": True}]
+
+    async def fake_fetch_company(company_id: int):
+        return {"id": company_id, "name": "Acme"}
+
+    with patch(
+        "app.services.xero.staff_repo.get_staff_by_id",
+        new=AsyncMock(return_value={
+            "id": 77,
+            "first_name": "Sam",
+            "last_name": "Requester",
+            "email": "sam@example.com",
+        }),
+    ):
+        invoices = await xero_service.build_ticket_invoices(
+            [42],
+            hourly_rate=Decimal("150"),
+            account_code="400",
+            tax_type=None,
+            line_amount_type="Exclusive",
+            reference_prefix="Support",
+            description_template="Ticket {ticket_id}: {ticket_subject} - {requester_name} - {requester_email}",
+            fetch_ticket=fake_fetch_ticket,
+            fetch_replies=fake_fetch_replies,
+            fetch_company=fake_fetch_company,
+        )
+
+    assert len(invoices) == 1
+    assert invoices[0]["line_items"][0]["Description"] == (
+        "Ticket 42: Printer jam - Sam Requester - sam@example.com"
+    )
+
+
+@pytest.mark.anyio("asyncio")
 async def test_build_order_invoice_returns_payload_with_context():
     async def fake_fetch_summary(order_number: str, company_id: int):
         return {"order_number": order_number, "status": "placed"}


### PR DESCRIPTION
### Motivation
- Ensure invoice line item templates can include requester display name and email by resolving missing requester fields from ticket, user, or staff records.
- Provide consistent requester resolution across invoice generation, scheduled-preview, and Xero invoice builders to improve template substitutions.

### Description
- Add requester resolution helpers in `app/services/xero.py`: `_requester_display_name`, `_ticket_requester_name`, `_ticket_requester_email`, and `resolve_ticket_requester`, plus import of `staff_repo` to fetch staff by id.
- Update `_format_line_description` in `xero.py` to fall back to ticket-derived requester name/email when values are not provided.
- Add `resolve_ticket_requester` wrapper and pass requester fields through to `_build_ticket_line_description` in `app/services/invoice_generator.py`, and include requester fields in generated ticket context.
- Update `app/services/scheduled_task_preview.py` to call the resolver and pass requester name/email into previewed line descriptions.
- Add unit tests that cover resolving requester from user and staff records and that previews use the resolved requester fields: tests added/updated in `tests/test_invoice_generator.py`, `tests/test_scheduled_task_preview.py`, and `tests/test_xero_module.py`.

### Testing
- Ran `tests/test_invoice_generator.py::test_generate_invoice_resolves_requester_name_for_template` which succeeded. 
- Ran `tests/test_scheduled_task_preview.py::test_generate_invoice_preview_resolves_requester_name_for_template` which succeeded. 
- Ran `tests/test_xero_module.py::test_build_ticket_invoices_resolves_staff_requester_for_template` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4355f8885483329cae8c3817b846dd)