### PR TITLE
Add global invoice review page for super-admins and persist table sort state

### DIFF
--- a/app/core/features.py
+++ b/app/core/features.py
@@ -271,6 +271,8 @@ class FeatureRegistry:
     def _build_parent_router(self, pack: FeaturePack) -> APIRouter:
         """Build a parent router that hosts all the pack's routes."""
 
+        if len(pack.routers) == 1:
+            return pack.routers[0]
         parent = APIRouter()
         for child in pack.routers:
             parent.include_router(child)
@@ -393,6 +395,13 @@ class FeatureRegistry:
         before = len(self._app.router.routes)
         self._app.include_router(parent)
         new_routes = self._app.router.routes[before:]
+        if (
+            len(new_routes) == 1
+            and getattr(new_routes[0], "path", None) is None
+            and hasattr(new_routes[0], "original_router")
+        ):
+            self._app.router.routes = self._app.router.routes[:before] + list(parent.routes)
+            new_routes = self._app.router.routes[before:]
         state.mounted_routes = list(new_routes)
         self._wrap_routes_with_state(new_routes, state)
         await self._run_hook(pack.startup, pack.slug, "startup")

--- a/app/features/invoices/routes.py
+++ b/app/features/invoices/routes.py
@@ -70,13 +70,7 @@ async def _load_invoice_context(request: Request):
     return user, membership, company, company_id, None
 
 
-@router.get("/invoices", response_class=HTMLResponse)
-async def invoices_page(request: Request):
-    main_module = _main()
-    user, membership, company, company_id, redirect = await _load_invoice_context(request)
-    if redirect:
-        return redirect
-    records = await invoice_repo.list_company_invoices(company_id)
+def _format_invoice_records(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], Decimal, int]:
     total_amount = Decimal("0.00")
     paid_count = 0
     today = datetime.now(timezone.utc).date()
@@ -130,6 +124,17 @@ async def invoices_page(request: Request):
                 "is_overdue": is_overdue,
             }
         )
+    return formatted, total_amount, paid_count
+
+
+@router.get("/invoices", response_class=HTMLResponse)
+async def invoices_page(request: Request):
+    main_module = _main()
+    user, membership, company, company_id, redirect = await _load_invoice_context(request)
+    if redirect:
+        return redirect
+    records = await invoice_repo.list_company_invoices(company_id)
+    formatted, total_amount, paid_count = _format_invoice_records(records)
     unpaid_count = max(len(records) - paid_count, 0)
     total_amount_display = f"${total_amount.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP):,.2f}"
     status_options = sorted({invoice["status_slug"] for invoice in formatted if invoice["status_slug"]})
@@ -143,6 +148,40 @@ async def invoices_page(request: Request):
         "unpaid_count": unpaid_count,
         "status_options": status_options,
         "can_delete_invoices": bool(user.get("is_super_admin")),
+        "is_global_invoices": False,
+        "invoice_table_id": "invoice",
+    }
+    return await main_module._render_template("invoices/index.html", request, user, extra=extra)
+
+
+@router.get("/invoices/global", response_class=HTMLResponse)
+async def global_invoices_page(request: Request):
+    main_module = _main()
+    user, redirect = await main_module._require_authenticated_user(request)
+    if redirect:
+        return redirect
+    if not bool(user.get("is_super_admin")):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Global invoice review requires super admin access",
+        )
+    records = await invoice_repo.list_all_invoices()
+    formatted, total_amount, paid_count = _format_invoice_records(records)
+    unpaid_count = max(len(records) - paid_count, 0)
+    total_amount_display = f"${total_amount.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP):,.2f}"
+    status_options = sorted({invoice["status_slug"] for invoice in formatted if invoice["status_slug"]})
+    extra = {
+        "title": "Global invoices",
+        "invoices": formatted,
+        "company": None,
+        "has_invoices": bool(formatted),
+        "total_amount_display": total_amount_display,
+        "paid_count": paid_count,
+        "unpaid_count": unpaid_count,
+        "status_options": status_options,
+        "can_delete_invoices": True,
+        "is_global_invoices": True,
+        "invoice_table_id": "invoice-global",
     }
     return await main_module._render_template("invoices/index.html", request, user, extra=extra)
 
@@ -154,8 +193,12 @@ async def invoice_detail_page(request: Request, invoice_id: int):
     if redirect:
         return redirect
     invoice = await invoice_repo.get_invoice_by_id(invoice_id)
