### PR TITLE
Fix Xero Intent to Receive webhook responses

### DIFF
--- a/app/api/routes/xero.py
+++ b/app/api/routes/xero.py
@@ -9,7 +9,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, Request, Response, status
 from fastapi.responses import RedirectResponse
 from itsdangerous import URLSafeSerializer
 from itsdangerous import BadSignature
@@ -152,7 +152,7 @@ async def _ensure_module_enabled() -> dict[str, Any]:
     status_code=status.HTTP_200_OK,
     name="xero_receive_webhook",
 )
-async def receive_webhook(request: Request) -> dict[str, Any]:
+async def receive_webhook(request: Request) -> Response:
     from app.services import webhook_monitor
 
     module = await _ensure_module_enabled()
@@ -167,10 +167,10 @@ async def receive_webhook(request: Request) -> dict[str, Any]:
             payload=body.decode("utf-8", errors="replace"),
             headers=request_headers,
             response_status=401,
-            response_body="Invalid signature",
+            response_body="",
             error_message="Invalid Xero webhook signature",
         )
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid signature")
+        return Response(status_code=status.HTTP_401_UNAUTHORIZED)
 
     try:
         payload = json.loads(body.decode("utf-8")) if body else {}
@@ -214,7 +214,7 @@ async def receive_webhook(request: Request) -> dict[str, Any]:
         )
         or None,
     )
-    return {"status": "accepted", "results": results}
+    return Response(status_code=status.HTTP_200_OK)
 
 
 @router.post(

--- a/docs/wiki/integrations/Xero Integration.md
+++ b/docs/wiki/integrations/Xero Integration.md
@@ -5,22 +5,34 @@ Xero. Before MyPortal can refresh OAuth tokens or receive webhook
 notifications, register an application inside the Xero developer portal and
 record the generated credentials inside **Admin → Integration modules → Xero**.
 
-## Callback URL
+## Callback and webhook URLs
 
-Xero requires a callback URL (also called a redirect URI) for OAuth flows and
-webhook notifications. MyPortal exposes a dedicated endpoint at:
+Xero uses separate URLs for OAuth redirects and signed webhook notifications.
+Paste the OAuth callback URL into the **Redirect URI** field within your Xero
+application settings:
 
 ```
 https://<your-domain>/api/integration-modules/xero/callback
 ```
 
-This URL is displayed inside the Xero module configuration panel so that it can
-be copied without leaving the admin interface. Paste the fully-qualified URL
-into the **Redirect URI** field within your Xero application settings.
+Paste the webhook URL into the Xero webhook delivery URL field:
 
-The endpoint accepts POST requests and responds with HTTP 202 to acknowledge
-callbacks from Xero. A lightweight GET handler is also available for diagnostic
-probes and returns HTTP 200 when the integration module is enabled.
+```
+https://<your-domain>/api/integration-modules/xero/webhook
+```
+
+The webhook endpoint validates the raw request body against the
+`x-xero-signature` header using the configured Xero webhook signing key. During
+Xero's Intent to Receive test, Xero sends one correctly signed payload and three
+incorrectly signed payloads; MyPortal returns an empty HTTP 200 response for the
+correctly signed payload and an empty HTTP 401 response for each incorrectly
+signed payload, which is the status-code contract Xero requires before enabling
+webhook delivery. The empty-events Intent to Receive payload is acknowledged
+without invoice processing.
+
+The legacy callback endpoint accepts POST requests and responds with HTTP 202 to
+acknowledge callbacks from Xero. A lightweight GET handler is also available for
+diagnostic probes and returns HTTP 200 when the integration module is enabled.
 
 ## Invoice synchronisation
 

--- a/docs/wiki/integrations/Xero OAuth Setup.md
+++ b/docs/wiki/integrations/Xero OAuth Setup.md
@@ -138,7 +138,8 @@ Note: These are the exact scope names used in the code. Xero may show these with
 
 - `GET /xero/connect` - Initiate OAuth2 authorization flow (requires super admin)
 - `GET /xero/callback` - OAuth2 callback handler (called by Xero)
-- `POST /api/integration-modules/xero/callback` - Webhook endpoint for Xero events
+- `POST /api/integration-modules/xero/webhook` - Signed webhook endpoint for Xero events and Intent to Receive tests
+- `POST /api/integration-modules/xero/callback` - Legacy callback endpoint
 
 ### Module Functions
 

--- a/tests/test_xero_webhook.py
+++ b/tests/test_xero_webhook.py
@@ -85,14 +85,115 @@ async def test_receive_webhook_acknowledges_valid_delivery_when_event_processing
         receive,
     )
 
