### PR TITLE
Add current-company scoped online device reports

### DIFF
--- a/app/features/reporting/handlers.py
+++ b/app/features/reporting/handlers.py
@@ -177,7 +177,10 @@ async def reporting_page(
                 )
             selected_report = record
             try:
-                result = await reporting_service.run_query(record["sql_query"])
+                result = await reporting_service.run_query_with_context(
+                    record["sql_query"],
+                    company_id=getattr(request.state, "active_company_id", None),
+                )
                 generated_at_iso = datetime.now(timezone.utc).isoformat()
                 await audit_service.record(
                     action="reporting.report.run",
@@ -234,7 +237,10 @@ async def reporting_export(request: Request, report_id: int, format: str = Query
         )
 
     try:
-        result = await reporting_service.run_query(record["sql_query"])
+        result = await reporting_service.run_query_with_context(
+            record["sql_query"],
+            company_id=getattr(request.state, "active_company_id", None),
+        )
     except reporting_service.ReportingQueryError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 

--- a/migrations/283_online_device_reporting_queries.sql
+++ b/migrations/283_online_device_reporting_queries.sql
@@ -1,0 +1,32 @@
+-- Add current-company scoped online device reports for the Reporting page.
+-- Idempotent via INSERT IGNORE on the unique slug.
+INSERT IGNORE INTO reporting_queries (slug, name, description, sql_query, is_system)
+VALUES
+    (
+        'online-physical-servers-last-30-days',
+        'Online Physical Servers - Last 30 Days',
+        'Physical server assets for the current company that have synced in the last 30 days.',
+        'SELECT a.id AS asset_id, a.name AS device_name, c.name AS company, COALESCE(NULLIF(TRIM(a.machine_type), ''''), NULLIF(TRIM(a.type), ''''), ''(unspecified)'') AS device_type, a.status, a.os_name, a.serial_number, a.last_sync FROM assets a JOIN companies c ON c.id = a.company_id WHERE a.company_id = {{current.company}} AND a.last_sync IS NOT NULL AND a.last_sync >= (CURRENT_DATE - INTERVAL 30 DAY) AND (LOWER(COALESCE(a.machine_type, '''')) IN (''physical_server'', ''physical server'', ''server_physical'') OR (LOWER(COALESCE(a.type, '''')) LIKE ''%server%'' AND LOWER(COALESCE(a.type, '''')) NOT LIKE ''%virtual%'' AND LOWER(COALESCE(a.type, '''')) NOT LIKE ''%vm%'')) ORDER BY a.last_sync DESC, a.name ASC',
+        1
+    ),
+    (
+        'online-virtual-servers-last-30-days',
+        'Online Virtual Servers - Last 30 Days',
+        'Virtual server assets for the current company that have synced in the last 30 days.',
+        'SELECT a.id AS asset_id, a.name AS device_name, c.name AS company, COALESCE(NULLIF(TRIM(a.machine_type), ''''), NULLIF(TRIM(a.type), ''''), ''(unspecified)'') AS device_type, a.status, a.os_name, a.serial_number, a.last_sync FROM assets a JOIN companies c ON c.id = a.company_id WHERE a.company_id = {{current.company}} AND a.last_sync IS NOT NULL AND a.last_sync >= (CURRENT_DATE - INTERVAL 30 DAY) AND (LOWER(COALESCE(a.machine_type, '''')) IN (''virtual_server'', ''virtual server'', ''server_virtual'', ''vm'') OR LOWER(COALESCE(a.type, '''')) LIKE ''%virtual%'' OR LOWER(COALESCE(a.type, '''')) LIKE ''%vm%'') ORDER BY a.last_sync DESC, a.name ASC',
+        1
+    ),
+    (
+        'online-workstations-last-30-days',
+        'Online Workstations - Last 30 Days',
+        'Workstation assets for the current company that have synced in the last 30 days.',
+        'SELECT a.id AS asset_id, a.name AS device_name, c.name AS company, COALESCE(NULLIF(TRIM(a.machine_type), ''''), NULLIF(TRIM(a.type), ''''), ''(unspecified)'') AS device_type, a.status, a.os_name, a.serial_number, a.last_sync FROM assets a JOIN companies c ON c.id = a.company_id WHERE a.company_id = {{current.company}} AND a.last_sync IS NOT NULL AND a.last_sync >= (CURRENT_DATE - INTERVAL 30 DAY) AND (LOWER(COALESCE(a.machine_type, '''')) IN (''workstation'', ''desktop'', ''laptop'') OR LOWER(COALESCE(a.type, '''')) LIKE ''%workstation%'' OR LOWER(COALESCE(a.type, '''')) LIKE ''%desktop%'' OR LOWER(COALESCE(a.type, '''')) LIKE ''%laptop%'') ORDER BY a.last_sync DESC, a.name ASC',
+        1
+    ),
+    (
+        'online-device-custom-field-last-30-days',
+        'Online Device - Custom Field - Last 30 Days',
+        'Online assets for the current company in the last 30 days with their configured custom field values.',
+        'SELECT a.id AS asset_id, a.name AS device_name, c.name AS company, COALESCE(NULLIF(TRIM(a.machine_type), ''''), NULLIF(TRIM(a.type), ''''), ''(unspecified)'') AS device_type, a.status, a.last_sync, acfd.name AS custom_field, CASE WHEN acfd.field_type = ''checkbox'' THEN CASE WHEN acfv.value_boolean = 1 THEN ''true'' WHEN acfv.value_boolean = 0 THEN ''false'' ELSE NULL END WHEN acfd.field_type = ''date'' THEN CAST(acfv.value_date AS CHAR) ELSE acfv.value_text END AS custom_field_value FROM assets a JOIN companies c ON c.id = a.company_id LEFT JOIN asset_custom_field_values acfv ON acfv.asset_id = a.id LEFT JOIN asset_custom_field_definitions acfd ON acfd.id = acfv.field_definition_id WHERE a.company_id = {{current.company}} AND a.last_sync IS NOT NULL AND a.last_sync >= (CURRENT_DATE - INTERVAL 30 DAY) ORDER BY a.last_sync DESC, a.name ASC, acfd.display_order ASC, acfd.name ASC',
+        1
+    );


### PR DESCRIPTION
### Motivation

- Provide default reporting queries for commonly requested online device groups (physical servers, virtual servers, workstations, and devices with custom fields) scoped to the current company and last 30 days. 
- Ensure reports are safe and limited in scope by leveraging the existing reporting context placeholder for the active company so reports don't leak cross-tenant data. 

### Description

- Add a new idempotent migration `migrations/283_online_device_reporting_queries.sql` that seeds four system reporting queries: `online-physical-servers-last-30-days`, `online-virtual-servers-last-30-days`, `online-workstations-last-30-days`, and `online-device-custom-field-last-30-days`, each using `{{current.company}}` in the SQL to restrict results to the current company. 
- Each seeded SQL filters `a.last_sync >= (CURRENT_DATE - INTERVAL 30 DAY)` so results are limited to the last 30 days and uses `INSERT IGNORE` so the seed is safe to run multiple times. 
- Update the reporting handlers to execute queries through `run_query_with_context()` so the `{{current.company}}` placeholder is substituted from `request.state.active_company_id` before validation/execution. 
- Apply the same context-aware execution for report exports so CSV/JSON/XML/PDF downloads are consistently scoped to the active company. 

### Testing

- Validated the four seeded SQL statements after substitution using `validate_select_query(substitute_query_context(...))` with environment variables set (`SESSION_SECRET` and `TOTP_ENCRYPTION_KEY`), and the assertions passed. 
- Confirmed Python modules compile with `python -m compileall app/features/reporting app/services/reporting.py` successfully. 
- Attempted to run `python -m pytest tests -k reporting -q`, but collection failed due to unrelated pre-existing test-suite issues (a syntax error in `tests/test_companies_members_endpoint.py`, a missing test dependency `respx`, and import errors in unrelated tests); these failures are not caused by the reporting changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a474e63d064832d9318fdc061593c85)