### PR TITLE
Make invoiced ticket status configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -342,6 +342,8 @@ XERO_TAX_TYPE=
 XERO_LINE_AMOUNT_TYPE=Exclusive
 XERO_REFERENCE_PREFIX=Support
 XERO_BILLABLE_STATUSES=resolved, closed
+# Ticket status applied after a ticket is successfully invoiced. Defaults to closed.
+TICKET_INVOICED_STATUS=closed
 XERO_LINE_ITEM_TEMPLATE=Ticket {ticket_id}: {ticket_subject} {labour_suffix} {requester_name} ({labour_duration})
 XERO_AUTO_CREATE_PRODUCTS=true
 

--- a/app/services/invoice_generator.py
+++ b/app/services/invoice_generator.py
@@ -402,13 +402,14 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
                     error=str(exc),
                 )
 
-        # Update ticket: mark as billed and close
+        # Update ticket: mark as billed and move to the configured invoiced status.
+        invoiced_status = xero_service.resolve_invoiced_ticket_status()
         try:
             await tickets_repo.update_ticket(
                 ticket_id,
                 xero_invoice_number=invoice_number,
                 billed_at=now,
-                status="closed",
+                status=invoiced_status,
                 closed_at=now,
             )
         except Exception as exc:

--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
@@ -19,6 +20,7 @@ from app.repositories import invoice_lines as invoice_lines_repo
 from app.repositories import staff as staff_repo
 from app.repositories import invoices as invoice_repo
 from app.repositories import ticket_billed_time_entries as billed_time_repo
+from app.repositories import ticket_statuses as ticket_status_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import users as users_repo
 from app.services.billing_time import format_billable_minutes
@@ -35,6 +37,16 @@ QuoteItemsFetcher = Callable[[str, int], Awaitable[Sequence[Mapping[str, Any]] |
 XERO_ITEM_NAME_MAX_LENGTH = 50
 _XERO_ERROR_DETAIL_MAX_LENGTH = 500
 _XERO_INVOICE_NUMBER_SUFFIX_RE = re.compile(r"^(.*)(\d+)$")
+_INVOICED_TICKET_STATUS_ENV = "TICKET_INVOICED_STATUS"
+_DEFAULT_INVOICED_TICKET_STATUS = "closed"
+
+
+def resolve_invoiced_ticket_status() -> str:
+    """Return the ticket status applied after successful invoice creation."""
+
+    configured = os.getenv(_INVOICED_TICKET_STATUS_ENV, _DEFAULT_INVOICED_TICKET_STATUS)
+    status = ticket_status_repo.slugify_status_label(configured)
+    return status or _DEFAULT_INVOICED_TICKET_STATUS
 
 
 class _TemplateValues(dict[str, Any]):
@@ -1993,13 +2005,14 @@ async def sync_billable_tickets(
                             error=str(entry_exc),
                         )
                 
-                # Update ticket: mark as billed and move to Closed status
+                # Update ticket: mark as billed and move to the configured invoiced status.
+                invoiced_status = resolve_invoiced_ticket_status()
                 try:
                     await tickets_repo.update_ticket(
                         ticket_id,
                         xero_invoice_number=xero_invoice_number,
                         billed_at=now,
-                        status="closed",
+                        status=invoiced_status,
                         closed_at=now,
                     )
                 except Exception as update_exc:

--- a/tests/test_xero_billable_tickets.py
+++ b/tests/test_xero_billable_tickets.py
@@ -370,3 +370,15 @@ async def test_sync_billable_tickets_closes_tickets_after_invoicing():
         assert kwargs["xero_invoice_number"] == "INV-12345"
         assert "closed_at" in kwargs
         assert "billed_at" in kwargs
+
+
+def test_resolve_invoiced_ticket_status_defaults_to_closed(monkeypatch):
+    monkeypatch.delenv("TICKET_INVOICED_STATUS", raising=False)
+
+    assert xero_service.resolve_invoiced_ticket_status() == "closed"
+
+
+def test_resolve_invoiced_ticket_status_uses_env_override(monkeypatch):
+    monkeypatch.setenv("TICKET_INVOICED_STATUS", "Billing Complete")
+
+    assert xero_service.resolve_invoiced_ticket_status() == "billing_complete"


### PR DESCRIPTION
### Motivation

- Tickets that are invoiced should be moved out of billable/workable states automatically to avoid further work by technicians. 
- Allowing the post-invoice ticket status to be overridden via environment configuration supports different customer workflows without changing code.

### Description

- Added `resolve_invoiced_ticket_status()` to `app/services/xero.py` which reads `TICKET_INVOICED_STATUS` from the environment, normalises it with `ticket_status_repo.slugify_status_label`, and falls back to `closed`.
- Replaced hardcoded `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b41820b84832d842ce346c23ec59a)