### PR TITLE
Potential fix for code scanning alert no. 2341: Unused import

### DIFF
--- a/app/services/rag_relationships.py
+++ b/app/services/rag_relationships.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import StrEnum
 from typing import Any, Mapping, Sequence


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2341](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2341)

Remove the unused `dataclass` import from `app/services/rag_relationships.py`.

Best fix without changing functionality:
- In the import section at the top of `app/services/rag_relationships.py`, delete:
  - `from dataclasses import dataclass`
- No other code changes are needed, since removing an unused import does not alter runtime behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
