### PR TITLE
Potential fix for code scanning alert no. 1920: DOM text reinterpreted as HTML

### DIFF
--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -68,7 +68,7 @@
       <select
         class="form-input shop-category-select"
         aria-label="Select product category"
-        onchange="window.location.href=this.options[this.selectedIndex].getAttribute('data-url');"
+        onchange="(function(selectEl){var raw=selectEl.options[selectEl.selectedIndex].getAttribute('data-url');if(!raw){return;}try{var parsed=new URL(raw, window.location.origin);if((parsed.protocol==='http:'||parsed.protocol==='https:')&&parsed.origin===window.location.origin){window.location.assign(parsed.pathname+parsed.search+parsed.hash);}}catch(e){}})(this);"
       >
         <option data-url="{{ request.url_for('shop_page') }}{{ shop_query() }}" {% if not current_category or current_category == 'packages' %}selected{% endif %}>All products</option>
         {% for category in categories %}


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/1920](https://github.com/bradhawkins85/MyPortal/security/code-scanning/1920)

General fix: avoid directly trusting URL-like strings read from DOM attributes. Parse and validate them, and only allow same-origin HTTP(S) navigation (or stricter, path-only navigation) before assigning to `window.location`.

Best fix in this file: replace the inline `onchange` JavaScript on the `<select>` so it:
1. Reads `data-url`.
2. Parses it with `new URL(raw, window.location.origin)`.
3. Verifies protocol is `http:` or `https:`.
4. Verifies origin matches `window.location.origin`.
5. Navigates using a normalized URL (path/query/hash), otherwise does nothing.

This preserves existing functionality (category changes still navigate) while preventing unsafe DOM-sourced values from being used directly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
