### PR TITLE
Fix Xero sync tenant env fallback and token checks

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -547,6 +547,7 @@ def _default_xero_settings() -> dict[str, Any]:
         "client_id": _clean_env("XERO_CLIENT_ID"),
         "client_secret": _clean_env("XERO_CLIENT_SECRET"),
         "webhook_key": _clean_env("XERO_WEBHOOK_KEY"),
+        "tenant_id": _clean_env("XERO_TENANT_ID"),
         # Note: refresh_token is obtained via OAuth2 code flow only (/xero/connect)
         # and should not be set manually via environment variables
         "company_name": _clean_env("XERO_COMPANY_NAME"),
@@ -992,6 +993,7 @@ _ENV_BACKED_MODULE_FIELDS: dict[str, tuple[str, ...]] = {
     "xero": (
         "client_id",
         "client_secret",
+        "tenant_id",
         "company_name",
         "default_hourly_rate",
         "account_code",
@@ -1040,6 +1042,9 @@ def _resolve_module_settings_for_runtime(
     raw_settings = _parse_module_settings((module or {}).get("settings"))
     resolved = _coerce_settings(slug, raw_settings, module)
     if slug == "xero":
+        env_tenant_id = str(os.getenv("XERO_TENANT_ID", "")).strip()
+        if env_tenant_id and not str(resolved.get("tenant_id") or "").strip():
+            resolved["tenant_id"] = env_tenant_id
         env_line_item_template = str(os.getenv("XERO_LINE_ITEM_TEMPLATE", "")).strip()
         if env_line_item_template:
             resolved["line_item_description_template"] = env_line_item_template

--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -2095,8 +2095,22 @@ async def sync_company(
         }
 
     settings = dict(module.get("settings") or {})
-    required_fields = ["client_id", "client_secret", "refresh_token", "tenant_id"]
-    missing = [field for field in required_fields if not str(settings.get(field) or "").strip()]
+    credentials = await modules_service.get_xero_credentials() or {}
+    tenant_id = str(credentials.get("tenant_id") or settings.get("tenant_id") or "").strip()
+    missing = [
+        field
+        for field in ("client_id", "client_secret", "tenant_id")
+        if not str(credentials.get(field) or settings.get(field) or "").strip()
+    ]
+    # A refresh token is required for durable OAuth operation because Xero
+    # access tokens expire quickly and refresh tokens are rotated. However, do
+    # not block a sync that still has a cached access token; acquire_xero_access_token()
+    # will reuse that token while it remains valid and will raise a clearer
+    # error if it has expired without a refresh token.
+    if not str(credentials.get("refresh_token") or "").strip() and not str(
+        credentials.get("access_token") or ""
+    ).strip():
+        missing.append("refresh_token")
     if missing:
         return {
             "status": "skipped",
@@ -2125,14 +2139,6 @@ async def sync_company(
             "reason": "No matching unsynchronised MyPortal invoices" if requested_invoice_ids else "No unsynchronised MyPortal invoices",
             "company_id": company_id,
             "invoice_count": 0,
-        }
-
-    tenant_id = str(settings.get("tenant_id", "")).strip()
-    if not tenant_id:
-        return {
-            "status": "skipped",
-            "reason": "Tenant ID not configured",
-            "company_id": company_id,
         }
 
     try:

--- a/tests/test_force_env_module_settings.py
+++ b/tests/test_force_env_module_settings.py
@@ -3,7 +3,7 @@ import pytest
 from app.services import modules as modules_service
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_force_env_module_settings_ignores_db_values_for_env_backed_fields(monkeypatch):
     monkeypatch.setenv("FORCE_ENV_MODULE_SETTINGS", "true")
     monkeypatch.setenv("HUDU_BASE_URL", "https://env.example")
@@ -30,7 +30,7 @@ async def test_force_env_module_settings_ignores_db_values_for_env_backed_fields
     }
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_force_env_module_settings_preserves_non_env_fields(monkeypatch):
     monkeypatch.setenv("FORCE_ENV_MODULE_SETTINGS", "true")
     monkeypatch.setenv("SYNCRO_BASE_URL", "https://env.syncro.example")
@@ -60,7 +60,7 @@ async def test_force_env_module_settings_preserves_non_env_fields(monkeypatch):
     assert result["settings"]["custom_runtime_state"] == "preserve-me"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio("asyncio")
 async def test_force_env_module_settings_uses_defaults_when_env_is_blank(monkeypatch):
     monkeypatch.setenv("FORCE_ENV_MODULE_SETTINGS", "true")
     monkeypatch.delenv("CALL_RECORDINGS_PATH", raising=False)
@@ -83,3 +83,27 @@ async def test_force_env_module_settings_uses_defaults_when_env_is_blank(monkeyp
 
     assert result["recordings_path"] == "/var/lib/myportal/call_recordings"
     assert result["phone_system_type"] == "generic"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_xero_tenant_id_can_be_sourced_from_env(monkeypatch):
+    monkeypatch.delenv("FORCE_ENV_MODULE_SETTINGS", raising=False)
+    monkeypatch.setenv("XERO_TENANT_ID", "tenant-from-env")
+
+    async def fake_get_module(slug: str):
+        assert slug == "xero"
+        return {
+            "slug": "xero",
+            "enabled": True,
+            "settings": {
+                "tenant_id": "",
+                "client_id": "db-client-id",
+                "client_secret": "db-client-secret",
+            },
+        }
+
+    monkeypatch.setattr(modules_service.module_repo, "get_module", fake_get_module)
+
+    result = await modules_service.get_module("xero", redact=False)
+
+    assert result["settings"]["tenant_id"] == "tenant-from-env"

--- a/tests/test_xero_auto_send.py
+++ b/tests/test_xero_auto_send.py
@@ -181,3 +181,74 @@ async def test_sync_company_auto_send_parameter():
         
         assert result["status"] == "skipped"
         assert result["reason"] == "Module disabled"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_sync_company_uses_credentials_for_config_check_with_cached_access_token():
+    """Cached access tokens should allow sync attempts without a stored refresh token."""
+
+    with patch("app.services.xero.modules_service") as mock_modules, \
+         patch("app.services.xero.company_repo") as mock_company_repo, \
+         patch("app.services.xero.invoice_repo") as mock_invoice_repo:
+
+        mock_modules.get_module = AsyncMock(
+            return_value={
+                "enabled": True,
+                "settings": {
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                    "tenant_id": "tenant-id",
+                },
+            }
+        )
+        mock_modules.get_xero_credentials = AsyncMock(
+            return_value={
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+                "tenant_id": "tenant-id",
+                "access_token": "cached-access-token",
+                "refresh_token": "",
+            }
+        )
+        mock_company_repo.get_company_by_id = AsyncMock(
+            return_value={"id": 1, "name": "Test Company", "xero_id": "xero-123"}
+        )
+        mock_invoice_repo.list_unsynced_company_invoices = AsyncMock(return_value=[])
+
+        result = await xero_service.sync_company(company_id=1)
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "No unsynchronised MyPortal invoices"
+        assert "missing" not in result
+
+
+@pytest.mark.anyio("asyncio")
+async def test_sync_company_requires_refresh_token_when_no_cached_access_token():
+    """Without refresh or cached access token, Xero sync should clearly report refresh_token missing."""
+
+    with patch("app.services.xero.modules_service") as mock_modules:
+        mock_modules.get_module = AsyncMock(
+            return_value={
+                "enabled": True,
+                "settings": {
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                    "tenant_id": "tenant-id",
+                },
+            }
+        )
+        mock_modules.get_xero_credentials = AsyncMock(
+            return_value={
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+                "tenant_id": "tenant-id",
+                "access_token": "",
+                "refresh_token": "",
+            }
+        )
+
+        result = await xero_service.sync_company(company_id=1)
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "Module not fully configured"
+        assert result["missing"] == ["refresh_token"]


### PR DESCRIPTION
### Motivation

- Allow the Xero integration to use a `XERO_TENANT_ID` value from environment defaults when the stored module setting is blank so `.env`-configured tenants work without DB changes.  
- Avoid skipping invoice syncs when a cached Xero access token is available even if a refresh token is not currently stored.  
- Make module configuration checks use the effective/decrypted credentials returned by `get_xero_credentials()` instead of only raw DB settings.

### Description

- Added `tenant_id` sourced from `XERO_TENANT_ID` into the Xero default settings returned by `_default_xero_settings()` in `app/services/modules.py`.  
- Included `tenant_id` in `_ENV_BACKED_MODULE_FIELDS` so `FORCE_ENV_MODULE_SETTINGS` can override/preserve the env tenant.  
- Implemented runtime env fallback for Xero tenant in `_resolve_module_settings_for_runtime()` so resolved module settings pick up `XERO_TENANT_ID` when DB value is blank.  
- Updated `sync_company()` in `app/services/xero.py` to use `modules_service.get_xero_credentials()` for configuration validation, require `client_id`, `client_secret`, and `tenant_id` from effective credentials/settings, and only mark `refresh_token` missing when there is neither a stored refresh token nor a cached `access_token` (so cached access tokens allow an immediate sync).  
- Removed the earlier strict duplicate check that forced `tenant_id` from raw settings and adjusted header logic to use the resolved `tenant_id`.  
- Added/updated regression tests in `tests/test_force_env_module_settings.py` and `tests/test_xero_auto_send.py` to cover env-sourced tenant resolution and cached-access-token vs missing-refresh-token behavior.

### Testing

- Ran `pytest tests/test_force_env_module_settings.py tests/test_xero_auto_send.py` and all targeted tests passed.  
- The new/modified unit tests exercise env fallback for `XERO_TENANT_ID` and the sync validation logic for cached access tokens versus missing refresh tokens and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b161ed538832d953122ab5ec88642)