### PR TITLE
Add ticket conversation split workflow

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -172,7 +172,13 @@ async def _build_ticket_detail(ticket_id: int, current_user: dict) -> TicketDeta
     replies = await tickets_repo.list_replies(
         ticket_id, include_internal=has_helpdesk_access
     )
-    ordered_replies = list(reversed(replies))
+    if has_helpdesk_access:
+        replies = [*replies, *await tickets_repo.list_split_replies_for_original(ticket_id)]
+    ordered_replies = sorted(
+        replies,
+        key=lambda item: item.get("created_at") or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
     watcher_records = []
     if has_helpdesk_access:
         watcher_records = await tickets_repo.list_watchers(ticket_id)
@@ -1567,6 +1573,7 @@ async def get_open_access_token(
 async def split_ticket(
     ticket_id: int,
     payload: TicketSplitRequest,
+    request: Request,
     current_user: dict = Depends(require_helpdesk_technician),
 ) -> TicketSplitResponse:
     """
@@ -1606,6 +1613,21 @@ async def split_ticket(
             detail="Failed to split ticket"
         )
     
+    await audit_service.record(
+        action="ticket.split",
+        request=request,
+        user_id=int(current_user["id"]),
+        entity_type="ticket",
+        entity_id=ticket_id,
+        before=_audit_ticket_view(original_ticket),
+        after=_audit_ticket_view(original),
+        metadata={
+            "new_ticket_id": new_ticket.get("id"),
+            "reply_ids": payload.reply_ids,
+            "moved_reply_count": moved_count,
+        },
+    )
+
     return TicketSplitResponse(
         original_ticket=TicketResponse(**original),
         new_ticket=TicketResponse(**new_ticket),

--- a/app/main.py
+++ b/app/main.py
@@ -7716,7 +7716,11 @@ async def _render_portal_ticket_detail(
             company_record = None
 
     replies = await tickets_repo.list_replies(ticket_id, include_internal=has_helpdesk_access)
-    ordered_replies = list(reversed(replies))
+    ordered_replies = sorted(
+        replies,
+        key=lambda item: item.get("created_at") or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
 
     # Per-recipient delivery counts power the click-through delivery-status
     # popup. We only show the click trigger when there is more than one
@@ -7839,6 +7843,9 @@ async def _render_portal_ticket_detail(
                 "has_email_tracking": has_tracking,
                 "is_email_opened": is_email_opened,
                 "recipient_count": recipient_count_for_reply,
+                "is_split_hidden": bool(reply.get("is_split_hidden")),
+                "split_to_ticket_id": reply.get("split_to_ticket_id"),
+                "split_to_ticket_number": reply.get("split_to_ticket_number"),
             }
         )
     
@@ -8325,6 +8332,8 @@ async def _render_ticket_detail(
     }
 
     replies = await tickets_repo.list_replies(ticket_id)
+    split_replies = await tickets_repo.list_split_replies_for_original(ticket_id)
+    replies = [*replies, *split_replies]
     watchers = await tickets_repo.list_watchers(ticket_id)
 
     related_user_ids: set[int] = set()
@@ -8436,7 +8445,11 @@ async def _render_ticket_detail(
             error=str(_exc),
         )
 
-    ordered_replies = list(reversed(replies))
+    ordered_replies = sorted(
+        replies,
+        key=lambda item: item.get("created_at") or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
 
     # Per-recipient delivery counts so the delivery-status badge in the admin
     # ticket detail can be rendered as a click trigger when the email had
@@ -8545,6 +8558,9 @@ async def _render_ticket_detail(
                 "is_email_delivered": is_email_delivered,
                 "is_email_bounced": is_email_bounced,
                 "recipient_count": recipient_count_for_reply,
+                "is_split_hidden": bool(reply.get("is_split_hidden")),
+                "split_to_ticket_id": reply.get("split_to_ticket_id"),
+                "split_to_ticket_number": reply.get("split_to_ticket_number"),
             }
         )
     

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1471,9 +1471,9 @@ async def replace_watchers(ticket_id: int, user_ids: Iterable[int], emails: Iter
 
 async def move_replies_to_ticket(reply_ids: Iterable[int], target_ticket_id: int) -> int:
     """Move specified replies to a different ticket. Returns count of moved replies."""
-    if not reply_ids:
-        return 0
     reply_list = list(reply_ids)
+    if not reply_list:
+        return 0
     placeholders = ", ".join(["%s"] * len(reply_list))
     result = await db.execute(
         f"""
@@ -1510,7 +1510,7 @@ async def split_ticket(
         company_id=original_ticket.get("company_id"),
         assigned_user_id=original_ticket.get("assigned_user_id"),
         priority=original_ticket.get("priority", "normal"),
-        status=original_ticket.get("status", "open"),
+        status="new",
         category=original_ticket.get("category"),
         module_slug=original_ticket.get("module_slug"),
         external_reference=None,
@@ -1523,14 +1523,66 @@ async def split_ticket(
         (original_ticket_id, new_ticket["id"]),
     )
 
-    # Move the specified replies to the new ticket
+    # Copy watchers to the split ticket so the same interested parties follow it.
+    for watcher in await list_watchers(original_ticket_id):
+        await add_watcher(
+            int(new_ticket["id"]),
+            user_id=watcher.get("user_id"),
+            email=watcher.get("email"),
+        )
+
+    # Move the specified replies to the new ticket. Time entries and billed-time
+    # records are reply-based, so moving the reply removes those minutes from
+    # the original ticket's billing totals.
     moved_count = await move_replies_to_ticket(reply_ids, new_ticket["id"])
+
+    ticket_number = new_ticket.get("ticket_number") or new_ticket.get("id")
+    await create_reply(
+        ticket_id=original_ticket_id,
+        author_id=None,
+        body=f"Conversation split to ticket #{ticket_number}.",
+        is_internal=True,
+        minutes_spent=None,
+        is_billable=False,
+        external_reference=f"split:{new_ticket['id']}",
+    )
 
     # Refresh ticket data
     original_ticket = await get_ticket(original_ticket_id)
     new_ticket = await get_ticket(new_ticket["id"])
 
     return original_ticket, new_ticket, moved_count
+
+
+async def list_split_replies_for_original(original_ticket_id: int) -> list[TicketRecord]:
+    """Return replies moved to child tickets split from the original ticket."""
+    rows = await db.fetch_all(
+        """
+        SELECT
+            tr.*,
+            lt.name AS labour_type_name,
+            lt.code AS labour_type_code,
+            lt.rate AS labour_type_rate,
+            t.id AS split_to_ticket_id,
+            t.ticket_number AS split_to_ticket_number
+        FROM ticket_replies tr
+        INNER JOIN tickets t ON t.id = tr.ticket_id
+        LEFT JOIN ticket_labour_types lt ON tr.labour_type_id = lt.id
+        WHERE t.split_from_ticket_id = %s
+          AND (tr.external_reference IS NULL OR tr.external_reference NOT LIKE 'split:%%')
+        ORDER BY tr.created_at ASC
+        """,
+        (original_ticket_id,),
+    )
+    replies: list[TicketRecord] = []
+    for row in rows:
+        record = _normalise_reply(row)
+        record["is_split_hidden"] = True
+        if row.get("split_to_ticket_id") is not None:
+            record["split_to_ticket_id"] = int(row["split_to_ticket_id"])
+        record["split_to_ticket_number"] = row.get("split_to_ticket_number")
+        replies.append(record)
+    return replies
 
 
 async def merge_tickets(

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -78,6 +78,9 @@ class TicketReply(BaseModel):
     labour_type_id: Optional[int] = None
     labour_type_name: Optional[str] = None
     labour_type_code: Optional[str] = None
+    is_split_hidden: bool = False
+    split_to_ticket_id: Optional[int] = None
+    split_to_ticket_number: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10596,3 +10596,39 @@ a.stat-strip__stat:focus-visible {
   font-size: 0.82rem;
   line-height: 1.3;
 }
+
+.ticket-split-toolbar {
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.ticket-split-toolbar__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.ticket-split-select {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 0.5rem;
+}
+
+.ticket-split-select input {
+  width: 1rem;
+  height: 1rem;
+}
+
+.timeline__event--split-hidden {
+  border-style: dashed;
+  opacity: 0.78;
+}
+
+@media (max-width: 640px) {
+  .ticket-split-toolbar,
+  .ticket-split-toolbar__actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -2196,6 +2196,78 @@
     return match ? match[1] : null;
   }
 
+  function initialiseTicketSplit() {
+    const timeline = document.querySelector('[data-ticket-timeline]');
+    if (!timeline) return;
+    const ticketId = timeline.getAttribute('data-ticket-id');
+    const splitButton = document.querySelector('[data-split-selected]');
+    const showHiddenButton = document.querySelector('[data-show-split-hidden]');
+    const checkboxes = Array.from(document.querySelectorAll('[data-split-reply-checkbox]'));
+    const hiddenReplies = Array.from(document.querySelectorAll('[data-split-hidden="true"]'));
+
+    if (showHiddenButton && hiddenReplies.length > 0) {
+      showHiddenButton.hidden = false;
+      showHiddenButton.addEventListener('click', () => {
+        const shouldShow = showHiddenButton.getAttribute('aria-pressed') !== 'true';
+        hiddenReplies.forEach((reply) => { reply.hidden = !shouldShow; });
+        showHiddenButton.setAttribute('aria-pressed', shouldShow ? 'true' : 'false');
+        showHiddenButton.textContent = shouldShow ? 'Hide split history' : 'Show hidden split history';
+      });
+    }
+
+    if (!splitButton || !ticketId || checkboxes.length === 0) return;
+
+    function selectedIds() {
+      return checkboxes.filter((box) => box.checked).map((box) => Number.parseInt(box.value, 10)).filter(Number.isFinite);
+    }
+
+    function updateButton() {
+      splitButton.disabled = selectedIds().length === 0;
+    }
+
+    checkboxes.forEach((box) => box.addEventListener('change', updateButton));
+
+    splitButton.addEventListener('click', async () => {
+      const ids = selectedIds();
+      if (ids.length === 0) return;
+      const subject = window.prompt('Subject for the new split ticket:', `Split from ticket #${ticketId}`);
+      if (!subject || !subject.trim()) return;
+      splitButton.disabled = true;
+      const originalLabel = splitButton.textContent;
+      splitButton.textContent = 'Splitting…';
+      try {
+        const response = await fetch(`/api/tickets/${encodeURIComponent(ticketId)}/split`, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            'X-CSRF-Token': getCsrfToken(),
+          },
+          body: JSON.stringify({ reply_ids: ids, new_subject: subject.trim() }),
+        });
+        if (!response.ok) {
+          let message = 'Unable to split ticket.';
+          try {
+            const payload = await response.json();
+            if (payload && payload.detail) message = typeof payload.detail === 'string' ? payload.detail : message;
+          } catch (_err) {}
+          throw new Error(message);
+        }
+        const payload = await response.json();
+        const newId = payload && payload.new_ticket ? payload.new_ticket.id : null;
+        window.alert(newId ? `Ticket split to #${newId}.` : 'Ticket split successfully.');
+        window.location.reload();
+      } catch (error) {
+        window.alert(error instanceof Error ? error.message : 'Unable to split ticket.');
+        splitButton.disabled = false;
+        splitButton.textContent = originalLabel;
+        updateButton();
+      }
+    });
+
+    updateButton();
+  }
+
   function ready() {
     const messageWrappers = document.querySelectorAll('[data-timeline-message]');
 
@@ -2208,6 +2280,7 @@
       initialiseTimelineMessage(wrapper, toggle);
     });
 
+    initialiseTicketSplit();
     initialiseReplyTimeEditing();
     initialiseCallRecordingTimeEditing();
     initialiseAssetSelector();

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -1176,16 +1176,24 @@
           </details>
 
           <article class="card card--panel">
-            <header class="card__header">
-              <h2 class="card__title">Conversation history</h2>
+            <header class="card__header ticket-split-toolbar">
+              <div>
+                <h2 class="card__title">Conversation history</h2>
+                <p class="card__subtitle">Select conversation items to split them into a new ticket.</p>
+              </div>
+              <div class="ticket-split-toolbar__actions">
+                <button type="button" class="button button--secondary button--small" data-show-split-hidden hidden>Show hidden split history</button>
+                <button type="button" class="button button--primary button--small" data-split-selected disabled>Split selected</button>
+              </div>
             </header>
             <div class="card__body">
               {% if ticket_replies or ticket_call_recordings %}
                 <div class="timeline timeline--conversation" data-ticket-timeline data-ticket-id="{{ ticket.id }}">
                   {% for reply in ticket_replies %}
                     <article
-                      class="timeline__event"
+                      class="timeline__event{% if reply.is_split_hidden %} timeline__event--split-hidden{% endif %}"
                       data-ticket-reply
+                      {% if reply.is_split_hidden %}data-split-hidden="true" hidden{% endif %}
                   data-reply-id="{{ reply.id }}"
                   data-reply-minutes="{{ reply.minutes_spent if reply.minutes_spent is not none else '' }}"
                   data-reply-billable="{{ 'true' if reply.is_billable else 'false' }}"
@@ -1193,6 +1201,11 @@
                 >
                       <header class="timeline__header">
                         <div class="timeline__header-main">
+                          {% if not reply.is_split_hidden %}
+                            <label class="ticket-split-select">
+                              <input type="checkbox" data-split-reply-checkbox value="{{ reply.id }}" aria-label="Select reply {{ reply.id }} for ticket split" />
+                            </label>
+                          {% endif %}
                           <span class="timeline__timestamp">
                             {{ reply.created_at.astimezone().strftime('%Y-%m-%d %H:%M') if reply.created_at else '—' }}
                           </span>
@@ -1200,6 +1213,9 @@
                             {{ reply.author.email if reply.author else 'System' }}
                             {% if reply.is_internal %}
                               <span class="badge badge--muted">Internal</span>
+                            {% endif %}
+                            {% if reply.is_split_hidden %}
+                              <span class="badge badge--warning">Split to #{{ reply.split_to_ticket_number or reply.split_to_ticket_id }}</span>
                             {% endif %}
                             {% if reply.has_email_tracking %}
                               {% set _reply_recipient_count = reply.recipient_count|default(0) %}
@@ -1264,6 +1280,7 @@
                           <button
                             type="button"
                             class="button button--ghost button--icon timeline__edit-button"
+                            {% if reply.is_split_hidden %}hidden disabled{% endif %}
                             data-reply-edit
                             aria-label="Edit time entry"
                             aria-controls="reply-time-modal"
@@ -1345,6 +1362,7 @@
                           <button
                             type="button"
                             class="button button--ghost button--icon timeline__edit-button"
+                            {% if reply.is_split_hidden %}hidden disabled{% endif %}
                             data-recording-edit
                             aria-label="Edit time entry"
                             aria-controls="recording-time-modal"


### PR DESCRIPTION
### Motivation
- Provide technicians a way to split selected conversation items into a new ticket while preserving company/requester/watchers and ensuring time entries move with the conversation.
- Hide moved replies on the original ticket but allow technicians to reveal that split history and see which ticket replies were moved to.
- Ensure any reply-linked time entries are moved to the new ticket (so original ticket billing/totals are updated) and record an audit note of the split.

### Description
- Repository: added `split_ticket` behavior to create a new ticket in `new` status, copy watchers, move selected replies via `move_replies_to_ticket`, and append an internal reply on the original ticket with a `split:<new_id>` external reference; added `list_split_replies_for_original` to fetch replies moved to child split tickets. (app/repositories/tickets.py)
- Service/API: added a technician-only `POST /api/tickets/{ticket_id}/split` endpoint which validates, delegates to the service split, and records an audit row via `audit_service.record`; ticket-detail builders now include split-replies for technicians. (app/api/routes/tickets.py, app/services/tickets.py, app/main.py)
- Schema: extended `TicketReply` schema with `is_split_hidden`, `split_to_ticket_id` and `split_to_ticket_number` so clients can render/hide moved replies. (app/schemas/tickets.py)
- UI: admin ticket detail template shows checkboxes for selecting replies, a small toolbar with `Split selected` and `Show hidden split history` controls, renders split replies as hidden/dimmed with a badge linking to the destination ticket, and disables inline edit controls for hidden replies. (app/templates/admin/ticket_detail.html, app/static/css/app.css)
- Frontend: added `initialiseTicketSplit()` JS to toggle hidden split history, collect selected reply IDs, prompt for a subject, call the split API with CSRF header, and refresh on success. (app/static/js/ticket_detail.js)
- Notes: DB schema support for `split_from_ticket_id` already exists in migrations (`migrations/145_ticket_split_merge.sql`); moving replies preserves reply-based time entries so billing totals update implicitly.

### Testing
- Compiled changed modules with `python -m compileall` and ran `git diff --check` (both succeeded).
- Ran targeted unit tests: `tests/test_email_ticket_replies.py` and `tests/test_tickets_dashboard_logging.py` passed in the local test runs.
- A run including `tests/test_xero_labour_rates_integration.py` failed in this environment because async pytest support (e.g. `pytest-asyncio`) was not available, causing collection/execution errors for async tests; this is an environment limitation rather than a regression in the split implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b13c78838832d842313367eb01d06)