### PR TITLE
Potential fix for code scanning alert no. 2349: Unused local variable

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -3464,7 +3464,6 @@ async def _invoke_create_ticket(
         existing = await tickets_repo.get_ticket(ticket_id_int)
     except RuntimeError:
         existing = None
-    previous_description = existing.get("description") if existing else None
 
     # Create webhook event for tracking
     event = await webhook_monitor.create_manual_event(


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2349](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2349)

To fix an unused local variable without changing functionality, remove the variable assignment but preserve any right-hand-side computation that may have side effects. Here, `previous_description = existing.get("description") if existing else None` has no required side effect beyond reading `existing`, so deleting this line is sufficient.

Best fix in `app/services/modules.py`:
- In the shown block around lines 3463–3468, delete the `previous_description` assignment line.
- Keep the `try/except` and `existing` assignment unchanged, since that may be needed by surrounding logic (or future immediate lines not shown).
- No imports, methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
