### PR TITLE
Add automation filter columns to tickets table

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8211,6 +8211,7 @@ async def _render_tickets_dashboard(
     labour_types = await labour_types_service.list_labour_types()
     ticket_ids = [int(t.get("id")) for t in dashboard.tickets if t.get("id") is not None]
     ticket_time_lookup = await tickets_repo.get_time_totals_by_ticket_ids(ticket_ids)
+    ticket_automation_filter_lookup = await tickets_repo.get_automation_filter_context_by_ticket_ids(ticket_ids)
     extra = {
         "title": "Ticketing workspace",
         "tickets": dashboard.tickets,
@@ -8228,6 +8229,8 @@ async def _render_tickets_dashboard(
         "ticket_user_lookup": reference_data["user_lookup"],
         "ticket_labour_types": labour_types,
         "ticket_time_lookup": ticket_time_lookup,
+        "ticket_automation_filter_lookup": ticket_automation_filter_lookup,
+        "ticket_dashboard_now": datetime.now(timezone.utc),
         "can_bulk_delete_tickets": bool(user.get("is_super_admin")),
         "success_message": success_message,
         "error_message": error_message,

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1268,6 +1268,116 @@ async def get_automation_filter_context(ticket_id: int) -> dict[str, int | bool]
     }
 
 
+async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> dict[int, dict[str, Any]]:
+    """Return automation filter helper values keyed by ticket ID for ticket lists."""
+
+    parsed_ids: set[int] = set()
+    for ticket_id in ticket_ids:
+        try:
+            parsed_id = int(ticket_id)
+        except (TypeError, ValueError):
+            continue
+        if parsed_id > 0:
+            parsed_ids.add(parsed_id)
+    unique_ids = sorted(parsed_ids)
+    if not unique_ids:
+        return {}
+
+    placeholders = ", ".join(["%s"] * len(unique_ids))
+    result: dict[int, dict[str, Any]] = {
+        ticket_id: {
+            "billable_minutes": 0,
+            "non_billable_minutes": 0,
+            "attachment_count": 0,
+            "has_attachments": False,
+            "task_count": 0,
+            "has_tasks": False,
+            "open_task_count": 0,
+            "has_open_tasks": False,
+            "latest_reply_id": None,
+            "latest_reply_at": None,
+            "latest_reply_is_internal": None,
+            "latest_reply_kind": None,
+        }
+        for ticket_id in unique_ids
+    }
+
+    time_rows = await db.fetch_all(
+        f"""
+        SELECT
+            ticket_id,
+            SUM(CASE WHEN is_billable = 1 AND minutes_spent IS NOT NULL THEN minutes_spent ELSE 0 END) AS billable_minutes,
+            SUM(CASE WHEN is_billable = 0 AND minutes_spent IS NOT NULL THEN minutes_spent ELSE 0 END) AS non_billable_minutes
+        FROM ticket_replies
+        WHERE ticket_id IN ({placeholders}) AND minutes_spent IS NOT NULL AND minutes_spent > 0
+        GROUP BY ticket_id
+        """,
+        tuple(unique_ids),
+    )
+    for row in time_rows:
+        ticket_id = int(row["ticket_id"])
+        result[ticket_id]["billable_minutes"] = int(row.get("billable_minutes") or 0)
+        result[ticket_id]["non_billable_minutes"] = int(row.get("non_billable_minutes") or 0)
+
+    attachment_rows = await db.fetch_all(
+        f"""
+        SELECT ticket_id, COUNT(*) AS attachment_count
+        FROM ticket_attachments
+        WHERE ticket_id IN ({placeholders})
+        GROUP BY ticket_id
+        """,
+        tuple(unique_ids),
+    )
+    for row in attachment_rows:
+        ticket_id = int(row["ticket_id"])
+        attachment_count = int(row.get("attachment_count") or 0)
+        result[ticket_id]["attachment_count"] = attachment_count
+        result[ticket_id]["has_attachments"] = attachment_count > 0
+
+    task_rows = await db.fetch_all(
+        f"""
+        SELECT
+            ticket_id,
+            COUNT(*) AS task_count,
+            SUM(CASE WHEN is_completed = 0 THEN 1 ELSE 0 END) AS open_task_count
+        FROM ticket_tasks
+        WHERE ticket_id IN ({placeholders})
+        GROUP BY ticket_id
+        """,
+        tuple(unique_ids),
+    )
+    for row in task_rows:
+        ticket_id = int(row["ticket_id"])
+        task_count = int(row.get("task_count") or 0)
+        open_task_count = int(row.get("open_task_count") or 0)
+        result[ticket_id]["task_count"] = task_count
+        result[ticket_id]["has_tasks"] = task_count > 0
+        result[ticket_id]["open_task_count"] = open_task_count
+        result[ticket_id]["has_open_tasks"] = open_task_count > 0
+
+    latest_reply_rows = await db.fetch_all(
+        f"""
+        SELECT tr.ticket_id, tr.id, tr.created_at, tr.is_internal, tr.kind
+        FROM ticket_replies AS tr
+        INNER JOIN (
+            SELECT ticket_id, MAX(id) AS latest_reply_id
+            FROM ticket_replies
+            WHERE ticket_id IN ({placeholders})
+            GROUP BY ticket_id
+        ) AS latest ON latest.latest_reply_id = tr.id
+        """,
+        tuple(unique_ids),
+    )
+    for row in latest_reply_rows:
+        ticket_id = int(row["ticket_id"])
+        result[ticket_id]["latest_reply_id"] = int(row.get("id")) if row.get("id") is not None else None
+        result[ticket_id]["latest_reply_at"] = _make_aware(row.get("created_at"))
+        result[ticket_id]["latest_reply_is_internal"] = bool(row.get("is_internal"))
+        result[ticket_id]["latest_reply_kind"] = row.get("kind")
+
+    return result
+
+
 async def validate_replies_belong_to_ticket(reply_ids: list[int], ticket_id: int) -> tuple[bool, str | None]:
     """
     Validate that all reply IDs belong to the specified ticket.

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -380,6 +380,31 @@
                     <input type="checkbox" class="ticket-column-toggle" data-column="non-billable-minutes" />
                     <span>Non-Billable Minutes</span>
                   </label>
+                  {% set automation_column_options = [
+                    ('requester-email', 'ticket.requester_email'),
+                    ('requester-display-name', 'ticket.requester_display_name'),
+                    ('assigned-user-email', 'ticket.assigned_user_email'),
+                    ('assigned-user-display-name', 'ticket.assigned_user_display_name'),
+                    ('company-id', 'ticket.company.id'),
+                    ('has-attachments', 'ticket.has_attachments'),
+                    ('attachment-count', 'ticket.attachment_count'),
+                    ('has-tasks', 'ticket.has_tasks'),
+                    ('task-count', 'ticket.task_count'),
+                    ('has-open-tasks', 'ticket.has_open_tasks'),
+                    ('open-task-count', 'ticket.open_task_count'),
+                    ('labels', 'ticket.labels'),
+                    ('age-days', 'ticket.age_days'),
+                    ('updated-age-hours', 'ticket.updated_age_hours'),
+                    ('last-reply-age-hours', 'ticket.last_reply_age_hours'),
+                    ('latest-reply-internal', 'reply.is_internal'),
+                    ('latest-reply-kind', 'reply.kind')
+                  ] %}
+                  {% for column_key, column_label in automation_column_options %}
+                    <label class="ticket-columns__option">
+                      <input type="checkbox" class="ticket-column-toggle" data-column="{{ column_key }}" />
+                      <span>{{ column_label }}</span>
+                    </label>
+                  {% endfor %}
                 </div>
               </div>
             </div>
@@ -444,6 +469,23 @@
                 <th scope="col" data-sort="string" data-column="ai-tags" class="tickets-table__column tickets-table__column--ai-tags">AI Tags</th>
                 <th scope="col" data-sort="int" data-column="billable-minutes" class="tickets-table__column tickets-table__column--billable-minutes">Billable Mins</th>
                 <th scope="col" data-sort="int" data-column="non-billable-minutes" class="tickets-table__column tickets-table__column--non-billable-minutes">Non-Billable Mins</th>
+                <th scope="col" data-sort="string" data-column="requester-email" class="tickets-table__column tickets-table__column--requester-email">ticket.requester_email</th>
+                <th scope="col" data-sort="string" data-column="requester-display-name" class="tickets-table__column tickets-table__column--requester-display-name">ticket.requester_display_name</th>
+                <th scope="col" data-sort="string" data-column="assigned-user-email" class="tickets-table__column tickets-table__column--assigned-user-email">ticket.assigned_user_email</th>
+                <th scope="col" data-sort="string" data-column="assigned-user-display-name" class="tickets-table__column tickets-table__column--assigned-user-display-name">ticket.assigned_user_display_name</th>
+                <th scope="col" data-sort="int" data-column="company-id" class="tickets-table__column tickets-table__column--company-id">ticket.company.id</th>
+                <th scope="col" data-sort="string" data-column="has-attachments" class="tickets-table__column tickets-table__column--has-attachments">ticket.has_attachments</th>
+                <th scope="col" data-sort="int" data-column="attachment-count" class="tickets-table__column tickets-table__column--attachment-count">ticket.attachment_count</th>
+                <th scope="col" data-sort="string" data-column="has-tasks" class="tickets-table__column tickets-table__column--has-tasks">ticket.has_tasks</th>
+                <th scope="col" data-sort="int" data-column="task-count" class="tickets-table__column tickets-table__column--task-count">ticket.task_count</th>
+                <th scope="col" data-sort="string" data-column="has-open-tasks" class="tickets-table__column tickets-table__column--has-open-tasks">ticket.has_open_tasks</th>
+                <th scope="col" data-sort="int" data-column="open-task-count" class="tickets-table__column tickets-table__column--open-task-count">ticket.open_task_count</th>
+                <th scope="col" data-sort="string" data-column="labels" class="tickets-table__column tickets-table__column--labels">ticket.labels</th>
+                <th scope="col" data-sort="int" data-column="age-days" class="tickets-table__column tickets-table__column--age-days">ticket.age_days</th>
+                <th scope="col" data-sort="int" data-column="updated-age-hours" class="tickets-table__column tickets-table__column--updated-age-hours">ticket.updated_age_hours</th>
+                <th scope="col" data-sort="int" data-column="last-reply-age-hours" class="tickets-table__column tickets-table__column--last-reply-age-hours">ticket.last_reply_age_hours</th>
+                <th scope="col" data-sort="string" data-column="latest-reply-internal" class="tickets-table__column tickets-table__column--latest-reply-internal">reply.is_internal</th>
+                <th scope="col" data-sort="string" data-column="latest-reply-kind" class="tickets-table__column tickets-table__column--latest-reply-kind">reply.kind</th>
                 <th scope="col" class="table__actions tickets-table__column tickets-table__column--actions">Actions</th>
               </tr>
             </thead>
@@ -511,6 +553,30 @@
                     {% set time_data = (ticket_time_lookup or {}).get(ticket.id, {}) %}
                     <td data-label="Billable Mins" data-column="billable-minutes" class="tickets-table__cell tickets-table__cell--billable-minutes">{{ time_data.get('billable_minutes', 0) }}</td>
                     <td data-label="Non-Billable Mins" data-column="non-billable-minutes" class="tickets-table__cell tickets-table__cell--non-billable-minutes">{{ time_data.get('non_billable_minutes', 0) }}</td>
+                    {% set automation_data = (ticket_automation_filter_lookup or {}).get(ticket.id, {}) %}
+                    {% set requester_email = ticket.requester_email or (requester.email if requester else '') %}
+                    {% set assigned_email = assigned.email if assigned else '' %}
+                    {% set created_age_days = ((ticket_dashboard_now - ticket.created_at).total_seconds() // 86400) | int if ticket.created_at else '' %}
+                    {% set updated_age_hours = ((ticket_dashboard_now - ticket.updated_at).total_seconds() // 3600) | int if ticket.updated_at else '' %}
+                    {% set latest_reply_at = automation_data.get('latest_reply_at') %}
+                    {% set last_reply_age_hours = ((ticket_dashboard_now - latest_reply_at).total_seconds() // 3600) | int if latest_reply_at else '' %}
+                    <td data-label="ticket.requester_email" data-column="requester-email" class="tickets-table__cell tickets-table__cell--requester-email">{{ requester_email or '—' }}</td>
+                    <td data-label="ticket.requester_display_name" data-column="requester-display-name" class="tickets-table__cell tickets-table__cell--requester-display-name">{{ requester_label }}</td>
+                    <td data-label="ticket.assigned_user_email" data-column="assigned-user-email" class="tickets-table__cell tickets-table__cell--assigned-user-email">{{ assigned_email or '—' }}</td>
+                    <td data-label="ticket.assigned_user_display_name" data-column="assigned-user-display-name" class="tickets-table__cell tickets-table__cell--assigned-user-display-name">{{ assigned_label }}</td>
+                    <td data-label="ticket.company.id" data-column="company-id" class="tickets-table__cell tickets-table__cell--company-id">{{ ticket.company_id or '—' }}</td>
+                    <td data-label="ticket.has_attachments" data-column="has-attachments" class="tickets-table__cell tickets-table__cell--has-attachments">{{ 'true' if automation_data.get('has_attachments') else 'false' }}</td>
+                    <td data-label="ticket.attachment_count" data-column="attachment-count" class="tickets-table__cell tickets-table__cell--attachment-count">{{ automation_data.get('attachment_count', 0) }}</td>
+                    <td data-label="ticket.has_tasks" data-column="has-tasks" class="tickets-table__cell tickets-table__cell--has-tasks">{{ 'true' if automation_data.get('has_tasks') else 'false' }}</td>
+                    <td data-label="ticket.task_count" data-column="task-count" class="tickets-table__cell tickets-table__cell--task-count">{{ automation_data.get('task_count', 0) }}</td>
+                    <td data-label="ticket.has_open_tasks" data-column="has-open-tasks" class="tickets-table__cell tickets-table__cell--has-open-tasks">{{ 'true' if automation_data.get('has_open_tasks') else 'false' }}</td>
+                    <td data-label="ticket.open_task_count" data-column="open-task-count" class="tickets-table__cell tickets-table__cell--open-task-count">{{ automation_data.get('open_task_count', 0) }}</td>
+                    <td data-label="ticket.labels" data-column="labels" class="tickets-table__cell tickets-table__cell--labels">{{ (ticket.ai_tags or []) | join(', ') or '—' }}</td>
+                    <td data-label="ticket.age_days" data-column="age-days" class="tickets-table__cell tickets-table__cell--age-days">{{ created_age_days if created_age_days != '' else '—' }}</td>
+                    <td data-label="ticket.updated_age_hours" data-column="updated-age-hours" class="tickets-table__cell tickets-table__cell--updated-age-hours">{{ updated_age_hours if updated_age_hours != '' else '—' }}</td>
+                    <td data-label="ticket.last_reply_age_hours" data-column="last-reply-age-hours" class="tickets-table__cell tickets-table__cell--last-reply-age-hours">{{ last_reply_age_hours if last_reply_age_hours != '' else '—' }}</td>
+                    <td data-label="reply.is_internal" data-column="latest-reply-internal" class="tickets-table__cell tickets-table__cell--latest-reply-internal">{{ 'true' if automation_data.get('latest_reply_is_internal') else ('false' if automation_data.get('latest_reply_id') else '—') }}</td>
+                    <td data-label="reply.kind" data-column="latest-reply-kind" class="tickets-table__cell tickets-table__cell--latest-reply-kind">{{ automation_data.get('latest_reply_kind') or '—' }}</td>
                     <td class="table__actions tickets-table__cell tickets-table__cell--actions">
                       <a href="/admin/tickets/{{ ticket.id }}" class="button button--ghost">Open</a>
                     </td>
@@ -518,7 +584,7 @@
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="{{ 19 + (1 if can_bulk_delete_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
+                  <td colspan="{{ 36 + (1 if can_bulk_delete_tickets or can_merge_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
                 </tr>
               {% endif %}
             </tbody>


### PR DESCRIPTION
### Motivation
- Make automation-related ticket fields visible in the `/admin/tickets` list so technicians can inspect automation filter values while building automations.
- Avoid per-ticket database lookups when rendering lists by loading automation-related aggregates in batch to keep dashboard performance acceptable.

### Description
- Added optional column toggles and corresponding table headers/cells in `app/templates/admin/tickets.html` for automation filter fields such as `ticket.requester_email`, `ticket.requester_display_name`, `ticket.assigned_user_email`, `ticket.company.id`, attachment/task aggregates, label/age metrics, and latest-reply metadata (`reply.is_internal`, `reply.kind`).
- Implemented `get_automation_filter_context_by_ticket_ids` in `app/repositories/tickets.py` to fetch batched aggregates (time totals, attachment counts, task counts, and latest reply metadata) for a set of ticket IDs.
- Wired the automation lookup into the dashboard render by populating `ticket_automation_filter_lookup` and a consistent `ticket_dashboard_now` timestamp in `app/main.py` so template age calculations are stable.
- Updated template cells to prefer enriched ticket fields (e.g. `ticket.requester_email`) and to use the batched `ticket_automation_filter_lookup` where needed.

### Testing
- Compiled changed modules with `python3 -m py_compile app/repositories/tickets.py app/main.py` (succeeded).
- Ran `pytest -q tests/test_ticket_column_customisation.py` (10 tests, all passed).
- Attempted to run broader integration test (`tests/test_ticket_column_customisation.py tests/test_ticket_access.py::test_helpdesk_ticket_listing_allows_global_filters`) but test collection failed due to missing system dependency `libmagic` required by `python-magic` in the test environment (blocked during collection).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c5a863550833298d4bb41ac3e65c1)