### PR TITLE
Fix Xero webhook acknowledgements

### DIFF
--- a/app/api/routes/xero.py
+++ b/app/api/routes/xero.py
@@ -194,18 +194,26 @@ async def receive_webhook(request: Request) -> dict[str, Any]:
             logger.exception("Failed to process Xero invoice webhook event")
             results.append({"status": "failed", "error": "Internal processing error"})
 
-    has_failure = any(result.get("status") == "failed" for result in results)
-    response_status = 502 if has_failure else 200
+    # Xero disables webhook deliveries when receivers do not acknowledge valid
+    # webhook notifications with a 2xx response quickly and consistently.  Event
+    # processing is best-effort here: signature/JSON validation failures still
+    # reject the request, but downstream invoice-sync errors are logged in the
+    # webhook monitor without turning the provider delivery into a failed HTTP
+    # attempt.
     await webhook_monitor.log_incoming_webhook(
         name="Xero Webhook - Invoice Updates",
         source_url=source_url,
         payload=payload,
         headers=request_headers,
-        response_status=response_status,
+        response_status=200,
         response_body=json.dumps({"status": "accepted", "results": results}),
+        error_message="; ".join(
+            str(result.get("error") or "Xero event processing failed")
+            for result in results
+            if result.get("status") == "failed"
+        )
+        or None,
     )
-    if has_failure:
-        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Failed to process one or more Xero webhook events")
     return {"status": "accepted", "results": results}
 
 

--- a/tests/test_xero_webhook.py
+++ b/tests/test_xero_webhook.py
@@ -54,3 +54,45 @@ async def test_apply_xero_invoice_event_marks_local_invoice_paid(monkeypatch):
     assert result == {"status": "updated", "invoice_id": 42}
     patch_mock.assert_awaited_once_with(42, status="paid")
     audit_mock.assert_awaited_once()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_receive_webhook_acknowledges_valid_delivery_when_event_processing_fails(monkeypatch):
+    from starlette.requests import Request
+    from app.services import webhook_monitor
+
+    body = b'{"events":[{"eventCategory":"INVOICE","resourceId":"xero-invoice-id"}]}'
+    key = "xero-webhook-key"
+    signature = base64.b64encode(hmac.new(key.encode(), body, hashlib.sha256).digest()).decode()
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/integration-modules/xero/webhook",
+            "headers": [
+                (b"host", b"testserver"),
+                (b"x-xero-signature", signature.encode()),
+                (b"content-type", b"application/json"),
+            ],
+            "scheme": "https",
+            "server": ("testserver", 443),
+            "client": ("127.0.0.1", 12345),
+        },
+        receive,
+    )
+
+    monkeypatch.setattr(xero, "_ensure_module_enabled", AsyncMock(return_value={"settings": {"webhook_key": key}}))
+    monkeypatch.setattr(xero, "_apply_xero_invoice_event", AsyncMock(side_effect=RuntimeError("Xero API timeout")))
+    log_mock = AsyncMock()
+    monkeypatch.setattr(webhook_monitor, "log_incoming_webhook", log_mock)
+
+    result = await xero.receive_webhook(request)
+
+    assert result == {"status": "accepted", "results": [{"status": "failed", "error": "Internal processing error"}]}
+    log_mock.assert_awaited_once()
+    assert log_mock.await_args.kwargs["response_status"] == 200
+    assert log_mock.await_args.kwargs["error_message"] == "Internal processing error"


### PR DESCRIPTION
### Motivation
- Xero disables webhook deliveries when receivers sometimes return non-2xx responses for valid notifications, so the handler should acknowledge valid signed JSON deliveries quickly while still recording downstream processing failures.

### Description
- Update `app/api/routes/xero.py` `receive_webhook` to always acknowledge valid signature/JSON payloads with HTTP 200 and stop raising HTTP 502 on per-event processing failures.
- Record downstream event-processing errors into the webhook monitor by setting `error_message` when logging via `webhook_monitor.log_incoming_webhook` and include results in the accepted response body.
- Preserve existing behaviour that invalid signatures still return `401` and invalid JSON still returns `400`.
- Add a regression test `tests/test_xero_webhook.py::test_receive_webhook_acknowledges_valid_delivery_when_event_processing_fails` that asserts the handler returns an accepted response and logs a `response_status=200` when event processing fails.

### Testing
- Run `pytest tests/test_xero_webhook.py` and all tests in that file passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b43d560888332937ad97196a7daac)