### PR TITLE
Add manual Xero invoice sync

### DIFF
--- a/app/api/routes/invoices.py
+++ b/app/api/routes/invoices.py
@@ -11,6 +11,7 @@ from app.repositories import invoices as invoice_repo
 from app.repositories import user_companies as user_company_repo
 from app.schemas.invoices import InvoiceCreate, InvoiceResponse, InvoiceUpdate
 from app.services import audit as audit_service
+from app.services import xero as xero_service
 
 router = APIRouter(prefix="/api/invoices", tags=["Invoices"])
 
@@ -162,6 +163,44 @@ async def patch_invoice(
         metadata=audit_metadata,
     )
     return InvoiceResponse.model_validate(updated)
+
+
+@router.post("/{invoice_id}/xero/sync")
+async def sync_invoice_to_xero(
+    invoice_id: int,
+    request: Request,
+    auto_send: bool = Query(default=False, alias="autoSend"),
+    _: None = Depends(require_database),
+    current_user: dict = Depends(require_super_admin),
+):
+    existing = await invoice_repo.get_invoice_by_id(invoice_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    result = await xero_service.sync_invoice(invoice_id, auto_send=auto_send)
+    if result.get("status") in {"failed", "error"}:
+        await audit_service.record(
+            action="invoice.xero_sync_failed",
+            request=request,
+            user_id=int(current_user["id"]),
+            entity_type="invoice",
+            entity_id=invoice_id,
+            before=existing,
+            after=None,
+            metadata={"company_id": int(existing["company_id"]), "result": result},
+        )
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=result)
+    updated = await invoice_repo.get_invoice_by_id(invoice_id)
+    await audit_service.record(
+        action="invoice.xero_sync",
+        request=request,
+        user_id=int(current_user["id"]),
+        entity_type="invoice",
+        entity_id=invoice_id,
+        before=existing,
+        after=updated,
+        metadata={"company_id": int(existing["company_id"]), "result": result},
+    )
+    return result
 
 
 @router.delete("/{invoice_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/app/features/invoices/routes.py
+++ b/app/features/invoices/routes.py
@@ -128,6 +128,8 @@ async def invoices_page(request: Request):
                 "status_class": status_class,
                 "status_slug": status_slug,
                 "is_overdue": is_overdue,
+                "xero_invoice_id": xero_invoice_id,
+                "can_sync_to_xero": is_super_admin and not xero_invoice_id,
             }
         )
     unpaid_count = max(len(records) - paid_count, 0)
@@ -143,6 +145,7 @@ async def invoices_page(request: Request):
         "unpaid_count": unpaid_count,
         "status_options": status_options,
         "can_delete_invoices": bool(user.get("is_super_admin")),
+        "can_sync_invoices_to_xero": bool(user.get("is_super_admin")),
     }
     return await main_module._render_template("invoices/index.html", request, user, extra=extra)
 
@@ -227,6 +230,7 @@ async def invoice_detail_page(request: Request, invoice_id: int):
         "company": company,
         "has_lines": bool(formatted_lines),
         "can_delete_invoices": bool(user.get("is_super_admin")),
+        "can_sync_invoices_to_xero": bool(user.get("is_super_admin")),
     }
     return await main_module._render_template("invoices/detail.html", request, user, extra=extra)
 

--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -2074,8 +2074,17 @@ async def sync_billable_tickets(
         }
 
 
-async def sync_company(company_id: int, auto_send: bool = False) -> dict[str, Any]:
-    """Upload unsynchronised MyPortal invoices for the given company to Xero."""
+async def sync_company(
+    company_id: int,
+    auto_send: bool = False,
+    invoice_ids: Sequence[int] | None = None,
+) -> dict[str, Any]:
+    """Upload unsynchronised MyPortal invoices for the given company to Xero.
+
+    When ``invoice_ids`` is provided, only those unsynchronised invoices are
+    pushed. This supports manual retry from the invoices UI without sending
+    every pending invoice for the company.
+    """
 
     module = await modules_service.get_module("xero", redact=False)
     if not module or not module.get("enabled"):
@@ -2105,10 +2114,15 @@ async def sync_company(company_id: int, auto_send: bool = False) -> dict[str, An
         }
 
     unsynced_invoices = await invoice_repo.list_unsynced_company_invoices(company_id)
+    requested_invoice_ids = {int(invoice_id) for invoice_id in invoice_ids or []}
+    if requested_invoice_ids:
+        unsynced_invoices = [
+            invoice for invoice in unsynced_invoices if int(invoice.get("id") or 0) in requested_invoice_ids
+        ]
     if not unsynced_invoices:
         return {
             "status": "skipped",
-            "reason": "No unsynchronised MyPortal invoices",
+            "reason": "No matching unsynchronised MyPortal invoices" if requested_invoice_ids else "No unsynchronised MyPortal invoices",
             "company_id": company_id,
             "invoice_count": 0,
         }
