### PR TITLE
Add saved-report template variables ({{ report.slug.count }} / {{ report.slug.list }}) and company context substitution

### DIFF
--- a/app/services/dynamic_variables.py
+++ b/app/services/dynamic_variables.py
@@ -7,6 +7,8 @@ from typing import Any
 from app.repositories import assets as assets_repo
 from app.repositories import asset_custom_fields as asset_custom_fields_repo
 from app.repositories import issues as issues_repo
+from app.repositories import reporting as reporting_repo
+from app.services import reporting as reporting_service
 
 
 def _utcnow() -> datetime:
@@ -38,13 +40,16 @@ def _extract_company_id(
                 return company_id
         ticket = context.get("ticket")
         if isinstance(ticket, Mapping):
-            ticket_company = _coerce_int(ticket.get("company_id") or ticket.get("companyId"))
+            ticket_company = _coerce_int(
+                ticket.get("company_id") or ticket.get("companyId")
+            )
             if ticket_company is not None:
                 return ticket_company
             ticket_company_entry = ticket.get("company")
             if isinstance(ticket_company_entry, Mapping):
                 ticket_company_id = _coerce_int(
-                    ticket_company_entry.get("id") or ticket_company_entry.get("company_id")
+                    ticket_company_entry.get("id")
+                    or ticket_company_entry.get("company_id")
                 )
                 if ticket_company_id is not None:
                     return ticket_company_id
@@ -84,7 +89,7 @@ def _extract_active_asset_requests(tokens: Iterable[str]) -> dict[str, int | Non
 
 def _extract_asset_custom_field_count_requests(tokens: Iterable[str]) -> dict[str, str]:
     """Extract count:asset:field-name tokens.
-    
+
     Returns a dict mapping the full token to the field name.
     For example: {"count:asset:bitdefender": "bitdefender"}
     """
@@ -107,7 +112,7 @@ def _extract_asset_custom_field_count_requests(tokens: Iterable[str]) -> dict[st
 
 def _extract_asset_custom_field_list_requests(tokens: Iterable[str]) -> dict[str, str]:
     """Extract list:asset:field-name tokens.
-    
+
     Returns a dict mapping the full token to the field name.
     For example: {"list:asset:bitdefender": "bitdefender"}
     """
@@ -130,7 +135,7 @@ def _extract_asset_custom_field_list_requests(tokens: Iterable[str]) -> dict[str
 
 def _extract_issue_count_requests(tokens: Iterable[str]) -> dict[str, str]:
     """Extract count:issue:slug tokens.
-    
+
     Returns a dict mapping the full token to the issue slug.
     For example: {"count:issue:network-outage": "network-outage"}
     """
@@ -153,7 +158,7 @@ def _extract_issue_count_requests(tokens: Iterable[str]) -> dict[str, str]:
 
 def _extract_issue_list_requests(tokens: Iterable[str]) -> dict[str, str]:
     """Extract list:issue:slug tokens.
-    
+
     Returns a dict mapping the full token to the issue slug.
     For example: {"list:issue:network-outage": "network-outage"}
     """
@@ -174,6 +179,24 @@ def _extract_issue_list_requests(tokens: Iterable[str]) -> dict[str, str]:
     return requests
 
 
+def _extract_report_requests(tokens: Iterable[str]) -> dict[str, tuple[str, str]]:
+    """Extract report.slug.count and report.slug.list tokens."""
+    requests: dict[str, tuple[str, str]] = {}
+    for token in tokens:
+        if not token:
+            continue
+        parts = token.split(".")
+        if len(parts) < 3 or parts[0].lower() != "report":
+            continue
+        action = parts[-1].lower()
+        if action not in {"count", "list"}:
+            continue
+        slug = ".".join(parts[1:-1]).strip()
+        if slug:
+            requests[token] = (slug, action)
+    return requests
+
+
 async def build_dynamic_token_map(
     tokens: Iterable[str],
     context: Mapping[str, Any] | None,
@@ -185,20 +208,22 @@ async def build_dynamic_token_map(
     custom_field_list_requests = _extract_asset_custom_field_list_requests(tokens)
     issue_count_requests = _extract_issue_count_requests(tokens)
     issue_list_requests = _extract_issue_list_requests(tokens)
-    
+    report_requests = _extract_report_requests(tokens)
+
     all_requests = [
         active_asset_requests,
         custom_field_requests,
         custom_field_list_requests,
         issue_count_requests,
         issue_list_requests,
+        report_requests,
     ]
     if not any(all_requests):
         return {}
 
     company_id = _extract_company_id(context, base_tokens)
     result: dict[str, str] = {}
-    
+
     # Handle active asset counts
     if active_asset_requests:
         now = _utcnow()
@@ -213,11 +238,18 @@ async def build_dynamic_token_map(
                 since = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
             else:
                 since = now - timedelta(days=duration)
-            count = await assets_repo.count_active_assets(company_id=company_id, since=since)
+            count = await assets_repo.count_active_assets(
+                company_id=company_id, since=since
+            )
             counts[duration] = str(count)
 
-        result.update({token: counts[duration] for token, duration in active_asset_requests.items()})
-    
+        result.update(
+            {
+                token: counts[duration]
+                for token, duration in active_asset_requests.items()
+            }
+        )
+
     # Handle custom field asset counts
     if custom_field_requests:
         for token, field_name in custom_field_requests.items():
@@ -227,7 +259,7 @@ async def build_dynamic_token_map(
                 field_value=True,
             )
             result[token] = str(count)
-    
+
     # Handle custom field asset lists
     if custom_field_list_requests:
         for token, field_name in custom_field_list_requests.items():
@@ -237,7 +269,7 @@ async def build_dynamic_token_map(
                 field_value=True,
             )
             result[token] = ", ".join(assets)
-    
+
     # Handle issue asset counts
     if issue_count_requests:
         for token, issue_slug in issue_count_requests.items():
@@ -246,7 +278,7 @@ async def build_dynamic_token_map(
                 company_id=company_id,
             )
             result[token] = str(count)
-    
+
     # Handle issue asset lists
     if issue_list_requests:
         for token, issue_slug in issue_list_requests.items():
@@ -255,5 +287,37 @@ async def build_dynamic_token_map(
                 company_id=company_id,
             )
             result[token] = ", ".join(assets)
-    
+
+    # Handle saved reporting query variables
+    if report_requests:
+        report_cache: dict[str, dict[str, Any] | None] = {}
+        run_cache: dict[str, dict[str, Any]] = {}
+        count_cache: dict[str, int] = {}
+        for token, (slug, action) in report_requests.items():
+            if slug not in report_cache:
+                report_cache[slug] = await reporting_repo.get_query_by_slug(slug)
+            report = report_cache[slug]
+            if not report:
+                result[token] = "0" if action == "count" else ""
+                continue
+            sql_query = str(report.get("sql_query") or "")
+            if action == "count":
+                if slug not in count_cache:
+                    count_cache[slug] = await reporting_service.count_query_rows(
+                        sql_query,
+                        company_id=company_id,
+                    )
+                result[token] = str(count_cache[slug])
+            else:
+                if slug not in run_cache:
+                    run_cache[slug] = await reporting_service.run_query_with_context(
+                        sql_query,
+                        company_id=company_id,
+                    )
+                report_result = run_cache[slug]
+                result[token] = reporting_service.export_csv(
+                    report_result.get("columns", []),
+                    report_result.get("rows", []),
+                ).strip()
+
     return result

--- a/app/services/reporting.py
+++ b/app/services/reporting.py
@@ -18,6 +18,7 @@ query we:
   ``credential``, ``private_key`` …) so that credentials stored in the
   database are never returned in plain text.
 """
+
 from __future__ import annotations
 
 import csv
@@ -32,7 +33,6 @@ from typing import Any, Iterable, Mapping
 
 from app.core.database import db
 
-
 MAX_RESULT_ROWS = 5000
 
 _REDACTED = "[REDACTED]"
@@ -45,6 +45,21 @@ _SENSITIVE_COLUMN_PATTERN = re.compile(
     r"(?<![a-zA-Z])(password[s]?|passwd|secret[s]?|token[s]?|api[_\-]?key[s]?|totp|otp[s]?|credential[s]?|private[_\-]?key[s]?|encrypted)(?![a-zA-Z])",
     re.IGNORECASE,
 )
+
+_CURRENT_COMPANY_PATTERN = re.compile(
+    r"\{\{\s*current\.company(?:_id)?\s*\}\}", re.IGNORECASE
+)
+
+
+def substitute_query_context(sql: str, *, company_id: int | None = None) -> str:
+    """Replace supported report SQL context placeholders with safe literals.
+
+    Only numeric company context is currently supported.  Missing context is
+    rendered as ``NULL`` so a filter such as ``company_id = {{current.company}}``
+    returns no rows instead of accidentally broadening scope.
+    """
+    replacement = "NULL" if company_id is None else str(int(company_id))
+    return _CURRENT_COMPANY_PATTERN.sub(replacement, sql or "")
 
 
 class ReportingQueryError(ValueError):
@@ -256,10 +271,7 @@ def _redact_sensitive_rows(
     if not sensitive:
         return rows
     return [
-        {
-            key: (_REDACTED if key in sensitive else value)
-            for key, value in row.items()
-        }
+        {key: (_REDACTED if key in sensitive else value) for key, value in row.items()}
         for row in rows
     ]
 
@@ -292,6 +304,34 @@ async def run_query(sql: str, *, max_rows: int = MAX_RESULT_ROWS) -> dict[str, A
         "row_count": len(rows),
         "truncated": truncated,
     }
+
+
+async def count_query_rows(sql: str, *, company_id: int | None = None) -> int:
+    """Return the number of rows found by a validated reporting query."""
+    statement = validate_select_query(
+        substitute_query_context(sql, company_id=company_id)
+    )
+    wrapped = f"SELECT COUNT(*) AS row_count FROM ({statement}) AS reporting_count_subq"
+    row = await db.fetch_one(wrapped)
+    if not row:
+        return 0
+    try:
+        return int(row.get("row_count", 0))
+    except (TypeError, ValueError, AttributeError):
+        return 0
+
+
+async def run_query_with_context(
+    sql: str,
+    *,
+    company_id: int | None = None,
+    max_rows: int = MAX_RESULT_ROWS,
+) -> dict[str, Any]:
+    """Run a report query after applying supported context placeholders."""
+    return await run_query(
+        substitute_query_context(sql, company_id=company_id),
+        max_rows=max_rows,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -340,8 +380,7 @@ def export_csv(columns: Iterable[str], rows: Iterable[Mapping[str, Any]]) -> str
 def export_json(columns: Iterable[str], rows: Iterable[Mapping[str, Any]]) -> str:
     column_list = list(columns)
     payload = [
-        {col: _coerce_for_json(row.get(col)) for col in column_list}
-        for row in rows
+        {col: _coerce_for_json(row.get(col)) for col in column_list} for row in rows
     ]
     return json.dumps(payload, indent=2, default=str)
 
@@ -381,7 +420,7 @@ def export_html_for_pdf(
     column_list = list(columns)
     rows_list = list(rows)
     parts: list[str] = []
-    parts.append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"/>")
+    parts.append('<!DOCTYPE html><html><head><meta charset="utf-8"/>')
     parts.append(f"<title>{escape(name)}</title>")
     parts.append(
         "<style>"
@@ -397,20 +436,18 @@ def export_html_for_pdf(
     )
     parts.append(f"<h1>{escape(name)}</h1>")
     parts.append(
-        "<p class=\"meta\">Generated "
+        '<p class="meta">Generated '
         f"{escape(generated_at.strftime('%Y-%m-%d %H:%M UTC'))} · "
         f"{len(rows_list)} row(s)</p>"
     )
     if description:
-        parts.append(f"<p class=\"desc\">{escape(description)}</p>")
+        parts.append(f'<p class="desc">{escape(description)}</p>')
     parts.append("<table><thead><tr>")
     for col in column_list:
         parts.append(f"<th>{escape(str(col))}</th>")
     parts.append("</tr></thead><tbody>")
     if not rows_list:
-        parts.append(
-            f"<tr><td colspan=\"{max(len(column_list), 1)}\">No rows.</td></tr>"
-        )
+        parts.append(f'<tr><td colspan="{max(len(column_list), 1)}">No rows.</td></tr>')
     else:
         for row in rows_list:
             parts.append("<tr>")

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -1063,6 +1063,12 @@
               and <em>Bit Defender EDR</em> → <code>{cf_active_Bit_Defender_EDR}</code>.
             </p>
             <p class="card__help-text">
+              <strong>Saved report variables:</strong> dynamic template variables such as
+              <code>{{ '{{ report.billable-assets.count }}' }}</code> and
+              <code>{{ '{{ report.billable-assets.list }}' }}</code> can be used where dynamic variables are supported.
+              Reports can filter to the current invoice company with <code>{{ '{{current.company}}' }}</code> in the saved SQL.
+            </p>
+            <p class="card__help-text">
               If no price override is specified, the price will be retrieved from Xero using the product code.
             </p>
           </div>

--- a/docs/wiki/administration/Automation Variables.md
+++ b/docs/wiki/administration/Automation Variables.md
@@ -82,6 +82,8 @@ emails or webhook requests). Newly added tokens include:
 | `{{ list:asset:field-name }}` | Comma-separated list of asset names with a specific custom field checkbox set to true (e.g., `{{ list:asset:bitdefender }}`). |
 | `{{ count:issue:slug }}` | Count of assets linked to a specific issue type (e.g., `{{ count:issue:network-outage }}`). |
 | `{{ list:issue:slug }}` | Comma-separated list of asset names linked to a specific issue type (e.g., `{{ list:issue:network-outage }}`). |
+| `{{ report.slug.count }}` | Count of rows returned by a saved Reporting query. Replace `slug` with the report slug from **Reporting → Manage reports**. |
+| `{{ report.slug.list }}` | CSV-formatted content returned by a saved Reporting query, including a header row. Replace `slug` with the report slug. |
 
 `{{ ACTIVE_ASSETS }}` tokens scope to the company in the current automation context when available (for example a ticket's company). When no company is present the counts cover the entire tenant. The default form returns assets with a Syncro sync timestamp in the current month; append `:N` to evaluate the past `N` days such as `{{ ACTIVE_ASSETS:1 }}` for the past day.
 
@@ -122,6 +124,37 @@ The `{{ list:asset:field-name }}` variables return a comma-separated list of ass
 **Context scoping and field matching:**
 
 List variables follow the same scoping and field name matching rules as count variables. The assets are returned as a comma-separated list (e.g., "Server-01, Server-02, Workstation-03"). When no assets match, an empty string is returned.
+
+### Saved report variables
+
+Admins can create SELECT-only reports in **Reporting → Manage reports** and reuse their output anywhere dynamic template variables are rendered, including invoice descriptions/quantities, ticket content, automations, and message templates. Use the report slug in the token:
+
+- `{{ report.billable-assets.count }}` returns the number of rows found by the `billable-assets` report.
+- `{{ report.billable-assets.list }}` returns the report result as CSV text with a header row.
+
+Report variables are useful when the built-in counters are not specific enough. For example, create a report that selects only assets with a particular lifecycle, contract, or custom join, then use `.count` for quantity-based billing or `.list` to include the matching records in ticket/invoice narrative text.
+
+Saved report SQL can include `{{current.company}}` or `{{current.company_id}}` as a numeric context placeholder. At render time this is replaced with the company ID from the current ticket, invoice, automation context, or top-level company context. If no company is available, the placeholder becomes `NULL` so company-filtered reports return no rows instead of leaking tenant-wide results.
+
+Example report SQL:
+
+```sql
+SELECT name, asset_type
+FROM assets
+WHERE company_id = {{current.company}}
+  AND status = 'active'
+ORDER BY name
+```
+
+Example template usage:
+
+```text
+Managed endpoint quantity: {{ report.managed-endpoints.count }}
+Managed endpoints:
+{{ report.managed-endpoints.list }}
+```
+
+Security notes: report SQL is still validated as a single read-only `SELECT`/`WITH` query, dangerous SQL keywords are rejected, result rows are capped for `.list`, and sensitive column names such as password, token, secret, API key, credential, or encrypted values are redacted.
 
 ### Conditional logic
 

--- a/tests/test_report_variables.py
+++ b/tests/test_report_variables.py
@@ -1,0 +1,107 @@
+"""Test dynamic saved-report template variables."""
+
+import pytest
+
+from app.services import dynamic_variables, reporting, value_templates
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def test_extract_report_requests():
+    tokens = [
+        "report.asset-billing.count",
+        "report.security.stack.list",
+        "report.invalid.total",
+        "template.asset-billing.count",
+    ]
+
+    assert dynamic_variables._extract_report_requests(tokens) == {
+        "report.asset-billing.count": ("asset-billing", "count"),
+        "report.security.stack.list": ("security.stack", "list"),
+    }
+
+
+def test_substitute_query_context_uses_safe_numeric_company_id():
+    sql = "SELECT * FROM assets WHERE company_id = {{current.company}}"
+
+    assert reporting.substitute_query_context(sql, company_id=42) == (
+        "SELECT * FROM assets WHERE company_id = 42"
+    )
+    assert reporting.substitute_query_context(sql, company_id=None) == (
+        "SELECT * FROM assets WHERE company_id = NULL"
+    )
+
+
+@pytest.mark.anyio
+async def test_report_count_and_list_variables(monkeypatch):
+    async def fake_get_query_by_slug(slug):
+        assert slug == "asset-billing"
+        return {
+            "slug": slug,
+            "sql_query": "SELECT name FROM assets WHERE company_id = {{current.company}}",
+        }
+
+    async def fake_count_query_rows(sql_query, *, company_id=None):
+        assert (
+            sql_query
+            == "SELECT name FROM assets WHERE company_id = {{current.company}}"
+        )
+        assert company_id == 42
+        return 2
+
+    async def fake_run_query_with_context(sql_query, *, company_id=None):
+        assert (
+            sql_query
+            == "SELECT name FROM assets WHERE company_id = {{current.company}}"
+        )
+        assert company_id == 42
+        return {
+            "columns": ["name"],
+            "rows": [{"name": "Server-01"}, {"name": "Laptop-02"}],
+        }
+
+    monkeypatch.setattr(
+        dynamic_variables.reporting_repo, "get_query_by_slug", fake_get_query_by_slug
+    )
+    monkeypatch.setattr(
+        dynamic_variables.reporting_service, "count_query_rows", fake_count_query_rows
+    )
+    monkeypatch.setattr(
+        dynamic_variables.reporting_service,
+        "run_query_with_context",
+        fake_run_query_with_context,
+    )
+
+    result = await dynamic_variables.build_dynamic_token_map(
+        ["report.asset-billing.count", "report.asset-billing.list"],
+        {"ticket": {"company_id": 42}},
+    )
+
+    assert result["report.asset-billing.count"] == "2"
+    assert result["report.asset-billing.list"] == "name\r\nServer-01\r\nLaptop-02"
+
+
+@pytest.mark.anyio
+async def test_report_variables_render_in_templates(monkeypatch):
+    async def fake_get_query_by_slug(slug):
+        return {"slug": slug, "sql_query": "SELECT name FROM assets"}
+
+    async def fake_count_query_rows(sql_query, *, company_id=None):
+        return 3
+
+    monkeypatch.setattr(
+        dynamic_variables.reporting_repo, "get_query_by_slug", fake_get_query_by_slug
+    )
+    monkeypatch.setattr(
+        dynamic_variables.reporting_service, "count_query_rows", fake_count_query_rows
+    )
+
+    rendered = await value_templates.render_string_async(
+        "Billable assets: {{ report.billable-assets.count }}",
+        {"company_id": 7},
+    )
+
+    assert rendered == "Billable assets: 3"


### PR DESCRIPTION
### Motivation
- Enable admins to reuse saved Reporting queries inside templates for invoicing/ticket content via tokens like `{{ report.slug }}.count` and `{{ report.slug }}.list` instead of ad-hoc built-in counters.  
- Allow saved report SQL to safely reference the current company (e.g. `{{current.company}}`) so report results can be limited to the company against which the invoice/ticket/report is being executed.  

### Description
- Added report token extraction and handling in `app/services/dynamic_variables.py` to recognise `report.<slug>.count` and `report.<slug>.list`, fetch the saved report via `reporting_repo`, and cache/run/count results via `reporting_service`.  
- Extended `app/services/reporting.py` with `substitute_query_context(sql, company_id=...)`, `count_query_rows(...)`, and `run_query_with_context(...)` so saved SQL can be safely substituted and executed while preserving the existing SELECT-only validation and redaction/limiting rules.  
- Documented the new variables and usage (including `{{current.company}}` behaviour and security notes) in `docs/wiki/administration/Automation Variables.md` and in the invoice/company UI help text `app/templates/admin/company_edit.html`.  
- Added regression tests in `tests/test_report_variables.py` covering token extraction, `{{current.company}}` substitution, `.count` and `.list` behaviours, and template rendering integration.  

### Testing
- Compiled modified modules with `python -m py_compile app/services/dynamic_variables.py app/services/reporting.py app/services/value_templates.py tests/test_report_variables.py` which completed successfully.  
- Ran targeted test suite with `pytest -q tests/test_report_variables.py tests/test_value_templates_dynamic.py tests/test_asset_custom_field_count_variables.py tests/test_asset_custom_field_list_variables.py` and all tests passed (`25 passed`, with repository-wide warnings unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a474222ad28832d8998bcc57474a51f)