### PR TITLE
Use Xero sales price when recurring item has zero local price

### DIFF
--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -400,17 +400,22 @@ def _build_xero_line_items_from_local_invoice(
     line_items: list[dict[str, Any]] = []
     for stored_line in invoice_lines:
         quantity = _to_decimal(stored_line.get("quantity")) or Decimal("1")
-        unit_amount = _to_decimal(stored_line.get("unit_amount")) or Decimal("0")
+        raw_unit_amount = _to_decimal(stored_line.get("unit_amount"))
+        unit_amount = raw_unit_amount if raw_unit_amount is not None else Decimal("0")
         description = str(stored_line.get("description") or "").strip() or "MyPortal invoice line"
         product_code = str(stored_line.get("product_code") or "").strip()
         line_item: dict[str, Any] = {
             "Description": description,
             "Quantity": float(_quantize(quantity, "0.0001")),
-            "UnitAmount": float(_quantize(unit_amount)),
             "AccountCode": account_code,
         }
         if product_code:
             line_item["ItemCode"] = product_code
+        # For item-coded lines, a stored zero can mean the recurring item had
+        # no price override. Do not send UnitAmount in that case so Xero can
+        # apply the product's configured sales price instead of a zero override.
+        if raw_unit_amount is not None and (unit_amount != Decimal("0") or not product_code):
+            line_item["UnitAmount"] = float(_quantize(unit_amount))
         if tax_type:
             line_item["TaxType"] = tax_type
         line_items.append(line_item)

--- a/tests/test_xero_recurring_items.py
+++ b/tests/test_xero_recurring_items.py
@@ -255,125 +255,131 @@ def test_build_recurring_invoice_items_with_custom_field_variable(monkeypatch):
     assert tl_item["Quantity"] == 25.0
 
 
-@pytest.mark.asyncio
-async def test_build_recurring_invoice_items_fetches_xero_rates(monkeypatch):
-    """Test that build_recurring_invoice_items fetches item rates from Xero."""
+def test_build_recurring_invoice_items_fetches_xero_rates(monkeypatch):
+    async def run_test():
+        """Test that build_recurring_invoice_items fetches item rates from Xero."""
     
-    # Track whether fetch_xero_item_rates was called
-    fetch_called = {"called": False, "item_codes": []}
+        # Track whether fetch_xero_item_rates was called
+        fetch_called = {"called": False, "item_codes": []}
     
-    async def fake_list_recurring_items(company_id: int):
-        return [
-            {
-                "id": 1,
-                "company_id": company_id,
-                "active": True,
-                "product_code": "MANAGED-SERVICES",
-                "description_template": "Managed Services",
-                "qty_expression": "1",
-                "price_override": None,  # No override, should fetch from Xero
-            },
-            {
-                "id": 2,
-                "company_id": company_id,
-                "active": True,
-                "product_code": "CLOUD-BACKUP",
-                "description_template": "Cloud Backup",
-                "qty_expression": "1",
-                "price_override": Decimal("50.00"),  # Has override, should NOT fetch
-            },
-            {
-                "id": 3,
-                "company_id": company_id,
-                "active": False,  # Inactive, should be skipped
-                "product_code": "INACTIVE-ITEM",
-                "description_template": "Inactive Item",
-                "qty_expression": "1",
-                "price_override": None,
-            },
-        ]
+        async def fake_list_recurring_items(company_id: int):
+            return [
+                {
+                    "id": 1,
+                    "company_id": company_id,
+                    "active": True,
+                    "product_code": "MANAGED-SERVICES",
+                    "description_template": "Managed Services",
+                    "qty_expression": "1",
+                    "price_override": None,  # No override, should fetch from Xero
+                },
+                {
+                    "id": 2,
+                    "company_id": company_id,
+                    "active": True,
+                    "product_code": "CLOUD-BACKUP",
+                    "description_template": "Cloud Backup",
+                    "qty_expression": "1",
+                    "price_override": Decimal("50.00"),  # Has override, should NOT fetch
+                },
+                {
+                    "id": 3,
+                    "company_id": company_id,
+                    "active": False,  # Inactive, should be skipped
+                    "product_code": "INACTIVE-ITEM",
+                    "description_template": "Inactive Item",
+                    "qty_expression": "1",
+                    "price_override": None,
+                },
+            ]
     
-    async def fake_fetch_xero_item_rates(item_codes, *, tenant_id, access_token):
-        # Record that the function was called
-        fetch_called["called"] = True
-        fetch_called["item_codes"] = list(item_codes)
+        async def fake_fetch_xero_item_rates(item_codes, *, tenant_id, access_token):
+            # Record that the function was called
+            fetch_called["called"] = True
+            fetch_called["item_codes"] = list(item_codes)
         
-        # Return rates for items
-        return {
-            "MANAGED-SERVICES": Decimal("150.00"),
-        }
+            # Return rates for items
+            return {
+                "MANAGED-SERVICES": Decimal("150.00"),
+            }
     
-    monkeypatch.setattr(xero.recurring_items_repo, "list_company_recurring_invoice_items", fake_list_recurring_items)
-    monkeypatch.setattr(xero, "fetch_xero_item_rates", fake_fetch_xero_item_rates)
+        monkeypatch.setattr(xero.recurring_items_repo, "list_company_recurring_invoice_items", fake_list_recurring_items)
+        monkeypatch.setattr(xero, "fetch_xero_item_rates", fake_fetch_xero_item_rates)
     
-    # Call the function with credentials
-    line_items = await xero.build_recurring_invoice_items(
-        company_id=1,
-        tax_type="OUTPUT",
-        context={},
-        tenant_id="test-tenant",
-        access_token="test-token",
-    )
+        # Call the function with credentials
+        line_items = await xero.build_recurring_invoice_items(
+            company_id=1,
+            tax_type="OUTPUT",
+            context={},
+            tenant_id="test-tenant",
+            access_token="test-token",
+        )
     
-    # Verify fetch_xero_item_rates was called
-    assert fetch_called["called"], "fetch_xero_item_rates should have been called"
-    assert "MANAGED-SERVICES" in fetch_called["item_codes"], "Should fetch rate for MANAGED-SERVICES"
-    assert "CLOUD-BACKUP" not in fetch_called["item_codes"], "Should NOT fetch rate for CLOUD-BACKUP (has override)"
-    assert "INACTIVE-ITEM" not in fetch_called["item_codes"], "Should NOT fetch rate for INACTIVE-ITEM (inactive)"
+        # Verify fetch_xero_item_rates was called
+        assert fetch_called["called"], "fetch_xero_item_rates should have been called"
+        assert "MANAGED-SERVICES" in fetch_called["item_codes"], "Should fetch rate for MANAGED-SERVICES"
+        assert "CLOUD-BACKUP" not in fetch_called["item_codes"], "Should NOT fetch rate for CLOUD-BACKUP (has override)"
+        assert "INACTIVE-ITEM" not in fetch_called["item_codes"], "Should NOT fetch rate for INACTIVE-ITEM (inactive)"
     
-    # Verify line items were created correctly
-    assert len(line_items) == 2, "Should have 2 line items (2 active items)"
+        # Verify line items were created correctly
+        assert len(line_items) == 2, "Should have 2 line items (2 active items)"
     
-    # Find the MANAGED-SERVICES item
-    managed_services_item = next(item for item in line_items if item["ItemCode"] == "MANAGED-SERVICES")
-    assert managed_services_item["UnitAmount"] == 150.00, "Should use Xero item rate"
+        # Find the MANAGED-SERVICES item
+        managed_services_item = next(item for item in line_items if item["ItemCode"] == "MANAGED-SERVICES")
+        assert managed_services_item["UnitAmount"] == 150.00, "Should use Xero item rate"
     
-    # Find the CLOUD-BACKUP item
-    cloud_backup_item = next(item for item in line_items if item["ItemCode"] == "CLOUD-BACKUP")
-    assert cloud_backup_item["UnitAmount"] == 50.00, "Should use price override"
+        # Find the CLOUD-BACKUP item
+        cloud_backup_item = next(item for item in line_items if item["ItemCode"] == "CLOUD-BACKUP")
+        assert cloud_backup_item["UnitAmount"] == 50.00, "Should use price override"
 
 
-@pytest.mark.asyncio
-async def test_build_recurring_invoice_items_without_credentials(monkeypatch):
-    """Test that build_recurring_invoice_items works without credentials (doesn't fetch rates)."""
+    asyncio.run(run_test())
+
+
+def test_build_recurring_invoice_items_without_credentials(monkeypatch):
+    async def run_test():
+        """Test that build_recurring_invoice_items works without credentials (doesn't fetch rates)."""
     
-    fetch_called = {"called": False}
+        fetch_called = {"called": False}
     
-    async def fake_list_recurring_items(company_id: int):
-        return [
-            {
-                "id": 1,
-                "company_id": company_id,
-                "active": True,
-                "product_code": "MANAGED-SERVICES",
-                "description_template": "Managed Services",
-                "qty_expression": "1",
-                "price_override": None,
-            },
-        ]
+        async def fake_list_recurring_items(company_id: int):
+            return [
+                {
+                    "id": 1,
+                    "company_id": company_id,
+                    "active": True,
+                    "product_code": "MANAGED-SERVICES",
+                    "description_template": "Managed Services",
+                    "qty_expression": "1",
+                    "price_override": None,
+                },
+            ]
     
-    async def fake_fetch_xero_item_rates(item_codes, *, tenant_id, access_token):
-        fetch_called["called"] = True
-        return {}
+        async def fake_fetch_xero_item_rates(item_codes, *, tenant_id, access_token):
+            fetch_called["called"] = True
+            return {}
     
-    monkeypatch.setattr(xero.recurring_items_repo, "list_company_recurring_invoice_items", fake_list_recurring_items)
-    monkeypatch.setattr(xero, "fetch_xero_item_rates", fake_fetch_xero_item_rates)
+        monkeypatch.setattr(xero.recurring_items_repo, "list_company_recurring_invoice_items", fake_list_recurring_items)
+        monkeypatch.setattr(xero, "fetch_xero_item_rates", fake_fetch_xero_item_rates)
     
-    # Call without credentials
-    line_items = await xero.build_recurring_invoice_items(
-        company_id=1,
-        tax_type="OUTPUT",
-        context={},
-        # No tenant_id or access_token
-    )
+        # Call without credentials
+        line_items = await xero.build_recurring_invoice_items(
+            company_id=1,
+            tax_type="OUTPUT",
+            context={},
+            # No tenant_id or access_token
+        )
     
-    # Verify fetch_xero_item_rates was NOT called
-    assert not fetch_called["called"], "fetch_xero_item_rates should NOT have been called without credentials"
+        # Verify fetch_xero_item_rates was NOT called
+        assert not fetch_called["called"], "fetch_xero_item_rates should NOT have been called without credentials"
     
-    # Verify line item was created (without UnitAmount, Xero will use default)
-    assert len(line_items) == 1
-    assert line_items[0]["ItemCode"] == "MANAGED-SERVICES"
-    assert "UnitAmount" not in line_items[0], "Should not have UnitAmount without credentials"
+        # Verify line item was created (without UnitAmount, Xero will use default)
+        assert len(line_items) == 1
+        assert line_items[0]["ItemCode"] == "MANAGED-SERVICES"
+        assert "UnitAmount" not in line_items[0], "Should not have UnitAmount without credentials"
+
+
+    asyncio.run(run_test())
 
 
 def test_build_recurring_invoice_items_with_report_variables(monkeypatch):
@@ -445,3 +451,56 @@ def test_build_recurring_invoice_items_with_report_variables(monkeypatch):
         result[0]["Description"]
         == "Online workstations:\nname\r\nPC-01\r\nPC-02\r\nPC-03"
     )