-    if not invoice or int(invoice.get("company_id", 0)) != company_id:
+    if not invoice:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    if not bool(user.get("is_super_admin")) and int(invoice.get("company_id", 0)) != company_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invoice not found")
+    if bool(user.get("is_super_admin")) and int(invoice.get("company_id", 0)) != company_id:
+        company = await company_repo.get_company_by_id(int(invoice.get("company_id", 0)))
     lines = await invoice_lines_repo.list_invoice_lines(invoice_id)
     amount_value = invoice.get("amount")
     amount_decimal = (

--- a/app/repositories/invoices.py
+++ b/app/repositories/invoices.py
@@ -39,6 +39,18 @@ async def list_company_invoices(company_id: int) -> list[dict[str, Any]]:
     return [_normalise_invoice(row) for row in rows]
 
 
+async def list_all_invoices() -> list[dict[str, Any]]:
+    rows = await db.fetch_all(
+        """
+        SELECT invoices.*, companies.name AS company_name
+        FROM invoices
+        LEFT JOIN companies ON companies.id = invoices.company_id
+        ORDER BY invoices.due_date DESC, invoices.invoice_number
+        """
+    )
+    return [_normalise_invoice(row) for row in rows]
+
+
 async def get_invoice_by_id(invoice_id: int) -> Optional[dict[str, Any]]:
     row = await db.fetch_one("SELECT * FROM invoices WHERE id = %s", (invoice_id,))
     return _normalise_invoice(row) if row else None

--- a/app/static/js/tables.js
+++ b/app/static/js/tables.js
@@ -16,7 +16,7 @@
     return value.toLowerCase();
   }
 
-  function sortTable(table, columnIndex, type, controller) {
+  function sortTable(table, columnIndex, type, controller, forcedOrder) {
     const tbody = table.tBodies[0];
     if (!tbody) {
       return;
@@ -26,7 +26,7 @@
     const current = table.getAttribute('data-sort-index') === String(columnIndex)
       ? table.getAttribute('data-sort-order')
       : null;
-    const ascending = current !== 'asc';
+    const ascending = forcedOrder ? forcedOrder === 'asc' : current !== 'asc';
 
     rows.sort((a, b) => {
       const valueA = parseValue(getCellValue(a, columnIndex), type);
@@ -61,6 +61,7 @@
     }));
 
     if (controller) {
+      controller.persistSortState(columnIndex, ascending ? 'asc' : 'desc', type);
       controller.refreshRows();
     }
   }
@@ -73,6 +74,9 @@
         sortTable(table, columnIndex, header.getAttribute('data-sort') || 'string', controller);
       });
     });
