### PR TITLE
Fix integer table sorting

### DIFF
--- a/app/static/js/tables.js
+++ b/app/static/js/tables.js
@@ -5,8 +5,8 @@
   }
 
   function parseValue(value, type) {
-    if (type === 'number') {
-      const parsed = parseFloat(value);
+    if (type === 'number' || type === 'int') {
+      const parsed = type === 'int' ? Number.parseInt(value, 10) : parseFloat(value);
       return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
     }
     if (type === 'date') {


### PR DESCRIPTION
### Motivation
- Automations table ID columns with `data-sort="int"` were being sorted lexicographically instead of numerically, causing IDs like `10` and `11` to appear before `2`.

### Description
- Change `parseValue` in `app/static/js/tables.js` to treat `data-sort="int"` as integers by using `Number.parseInt(value, 10)` while preserving existing `data-sort="number"` (decimal) behavior.

### Testing
- A quick verification with a Node snippet confirmed integer sorting produces `1,2,3,4,6,7,8,9,10,11,12`; running `pytest tests/test_automation_form_parsing.py tests/test_automations_repository.py` could not collect tests because the environment is missing the system `libmagic` library required by `python-magic`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c64dd08e4832d87cbbeb8cff0daec)