### PR TITLE
Handle duplicate session cookies and raw/hashed token lookup; preserve raw token on creation

### DIFF
--- a/app/repositories/auth.py
+++ b/app/repositories/auth.py
@@ -81,8 +81,10 @@ async def create_session(
 
 
 async def get_session_by_token(token: str) -> Optional[dict[str, Any]]:
+    token_hash = _hash_session_token(token)
     row = await db.fetch_one(
-        "SELECT * FROM user_sessions WHERE session_token = %s", (_hash_session_token(token),)
+        "SELECT * FROM user_sessions WHERE session_token = %s OR session_token = %s",
+        (token_hash, token),
     )
     return row
 

--- a/app/security/session.py
+++ b/app/security/session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Optional
+from urllib.parse import unquote
 
 from fastapi import Request, Response
 
@@ -69,6 +70,11 @@ class SessionManager:
             impersonator_session_id=impersonator_session_id,
             impersonation_started_at=now if impersonator_user_id is not None else None,
         )
+        # The repository stores only a hash of the session token. Keep the raw
+        # token in the in-memory session returned to the login handler so the
+        # browser receives the usable token, not the database digest.
+        record = dict(record)
+        record["session_token"] = session_token
         return self._map_session(record)
 
     async def load_session(
@@ -80,10 +86,15 @@ class SessionManager:
         cached: SessionData | None = getattr(request.state, "session", None)
         if cached:
             return cached
-        token = request.cookies.get(self.session_cookie_name)
-        if not token:
+        tokens = self._session_cookie_candidates(request)
+        if not tokens:
             return None
-        record = await auth_repo.get_session_by_token(token)
+
+        record = None
+        for token in tokens:
+            record = await auth_repo.get_session_by_token(token)
+            if record:
+                break
         if not record:
             return None
         if not allow_inactive and int(record.get("is_active", 0)) != 1:
@@ -168,6 +179,37 @@ class SessionManager:
     def clear_session_cookies(self, response: Response) -> None:
         response.delete_cookie(self.session_cookie_name)
         response.delete_cookie(self.csrf_cookie_name)
+
+    def _session_cookie_candidates(self, request: Request) -> list[str]:
+        """Return all candidate session cookie values sent by the browser.
+
+        Browsers can send duplicate cookie names when a deployment changes
+        cookie scope (for example from a domain cookie to a host-only cookie).
+        Starlette's parsed cookie mapping keeps only one value, so try every
+        matching value from the raw Cookie header before treating the user as
+        unauthenticated.
+        """
+
+        candidates: list[str] = []
+        parsed_token = request.cookies.get(self.session_cookie_name)
+        if parsed_token:
+            candidates.append(parsed_token)
+
+        raw_cookie = request.headers.get("cookie", "")
+        if raw_cookie:
+            cookie_prefix = f"{self.session_cookie_name}="
+            for part in raw_cookie.split(";"):
+                item = part.strip()
+                if not item.startswith(cookie_prefix):
+                    continue
+                raw_value = item[len(cookie_prefix) :]
+                if not raw_value:
+                    continue
+                value = unquote(raw_value.strip('"'))
+                if value not in candidates:
+                    candidates.append(value)
+
+        return candidates
 
     def _map_session(self, record: dict[str, Any]) -> SessionData:
         pending_secret = record.get("pending_totp_secret")

--- a/tests/test_session_duplicate_cookies.py
+++ b/tests/test_session_duplicate_cookies.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.modules.setdefault(
+    "magic",
+    SimpleNamespace(
+        Magic=lambda *args, **kwargs: None,
+        from_buffer=lambda *args, **kwargs: "application/octet-stream",
+    ),
+)
+from starlette.requests import Request
+
+from app.security.session import SessionManager
+
+
+@pytest.mark.anyio
+async def test_load_session_tries_duplicate_cookie_values(monkeypatch):
+    manager = SessionManager()
+    now = datetime.utcnow()
+    valid_record = {
+        "id": 1,
+        "user_id": 2,
+        "session_token": "new-token",
+        "csrf_token": "csrf-token",
+        "created_at": now,
+        "expires_at": now + timedelta(hours=1),
+        "last_seen_at": now,
+        "ip_address": "203.0.113.10",
+        "user_agent": "pytest",
+        "is_active": 1,
+        "active_company_id": None,
+    }
+    looked_up: list[str] = []
+
+    async def fake_get_session_by_token(token: str):
+        looked_up.append(token)
+        return valid_record if token == "new-token" else None
+
+    async def fake_update_session(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("app.security.session.auth_repo.get_session_by_token", fake_get_session_by_token)
+    monkeypatch.setattr("app.security.session.auth_repo.update_session", fake_update_session)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [
+                (
+                    b"cookie",
+                    f"{manager.session_cookie_name}=new-token; {manager.session_cookie_name}=old-token".encode(),
+                )
+            ],
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+            "scheme": "http",
+        }
+    )
+
+    session = await manager.load_session(request)
+
+    assert session is not None
+    assert session.session_token == "new-token"
+    assert looked_up == ["old-token", "new-token"]

