### PR TITLE
Merge inbound SMS into existing open tickets

### DIFF
--- a/app/features/receive_sms/routes.py
+++ b/app/features/receive_sms/routes.py
@@ -114,6 +114,19 @@ async def _find_contact(phone: str) -> dict[str, Any]:
 
 
 async def _find_sms_ticket(normalised_phone: str, sms_day: date) -> dict[str, Any] | None:
+    open_row = await db.fetch_one(
+        """
+        SELECT t.id FROM tickets t
+        INNER JOIN sms_ticket_links l ON l.ticket_id = t.id
+        WHERE l.from_number_normalized = %s
+          AND LOWER(COALESCE(t.status, '')) NOT IN ('closed', 'resolved')
+        ORDER BY t.updated_at DESC, t.id DESC LIMIT 1
+        """,
+        (normalised_phone,),
+    )
+    if open_row:
+        return await tickets_repo.get_ticket(int(open_row["id"]))
+
     row = await db.fetch_one(
         """
         SELECT t.id FROM tickets t

--- a/tests/test_receive_sms_feature_pack.py
+++ b/tests/test_receive_sms_feature_pack.py
@@ -137,3 +137,28 @@ def test_receive_sms_existing_ticket_reply_refreshes_ai(monkeypatch):
         assert calls == [("reply", 456), ("summary", 456), ("tags", 456)]
 
     asyncio.run(run_test())
+
+
+def test_find_sms_ticket_prefers_existing_open_ticket_before_sms_date(monkeypatch):
+    async def run_test():
+        queries: list[tuple[str, tuple]] = []
+
+        async def fake_fetch_one(query, params):
+            queries.append((query, params))
+            return {"id": 789}
+
+        async def fake_get_ticket(ticket_id):
+            return {"id": ticket_id, "status": "pending"}
+
+        monkeypatch.setattr(receive_sms_routes.db, "fetch_one", fake_fetch_one)
+        monkeypatch.setattr(receive_sms_routes.tickets_repo, "get_ticket", fake_get_ticket)
+
+        ticket = await receive_sms_routes._find_sms_ticket("61400123456", datetime(2026, 6, 17, tzinfo=timezone.utc).date())
+
+        assert ticket == {"id": 789, "status": "pending"}
+        assert len(queries) == 1
+        assert queries[0][1] == ("61400123456",)
+        assert "NOT IN ('closed', 'resolved')" in queries[0][0]
+        assert "l.sms_date = %s" not in queries[0][0]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
### Motivation
- Prevent creating a new ticket each day for SMS senders when an earlier SMS ticket is still open by preferring to merge inbound messages into an existing open ticket. 

### Description
- Update `_find_sms_ticket` in `app/features/receive_sms/routes.py` to first query for the latest ticket linked to the sender where `status` is not `closed` or `resolved`, ordered by `updated_at DESC, id DESC`. 
- Preserve the existing same-day fallback lookup that uses `sms_date` when no open ticket is found. 
- Add a regression test `test_find_sms_ticket_prefers_existing_open_ticket_before_sms_date` to `tests/test_receive_sms_feature_pack.py` to assert the new lookup preference. 

### Testing
- Ran `pytest tests/test_receive_sms_feature_pack.py` and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a475c70f3c4832d91d14cb01a31b8bb)