### PR TITLE
Potential fix for code scanning alert no. 2351: Unused local variable

### DIFF
--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -1238,9 +1238,7 @@ class SchedulerService:
 
                             if plan_id:
                                 # Get distribution list for the plan
-                                distribution_list = (
-                                    await bcp_repo.list_distribution_list(plan_id)
-                                )
+                                await bcp_repo.list_distribution_list(plan_id)
 
                                 # Create notification for each distribution list member
                                 message = f"Upcoming BCP training scheduled for {item['training_date'].strftime('%Y-%m-%d %H:%M')}"


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2351](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2351)

The best fix is to remove the unused local variable binding while preserving current runtime behavior. Since the function call is `await`ed, if it has side effects they should still occur. So replace:

- `distribution_list = (await bcp_repo.list_distribution_list(plan_id))`

with:

- `await bcp_repo.list_distribution_list(plan_id)`

This change is in `app/services/scheduler.py` within the `elif command == "bcp_notify_upcoming_training":` block around lines 1241–1243. No imports, new methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
