### PR TITLE
Fix login session lookup when duplicate cookies are present

### DIFF
--- a/app/security/session.py
+++ b/app/security/session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Optional
+from urllib.parse import unquote
 
 from fastapi import Request, Response
 
@@ -80,10 +81,15 @@ class SessionManager:
         cached: SessionData | None = getattr(request.state, "session", None)
         if cached:
             return cached
-        token = request.cookies.get(self.session_cookie_name)
-        if not token:
+        tokens = self._session_cookie_candidates(request)
+        if not tokens:
             return None
-        record = await auth_repo.get_session_by_token(token)
+
+        record = None
+        for token in tokens:
+            record = await auth_repo.get_session_by_token(token)
+            if record:
+                break
         if not record:
             return None
         if not allow_inactive and int(record.get("is_active", 0)) != 1:
@@ -168,6 +174,37 @@ class SessionManager:
     def clear_session_cookies(self, response: Response) -> None:
         response.delete_cookie(self.session_cookie_name)
         response.delete_cookie(self.csrf_cookie_name)
+
+    def _session_cookie_candidates(self, request: Request) -> list[str]:
+        """Return all candidate session cookie values sent by the browser.
+
+        Browsers can send duplicate cookie names when a deployment changes
+        cookie scope (for example from a domain cookie to a host-only cookie).
+        Starlette's parsed cookie mapping keeps only one value, so try every
+        matching value from the raw Cookie header before treating the user as
+        unauthenticated.
+        """
+
+        candidates: list[str] = []
+        parsed_token = request.cookies.get(self.session_cookie_name)
+        if parsed_token:
+            candidates.append(parsed_token)
+
+        raw_cookie = request.headers.get("cookie", "")
+        if raw_cookie:
+            cookie_prefix = f"{self.session_cookie_name}="
+            for part in raw_cookie.split(";"):
+                item = part.strip()
+                if not item.startswith(cookie_prefix):
+                    continue
+                raw_value = item[len(cookie_prefix) :]
+                if not raw_value:
+                    continue
+                value = unquote(raw_value.strip('"'))
+                if value not in candidates:
+                    candidates.append(value)
+
+        return candidates
 
     def _map_session(self, record: dict[str, Any]) -> SessionData:
         pending_secret = record.get("pending_totp_secret")

--- a/tests/test_session_duplicate_cookies.py
+++ b/tests/test_session_duplicate_cookies.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.modules.setdefault(
+    "magic",
+    SimpleNamespace(
+        Magic=lambda *args, **kwargs: None,
+        from_buffer=lambda *args, **kwargs: "application/octet-stream",
+    ),
+)
+from starlette.requests import Request
+
+from app.security.session import SessionManager
+
+
+@pytest.mark.anyio
+async def test_load_session_tries_duplicate_cookie_values(monkeypatch):
+    manager = SessionManager()
+    now = datetime.utcnow()
+    valid_record = {
+        "id": 1,
+        "user_id": 2,
+        "session_token": "new-token",
+        "csrf_token": "csrf-token",
+        "created_at": now,
+        "expires_at": now + timedelta(hours=1),
+        "last_seen_at": now,
+        "ip_address": "203.0.113.10",
+        "user_agent": "pytest",
+        "is_active": 1,
+        "active_company_id": None,
+    }
+    looked_up: list[str] = []
+
+    async def fake_get_session_by_token(token: str):
+        looked_up.append(token)
+        return valid_record if token == "new-token" else None
+
+    async def fake_update_session(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("app.security.session.auth_repo.get_session_by_token", fake_get_session_by_token)
+    monkeypatch.setattr("app.security.session.auth_repo.update_session", fake_update_session)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [
+                (
+                    b"cookie",
+                    f"{manager.session_cookie_name}=new-token; {manager.session_cookie_name}=old-token".encode(),
+                )
+            ],
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+            "scheme": "http",
+        }
+    )
+
+    session = await manager.load_session(request)
+
+    assert session is not None
+    assert session.session_token == "new-token"
+    assert looked_up == ["old-token", "new-token"]


### PR DESCRIPTION
### Motivation
- Browser deployments that change cookie scope or domain can cause a client to send duplicate cookies with the same name, and Starlette's parsed `request.cookies` keeps only one value which can be stale and cause valid sessions to be missed.
- The change ensures the server will find the active session when one of multiple cookie values is valid so users are not unexpectedly redirected back to the login page.

### Description
- Updated `SessionManager.load_session` in `app/security/session.py` to try every candidate session cookie value instead of relying on the single parsed cookie value. 
- Added `SessionManager._session_cookie_candidates` which extracts all matching cookie values from the raw `Cookie` header (and uses `unquote` to decode values). 
- Iterates tokens and calls `auth_repo.get_session_by_token` until a valid session record is found. 
- Added regression test `tests/test_session_duplicate_cookies.py` which simulates duplicate cookie values and validates the lookup order and successful session resolution.

### Testing
- Ran `python -m py_compile app/security/session.py tests/test_session_duplicate_cookies.py` which succeeded. 
- Ran `pytest -q tests/test_session_duplicate_cookies.py` which passed. 
- Attempted to run broader auth tests with `pytest -q tests/test_auth_last_login.py tests/test_csrf_bypass_protection.py` but collection failed due to a missing system dependency (`ImportError: failed to find libmagic`) in this environment, blocking those runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c4e20c65c8332adab03759d417314)