### PR TITLE
Show collapsed ticket description preview

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1842,6 +1842,40 @@ button.header-title-menu__link,
   min-width: 0;
 }
 
+.ticket-description-summary {
+  align-items: flex-start;
+}
+
+.ticket-description-summary__main {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ticket-description-summary__preview {
+  display: -webkit-box;
+  max-height: 7.5em;
+  overflow: hidden;
+  color: rgba(226, 232, 240, 0.82);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+  line-clamp: 5;
+}
+
+.ticket-description-summary__preview > :first-child {
+  margin-top: 0;
+}
+
+.ticket-description-summary__preview > :last-child {
+  margin-bottom: 0;
+}
+
+.card-collapsible[open] .ticket-description-summary__preview {
+  display: none;
+}
+
 @media (max-width: 1024px) {
   .layout {
     overflow: visible;

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -655,8 +655,15 @@
           <div class="management__column management__column--content">
           {% set description_html = ticket.description_html if ticket.description_html is defined else '' %}
           <details class="card card--panel card-collapsible" data-ticket-description-panel>
-            <summary class="card__header card__header--collapsible">
-              <h2 class="card__title">Description</h2>
+            <summary class="card__header card__header--collapsible ticket-description-summary">
+              <div class="ticket-description-summary__main">
+                <h2 class="card__title">Description</h2>
+                {% if description_html %}
+                  <div class="rich-text-viewer ticket-description-summary__preview" data-ticket-description-preview>
+                    {{ description_html | safe }}
+                  </div>
+                {% endif %}
+              </div>
               <div class="card__collapsible-meta">
                 <span class="card__toggle-icon" aria-hidden="true"></span>
               </div>


### PR DESCRIPTION
### Motivation
- Improve the admin ticket detail UX so the Description section shows a short rendered preview when collapsed, letting technicians scan 3–5 lines of content without opening the editor. 
- Make sure expanding the Description panel hides the preview and reveals the full rich-text editor.

### Description
- Render a rich-text preview inside the description `summary` when `ticket.description_html` exists by updating `app/templates/admin/ticket_detail.html` and adding a `data-ticket-description-preview` element. 
- Add styles in `app/static/css/app.css` to clamp the preview to five lines using `-webkit-line-clamp` and to hide the preview when the collapsible is open via `.card-collapsible[open] .ticket-description-summary__preview`.
- No JavaScript logic changes were required; the visibility is handled with the new markup and CSS.

### Testing
- Ran `python -m pytest tests/test_ticket_rename.py`, which succeeded (`2 passed`).
- No other automated tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c3f09422083329383252e6819a9ce)