### PR TITLE
Fix ticket detail medium layout gap

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5143,27 +5143,39 @@ dialog.modal:not([open]) {
   min-width: 0;
 }
 
+.management__column-group {
+  min-width: 0;
+}
+
+.management__column-group--main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
 @media (min-width: 961px) and (max-width: 1799px) {
   .management__column--details {
     grid-column: 1;
-    grid-row: 1 / 3;
-  }
-
-  .management__column--content {
-    grid-column: 2;
     grid-row: 1;
   }
 
-  .management__column--activity,
-  .management__column--conversation {
+  .management__column-group--main {
     grid-column: 2;
-    grid-row: 2;
+    grid-row: 1;
   }
 }
 
 @media (min-width: 1800px) {
   .management__body--columns {
     grid-template-columns: minmax(280px, 320px) minmax(360px, 1fr) minmax(0, 1fr);
+  }
+
+  .management__column-group--main {
+    display: contents;
+  }
+
+  .management__column--content {
+    grid-column: 2;
   }
 
   .management__column--activity,

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -662,7 +662,8 @@
           {% endif %}
         </div>
 
-        <div class="management__column management__column--content">
+        <div class="management__column-group management__column-group--main">
+          <div class="management__column management__column--content">
           {% set description_html = ticket.description_html if ticket.description_html is defined else '' %}
           <details class="card card--panel card-collapsible" data-ticket-description-panel>
             <summary class="card__header card__header--collapsible">
@@ -1412,6 +1413,7 @@
               {% endif %}
             </div>
           </article>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation

- Medium-width layouts showed a large vertical gap between the Assets panel and the Add a reply panel when both the Ticket Details and Additional Details sections were expanded because the right-side columns were influenced by the height of the left details column.  
- The Assets column should stack independently and not be affected by the other column's height at medium screen sizes.

### Description

- Wrap the content/activity columns in a new container `management__column-group management__column-group--main` in `app/templates/admin/ticket_detail.html` so the right-side columns can be treated as a single group.  
- Add CSS rules for `.management__column-group` and `.management__column-group--main` in `app/static/css/app.css` and adjust the medium/large media-query grid placement so the grouped right-side columns occupy a single grid cell at medium widths and revert to the three-column layout on very wide screens.  
- Update the `.management__column--details` grid-row placement so the left sidebar no longer forces a second grid-row for the right-side columns at medium widths.  
- Modified files: `app/templates/admin/ticket_detail.html` and `app/static/css/app.css`.

### Testing

- Ran `git diff --check` to validate formatting and no whitespace errors.  
- Executed the admin ticket detail test file with `pytest tests/test_admin_ticket_detail.py`; the run collected 5 tests with 3 passing and 2 failing.  
- The 2 failing tests report `RuntimeError: Database pool not initialised` caused by unmocked database calls in the test environment rather than the layout changes, so failures appear unrelated to the CSS/template fix.  
- Manual inspection of the template/CSS diff confirms the grouped layout change is localized to the ticket detail page and media-query adjustments preserve the wide-screen layout while fixing medium-screen stacking.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b5bc7f93c8332a056def97469e422)