### PR TITLE
Fix report variables in recurring invoice items

### DIFF
--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -23,7 +23,7 @@ from app.repositories import tickets as tickets_repo
 from app.repositories import users as users_repo
 from app.services.billing_time import format_billable_minutes
 from app.services import modules as modules_service
-from app.services import webhook_monitor
+from app.services import value_templates, webhook_monitor
 
 TicketFetcher = Callable[[int], Awaitable[Mapping[str, Any] | None]]
 RepliesFetcher = Callable[[int], Awaitable[Sequence[Mapping[str, Any]] | None]]
@@ -1405,37 +1405,53 @@ async def build_quote_invoice(
 
 
 def _evaluate_qty_expression(expression: str, context: dict[str, Any]) -> float:
-    """Evaluate a quantity expression, supporting both static numbers and variables.
-    
-    Args:
-        expression: The quantity expression (e.g., "5", "{active_agents}", "10")
-        context: Dictionary of available variables for substitution
-    
-    Returns:
-        The evaluated quantity as a float
-    """
+    """Evaluate a quantity expression, supporting static numbers and legacy variables."""
     if not expression:
         return 1.0
-    
-    # Try to evaluate as a direct number first
+
     try:
         return float(expression)
     except ValueError:
         pass
-    
-    # Try to substitute variables and then evaluate
+
     try:
-        # Simple variable substitution using format_map
         evaluated = expression.format_map(_TemplateValues(context))
         return float(evaluated)
     except (ValueError, KeyError):
-        # If evaluation fails, default to 1
         logger.warning(
             "Failed to evaluate quantity expression, defaulting to 1",
             expression=expression,
             context_keys=list(context.keys()),
         )
         return 1.0
+
+
+async def _render_recurring_template_value(
+    template: str,
+    context: dict[str, Any],
+) -> Any:
+    """Render dynamic ``{{ token }}`` variables and legacy ``{token}`` placeholders."""
+    rendered = await value_templates.render_string_async(template, context)
+    if not isinstance(rendered, str):
+        return rendered
+    try:
+        return rendered.format_map(_TemplateValues(context))
+    except Exception:
+        return rendered
+
+
+async def _evaluate_recurring_qty_expression(
+    expression: str,
+    context: dict[str, Any],
+) -> float:
+    """Evaluate recurring item quantity after resolving all supported variables."""
+    if not expression:
+        return 1.0
+    rendered = await _render_recurring_template_value(expression, context)
+    try:
+        return float(rendered)
+    except (TypeError, ValueError):
+        return _evaluate_qty_expression(expression, context)
 
 
 async def build_invoice_context(company_id: int) -> dict[str, Any]:
@@ -1546,7 +1562,8 @@ async def build_recurring_invoice_items(
     if not recurring_items:
         return []
     
-    template_context = _TemplateValues(context or {})
+    raw_context = dict(context or {})
+    raw_context.setdefault("company_id", company_id)
     
     # Collect item codes that need rates from Xero (those without price_override)
     item_codes_to_fetch: set[str] = set()
@@ -1587,10 +1604,15 @@ async def build_recurring_invoice_items(
         if not item.get("active"):
             continue
         
-        # Format description using template
+        # Format description using dynamic variables and legacy template placeholders.
         description_template = str(item.get("description_template") or "")
         try:
-            description = description_template.format_map(template_context).strip()
+            description = str(
+                await _render_recurring_template_value(
+                    description_template,
+                    raw_context,
+                )
+            ).strip()
         except Exception:
             description = description_template.strip()
         
@@ -1599,7 +1621,7 @@ async def build_recurring_invoice_items(
         
         # Evaluate quantity expression
         qty_expression = str(item.get("qty_expression") or "1")
-        quantity = _evaluate_qty_expression(qty_expression, template_context)
+        quantity = await _evaluate_recurring_qty_expression(qty_expression, raw_context)
         
         product_code = str(item.get("product_code") or "")
         

--- a/tests/test_xero_recurring_items.py
+++ b/tests/test_xero_recurring_items.py
@@ -374,3 +374,74 @@ async def test_build_recurring_invoice_items_without_credentials(monkeypatch):
     assert len(line_items) == 1
     assert line_items[0]["ItemCode"] == "MANAGED-SERVICES"
     assert "UnitAmount" not in line_items[0], "Should not have UnitAmount without credentials"
+
+
+def test_build_recurring_invoice_items_with_report_variables(monkeypatch):
+    """Recurring item descriptions and quantities render saved-report variables."""
+
+    async def fake_list_items(company_id):
+        return [
+            {
+                "id": 1,
+                "company_id": company_id,
+                "product_code": "ONLINE-WORKSTATIONS",
+                "description_template": "Online workstations:\n{{ report.online-workstations-last-30-days.list }}",
+                "qty_expression": "{{ report.online-workstations-last-30-days.count }}",
+                "price_override": 2.50,
+                "active": True,
+            }
+        ]
+
+    async def fake_get_query_by_slug(slug):
+        assert slug == "online-workstations-last-30-days"
+        return {
+            "slug": slug,
+            "sql_query": "SELECT name FROM assets WHERE company_id = {{current.company}}",
+        }
+
+    async def fake_count_query_rows(sql_query, *, company_id=None):
+        assert company_id == 77
+        return 3
+
+    async def fake_run_query_with_context(sql_query, *, company_id=None):
+        assert company_id == 77
+        return {
+            "columns": ["name"],
+            "rows": [{"name": "PC-01"}, {"name": "PC-02"}, {"name": "PC-03"}],
+        }
+
+    monkeypatch.setattr(
+        xero.recurring_items_repo,
+        "list_company_recurring_invoice_items",
+        fake_list_items,
+    )
+    monkeypatch.setattr(
+        xero.value_templates.dynamic_variables.reporting_repo,
+        "get_query_by_slug",
+        fake_get_query_by_slug,
+    )
+    monkeypatch.setattr(
+        xero.value_templates.dynamic_variables.reporting_service,
+        "count_query_rows",
+        fake_count_query_rows,
+    )
+    monkeypatch.setattr(
+        xero.value_templates.dynamic_variables.reporting_service,
+        "run_query_with_context",
+        fake_run_query_with_context,
+    )
+
+    result = asyncio.run(
+        xero.build_recurring_invoice_items(
+            company_id=77,
+            tax_type="OUTPUT2",
+            context={"company_name": "Acme"},
+        )
+    )
+
+    assert len(result) == 1
+    assert result[0]["Quantity"] == 3.0
+    assert (
+        result[0]["Description"]
+        == "Online workstations:\nname\r\nPC-01\r\nPC-02\r\nPC-03"
+    )


### PR DESCRIPTION
### Motivation
- Recurring invoice item descriptions and quantities were not resolving new `{{ report.slug.list }}` / `{{ report.slug.count }}` dynamic variables and instead left unprocessed or returned incorrect counts. 
- The recurring-item generator still used legacy `{token}` formatting without routing strings through the shared dynamic variable renderer used elsewhere.

### Description
- Import the shared dynamic template system by adding `value_templates` to `app/services/xero.py` and implement async helpers `_render_recurring_template_value` and `_evaluate_recurring_qty_expression` to render `{{ ... }}` variables and then fall back to legacy `{token}` placeholders. 
- Populate a `raw_context` (ensuring `company_id` is present) and use it to render `description_template` via the new renderer before applying legacy formatting. 
- Evaluate `qty_expression` after resolving dynamic variables so saved-report `.count` variables can drive the numeric `Quantity` value. 
- Add a regression test `test_build_recurring_invoice_items_with_report_variables` to `tests/test_xero_recurring_items.py` that verifies saved-report `.list` appears in descriptions and `.count` controls the quantity.

### Testing
- Run `pytest -q tests/test_report_variables.py tests/test_xero_recurring_items.py::test_build_recurring_invoice_items_with_report_variables` and the targeted checks passed. 
- Running the full `tests/test_xero_recurring_items.py` in this environment still reports two unrelated failures due to pre-existing async test markers and missing async pytest plugin support, not caused by these changes. 
- `git diff --check` was run to validate whitespace and formatting with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b219c8e00832daa3bf03340471b98)