### PR TITLE
Potential fix for code scanning alert no. 2268: URL redirection from remote source

### DIFF
--- a/app/features/assets/routes.py
+++ b/app/features/assets/routes.py
@@ -298,7 +298,10 @@ async def asset_detail_page(request: Request, asset_id: int):
     if record_company_id is None or int(record_company_id) != company_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Asset not found")
 
-    return RedirectResponse(url=f"/assets#asset-{asset_id}", status_code=status.HTTP_303_SEE_OTHER)
+    safe_asset_id = int(asset_id)
+    if safe_asset_id <= 0:
+        return RedirectResponse(url="/assets", status_code=status.HTTP_303_SEE_OTHER)
+    return RedirectResponse(url=f"/assets#asset-{safe_asset_id}", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @router.delete("/assets/{asset_id}", response_class=JSONResponse)


### PR DESCRIPTION
Potential fix for [https://github.com/bradhawkins85/MyPortal/security/code-scanning/2268](https://github.com/bradhawkins85/MyPortal/security/code-scanning/2268)

Use a fixed internal redirect base and only append a strictly validated identifier.  
Best minimal fix here: normalize `asset_id` to a safe positive integer local variable and build the URL from that normalized value, with a defensive fallback redirect to `"/assets"` if anything is unexpected.

In `app/features/assets/routes.py`, inside `asset_detail_page` near line 301:
- Add a small normalization step (`safe_asset_id = int(asset_id)` and positivity check).
- Use `safe_asset_id` in the f-string for the hash fragment.
- If invalid (defensive), redirect to `"/assets"` instead of using tainted data.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
