### PR TITLE
Load WhisperX transcription settings from .env (ignore DB module settings)

### DIFF
--- a/app/services/call_recordings.py
+++ b/app/services/call_recordings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import array
 import csv
 import json
+import os
 import re
 import wave
 from datetime import datetime, timezone
@@ -10,6 +11,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 import httpx
+from dotenv import load_dotenv
 from loguru import logger
 
 from app.repositories import call_recordings as call_recordings_repo
@@ -33,6 +35,34 @@ _GRANDSTREAM_CSV_PATTERN = re.compile(
     r"^\.rd_files_netdisk_(?P<period>\d{4}-\d{2})\.csv$"
 )
 _GRANDSTREAM_CSV_GLOB = ".rd_files_netdisk_*.csv"
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_ENV_PATH = _PROJECT_ROOT / ".env"
+
+
+def _env_bool(value: str | None, default: bool = False) -> bool:
+    if value is None or not value.strip():
+        return default
+    return value.strip().lower() not in {"false", "0", "no", "off"}
+
+
+def _whisperx_env_settings() -> dict[str, Any]:
+    """Return WhisperX transcription settings sourced only from ``.env``/env.
+
+    Call recording transcription intentionally ignores the WhisperX module's
+    persisted settings so stale database values cannot redirect audio or leak
+    credentials to the wrong service. ``load_dotenv(..., override=True)`` lets
+    an updated project ``.env`` take precedence over inherited process values.
+    """
+
+    if _ENV_PATH.exists():
+        load_dotenv(_ENV_PATH, override=True)
+    return {
+        "base_url": os.getenv("WHISPERX_BASE_URL", "").strip().rstrip("/"),
+        "api_key": os.getenv("WHISPERX_API_KEY", "").strip(),
+        "language": os.getenv("WHISPERX_LANGUAGE", "").strip(),
+        "stereo_split": _env_bool(os.getenv("WHISPERX_STEREO_SPLIT"), False),
+    }
 
 
 def _extract_phone_from_title(title: str | None) -> str | None:
@@ -1080,19 +1110,12 @@ async def transcribe_recording(recording_id: int, *, force: bool = False) -> dic
         logger.info(f"Recording {recording_id} already being processed, skipping")
         return recording
 
-    # Get WhisperX module settings
-    module = await modules_service.get_module("whisperx", redact=False)
-    if not module or not module.get("enabled"):
-        logger.warning("WhisperX module not enabled")
-        await call_recordings_repo.update_call_recording(
-            recording_id,
-            transcription_status="failed",
-        )
-        raise ValueError("WhisperX module not enabled")
-
-    settings = module.get("settings", {})
-    base_url = settings.get("base_url")
-    api_key = settings.get("api_key")
+    # WhisperX transcription runtime settings are intentionally sourced only
+    # from .env/environment variables. Do not use the module database settings
+    # here: stale DB values can point transcription at the wrong endpoint.
+    settings = _whisperx_env_settings()
+    base_url = settings["base_url"]
+    api_key = settings["api_key"]
 
     if not base_url:
         logger.error("WhisperX base URL not configured")

--- a/tests/test_call_recordings.py
+++ b/tests/test_call_recordings.py
@@ -869,3 +869,74 @@ async def test_create_call_recording_with_phone_number():
         assert result["caller_staff_id"] == 42
         assert mock_execute.called
         assert mock_lookup.call_count == 1
+
+
+def test_transcribe_recording_uses_whisperx_env_over_database(monkeypatch, tmp_path):
+    """Call recording transcription must ignore stale WhisperX DB settings."""
+    from app.services import call_recordings as service
+    from app.repositories import call_recordings as call_recordings_repo
+    from app.services import modules as modules_service
+
+    audio_path = tmp_path / "call.wav"
+    audio_path.write_bytes(b"fake audio data")
+    recording = {
+        "id": 99,
+        "file_path": str(audio_path),
+        "file_name": "call.wav",
+        "transcription": None,
+        "transcription_status": "pending",
+    }
+
+    monkeypatch.setenv("WHISPERX_BASE_URL", "http://env-whisperx.local/")
+    monkeypatch.setenv("WHISPERX_API_KEY", "env-api-key")
+    monkeypatch.setenv("WHISPERX_LANGUAGE", "en-AU")
+    monkeypatch.setenv("WHISPERX_STEREO_SPLIT", "false")
+
+    async def fake_get_module(slug: str, *args, **kwargs):
+        if slug == "whisperx":
+            return {
+                "slug": "whisperx",
+                "enabled": True,
+                "settings": {
+                    "base_url": "http://stale-db-whisperx.local",
+                    "api_key": "stale-db-key",
+                    "language": "fr",
+                },
+            }
+        if slug == "call-recordings":
+            return {"slug": "call-recordings", "settings": {"phone_system_type": "generic"}}
+        return None
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"text": "transcribed from env"}'
+    mock_response.text = '{"text": "transcribed from env"}'
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"text": "transcribed from env"}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(call_recordings_repo, "get_call_recording_by_id", new_callable=AsyncMock) as mock_get, \
+         patch.object(modules_service, "get_module", side_effect=fake_get_module) as mock_get_module, \
+         patch.object(call_recordings_repo, "update_call_recording", new_callable=AsyncMock) as mock_update, \
+         patch("httpx.AsyncClient") as mock_client_class:
+        mock_get.return_value = recording
+        mock_update.return_value = {
+            **recording,
+            "transcription": "transcribed from env",
+            "transcription_status": "completed",
+        }
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+
+        import asyncio
+        result = asyncio.run(service.transcribe_recording(99))
+
+    assert result["transcription"] == "transcribed from env"
+    mock_get_module.assert_called_once_with("call-recordings", redact=False)
+    post_args = mock_client.post.call_args
+    assert post_args.args[0] == "http://env-whisperx.local/asr"
+    assert post_args.kwargs["headers"]["Authorization"] == "Bearer env-api-key"
+    assert post_args.kwargs["params"]["language"] == "en-AU"


### PR DESCRIPTION
### Motivation
- Prevent stale or malicious WhisperX module settings persisted in the database from controlling the transcription endpoint or credentials. 
- Ensure runtime transcription always uses operator-managed environment configuration (including project `.env`) so updated env values take immediate effect and credentials are not leaked via DB values.

### Description
- Change `app/services/call_recordings.py` to source WhisperX runtime settings from environment/`.env` only by adding `_whisperx_env_settings()` and `_env_bool()` and calling `load_dotenv(..., override=True)` when a `.env` file is present. 
- Remove lookup of the WhisperX integration module settings from the database in the `transcribe_recording` flow and use the env-derived `base_url`, `api_key`, `language`, and `stereo_split` instead. 
- Add a regression test `test_transcribe_recording_uses_whisperx_env_over_database` in `tests/test_call_recordings.py` that sets env vars, provides conflicting DB module values, and asserts the outgoing `/asr` request uses the env endpoint, Authorization header, and language param.

### Testing
- `python -m py_compile app/services/call_recordings.py` succeeded. 
- `pytest -q tests/test_call_recordings.py::test_transcribe_recording_uses_whisperx_env_over_database` succeeded (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a474dcd3db0832d8e8f6996c3f84487)