-    monkeypatch.setattr(xero, "_ensure_module_enabled", AsyncMock(return_value={"settings": {"webhook_key": key}}))
-    monkeypatch.setattr(xero, "_apply_xero_invoice_event", AsyncMock(side_effect=RuntimeError("Xero API timeout")))
+    monkeypatch.setattr(
+        xero,
+        "_ensure_module_enabled",
+        AsyncMock(return_value={"settings": {"webhook_key": key}}),
+    )
+    monkeypatch.setattr(
+        xero,
+        "_apply_xero_invoice_event",
+        AsyncMock(side_effect=RuntimeError("Xero API timeout")),
+    )
     log_mock = AsyncMock()
     monkeypatch.setattr(webhook_monitor, "log_incoming_webhook", log_mock)
 
-    result = await xero.receive_webhook(request)
+    response = await xero.receive_webhook(request)
 
-    assert result == {"status": "accepted", "results": [{"status": "failed", "error": "Internal processing error"}]}
+    assert response.status_code == 200
+    assert response.body == b""
     log_mock.assert_awaited_once()
     assert log_mock.await_args.kwargs["response_status"] == 200
     assert log_mock.await_args.kwargs["error_message"] == "Internal processing error"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_receive_webhook_returns_empty_401_for_invalid_intent_signature(monkeypatch):
+    from starlette.requests import Request
+    from app.services import webhook_monitor
+
+    body = b'{"events":[],"firstEventSequence":0,"lastEventSequence":0,"entropy":"BAD"}'
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/integration-modules/xero/webhook",
+            "headers": [
+                (b"host", b"testserver"),
+                (b"x-xero-signature", b"not-a-valid-signature"),
+                (b"content-type", b"application/json"),
+            ],
+            "scheme": "https",
+            "server": ("testserver", 443),
+            "client": ("127.0.0.1", 12345),
+        },
+        receive,
+    )
+
+    monkeypatch.setattr(
+        xero,
+        "_ensure_module_enabled",
+        AsyncMock(return_value={"settings": {"webhook_key": "xero-webhook-key"}}),
+    )
+    log_mock = AsyncMock()
+    monkeypatch.setattr(webhook_monitor, "log_incoming_webhook", log_mock)
+
+    response = await xero.receive_webhook(request)
+
+    assert response.status_code == 401
+    assert response.body == b""
+    log_mock.assert_awaited_once()
+    assert log_mock.await_args.kwargs["response_status"] == 401
+    assert log_mock.await_args.kwargs["response_body"] == ""
+
+
+@pytest.mark.anyio("asyncio")
+async def test_receive_webhook_returns_empty_200_for_valid_intent_payload(monkeypatch):
+    from starlette.requests import Request
+    from app.services import webhook_monitor
+
+    body = b'{"events":[],"firstEventSequence":0,"lastEventSequence":0,"entropy":"GOOD"}'
+    key = "xero-webhook-key"
+    signature = base64.b64encode(hmac.new(key.encode(), body, hashlib.sha256).digest()).decode()
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/integration-modules/xero/webhook",
+            "headers": [
+                (b"host", b"testserver"),
+                (b"x-xero-signature", signature.encode()),
+                (b"content-type", b"application/json"),
+            ],
+            "scheme": "https",
+            "server": ("testserver", 443),
+            "client": ("127.0.0.1", 12345),
+        },
+        receive,
+    )
+
+    monkeypatch.setattr(
+        xero,
+        "_ensure_module_enabled",
+        AsyncMock(return_value={"settings": {"webhook_key": key}}),
+    )
+    apply_mock = AsyncMock()
+    monkeypatch.setattr(xero, "_apply_xero_invoice_event", apply_mock)
+    log_mock = AsyncMock()
+    monkeypatch.setattr(webhook_monitor, "log_incoming_webhook", log_mock)
+
+    response = await xero.receive_webhook(request)
+
+    assert response.status_code == 200
+    assert response.body == b""
+    apply_mock.assert_not_awaited()
+    log_mock.assert_awaited_once()
+    assert log_mock.await_args.kwargs["response_status"] == 200

