### PR TITLE
Remove ticket header badge and improve ticket-reference link colors in rich text viewer

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -718,6 +718,20 @@ html {
   text-decoration: underline;
 }
 
+.ticket-reference-link,
+.ticket-reference-link:visited,
+.rich-text-viewer a.ticket-reference-link,
+.rich-text-viewer a.ticket-reference-link:visited {
+  color: #f8fafc !important;
+}
+
+.ticket-reference-link:hover,
+.ticket-reference-link:focus,
+.rich-text-viewer a.ticket-reference-link:hover,
+.rich-text-viewer a.ticket-reference-link:focus {
+  color: #ffffff !important;
+}
+
 .rich-text-viewer table {
   width: 100%;
   border-collapse: collapse;

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -21,13 +21,6 @@
         <div>
           <h1 class="management__title">{{ ticket.subject }}</h1>
           {% set ticket_status = (ticket.status or 'open') %}
-          {% set status_badge_map = {
-            'open': 'badge--warning',
-            'in_progress': 'badge--warning',
-            'pending': 'badge--warning',
-            'resolved': 'badge--success',
-            'closed': 'badge--muted'
-          } %}
           {% set ai_badge_map = {'succeeded': 'badge--success', 'error': 'badge--danger', 'skipped': 'badge--muted', 'unknown': 'badge--muted'} %}
           {% set ai_date_color_map = {'succeeded': '#bbf7d0', 'error': '#fecaca', 'skipped': 'rgba(226, 232, 240, 0.75)', 'unknown': 'rgba(226, 232, 240, 0.75)'} %}
           {% set resolution_label_map = {'likely_resolved': 'Likely Resolved', 'likely_in_progress': 'Likely In Progress'} %}
@@ -38,10 +31,6 @@
           {% set tag_status_value = ticket.ai_tags_status if ticket.ai_tags_status is not none else 'skipped' %}
           {% set tag_status_lower = tag_status_value | lower %}
           {% set ticket_status_label = ticket_status_label_map.get(ticket_status, ticket_status.replace('_', ' ').title()) %}
-          <p class="management__subtitle">
-            Ticket #{{ ticket.id }}
-            <span class="badge {{ status_badge_map.get(ticket_status, 'badge--muted') }}">{{ ticket_status_label }}</span>
-          </p>
         </div>
         <div class="management__header-actions">
           <a href="/admin/tickets" class="button button--ghost">Back to tickets</a>

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -15,10 +15,6 @@
       <header class="management__header">
         <div>
           <h1 class="management__title">{{ ticket.subject or 'Ticket' }}</h1>
-          <p class="management__subtitle">
-            Ticket #{{ ticket.id }}
-            <span class="badge {{ ticket.status_badge }}">{{ ticket.status_label }}</span>
-          </p>
         </div>
         <div class="management__header-actions">
           <a class="button button--ghost" href="/tickets">Back to tickets</a>


### PR DESCRIPTION
### Motivation
- Simplify the ticket header by removing the redundant ticket number and status badge from the top-of-page subtitle. 
- Ensure ticket reference links inside rich text content are visible against the dark background. 

### Description
- Removed the subtitle block that rendered `Ticket #{{ ticket.id }}` and the status badge from `tickets/detail.html` and `admin/ticket_detail.html`. 
- Removed the unused `status_badge_map` from the admin ticket detail template. 
- Added `.ticket-reference-link` CSS rules to `app/static/css/app.css` to force light colors for link, visited, hover, and focus states inside the `.rich-text-viewer` area. 

### Testing
- Ran the project's automated test suite and observed all tests passing. 
- Verified template rendering via the application's template tests and found no failures. 
- Executed the frontend asset build/lint step and confirmed there were no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c3c64caa88332888db16afc7493a5)