@@ -2384,6 +2398,29 @@ async def sync_company(company_id: int, auto_send: bool = False) -> dict[str, An
         "auto_send": auto_send,
     }
 
+
+async def sync_invoice(invoice_id: int, auto_send: bool = False) -> dict[str, Any]:
+    """Upload one unsynchronised MyPortal invoice to Xero."""
+
+    invoice = await invoice_repo.get_invoice_by_id(invoice_id)
+    if not invoice:
+        return {
+            "status": "skipped",
+            "reason": "Invoice not found",
+            "invoice_id": invoice_id,
+        }
+    xero_invoice_id = str(invoice.get("xero_invoice_id") or "").strip()
+    if xero_invoice_id:
+        return {
+            "status": "skipped",
+            "reason": "Invoice is already linked to Xero",
+            "invoice_id": invoice_id,
+            "xero_invoice_id": xero_invoice_id,
+        }
+    company_id = int(invoice["company_id"])
+    result = await sync_company(company_id, auto_send=auto_send, invoice_ids=[invoice_id])
+    result["invoice_id"] = invoice_id
+    return result
 
 
 async def send_order_to_xero(

--- a/app/templates/invoices/index.html
+++ b/app/templates/invoices/index.html
@@ -52,7 +52,7 @@
             <th scope="col" data-sort="date" data-mobile-priority="essential">Created</th>
             <th scope="col" data-sort="date" data-mobile-priority="essential">Due date</th>
             <th scope="col" data-sort="string" data-mobile-priority="essential">Status</th>
-            {% if can_delete_invoices %}<th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>{% endif %}
+            {% if can_delete_invoices or can_sync_invoices_to_xero %}<th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>{% endif %}
           </tr>
         </thead>
         <tbody>
@@ -83,11 +83,23 @@
                 <span class="text-muted">No status</span>
               {% endif %}
             </td>
-            {% if can_delete_invoices %}
+            {% if can_delete_invoices or can_sync_invoices_to_xero %}
             <td class="table__actions">
+              {% if can_sync_invoices_to_xero %}
+                <button
+                  type="button"
+                  class="button button--secondary button--small"
+                  data-invoice-xero-sync="{{ invoice.id }}"
+                  {% if not invoice.can_sync_to_xero %}disabled aria-disabled="true" title="Invoice is already linked to Xero"{% endif %}
+                >
+                  Push to Xero
+                </button>
+              {% endif %}
+              {% if can_delete_invoices %}
               <button type="button" class="button button--danger button--small" data-invoice-delete="{{ invoice.id }}">
                 Delete
               </button>
+              {% endif %}
             </td>
             {% endif %}
           </tr>
@@ -191,6 +203,41 @@
       }
       applyStatusFilter();
       updateSummary();
