### PR TITLE
Potential fix for code scanning alert no. 2216: Uncontrolled data used in path expression

### DIFF
--- a/app/core/plugin_loader.py
+++ b/app/core/plugin_loader.py
@@ -162,12 +162,14 @@ class PluginLoader:
         return root
 
     async def install_from_directory(self, source_path: str) -> list[str]:
+        target_root = self._target_root()
         source = Path(source_path).expanduser().resolve()
+        if not source.is_relative_to(target_root):
+            raise ValueError("Plugin source directory must be inside the plugin root.")
         if not source.exists() or not source.is_dir():
             raise ValueError("Plugin source directory does not exist.")
         if not (source / "__init__.py").exists():
             raise ValueError("Plugin source must contain __init__.py.")
-        target_root = self._target_root()
         target = target_root / source.name
         if target.exists():
             raise ValueError(f"Plugin directory already exists: {target.name}")


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2216](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2216)

To fix this safely without changing intended plugin install behavior, validate the user-provided directory path against an explicit safe root before using it. The best place is inside `PluginLoader.install_from_directory` so all callers are protected.

Best approach:
- Normalize/resolve the user path (already done).
- Define an allowed source root (use the loader’s plugin target root to avoid introducing new config assumptions).
- Reject any source path that is not under that root using `Path.is_relative_to(...)`.
- Keep existing functional checks (`exists`, `is_dir`, `__init__.py`, target collision) unchanged.

Change needed in:
- `app/core/plugin_loader.py` around `install_from_directory` (lines 164–175 in provided snippet).

No new dependency is required. No import changes required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
