### PR TITLE
Improve ticket link contrast

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -718,6 +718,15 @@ html {
   text-decoration: underline;
 }
 
+.rich-text-viewer a.ticket-reference-link {
+  color: #f8fafc;
+}
+
+.rich-text-viewer a.ticket-reference-link:hover,
+.rich-text-viewer a.ticket-reference-link:focus {
+  color: #ffffff;
+}
+
 .rich-text-viewer table {
   width: 100%;
   border-collapse: collapse;

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -21,13 +21,6 @@
         <div>
           <h1 class="management__title">{{ ticket.subject }}</h1>
           {% set ticket_status = (ticket.status or 'open') %}
-          {% set status_badge_map = {
-            'open': 'badge--warning',
-            'in_progress': 'badge--warning',
-            'pending': 'badge--warning',
-            'resolved': 'badge--success',
-            'closed': 'badge--muted'
-          } %}
           {% set ai_badge_map = {'succeeded': 'badge--success', 'error': 'badge--danger', 'skipped': 'badge--muted', 'unknown': 'badge--muted'} %}
           {% set ai_date_color_map = {'succeeded': '#bbf7d0', 'error': '#fecaca', 'skipped': 'rgba(226, 232, 240, 0.75)', 'unknown': 'rgba(226, 232, 240, 0.75)'} %}
           {% set resolution_label_map = {'likely_resolved': 'Likely Resolved', 'likely_in_progress': 'Likely In Progress'} %}
@@ -38,10 +31,6 @@
           {% set tag_status_value = ticket.ai_tags_status if ticket.ai_tags_status is not none else 'skipped' %}
           {% set tag_status_lower = tag_status_value | lower %}
           {% set ticket_status_label = ticket_status_label_map.get(ticket_status, ticket_status.replace('_', ' ').title()) %}
-          <p class="management__subtitle">
-            Ticket #{{ ticket.id }}
-            <span class="badge {{ status_badge_map.get(ticket_status, 'badge--muted') }}">{{ ticket_status_label }}</span>
-          </p>
         </div>
         <div class="management__header-actions">
           <a href="/admin/tickets" class="button button--ghost">Back to tickets</a>


### PR DESCRIPTION
### Motivation
- Detected ticket-reference links in rich text were low-contrast against the site colour scheme and were hard to read, and the admin ticket detail page displayed a redundant second line showing `Ticket #` plus a status badge beneath the subject.

### Description
- Add CSS rules in `app/static/css/app.css` to force detected ticket-reference anchors inside the rich-text viewer to remain white by default and on hover/focus using `.rich-text-viewer a.ticket-reference-link`.
- Remove the redundant subtitle block (the `Ticket #{{ ticket.id }}` line and status badge) from `app/templates/admin/ticket_detail.html` and the now-unused local `status_badge_map` definition.

### Testing
- Ran `python -m compileall app` with no syntax errors reported (succeeded). 
- Ran `git diff --check` to validate whitespace/patch issues (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c3c64caa88332888db16afc7493a5)