### PR TITLE
Add billing limits and scheduling to recurring invoice items

### DIFF
--- a/app/api/routes/companies.py
+++ b/app/api/routes/companies.py
@@ -347,9 +347,23 @@ async def update_recurring_invoice_item(
     item = await recurring_items_repo.get_recurring_invoice_item(item_id)
     if not item or item.get("company_id") != company_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Recurring invoice item not found")
+    update_data = payload.model_dump(exclude_unset=True)
+    fields_set = payload.model_fields_set
+    if "price_override" in fields_set and payload.price_override is None:
+        update_data.pop("price_override", None)
+        update_data["clear_price_override"] = True
+    if "billing_interval" in fields_set and payload.billing_interval is None:
+        update_data.pop("billing_interval", None)
+        update_data["clear_billing_interval"] = True
+    if "start_date" in fields_set and payload.start_date is None:
+        update_data.pop("start_date", None)
+        update_data["clear_start_date"] = True
+    if "end_date" in fields_set and payload.end_date is None:
+        update_data.pop("end_date", None)
+        update_data["clear_end_date"] = True
     updated = await recurring_items_repo.update_recurring_invoice_item(
         item_id,
-        **payload.model_dump(exclude_unset=True),
+        **update_data,
     )
     if not updated:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Recurring invoice item not found")

--- a/app/repositories/company_recurring_invoice_items.py
+++ b/app/repositories/company_recurring_invoice_items.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date, datetime
 from typing import Any, Optional, Sequence
 
 from app.core.database import db
@@ -15,7 +16,8 @@ async def list_company_recurring_invoice_items(company_id: int) -> Sequence[dict
     rows = await db.fetch_all(
         """
         SELECT id, company_id, product_code, description_template, qty_expression,
-               price_override, active, created_at, updated_at
+               price_override, active, billing_frequency, billing_interval,
+               start_date, end_date, last_billed_at, created_at, updated_at
         FROM company_recurring_invoice_items
         WHERE company_id = %s
         ORDER BY created_at DESC
@@ -30,7 +32,8 @@ async def get_recurring_invoice_item(item_id: int) -> Optional[dict[str, Any]]:
     row = await db.fetch_one(
         """
         SELECT id, company_id, product_code, description_template, qty_expression,
-               price_override, active, created_at, updated_at
+               price_override, active, billing_frequency, billing_interval,
+               start_date, end_date, last_billed_at, created_at, updated_at
         FROM company_recurring_invoice_items
         WHERE id = %s
         """,
@@ -46,20 +49,37 @@ async def create_recurring_invoice_item(
     qty_expression: str,
     price_override: Optional[float] = None,
     active: bool = True,
+    billing_frequency: str = "every_run",
+    billing_interval: Optional[int] = None,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
 ) -> dict[str, Any]:
     """Create a new recurring invoice item."""
     item_id = await db.execute_returning_lastrowid(
         """
         INSERT INTO company_recurring_invoice_items
-        (company_id, product_code, description_template, qty_expression, price_override, active)
-        VALUES (%s, %s, %s, %s, %s, %s)
+        (company_id, product_code, description_template, qty_expression, price_override, active,
+         billing_frequency, billing_interval, start_date, end_date)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """,
-        (company_id, product_code, description_template, qty_expression, price_override, _bool_to_tinyint(active)),
+        (
+            company_id,
+            product_code,
+            description_template,
+            qty_expression,
+            price_override,
+            _bool_to_tinyint(active),
+            billing_frequency,
+            billing_interval,
+            start_date,
+            end_date,
+        ),
     )
     row = await db.fetch_one(
         """
         SELECT id, company_id, product_code, description_template, qty_expression,
-               price_override, active, created_at, updated_at
+               price_override, active, billing_frequency, billing_interval,
+               start_date, end_date, last_billed_at, created_at, updated_at
         FROM company_recurring_invoice_items
         WHERE id = %s
         """,
@@ -77,6 +97,14 @@ async def update_recurring_invoice_item(
     qty_expression: Optional[str] = None,
     price_override: Optional[float] = None,
     active: Optional[bool] = None,
+    billing_frequency: Optional[str] = None,
+    billing_interval: Optional[int] = None,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    clear_price_override: bool = False,
+    clear_billing_interval: bool = False,
+    clear_start_date: bool = False,
+    clear_end_date: bool = False,
 ) -> Optional[dict[str, Any]]:
     """Update a recurring invoice item."""
     updates = []
@@ -94,13 +122,37 @@ async def update_recurring_invoice_item(
         updates.append("qty_expression = %s")
         params.append(qty_expression)
     
-    if price_override is not None:
+    if clear_price_override:
+        updates.append("price_override = NULL")
+    elif price_override is not None:
         updates.append("price_override = %s")
         params.append(price_override)
     
     if active is not None:
         updates.append("active = %s")
         params.append(_bool_to_tinyint(active))
+
+    if billing_frequency is not None:
+        updates.append("billing_frequency = %s")
+        params.append(billing_frequency)
+
+    if clear_billing_interval:
+        updates.append("billing_interval = NULL")
+    elif billing_interval is not None:
+        updates.append("billing_interval = %s")
+        params.append(billing_interval)
+
+    if clear_start_date:
+        updates.append("start_date = NULL")
+    elif start_date is not None:
+        updates.append("start_date = %s")
+        params.append(start_date)
+
+    if clear_end_date:
+        updates.append("end_date = NULL")
+    elif end_date is not None:
+        updates.append("end_date = %s")
+        params.append(end_date)
     
     if not updates:
         return await get_recurring_invoice_item(item_id)
@@ -119,4 +171,24 @@ async def delete_recurring_invoice_item(item_id: int) -> None:
     await db.execute(
         "DELETE FROM company_recurring_invoice_items WHERE id = %s",
         (item_id,),
+    )
+
+
+async def mark_recurring_invoice_items_billed(
+    item_ids: Sequence[int],
+    *,
+    billed_at: Optional[datetime] = None,
+) -> None:
+    """Record the UTC timestamp when recurring items were successfully invoiced."""
+    unique_ids = sorted({int(item_id) for item_id in item_ids if item_id})
+    if not unique_ids:
+        return
+    placeholders = ", ".join(["%s"] * len(unique_ids))
+    await db.execute(
+        f"""
+        UPDATE company_recurring_invoice_items
+        SET last_billed_at = %s
+        WHERE id IN ({placeholders})
+        """,
+        tuple([billed_at or datetime.utcnow(), *unique_ids]),
     )

--- a/app/schemas/company_recurring_invoice_items.py
+++ b/app/schemas/company_recurring_invoice_items.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+BILLING_FREQUENCIES = {"every_run", "once", "weekly", "monthly", "quarterly", "yearly", "times_per_year"}
 
 
 class RecurringInvoiceItemBase(BaseModel):
@@ -12,6 +15,34 @@ class RecurringInvoiceItemBase(BaseModel):
     qty_expression: str = Field(..., description="Quantity expression (static number or variable)")
     price_override: Optional[float] = Field(None, description="Price override, null to use Xero default")
     active: bool = Field(True, description="Whether this item is active")
+    billing_frequency: str = Field(
+        "every_run",
+        description="Billing limit for automatic invoice generation: every_run, once, weekly, monthly, quarterly, yearly, or times_per_year",
+    )
+    billing_interval: Optional[int] = Field(
+        None,
+        ge=1,
+        le=365,
+        description="Frequency value used by times_per_year, for example 12 for twelve times per year",
+    )
+    start_date: Optional[date] = Field(None, description="Optional first UTC date this item may be billed")
+    end_date: Optional[date] = Field(None, description="Optional final UTC date this item may be billed")
+
+    @field_validator("billing_frequency")
+    @classmethod
+    def validate_billing_frequency(cls, value: str) -> str:
+        normalized = (value or "every_run").strip().lower()
+        if normalized not in BILLING_FREQUENCIES:
+            raise ValueError("Unsupported billing frequency")
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_schedule(self):
+        if self.billing_frequency == "times_per_year" and not self.billing_interval:
+            raise ValueError("billing_interval is required when billing_frequency is times_per_year")
+        if self.start_date and self.end_date and self.end_date < self.start_date:
+            raise ValueError("end_date must be on or after start_date")
+        return self
 
 
 class RecurringInvoiceItemCreate(RecurringInvoiceItemBase):
@@ -24,11 +55,32 @@ class RecurringInvoiceItemUpdate(BaseModel):
     qty_expression: Optional[str] = None
     price_override: Optional[float] = None
     active: Optional[bool] = None
+    billing_frequency: Optional[str] = None
+    billing_interval: Optional[int] = Field(None, ge=1, le=365)
+    start_date: Optional[date] = None
+    end_date: Optional[date] = None
+
+    @field_validator("billing_frequency")
+    @classmethod
+    def validate_billing_frequency(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        if normalized not in BILLING_FREQUENCIES:
+            raise ValueError("Unsupported billing frequency")
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_schedule(self):
+        if self.start_date and self.end_date and self.end_date < self.start_date:
+            raise ValueError("end_date must be on or after start_date")
+        return self
 
 
 class RecurringInvoiceItemResponse(RecurringInvoiceItemBase):
     id: int
     company_id: int
+    last_billed_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
 

--- a/app/services/invoice_generator.py
+++ b/app/services/invoice_generator.py
@@ -15,6 +15,7 @@ from loguru import logger
 from app.repositories import companies as company_repo
 from app.repositories import invoice_lines as invoice_lines_repo
 from app.repositories import invoices as invoice_repo
+from app.repositories import company_recurring_invoice_items as recurring_items_repo
 from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import users as users_repo
@@ -174,6 +175,7 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
         context=context,
         tenant_id=tenant_id,
         access_token=access_token,
+        include_metadata=True,
     )
 
     line_item_template = await _get_xero_line_item_template()
@@ -363,9 +365,24 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
                 error=str(exc),
             )
 
+    recurring_item_ids = [
+        int(item["MyPortalRecurringItemId"])
+        for item in recurring_line_items
+        if item.get("MyPortalRecurringItemId")
+    ]
+    now = datetime.now(timezone.utc)
+    try:
+        await recurring_items_repo.mark_recurring_invoice_items_billed(recurring_item_ids, billed_at=now)
+    except Exception as exc:
+        logger.error(
+            "Failed to update recurring invoice item billing timestamps",
+            company_id=company_id,
+            invoice_id=invoice_id,
+            error=str(exc),
+        )
+
     # Mark time entries as billed and update ticket statuses
     billed_count = 0
-    now = datetime.now(timezone.utc)
 
     for ticket_ctx in tickets_context:
         ticket_id = ticket_ctx.get("id")

--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -1543,6 +1543,89 @@ async def build_invoice_context(company_id: int) -> dict[str, Any]:
     return context
 
 
+
+def _coerce_utc_date(value: Any) -> date | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).date() if value.tzinfo else value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+        except ValueError:
+            try:
+                return date.fromisoformat(value[:10])
+            except ValueError:
+                return None
+    return None
+
+
+def _coerce_utc_datetime(value: Any) -> datetime | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed.astimezone(timezone.utc) if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return None
+
+
+def _recurring_item_minimum_days(item: Mapping[str, Any]) -> int | None:
+    frequency = str(item.get("billing_frequency") or "every_run").strip().lower()
+    if frequency == "weekly":
+        return 7
+    if frequency == "monthly":
+        return 28
+    if frequency == "quarterly":
+        return 91
+    if frequency == "yearly":
+        return 365
+    if frequency == "times_per_year":
+        try:
+            times = int(item.get("billing_interval") or 0)
+        except (TypeError, ValueError):
+            return None
+        if times <= 0:
+            return None
+        return max(1, 365 // times)
+    return None
+
+
+def recurring_invoice_item_is_due(item: Mapping[str, Any], *, today: date | None = None) -> bool:
+    """Return whether a recurring item should be included in an automatic invoice run."""
+    if not item.get("active"):
+        return False
+    current_date = today or datetime.now(timezone.utc).date()
+    start_date = _coerce_utc_date(item.get("start_date"))
+    end_date = _coerce_utc_date(item.get("end_date"))
+    if start_date and current_date < start_date:
+        return False
+    if end_date and current_date > end_date:
+        return False
+
+    frequency = str(item.get("billing_frequency") or "every_run").strip().lower()
+    if frequency == "every_run":
+        return True
+
+    last_billed_at = _coerce_utc_datetime(item.get("last_billed_at"))
+    if last_billed_at is None:
+        return True
+    if frequency == "once":
+        return False
+
+    minimum_days = _recurring_item_minimum_days(item)
+    if minimum_days is None:
+        return False
+    return (current_date - last_billed_at.date()).days >= minimum_days
+
 async def build_recurring_invoice_items(
     company_id: int,
     *,
@@ -1550,6 +1633,7 @@ async def build_recurring_invoice_items(
     context: dict[str, Any] | None = None,
     tenant_id: str | None = None,
     access_token: str | None = None,
+    include_metadata: bool = False,
 ) -> list[dict[str, Any]]:
     """Build line items for recurring invoice items configured for a company.
     
@@ -1573,7 +1657,7 @@ async def build_recurring_invoice_items(
     # Collect item codes that need rates from Xero (those without price_override)
     item_codes_to_fetch: set[str] = set()
     for item in recurring_items:
-        if not item.get("active"):
+        if not recurring_invoice_item_is_due(item):
             continue
         product_code = str(item.get("product_code") or "").strip()
         price_override = item.get("price_override")
@@ -1606,7 +1690,7 @@ async def build_recurring_invoice_items(
     
     for item in recurring_items:
         # Skip inactive items
-        if not item.get("active"):
+        if not recurring_invoice_item_is_due(item):
             continue
         
         # Format description using dynamic variables and legacy template placeholders.
@@ -1654,6 +1738,8 @@ async def build_recurring_invoice_items(
         # Add tax type if specified
         if tax_type:
             line_item["TaxType"] = str(tax_type).strip()
+        if include_metadata:
+            line_item["MyPortalRecurringItemId"] = item.get("id")
         
         line_items.append(line_item)
     

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -2837,6 +2837,23 @@
     const deleteButtons = document.querySelectorAll('[data-recurring-item-delete]');
     const deleteModalButton = document.querySelector('[data-recurring-item-delete-modal]');
     const resetButton = document.querySelector('[data-recurring-item-reset]');
+    const frequencyInput = document.getElementById('recurring-item-frequency');
+    const intervalField = document.getElementById('recurring-item-interval-field');
+
+    function syncIntervalVisibility() {
+      if (!frequencyInput || !intervalField) {
+        return;
+      }
+      if (frequencyInput.value === 'times_per_year') {
+        intervalField.removeAttribute('hidden');
+      } else {
+        intervalField.setAttribute('hidden', '');
+      }
+    }
+
+    if (frequencyInput) {
+      frequencyInput.addEventListener('change', syncIntervalVisibility);
+    }
 
     function openModal() {
       modal.removeAttribute('hidden');
@@ -2854,6 +2871,11 @@
     function resetForm() {
       form.reset();
       document.getElementById('recurring-item-id').value = '';
+      document.getElementById('recurring-item-frequency').value = 'every_run';
+      document.getElementById('recurring-item-interval').value = '';
+      document.getElementById('recurring-item-start-date').value = '';
+      document.getElementById('recurring-item-end-date').value = '';
+      syncIntervalVisibility();
       if (deleteModalButton) {
         deleteModalButton.setAttribute('hidden', '');
         deleteModalButton.setAttribute('aria-hidden', 'true');
@@ -2867,6 +2889,11 @@
       document.getElementById('recurring-item-qty').value = item.qty_expression || '';
       document.getElementById('recurring-item-price').value = item.price_override || '';
       document.getElementById('recurring-item-active').checked = !!item.active;
+      document.getElementById('recurring-item-frequency').value = item.billing_frequency || 'every_run';
+      document.getElementById('recurring-item-interval').value = item.billing_interval || '';
+      document.getElementById('recurring-item-start-date').value = (item.start_date || '').slice(0, 10);
+      document.getElementById('recurring-item-end-date').value = (item.end_date || '').slice(0, 10);
+      syncIntervalVisibility();
 
       if (item.id && deleteModalButton) {
         deleteModalButton.removeAttribute('hidden');
@@ -2924,12 +2951,18 @@
         }
       }
 
+      const billingFrequency = document.getElementById('recurring-item-frequency').value;
+      const billingIntervalValue = document.getElementById('recurring-item-interval').value.trim();
       const formData = {
         product_code: document.getElementById('recurring-item-product-code').value.trim(),
         description_template: document.getElementById('recurring-item-description').value.trim(),
         qty_expression: document.getElementById('recurring-item-qty').value.trim(),
         price_override: priceOverride,
         active: document.getElementById('recurring-item-active').checked,
+        billing_frequency: billingFrequency,
+        billing_interval: billingFrequency === 'times_per_year' && billingIntervalValue ? parseInt(billingIntervalValue, 10) : null,
+        start_date: document.getElementById('recurring-item-start-date').value || null,
+        end_date: document.getElementById('recurring-item-end-date').value || null,
       };
 
       try {

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -980,6 +980,9 @@
                   <th scope="col" data-sort="string">Description</th>
                   <th scope="col" data-sort="string">Qty Expression</th>
                   <th scope="col" data-sort="number">Price Override</th>
+                  <th scope="col" data-sort="string">Billing limit</th>
+                  <th scope="col" data-sort="string">Window</th>
+                  <th scope="col" data-sort="string">Last billed</th>
                   <th scope="col" data-sort="string">Active</th>
                   <th scope="col" class="table__actions">Actions</th>
                 </tr>
@@ -1000,6 +1003,22 @@
                           <span class="text-muted">Use Xero default</span>
                         {% endif %}
                       </td>
+                      <td data-label="Billing limit">
+                        {% set frequency_labels = {
+                          'every_run': 'Every run',
+                          'once': 'Once only',
+                          'weekly': 'Once per week',
+                          'monthly': 'Once per month',
+                          'quarterly': 'Once per quarter',
+                          'yearly': 'Once per year',
+                          'times_per_year': (item.billing_interval|string) ~ ' times per year' if item.billing_interval else 'Times per year'
+                        } %}
+                        {{ frequency_labels.get(item.billing_frequency or 'every_run', item.billing_frequency or 'Every run') }}
+                      </td>
+                      <td data-label="Window">
+                        {{ item.start_date or 'Any start' }} – {{ item.end_date or 'No end' }}
+                      </td>
+                      <td data-label="Last billed">{{ item.last_billed_at or 'Never' }}</td>
                       <td data-label="Active">
                         <span class="tag {{ 'tag--success' if item.active else 'tag--muted' }}">
                           {{ 'Yes' if item.active else 'No' }}
@@ -1015,7 +1034,7 @@
                   {% endfor %}
                 {% else %}
                   <tr>
-                    <td colspan="6" class="table__empty">No recurring invoice items configured yet.</td>
+                    <td colspan="9" class="table__empty">No recurring invoice items configured yet.</td>
                   </tr>
                 {% endif %}
               </tbody>
@@ -1581,6 +1600,33 @@
                 placeholder="Leave empty to use Xero default"
               />
               <p class="form-help">Override the price from Xero, or leave blank to use the default price.</p>
+            </div>
+
+            <div class="form-field">
+              <label class="form-label" for="recurring-item-frequency">Billing limit</label>
+              <select class="form-input" id="recurring-item-frequency" name="billing_frequency">
+                <option value="every_run">Every automatic run</option>
+                <option value="once">Once only</option>
+                <option value="weekly">Once per week</option>
+                <option value="monthly">Once per month</option>
+                <option value="quarterly">Once per quarter</option>
+                <option value="yearly">Once per year</option>
+                <option value="times_per_year">X times per year</option>
+              </select>
+              <p class="form-help">Limits repeat billing when invoice generation runs frequently.</p>
+            </div>
+            <div class="form-field" id="recurring-item-interval-field" hidden>
+              <label class="form-label" for="recurring-item-interval">Times per year</label>
+              <input class="form-input" id="recurring-item-interval" name="billing_interval" type="number" min="1" max="365" placeholder="12" />
+            </div>
+            <div class="form-field">
+              <label class="form-label" for="recurring-item-start-date">Start date (optional)</label>
+              <input class="form-input" id="recurring-item-start-date" name="start_date" type="date" />
+              <p class="form-help">Stored and evaluated as a UTC date.</p>
+            </div>
+            <div class="form-field">
+              <label class="form-label" for="recurring-item-end-date">End date (optional)</label>
+              <input class="form-input" id="recurring-item-end-date" name="end_date" type="date" />
             </div>
             <div class="form-field form-field--checkbox">
               <label class="checkbox">

--- a/migrations/284_recurring_invoice_item_limits.sql
+++ b/migrations/284_recurring_invoice_item_limits.sql
@@ -1,0 +1,9 @@
+ALTER TABLE company_recurring_invoice_items
+  ADD COLUMN IF NOT EXISTS billing_frequency VARCHAR(32) NOT NULL DEFAULT 'every_run' AFTER active,
+  ADD COLUMN IF NOT EXISTS billing_interval INT NULL AFTER billing_frequency,
+  ADD COLUMN IF NOT EXISTS start_date DATE NULL AFTER billing_interval,
+  ADD COLUMN IF NOT EXISTS end_date DATE NULL AFTER start_date,
+  ADD COLUMN IF NOT EXISTS last_billed_at DATETIME(6) NULL AFTER end_date;
+
+CREATE INDEX IF NOT EXISTS idx_recurring_invoice_items_schedule
+  ON company_recurring_invoice_items(active, billing_frequency, start_date, end_date, last_billed_at);

--- a/tests/test_company_recurring_invoice_items.py
+++ b/tests/test_company_recurring_invoice_items.py
@@ -68,7 +68,7 @@ def test_create_recurring_invoice_item_builds_expected_query(monkeypatch):
     assert result["id"] == 1
     assert result["company_id"] == 5
     assert "INSERT INTO company_recurring_invoice_items" in captured["sql"]
-    assert captured["params"] == (5, "LABOR-MANAGED", "Monthly managed services", "1", None, 1)
+    assert captured["params"] == (5, "LABOR-MANAGED", "Monthly managed services", "1", None, 1, "every_run", None, None, None)
     # Verify fetch_one uses the returned ID instead of LAST_INSERT_ID()
     assert "WHERE id = %s" in captured["fetch_sql"]
     assert captured["fetch_params"] == (1,)

--- a/tests/test_xero_recurring_items.py
+++ b/tests/test_xero_recurring_items.py
@@ -504,3 +504,25 @@ def test_local_invoice_line_without_item_code_keeps_zero_price():
             "UnitAmount": 0.0,
         }
     ]
+
+
+def test_recurring_invoice_item_is_due_respects_frequency_and_dates():
+    today = xero.date(2026, 7, 6)
+    assert xero.recurring_invoice_item_is_due({"active": True, "billing_frequency": "weekly", "last_billed_at": "2026-06-28T00:00:00+00:00"}, today=today)
+    assert not xero.recurring_invoice_item_is_due({"active": True, "billing_frequency": "weekly", "last_billed_at": "2026-07-04T00:00:00+00:00"}, today=today)
+    assert not xero.recurring_invoice_item_is_due({"active": True, "billing_frequency": "once", "last_billed_at": "2026-06-01T00:00:00+00:00"}, today=today)
+    assert not xero.recurring_invoice_item_is_due({"active": True, "billing_frequency": "monthly", "start_date": "2026-07-07"}, today=today)
+    assert not xero.recurring_invoice_item_is_due({"active": True, "billing_frequency": "monthly", "end_date": "2026-07-05"}, today=today)
+
+
+def test_build_recurring_invoice_items_skips_items_not_due(monkeypatch):
+    async def fake_list_items(company_id):
+        return [
+            {"id": 1, "product_code": "DUE", "description_template": "Due", "qty_expression": "1", "active": True, "billing_frequency": "weekly", "last_billed_at": "2026-06-01T00:00:00+00:00"},
+            {"id": 2, "product_code": "SKIP", "description_template": "Skip", "qty_expression": "1", "active": True, "billing_frequency": "once", "last_billed_at": "2026-06-01T00:00:00+00:00"},
+        ]
+
+    monkeypatch.setattr(xero.recurring_items_repo, "list_company_recurring_invoice_items", fake_list_items)
+    result = asyncio.run(xero.build_recurring_invoice_items(company_id=1, tax_type=None, include_metadata=True))
+    assert [item["ItemCode"] for item in result] == ["DUE"]
+    assert result[0]["MyPortalRecurringItemId"] == 1


### PR DESCRIPTION
### Motivation
- Provide scheduling controls for company recurring invoice items so admins can limit frequency (once, weekly, monthly, quarterly, yearly, X times per year, or every run), set optional start/end windows, and enable/disable items.  
- Prevent duplicate charges when automatic invoice generation runs frequently (e.g., daily) by evaluating due state before adding recurring lines.  
- Record when items were successfully invoiced so subsequent runs can respect configured limits and windows.

### Description
- Add a database migration `migrations/284_recurring_invoice_item_limits.sql` to add `billing_frequency`, `billing_interval`, `start_date`, `end_date`, and `last_billed_at` columns plus a schedule-focused index.  
- Extend API schemas in `app/schemas/company_recurring_invoice_items.py` to include scheduling fields and validation, including `times_per_year` handling and UTC date-window validation.  
- Update repository `app/repositories/company_recurring_invoice_items.py` to persist new fields, support clearing optional fields on update, and add `mark_recurring_invoice_items_billed` to record UTC `last_billed_at`.  
- Add scheduling/due-check logic and UTC helpers to `app/services/xero.py` (`recurring_invoice_item_is_due`, `_coerce_utc_date`, `_coerce_utc_datetime`, and minimum-days calculation) and return metadata when requested; update invoice generation in `app/services/invoice_generator.py` to mark items as billed after lines are created.  
- Update API patch flow in `app/api/routes/companies.py` to permit explicit clearing of optional fields (price override, interval, start/end dates).  
- Update admin UI `app/templates/admin/company_edit.html` to display billing limit, window and last-billed columns and add editor controls for schedule fields, and update client behavior in `app/static/js/admin.js` to populate, reset, validate and submit the new fields.

### Testing
- Ran unit/regression tests with `pytest tests/test_company_recurring_invoice_items.py tests/test_xero_recurring_items.py` which completed successfully (`20 passed`).  
- Performed static checks by compiling modified modules with `python -m py_compile app/services/xero.py app/services/invoice_generator.py app/repositories/company_recurring_invoice_items.py app/schemas/company_recurring_invoice_items.py app/api/routes/companies.py` which succeeded.  
- Verified changes by running the newly added/updated tests that cover scheduling behavior and metadata handling which all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b410ebc94832d99b89efc183d3465)