--- a/tests/test_session_token_hashing.py
+++ b/tests/test_session_token_hashing.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import sys
+from types import SimpleNamespace
+
+import pytest
+from starlette.requests import Request
+
+sys.modules.setdefault(
+    "magic",
+    SimpleNamespace(
+        Magic=lambda *args, **kwargs: None,
+        from_buffer=lambda *args, **kwargs: "application/octet-stream",
+    ),
+)
+
+from app.repositories import auth as auth_repo
+from app.security.session import SessionManager
+
+
+@pytest.mark.anyio
+async def test_create_session_returns_raw_cookie_token(monkeypatch):
+    manager = SessionManager()
+    hashed_token = "h" * 64
+    raw_token = "r" * 64
+    now = datetime.utcnow()
+
+    monkeypatch.setattr("app.security.session.secrets_token", lambda: raw_token)
+
+    async def fake_create_session(**kwargs):
+        return {
+            "id": 1,
+            "user_id": kwargs["user_id"],
+            "session_token": hashed_token,
+            "csrf_token": kwargs["csrf_token"],
+            "created_at": now,
+            "expires_at": now + timedelta(hours=12),
+            "last_seen_at": now,
+            "ip_address": kwargs["ip_address"],
+            "user_agent": kwargs["user_agent"],
+            "is_active": 1,
+            "active_company_id": kwargs["active_company_id"],
+        }
+
+    monkeypatch.setattr("app.security.session.auth_repo.create_session", fake_create_session)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/auth/login",
+            "headers": [(b"user-agent", b"pytest")],
+            "client": ("127.0.0.1", 12345),
+            "server": ("testserver", 80),
+            "scheme": "http",
+        }
+    )
+
+    session = await manager.create_session(2, request, active_company_id=1)
+
+    assert session.session_token == raw_token
+    assert session.session_token != hashed_token
+
+
+@pytest.mark.anyio
+async def test_get_session_by_token_accepts_raw_hash_fallback(monkeypatch):
+    calls = []
+
+    async def fake_fetch_one(sql, params):
+        calls.append((sql, params))
+        return {"id": 1}
+
+    monkeypatch.setattr(auth_repo.db, "fetch_one", fake_fetch_one)
+
+    row = await auth_repo.get_session_by_token("cookie-token")
+
+    assert row == {"id": 1}
+    sql, params = calls[0]
+    assert "session_token = %s OR session_token = %s" in sql
+    assert params == (auth_repo._hash_session_token("cookie-token"), "cookie-token")


### PR DESCRIPTION
### Motivation

- Allow authentication to succeed when browsers send duplicate cookie names due to scope changes and when the repository stores only a hashed token.
- Ensure the login handler receives the raw session token (so the browser can use it) while the database keeps a digest.

### Description

- Added `_session_cookie_candidates` to `SessionManager` to return all matching cookie values by parsing the raw `Cookie` header and `unquote`ing values. 
- Updated `SessionManager.load_session` to iterate candidate cookie values and try each with `auth_repo.get_session_by_token` until a record is found.
- When creating a session, preserve the generated raw token in the returned `record` before mapping so the response cookie contains the usable token rather than the stored hash.
- Updated `auth.get_session_by_token` to compute `token_hash` once and query `user_sessions` with `WHERE session_token = %s OR session_token = %s` to accept either the hashed or raw token.

### Testing

- Added unit tests `tests/test_session_duplicate_cookies.py` and `tests/test_session_token_hashing.py` and ran them with `pytest`, and both tests passed.
- Verified `get_session_by_token` SQL uses the combined `OR` lookup and that `create_session` returns the raw token in `SessionManager.create_session` via the unit tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c4e20c65c8332adab03759d417314)