### PR TITLE
Derive ticket-reply `kind` from `is_internal` and fix latest-reply query

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -224,6 +224,8 @@ def _normalise_reply(row: dict[str, Any]) -> TicketRecord:
         record[key] = _make_aware(record.get(key))
     if "is_billable" in record:
         record["is_billable"] = bool(record.get("is_billable"))
+    if not record.get("kind"):
+        record["kind"] = "internal_note" if bool(record.get("is_internal")) else "message"
     labour_name = record.get("labour_type_name")
     if labour_name is not None:
         record["labour_type_name"] = str(labour_name)
@@ -1357,7 +1359,12 @@ async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> 
 
     latest_reply_rows = await db.fetch_all(
         f"""
-        SELECT tr.ticket_id, tr.id, tr.created_at, tr.is_internal, tr.kind
+        SELECT
+            tr.ticket_id,
+            tr.id,
+            tr.created_at,
+            tr.is_internal,
+            CASE WHEN tr.is_internal = 1 THEN 'internal_note' ELSE 'message' END AS kind
         FROM ticket_replies AS tr
         INNER JOIN (
             SELECT ticket_id, MAX(id) AS latest_reply_id

--- a/tests/test_tickets_repository.py
+++ b/tests/test_tickets_repository.py
@@ -96,6 +96,31 @@ class _ListTicketAssetsDB:
         return self._rows
 
 
+class _AutomationContextDB:
+    def __init__(self):
+        self.fetch_calls = []
+
+    async def fetch_all(self, sql, params):
+        self.fetch_calls.append((sql.strip(), params))
+        if "SUM(CASE WHEN is_billable" in sql:
+            return []
+        if "FROM ticket_attachments" in sql:
+            return []
+        if "FROM ticket_tasks" in sql:
+            return []
+        if "FROM ticket_replies AS tr" in sql:
+            return [
+                {
+                    "ticket_id": 5,
+                    "id": 12,
+                    "created_at": None,
+                    "is_internal": 1,
+                    "kind": "internal_note",
+                }
+            ]
+        return []
+
+
 class _ReplaceTicketAssetsDB:
     def __init__(self, existing_rows, final_rows):
         self.fetch_calls: list[tuple[str, tuple]] = []
@@ -301,6 +326,7 @@ async def test_create_reply_returns_inserted_record(monkeypatch):
     assert "FROM ticket_replies tr" in dummy_db.fetch_sql
     assert "LEFT JOIN ticket_labour_types lt ON tr.labour_type_id = lt.id" in dummy_db.fetch_sql
     assert dummy_db.fetch_params == (42,)
+    assert record["kind"] == "message"
 
 
 @pytest.mark.anyio
@@ -322,6 +348,24 @@ async def test_create_reply_falls_back_when_fetch_missing(monkeypatch):
     assert record["is_internal"] == 1
     assert record["minutes_spent"] is None
     assert record["is_billable"] is False
+    assert record["kind"] == "internal_note"
+
+
+@pytest.mark.anyio
+async def test_automation_filter_context_derives_latest_reply_kind(monkeypatch):
+    dummy_db = _AutomationContextDB()
+    monkeypatch.setattr(tickets, "db", dummy_db)
+
+    context = await tickets.get_automation_filter_context_by_ticket_ids([5])
+
+    latest_query = dummy_db.fetch_calls[-1][0]
+    assert "tr.kind" not in latest_query
+    assert (
+        "CASE WHEN tr.is_internal = 1 THEN 'internal_note' ELSE 'message' END AS kind"
+        in latest_query
+    )
+    assert context[5]["latest_reply_id"] == 12
+    assert context[5]["latest_reply_kind"] == "internal_note"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- `/admin/tickets` was failing with a SQL error referencing a non-existent `ticket_replies.kind` column when assembling automation filter context.
- Consumers expect a stable `kind` value on reply records even when the DB row doesn't store an explicit `kind` column.

### Description
- When normalising replies, set a fallback `kind` value derived from `is_internal` so callers always see `"internal_note"` for internal replies and `"message"` for public replies (update in `app/repositories/tickets.py` in `_normalise_reply`).
- Replace the direct `tr.kind` selection in the latest-reply lookup with a derived expression `CASE WHEN tr.is_internal = 1 THEN 'internal_note' ELSE 'message' END AS kind` so the query no longer references a missing column (update in `app/repositories/tickets.py` in `get_automation_filter_context_by_ticket_ids`).
- Add test support and assertions in `tests/test_tickets_repository.py` to cover the derived `kind` value on created/fallback replies and to verify the latest-reply query uses the `CASE ... END AS kind` expression instead of `tr.kind` (new `_AutomationContextDB` helper and `test_automation_filter_context_derives_latest_reply_kind`).

### Testing
- Ran static checks by compiling modified modules with `python -m py_compile app/repositories/tickets.py tests/test_tickets_repository.py`, which succeeded.
- Attempted to run the repository tests with `pytest tests/test_tickets_repository.py -q`, but test collection failed due to a missing system dependency (`libmagic`) in the environment (`ImportError: failed to find libmagic`), so full pytest run could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c5c2de96c83329fcf3ca9d2ee6f63)