### PR TITLE
Add technician-hidden ticket statuses

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -359,12 +359,15 @@ async def list_ticket_statuses_endpoint(
     current_user: dict = Depends(require_helpdesk_technician),
 ) -> TicketStatusListResponse:
     definitions = await tickets_service.list_status_definitions()
+    if not current_user.get("is_super_admin"):
+        definitions = [definition for definition in definitions if not definition.hide_from_technicians]
     items = [
         TicketStatusDefinitionModel(
             tech_status=definition.tech_status,
             tech_label=definition.tech_label,
             public_status=definition.public_status,
             is_default=definition.is_default,
+            hide_from_technicians=definition.hide_from_technicians,
         )
         for definition in definitions
     ]
@@ -396,6 +399,7 @@ async def replace_ticket_statuses_endpoint(
             tech_label=definition.tech_label,
             public_status=definition.public_status,
             is_default=definition.is_default,
+            hide_from_technicians=definition.hide_from_technicians,
         )
         for definition in definitions
     ]
@@ -523,7 +527,7 @@ async def create_ticket(
     if has_helpdesk_access:
         if payload.status:
             try:
-                status_value = await tickets_service.validate_status_choice(payload.status)
+                status_value = await tickets_service.validate_status_choice(payload.status, allow_hidden=bool(current_user.get("is_super_admin")))
             except ValueError as exc:
                 error_id = new_error_id()
                 log_exception_with_error_id(
@@ -601,7 +605,7 @@ async def update_ticket(
     description_value = fields.pop("description", description_marker)
     if "status" in fields and fields["status"] is not None:
         try:
-            fields["status"] = await tickets_service.validate_status_choice(fields["status"])
+            fields["status"] = await tickets_service.validate_status_choice(fields["status"], allow_hidden=bool(current_user.get("is_super_admin")))
         except ValueError as exc:
             error_id = new_error_id()
             log_exception_with_error_id(

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -455,7 +455,7 @@ async def admin_create_ticket(request: Request):
         )
     try:
         if status_raw:
-            status_value = await tickets_service.validate_status_choice(status_raw)
+            status_value = await tickets_service.validate_status_choice(status_raw, allow_hidden=bool(current_user.get("is_super_admin")))
         else:
             status_value = await tickets_service.resolve_status_or_default(None)
         created = await tickets_service.create_ticket(
@@ -505,7 +505,7 @@ async def admin_update_ticket_status(ticket_id: int, request: Request):
     return_url_raw = form.get("returnUrl")
     return_url = str(return_url_raw).strip() if isinstance(return_url_raw, str) else None
     try:
-        status_value = await tickets_service.validate_status_choice(status_raw)
+        status_value = await tickets_service.validate_status_choice(status_raw, allow_hidden=bool(current_user.get("is_super_admin")))
     except ValueError as exc:
         error_message = str(exc)
         if return_url and return_url.startswith(f"/admin/tickets/{ticket_id}"):
@@ -546,11 +546,12 @@ def _build_ticket_status_payloads(
     tech_labels: Sequence[str],
     public_labels: Sequence[str],
     existing_slugs: Sequence[str],
+    hidden_flags: Sequence[str],
     default_status_value: str,
 ) -> list[dict[str, Any]]:
     statuses: list[dict[str, Any]] = []
     max_length = (
-        max(len(tech_labels), len(public_labels), len(existing_slugs))
+        max(len(tech_labels), len(public_labels), len(existing_slugs), len(hidden_flags))
         if (tech_labels or public_labels or existing_slugs)
         else 0
     )
@@ -558,6 +559,7 @@ def _build_ticket_status_payloads(
         tech_label = tech_labels[index] if index < len(tech_labels) else ""
         public_status = public_labels[index] if index < len(public_labels) else ""
         existing_slug = existing_slugs[index] if index < len(existing_slugs) else None
+        hide_from_technicians = index < len(hidden_flags) and str(hidden_flags[index]).strip().lower() in {"1", "true", "on", "yes"}
         if not tech_label and not public_status:
             continue
         candidate_slug = ticket_status_repo.slugify_status_label(tech_label)
@@ -574,6 +576,7 @@ def _build_ticket_status_payloads(
                 "publicStatus": public_status,
                 "existingSlug": existing_slug,
                 "isDefault": is_default,
+                "hideFromTechnicians": hide_from_technicians,
             }
         )
     return statuses
@@ -590,12 +593,14 @@ async def admin_replace_ticket_statuses(request: Request):
     tech_labels = form.getlist("techLabel")
     public_labels = form.getlist("publicLabel")
     existing_slugs = form.getlist("existingSlug")
+    hidden_flags = form.getlist("hideFromTechnicians")
     default_status_value = ticket_status_repo.slugify_status_label(str(form.get("defaultStatus") or ""))
 
     statuses = _build_ticket_status_payloads(
         tech_labels,
         public_labels,
         existing_slugs,
+        hidden_flags,
         default_status_value,
     )
 
@@ -793,7 +798,10 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
 
     if status_raw:
         try:
-            status_value = await tickets_service.validate_status_choice(status_raw)
+            status_value = await tickets_service.validate_status_choice(
+                status_raw,
+                allow_hidden=bool(current_user.get("is_super_admin")) or status_raw == str(ticket.get("status") or "").strip().lower(),
+            )
         except ValueError as exc:
             return await main_module._render_ticket_detail(
                 request,
@@ -1292,8 +1300,13 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
 
     status_definitions = await tickets_service.list_status_definitions()
-    valid_reply_statuses = {definition.tech_status for definition in status_definitions}
-    default_reply_status = next((definition.tech_status for definition in status_definitions if definition.is_default), None)
+    selectable_status_definitions = [
+        definition
+        for definition in status_definitions
+        if bool(current_user.get("is_super_admin")) or not definition.hide_from_technicians
+    ]
+    valid_reply_statuses = {definition.tech_status for definition in selectable_status_definitions}
+    default_reply_status = next((definition.tech_status for definition in selectable_status_definitions if definition.is_default), None)
     if not default_reply_status:
         default_reply_status = "pending" if "pending" in valid_reply_statuses else (next(iter(valid_reply_statuses), "open"))
     reply_status = str(get_last_form_value(form, "replyStatus", default_reply_status) or default_reply_status).strip().lower()

--- a/app/main.py
+++ b/app/main.py
@@ -7668,9 +7668,14 @@ async def _render_portal_ticket_detail(
 
     sanitized_description = sanitize_rich_text(str(ticket.get("description") or ""))
     status_definitions = await tickets_service.list_status_definitions()
+    selectable_status_definitions = [
+        definition
+        for definition in status_definitions
+        if is_super_admin or not definition.hide_from_technicians
+    ]
     status_label_map = {definition.tech_status: definition.public_status for definition in status_definitions}
-    available_statuses = [definition.tech_status for definition in status_definitions]
-    reply_default_status = next((definition.tech_status for definition in status_definitions if definition.is_default), None)
+    available_statuses = [definition.tech_status for definition in selectable_status_definitions]
+    reply_default_status = next((definition.tech_status for definition in selectable_status_definitions if definition.is_default), None)
     if not reply_default_status:
         reply_default_status = "pending" if "pending" in available_statuses else (available_statuses[0] if available_statuses else "open")
     status_value = str(ticket.get("status") or "open").lower()
@@ -8023,6 +8028,7 @@ async def _render_portal_ticket_detail(
                 "tech_label": definition.tech_label,
                 "public_status": definition.public_status,
                 "is_default": definition.is_default,
+                "hide_from_technicians": definition.hide_from_technicians,
             }
             for definition in status_definitions
         ],
@@ -8186,14 +8192,20 @@ async def _render_tickets_dashboard(
         )
     reference_data = await _get_ticket_dashboard_reference_data()
     dashboard_endpoint = "/api/tickets/dashboard"
+    selectable_status_definitions = [
+        definition
+        for definition in dashboard.status_definitions
+        if bool(user.get("is_super_admin")) or not definition.hide_from_technicians
+    ]
     status_definitions_payload = [
         {
             "tech_status": definition.tech_status,
             "tech_label": definition.tech_label,
             "public_status": definition.public_status,
             "is_default": definition.is_default,
+            "hide_from_technicians": definition.hide_from_technicians,
         }
-        for definition in dashboard.status_definitions
+        for definition in selectable_status_definitions
     ]
     status_label_map = {
         definition.tech_status: definition.tech_label for definition in dashboard.status_definitions
@@ -8202,7 +8214,7 @@ async def _render_tickets_dashboard(
         definition.tech_status: definition.public_status for definition in dashboard.status_definitions
     }
     reply_default_status = next(
-        (definition.tech_status for definition in dashboard.status_definitions if definition.is_default),
+        (definition.tech_status for definition in selectable_status_definitions if definition.is_default),
         None,
     )
     if not reply_default_status:
@@ -8614,10 +8626,15 @@ async def _render_ticket_detail(
     labour_types = await labour_types_service.list_labour_types()
 
     status_definitions = await tickets_service.list_status_definitions()
+    selectable_status_definitions = [
+        definition
+        for definition in status_definitions
+        if bool(user.get("is_super_admin")) or not definition.hide_from_technicians
+    ]
     status_label_map = {definition.tech_status: definition.tech_label for definition in status_definitions}
     public_status_map = {definition.tech_status: definition.public_status for definition in status_definitions}
-    available_statuses = [definition.tech_status for definition in status_definitions]
-    reply_default_status = next((definition.tech_status for definition in status_definitions if definition.is_default), None)
+    available_statuses = [definition.tech_status for definition in selectable_status_definitions]
+    reply_default_status = next((definition.tech_status for definition in selectable_status_definitions if definition.is_default), None)
     if not reply_default_status:
         reply_default_status = "pending" if "pending" in available_statuses else (available_statuses[0] if available_statuses else "open")
     ticket_status_slug = ticket.get("status") or "open"
@@ -8788,14 +8805,16 @@ async def _render_ticket_detail(
         "ticket_billable_minutes": total_billable_minutes,
         "ticket_non_billable_minutes": total_non_billable_minutes,
         "ticket_available_statuses": available_statuses,
+        "ticket_selectable_status_values": [definition.tech_status for definition in selectable_status_definitions],
         "ticket_status_definitions": [
             {
                 "tech_status": definition.tech_status,
                 "tech_label": definition.tech_label,
                 "public_status": definition.public_status,
                 "is_default": definition.is_default,
+                "hide_from_technicians": definition.hide_from_technicians,
             }
-            for definition in status_definitions
+            for definition in selectable_status_definitions
         ],
         "ticket_status_label_map": status_label_map,
         "ticket_public_status_map": public_status_map,

--- a/app/repositories/ticket_statuses.py
+++ b/app/repositories/ticket_statuses.py
@@ -36,17 +36,19 @@ def _normalise_row(row: dict[str, Any]) -> dict[str, Any]:
     label = str(row.get("tech_label") or "").strip()
     public = str(row.get("public_status") or "").strip()
     is_default = bool(row.get("is_default", False))
+    hide_from_technicians = bool(row.get("hide_from_technicians", False))
     return {
         "tech_status": slug,
         "tech_label": label or slug.replace("_", " ").title(),
         "public_status": public or label or slug.replace("_", " ").title(),
         "is_default": is_default,
+        "hide_from_technicians": hide_from_technicians,
     }
 
 
 async def list_statuses() -> list[dict[str, Any]]:
     rows = await db.fetch_all(
-        "SELECT tech_status, tech_label, public_status, is_default FROM ticket_statuses ORDER BY tech_label ASC"
+        "SELECT tech_status, tech_label, public_status, is_default, hide_from_technicians FROM ticket_statuses ORDER BY tech_label ASC"
     )
     return [_normalise_row(row) for row in rows]
 
@@ -62,17 +64,19 @@ async def ensure_default_statuses() -> list[dict[str, str]]:
                 for definition in DEFAULT_STATUS_DEFINITIONS:
                     await cursor.execute(
                         """
-                        INSERT INTO ticket_statuses (tech_status, tech_label, public_status, created_at, updated_at)
-                        VALUES (%s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
+                        INSERT INTO ticket_statuses (tech_status, tech_label, public_status, hide_from_technicians, created_at, updated_at)
+                        VALUES (%s, %s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
                         ON DUPLICATE KEY UPDATE
                             tech_label = VALUES(tech_label),
                             public_status = VALUES(public_status),
+                            hide_from_technicians = VALUES(hide_from_technicians),
                             updated_at = UTC_TIMESTAMP(6)
                         """,
                         (
                             definition["tech_status"],
                             definition["tech_label"],
                             definition["public_status"],
+                            int(bool(definition.get("hide_from_technicians", False))),
                         ),
                     )
                 await conn.commit()
@@ -139,10 +143,11 @@ async def replace_statuses(definitions: Sequence[dict[str, Any]]) -> list[dict[s
                                 SET tech_label = %s,
                                     public_status = %s,
                                     is_default = %s,
+                                    hide_from_technicians = %s,
                                     updated_at = UTC_TIMESTAMP(6)
                                 WHERE tech_status = %s
                                 """,
-                                (label, public_status, is_default, original_slug),
+                                (label, public_status, is_default, int(bool(definition.get("hide_from_technicians", False))), original_slug),
                             )
                         else:
                             if slug in current_slugs and slug != original_slug:
@@ -156,10 +161,11 @@ async def replace_statuses(definitions: Sequence[dict[str, Any]]) -> list[dict[s
                                     tech_label = %s,
                                     public_status = %s,
                                     is_default = %s,
+                                    hide_from_technicians = %s,
                                     updated_at = UTC_TIMESTAMP(6)
                                 WHERE tech_status = %s
                                 """,
-                                (slug, label, public_status, is_default, original_slug),
+                                (slug, label, public_status, is_default, int(bool(definition.get("hide_from_technicians", False))), original_slug),
                             )
                             await cursor.execute(
                                 "UPDATE tickets SET status = %s WHERE status = %s",
@@ -172,10 +178,10 @@ async def replace_statuses(definitions: Sequence[dict[str, Any]]) -> list[dict[s
                             raise ValueError("Tech status values must be unique.")
                         await cursor.execute(
                             """
-                            INSERT INTO ticket_statuses (tech_status, tech_label, public_status, is_default, created_at, updated_at)
-                            VALUES (%s, %s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
+                            INSERT INTO ticket_statuses (tech_status, tech_label, public_status, is_default, hide_from_technicians, created_at, updated_at)
+                            VALUES (%s, %s, %s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
                             """,
-                            (slug, label, public_status, is_default),
+                            (slug, label, public_status, is_default, int(bool(definition.get("hide_from_technicians", False))),)
                         )
                         current_slugs.add(slug)
 
@@ -220,7 +226,7 @@ async def get_status_definition(slug: str) -> dict[str, Any] | None:
     if not slug:
         return None
     row = await db.fetch_one(
-        "SELECT tech_status, tech_label, public_status, is_default FROM ticket_statuses WHERE tech_status = %s",
+        "SELECT tech_status, tech_label, public_status, is_default, hide_from_technicians FROM ticket_statuses WHERE tech_status = %s",
         (slug,),
     )
     return _normalise_row(row) if row else None
@@ -229,6 +235,6 @@ async def get_status_definition(slug: str) -> dict[str, Any] | None:
 async def get_default_status() -> dict[str, Any] | None:
     """Get the default status definition."""
     row = await db.fetch_one(
-        "SELECT tech_status, tech_label, public_status, is_default FROM ticket_statuses WHERE is_default = 1",
+        "SELECT tech_status, tech_label, public_status, is_default, hide_from_technicians FROM ticket_statuses WHERE is_default = 1",
     )
     return _normalise_row(row) if row else None

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -205,6 +205,7 @@ class TicketStatusDefinitionModel(BaseModel):
     tech_label: str = Field(alias="techLabel")
     public_status: str = Field(alias="publicStatus")
     is_default: bool = Field(default=False, alias="isDefault")
+    hide_from_technicians: bool = Field(default=False, alias="hideFromTechnicians")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -215,6 +216,7 @@ class TicketStatusUpdateInput(BaseModel):
     existing_slug: str | None = Field(default=None, alias="existingSlug", max_length=64)
     tech_status: str | None = Field(default=None, alias="techStatus", max_length=64)
     is_default: bool = Field(default=False, alias="isDefault")
+    hide_from_technicians: bool = Field(default=False, alias="hideFromTechnicians")
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -119,6 +119,7 @@ class TicketStatusDefinition:
     tech_label: str
     public_status: str
     is_default: bool = False
+    hide_from_technicians: bool = False
 
 
 def _build_status_definitions(records: Sequence[Mapping[str, Any]]) -> list[TicketStatusDefinition]:
@@ -130,12 +131,14 @@ def _build_status_definitions(records: Sequence[Mapping[str, Any]]) -> list[Tick
         label = str(record.get("tech_label") or "").strip() or slug.replace("_", " ").title()
         public_status = str(record.get("public_status") or "").strip() or label
         is_default = bool(record.get("is_default", False))
+        hide_from_technicians = bool(record.get("hide_from_technicians", False))
         definitions.append(
             TicketStatusDefinition(
                 tech_status=slug,
                 tech_label=label,
                 public_status=public_status,
                 is_default=is_default,
+                hide_from_technicians=hide_from_technicians,
             )
         )
     return definitions
@@ -147,6 +150,7 @@ def _default_status_records() -> list[dict[str, str]]:
             "tech_status": item["tech_status"],
             "tech_label": item["tech_label"],
             "public_status": item["public_status"],
+            "hide_from_technicians": item.get("hide_from_technicians", False),
         }
         for item in ticket_status_repo.DEFAULT_STATUS_DEFINITIONS
     ]
@@ -226,6 +230,11 @@ async def replace_ticket_statuses(status_inputs: Sequence[Mapping[str, Any]]) ->
             or definition.get("isDefault")
             or False
         )
+        hide_from_technicians = bool(
+            definition.get("hide_from_technicians")
+            or definition.get("hideFromTechnicians")
+            or False
+        )
 
         if is_default:
             if has_default:
@@ -257,6 +266,7 @@ async def replace_ticket_statuses(status_inputs: Sequence[Mapping[str, Any]]) ->
                 "public_status": public_status,
                 "original_slug": original_slug or slug,
                 "is_default": is_default,
+                "hide_from_technicians": hide_from_technicians,
             }
         )
 
@@ -268,12 +278,15 @@ async def replace_ticket_statuses(status_inputs: Sequence[Mapping[str, Any]]) ->
     return _build_status_definitions(records)
 
 
-async def validate_status_choice(value: str) -> str:
+async def validate_status_choice(value: str, *, allow_hidden: bool = True) -> str:
     slug = ticket_status_repo.slugify_status_label(value)
     if not slug:
         raise ValueError("Select a status to apply.")
-    if not await ticket_status_repo.status_exists(slug):
+    definition = await ticket_status_repo.get_status_definition(slug)
+    if not definition:
         raise ValueError("Select a valid status to apply.")
+    if definition.get("hide_from_technicians") and not allow_hidden:
+        raise ValueError("Select a ticket status available to technicians.")
     return slug
 
 

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -2448,6 +2448,17 @@
       });
     }
 
+    function syncHiddenStatusInputs() {
+      const rows = Array.from(list.querySelectorAll('[data-status-row]'));
+      rows.forEach((row) => {
+        const hiddenInput = row.querySelector('[data-status-hidden-input]');
+        const checkbox = row.querySelector('[data-status-hidden-checkbox]');
+        if (hiddenInput && checkbox) {
+          hiddenInput.value = checkbox.checked ? '1' : '0';
+        }
+      });
+    }
+
     function ensureDefaultRadioChecked() {
       const defaultRadios = form.querySelectorAll('input[name="defaultStatus"]');
       const hasChecked = Array.from(defaultRadios).some(radio => radio.checked);
@@ -2491,6 +2502,14 @@
       }
       if (slugInput) {
         slugInput.value = '';
+      }
+      const hiddenInput = row.querySelector('[data-status-hidden-input]');
+      const checkbox = row.querySelector('[data-status-hidden-checkbox]');
+      if (hiddenInput) {
+        hiddenInput.value = '0';
+      }
+      if (checkbox) {
+        checkbox.checked = false;
       }
       list.appendChild(row);
       updateRowIdentifiers();
@@ -2549,10 +2568,17 @@
 
     form.addEventListener('input', () => {
       clearError();
+      syncHiddenStatusInputs();
+    });
+
+    form.addEventListener('change', () => {
+      clearError();
+      syncHiddenStatusInputs();
     });
 
     form.addEventListener('submit', (event) => {
       clearError();
+      syncHiddenStatusInputs();
       const rows = Array.from(list.querySelectorAll('[data-status-row]'));
       const seen = new Set();
       const selectedDefaultRadio = form.querySelector('input[name="defaultStatus"]:checked');
@@ -2598,6 +2624,7 @@
     updateRowIdentifiers();
     updateRemoveButtons();
     ensureDefaultRadioChecked();
+    syncHiddenStatusInputs();
 
     // Return the initialization function for use in onOpen callback
     return {
@@ -2761,10 +2788,17 @@
 
     form.addEventListener('input', () => {
       clearError();
+      syncHiddenStatusInputs();
+    });
+
+    form.addEventListener('change', () => {
+      clearError();
+      syncHiddenStatusInputs();
     });
 
     form.addEventListener('submit', (event) => {
       clearError();
+      syncHiddenStatusInputs();
       const rows = Array.from(list.querySelectorAll('[data-labour-row]'));
       const seenCodes = new Set();
 

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -126,7 +126,7 @@
               <div class="form-field">
                 <label class="form-label" for="ticket-status-detail">Status</label>
                 <select id="ticket-status-detail" name="status" class="form-input">
-                  {% if ticket_status not in ticket_status_label_map %}
+                  {% if ticket_status not in ticket_selectable_status_values %}
                     <option value="{{ ticket_status }}" selected>{{ ticket_status_label }}</option>
                   {% endif %}
                   {% for status_option in ticket_status_definitions %}

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -676,6 +676,7 @@
                 <th scope="col">Default</th>
                 <th scope="col">Tech status (technician label)</th>
                 <th scope="col">Public status (customer label)</th>
+                <th scope="col">Hide from technicians</th>
                 <th scope="col" class="table__actions">Actions</th>
               </tr>
             </thead>
@@ -717,6 +718,13 @@
                         required
                       />
                     </td>
+                    <td data-label="Hide from technicians">
+                      <input type="hidden" name="hideFromTechnicians" value="{% if status_option.hide_from_technicians %}1{% else %}0{% endif %}" data-status-hidden-input />
+                      <label class="checkbox">
+                        <input type="checkbox" data-status-hidden-checkbox {% if status_option.hide_from_technicians %}checked{% endif %} />
+                        <span>Hide</span>
+                      </label>
+                    </td>
                     <td class="table__actions">
                       <button
                         type="button"
@@ -751,6 +759,13 @@
                     <label class="visually-hidden" for="status-public-0">Public status</label>
                     <input id="status-public-0" name="publicLabel" class="form-input" maxlength="128" required />
                   </td>
+                  <td data-label="Hide from technicians">
+                    <input type="hidden" name="hideFromTechnicians" value="0" data-status-hidden-input />
+                    <label class="checkbox">
+                      <input type="checkbox" data-status-hidden-checkbox />
+                      <span>Hide</span>
+                    </label>
+                  </td>
                   <td class="table__actions">
                     <button type="button" class="button button--ghost" data-status-remove disabled>Remove</button>
                   </td>
@@ -781,6 +796,13 @@
       <td data-label="Public status">
         <label class="visually-hidden">Public status</label>
         <input name="publicLabel" class="form-input" maxlength="128" required />
+      </td>
+      <td data-label="Hide from technicians">
+        <input type="hidden" name="hideFromTechnicians" value="0" data-status-hidden-input />
+        <label class="checkbox">
+          <input type="checkbox" data-status-hidden-checkbox />
+          <span>Hide</span>
+        </label>
       </td>
       <td class="table__actions">
         <button type="button" class="button button--ghost" data-status-remove>Remove</button>

--- a/migrations/282_ticket_status_hide_from_technicians.sql
+++ b/migrations/282_ticket_status_hide_from_technicians.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ticket_statuses
+ADD COLUMN IF NOT EXISTS hide_from_technicians TINYINT(1) NOT NULL DEFAULT 0 AFTER is_default;
+
+CREATE INDEX IF NOT EXISTS idx_ticket_statuses_hide_from_technicians ON ticket_statuses (hide_from_technicians);


### PR DESCRIPTION
### Motivation
- Provide super admins a way to prevent technicians from selecting specific ticket statuses (e.g. `closed`) so staff cannot close or set certain states before billing or approval.
- Ensure hidden statuses remain configurable by super admins while remaining invisible/unselectable to non-super-admin technicians.

### Description
- Added a persistent `hide_from_technicians` boolean column and index on `ticket_statuses` with a migration `migrations/282_ticket_status_hide_from_technicians.sql` and extended DB read/write logic to include this flag in `app/repositories/ticket_statuses.py`.
- Extended the ticket status service and schema models in `app/services/tickets.py` and `app/schemas/tickets.py` to carry `hide_from_technicians`, and updated `replace_ticket_statuses` and `_build_status_definitions` to persist and surface the flag.
- Enforced visibility rules by filtering status lists and dropdowns for non-super-admins (API: `app/api/routes/tickets.py`, server-rendered pages and dashboard: `app/main.py`), and updated validation to `validate_status_choice(..., allow_hidden=...)` so hidden statuses are rejected for technicians but allowed for super admins.
- Updated the super-admin status editor UI to include a `Hide from technicians` checkbox and sync it via `app/static/js/admin.js` and templates (`app/templates/admin/tickets.html` and `app/templates/admin/ticket_detail.html`) so super admins can set the flag when editing statuses.

### Testing
- Ran Python bytecode checks with `python -m compileall` for modified modules and they succeeded.
- Ran `python -m py_compile` for modified modules and it succeeded.
- Ran `git diff --check` to validate whitespace/patch issues and it reported no problems.
- Attempted a small runtime invocation to exercise `_build_ticket_status_payloads`, but importing the application failed in the local test run due to missing environment secrets (`SESSION_SECRET`, `TOTP_ENCRYPTION_KEY`), so that runtime test could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b42cd41e883329b4f4e858c24f224)