### PR TITLE
Support M365 custom field mapping alternatives

### DIFF
--- a/app/services/m365.py
+++ b/app/services/m365.py
@@ -5141,6 +5141,25 @@ def _normalise_m365_upn(value: Any) -> str:
     return str(value or "").strip().lower()
 
 
+def _m365_mapping_identifiers(value: Any) -> set[str]:
+    """Return configured M365 mailbox/group identifiers for a custom-field map.
+
+    Values may contain ``|`` separated alternatives so admins can keep the
+    MyPortal field/option label user-friendly while matching a different M365
+    display name or address, e.g. ``Netsuite|Netsuite Users``.
+    """
+    return {
+        identifier
+        for part in str(value or "").split("|")
+        if (identifier := _normalise_m365_upn(part))
+    }
+
+
+def _m365_mapping_matches(value: Any, accessible_identifiers: set[str]) -> bool:
+    identifiers = _m365_mapping_identifiers(value)
+    return bool(identifiers and identifiers.intersection(accessible_identifiers))
+
+
 def _yes_no_select_value(options: list[dict[str, Any]], is_member: bool) -> str | None:
     wanted = "yes" if is_member else "no"
     for option in options:
@@ -5166,13 +5185,13 @@ async def sync_staff_custom_fields_from_m365_mailboxes(company_id: int) -> int:
             options = [
                 option
                 for option in (definition.get("options") or [])
-                if _normalise_m365_upn(option.get("m365_upn"))
+                if _m365_mapping_identifiers(option.get("m365_upn"))
             ]
             if options:
                 mapped = dict(definition)
                 mapped["options"] = options
                 mapped_definitions.append(mapped)
