### PR TITLE
Add configurable next ticket number (super-admin)

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -28,7 +28,8 @@ from urllib.parse import urlsplit
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
-from app.core.logging import log_error, log_info
+from app.core.database import db
+from app.core.logging import log_debug, log_error, log_info
 from app.features.tickets.form_helpers import get_last_form_value
 from app.security.flash import flash_redirect
 from app.repositories import assets as assets_repo
@@ -39,6 +40,7 @@ from app.repositories import ticket_statuses as ticket_status_repo
 from app.repositories import ticket_attachments as attachments_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import users as user_repo
+from app.repositories import site_settings as site_settings_repo
 from app.services import agent as agent_service
 from app.services import labour_types as labour_types_service
 from app.services import ticket_attachments as attachments_service
@@ -373,6 +375,32 @@ async def admin_rescan_ticket_related(ticket_id: int, request: Request):
         "skipped": False,
         "generated_at": result.get("generated_at"),
     })
+
+@router.post("/admin/tickets/next-number", response_class=HTMLResponse)
+async def admin_update_next_ticket_number(request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        return redirect
+    if not current_user.get("is_super_admin"):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Super admin access required")
+
+    form = await request.form()
+    raw_next_ticket_number = str(form.get("nextTicketNumber", "")).strip()
+    try:
+        next_ticket_number = int(raw_next_ticket_number)
+    except (TypeError, ValueError):
+        return flash_redirect("/admin/tickets", "Enter a valid next ticket number.", "error")
+    if next_ticket_number <= 0:
+        return flash_redirect("/admin/tickets", "Next ticket number must be a positive integer.", "error")
+
+    await site_settings_repo.set_next_ticket_number(next_ticket_number)
+    try:
+        await db.execute(f"ALTER TABLE tickets AUTO_INCREMENT = {next_ticket_number}")
+    except Exception as exc:  # pragma: no cover - SQLite and some MySQL versions may reject lower values
+        log_debug("Failed to update ticket AUTO_INCREMENT from admin setting", error=str(exc))
+    return flash_redirect("/admin/tickets", f"Next ticket number set to {next_ticket_number}.", "success")
+
 
 @router.post("/admin/tickets", response_class=HTMLResponse)
 async def admin_create_ticket(request: Request):

--- a/app/main.py
+++ b/app/main.py
@@ -8229,6 +8229,7 @@ async def _render_tickets_dashboard(
         "ticket_labour_types": labour_types,
         "ticket_time_lookup": ticket_time_lookup,
         "can_bulk_delete_tickets": bool(user.get("is_super_admin")),
+        "next_ticket_number": await site_settings_repo.get_next_ticket_number(),
         "success_message": success_message,
         "error_message": error_message,
         "ticket_dashboard_endpoint": dashboard_endpoint,

--- a/app/repositories/site_settings.py
+++ b/app/repositories/site_settings.py
@@ -1,7 +1,7 @@
 """Repository for global site settings (single-row configuration table)."""
 from __future__ import annotations
 
-from typing import Mapping
+from typing import Any, Mapping
 
 from app.core.database import db
 
@@ -106,9 +106,48 @@ async def set_tray_icon_tooltip_name(name: str | None) -> None:
         )
 
 
+async def get_next_ticket_number() -> int | None:
+    """Return the configured next local ticket number, or ``None`` if unset."""
+    row = await db.fetch_one(
+        "SELECT next_ticket_number FROM site_settings WHERE id = 1",
+        (),
+    )
+    if row is None:
+        return None
+    value: Any = row.get("next_ticket_number") if isinstance(row, Mapping) else row["next_ticket_number"]
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number > 0 else None
+
+
+async def set_next_ticket_number(number: int | None) -> None:
+    """Persist the configured next local ticket number."""
+    value = int(number) if number is not None else None
+    if value is not None and value <= 0:
+        raise ValueError("Next ticket number must be a positive integer.")
+    existing = await db.fetch_one(
+        "SELECT id FROM site_settings WHERE id = 1",
+        (),
+    )
+    if existing is None:
+        await db.execute(
+            "INSERT INTO site_settings (id, next_ticket_number) VALUES (1, %s)",
+            (value,),
+        )
+    else:
+        await db.execute(
+            "UPDATE site_settings SET next_ticket_number = %s WHERE id = 1",
+            (value,),
+        )
+
+
 __all__ = [
     "get_pdf_cover_image",
+    "set_next_ticket_number",
     "set_pdf_cover_image",
+    "get_next_ticket_number",
     "get_tray_icon_path",
     "get_tray_icon_tooltip_name",
     "set_tray_icon_path",

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable, Sequence
 
 from app.core.database import db
 from app.core.logging import log_debug, log_error, log_info
+from app.repositories import site_settings as site_settings_repo
 
 TicketRecord = dict[str, Any]
 
@@ -272,6 +273,19 @@ async def create_ticket(
         explicit_id=id,
     )
 
+    configured_next_ticket_number: int | None = None
+    if id is None:
+        configured_next_ticket_number = await site_settings_repo.get_next_ticket_number()
+        if configured_next_ticket_number is not None:
+            max_id_row = await db.fetch_one("SELECT MAX(id) as max_id FROM tickets")
+            max_id_value = max_id_row.get("max_id") if max_id_row else None
+            try:
+                max_id = int(max_id_value) if max_id_value is not None else 0
+            except (TypeError, ValueError):
+                max_id = 0
+            if max_id < configured_next_ticket_number:
+                id = configured_next_ticket_number
+
     # If an explicit ID is provided, insert with that ID
     if id is not None:
         ticket_id = await db.execute_returning_lastrowid(
@@ -309,6 +323,8 @@ async def create_ticket(
                 )
         except Exception as exc:  # pragma: no cover - defensive
             log_debug("Failed to update AUTO_INCREMENT after explicit ID insert", error=str(exc))
+        if configured_next_ticket_number is not None and ticket_id >= configured_next_ticket_number:
+            await site_settings_repo.set_next_ticket_number(ticket_id + 1)
     else:
         # Use normal auto-increment behavior
         ticket_id = await db.execute_returning_lastrowid(
@@ -332,6 +348,8 @@ async def create_ticket(
                 ticket_number,
             ),
         )
+        if configured_next_ticket_number is not None and ticket_id >= configured_next_ticket_number:
+            await site_settings_repo.set_next_ticket_number(ticket_id + 1)
     if ticket_id:
         log_info("Ticket created successfully", ticket_id=ticket_id)
         row = await db.fetch_one("SELECT * FROM tickets WHERE id = %s", (ticket_id,))

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -6,8 +6,9 @@
   {% set show_ticket_status_editor = is_super_admin %}
   {% set show_labour_type_editor = is_super_admin %}
   {% set show_tag_exclusions = is_super_admin %}
+  {% set show_next_ticket_number = is_super_admin %}
   {% set can_merge_tickets = is_helpdesk_technician | default(false) %}
-  {% set show_ticket_tools = show_ticket_automations or show_syncro_import or show_ticket_status_editor or show_labour_type_editor or show_tag_exclusions or can_bulk_delete_tickets or can_merge_tickets %}
+  {% set show_ticket_tools = show_ticket_automations or show_syncro_import or show_ticket_status_editor or show_labour_type_editor or show_next_ticket_number or show_tag_exclusions or can_bulk_delete_tickets or can_merge_tickets %}
   <div class="header-title-menu">
     <span class="header-title-menu__label">Ticketing workspace</span>
     <button
@@ -67,6 +68,19 @@
               </button>
             </li>
           {% endif %}
+          {% if show_next_ticket_number %}
+            <li class="header-title-menu__item" role="none">
+              <button
+                type="button"
+                class="header-title-menu__link"
+                role="menuitem"
+                data-next-ticket-number-open
+                data-current-next-ticket-number="{{ next_ticket_number or '' }}"
+              >
+                Next ticket number
+              </button>
+            </li>
+          {% endif %}
           {% if show_tag_exclusions %}
             <li class="header-title-menu__item" role="none">
               <a href="/admin/tag-exclusions" class="header-title-menu__link" role="menuitem">AI tag exclusions</a>
@@ -107,6 +121,13 @@
       </details>
     {% endif %}
   </div>
+
+  {% if show_next_ticket_number %}
+    <form action="/admin/tickets/next-number" method="post" data-next-ticket-number-form hidden>
+      {% include "partials/csrf.html" %}
+      <input type="hidden" name="nextTicketNumber" value="" data-next-ticket-number-input />
+    </form>
+  {% endif %}
 
   {% if can_merge_tickets %}
     <div class="modal" id="merge-tickets-modal" data-ticket-merge-modal hidden role="dialog" aria-modal="true" aria-labelledby="merge-tickets-title">
@@ -1023,4 +1044,27 @@
   <script src="{{ static_url('/static/js/ticket_views.js') }}" defer></script>
   <script src="{{ static_url('/static/js/ticket_columns.js') }}" defer></script>
   <script src="{{ static_url('/static/js/admin.js') }}" defer></script>
+
+  {% if show_next_ticket_number %}
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const button = document.querySelector('[data-next-ticket-number-open]');
+        const form = document.querySelector('[data-next-ticket-number-form]');
+        const input = document.querySelector('[data-next-ticket-number-input]');
+        if (!button || !form || !input) return;
+        button.addEventListener('click', () => {
+          const currentValue = button.getAttribute('data-current-next-ticket-number') || '';
+          const value = window.prompt('Enter the next ticket number to use for newly-created tickets.', currentValue);
+          if (value === null) return;
+          const cleaned = value.trim();
+          if (!/^\d+$/.test(cleaned) || Number(cleaned) <= 0) {
+            window.alert('Enter a positive whole number.');
+            return;
+          }
+          input.value = cleaned;
+          form.requestSubmit();
+        });
+      });
+    </script>
+  {% endif %}
 {% endblock %}

--- a/migrations/285_next_ticket_number.sql
+++ b/migrations/285_next_ticket_number.sql
@@ -1,0 +1,2 @@
+ALTER TABLE site_settings
+  ADD COLUMN IF NOT EXISTS next_ticket_number INT NULL;


### PR DESCRIPTION
### Motivation
- Allow super administrators to configure the starting ticket number to avoid collisions when importing/migrating tickets (e.g. from Syncro) and to adjust sequence occasionally.

### Description
- Added a super-admin-only `Next ticket number` item to the Ticket tools menu that opens a browser `prompt()` and submits a hidden CSRF-protected form to set the value. (`app/templates/admin/tickets.html`)
- Added a POST endpoint `POST /admin/tickets/next-number` which validates a positive integer, persists it to `site_settings.next_ticket_number`, and attempts to update MySQL `AUTO_INCREMENT`. (`app/features/tickets/admin_routes.py`)
- Persisted the setting with a migration `migrations/285_next_ticket_number.sql` and repository helpers `get_next_ticket_number` / `set_next_ticket_number` in `app/repositories/site_settings.py`.
- Updated ticket creation logic to consult the configured next number: if it is higher than the current max ticket `id`, new tickets are created at that `id` and the stored next number is advanced after ticket creation. (`app/repositories/tickets.py`)
- Supplied the current configured next ticket number into the admin template context so the prompt can preflll the value. (`app/main.py`)

### Testing
- Compiled modified modules with `python3 -m compileall` which succeeded for `site_settings.py`, `tickets.py`, `admin_routes.py`, and `main.py`.
- Rendered the updated template with Jinja2 using `Environment(...).get_template('admin/tickets.html')` which parsed successfully.
- Ran `git diff --check` to ensure no trailing whitespace errors and confirmed diffs; all checks passed.
- Created migration file `migrations/285_next_ticket_number.sql` and committed changes; no automated test failures reported during these checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c5b2f2984833285d11f496cc8920d)