--- a/wiki/Xero-Integration.md
+++ b/wiki/Xero-Integration.md
@@ -5,22 +5,34 @@ Xero. Before MyPortal can refresh OAuth tokens or receive webhook
 notifications, register an application inside the Xero developer portal and
 record the generated credentials inside **Admin → Integration modules → Xero**.
 
-## Callback URL
+## Callback and webhook URLs
 
-Xero requires a callback URL (also called a redirect URI) for OAuth flows and
-webhook notifications. MyPortal exposes a dedicated endpoint at:
+Xero uses separate URLs for OAuth redirects and signed webhook notifications.
+Paste the OAuth callback URL into the **Redirect URI** field within your Xero
+application settings:
 
 ```
 https://<your-domain>/api/integration-modules/xero/callback
 ```
 
-This URL is displayed inside the Xero module configuration panel so that it can
-be copied without leaving the admin interface. Paste the fully-qualified URL
-into the **Redirect URI** field within your Xero application settings.
+Paste the webhook URL into the Xero webhook delivery URL field:
 
-The endpoint accepts POST requests and responds with HTTP 202 to acknowledge
-callbacks from Xero. A lightweight GET handler is also available for diagnostic
-probes and returns HTTP 200 when the integration module is enabled.
+```
+https://<your-domain>/api/integration-modules/xero/webhook
+```
+
+The webhook endpoint validates the raw request body against the
+`x-xero-signature` header using the configured Xero webhook signing key. During
+Xero's Intent to Receive test, Xero sends one correctly signed payload and three
+incorrectly signed payloads; MyPortal returns an empty HTTP 200 response for the
+correctly signed payload and an empty HTTP 401 response for each incorrectly
+signed payload, which is the status-code contract Xero requires before enabling
+webhook delivery. The empty-events Intent to Receive payload is acknowledged
+without invoice processing.
+
+The legacy callback endpoint accepts POST requests and responds with HTTP 202 to
+acknowledge callbacks from Xero. A lightweight GET handler is also available for
+diagnostic probes and returns HTTP 200 when the integration module is enabled.
 
 ## Ticket billing controls
 

--- a/wiki/Xero-OAuth-Setup.md
+++ b/wiki/Xero-OAuth-Setup.md
@@ -138,7 +138,8 @@ Note: These are the exact scope names used in the code. Xero may show these with
 
 - `GET /xero/connect` - Initiate OAuth2 authorization flow (requires super admin)
 - `GET /xero/callback` - OAuth2 callback handler (called by Xero)
-- `POST /api/integration-modules/xero/callback` - Webhook endpoint for Xero events
+- `POST /api/integration-modules/xero/webhook` - Signed webhook endpoint for Xero events and Intent to Receive tests
+- `POST /api/integration-modules/xero/callback` - Legacy callback endpoint
 
 ### Module Functions
 


### PR DESCRIPTION
### Motivation

- Xero's Intent to Receive webhook check sends one correctly-signed and three incorrectly-signed deliveries and requires specific empty `2xx`/`4xx` responses rather than JSON error bodies. 
- The webhook receiver must acknowledge valid signed deliveries quickly while returning empty `401` responses for invalid signatures so Xero will enable delivery. 

### Description

- Updated `POST /api/integration-modules/xero/webhook` in `app/api/routes/xero.py` to return an empty `401` `Response` for invalid signatures and an empty `200` `Response` for valid signed deliveries, while preserving internal logging. 
- Changed the route return type to `Response` and adjusted the webhook-monitor logging to record the payload, headers and the sentinel `response_status/response_body` values. 
- Added intent-to-receive unit tests in `tests/test_xero_webhook.py` to assert empty `401` for invalid Intent signatures and empty `200` for valid Intent payloads, and adjusted an existing test to expect an empty `200` response on delivery acknowledgement. 
- Updated documentation in `wiki/Xero-Integration.md`, `wiki/Xero-OAuth-Setup.md` and corresponding `docs/wiki/integrations/*` files to distinguish the OAuth callback URL from the signed webhook URL and to document the Intent-to-Receive 1-valid/3-invalid status-code contract. 

### Testing

- Ran `pytest -q tests/test_xero_webhook.py` and the tests completed successfully (`6 passed`).
- Ran `python -m compileall -q app/api/routes/xero.py tests/test_xero_webhook.py` which completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b47803c5c83329a8242aa491dfb8f)