### PR TITLE
Potential fix for code scanning alert no. 2329: Information exposure through an exception

### DIFF
--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -488,9 +488,14 @@ async def _invoke_agent_llm_conversation(
                 background=False,
             )
         except ValueError as exc:
+            log_error(
+                "Agent LLM conversation validation failed",
+                stage=turn_name,
+                error=str(exc),
+            )
             return {
                 "status": "error",
-                "message": str(exc),
+                "message": "Unable to process the request at this time",
                 "text": None,
                 "model": None,
                 "event_id": None,

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -2139,7 +2139,11 @@ async def trigger_module(
             )
             if event_future and not event_future.done():
                 event_future.set_result(None)
-            result = {"status": "error", "error": str(exc), "module": slug}
+            result = {
+                "status": "error",
+                "error": "An internal module error occurred",
+                "module": slug,
+            }
         if event_future and not event_future.done():
             event_id_value = result.get("event_id")
             event_future.set_result(event_id_value if isinstance(event_id_value, int) else None)


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2329](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2329)

To fix this without changing core behavior, keep detailed exception logging internally but replace externally returned exception text with generic, safe messages.

Best approach in this codebase:
1. **`app/services/agent.py`**: in `_invoke_agent_llm_conversation`, replace `message: str(exc)` in the `except ValueError` return with a generic message. Optionally log the original exception for diagnostics.
2. **`app/services/modules.py`**: in `trigger_module`’s `_invoke_handler`, keep `logger.exception(...)` but replace returned `"error": str(exc)` with a generic message like `"An internal module error occurred"`.

This preserves:
- existing control flow (`status: "error"`, `module`, etc.),
- existing logging for debugging,
- client-facing contract shape, while removing sensitive exception detail exposure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