+
+      document.querySelectorAll('[data-invoice-xero-sync]').forEach((button) => {
+        button.addEventListener('click', async () => {
+          const invoiceId = button.getAttribute('data-invoice-xero-sync');
+          if (!invoiceId || button.disabled) return;
+          if (!window.confirm('Push this invoice to Xero now?')) return;
+          const originalText = button.textContent;
+          button.disabled = true;
+          button.textContent = 'Pushing…';
+          try {
+            const response = await fetch(`/api/invoices/${invoiceId}/xero/sync`, { method: 'POST' });
+            const payload = await response.json().catch(() => ({}));
+            if (!response.ok) {
+              const detail = payload.detail || {};
+              throw new Error(detail.error || detail.reason || 'Failed to push invoice to Xero');
+            }
+            const row = button.closest('tr');
+            const statusCell = row?.querySelector('td[data-label="Status"]');
+            if (row) row.setAttribute('data-status', 'xero');
+            if (statusCell) {
+              statusCell.setAttribute('data-value', 'xero');
+              statusCell.innerHTML = '<span class="status status--xero">Xero</span>';
+            }
+            button.textContent = 'Pushed';
+            button.setAttribute('title', 'Invoice is already linked to Xero');
+            window.alert('Invoice pushed to Xero successfully.');
+            updateSummary();
+          } catch (error) {
+            console.error(error);
+            window.alert(error.message || 'Unable to push invoice to Xero. Please try again.');
+            button.disabled = false;
+            button.textContent = originalText;
+          }
+        });
+      });
 
       document.querySelectorAll('[data-invoice-delete]').forEach((button) => {
         button.addEventListener('click', async () => {

--- a/tests/test_xero_sync_company_labour_rates.py
+++ b/tests/test_xero_sync_company_labour_rates.py
@@ -279,3 +279,77 @@ async def test_sync_company_creates_missing_xero_items_and_retries():
         assert result["synced_invoices"][0]["invoice_number"] == "XERO-2003"
         assert mock_client_instance.get.await_count == 1
         assert mock_client_instance.post.await_count == 3
+
+
+@pytest.mark.anyio("asyncio")
+async def test_sync_company_filters_to_requested_invoice_ids():
+    module_settings = {
+        "enabled": True,
+        "settings": {
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",
+            "refresh_token": "test-refresh-token",
+            "tenant_id": "test-tenant-id",
+            "account_code": "400",
+        },
+    }
+    invoices = [
+        {"id": 10, "invoice_number": "INV-10", "due_date": None},
+        {"id": 11, "invoice_number": "INV-11", "due_date": None},
+    ]
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = json.dumps(
+        {"Invoices": [{"InvoiceID": "xero-11", "InvoiceNumber": "XERO-11", "Status": "DRAFT"}]}
+    )
+    mock_response.headers = {}
+
+    with patch("app.services.xero.modules_service") as mock_modules, \
+         patch("app.services.xero.company_repo") as mock_company_repo, \
+         patch("app.services.xero.invoice_repo") as mock_invoice_repo, \
+         patch("app.services.xero.invoice_lines_repo") as mock_invoice_lines_repo, \
+         patch("app.services.xero.billed_time_repo") as mock_billed_repo, \
+         patch("app.services.xero.tickets_repo") as mock_tickets_repo, \
+         patch("app.services.xero.webhook_monitor") as mock_webhook, \
+         patch("app.services.xero.httpx.AsyncClient") as mock_client:
+        mock_modules.get_module = AsyncMock(return_value=module_settings)
+        mock_modules.acquire_xero_access_token = AsyncMock(return_value="test-access-token")
+        mock_company_repo.get_company_by_id = AsyncMock(return_value={"id": 1, "name": "Test", "xero_id": "contact"})
+        mock_invoice_repo.list_unsynced_company_invoices = AsyncMock(return_value=invoices)
+        mock_invoice_repo.patch_invoice = AsyncMock()
+        mock_invoice_lines_repo.list_invoice_lines = AsyncMock(
+            return_value=[{"description": "Managed services", "quantity": 1, "unit_amount": 150.00}]
+        )
+        mock_billed_repo.rename_invoice_number = AsyncMock()
+        mock_tickets_repo.rename_xero_invoice_number = AsyncMock()
+        mock_webhook.create_manual_event = AsyncMock(return_value={"id": 1})
+        mock_webhook.record_manual_success = AsyncMock()
+        mock_client_instance = MagicMock()
+        mock_client_instance.post = AsyncMock(return_value=mock_response)
+        mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client.return_value.__aexit__ = AsyncMock()
+
+        result = await xero_service.sync_company(company_id=1, invoice_ids=[11])
+
+    assert result["status"] == "succeeded"
+    assert result["invoice_count"] == 1
+    assert result["synced_invoices"][0]["previous_invoice_number"] == "INV-11"
+    mock_invoice_lines_repo.list_invoice_lines.assert_awaited_once_with(11)
+    mock_invoice_repo.patch_invoice.assert_awaited_once()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_sync_invoice_skips_already_linked_invoice():
+    with patch("app.services.xero.invoice_repo") as mock_invoice_repo:
+        mock_invoice_repo.get_invoice_by_id = AsyncMock(
+            return_value={"id": 10, "company_id": 1, "xero_invoice_id": "existing-xero-id"}
+        )
+
+        result = await xero_service.sync_invoice(10)
+
+    assert result == {
+        "status": "skipped",
+        "reason": "Invoice is already linked to Xero",
+        "invoice_id": 10,
+        "xero_invoice_id": "existing-xero-id",
+    }


### PR DESCRIPTION
### Motivation
- Provide super admins a way to manually push a single invoice to Xero to recover from failed scheduled pushes and avoid having to run a full company sync.

### Description
- Add a super-admin API endpoint `POST /api/invoices/{invoice_id}/xero/sync` that invokes the Xero sync helper and records audit events on success or failure (`app/api/routes/invoices.py`).
- Extend Xero sync to accept an `invoice_ids` filter on `sync_company()` and add `sync_invoice()` to safely push a single invoice and skip already-linked invoices (`app/services/xero.py`).
- Expose controls in the invoices UI for super admins and add a "Push to Xero" action with disabled state for already-synced invoices and client-side UX updates (`app/features/invoices/routes.py` and `app/templates/invoices/index.html`).
- Add regression tests covering company sync filtering to requested invoice IDs and skipping already-linked invoices (`tests/test_xero_sync_company_labour_rates.py`).

### Testing
- Compiled modified modules with `python -m compileall app/services/xero.py app/api/routes/invoices.py app/features/invoices/routes.py` which succeeded.
- Ran targeted tests with `pytest tests/test_xero_sync_company_labour_rates.py::test_sync_company_filters_to_requested_invoice_ids tests/test_xero_sync_company_labour_rates.py::test_sync_invoice_skips_already_linked_invoice -q` and both passed.
- Ran the full `tests/test_xero_sync_company_labour_rates.py -q` where one pre-existing unrelated test (`test_sync_company_creates_missing_xero_items_and_retries`) failed (assertion on returned invoice number); the new tests still pass despite that existing failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b1237dc10832da49b44314c194b04)