### PR TITLE
Add "In Status Hours" automation filter and admin column

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -335,6 +335,7 @@ async def get_ticket_dashboard(
                 module_slug=ticket.get("module_slug"),
                 requester_id=ticket.get("requester_id"),
                 updated_at=ticket.get("updated_at"),
+                status_changed_at=ticket.get("status_changed_at"),
             )
         )
     filters = TicketSearchFilters(

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -207,7 +207,7 @@ def _normalise_ticket(row: dict[str, Any]) -> TicketRecord:
     for key in ("id", "company_id", "requester_id", "requester_staff_id", "assigned_user_id", "merged_into_ticket_id", "split_from_ticket_id"):
         if key in record and record[key] is not None:
             record[key] = int(record[key])
-    for key in ("created_at", "updated_at", "closed_at", "ai_summary_updated_at"):
+    for key in ("created_at", "updated_at", "closed_at", "status_changed_at", "ai_summary_updated_at"):
         record[key] = _make_aware(record.get(key))
     record["ai_tags"] = _deserialise_tags(record.get("ai_tags"))
     record["ai_tags_updated_at"] = _make_aware(record.get("ai_tags_updated_at"))
@@ -995,6 +995,12 @@ async def update_ticket(ticket_id: int, **fields: Any) -> TicketRecord | None:
     if "updated_at" in fields:
         override_updated_at = fields.pop("updated_at")
     for key, value in fields.items():
+        if key == "status" and "status_changed_at" not in fields:
+            assignments.append(
+                "status_changed_at = CASE WHEN status <> %s "
+                "THEN UTC_TIMESTAMP(6) ELSE COALESCE(status_changed_at, created_at) END"
+            )
+            params.append(value)
         if key == "ai_tags":
             assignments.append(f"{key} = %s")
             params.append(_serialise_tags(value))

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -102,6 +102,7 @@ class TicketResponse(TicketBase):
     requester_id: Optional[int]
     created_at: datetime
     updated_at: datetime
+    status_changed_at: Optional[datetime] = None
     closed_at: Optional[datetime]
     ai_summary: Optional[str] = None
     ai_summary_status: Optional[str] = None
@@ -143,6 +144,7 @@ class TicketDashboardRow(BaseModel):
     module_slug: Optional[str] = None
     requester_id: Optional[int] = None
     updated_at: Optional[datetime] = None
+    status_changed_at: Optional[datetime] = None
 
     class Config:
         from_attributes = True
@@ -161,6 +163,7 @@ class LabourTypeModel(BaseModel):
     is_default: bool = False
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+    status_changed_at: Optional[datetime] = None
 
     class Config:
         from_attributes = True

--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -471,22 +471,26 @@ def _attach_ticket_age_context(ticket: Mapping[str, Any], *, now: datetime) -> d
     enriched = dict(ticket)
     created_at = enriched.get("created_at")
     updated_at = enriched.get("updated_at")
+    status_changed_at = enriched.get("status_changed_at") or created_at
     latest_reply_at = enriched.get("latest_reply_at")
     last_activity_at = latest_reply_at or updated_at or created_at
 
     enriched["age"] = _age_metrics(created_at, now=now)
     enriched["updated_age"] = _age_metrics(updated_at, now=now)
+    enriched["status_changed_at"] = status_changed_at
+    enriched["in_status_age"] = _age_metrics(status_changed_at, now=now)
     enriched["last_reply_at"] = latest_reply_at
     enriched["last_activity_at"] = last_activity_at
     enriched["last_reply_age"] = _age_metrics(latest_reply_at or created_at, now=now)
     enriched["last_activity_age"] = _age_metrics(last_activity_at, now=now)
 
     # Flat aliases keep the builder simple and make advanced JSON easy to read.
-    for prefix in ("age", "updated_age", "last_reply_age", "last_activity_age"):
+    for prefix in ("age", "updated_age", "in_status_age", "last_reply_age", "last_activity_age"):
         metrics = enriched.get(prefix)
         if isinstance(metrics, Mapping):
             for unit, metric_value in metrics.items():
                 enriched[f"{prefix}_{unit}"] = metric_value
+    enriched["status_changed_at_iso"] = _serialise_datetime(status_changed_at)
     enriched["last_reply_at_iso"] = _serialise_datetime(latest_reply_at)
     enriched["last_activity_at_iso"] = _serialise_datetime(last_activity_at)
     return enriched

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -47,6 +47,14 @@
       }),
     },
     {
+      label: 'Ticket has been in current status for 24 hours',
+      value: toJsonTemplate({
+        greater_than: {
+          'ticket.in_status_age_hours': 24,
+        },
+      }),
+    },
+    {
       label: 'Ticket has not had a reply for 24 hours',
       value: toJsonTemplate({
         greater_than: {
@@ -1836,6 +1844,7 @@
             'ticket.labels',
             'ticket.age_days',
             'ticket.updated_age_hours',
+            'ticket.in_status_age_hours',
             'ticket.last_reply_age_hours',
             'ticket_update.actor_type',
             'reply.is_internal',

--- a/app/templates/admin/automations_create_scheduled.html
+++ b/app/templates/admin/automations_create_scheduled.html
@@ -126,7 +126,7 @@
                   >{{ values.get('triggerFiltersRaw', '') }}</textarea>
                 </div>
                 <p class="form-help" data-filter-builder-error hidden></p>
-                <p class="form-help">Use ticket fields such as <code>ticket.status</code>, <code>ticket.age_days</code>, <code>ticket.updated_age_hours</code>, and <code>ticket.last_reply_age_hours</code>. Use Advanced JSON for complex nested logic.</p>
+                <p class="form-help">Use ticket fields such as <code>ticket.status</code>, <code>ticket.age_days</code>, <code>ticket.updated_age_hours</code>, <code>ticket.in_status_age_hours</code>, and <code>ticket.last_reply_age_hours</code>. Use Advanced JSON for complex nested logic.</p>
               </div>
               <div class="form-field" data-automation-actions>
                 <label class="form-label">Scheduled actions</label>

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -416,6 +416,7 @@
                     ('labels', 'ticket.labels'),
                     ('age-days', 'ticket.age_days'),
                     ('updated-age-hours', 'ticket.updated_age_hours'),
+                    ('in-status-hours', 'ticket.in_status_age_hours'),
                     ('last-reply-age-hours', 'ticket.last_reply_age_hours'),
                     ('latest-reply-internal', 'reply.is_internal'),
                     ('latest-reply-kind', 'reply.kind')
@@ -504,6 +505,7 @@
                 <th scope="col" data-sort="string" data-column="labels" class="tickets-table__column tickets-table__column--labels">ticket.labels</th>
                 <th scope="col" data-sort="int" data-column="age-days" class="tickets-table__column tickets-table__column--age-days">ticket.age_days</th>
                 <th scope="col" data-sort="int" data-column="updated-age-hours" class="tickets-table__column tickets-table__column--updated-age-hours">ticket.updated_age_hours</th>
+                <th scope="col" data-sort="int" data-column="in-status-hours" class="tickets-table__column tickets-table__column--in-status-hours">ticket.in_status_age_hours</th>
                 <th scope="col" data-sort="int" data-column="last-reply-age-hours" class="tickets-table__column tickets-table__column--last-reply-age-hours">ticket.last_reply_age_hours</th>
                 <th scope="col" data-sort="string" data-column="latest-reply-internal" class="tickets-table__column tickets-table__column--latest-reply-internal">reply.is_internal</th>
                 <th scope="col" data-sort="string" data-column="latest-reply-kind" class="tickets-table__column tickets-table__column--latest-reply-kind">reply.kind</th>
@@ -579,6 +581,8 @@
                     {% set assigned_email = assigned.email if assigned else '' %}
                     {% set created_age_days = ((ticket_dashboard_now - ticket.created_at).total_seconds() // 86400) | int if ticket.created_at else '' %}
                     {% set updated_age_hours = ((ticket_dashboard_now - ticket.updated_at).total_seconds() // 3600) | int if ticket.updated_at else '' %}
+                    {% set status_changed_at = ticket.status_changed_at or ticket.created_at %}
+                    {% set in_status_age_hours = ((ticket_dashboard_now - status_changed_at).total_seconds() // 3600) | int if status_changed_at else '' %}
                     {% set latest_reply_at = automation_data.get('latest_reply_at') %}
                     {% set last_reply_age_hours = ((ticket_dashboard_now - latest_reply_at).total_seconds() // 3600) | int if latest_reply_at else '' %}
                     <td data-label="ticket.requester_email" data-column="requester-email" class="tickets-table__cell tickets-table__cell--requester-email">{{ requester_email or '—' }}</td>
@@ -595,6 +599,7 @@
                     <td data-label="ticket.labels" data-column="labels" class="tickets-table__cell tickets-table__cell--labels">{{ (ticket.ai_tags or []) | join(', ') or '—' }}</td>
                     <td data-label="ticket.age_days" data-column="age-days" class="tickets-table__cell tickets-table__cell--age-days">{{ created_age_days if created_age_days != '' else '—' }}</td>
                     <td data-label="ticket.updated_age_hours" data-column="updated-age-hours" class="tickets-table__cell tickets-table__cell--updated-age-hours">{{ updated_age_hours if updated_age_hours != '' else '—' }}</td>
+                    <td data-label="ticket.in_status_age_hours" data-column="in-status-hours" class="tickets-table__cell tickets-table__cell--in-status-hours">{{ in_status_age_hours if in_status_age_hours != '' else '—' }}</td>
                     <td data-label="ticket.last_reply_age_hours" data-column="last-reply-age-hours" class="tickets-table__cell tickets-table__cell--last-reply-age-hours">{{ last_reply_age_hours if last_reply_age_hours != '' else '—' }}</td>
                     <td data-label="reply.is_internal" data-column="latest-reply-internal" class="tickets-table__cell tickets-table__cell--latest-reply-internal">{{ 'true' if automation_data.get('latest_reply_is_internal') else ('false' if automation_data.get('latest_reply_id') else '—') }}</td>
                     <td data-label="reply.kind" data-column="latest-reply-kind" class="tickets-table__cell tickets-table__cell--latest-reply-kind">{{ automation_data.get('latest_reply_kind') or '—' }}</td>
@@ -605,7 +610,7 @@
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="{{ 36 + (1 if can_bulk_delete_tickets or can_merge_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
+                  <td colspan="{{ 37 + (1 if can_bulk_delete_tickets or can_merge_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
                 </tr>
               {% endif %}
             </tbody>

--- a/migrations/070_tickets_automations_modules.sql
+++ b/migrations/070_tickets_automations_modules.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS tickets (
     subject VARCHAR(255) NOT NULL,
     description TEXT NULL,
     status VARCHAR(32) NOT NULL DEFAULT 'open',
+    status_changed_at DATETIME(6) NULL,
     priority VARCHAR(32) NOT NULL DEFAULT 'normal',
     category VARCHAR(64) NULL,
     module_slug VARCHAR(64) NULL,

--- a/migrations/271_ticket_status_changed_at.sql
+++ b/migrations/271_ticket_status_changed_at.sql
@@ -1,0 +1,10 @@
+-- Track when a ticket entered its current status for automation filters and list columns.
+ALTER TABLE tickets
+    ADD COLUMN IF NOT EXISTS status_changed_at DATETIME(6) NULL AFTER status;
+
+UPDATE tickets
+SET status_changed_at = COALESCE(status_changed_at, updated_at, created_at)
+WHERE status_changed_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tickets_status_changed_at
+    ON tickets (status, status_changed_at);

--- a/tests/test_automations_service.py
+++ b/tests/test_automations_service.py
@@ -745,6 +745,7 @@ def test_filters_match_supports_ticket_age_comparisons():
             "status": "open",
             "age_days": 31,
             "updated_age_hours": 49,
+            "in_status_age_hours": 25,
             "last_reply_age_hours": 12,
         }
     }
@@ -755,6 +756,7 @@ def test_filters_match_supports_ticket_age_comparisons():
                 {"match": {"ticket.status": "open"}},
                 {"greater_than": {"ticket.age_days": 30}},
                 {"greater_than_or_equal": {"ticket.updated_age_hours": 48}},
+                {"greater_than": {"ticket.in_status_age_hours": 24}},
             ]
         },
         context,

--- a/tests/test_tickets_repository.py
+++ b/tests/test_tickets_repository.py
@@ -561,6 +561,9 @@ async def test_update_ticket_allows_updated_at_override(monkeypatch):
     await tickets.update_ticket(1, status="resolved", updated_at=override)
 
     assert dummy_db.execute_sql.startswith("UPDATE tickets SET")
+    assert "status_changed_at = CASE WHEN status <> %s" in dummy_db.execute_sql
+    assert "ELSE COALESCE(status_changed_at, created_at) END" in dummy_db.execute_sql
+    assert dummy_db.execute_params[0] == "resolved"
     assert dummy_db.execute_params[-1] == 1
     assert dummy_db.execute_params[-2] == override
 


### PR DESCRIPTION
### Motivation
- Provide a filter and column for how long a ticket has been in its current status (hours) so automations and admins can target tickets based on time-in-current-status.
- Make this available for scheduled automation rules and as a toggleable column on the `/admin/tickets` table.

### Description
- Added a `status_changed_at` DATETIME column and migration `migrations/271_ticket_status_changed_at.sql` that backfills existing tickets and adds an index for `(status, status_changed_at)`.
- Persist and maintain `status_changed_at` during ticket updates by updating `app/repositories/tickets.py` to set `status_changed_at` when `status` changes and to normalise the new field on read (`_normalise_ticket`).
- Exposed `status_changed_at` in ticket schemas and dashboard rows by updating `app/schemas/tickets.py` and the ticket dashboard API payload in `app/api/routes/tickets.py`.
- Enriched automation ticket context in `app/services/automations.py` with `in_status_age` metrics (flat aliases such as `ticket.in_status_age_hours`) and ISO timestamp fields so filters can reference `ticket.in_status_age_hours`.
- Updated the automation UI and builder to include a snippet and field suggestion for the new `ticket.in_status_age_hours` field in `app/static/js/automation.js` and help text in `app/templates/admin/automations_create_scheduled.html`.
- Added a toggleable column for the admin tickets table and render logic that computes hours in current status (falling back to `created_at`) in `app/templates/admin/tickets.html`.
- Adjusted the initial tickets DDL template to include `status_changed_at` in `migrations/070_tickets_automations_modules.sql` and added/updated unit tests to cover the new metrics and SQL behavior (`tests/test_automations_service.py`, `tests/test_tickets_repository.py`).

### Testing
- Static checks: ran `python -m py_compile app/repositories/tickets.py app/services/automations.py` and `python -m py_compile app/schemas/tickets.py app/api/routes/tickets.py` and `node --check app/static/js/automation.js`, all succeeded.
- Unit tests: ran `pytest -q` for the modified tests including `tests/test_tickets_repository.py::test_update_ticket_allows_updated_at_override`, `tests/test_tickets_repository.py::test_automation_filter_context_derives_latest_reply_kind`, and `tests/test_automations_service.py::test_filters_match_supports_ticket_age_comparisons`, and they passed (3 passed, with warnings from unrelated schema deprecations).
- Notes: an environment dependency (`libmagic`) was installed during testing to allow the test imports to load; all automated test runs completed successfully after that change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c5f1bfce083328dbc5d6f33a2b0de)