### PR TITLE
Fix empty Xero webhook response framing

### DIFF
--- a/app/api/routes/xero.py
+++ b/app/api/routes/xero.py
@@ -68,6 +68,20 @@ def _verify_xero_webhook_signature(body: bytes, signature: str | None, webhook_k
     return hmac.compare_digest(expected, provided)
 
 
+def _empty_xero_webhook_response(status_code: int) -> Response:
+    """Return Xero's required empty webhook acknowledgement without a length header.
+
+    Xero webhook probes are sensitive to mismatched response framing.  The
+    endpoint intentionally sends no response body; omitting ``Content-Length``
+    avoids declaring a body size that intermediaries can accidentally make
+    inconsistent with the empty acknowledgement.
+    """
+
+    response = Response(content=b"", status_code=status_code)
+    del response.headers["content-length"]
+    return response
+
+
 def _extract_xero_invoice_id(event: dict[str, Any]) -> str | None:
     invoice_id = str(event.get("resourceId") or event.get("resourceID") or "").strip()
     if invoice_id:
@@ -170,7 +184,7 @@ async def receive_webhook(request: Request) -> Response:
             response_body="",
             error_message="Invalid Xero webhook signature",
         )
-        return Response(status_code=status.HTTP_401_UNAUTHORIZED)
+        return _empty_xero_webhook_response(status.HTTP_401_UNAUTHORIZED)
 
     try:
         payload = json.loads(body.decode("utf-8")) if body else {}
@@ -214,7 +228,7 @@ async def receive_webhook(request: Request) -> Response:
         )
         or None,
     )
-    return Response(status_code=status.HTTP_200_OK)
+    return _empty_xero_webhook_response(status.HTTP_200_OK)
 
 
 @router.post(

--- a/tests/test_xero_webhook.py
+++ b/tests/test_xero_webhook.py
@@ -17,6 +17,14 @@ def test_verify_xero_webhook_signature_accepts_valid_hmac():
     assert xero._verify_xero_webhook_signature(body, signature, "wrong") is False
 
 
+def test_empty_xero_webhook_response_omits_content_length():
+    response = xero._empty_xero_webhook_response(200)
+
+    assert response.status_code == 200
+    assert response.body == b""
+    assert "content-length" not in response.headers
+
+
 def test_extract_xero_invoice_id_from_resource_url():
     event = {"resourceUrl": "https://api.xero.com/api.xro/2.0/Invoices/inv-123"}
 


### PR DESCRIPTION
### Motivation
- Xero webhook deliveries can fail with “Too little data for declared Content-Length” when an empty acknowledgement is returned with a `Content-Length` header, so the endpoint must return an empty 2xx/4xx response without declaring a body length.

### Description
- Add a helper ` _empty_xero_webhook_response(status_code: int) -> Response` that returns an empty `Response` and removes the `Content-Length` header in `app/api/routes/xero.py`.
- Replace direct `Response(status_code=...)` returns in the Xero webhook handler `receive_webhook` with calls to ` _empty_xero_webhook_response` for both the invalid-signature `401` path and the normal `200` acknowledgement.
- Add a regression test `test_empty_xero_webhook_response_omits_content_length` in `tests/test_xero_webhook.py` to assert the response is empty and that `content-length` is not present.

### Testing
- Ran the scoped test file with `SESSION_SECRET=test TOTP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= pytest tests/test_xero_webhook.py -q` and observed `8 passed` for the Xero webhook test suite.
- Verified the new helper by importing and inspecting the returned `Response` to ensure `status_code` is correct, `body` is empty, and `content-length` header is omitted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c3e1fc1dc8332b168b4d766c58194)