### PR TITLE
Add message template cloning

### DIFF
--- a/app/api/routes/message_templates.py
+++ b/app/api/routes/message_templates.py
@@ -74,6 +74,33 @@ async def create_message_template(
     return MessageTemplateResponse(**record)
 
 
+@router.post("/{template_id}/clone", response_model=MessageTemplateResponse, status_code=status.HTTP_201_CREATED)
+async def clone_message_template(
+    template_id: int,
+    request: Request,
+    current_user: dict = Depends(require_super_admin),
+) -> MessageTemplateResponse:
+    existing = await message_templates_service.get_template(template_id)
+    if not existing:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    try:
+        record = await message_templates_service.clone_template(template_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    if not record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
+    await audit_service.record(
+        action="message_template.clone",
+        request=request,
+        user_id=int(current_user["id"]),
+        entity_type="message_template",
+        entity_id=int(record["id"]) if record.get("id") is not None else None,
+        before=_audit_template_summary(existing),
+        after=_audit_template_summary(record),
+    )
+    return MessageTemplateResponse(**record)
+
+
 @router.get("/{template_id}", response_model=MessageTemplateResponse)
 async def get_message_template(
     template_id: int,

--- a/app/services/message_templates.py
+++ b/app/services/message_templates.py
@@ -92,6 +92,24 @@ def _normalise_slug(slug: str) -> str:
     return candidate
 
 
+def _build_clone_slug_candidate(source_slug: str, index: int | None = None) -> str:
+    suffix = "-copy" if index is None else f"-copy-{index}"
+    max_base_length = 120 - len(suffix)
+    base = source_slug[:max_base_length].rstrip("._-")
+    return f"{base}{suffix}"
+
+
+async def _generate_clone_slug(source_slug: str) -> str:
+    candidate = _build_clone_slug_candidate(source_slug)
+    if not await template_repo.get_template_by_slug(candidate):
+        return candidate
+    for index in range(2, 1000):
+        candidate = _build_clone_slug_candidate(source_slug, index)
+        if not await template_repo.get_template_by_slug(candidate):
+            return candidate
+    raise ValueError("Unable to generate a unique clone slug")
+
+
 def _normalise_content_type(content_type: str | None) -> str:
     if not content_type:
         return "text/plain"
@@ -266,6 +284,25 @@ async def create_template(
         description=clean_description,
         content_type=normalised_content_type,
         content=content,
+    )
+    template = _coerce_template(record)
+    await refresh_cache()
+    return _to_dict(template)
+
+
+async def clone_template(template_id: int) -> dict[str, Any] | None:
+    source_record = await template_repo.get_template(template_id)
+    if not source_record:
+        return None
+    source = _coerce_template(source_record)
+    clone_slug = await _generate_clone_slug(source.slug)
+    clone_name = f"{source.name} (Copy)"
+    record = await template_repo.create_template(
+        slug=clone_slug,
+        name=clone_name,
+        description=source.description,
+        content_type=source.content_type,
+        content=source.content,
     )
     template = _coerce_template(record)
     await refresh_cache()

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1483,6 +1483,41 @@
     }
   }
 
+  function bindMessageTemplateCloneButtons() {
+    document.querySelectorAll('[data-template-clone]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const row = button.closest('tr');
+        if (!row) {
+          return;
+        }
+        const templateId = row.dataset.templateId;
+        if (!templateId) {
+          return;
+        }
+        const payload = getTemplatePayload(row.dataset.templateJson);
+        const templateName =
+          payload?.name || row.querySelector('[data-label="Name"]')?.textContent || 'this template';
+        if (!confirm(`Clone ${templateName.trim()}? A new template will be created with a unique slug.`)) {
+          return;
+        }
+        button.disabled = true;
+        try {
+          const cloned = await requestJson(
+            `/api/message-templates/${encodeURIComponent(templateId)}/clone`,
+            { method: 'POST' },
+          );
+          const message = `Template cloned as ${cloned.slug}.`;
+          window.location.href = `/admin/message-templates/${encodeURIComponent(
+            cloned.id,
+          )}/edit?success=${encodeURIComponent(message)}`;
+        } catch (error) {
+          alert(`Unable to clone template: ${error.message}`);
+          button.disabled = false;
+        }
+      });
+    });
+  }
+
   function bindMessageTemplateDeleteButtons() {
     document.querySelectorAll('[data-template-delete]').forEach((button) => {
       button.addEventListener('click', async () => {
@@ -1495,7 +1530,8 @@
           return;
         }
         const payload = getTemplatePayload(row.dataset.templateJson);
-        const templateName = payload?.name || row.querySelector('[data-label="Name"]')?.textContent || 'this template';
+        const templateName =
+          payload?.name || row.querySelector('[data-label="Name"]')?.textContent || 'this template';
         if (!confirm(`Delete ${templateName.trim()}? This action cannot be undone.`)) {
           return;
         }
@@ -3628,6 +3664,7 @@
     bindTicketAiReplaceDescription();
     bindTicketAiRefresh();
     bindMessageTemplateForm();
+    bindMessageTemplateCloneButtons();
     bindMessageTemplateDeleteButtons();
     bindRoleForm();
     bindCompanyAssignForm();

--- a/app/templates/admin/message_templates.html
+++ b/app/templates/admin/message_templates.html
@@ -71,6 +71,15 @@
                           href="/admin/message-templates/{{ template.id }}/edit"
                         >Edit</a>
                       </li>
+
+                      <li class="header-title-menu__item" role="none">
+                        <button
+                          type="button"
+                          class="header-title-menu__link"
+                          role="menuitem"
+                          data-template-clone
+                        >Clone</button>
+                      </li>
                       <li class="header-title-menu__item" role="none">
                         <button
                           type="button"

--- a/docs/wiki/administration/Message Templates.md
+++ b/docs/wiki/administration/Message Templates.md
@@ -15,6 +15,7 @@ available through the Swagger UI once authenticated.
 | --- | --- |
 | `GET /api/message-templates` | List existing templates with optional search or content-type filters. |
 | `POST /api/message-templates` | Create a new template by providing a slug, name, content type, and body. |
+| `POST /api/message-templates/{id}/clone` | Clone an existing template, copying its metadata and body into a new template with a generated unique slug. |
 | `GET /api/message-templates/{id}` | Retrieve a template by numeric identifier. |
 | `GET /api/message-templates/slug/{slug}` | Retrieve a template by slug for quick lookups. |
 | `PUT /api/message-templates/{id}` | Update the template metadata or body content. |

--- a/tests/test_message_templates_service_clone.py
+++ b/tests/test_message_templates_service_clone.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services import message_templates as service
+
+
+@pytest.mark.asyncio
+async def test_clone_template_copies_content_with_unique_slug(monkeypatch):
+    records = [
+        {
+            "id": 7,
+            "slug": "welcome.email",
+            "name": "Welcome Email",
+            "description": "Sent to new users",
+            "content_type": "text/html",
+            "content": "<p>Hello {{ user.first_name }}</p>",
+            "created_at": None,
+            "updated_at": None,
+        },
+        {"id": 8, "slug": "welcome.email-copy"},
+    ]
+    created_payload = {}
+
+    async def fake_get_template(template_id):
+        assert template_id == 7
+        return records[0]
+
+    async def fake_get_template_by_slug(slug):
+        return next((record for record in records if record.get("slug") == slug), None)
+
+    async def fake_create_template(**kwargs):
+        created_payload.update(kwargs)
+        return {"id": 9, "created_at": None, "updated_at": None, **kwargs}
+
+    async def fake_refresh_cache():
+        return None
+
+    monkeypatch.setattr(service.template_repo, "get_template", fake_get_template)
+    monkeypatch.setattr(service.template_repo, "get_template_by_slug", fake_get_template_by_slug)
+    monkeypatch.setattr(service.template_repo, "create_template", fake_create_template)
+    monkeypatch.setattr(service, "refresh_cache", fake_refresh_cache)
+
+    cloned = await service.clone_template(7)
+
+    assert cloned["id"] == 9
+    assert cloned["slug"] == "welcome.email-copy-2"
+    assert cloned["name"] == "Welcome Email (Copy)"
+    assert cloned["description"] == "Sent to new users"
+    assert cloned["content_type"] == "text/html"
+    assert cloned["content"] == "<p>Hello {{ user.first_name }}</p>"
+    assert created_payload["slug"] == "welcome.email-copy-2"
+
+
+@pytest.mark.asyncio
+async def test_clone_template_returns_none_when_source_missing(monkeypatch):
+    async def fake_get_template(template_id):
+        return None
+
+    monkeypatch.setattr(service.template_repo, "get_template", fake_get_template)
+
+    assert await service.clone_template(404) is None


### PR DESCRIPTION
### Motivation
- Provide administrators a convenient way to duplicate existing message templates while generating a safe, unique slug for the clone.
- Keep template editing workflows efficient by immediately navigating to the cloned template's edit page after cloning.
- Ensure clones appear in the runtime template cache so downstream rendering and variable substitution see the new template immediately.

### Description
- Add a service-level clone workflow in `app/services/message_templates.py` including `_build_clone_slug_candidate`, `async _generate_clone_slug(...)`, and `async clone_template(template_id)` which copies metadata/content and refreshes the cache.
- Add a super-admin API endpoint `POST /api/message-templates/{template_id}/clone` in `app/api/routes/message_templates.py` that calls the service, returns the new record, and writes an audit row using the existing audit helper.
- Add a `Clone` row action to the admin list template view in `app/templates/admin/message_templates.html` and a client handler `bindMessageTemplateCloneButtons()` in `app/static/js/admin.js` that calls the clone endpoint and redirects to the cloned template edit page.
- Update documentation `docs/wiki/administration/Message Templates.md` to list the new clone endpoint and add unit tests in `tests/test_message_templates_service_clone.py` covering slug generation and missing-source behavior.

### Testing
- Compiled modified modules successfully with `python -m py_compile app/services/message_templates.py app/api/routes/message_templates.py tests/test_message_templates_service_clone.py` (passed).
- Ran `pytest tests/test_message_templates_service_clone.py tests/test_message_templates_feature_pack.py` but collection failed due to the environment missing the system library required by `python-magic` (`libmagic`), preventing app import; clone tests themselves are unit-level and exercise the new service logic with monkeypatched repository calls.
- Added and ran focused unit tests `tests/test_message_templates_service_clone.py` locally via pytest in CI-like environments (intended; blocked in this run by `libmagic`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c59d099488332a661a65af7837a15)