### PR TITLE
Potential fix for code scanning alert no. 2230: Construction of a cookie using user-supplied input

### DIFF
--- a/app/security/flash.py
+++ b/app/security/flash.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import re
 from typing import Literal
 
 from fastapi import Request, Response
@@ -34,6 +35,14 @@ _VALID_VARIANTS = frozenset({"info", "success", "warning", "error"})
 
 def _secret() -> bytes:
     return get_settings().secret_key.encode()
+
+
+def _sanitize_flash_message(message: str) -> str:
+    """Normalize untrusted flash text before embedding it in a cookie payload."""
+    text = str(message)
+    text = re.sub(r"[\x00-\x1f\x7f]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:200]
 
 
 def _sign(payload: str) -> str:
@@ -64,7 +73,8 @@ def set_flash(
     It is readable only by the server (``pop_flash``).
     """
     safe_variant = variant if variant in _VALID_VARIANTS else "info"
-    payload = json.dumps({"message": str(message)[:200], "variant": safe_variant})
+    safe_message = _sanitize_flash_message(message)
+    payload = json.dumps({"message": safe_message, "variant": safe_variant})
     signed = _sign(payload)
     settings = get_settings()
     secure = settings.environment.lower() == "production"


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2230](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2230)

General fix: sanitize and normalize any user-influenced flash message before serializing/signing and setting it as a cookie value.

Best single fix without changing behavior: update `app/security/flash.py` in `set_flash()` to pass `message` through a dedicated sanitizer that:
- coerces to string,
- strips control characters (including CR/LF/NUL),
- collapses excessive whitespace,
- trims and truncates to existing 200-char limit.

This keeps user-visible flash messaging intact while preventing problematic cookie content and addresses all alert variants centrally (since every route goes through `flash_redirect` -> `set_flash`).

Changes needed:
- In `app/security/flash.py`, add a private helper (e.g., `_sanitize_flash_message`).
- Update `set_flash` to use sanitized message in JSON payload.
- No external dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
