### PR TITLE
Fix Xero webhook monitoring status

### DIFF
--- a/app/api/routes/xero.py
+++ b/app/api/routes/xero.py
@@ -82,6 +82,22 @@ def _empty_xero_webhook_response(status_code: int) -> Response:
     return response
 
 
+def _summarise_xero_webhook_results(results: list[dict[str, Any]]) -> str | None:
+    """Summarise best-effort event processing failures without duplicating noise."""
+
+    failures = [result for result in results if result.get("status") == "failed"]
+    if not failures:
+        return None
+    counts: dict[str, int] = {}
+    for result in failures:
+        reason = str(result.get("error") or "Xero event processing failed")
+        counts[reason] = counts.get(reason, 0) + 1
+    return "; ".join(
+        f"{reason} ({count} event{'s' if count != 1 else ''})"
+        for reason, count in counts.items()
+    )
+
+
 def _extract_xero_invoice_id(event: dict[str, Any]) -> str | None:
     invoice_id = str(event.get("resourceId") or event.get("resourceID") or "").strip()
     if invoice_id:
@@ -214,19 +230,18 @@ async def receive_webhook(request: Request) -> Response:
     # reject the request, but downstream invoice-sync errors are logged in the
     # webhook monitor without turning the provider delivery into a failed HTTP
     # attempt.
+    processing_warning = _summarise_xero_webhook_results(results)
+    response_body = {"status": "accepted", "results": results}
+    if processing_warning:
+        response_body["processing_warning"] = processing_warning
     await webhook_monitor.log_incoming_webhook(
         name="Xero Webhook - Invoice Updates",
         source_url=source_url,
         payload=payload,
         headers=request_headers,
         response_status=200,
-        response_body=json.dumps({"status": "accepted", "results": results}),
-        error_message="; ".join(
-            str(result.get("error") or "Xero event processing failed")
-            for result in results
-            if result.get("status") == "failed"
-        )
-        or None,
+        response_body=json.dumps(response_body),
+        error_message=None,
     )
     return _empty_xero_webhook_response(status.HTTP_200_OK)
 

--- a/tests/test_xero_webhook.py
+++ b/tests/test_xero_webhook.py
@@ -31,6 +31,19 @@ def test_extract_xero_invoice_id_from_resource_url():
     assert xero._extract_xero_invoice_id(event) == "inv-123"
 
 
+def test_summarise_xero_webhook_results_deduplicates_failures():
+    results = [
+        {"status": "failed", "error": "Internal processing error"},
+        {"status": "failed", "error": "Internal processing error"},
+        {"status": "ignored", "reason": "unsupported category"},
+        {"status": "failed", "error": "Xero API timeout"},
+    ]
+
+    assert xero._summarise_xero_webhook_results(results) == (
+        "Internal processing error (2 events); Xero API timeout (1 event)"
+    )
+
+
 @pytest.mark.anyio("asyncio")
 async def test_apply_xero_invoice_event_marks_local_invoice_paid(monkeypatch):
     local_invoice = {
@@ -131,7 +144,10 @@ async def test_receive_webhook_acknowledges_valid_delivery_when_event_processing
     assert response.body == b""
     log_mock.assert_awaited_once()
     assert log_mock.await_args.kwargs["response_status"] == 200
-    assert log_mock.await_args.kwargs["error_message"] == "Internal processing error"
+    assert log_mock.await_args.kwargs["error_message"] is None
+    logged_body = log_mock.await_args.kwargs["response_body"]
+    assert "processing_warning" in logged_body
+    assert "Internal processing error (1 event)" in logged_body
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation
- Xero sends signed webhook deliveries that must be acknowledged with a 2xx HTTP response quickly and consistently, but downstream invoice processing can fail best-effort; logging each per-event processing failure as a webhook delivery failure made monitoring noisy and risked Xero disabling deliveries.

### Description
- Add `_summarise_xero_webhook_results(results)` to aggregate and deduplicate per-event processing failures into a compact human-readable summary.
- When acknowledging valid signed deliveries in `receive_webhook`, include the aggregated `processing_warning` in the logged response body and record the incoming webhook as successful by setting `error_message` to `None` while still returning the required empty 200 acknowledgement to Xero in `app/api/routes/xero.py`.
- Update `tests/test_xero_webhook.py` to add a unit test for the summarisation helper and to assert that acknowledged deliveries with downstream processing failures are logged as successful and include the `processing_warning` in the logged `response_body`.
- Modified files: `app/api/routes/xero.py` and `tests/test_xero_webhook.py`.

### Testing
- Ran static compile check with `python -m py_compile app/api/routes/xero.py tests/test_xero_webhook.py`, which succeeded. 
- Ran the webhook regression tests with `pytest -q tests/test_xero_webhook.py`, which passed (`9 passed, 108 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c605e6cd0832d99916ee295e28467)