### PR TITLE
Fix invoice pages super admin formatting error

### DIFF
--- a/app/features/invoices/routes.py
+++ b/app/features/invoices/routes.py
@@ -70,7 +70,9 @@ async def _load_invoice_context(request: Request):
     return user, membership, company, company_id, None
 
 
-def _format_invoice_records(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], Decimal, int]:
+def _format_invoice_records(
+    records: list[dict[str, Any]], *, is_super_admin: bool = False
+) -> tuple[list[dict[str, Any]], Decimal, int]:
     total_amount = Decimal("0.00")
     paid_count = 0
     today = datetime.now(timezone.utc).date()
@@ -129,14 +131,16 @@ def _format_invoice_records(records: list[dict[str, Any]]) -> tuple[list[dict[st
     return formatted, total_amount, paid_count
 
 
-@router.get("/invoices", response_class=HTMLResponse)
+@router.api_route("/invoices", methods=["GET", "HEAD"], response_class=HTMLResponse)
 async def invoices_page(request: Request):
     main_module = _main()
     user, membership, company, company_id, redirect = await _load_invoice_context(request)
     if redirect:
         return redirect
     records = await invoice_repo.list_company_invoices(company_id)
-    formatted, total_amount, paid_count = _format_invoice_records(records)
+    formatted, total_amount, paid_count = _format_invoice_records(
+        records, is_super_admin=bool(user.get("is_super_admin"))
+    )
     unpaid_count = max(len(records) - paid_count, 0)
     total_amount_display = f"${total_amount.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP):,.2f}"
     status_options = sorted({invoice["status_slug"] for invoice in formatted if invoice["status_slug"]})
@@ -157,7 +161,7 @@ async def invoices_page(request: Request):
     return await main_module._render_template("invoices/index.html", request, user, extra=extra)
 
 
-@router.get("/invoices/global", response_class=HTMLResponse)
+@router.api_route("/invoices/global", methods=["GET", "HEAD"], response_class=HTMLResponse)
 async def global_invoices_page(request: Request):
     main_module = _main()
     user, redirect = await main_module._require_authenticated_user(request)
@@ -169,7 +173,7 @@ async def global_invoices_page(request: Request):
             detail="Global invoice review requires super admin access",
         )
     records = await invoice_repo.list_all_invoices()
-    formatted, total_amount, paid_count = _format_invoice_records(records)
+    formatted, total_amount, paid_count = _format_invoice_records(records, is_super_admin=True)
     unpaid_count = max(len(records) - paid_count, 0)
     total_amount_display = f"${total_amount.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP):,.2f}"
     status_options = sorted({invoice["status_slug"] for invoice in formatted if invoice["status_slug"]})

--- a/tests/test_head_requests.py
+++ b/tests/test_head_requests.py
@@ -47,6 +47,15 @@ def test_invoices_head_request():
     assert response.status_code in {200, 303, 401, 403}
 
 
+def test_global_invoices_head_request():
+    """Test that HEAD requests to /invoices/global don't return 405."""
+    with TestClient(app, follow_redirects=False) as client:
+        response = client.head("/invoices/global")
+
+    assert response.status_code != 405, "HEAD requests should be supported"
+    assert response.status_code in {200, 303, 401, 403}
+
+
 def test_admin_service_status_head_request():
     """Test that HEAD requests to /admin/service-status don't return 405."""
     with TestClient(app, follow_redirects=False) as client:

--- a/tests/test_invoice_routes.py
+++ b/tests/test_invoice_routes.py
@@ -1,0 +1,25 @@
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from app.features.invoices.routes import _format_invoice_records
+
+
+def test_format_invoice_records_uses_explicit_super_admin_flag():
+    records = [
+        {
+            "id": 1,
+            "invoice_number": "INV-1",
+            "amount": Decimal("12.30"),
+            "status": "draft",
+            "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "due_date": None,
+            "xero_invoice_id": "",
+        }
+    ]
+
+    formatted_regular, _, _ = _format_invoice_records(records, is_super_admin=False)
+    formatted_admin, _, _ = _format_invoice_records(records, is_super_admin=True)
+
+    assert formatted_regular[0]["can_sync_to_xero"] is False
+    assert formatted_admin[0]["can_sync_to_xero"] is True


### PR DESCRIPTION
### Motivation
- Prevent a `NameError` and ensure Xero sync permission is computed correctly by avoiding reliance on an undefined `is_super_admin` name inside the invoice formatter. 
- Ensure invoice listing endpoints support `HEAD` requests like other monitored routes so status probes and clients don't get `405` responses. 
- Add focused regression tests to cover the formatter behavior and `HEAD` handling for the global invoices route.

### Description
- Updated `_format_invoice_records` signature to accept an explicit `is_super_admin: bool` flag and use it to compute `can_sync_to_xero`. 
- Passed `is_super_admin` into `_format_invoice_records` from `invoices_page` and set `is_super_admin=True` when formatting `global` invoices. 
- Switched invoice list routes to use `@router.api_route(..., methods=["GET", "HEAD"])` for both `"/invoices"` and `"/invoices/global"` to add `HEAD` support. 
- Added a new regression test `tests/test_invoice_routes.py` for the `is_super_admin` flag and updated `tests/test_head_requests.py` to include a `HEAD /invoices/global` check.

### Testing
- Ran `pytest -q tests/test_invoice_routes.py tests/test_head_requests.py::test_invoices_head_request tests/test_head_requests.py::test_global_invoices_head_request` and the selected tests passed. 
- Verified Python syntax by running `python -m py_compile app/features/invoices/routes.py` which succeeded. 
- A broader `pytest -q tests/test_invoice_routes.py tests/test_head_requests.py` run revealed an existing unrelated failure where `HEAD /service-status` returned `405` for `test_service_status_head_request`, which is not caused by these invoice changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b1c0052d4832dbe2c4219d6460033)