+    if (controller) {
+      controller.restorePersistedSort();
+    }
   }
 
   class TableController {
@@ -247,13 +251,22 @@
       if (!key) {
         return;
       }
+      const currentSortIndex = this.table.getAttribute('data-sort-index');
+      const currentSortOrder = this.table.getAttribute('data-sort-order');
+      const currentSortType = this.table.getAttribute('data-sort-type');
       const state = {
         global: this.filterInputValue || '',
         columns: this.columnFilters || {},
+        sort: currentSortIndex && currentSortOrder ? {
+          index: Number.parseInt(currentSortIndex, 10),
+          order: currentSortOrder,
+          type: currentSortType || undefined,
+        } : null,
       };
       const hasColumns = Object.values(state.columns).some((value) => Boolean(value));
+      const hasSort = state.sort && Number.isInteger(state.sort.index) && ['asc', 'desc'].includes(state.sort.order);
       try {
-        if (state.global || hasColumns) {
+        if (state.global || hasColumns || hasSort) {
           window.localStorage.setItem(key, JSON.stringify(state));
         } else {
           window.localStorage.removeItem(key);
@@ -261,6 +274,27 @@
       } catch (error) {
         /* Ignore storage failures so table filtering remains usable. */
       }
+    }
+
+
+    persistSortState(columnIndex, order, type) {
+      if (!this.table) {
+        return;
+      }
+      this.table.setAttribute('data-sort-type', type || 'string');
+      this.persistFilterState();
+    }
+
+    restorePersistedSort() {
+      const sort = this.persistedFilterState?.sort;
+      if (!sort || !Number.isInteger(sort.index) || !['asc', 'desc'].includes(sort.order)) {
+        return;
+      }
+      const header = this.table?.tHead?.rows?.[0]?.children?.[sort.index];
+      if (!header || !header.hasAttribute('data-sort')) {
+        return;
+      }
+      sortTable(this.table, sort.index, sort.type || header.getAttribute('data-sort') || 'string', this, sort.order);
     }
 
     restorePersistedFilters() {

--- a/app/templates/invoices/index.html
+++ b/app/templates/invoices/index.html
@@ -1,26 +1,37 @@
 {% extends "base.html" %}
 
-{% block header_title %}Invoices{% endblock %}
+{% block header_title %}{{ 'Global invoices' if is_global_invoices else 'Invoices' }}{% endblock %}
 
-{% block title %}Invoices{% endblock %}
+{% block header_actions %}
+  {% from "macros/header.html" import page_header_actions %}
+  {% set invoice_actions = [] %}
+  {% if is_super_admin and not is_global_invoices %}
+    {% set _ = invoice_actions.append({"label": "Global invoices", "type": "link", "href": "/invoices/global"}) %}
+  {% elif is_global_invoices %}
+    {% set _ = invoice_actions.append({"label": "Company invoices", "type": "link", "href": "/invoices"}) %}
+  {% endif %}
+  {{ page_header_actions(invoice_actions) }}
+{% endblock %}
+
+{% block title %}{{ 'Global invoices' if is_global_invoices else 'Invoices' }}{% endblock %}
 
 {% block content %}
 <div class="admin-grid admin-grid--columns">
   <section class="card card--panel admin-grid__full">
     <header class="card__header">
       <div class="card__controls">
-        {% if company %}<span class="tag">{{ company.name }}</span>{% endif %}
-        <label class="visually-hidden" for="invoice-search">Search invoices</label>
+        {% if is_global_invoices %}<span class="tag">All companies</span>{% elif company %}<span class="tag">{{ company.name }}</span>{% endif %}
+        <label class="visually-hidden" for="{{ invoice_table_id }}-search">Search invoices</label>
         <input
           type="search"
-          id="invoice-search"
+          id="{{ invoice_table_id }}-search"
           class="form-input"
           placeholder="Search invoices"
           aria-label="Search invoices"
-          data-table-filter="invoice-table"
+          data-table-filter="{{ invoice_table_id }}-table"
         />
-        <label class="visually-hidden" for="invoice-status-filter">Filter by status</label>
-        <select id="invoice-status-filter" class="form-input" aria-label="Filter by status">
+        <label class="visually-hidden" for="{{ invoice_table_id }}-status-filter">Filter by status</label>
+        <select id="{{ invoice_table_id }}-status-filter" class="form-input" aria-label="Filter by status" data-table-column-filter="status" data-table-column-filter-table="{{ invoice_table_id }}-table">
           <option value="">All statuses</option>
           {% for status in status_options %}
             <option value="{{ status }}">{{ status|replace('_', ' ')|title }}</option>
@@ -44,9 +55,10 @@
     </div>
     {% if has_invoices %}
     <div class="table-wrapper">
-      <table class="table" id="invoice-table" data-table data-table-id="invoice">
+      <table class="table table--stack-mobile" id="{{ invoice_table_id }}-table" data-table data-table-id="{{ invoice_table_id }}" data-invoice-table>
         <thead>
           <tr>
+            {% if is_global_invoices %}<th scope="col" data-sort="string" data-mobile-priority="essential">Company</th>{% endif %}
             <th scope="col" data-sort="string" data-mobile-priority="essential">Invoice #</th>
             <th scope="col" data-sort="number" data-mobile-priority="essential">Amount</th>
             <th scope="col" data-sort="date" data-mobile-priority="essential">Created</th>
@@ -58,10 +70,13 @@
         <tbody>
           {% for invoice in invoices %}
           <tr data-status="{{ invoice.status_slug }}"{% if invoice.is_overdue %} class="invoice-row--overdue"{% endif %}>
-            <td data-label="Invoice number">
+            {% if is_global_invoices %}
+            <td data-label="Company" data-value="{{ invoice.company_name or '' }}">{{ invoice.company_name or 'Unknown company' }}</td>
+            {% endif %}
+            <td data-label="Invoice number" data-value="{{ invoice.invoice_number }}">
               <a href="/invoices/{{ invoice.id }}" class="link">{{ invoice.invoice_number }}</a>
             </td>
-            <td data-label="Amount" data-value="{{ invoice.amount }}">{{ invoice.amount_display }}</td>
+            <td data-label="Amount" data-value="{{ invoice.amount }}" data-invoice-amount>{{ invoice.amount_display }}</td>
             <td data-label="Created" data-value="{{ invoice.created_sort }}" data-utc="{{ invoice.created_iso }}">
               {% if invoice.created_display %}
                 {{ invoice.created_display }}
@@ -76,7 +91,7 @@
                 <span class="text-muted">No due date</span>
               {% endif %}
             </td>
-            <td data-label="Status" data-value="{{ invoice.status_slug }}">
+            <td data-label="Status" data-column-key="status" data-value="{{ invoice.status_slug }}">
               {% if invoice.status_slug %}
                 <span class="status {{ invoice.status_class }}">{{ invoice.status_display }}</span>
               {% else %}
@@ -115,7 +130,7 @@
       const totalEl = document.querySelector('[data-invoice-total]');
       const paidEl = document.querySelector('[data-invoice-paid]');
       const openEl = document.querySelector('[data-invoice-open]');
-      const table = document.getElementById('invoice-table');
+      const table = document.querySelector('[data-invoice-table]');
       if (!totalEl && !paidEl && !openEl) {
         return;
       }
@@ -144,7 +159,7 @@
       let total = 0;
       let paid = 0;
       visibleRows.forEach((row) => {
-        const amountCell = row.querySelector('td[data-value]');
+        const amountCell = row.querySelector('[data-invoice-amount]');
         if (amountCell) {
           const value = parseFloat(amountCell.getAttribute('data-value') || '0');
           if (!Number.isNaN(value)) total += value;
@@ -163,33 +178,13 @@
       if (openEl) openEl.textContent = String(visibleRows.length - paid);
     }
 
-    function applyStatusFilter() {
-      const table = document.getElementById('invoice-table');
-      const filter = document.getElementById('invoice-status-filter');
-      if (!table || !filter) return;
-      const selected = filter.value.trim().toLowerCase();
-      table.querySelectorAll('tbody tr').forEach((row) => {
-        const status = (row.getAttribute('data-status') || '').toLowerCase();
-        const matches = !selected || status === selected;
-        row.style.display = matches ? '' : 'none';
-      });
-    }
 
     document.addEventListener('DOMContentLoaded', () => {
-      const filter = document.getElementById('invoice-status-filter');
-      if (filter) {
-        filter.addEventListener('change', () => {
-          applyStatusFilter();
-          updateSummary();
-        });
+      const table = document.querySelector('[data-invoice-table]');
+      if (table) {
+        table.addEventListener('table:render', updateSummary);
+        table.addEventListener('table:sorted', updateSummary);
       }
-      const searchInput = document.querySelector('[data-table-filter="invoice-table"]');
-      if (searchInput) {
-        searchInput.addEventListener('input', () => {
-          window.setTimeout(updateSummary, 0);
-        });
-      }
-      applyStatusFilter();
       updateSummary();
 
       document.querySelectorAll('[data-invoice-delete]').forEach((button) => {
@@ -206,7 +201,7 @@
             if (row) {
               row.remove();
             }
-            const table = document.getElementById('invoice-table');
+            const table = document.querySelector('[data-invoice-table]');
             if (table && !table.querySelector('tbody tr')) {
               const wrapper = table.closest('.table-wrapper');
               const container = wrapper?.parentElement;

--- a/tests/test_invoices_feature_pack.py
+++ b/tests/test_invoices_feature_pack.py
@@ -11,6 +11,7 @@ from app.features.invoices import PACK
 
 EXPECTED = {
     ("GET", "/invoices"),
+    ("GET", "/invoices/global"),
     ("GET", "/invoices/{invoice_id}"),
     ("HEAD", "/invoices/{invoice_id}"),
 }


### PR DESCRIPTION
### Motivation
- Provide a super-admin view to review all invoices across companies independent of the active company selector so global invoice reconciliation and oversight is possible.
- Reuse the existing invoices UI and table infrastructure while preserving scoped access rules for non-super-admins.
- Improve UX by persisting table filter and sort state so reviewers keep their view after refreshes.

### Description
- Added a new super-admin-only route `GET /invoices/global` that lists invoices for all companies and reuses a shared formatter to produce the same display fields as the company-scoped page. (routes, formatting helper, template flags).
- Added `list_all_invoices()` in the invoices repository to join invoice rows with company names for the global table.
- Updated the invoices template to include a top-right action menu to toggle between company and global views, to show an "All companies" tag, and to add a company column when viewing global invoices while keeping sorting/filtering mobile-friendly.
- Extended the client-side table logic to persist sort state to `localStorage` and to restore persisted sort on load so applied sort+filters survive page refreshes.
- Adjusted the feature-pack mounting logic to correctly mount single-child routers (compatibility with current FastAPI router include behavior) and updated the invoices feature-pack test expectation for the added route.

### Testing
- Compiled modified modules with `python3 -m compileall app/core/features.py app/features/invoices/routes.py app/repositories/invoices.py` and it succeeded.
- Ran the invoices feature pack tests with `pytest -q tests/test_invoices_feature_pack.py` and they passed (3 tests).
- Ran targeted checks while iterating (including `pytest` runs that exposed and then validated fixes to router mounting and template mobile class updates); fixes were iterated until the invoice-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b12bd7280832d8225db999f183fb5)