-        elif field_type in {"checkbox", "select"} and _normalise_m365_upn(
+        elif field_type in {"checkbox", "select"} and _m365_mapping_identifiers(
             definition.get("m365_upn")
         ):
             mapped_definitions.append(definition)
@@ -5189,12 +5208,12 @@ async def sync_staff_custom_fields_from_m365_mailboxes(company_id: int) -> int:
         staff_upns.discard("")
         if not staff_id or not staff_upns:
             continue
-        accessible = {
-            _normalise_m365_upn(row.get("mailbox_email"))
-            for row in await m365_repo.get_mailboxes_accessible_by_member(
-                company_id, list(staff_upns)
-            )
-        }
+        accessible: set[str] = set()
+        for row in await m365_repo.get_mailboxes_accessible_by_member(
+            company_id, list(staff_upns)
+        ):
+            accessible.update(_m365_mapping_identifiers(row.get("mailbox_email")))
+            accessible.update(_m365_mapping_identifiers(row.get("display_name")))
         values: dict[str, Any] = {}
         for definition in mapped_definitions:
             name = str(definition.get("name") or "").strip()
@@ -5205,14 +5224,12 @@ async def sync_staff_custom_fields_from_m365_mailboxes(company_id: int) -> int:
                 selected = [
                     str(option.get("value") or "").strip()
                     for option in (definition.get("options") or [])
-                    if _normalise_m365_upn(option.get("m365_upn")) in accessible
+                    if _m365_mapping_matches(option.get("m365_upn"), accessible)
                     and str(option.get("value") or "").strip()
                 ]
                 values[name] = ",".join(selected) if selected else None
             else:
-                is_member = (
-                    _normalise_m365_upn(definition.get("m365_upn")) in accessible
-                )
+                is_member = _m365_mapping_matches(definition.get("m365_upn"), accessible)
                 if field_type == "checkbox":
                     values[name] = is_member
                 elif field_type == "select":

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -533,12 +533,12 @@
             <div class="form-field admin-grid__full">
               <label class="form-label" for="new-custom-options">Options (select / multiselect only)</label>
               <input class="form-input" id="new-custom-options" name="options" placeholder="small:Small|mailbox@example.com, medium:Medium|other@example.com" />
-              <p class="form-help">For M365 multi-select sync, append <code>|UPN</code> to each option.</p>
+              <p class="form-help">For M365 multi-select sync, append <code>|UPN</code> or <code>|Group Display Name</code> to each option. Multiple alternatives can be separated with <code>|</code>.</p>
             </div>
             <div class="form-field admin-grid__full">
               <label class="form-label" for="new-custom-m365-upn">M365 mailbox/group UPN (checkbox / select only)</label>
               <input class="form-input" id="new-custom-m365-upn" name="m365_upn" placeholder="mailbox@example.com" />
-              <p class="form-help">When set, M365 mailbox sync updates this field from the staff member's mailbox memberships without creating tickets.</p>
+              <p class="form-help">When set, M365 mailbox sync updates this field from the staff member's mailbox memberships without creating tickets. Use <code>|</code> to add display-name alternatives such as <code>Netsuite|Netsuite Users</code>.</p>
             </div>
             <div class="form-field">
               <label class="form-label" for="new-custom-visible-job-titles">Visible to job titles</label>
@@ -588,7 +588,7 @@
                   <th>Conditional logic</th>
                   <th>Visibility</th>
                   <th>Options</th>
-                  <th>M365 UPN</th>
+                  <th>M365 mapping</th>
                   <th>Actions</th>
                 </tr>
               </thead>
@@ -636,7 +636,7 @@
                         </div>
                       </td>
                       <td><input class="form-input" name="options" value="{% for option in field.options %}{{ option.value }}{% if option.label != option.value %}:{{ option.label }}{% endif %}{% if option.m365_upn %}|{{ option.m365_upn }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}" /></td>
-                      <td><input class="form-input" name="m365_upn" value="{{ field.m365_upn or '' }}" placeholder="mailbox@example.com" /></td>
+                      <td><input class="form-input" name="m365_upn" value="{{ field.m365_upn or '' }}" placeholder="mailbox@example.com or Group Name" /></td>
                       <td class="table__actions">
                         <button type="submit" class="button button--ghost">Save</button>
                     </form>

--- a/tests/test_m365_custom_field_mapping.py
+++ b/tests/test_m365_custom_field_mapping.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+
+from app.services import m365 as m365_service
+
+
+def test_sync_staff_custom_fields_matches_pipe_alternative_display_name(monkeypatch):
+    """Checkbox M365 mappings can use | alternatives for non-UPN group names."""
+    saved: list[dict] = []
+
+    async def fake_definitions(company_id: int) -> list[dict]:
+        assert company_id == 42
+        return [
+            {
+                "name": "netsuite",
+                "field_type": "checkbox",
+                "m365_upn": "Netsuite|Netsuite Users",
+            }
+        ]
+
+    async def fake_staff(company_id: int) -> list[dict]:
+        assert company_id == 42
+        return [{"id": 7, "email": "alex@example.com"}]
+
+    async def fake_accessible(company_id: int, member_upns: list[str]) -> list[dict]:
+        assert company_id == 42
+        assert member_upns == ["alex@example.com"]
+        return [
+            {
+                "mailbox_email": "netsuite-users@example.com",
+                "display_name": "Netsuite Users",
+            }
+        ]
+
+    async def fake_save(**kwargs):
+        saved.append(kwargs)
+
+    monkeypatch.setattr(
+        m365_service.staff_custom_fields_repo,
+        "list_field_definitions",
+        fake_definitions,
+    )
+    monkeypatch.setattr(
+        m365_service.staff_repo, "list_all_staff_for_import", fake_staff
+    )
+    monkeypatch.setattr(
+        m365_service.m365_repo,
+        "get_mailboxes_accessible_by_member",
+        fake_accessible,
+    )
+    monkeypatch.setattr(
+        m365_service.staff_custom_fields_repo,
+        "set_staff_field_values_by_name",
+        fake_save,
+    )
+
+    updated = asyncio.run(m365_service.sync_staff_custom_fields_from_m365_mailboxes(42))
+
+    assert updated == 1
+    assert saved == [{"company_id": 42, "staff_id": 7, "values": {"netsuite": True}}]
+
+
+def test_m365_mapping_identifiers_split_pipe_alternatives():
+    assert m365_service._m365_mapping_identifiers("Netsuite|Netsuite Users") == {
+        "netsuite",
+        "netsuite users",
+    }


### PR DESCRIPTION
### Motivation
- Admins need custom-field mappings to match non-UPN group names (e.g. display names) as well as mailbox UPNs, so a single field can be labelled for users while matching actual M365 identifiers.
- Allowing pipe-delimited alternatives (e.g. `Netsuite|Netsuite Users`) makes MyPortal resilient when Azure/AD groups do not expose a UPN.

### Description
- Add `_m365_mapping_identifiers` and `_m365_mapping_matches` helpers to parse pipe-delimited alternatives and normalize identifiers for matching.
- Update `sync_staff_custom_fields_from_m365_mailboxes` to include both `mailbox_email` and synced mailbox `display_name` in the accessible identifier set and use the new matching logic for checkbox/select/multiselect mappings.
- Update the admin staff-custom-field UI help text and placeholders to document `|UPN` and `|Group Display Name` alternatives and multi-alternative usage.
- Add regression tests (`tests/test_m365_custom_field_mapping.py`) verifying pipe-separated alternatives are parsed and matched correctly.

### Testing
- Compiled relevant modules with `python -m compileall app/services/m365.py tests/test_m365_custom_field_mapping.py` which succeeded.
- Ran unit tests `pytest tests/test_m365_custom_field_mapping.py tests/test_license_group_assignments.py` and observed all tests passed (5 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a44c3758004832d8a21020bf4d69f00)