### PR TITLE
Add automation cloning (scheduled & event)

### DIFF
--- a/app/features/automations/__init__.py
+++ b/app/features/automations/__init__.py
@@ -10,6 +10,7 @@ Owns the admin automations page routes:
 * ``POST /admin/automations/{automation_id}``
 * ``POST /admin/automations/{automation_id}/status``
 * ``POST /admin/automations/{automation_id}/execute``
+* ``POST /admin/automations/{automation_id}/clone``
 * ``POST /admin/automations/{automation_id}/delete``
 """
 

--- a/app/features/automations/handlers.py
+++ b/app/features/automations/handlers.py
@@ -609,6 +609,50 @@ async def admin_execute_automation(automation_id: int, request: Request):
     return flash_redirect("/admin/automations", message, "success")
 
 
+async def admin_clone_automation(automation_id: int, request: Request):
+    from app.core.logging import log_error, log_info
+    from app.repositories import automations as automation_repo
+    from app.services import automations as automations_service
+
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    automation = await automation_repo.get_automation(automation_id)
+    if not automation:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+
+    next_run = None
+    if automation.get("status") == "active":
+        next_run = automations_service.calculate_next_run(automation)
+
+    try:
+        cloned = await automation_repo.clone_automation(automation_id, next_run_at=next_run)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log_error("Failed to clone automation", automation_id=automation_id, error=str(exc))
+        return await _render_automations_dashboard(
+            request,
+            current_user,
+            error_message="Unable to clone the automation. Please try again.",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+    if not cloned:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+
+    if cloned.get("status") == "active":
+        await automations_service.refresh_schedule(int(cloned["id"]))
+
+    log_info(
+        "Automation cloned",
+        automation_id=automation_id,
+        cloned_automation_id=cloned.get("id"),
+        cloned_by=current_user.get("id") if isinstance(current_user, Mapping) else None,
+    )
+    message = f"Automation {cloned.get('name') or cloned.get('id')} cloned."
+    return flash_redirect("/admin/automations", message, "success")
+
+
 async def admin_delete_automation(automation_id: int, request: Request):
     from app.core.logging import log_error, log_info
     from app.repositories import automations as automation_repo

--- a/app/features/automations/routes.py
+++ b/app/features/automations/routes.py
@@ -69,6 +69,12 @@ router.add_api_route(
     response_class=HTMLResponse,
 )
 router.add_api_route(
+    "/admin/automations/{automation_id}/clone",
+    handlers.admin_clone_automation,
+    methods=["POST"],
+    response_class=HTMLResponse,
+)
+router.add_api_route(
     "/admin/automations/{automation_id}/delete",
     handlers.admin_delete_automation,
     methods=["POST"],

--- a/app/repositories/automations.py
+++ b/app/repositories/automations.py
@@ -193,6 +193,43 @@ async def get_automation(automation_id: int) -> AutomationRecord | None:
     return _normalise_automation(row) if row else None
 
 
+def _copy_name(base_name: Any, existing_names: set[str]) -> str:
+    name = str(base_name or "Automation").strip() or "Automation"
+    clone_name = f"{name} (copy)"
+    suffix = 2
+    while clone_name in existing_names:
+        clone_name = f"{name} (copy {suffix})"
+        suffix += 1
+    return clone_name
+
+
+async def clone_automation(automation_id: int, *, next_run_at: datetime | None = None) -> AutomationRecord | None:
+    original = await get_automation(automation_id)
+    if not original:
+        return None
+
+    existing = await list_automations(limit=1000)
+    existing_names = {str(item.get("name")) for item in existing if item.get("name")}
+    clone_name = _copy_name(original.get("name"), existing_names)
+
+    return await create_automation(
+        name=clone_name,
+        description=original.get("description"),
+        kind=str(original.get("kind") or "scheduled"),
+        execution_order=int(original.get("execution_order") or 0),
+        cadence=original.get("cadence"),
+        cron_expression=original.get("cron_expression"),
+        scheduled_time=original.get("scheduled_time"),
+        run_once=bool(original.get("run_once", False)),
+        trigger_event=original.get("trigger_event"),
+        trigger_filters=original.get("trigger_filters"),
+        action_module=original.get("action_module"),
+        action_payload=original.get("action_payload"),
+        status=str(original.get("status") or "inactive"),
+        next_run_at=next_run_at,
+    )
+
+
 async def list_automations(
     *,
     status: str | None = None,

--- a/app/templates/admin/automations.html
+++ b/app/templates/admin/automations.html
@@ -133,6 +133,12 @@
                             </form>
                           </li>
                           <li class="header-title-menu__item" role="none">
+                            <form action="/admin/automations/{{ automation.id }}/clone" method="post" class="inline-form">
+                              {% include "partials/csrf.html" %}
+                              <button type="submit" class="header-title-menu__link" role="menuitem">Clone</button>
+                            </form>
+                          </li>
+                          <li class="header-title-menu__item" role="none">
                             <form
                               action="/admin/automations/{{ automation.id }}/delete"
                               method="post"

--- a/tests/test_admin_delete_automation.py
+++ b/tests/test_admin_delete_automation.py
@@ -30,6 +30,38 @@ def _make_request(path: str = "/admin/automations/1/delete") -> Request:
 
 
 @pytest.mark.anyio("asyncio")
+async def test_admin_clone_automation_redirects_and_refreshes_active_clone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = _make_request("/admin/automations/1/clone")
+
+    current_user = {"id": 5}
+    monkeypatch.setattr(
+        main,
+        "_require_super_admin_page",
+        AsyncMock(return_value=(current_user, None)),
+    )
+
+    automation = {"id": 1, "name": "Nightly cleanup", "status": "active"}
+    cloned = {"id": 2, "name": "Nightly cleanup (copy)", "status": "active"}
+    get_mock = AsyncMock(return_value=automation)
+    clone_mock = AsyncMock(return_value=cloned)
+    refresh_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(main.automation_repo, "get_automation", get_mock)
+    monkeypatch.setattr(main.automation_repo, "clone_automation", clone_mock)
+    monkeypatch.setattr(main.automations_service, "calculate_next_run", lambda data: "next-run")
+    monkeypatch.setattr(main.automations_service, "refresh_schedule", refresh_mock)
+
+    response = await handlers.admin_clone_automation(1, request)
+
+    assert response.status_code == status.HTTP_303_SEE_OTHER
+    assert response.headers["location"] == "/admin/automations"
+    get_mock.assert_awaited_once_with(1)
+    clone_mock.assert_awaited_once_with(1, next_run_at="next-run")
+    refresh_mock.assert_awaited_once_with(2)
+
+
+@pytest.mark.anyio("asyncio")
 async def test_admin_delete_automation_redirects(monkeypatch: pytest.MonkeyPatch) -> None:
     request = _make_request()
 

--- a/tests/test_automations_feature_pack.py
+++ b/tests/test_automations_feature_pack.py
@@ -16,10 +16,13 @@ EXPECTED = {
     ("GET", "/admin/automations/create/scheduled"),
     ("GET", "/admin/automations/create/event"),
     ("POST", "/admin/automations"),
+    ("GET", "/admin/automations/{automation_id}/preview"),
     ("GET", "/admin/automations/{automation_id}/edit"),
     ("POST", "/admin/automations/{automation_id}"),
     ("POST", "/admin/automations/{automation_id}/status"),
+    ("GET", "/admin/automations/{automation_id}/history"),
     ("POST", "/admin/automations/{automation_id}/execute"),
+    ("POST", "/admin/automations/{automation_id}/clone"),
     ("POST", "/admin/automations/{automation_id}/delete"),
 }
 
@@ -74,14 +77,17 @@ def test_automations_pack_owns_handlers():
         == automation_handlers.admin_create_event_automation_page
     )
     assert automation_routes.router.routes[3].endpoint == automation_handlers.admin_create_automation
-    assert automation_routes.router.routes[4].endpoint == automation_handlers.admin_edit_automation_page
-    assert automation_routes.router.routes[5].endpoint == automation_handlers.admin_update_automation
+    assert automation_routes.router.routes[4].endpoint == automation_handlers.admin_preview_automation
+    assert automation_routes.router.routes[5].endpoint == automation_handlers.admin_edit_automation_page
+    assert automation_routes.router.routes[6].endpoint == automation_handlers.admin_update_automation
     assert (
-        automation_routes.router.routes[6].endpoint
+        automation_routes.router.routes[7].endpoint
         == automation_handlers.admin_update_automation_status
     )
-    assert automation_routes.router.routes[7].endpoint == automation_handlers.admin_execute_automation
-    assert automation_routes.router.routes[8].endpoint == automation_handlers.admin_delete_automation
+    assert automation_routes.router.routes[8].endpoint == automation_handlers.admin_automation_history
+    assert automation_routes.router.routes[9].endpoint == automation_handlers.admin_execute_automation
+    assert automation_routes.router.routes[10].endpoint == automation_handlers.admin_clone_automation
+    assert automation_routes.router.routes[11].endpoint == automation_handlers.admin_delete_automation
 
 
 def test_automations_pack_loads_and_reloads_cleanly():

--- a/tests/test_automations_repository.py
+++ b/tests/test_automations_repository.py
@@ -258,3 +258,11 @@ async def test_list_event_automations_orders_by_execution_order(monkeypatch):
     sql = dummy_db.fetch_all_sql or ""
     assert "execution_order" in sql.lower()
     assert "ORDER BY" in sql.upper()
+
+
+def test_copy_name_generates_unique_clone_names():
+    existing = {"Escalate stale tickets (copy)", "Escalate stale tickets (copy 2)"}
+
+    clone_name = automations._copy_name("Escalate stale tickets", existing)
+
+    assert clone_name == "Escalate stale tickets (copy 3)"


### PR DESCRIPTION
### Motivation
- Provide a way for administrators to duplicate existing automations (both scheduled and event-driven) from the admin UI so configurations can be reused and adjusted quickly.

### Description
- Add `clone_automation` and helper `_copy_name` to `app/repositories/automations.py` to duplicate an automation record, preserve configuration fields, and generate a unique "(copy)" name. 
- Add `POST /admin/automations/{automation_id}/clone` route and `admin_clone_automation` handler in `app/features/automations` to validate the source, compute `next_run_at` for active clones, refresh schedules for active clones, log activity, and redirect with a flash message. 
- Add a "Clone" action to the automations actions menu in `app/templates/admin/automations.html` and update the feature-pack manifest and routes accordingly. 
- Add tests covering the new clone flow and the unique name generator in `tests/test_admin_delete_automation.py` and `tests/test_automations_repository.py`, and update the automations feature-pack smoke tests to include the new route. 

### Testing
- Ran `pytest -q tests/test_automations_feature_pack.py tests/test_admin_delete_automation.py tests/test_automations_repository.py` and the selected tests passed (`16 passed`).
- Ran `python -m compileall app/features/automations app/repositories/automations.py` which succeeded. 
- Ran `git diff --check` to ensure no whitespace/merge issues which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c59dc49f48332b01e00ceee677b35)