### PR TITLE
Potential fix for code scanning alert no. 2293: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/app/services/solidtime.py
+++ b/app/services/solidtime.py
@@ -928,10 +928,35 @@ def reply_to_time_entry_payload(
 
 
 def _hash_payload(payload: Any) -> str:
+    sensitive_keys = {
+        "api_token",
+        "token",
+        "password",
+        "secret",
+        "authorization",
+    }
+
+    def _redact_sensitive(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            redacted: dict[str, Any] = {}
+            for key, item in value.items():
+                key_text = str(key)
+                if key_text.lower() in sensitive_keys:
+                    redacted[key_text] = "***REDACTED***"
+                else:
+                    redacted[key_text] = _redact_sensitive(item)
+            return redacted
+        if isinstance(value, list):
+            return [_redact_sensitive(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(_redact_sensitive(item) for item in value)
+        return value
+
+    safe_payload = _redact_sensitive(payload)
     try:
-        serialised = json.dumps(payload, sort_keys=True, default=str)
+        serialised = json.dumps(safe_payload, sort_keys=True, default=str)
     except (TypeError, ValueError):
-        serialised = repr(payload)
+        serialised = repr(safe_payload)
     return hashlib.sha256(serialised.encode("utf-8")).hexdigest()
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2293](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2293)

To fix this without changing behavior, keep `_hash_payload` as a deterministic non-cryptographic business fingerprint helper, but sanitize payload content before hashing so secrets (notably `api_token`) are never part of the hashed material.  
Best approach in this file: update `_hash_payload` to recursively redact sensitive keys (for example: `api_token`, `token`, `password`, `secret`, `authorization`) from mappings/lists before JSON serialization and SHA-256 hashing. This keeps stable change detection for non-sensitive fields while breaking the taint path from credentials to hash sink.

**What to change (app/services/solidtime.py):**
- Edit `_hash_payload` (around lines 930–935) to:
  - define a local recursive sanitizer helper.
  - redact sensitive key names case-insensitively.
  - hash the sanitized structure instead of raw payload.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
