### PR TITLE
Allow ticket subject renaming

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -610,6 +610,13 @@ async def update_ticket(
                 "Invalid ticket status.",
                 error_id=error_id,
             ) from exc
+    if "subject" in fields and fields["subject"] is not None:
+        fields["subject"] = str(fields["subject"]).strip()
+        if not fields["subject"]:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Ticket subject is required",
+            )
     if fields:
         await tickets_repo.update_ticket(ticket_id, **fields)
     if description_value is not description_marker:

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -780,6 +780,7 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
     def _clean_text(value: Any) -> str:
         return str(value).strip() if isinstance(value, str) else ""
 
+    subject_value = _clean_text(form.get("subject"))
     status_raw = _clean_text(form.get("status"))
     priority_value = _clean_text(form.get("priority")).lower()
     requester_raw = form.get("requesterId")
@@ -803,6 +804,23 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
             )
     else:
         status_value = ticket.get("status") or await tickets_service.resolve_status_or_default(None)
+
+    if not subject_value:
+        return await main_module._render_ticket_detail(
+            request,
+            current_user,
+            ticket_id=ticket_id,
+            error_message="Enter a ticket subject.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    if len(subject_value) > 255:
+        return await main_module._render_ticket_detail(
+            request,
+            current_user,
+            ticket_id=ticket_id,
+            error_message="Subject must be 255 characters or fewer.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
 
     default_priorities = {"urgent", "high", "normal", "low"}
     ticket_priority = (ticket.get("priority") or "normal").lower()
@@ -949,6 +967,7 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
         requester_staff_id = matched.get("staff_id")
 
     update_fields: dict[str, Any] = {
+        "subject": subject_value,
         "priority": priority_value,
         "requester_id": requester_id,
         "requester_staff_id": requester_staff_id,

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -112,6 +112,18 @@
               {% endif %}
               <input type="hidden" name="returnUrl" value="{{ ticket_return_url }}" />
               <div class="form-field">
+                <label class="form-label required" for="ticket-subject-detail">Subject</label>
+                <input
+                  id="ticket-subject-detail"
+                  name="subject"
+                  class="form-input"
+                  maxlength="255"
+                  value="{{ ticket.subject or '' }}"
+                  required
+                  placeholder="Briefly describe the request"
+                />
+              </div>
+              <div class="form-field">
                 <label class="form-label" for="ticket-status-detail">Status</label>
                 <select id="ticket-status-detail" name="status" class="form-input">
                   {% if ticket_status not in ticket_status_label_map %}

--- a/tests/test_ticket_rename.py
+++ b/tests/test_ticket_rename.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+def test_admin_ticket_detail_form_allows_subject_rename():
+    template = Path("app/templates/admin/ticket_detail.html").read_text()
+
+    assert 'id="ticket-subject-detail"' in template
+    assert 'name="subject"' in template
+    assert 'value="{{ ticket.subject or \'\' }}"' in template
+    assert "maxlength=\"255\"" in template
+    assert "required" in template
+
+
+def test_admin_ticket_details_route_persists_subject_update():
+    route_source = Path("app/features/tickets/admin_routes.py").read_text()
+
+    assert 'subject_value = _clean_text(form.get("subject"))' in route_source
+    assert '"subject": subject_value' in route_source
+    assert 'error_message="Enter a ticket subject."' in route_source
+    assert 'error_message="Subject must be 255 characters or fewer."' in route_source


### PR DESCRIPTION
### Motivation
- Technicians must be able to rename tickets from the admin ticket detail page because the subject was previously immutable after creation. 
- Ensure subject updates are validated and sanitised to prevent blank or overly-long subjects from being stored.

### Description
- Add an editable `Subject` field to the admin ticket details form (`app/templates/admin/ticket_detail.html`) with `id="ticket-subject-detail"`, `name="subject"`, `maxlength="255"` and `required` attributes.
- Read, trim and validate the submitted subject in the admin handler (`app/features/tickets/admin_routes.py`) and include it in the persisted `update_fields` payload, returning friendly errors for missing or too-long subjects.
- Harden the ticket API update endpoint (`/api/tickets/{ticket_id}`) in `app/api/routes/tickets.py` to trim incoming `subject` updates and reject blank subjects with a `400` response.
- Add regression tests (`tests/test_ticket_rename.py`) that assert the presence of the new form field and the admin route wiring and validations.

### Testing
- Ran `pytest tests/test_ticket_rename.py` and the suite passed (`2 passed`).
- Compiled updated modules with `python -m compileall app/api/routes/tickets.py app/features/tickets/admin_routes.py` with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b11f661a8832d9c80b182b77b1b6d)