+
+
+def test_local_invoice_line_with_item_code_and_zero_price_uses_xero_default():
+    """Zero stored prices for item-coded lines should not override Xero item pricing."""
+
+    result = xero._build_xero_line_items_from_local_invoice(
+        [
+            {
+                "description": "Managed Desktops",
+                "quantity": Decimal("5"),
+                "unit_amount": Decimal("0.00"),
+                "product_code": "Managed-Desktops",
+            }
+        ],
+        account_code="400",
+        tax_type="OUTPUT",
+    )
+
+    assert result == [
+        {
+            "Description": "Managed Desktops",
+            "Quantity": 5.0,
+            "AccountCode": "400",
+            "ItemCode": "Managed-Desktops",
+            "TaxType": "OUTPUT",
+        }
+    ]
+
+
+def test_local_invoice_line_without_item_code_keeps_zero_price():
+    """Lines without Xero item codes still need an explicit zero amount."""
+
+    result = xero._build_xero_line_items_from_local_invoice(
+        [
+            {
+                "description": "Manual adjustment",
+                "quantity": Decimal("1"),
+                "unit_amount": Decimal("0.00"),
+                "product_code": None,
+            }
+        ],
+        account_code="400",
+        tax_type=None,
+    )
+
+    assert result == [
+        {
+            "Description": "Manual adjustment",
+            "Quantity": 1.0,
+            "AccountCode": "400",
+            "UnitAmount": 0.0,
+        }
+    ]


### PR DESCRIPTION
### Motivation
- Recurring invoice line items configured with an item code were being sent to Xero with an explicit zero `UnitAmount`, which prevented Xero from applying the product's configured sales price.
- The intent is to treat a stored zero price on item-coded recurring items as “no local override” and let Xero provide the price, while preserving explicit zero pricing for non-item-coded lines.

### Description
- Update `_build_xero_line_items_from_local_invoice` so it omits `UnitAmount` when the stored value is zero for lines that include a Xero `ItemCode`, allowing Xero to apply the product sales price (`app/services/xero.py`).
- Preserve sending `UnitAmount: 0.0` for lines without an `ItemCode` where Xero cannot supply a default product price (`app/services/xero.py`).
- Add regression tests that assert item-coded zero-price lines omit `UnitAmount` and non-item-coded zero-price lines keep `UnitAmount: 0.0` and adapt existing recurring-item async tests to run via `asyncio.run` so they execute without requiring a pytest-async plugin (`tests/test_xero_recurring_items.py`).

### Testing
- Ran `pytest tests/test_xero_recurring_items.py -q` which completed successfully with `14 passed`.
- Existing recurring-item behaviour and new regression assertions are covered by the modified test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b3d33b20c832d9bc57a5b23d8a90b)