### PR TITLE
Potential fix for code scanning alert no. 2340: Unused import

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -177,7 +177,6 @@ from app.services import company_access
 from app.services import dashboard as dashboard_service
 from app.services import email as email_service
 from app.services import m365_mail as m365_mail_service
-from app.services import knowledge_base as knowledge_base_service
 from app.services import rag_relationships as rag_relationship_service
 from app.services import m365 as m365_service
 from app.services import cis_benchmark as cis_benchmark_service


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2340](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2340)

The fix is to remove the unused import line so the module is no longer brought into scope unnecessarily.

Best single change without altering behavior:
- In `app/main.py`, delete only the import:
  - `from app.services import knowledge_base as knowledge_base_service`
- Keep all other imports unchanged.

No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
