### PR TITLE
Potential fix for code scanning alert no. 2359: Information exposure through an exception

### DIFF
--- a/app/api/routes/invoices.py
+++ b/app/api/routes/invoices.py
@@ -188,7 +188,10 @@ async def sync_invoice_to_xero(
             after=None,
             metadata={"company_id": int(existing["company_id"]), "result": result},
         )
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=result)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to synchronise invoice with Xero",
+        )
     updated = await invoice_repo.get_invoice_by_id(invoice_id)
     await audit_service.record(
         action="invoice.xero_sync",
@@ -200,7 +203,12 @@ async def sync_invoice_to_xero(
         after=updated,
         metadata={"company_id": int(existing["company_id"]), "result": result},
     )
-    return result
+    return {
+        "status": result.get("status"),
+        "reason": result.get("reason"),
+        "invoice_id": result.get("invoice_id", invoice_id),
+        "xero_invoice_id": result.get("xero_invoice_id"),
+    }
 
 
 @router.delete("/{invoice_id}", status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2359](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2359)

The best fix is to stop returning raw service error payloads (which may contain exception-derived `"error"` values) to clients, and instead return a generic message for failures. Keep full diagnostic details only in internal logging/audit metadata.

Specifically in `app/api/routes/invoices.py` within `sync_invoice_to_xero`:
- Keep calling `xero_service.sync_invoice(...)` unchanged.
- Keep recording the full `result` in `audit_service.record(...)` (server-side).
- Replace `raise HTTPException(..., detail=result)` with a sanitized, constant/generic detail string.
- Replace `return result` with a sanitized success response that does not expose raw downstream fields; include only safe, expected fields such as status/reason/invoice identifiers.

This single route-level sanitization addresses all three variants because all tainted flows ultimately sink at the same external response location in this route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
