### PR TITLE
Use Xero prices for recurring invoice items

### DIFF
--- a/app/services/invoice_generator.py
+++ b/app/services/invoice_generator.py
@@ -98,6 +98,45 @@ async def _generate_invoice_number() -> str:
     return f"{prefix}{seq + 1:04d}"
 
 
+async def _get_xero_rate_lookup_credentials() -> tuple[str | None, str | None]:
+    """Return Xero tenant/access token when item-price lookup is available.
+
+    Recurring invoice items can intentionally omit a local price override so
+    Xero remains the source of truth for product pricing. Rate lookup is best
+    effort: invoice generation should still work when Xero is disabled or
+    temporarily unavailable, but callers that can reach Xero should pass these
+    credentials into the recurring line builder.
+    """
+
+    try:
+        module = await modules_service.get_module("xero", redact=False)
+    except Exception as exc:
+        logger.warning("Failed to load Xero module for recurring item price lookup", error=str(exc))
+        return None, None
+
+    if not module or not module.get("enabled"):
+        return None, None
+
+    settings = dict(module.get("settings") or {})
+    try:
+        credentials = await modules_service.get_xero_credentials() or {}
+    except Exception as exc:
+        logger.warning("Failed to load Xero credentials for recurring item price lookup", error=str(exc))
+        credentials = {}
+
+    tenant_id = str(credentials.get("tenant_id") or settings.get("tenant_id") or "").strip()
+    if not tenant_id:
+        return None, None
+
+    try:
+        access_token = await modules_service.acquire_xero_access_token()
+    except Exception as exc:
+        logger.warning("Failed to acquire Xero access token for recurring item price lookup", error=str(exc))
+        return None, None
+
+    return tenant_id, access_token
+
+
 async def generate_invoice(company_id: int) -> dict[str, Any]:
     """Generate a local invoice for the given company.
 
@@ -125,11 +164,16 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
     # Build context for template substitution (device counts etc.)
     context = await xero_service.build_invoice_context(company_id)
 
-    # Build recurring invoice items (no Xero credentials needed)
+    tenant_id, access_token = await _get_xero_rate_lookup_credentials()
+
+    # Build recurring invoice items. When Xero is configured, pass credentials
+    # so items without a local price override use their Xero sales price.
     recurring_line_items = await xero_service.build_recurring_invoice_items(
         company_id,
         tax_type=None,
         context=context,
+        tenant_id=tenant_id,
+        access_token=access_token,
     )
 
     line_item_template = await _get_xero_line_item_template()

--- a/tests/test_invoice_generator.py
+++ b/tests/test_invoice_generator.py
@@ -200,6 +200,47 @@ def test_generate_invoice_recurring_items_only(monkeypatch):
     assert created_invoices[0]["company_id"] == 1
 
 
+def test_generate_invoice_passes_xero_credentials_for_recurring_price_lookup(monkeypatch):
+    build_recurring = AsyncMock(return_value=_make_recurring_items())
+
+    async def fake_create_invoice(**kwargs):
+        return {"id": 404, **kwargs}
+
+    async def fake_create_line(**kwargs):
+        return {"id": 1, **kwargs}
+
+    monkeypatch.setattr(invoice_generator.company_repo, "get_company_by_id", AsyncMock(return_value=_make_company()))
+    monkeypatch.setattr(invoice_generator.xero_service, "build_invoice_context", AsyncMock(return_value={}))
+    monkeypatch.setattr(invoice_generator.xero_service, "build_recurring_invoice_items", build_recurring)
+    monkeypatch.setattr(
+        invoice_generator.modules_service,
+        "get_module",
+        AsyncMock(return_value={"enabled": True, "settings": {"tenant_id": "tenant-from-settings"}}),
+    )
+    monkeypatch.setattr(
+        invoice_generator.modules_service,
+        "get_xero_credentials",
+        AsyncMock(return_value={"tenant_id": "tenant-from-credentials"}),
+    )
+    monkeypatch.setattr(
+        invoice_generator.modules_service,
+        "acquire_xero_access_token",
+        AsyncMock(return_value="access-token"),
+    )
+    monkeypatch.setattr(invoice_generator.tickets_repo, "list_tickets", AsyncMock(return_value=[]))
+    monkeypatch.setattr(invoice_generator.invoice_repo, "create_invoice", fake_create_invoice)
+    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0))
+    monkeypatch.setattr(invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line)
+
+    result = asyncio.run(invoice_generator.generate_invoice(1))
+
+    assert result["status"] == "succeeded"
+    build_recurring.assert_awaited_once()
+    _, kwargs = build_recurring.await_args
+    assert kwargs["tenant_id"] == "tenant-from-credentials"
+    assert kwargs["access_token"] == "access-token"
+
+
 def test_generate_invoice_billable_ticket_uses_hours_and_minutes(monkeypatch):
     created_lines: list[dict[str, Any]] = []
 


### PR DESCRIPTION
### Motivation
- Recurring invoice lines without a local price override were being sent to Xero with no price, so the integration should use the Xero item sales price when no override is present.

### Description
- Added a best-effort credential helper `_get_xero_rate_lookup_credentials()` in `app/services/invoice_generator.py` to resolve an enabled Xero module, credentials, and an access token while safely falling back when unavailable.
- Updated `generate_invoice()` to pass `tenant_id` and `access_token` into `xero_service.build_recurring_invoice_items()` so items without `price_override` can use their Xero sales price.
- Added a regression test `test_generate_invoice_passes_xero_credentials_for_recurring_price_lookup` in `tests/test_invoice_generator.py` to assert the Xero credentials are forwarded to the recurring item builder.

### Testing
- Ran `pytest -q tests/test_invoice_generator.py::test_generate_invoice_passes_xero_credentials_for_recurring_price_lookup tests/test_invoice_generator.py::test_generate_invoice_recurring_items_only` and both tests passed.
- Ran `python -m py_compile app/services/invoice_generator.py tests/test_invoice_generator.py` and compilation succeeded.
- Note: a broader run earlier surfaced unrelated async-test configuration failures in other Xero tests; the changes in this PR target recurring-item price lookup behavior and the invoice-generator tests above now pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b3871fb38832d9849031a6e73bb3f)