### PR TITLE
Support report variables in scheduled ticket payloads

### DIFF
--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -1026,9 +1026,24 @@ class SchedulerService:
                             error=str(exc),
                         )
                     else:
-                        # Render template variables in the payload
+                        company_id = task.get("company_id")
+                        render_context: dict[str, Any] = {
+                            "schedule": {
+                                "task_id": task_id,
+                                "task_name": task.get("name"),
+                                "command": command,
+                            }
+                        }
+                        if company_id:
+                            render_context["company_id"] = company_id
+                            render_context["company"] = {"id": company_id}
+
+                        # Render template variables in the payload. Scheduled ticket
+                        # payloads include the task company in context so saved
+                        # report variables such as {{ report.slug.list }} can
+                        # safely use {{current.company}} placeholders.
                         payload = await value_templates.render_value_async(
-                            payload, context=None
+                            payload, context=render_context
                         )
 
                         # Extract ticket fields from payload

--- a/tests/test_scheduled_ticket_creation.py
+++ b/tests/test_scheduled_ticket_creation.py
@@ -5,6 +5,11 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
 @pytest.mark.asyncio
 async def test_create_scheduled_ticket_handler():
     """Test that create_scheduled_ticket command processes JSON payload correctly."""
@@ -181,3 +186,59 @@ async def test_create_scheduled_ticket_interpolates_variables():
                 assert "Created at" in description
                 # Verify it contains some interpolated content
                 assert len(description) > len("Created at  on "), "Description should have interpolated values"
+
+
+@pytest.mark.anyio
+async def test_create_scheduled_ticket_renders_report_variables_with_company_context(monkeypatch):
+    """Report variables in scheduled ticket payloads use the task company context."""
+
+    async def fake_get_query_by_slug(slug):
+        assert slug == "online-workstations-last-30-days"
+        return {
+            "slug": slug,
+            "sql_query": "SELECT name FROM assets WHERE company_id = {{current.company}}",
+        }
+
+    async def fake_run_query_with_context(sql_query, *, company_id=None):
+        assert sql_query == "SELECT name FROM assets WHERE company_id = {{current.company}}"
+        assert company_id == 20
+        return {"columns": ["name"], "rows": [{"name": "WS-01"}]}
+
+    monkeypatch.setattr(
+        "app.services.dynamic_variables.reporting_repo.get_query_by_slug",
+        fake_get_query_by_slug,
+    )
+    monkeypatch.setattr(
+        "app.services.dynamic_variables.reporting_service.run_query_with_context",
+        fake_run_query_with_context,
+    )
+
+    task = {
+        "id": 5,
+        "name": "Daily workstation report",
+        "command": "create_scheduled_ticket",
+        "company_id": 20,
+        "description": json.dumps(
+            {
+                "subject": "Online workstation report",
+                "description": "{{ report.online-workstations-last-30-days.list }}",
+                "priority": "normal",
+                "status": "open",
+            }
+        ),
+    }
+
+    with patch("app.services.scheduler.tickets_service.create_ticket", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = {"id": 201, "number": "T-5679"}
+
+        from app.services.scheduler import SchedulerService
+
+        scheduler = SchedulerService()
+        with patch("app.services.scheduler.scheduled_tasks_repo.record_task_run", new_callable=AsyncMock):
+            with patch("app.services.scheduler.db.acquire_lock") as mock_lock:
+                mock_lock.return_value.__aenter__.return_value = True
+
+                await scheduler._run_task(task)
+
+    mock_create.assert_called_once()
+    assert mock_create.call_args.kwargs["description"] == "name\r\nWS-01"


### PR DESCRIPTION
### Motivation
- Scheduled-ticket payloads need access to saved reporting variables (e.g. `{{ report.online-workstations-last-30-days.list }}`) and must scope `{{current.company}}` to the task company so report queries evaluate correctly for the scheduled task's company.

### Description
- Pass a `render_context` into `value_templates.render_value_async` when handling the `create_scheduled_ticket` command in `app/services/scheduler.py`, including `schedule` metadata and `company_id`/`company` so report tokens can resolve using `{{current.company}}`.
- Add a regression test in `tests/test_scheduled_ticket_creation.py` that stubs the reporting repo/service and verifies a scheduled ticket payload containing `{{ report.<slug>.list }}` renders the expected CSV using the task's `company_id`.
- Add an `anyio_backend` fixture to the test file to ensure async tests run in the CI/test environment used here.

### Testing
- `python -m py_compile app/services/scheduler.py tests/test_scheduled_ticket_creation.py` — success.
- `pytest -q tests/test_report_variables.py tests/test_scheduled_ticket_creation.py::test_create_scheduled_ticket_renders_report_variables_with_company_context` — passed.
- Running the full `tests/test_scheduled_ticket_creation.py` with the current environment initially surfaced failures due to the test environment lacking a pytest plugin for tests marked with `@pytest.mark.asyncio`; that is an environment/test harness issue not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b2247f114832d89549ce40eca5f72)