### PR TITLE
Potential fix for code scanning alert no. 2353: Information exposure through an exception

### DIFF
--- a/app/api/routes/xero.py
+++ b/app/api/routes/xero.py
@@ -192,7 +192,7 @@ async def receive_webhook(request: Request) -> dict[str, Any]:
             results.append(await _apply_xero_invoice_event(event, request))
         except Exception as exc:
             logger.exception("Failed to process Xero invoice webhook event")
-            results.append({"status": "failed", "error": str(exc)})
+            results.append({"status": "failed", "error": "Internal processing error"})
 
     has_failure = any(result.get("status") == "failed" for result in results)
     response_status = 502 if has_failure else 200


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2353](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2353)

To fix this without changing functional behavior, keep the same success/failure structure but stop returning raw exception text to the client.

Best fix in this snippet:
- In `app/api/routes/xero.py`, inside `receive_webhook`, update the `except Exception as exc:` block in the event loop.
- Keep `logger.exception("Failed to process Xero invoice webhook event")` so detailed diagnostics remain in server logs.
- Replace `{"status": "failed", "error": str(exc)}` with a generic message such as `{"status": "failed", "error": "Internal processing error"}`.
- No new imports or dependencies are required.

This preserves:
- per-event failure signaling,
- `has_failure` logic,
- webhook monitor logging behavior,
while preventing exception detail leakage in the response body.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
