### PR TITLE
Use MySQL upsert for plugin registration to prevent duplicate startup warnings

### DIFF
--- a/app/repositories/plugin_registry.py
+++ b/app/repositories/plugin_registry.py
@@ -22,8 +22,9 @@ async def ensure_registered(slug: str) -> None:
     else:
         await db.execute(
             """
-            INSERT IGNORE INTO plugin_registry (slug, enabled)
+            INSERT INTO plugin_registry (slug, enabled)
             VALUES (%s, 1)
+            ON DUPLICATE KEY UPDATE slug = slug
             """,
             (slug,),
         )

--- a/changes/7117b959-8f53-443e-83a3-70f9bcd4d210.json
+++ b/changes/7117b959-8f53-443e-83a3-70f9bcd4d210.json
@@ -1,0 +1,7 @@
+{
+  "guid": "7117b959-8f53-443e-83a3-70f9bcd4d210",
+  "occurred_at": "2026-07-01T07:38Z",
+  "change_type": "Fix",
+  "summary": "Prevent duplicate plugin registry startup warnings by using a MySQL upsert when registering built-in plugins.",
+  "content_hash": "b1d6a12fc0f704fc1e420b36a476200cddcbdb6cbae91e031623bb8852786bfe"
+}

--- a/tests/test_plugin_registry_repository.py
+++ b/tests/test_plugin_registry_repository.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from app.repositories import plugin_registry
+
+
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_ensure_registered_mysql_uses_upsert_without_insert_ignore(monkeypatch):
+    executed: list[tuple[str, tuple[str, ...]]] = []
+
+    monkeypatch.setattr(plugin_registry.db, "is_connected", lambda: True)
+    monkeypatch.setattr(plugin_registry.db, "is_sqlite", lambda: False)
+
+    async def fake_execute(sql: str, params: tuple[str, ...]) -> None:
+        executed.append((sql, params))
+
+    monkeypatch.setattr(plugin_registry.db, "execute", fake_execute)
+
+    await plugin_registry.ensure_registered("plugin.demo")
+
+    assert executed == [
+        (
+            """
+            INSERT INTO plugin_registry (slug, enabled)
+            VALUES (%s, 1)
+            ON DUPLICATE KEY UPDATE slug = slug
+            """,
+            ("plugin.demo",),
+        )
+    ]
+    assert "INSERT IGNORE" not in executed[0][0]
+    assert "ON DUPLICATE KEY UPDATE" in executed[0][0]


### PR DESCRIPTION
### Motivation
- Prevent duplicate plugin registry startup warnings by using a proper MySQL upsert instead of `INSERT IGNORE` when ensuring built-in plugins are registered.

### Description
- Replace `INSERT IGNORE` with `INSERT ... ON DUPLICATE KEY UPDATE slug = slug` in `ensure_registered` in `app/repositories/plugin_registry.py`, and add a change record at `changes/7117b959-8f53-443e-83a3-70f9bcd4d210.json` plus a unit test `tests/test_plugin_registry_repository.py` to assert the MySQL path emits the upsert SQL.

### Testing
- Ran the new unit test `pytest tests/test_plugin_registry_repository.py` which verifies the emitted SQL uses the upsert and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a43524b42a8832d84b0e9e802317ff4)