### PR TITLE
Persist rotated Xero refresh tokens

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -4107,11 +4107,29 @@ async def _discover_xero_tenant_id(
             token_response.raise_for_status()
             token_data_response = token_response.json()
             access_token = token_data_response.get("access_token")
-            
+            new_refresh_token = token_data_response.get("refresh_token")
+            expires_in = token_data_response.get("expires_in")
+
             if not access_token:
                 logger.error("Failed to get access token from Xero")
                 return None
-            
+
+            expires_at = None
+            if isinstance(expires_in, (int, float)):
+                expires_at = datetime.now(timezone.utc) + timedelta(seconds=float(expires_in))
+
+            # Xero rotates refresh tokens on every refresh-token grant.  Persist
+            # any replacement immediately so validation/tenant discovery cannot
+            # leave the module with a stale token that later produces
+            # ``invalid_grant`` and causes syncs to report a missing/unusable
+            # refresh_token.
+            if new_refresh_token:
+                await update_xero_tokens(
+                    access_token=str(access_token),
+                    refresh_token=str(new_refresh_token),
+                    token_expires_at=expires_at,
+                )
+
             # Step 2: Get connections (tenants)
             connections_url = "https://api.xero.com/connections"
             connections_response = await client.get(

--- a/tests/test_xero_module.py
+++ b/tests/test_xero_module.py
@@ -390,6 +390,48 @@ async def test_discover_xero_tenant_id_from_connections_api():
 
 
 @pytest.mark.anyio("asyncio")
+async def test_discover_xero_tenant_id_persists_rotated_refresh_token():
+    """Tenant discovery must store Xero's rotated refresh token for later syncs."""
+
+    with patch("app.services.modules.httpx.AsyncClient") as mock_client_class, patch(
+        "app.services.modules.update_xero_tokens", new_callable=AsyncMock
+    ) as mock_update_tokens:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        mock_token_response = MagicMock()
+        mock_token_response.json.return_value = {
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "expires_in": 1800,
+        }
+        mock_token_response.raise_for_status.return_value = None
+
+        mock_connections_response = MagicMock()
+        mock_connections_response.json.return_value = [
+            {"tenantId": "tenant-123", "tenantName": "Test Company"},
+        ]
+        mock_connections_response.raise_for_status.return_value = None
+
+        mock_client.post.return_value = mock_token_response
+        mock_client.get.return_value = mock_connections_response
+
+        tenant_id = await modules_service._discover_xero_tenant_id(
+            client_id="test-client",
+            client_secret="test-secret",
+            refresh_token="old-refresh-token",
+            company_name="Test Company",
+        )
+
+    assert tenant_id == "tenant-123"
+    mock_update_tokens.assert_awaited_once()
+    update_kwargs = mock_update_tokens.await_args.kwargs
+    assert update_kwargs["access_token"] == "new-access-token"
+    assert update_kwargs["refresh_token"] == "new-refresh-token"
+    assert update_kwargs["token_expires_at"] is not None
+
+
+@pytest.mark.anyio("asyncio")
 async def test_discover_xero_tenant_id_case_insensitive_matching():
     """Test that tenant name matching is case-insensitive."""
     


### PR DESCRIPTION
### Motivation

- Xero rotates `refresh_token` values on each refresh-token grant and failing to persist replacements can cause subsequent `invalid_grant` errors and broken background syncs. 
- The refresh token must be stored encrypted in the `myportal.integration_modules` settings for the Xero module rather than left in environment variables so the app can perform durable OAuth flows. 

### Description

- Capture `refresh_token` and `expires_in` from Xero's token response during tenant discovery in `app/services/modules.py` and compute `token_expires_at`. 
- Persist the rotated tokens by calling the existing `update_xero_tokens` path which encrypts and writes settings into the Xero record in `integration_modules` (so tokens are stored against the Xero module in `myportal.integration_modules`). 
- Add a regression test `test_discover_xero_tenant_id_persists_rotated_refresh_token` in `tests/test_xero_module.py` to verify the rotated `refresh_token`, `access_token`, and expiry are stored. 

### Testing

- Ran `pytest tests/test_xero_module.py -q` which passed (all tests in that file succeeded). 
- Ran `python -m compileall app/services/modules.py` to validate byte-compilation succeeded. 
- Added unit test coverage for the new behavior (`test_discover_xero_tenant_id_persists_rotated_refresh_token`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b1c96a434832d8052c82ec81b7895)