### PR TITLE
Sync staff custom fields from M365 mailbox access

### DIFF
--- a/app/features/companies/handlers.py
+++ b/app/features/companies/handlers.py
@@ -867,6 +867,11 @@ def _parse_custom_field_options(options_text: str) -> list[dict[str, str]]:
         item = part.strip()
         if not item:
             continue
+        m365_upn = ""
+        if "|" in item:
+            item, m365_upn = item.split("|", 1)
+            item = item.strip()
+            m365_upn = m365_upn.strip().lower()
         if ":" in item:
             value_part, label_part = item.split(":", 1)
             value = value_part.strip()
@@ -876,7 +881,7 @@ def _parse_custom_field_options(options_text: str) -> list[dict[str, str]]:
             label = item
         if not value:
             continue
-        options.append({"value": value, "label": label})
+        options.append({"value": value, "label": label, "m365_upn": m365_upn})
     return options
 
 
@@ -1607,6 +1612,7 @@ async def admin_create_company_staff_custom_field(company_id: int, request: Requ
         form.get("visible_to_requester_emails")
     )
     options = _parse_custom_field_options(str(form.get("options") or ""))
+    m365_upn = str(form.get("m365_upn") or "").strip().lower() or None
     if not name:
         return _main()._company_edit_redirect(
             company_id=company_id, error="Custom field name is required."
@@ -1628,6 +1634,7 @@ async def admin_create_company_staff_custom_field(company_id: int, request: Requ
         condition_value=condition_value,
         visible_to_job_titles=visible_to_job_titles,
         visible_to_requester_emails=visible_to_requester_emails,
+        m365_upn=m365_upn,
         options=options,
     )
     return _main()._company_edit_redirect(
@@ -1673,6 +1680,7 @@ async def admin_update_company_staff_custom_field(
         form.get("visible_to_requester_emails")
     )
     options = _parse_custom_field_options(str(form.get("options") or ""))
+    m365_upn = str(form.get("m365_upn") or "").strip().lower() or None
     await staff_custom_fields_repo.update_company_definition(
         definition_id,
         company_id=company_id,
@@ -1687,6 +1695,7 @@ async def admin_update_company_staff_custom_field(
         condition_value=condition_value,
         visible_to_job_titles=visible_to_job_titles,
         visible_to_requester_emails=visible_to_requester_emails,
+        m365_upn=m365_upn,
         options=options,
     )
     return _main()._company_edit_redirect(

--- a/app/repositories/staff_custom_fields.py
+++ b/app/repositories/staff_custom_fields.py
@@ -65,6 +65,7 @@ async def list_field_definitions(
             COALESCE(ovr.condition_value, base.condition_value) AS condition_value,
             COALESCE(ovr.visible_to_job_titles, base.visible_to_job_titles) AS visible_to_job_titles,
             COALESCE(ovr.visible_to_requester_emails, base.visible_to_requester_emails) AS visible_to_requester_emails,
+            COALESCE(ovr.m365_upn, base.m365_upn) AS m365_upn,
             COALESCE(ovr.company_id, base.company_id) AS company_id
         FROM staff_custom_field_definitions AS base
         LEFT JOIN staff_custom_field_definitions AS ovr
@@ -99,7 +100,7 @@ async def list_field_definitions(
     id_csv = _int_csv(ids)
     option_rows = await db.fetch_all(
         """
-        SELECT field_definition_id, option_value, option_label, sort_order
+        SELECT field_definition_id, option_value, option_label, m365_upn, sort_order
         FROM staff_custom_field_options
         WHERE FIND_IN_SET(field_definition_id, %s) > 0
         ORDER BY field_definition_id, sort_order, id
@@ -115,6 +116,7 @@ async def list_field_definitions(
                 "label": str(
                     row.get("option_label") or row.get("option_value") or ""
                 ).strip(),
+                "m365_upn": str(row.get("m365_upn") or "").strip(),
             }
         )
 
@@ -142,6 +144,7 @@ async def list_company_owned_definitions(company_id: int) -> list[dict[str, Any]
             condition_value,
             visible_to_job_titles,
             visible_to_requester_emails,
+            m365_upn,
             created_at,
             updated_at
         FROM staff_custom_field_definitions
@@ -161,7 +164,7 @@ async def list_company_owned_definitions(company_id: int) -> list[dict[str, Any]
     id_csv = _int_csv(ids)
     option_rows = await db.fetch_all(
         """
-        SELECT field_definition_id, option_value, option_label, sort_order
+        SELECT field_definition_id, option_value, option_label, m365_upn, sort_order
         FROM staff_custom_field_options
         WHERE FIND_IN_SET(field_definition_id, %s) > 0
         ORDER BY field_definition_id, sort_order, id
@@ -177,6 +180,7 @@ async def list_company_owned_definitions(company_id: int) -> list[dict[str, Any]
                 "label": str(
                     row.get("option_label") or row.get("option_value") or ""
                 ).strip(),
+                "m365_upn": str(row.get("m365_upn") or "").strip(),
             }
         )
     for definition in definitions:
@@ -198,6 +202,7 @@ async def create_company_definition(
     condition_value: str | None = None,
     visible_to_job_titles: str | None = None,
     visible_to_requester_emails: str | None = None,
+    m365_upn: str | None = None,
     options: list[dict[str, str]] | None = None,
 ) -> int:
     definition_id = await db.execute_returning_lastrowid(
@@ -216,8 +221,9 @@ async def create_company_definition(
             condition_operator,
             condition_value,
             visible_to_job_titles,
-            visible_to_requester_emails
-        ) VALUES (%s, NULL, %s, %s, %s, %s, %s, %s, 1, %s, %s, %s, %s, %s)
+            visible_to_requester_emails,
+            m365_upn
+        ) VALUES (%s, NULL, %s, %s, %s, %s, %s, %s, 1, %s, %s, %s, %s, %s, %s)
         """,
         (
             company_id,
@@ -232,6 +238,7 @@ async def create_company_definition(
             condition_value or None,
             visible_to_job_titles or None,
             visible_to_requester_emails or None,
+            m365_upn or None,
         ),
     )
     if not definition_id:
@@ -255,6 +262,7 @@ async def update_company_definition(
     condition_value: str | None,
     visible_to_job_titles: str | None,
     visible_to_requester_emails: str | None,
+    m365_upn: str | None,
     options: list[dict[str, str]] | None = None,
 ) -> None:
     await db.execute(
@@ -270,7 +278,8 @@ async def update_company_definition(
             condition_operator = %s,
             condition_value = %s,
             visible_to_job_titles = %s,
-            visible_to_requester_emails = %s
+            visible_to_requester_emails = %s,
+            m365_upn = %s
         WHERE id = %s AND company_id = %s
         """,
         (
@@ -285,6 +294,7 @@ async def update_company_definition(
             condition_value or None,
             visible_to_job_titles or None,
             visible_to_requester_emails or None,
+            m365_upn or None,
             definition_id,
             company_id,
         ),
@@ -314,10 +324,16 @@ async def replace_field_options(
         await db.execute(
             """
             INSERT INTO staff_custom_field_options (
-                field_definition_id, option_value, option_label, sort_order
-            ) VALUES (%s, %s, %s, %s)
+                field_definition_id, option_value, option_label, m365_upn, sort_order
+            ) VALUES (%s, %s, %s, %s, %s)
             """,
-            (definition_id, value, label, idx),
+            (
+                definition_id,
+                value,
+                label,
+                str(option.get("m365_upn") or "").strip() or None,
+                idx,
+            ),
         )
 
 

--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -27,6 +27,7 @@ from app.repositories import license_sku_friendly_names as sku_friendly_repo
 from app.repositories import integration_modules as modules_repo
 from app.repositories import m365 as m365_repo
 from app.repositories import staff as staff_repo
+from app.repositories import staff_custom_fields as staff_custom_fields_repo
 from app.security.encryption import decrypt_secret, encrypt_secret
 from app.services import modules as modules_service
 
@@ -5079,10 +5080,15 @@ async def sync_mailboxes(company_id: int) -> int:
     # to previous syncs and should be removed.
     await m365_repo.delete_stale_mailbox_members(company_id, member_sync_start)
 
+    synced_staff_custom_fields = await sync_staff_custom_fields_from_m365_mailboxes(
+        company_id
+    )
+
     log_info(
         "M365 mailbox sync complete",
         company_id=company_id,
         total=len(rows_to_upsert),
+        staff_custom_fields_synced=synced_staff_custom_fields,
         user_mailboxes=sum(
             1 for r in rows_to_upsert if r["mailbox_type"] == "UserMailbox"
         ),
@@ -5129,6 +5135,98 @@ async def check_report_privacy(company_id: int) -> bool:
     if not primary_upns:
         return False
     return obfuscated_count >= max(1, int(len(primary_upns) * 0.8))
+
+
+def _normalise_m365_upn(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _yes_no_select_value(options: list[dict[str, Any]], is_member: bool) -> str | None:
+    wanted = "yes" if is_member else "no"
+    for option in options:
+        value = str(option.get("value") or "").strip()
+        label = str(option.get("label") or "").strip()
+        if value.lower() == wanted or label.lower() == wanted:
+            return value
+    return wanted
+
+
+async def sync_staff_custom_fields_from_m365_mailboxes(company_id: int) -> int:
+    """Update M365-mapped staff custom fields from synced mailbox memberships.
+
+    This is intentionally one-way from Microsoft 365 into MyPortal. Manual staff
+    edits still follow the normal change-request/ticket flow and are never
+    pushed back to M365 by this sync.
+    """
+    definitions = await staff_custom_fields_repo.list_field_definitions(company_id)
+    mapped_definitions = []
+    for definition in definitions:
+        field_type = str(definition.get("field_type") or "text").lower()
+        if field_type == "multiselect":
+            options = [
+                option
+                for option in (definition.get("options") or [])
+                if _normalise_m365_upn(option.get("m365_upn"))
+            ]
+            if options:
+                mapped = dict(definition)
+                mapped["options"] = options
+                mapped_definitions.append(mapped)
+        elif field_type in {"checkbox", "select"} and _normalise_m365_upn(
+            definition.get("m365_upn")
+        ):
+            mapped_definitions.append(definition)
+    if not mapped_definitions:
+        return 0
+
+    staff_rows = await staff_repo.list_all_staff_for_import(company_id)
+    updated = 0
+    for staff in staff_rows:
+        staff_id = staff.get("id")
+        staff_upns = {
+            _normalise_m365_upn(staff.get("email")),
+        }
+        staff_upns.discard("")
+        if not staff_id or not staff_upns:
+            continue
+        accessible = {
+            _normalise_m365_upn(row.get("mailbox_email"))
+            for row in await m365_repo.get_mailboxes_accessible_by_member(
+                company_id, list(staff_upns)
+            )
+        }
+        values: dict[str, Any] = {}
+        for definition in mapped_definitions:
+            name = str(definition.get("name") or "").strip()
+            field_type = str(definition.get("field_type") or "text").lower()
+            if not name:
+                continue
+            if field_type == "multiselect":
+                selected = [
+                    str(option.get("value") or "").strip()
+                    for option in (definition.get("options") or [])
+                    if _normalise_m365_upn(option.get("m365_upn")) in accessible
+                    and str(option.get("value") or "").strip()
+                ]
+                values[name] = ",".join(selected) if selected else None
+            else:
+                is_member = (
+                    _normalise_m365_upn(definition.get("m365_upn")) in accessible
+                )
+                if field_type == "checkbox":
+                    values[name] = is_member
+                elif field_type == "select":
+                    values[name] = _yes_no_select_value(
+                        definition.get("options") or [], is_member
+                    )
+        if values:
+            await staff_custom_fields_repo.set_staff_field_values_by_name(
+                company_id=company_id,
+                staff_id=int(staff_id),
+                values=values,
+            )
+            updated += 1
+    return updated
 
 
 async def get_user_mailboxes(company_id: int) -> list[dict[str, Any]]:

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -532,7 +532,13 @@
             </div>
             <div class="form-field admin-grid__full">
               <label class="form-label" for="new-custom-options">Options (select / multiselect only)</label>
-              <input class="form-input" id="new-custom-options" name="options" placeholder="small:Small, medium:Medium" />
+              <input class="form-input" id="new-custom-options" name="options" placeholder="small:Small|mailbox@example.com, medium:Medium|other@example.com" />
+              <p class="form-help">For M365 multi-select sync, append <code>|UPN</code> to each option.</p>
+            </div>
+            <div class="form-field admin-grid__full">
+              <label class="form-label" for="new-custom-m365-upn">M365 mailbox/group UPN (checkbox / select only)</label>
+              <input class="form-input" id="new-custom-m365-upn" name="m365_upn" placeholder="mailbox@example.com" />
+              <p class="form-help">When set, M365 mailbox sync updates this field from the staff member's mailbox memberships without creating tickets.</p>
             </div>
             <div class="form-field">
               <label class="form-label" for="new-custom-visible-job-titles">Visible to job titles</label>
@@ -582,6 +588,7 @@
                   <th>Conditional logic</th>
                   <th>Visibility</th>
                   <th>Options</th>
+                  <th>M365 UPN</th>
                   <th>Actions</th>
                 </tr>
               </thead>
@@ -628,7 +635,8 @@
                           <input class="form-input" name="visible_to_requester_emails" value="{{ field.visible_to_requester_emails or '' }}" placeholder="manager@example.com" />
                         </div>
                       </td>
-                      <td><input class="form-input" name="options" value="{% for option in field.options %}{{ option.value }}{% if option.label != option.value %}:{{ option.label }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}" /></td>
+                      <td><input class="form-input" name="options" value="{% for option in field.options %}{{ option.value }}{% if option.label != option.value %}:{{ option.label }}{% endif %}{% if option.m365_upn %}|{{ option.m365_upn }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}" /></td>
+                      <td><input class="form-input" name="m365_upn" value="{{ field.m365_upn or '' }}" placeholder="mailbox@example.com" /></td>
                       <td class="table__actions">
                         <button type="submit" class="button button--ghost">Save</button>
                     </form>

--- a/migrations/277_staff_custom_field_m365_sync.sql
+++ b/migrations/277_staff_custom_field_m365_sync.sql
@@ -1,0 +1,7 @@
+-- Migration 277: add M365 mailbox/group UPN mappings for staff custom fields
+
+ALTER TABLE staff_custom_field_definitions
+    ADD COLUMN m365_upn VARCHAR(255) NULL AFTER visible_to_requester_emails;
+
+ALTER TABLE staff_custom_field_options
+    ADD COLUMN m365_upn VARCHAR(255) NULL AFTER option_label;


### PR DESCRIPTION
### Motivation

- Provide a way to map staff custom fields to Microsoft 365 mailbox/group UPNs so staff records reflect mailbox group membership automatically. 
- Support both per-field single-UPN mappings (checkbox/select) and per-option UPN mappings for `multiselect` fields so syncs use UPNs rather than display names. 
- Ensure the sync is one-way from M365 into MyPortal (manual edits still use the normal change-request/ticket flow) and automatic changes do not create tickets. 

### Description

- Add database migration `migrations/277_staff_custom_field_m365_sync.sql` to add `m365_upn` columns to `staff_custom_field_definitions` and `staff_custom_field_options`. 
- Persist and return `m365_upn` in the staff custom fields repository by updating `app/repositories/staff_custom_fields.py` (reads/writes options and definitions include `m365_upn`). 
- Extend admin parsing and UI: update `app/features/companies/handlers.py` to parse per-option `|UPN` syntax and accept a single `m365_upn` for checkbox/select fields, and update `app/templates/admin/company_edit.html` to expose help text and inputs for `m365_upn` and per-option `|UPN` values. 
- Implement one-way sync logic in `app/services/m365.py` by adding `sync_staff_custom_fields_from_m365_mailboxes(company_id)` and invoking it at the end of mailbox sync; the sync: 1) finds mapped definitions, 2) resolves which mailboxes each staff UPN can access via `get_mailboxes_accessible_by_member`, and 3) updates staff custom fields via `set_staff_field_values_by_name` (multiselect selects option values where option `m365_upn` matches accessible mailboxes, checkbox/select are set to yes/no or boolean). 
- Preserve existing change-request behaviour: manual edits are not pushed to M365, and automatic sync changes do not raise tickets. 

### Testing

- Compiled modified modules with `python -m py_compile app/repositories/staff_custom_fields.py app/features/companies/handlers.py app/services/m365.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a43687e54808332873c441674424a6a)