### PR TITLE
Potential fix for code scanning alert no. 2315: Double escaping or unescaping

### DIFF
--- a/app/static/js/cart.js
+++ b/app/static/js/cart.js
@@ -212,11 +212,11 @@
       .replace(/&#(\d+);/g, (_match, codepoint) => String.fromCodePoint(Number(codepoint)))
       .replace(/&#x([0-9a-f]+);/gi, (_match, codepoint) => String.fromCodePoint(parseInt(codepoint, 16)))
       .replace(/&nbsp;/g, '\u00a0')
-      .replace(/&amp;/g, '&')
       .replace(/&lt;/g, '<')
       .replace(/&gt;/g, '>')
       .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'");
+      .replace(/&#39;/g, "'")
+      .replace(/&amp;/g, '&');
   }
 
   function isSafeRichTextUrl(value) {


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2315](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2315)

To fix double-unescaping, decode `&amp;` **last** in `decodeHtmlEntities`.  
General rule: when unescaping HTML entities, any transformation that introduces `&` must occur after all specific `&...;` entity replacements, otherwise newly created entity prefixes can be decoded again in the same chain.

Best minimal fix (no functional redesign) is to reorder line sequence in `decodeHtmlEntities` in `app/static/js/cart.js` so that:

1. Numeric entities and specific named entities (`&nbsp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`) are decoded first.
2. `&amp;` is decoded at the very end.

No imports or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
