### PR TITLE
Restrict ticket assignees to helpdesk technicians

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -118,6 +118,19 @@ async def _has_helpdesk_permission(current_user: dict) -> bool:
         return False
 
 
+async def _validate_ticket_assignee(assigned_user_id: int | None) -> None:
+    if assigned_user_id is None:
+        return
+    has_permission = await membership_repo.user_has_permission(
+        assigned_user_id, tickets_service.HELPDESK_PERMISSION_KEY
+    )
+    if not has_permission:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Selected user cannot be assigned to tickets.",
+        )
+
+
 async def _resolve_ticket_actor(
     optional_user: dict | None = Depends(get_optional_user),
     api_key_record: dict | None = Depends(get_optional_api_key),
@@ -523,6 +536,7 @@ async def create_ticket(
             )
 
     assigned_user_id = payload.assigned_user_id if has_helpdesk_access else None
+    await _validate_ticket_assignee(assigned_user_id)
     priority = payload.priority if has_helpdesk_access else "normal"
     if has_helpdesk_access:
         if payload.status:
@@ -627,6 +641,8 @@ async def update_ticket(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Ticket subject is required",
             )
+    if "assigned_user_id" in fields:
+        await _validate_ticket_assignee(fields.get("assigned_user_id"))
     if fields:
         await tickets_repo.update_ticket(ticket_id, **fields)
     if description_value is not description_marker:

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -424,7 +424,24 @@ async def admin_create_ticket(request: Request):
     try:
         assigned_user_id = int(assigned_raw) if assigned_raw else None
     except (TypeError, ValueError):
-        assigned_user_id = None
+        return await main_module._render_tickets_dashboard(
+            request,
+            current_user,
+            error_message="Select a valid assignee.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    if assigned_user_id is not None:
+        has_permission = await membership_repo.user_has_permission(
+            assigned_user_id,
+            main_module.HELPDESK_PERMISSION_KEY,
+        )
+        if not has_permission:
+            return await main_module._render_tickets_dashboard(
+                request,
+                current_user,
+                error_message="Selected user cannot be assigned to tickets.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
     requester_id: int | None = None
     requester_staff_id: int | None = None
     if requester_raw:

--- a/app/repositories/company_memberships.py
+++ b/app/repositories/company_memberships.py
@@ -220,10 +220,12 @@ async def list_users_with_permission(permission: str) -> List[dict[str, Any]]:
             u.company_id,
             u.is_super_admin,
             r.permissions
-        FROM company_memberships AS m
-        INNER JOIN roles AS r ON r.id = m.role_id
-        INNER JOIN users AS u ON u.id = m.user_id
-        WHERE LOWER(m.status) = 'active'
+        FROM users AS u
+        LEFT JOIN company_memberships AS m
+            ON m.user_id = u.id
+            AND LOWER(m.status) = 'active'
+        LEFT JOIN roles AS r ON r.id = m.role_id
+        WHERE m.id IS NOT NULL OR u.is_super_admin = 1
         ORDER BY u.email
         """,
     )


### PR DESCRIPTION
### Motivation
- Prevent tickets from being assigned to arbitrary users by limiting assignees to those with the helpdesk technician permission or super admins. 
- Ensure the assignee lookup includes super admins even if they lack an active `company_membership` record. 

### Description
- Update `list_users_with_permission` SQL in `app/repositories/company_memberships.py` to query from `users` left-joined to `company_memberships` and include rows where `m.id IS NOT NULL OR u.is_super_admin = 1`, so super admins are included in results. 
- Add validation in the admin ticket creation flow in `app/features/tickets/admin_routes.py` to reject invalid `assignedUserId` values and to require that a supplied assignee has the `HELPDESK_PERMISSION_KEY` (or is a super admin) before saving. 
- Add a shared `_validate_ticket_assignee` helper to `app/api/routes/tickets.py` and call it from the ticket create and update API paths so API consumers cannot assign tickets to users without the `helpdesk.technician` permission. 

### Testing
- Successfully compiled the modified modules with `python -m py_compile app/repositories/company_memberships.py app/features/tickets/admin_routes.py app/api/routes/tickets.py`. 
- Ran `pytest tests/test_company_memberships.py -q` but collection failed due to an environment dependency (`libmagic` required by `python-magic`) causing import error, so unit tests were blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c6064aa1c832d9af11d4265a35adf)