### PR TITLE
Avoid repeated Matrix AI analysis

### DIFF
--- a/app/services/matrix_ai_waiting_assistant.py
+++ b/app/services/matrix_ai_waiting_assistant.py
@@ -588,6 +588,20 @@ async def handle_chat_closed(room_id: int) -> None:
     await _audit("matrix_ai_waiting_assistant.queue_cancelled", room_id, {"reason": "chat_closed"})
 
 
+def _room_analysis_current(room: Mapping[str, Any]) -> bool:
+    """Return whether the last KB analysis covers the latest user activity.
+
+    The worker scans unattended rooms every minute.  If a previous analysis did
+    not find a sendable article, the response count stays at 1 (the initial
+    acknowledgement), so the room still looks eligible for a second response.
+    Treat an analysis at or after the most recent customer activity as current
+    so we do not keep re-querying the LLM for the same unchanged transcript.
+    """
+
+    last_analysis_at = _as_datetime(room.get("ai_last_analysis_at"))
+    last_user_message_at = _as_datetime(room.get("ai_last_user_message_at"))
+    return bool(last_analysis_at and last_user_message_at and last_analysis_at >= last_user_message_at)
+
 async def _eligible_room(room: Mapping[str, Any]) -> bool:
     if not _enabled():
         return False
@@ -619,6 +633,8 @@ async def scan_waiting_rooms_once() -> None:
                 await chat_repo.release_ai_bot_response_reservation(int(room["id"]), reserved_count=1)
             continue
         if count == 1 and settings.matrixbot_ai_max_responses >= 2:
+            if _room_analysis_current(room):
+                continue
             active = await chat_repo.get_active_ai_queue_item(int(room["id"]))
             if active:
                 continue

--- a/tests/services/test_matrix_ai_waiting_assistant.py
+++ b/tests/services/test_matrix_ai_waiting_assistant.py
@@ -122,6 +122,47 @@ def test_scan_waiting_rooms_skips_ack_when_response_slot_already_reserved(monkey
     assert sent == []
 
 
+def test_scan_waiting_rooms_skips_second_response_when_analysis_is_current(monkeypatch):
+    settings = SimpleNamespace(
+        matrix_enabled=True,
+        matrixbot_ai_waiting_assistant_enabled=True,
+        matrixbot_ai_ollama_enabled=True,
+        matrixbot_ai_ollama_url="http://ollama.test",
+        matrixbot_ai_ollama_model="llama3",
+        matrixbot_ai_max_responses=2,
+        matrixbot_ai_response_delay_minutes=5,
+        matrixbot_ai_queue_timeout_minutes=60,
+    )
+    created: list[dict] = []
+
+    monkeypatch.setattr(assistant, "get_settings", lambda: settings)
+
+    async def fake_list(due_before):
+        return [{
+            "id": 42,
+            "status": "open",
+            "assigned_tech_user_id": None,
+            "ai_bot_response_count": 1,
+            "ai_last_user_message_at": "2026-07-03T10:00:00",
+            "ai_last_analysis_at": "2026-07-03T10:01:00",
+        }]
+
+    async def fake_has_technician_message(room_id):
+        return False
+
+    async def fake_create(**kwargs):
+        created.append(kwargs)
+        return {"id": 7}
+
+    monkeypatch.setattr(assistant.chat_repo, "list_ai_waiting_candidate_rooms", fake_list)
+    monkeypatch.setattr(assistant.chat_repo, "has_technician_message", fake_has_technician_message)
+    monkeypatch.setattr(assistant.chat_repo, "create_ai_queue_item", fake_create)
+
+    asyncio.run(assistant.scan_waiting_rooms_once())
+
+    assert created == []
+
+
 def test_scan_waiting_rooms_queues_second_response_analysis(monkeypatch):
     settings = SimpleNamespace(
         matrix_enabled=True,


### PR DESCRIPTION
### Motivation
- Prevent the MatrixBot AI worker from repeatedly querying the LLM for the same unchanged chat transcript by detecting when a previous KB analysis already covers the latest user activity.

### Description
- Add `_room_analysis_current(room)` which returns true when `ai_last_analysis_at` is at-or-after `ai_last_user_message_at` to treat the analysis as fresh.
- Update `scan_waiting_rooms_once` to skip creating a new analysis queue item when `_room_analysis_current(room)` is true.
- Add a regression test `test_scan_waiting_rooms_skips_second_response_when_analysis_is_current` in `tests/services/test_matrix_ai_waiting_assistant.py` to verify no new queue item is created for already-analysed rooms.

### Testing
- Ran `pytest tests/services/test_matrix_ai_waiting_assistant.py -q` and the suite completed successfully with all tests passing (`16 passed`, with warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a474ed6a730832db42a73c33b6655b2)