### PR TITLE
Import Syncro ticket attachments and deduplicate originals

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -1673,6 +1673,39 @@ def _extract_total_pages(meta: dict[str, Any]) -> int | None:
     return None
 
 
+async def _fetch_ticket_detail_for_import(
+    ticket: dict[str, Any],
+    *,
+    rate_limiter: syncro.AsyncRateLimiter | None = None,
+) -> dict[str, Any]:
+    """Fetch a detailed ticket payload when a list item lacks import-only fields.
+
+    Syncro list endpoints can return ticket summaries that omit heavy nested
+    collections such as attachments and comments.  The per-ticket endpoint is
+    used to hydrate those summaries before importing so attachments are not
+    silently skipped during bulk imports.
+    """
+    if ticket.get("attachments") is not None and ticket.get("comments") is not None:
+        return ticket
+    ticket_id = ticket.get("id")
+    if ticket_id is None:
+        return ticket
+    try:
+        detail = await syncro.get_ticket(ticket_id, rate_limiter=rate_limiter)
+    except Exception as exc:  # pragma: no cover - caller handles import with summary
+        log_error(
+            "Failed to hydrate Syncro ticket detail",
+            syncro_id=ticket_id,
+            error=str(exc),
+        )
+        return ticket
+    if not detail:
+        return ticket
+    merged = dict(ticket)
+    merged.update(detail)
+    return merged
+
+
 async def import_all_tickets(
     *,
     rate_limiter: syncro.AsyncRateLimiter | None = None,
@@ -1690,8 +1723,11 @@ async def import_all_tickets(
         summary.fetched += len(tickets)
         for ticket in tickets:
             try:
+                ticket_detail = await _fetch_ticket_detail_for_import(
+                    ticket, rate_limiter=limiter
+                )
                 outcome = await _upsert_ticket(
-                    ticket, allowed_statuses, default_status, status_mappings
+                    ticket_detail, allowed_statuses, default_status, status_mappings
                 )
             except Exception as exc:  # pragma: no cover - defensive logging
                 reason = f"Syncro ticket {ticket.get('id') or 'unknown'} failed to import: {exc}"

--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -15,6 +15,7 @@ from app.core.logging import log_error, log_info
 from app.repositories import assets as assets_repo
 from app.repositories import companies as company_repo
 from app.repositories import tickets as tickets_repo
+from app.repositories import ticket_attachments as attachments_repo
 from app.repositories import users as user_repo
 from app.repositories import webhook_events as webhook_events_repo
 from app.services import (
@@ -34,7 +35,14 @@ async def _get_status_context() -> tuple[set[str], str, dict[str, str]]:
     definitions = await tickets_service.list_status_definitions()
     if definitions:
         slugs = [definition.tech_status for definition in definitions]
-        default = next((definition.tech_status for definition in definitions if definition.is_default), slugs[0])
+        default = next(
+            (
+                definition.tech_status
+                for definition in definitions
+                if definition.is_default
+            ),
+            slugs[0],
+        )
     else:
         slugs = list(_ALLOWED_STATUSES)
         default = _DEFAULT_STATUS
@@ -42,7 +50,9 @@ async def _get_status_context() -> tuple[set[str], str, dict[str, str]]:
     return set(slugs), default, mappings
 
 
-async def _get_syncro_status_mappings(allowed_statuses: Collection[str]) -> dict[str, str]:
+async def _get_syncro_status_mappings(
+    allowed_statuses: Collection[str],
+) -> dict[str, str]:
     try:
         module = await syncro._load_module_settings()
     except Exception as exc:  # pragma: no cover - defensive fallback
@@ -55,14 +65,19 @@ async def _get_syncro_status_mappings(allowed_statuses: Collection[str]) -> dict
     for item in configured:
         if not isinstance(item, dict):
             continue
-        syncro_status = _clean_text(item.get("syncro_status") or item.get("syncroStatus"))
-        myportal_status = _clean_text(item.get("myportal_status") or item.get("myportalStatus"))
+        syncro_status = _clean_text(
+            item.get("syncro_status") or item.get("syncroStatus")
+        )
+        myportal_status = _clean_text(
+            item.get("myportal_status") or item.get("myportalStatus")
+        )
         if not syncro_status or not myportal_status:
             continue
         normalized_myportal = myportal_status.lower().replace(" ", "_")
         if normalized_myportal in allowed_statuses:
             mappings[syncro_status.casefold()] = normalized_myportal
     return mappings
+
 
 @dataclass(slots=True)
 class TicketImportSummary:
@@ -99,6 +114,8 @@ class TicketImportSummary:
             "skipped": self.skipped,
             "skipped_reasons": self.skipped_reasons or [],
         }
+
+
 _HTML_NEWLINE_TAGS = re.compile(
     r"<\s*(?:br\s*/?|/(?:p|div|li|tr|table|thead|tbody|tfoot|section|article|header|footer|h[1-6]))\b[^>]*>",
     flags=re.IGNORECASE,
@@ -151,7 +168,9 @@ def _normalise_status(
         ):
             return candidate
     for candidate in allowed_statuses:
-        if ("resolv" in normalized or "complete" in normalized) and "resolv" in candidate:
+        if (
+            "resolv" in normalized or "complete" in normalized
+        ) and "resolv" in candidate:
             return candidate
     for candidate in allowed_statuses:
         if "clos" in normalized and "clos" in candidate:
@@ -217,7 +236,13 @@ def _extract_comment_body(comment: dict[str, Any]) -> str | None:
     )
 
 
-_IMAGE_MIME_TYPES = {"image/jpeg", "image/png", "image/gif", "image/webp", "image/svg+xml"}
+_IMAGE_MIME_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+    "image/svg+xml",
+}
 _IMAGE_EXTENSIONS = {
     "image/jpeg": ".jpg",
     "image/png": ".png",
@@ -247,11 +272,20 @@ _COMMENT_IMAGE_URL_KEYS = (
     "fullUrl",
     "href",
 )
-_COMMENT_IMAGE_FILENAME_KEYS = ("filename", "file_name", "fileName", "name", "title", "alt")
+_COMMENT_IMAGE_FILENAME_KEYS = (
+    "filename",
+    "file_name",
+    "fileName",
+    "name",
+    "title",
+    "alt",
+)
 _COMMENT_IMAGE_MIME_KEYS = ("content_type", "contentType", "mime_type", "mimeType")
 
 
-def _extract_comment_image_candidates(comment: dict[str, Any]) -> list[dict[str, str | None]]:
+def _extract_comment_image_candidates(
+    comment: dict[str, Any],
+) -> list[dict[str, str | None]]:
     """Return image attachment candidates embedded in a Syncro comment."""
     candidates: list[dict[str, str | None]] = []
     seen: set[tuple[str, str]] = set()
@@ -277,18 +311,31 @@ def _extract_comment_image_candidates(comment: dict[str, Any]) -> list[dict[str,
         if key in seen:
             return
         seen.add(key)
-        candidates.append({"url": url_text, "filename": filename_text, "mime_type": mime})
+        candidates.append(
+            {"url": url_text, "filename": filename_text, "mime_type": mime}
+        )
 
     def scan(value: Any) -> None:
         if isinstance(value, dict):
-            url = next((value.get(key) for key in _COMMENT_IMAGE_URL_KEYS if value.get(key)), None)
+            url = next(
+                (value.get(key) for key in _COMMENT_IMAGE_URL_KEYS if value.get(key)),
+                None,
+            )
             if url:
                 filename = next(
-                    (value.get(key) for key in _COMMENT_IMAGE_FILENAME_KEYS if value.get(key)),
+                    (
+                        value.get(key)
+                        for key in _COMMENT_IMAGE_FILENAME_KEYS
+                        if value.get(key)
+                    ),
                     None,
                 )
                 content_type = next(
-                    (value.get(key) for key in _COMMENT_IMAGE_MIME_KEYS if value.get(key)),
+                    (
+                        value.get(key)
+                        for key in _COMMENT_IMAGE_MIME_KEYS
+                        if value.get(key)
+                    ),
                     None,
                 )
                 add(url, filename, content_type)
@@ -302,7 +349,14 @@ def _extract_comment_image_candidates(comment: dict[str, Any]) -> list[dict[str,
                 elif isinstance(item, (dict, list)):
                     scan(item)
 
-    for key in ("attachments", "files", "uploads", "images", "inline_images", "inlineImages"):
+    for key in (
+        "attachments",
+        "files",
+        "uploads",
+        "images",
+        "inline_images",
+        "inlineImages",
+    ):
         scan(comment.get(key))
 
     for body_key in ("body", "html_body", "htmlBody", "comment", "text", "content"):
@@ -320,7 +374,10 @@ def _extract_comment_image_candidates(comment: dict[str, Any]) -> list[dict[str,
                 tag,
                 flags=re.IGNORECASE,
             )
-            add(unescape(match.group(1)), unescape(filename_match.group(1)) if filename_match else None)
+            add(
+                unescape(match.group(1)),
+                unescape(filename_match.group(1)) if filename_match else None,
+            )
     return candidates
 
 
@@ -331,10 +388,14 @@ def _filename_for_image_candidate(
     if filename and filename.lower() not in {"[embedded image]", "embedded image"}:
         name = PurePosixPath(unquote(urlparse(filename).path)).name or filename
     else:
-        parsed_name = PurePosixPath(unquote(urlparse(candidate.get("url") or "").path)).name
+        parsed_name = PurePosixPath(
+            unquote(urlparse(candidate.get("url") or "").path)
+        ).name
         name = parsed_name or f"syncro-comment-image-{index}"
     if "." not in name:
-        ext = _IMAGE_EXTENSIONS.get((content_type or candidate.get("mime_type") or "").lower(), ".img")
+        ext = _IMAGE_EXTENSIONS.get(
+            (content_type or candidate.get("mime_type") or "").lower(), ".img"
+        )
         name = f"{name}{ext}"
     return name[:255]
 
@@ -346,14 +407,12 @@ async def _import_comment_images(
     imported: list[dict[str, Any]] = []
     for index, candidate in enumerate(candidates, start=1):
         try:
-            contents, downloaded_type = await syncro.download_file(candidate["url"] or "")
-            content_type = (
-                (downloaded_type or candidate.get("mime_type") or "")
-                .split(";", 1)[0]
-                .strip()
-                .lower()
-                or None
+            contents, downloaded_type = await syncro.download_file(
+                candidate["url"] or ""
             )
+            content_type = (downloaded_type or candidate.get("mime_type") or "").split(
+                ";", 1
+            )[0].strip().lower() or None
             if content_type not in _IMAGE_MIME_TYPES:
                 guessed, _ = mimetypes.guess_type(candidate.get("url") or "")
                 content_type = guessed if guessed in _IMAGE_MIME_TYPES else content_type
@@ -367,14 +426,18 @@ async def _import_comment_images(
             attachment = await attachments_service.save_file_bytes(
                 ticket_id=ticket_id,
                 contents=contents,
-                original_filename=_filename_for_image_candidate(candidate, content_type, index),
+                original_filename=_filename_for_image_candidate(
+                    candidate, content_type, index
+                ),
                 mime_type=content_type,
                 access_level="closed",
                 uploaded_by_user_id=author_id,
             )
             if attachment:
                 imported.append(attachment)
-        except Exception as exc:  # pragma: no cover - import should continue if an image fails
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - import should continue if an image fails
             log_error(
                 "Failed to import Syncro embedded image",
                 ticket_id=ticket_id,
@@ -384,7 +447,9 @@ async def _import_comment_images(
     return imported
 
 
-def _build_imported_image_markup(ticket_id: int, attachments: list[dict[str, Any]]) -> str:
+def _build_imported_image_markup(
+    ticket_id: int, attachments: list[dict[str, Any]]
+) -> str:
     """Build inline image HTML for imported Syncro image attachments."""
     image_tags: list[str] = []
     for attachment in attachments:
@@ -423,7 +488,14 @@ def _append_imported_image_markup(
 
 def _extract_comment_author_name(comment: dict[str, Any]) -> str | None:
     """Return the display name for the comment author."""
-    for key in ("tech_name", "techName", "author_name", "authorName", "user_name", "userName"):
+    for key in (
+        "tech_name",
+        "techName",
+        "author_name",
+        "authorName",
+        "user_name",
+        "userName",
+    ):
         name = _clean_text(comment.get(key))
         if name:
             return name
@@ -620,9 +692,7 @@ def _extract_ticket_assets(ticket: dict[str, Any]) -> list[dict[str, Any]]:
                 if not isinstance(asset, dict):
                     continue
                 name = _clean_text(asset.get("name"))
-                asset_tag = _clean_text(
-                    asset.get("asset_tag") or asset.get("assetTag")
-                )
+                asset_tag = _clean_text(asset.get("asset_tag") or asset.get("assetTag"))
                 serial = _clean_text(
                     asset.get("serial_number") or asset.get("serialNumber")
                 )
@@ -714,6 +784,147 @@ def _build_ticket_metadata_note(ticket: dict[str, Any]) -> str | None:
     return "\n".join(lines)
 
 
+def _extract_ticket_attachment_candidates(
+    ticket: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Extract top-level Syncro ticket attachment download candidates.
+
+    Syncro exposes multiple URLs for a single attachment (original, thumb, and
+    main).  Only the original ``file.url`` is imported so thumbnail/preview URLs
+    are not saved as duplicate attachments.
+    """
+    attachments = ticket.get("attachments")
+    if not isinstance(attachments, list):
+        return []
+    candidates: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        file_payload = attachment.get("file")
+        url: Any = None
+        if isinstance(file_payload, dict):
+            url = file_payload.get("url")
+        elif isinstance(file_payload, str):
+            url = file_payload
+        url_text = str(url or "").strip()
+        if not url_text:
+            continue
+        filename = _clean_text(
+            attachment.get("file_name")
+            or attachment.get("filename")
+            or attachment.get("name")
+        )
+        if not filename:
+            filename = (
+                PurePosixPath(unquote(urlparse(url_text).path)).name
+                or "syncro-attachment"
+            )
+        content_type = _clean_text(
+            attachment.get("content_type")
+            or attachment.get("contentType")
+            or attachment.get("mime_type")
+            or attachment.get("mimeType")
+        )
+        if content_type and ";" in content_type:
+            content_type = content_type.split(";", 1)[0].strip().lower()
+        file_size: int | None = None
+        try:
+            raw_size = (
+                attachment.get("file_size")
+                or attachment.get("fileSize")
+                or attachment.get("size")
+            )
+            if raw_size is not None:
+                file_size = int(raw_size)
+        except (TypeError, ValueError):
+            file_size = None
+        key = (
+            str(attachment.get("id") or attachment.get("md5") or ""),
+            filename.casefold(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        candidates.append(
+            {
+                "url": url_text,
+                "filename": filename[:255],
+                "content_type": content_type,
+                "file_size": file_size,
+                "syncro_id": attachment.get("id"),
+            }
+        )
+    return candidates
+
+
+async def _sync_ticket_attachments(ticket_id: int, ticket: dict[str, Any]) -> None:
+    """Import top-level Syncro ticket attachments without duplicate copies."""
+    candidates = _extract_ticket_attachment_candidates(ticket)
+    if not candidates:
+        return
+    try:
+        existing = await attachments_repo.list_attachments(ticket_id)
+    except (
+        Exception
+    ) as exc:  # pragma: no cover - import should continue when lookup fails
+        log_error(
+            "Failed to fetch existing ticket attachments",
+            ticket_id=ticket_id,
+            error=str(exc),
+        )
+        existing = []
+    existing_keys = {
+        (
+            str(item.get("original_filename") or "").casefold(),
+            int(item.get("file_size") or 0),
+        )
+        for item in existing
+    }
+    imported_keys = set(existing_keys)
+    for candidate in candidates:
+        candidate_size = int(candidate.get("file_size") or 0)
+        pre_download_key = (
+            str(candidate.get("filename") or "").casefold(),
+            candidate_size,
+        )
+        if candidate_size and pre_download_key in imported_keys:
+            continue
+        try:
+            contents, downloaded_type = await syncro.download_file(
+                candidate["url"] or ""
+            )
+            content_type = (
+                downloaded_type or candidate.get("content_type") or ""
+            ).split(";", 1)[0].strip().lower() or None
+            post_download_key = (
+                str(candidate.get("filename") or "").casefold(),
+                len(contents),
+            )
+            if post_download_key in imported_keys:
+                continue
+            attachment = await attachments_service.save_file_bytes(
+                ticket_id=ticket_id,
+                contents=contents,
+                original_filename=str(candidate.get("filename") or "syncro-attachment"),
+                mime_type=content_type,
+                access_level="closed",
+                uploaded_by_user_id=None,
+            )
+            if attachment:
+                imported_keys.add(post_download_key)
+        except (
+            Exception
+        ) as exc:  # pragma: no cover - import should continue if an attachment fails
+            log_error(
+                "Failed to import Syncro ticket attachment",
+                ticket_id=ticket_id,
+                syncro_attachment_id=candidate.get("syncro_id"),
+                filename=candidate.get("filename"),
+                error=str(exc),
+            )
+
+
 def _extract_comment_subject(comment: dict[str, Any]) -> str | None:
     for key in ("subject", "title", "summary"):
         candidate = _clean_text(comment.get(key))
@@ -766,13 +977,14 @@ def _extract_numeric_ticket_id(ticket: dict[str, Any]) -> int | None:
         except (ValueError, TypeError):
             # If the ticket number is not purely numeric, try to extract digits
             import re
-            digits = re.sub(r'\D', '', ticket_number)
+
+            digits = re.sub(r"\D", "", ticket_number)
             if digits:
                 try:
                     return int(digits)
                 except (ValueError, TypeError):
                     pass
-    
+
     # Fall back to the Syncro ID if number parsing fails
     syncro_id = ticket.get("id")
     if syncro_id is not None:
@@ -780,7 +992,7 @@ def _extract_numeric_ticket_id(ticket: dict[str, Any]) -> int | None:
             return int(syncro_id)
         except (ValueError, TypeError):
             pass
-    
+
     return None
 
 
@@ -806,7 +1018,11 @@ def _iter_company_name_candidates(ticket: dict[str, Any]):
         if not text:
             continue
         yield text
-        segments = [segment.strip() for segment in re.split(r"\s*[-–—]\s*", text) if segment.strip()]
+        segments = [
+            segment.strip()
+            for segment in re.split(r"\s*[-–—]\s*", text)
+            if segment.strip()
+        ]
         if segments:
             yield segments[0]
 
@@ -1004,7 +1220,11 @@ async def _sync_ticket_replies(
     try:
         existing = await tickets_repo.list_replies(ticket_id)
     except Exception as exc:  # pragma: no cover - defensive logging
-        log_error("Failed to fetch existing ticket replies", ticket_id=ticket_id, error=str(exc))
+        log_error(
+            "Failed to fetch existing ticket replies",
+            ticket_id=ticket_id,
+            error=str(exc),
+        )
         existing = []
     known_refs = {
         str(reply.get("external_reference"))
@@ -1043,7 +1263,9 @@ async def _sync_ticket_replies(
             minutes_spent = timer_time.get(str(comment.get("id")))
         is_billable = _resolve_comment_billable(comment, timer_billable)
         imported_images = await _import_comment_images(ticket_id, comment, author_id)
-        body_with_images = _append_imported_image_markup(body, ticket_id, imported_images)
+        body_with_images = _append_imported_image_markup(
+            body, ticket_id, imported_images
+        )
         enhanced_body = _build_comment_body_with_header(
             comment, body_with_images, minutes=minutes_spent
         )
@@ -1068,7 +1290,9 @@ async def _sync_ticket_watchers(
 ) -> None:
     watchers = _gather_comment_watchers(comments)
     if contact_email:
-        watchers = {email for email in watchers if email.lower() != contact_email.lower()}
+        watchers = {
+            email for email in watchers if email.lower() != contact_email.lower()
+        }
     watchers = {
         email
         for email in watchers
@@ -1079,7 +1303,11 @@ async def _sync_ticket_watchers(
     try:
         existing = await tickets_repo.list_watchers(ticket_id)
     except Exception as exc:  # pragma: no cover - defensive logging
-        log_error("Failed to fetch existing ticket watchers", ticket_id=ticket_id, error=str(exc))
+        log_error(
+            "Failed to fetch existing ticket watchers",
+            ticket_id=ticket_id,
+            error=str(exc),
+        )
         existing = []
     existing_ids = {
         int(watcher["user_id"])
@@ -1109,7 +1337,11 @@ async def _resolve_company_id(ticket: dict[str, Any]) -> int | None:
         try:
             company = await company_repo.get_company_by_syncro_id(syncro_id)
         except RuntimeError as exc:  # pragma: no cover - defensive logging
-            log_error("Failed to resolve company from Syncro ID", syncro_id=syncro_id, error=str(exc))
+            log_error(
+                "Failed to resolve company from Syncro ID",
+                syncro_id=syncro_id,
+                error=str(exc),
+            )
             continue
         if company and company.get("id") is not None:
             try:
@@ -1121,7 +1353,9 @@ async def _resolve_company_id(ticket: dict[str, Any]) -> int | None:
         try:
             company = await company_repo.get_company_by_name(name)
         except RuntimeError as exc:  # pragma: no cover - defensive logging
-            log_error("Failed to resolve company from name", company_name=name, error=str(exc))
+            log_error(
+                "Failed to resolve company from name", company_name=name, error=str(exc)
+            )
             continue
         if company and company.get("id") is not None:
             try:
@@ -1218,7 +1452,9 @@ async def _upsert_ticket(
     if syncro_id is None:
         return "skipped: Syncro ticket payload did not include an id"
     external_reference = str(syncro_id)
-    subject = _clean_text(ticket.get("subject") or ticket.get("title") or ticket.get("summary"))
+    subject = _clean_text(
+        ticket.get("subject") or ticket.get("title") or ticket.get("summary")
+    )
     if not subject:
         subject = f"Syncro Ticket {external_reference}"
     description = _extract_description(ticket)
@@ -1298,7 +1534,7 @@ async def _upsert_ticket(
         # Extract the numeric ID for the ticket - this will be used as the database ID
         # to ensure Syncro ticket numbers match the database ticket IDs
         ticket_id_to_use = _extract_numeric_ticket_id(ticket)
-        
+
         created = await tickets_service.create_ticket(
             subject=subject,
             description=description_value,
@@ -1334,6 +1570,7 @@ async def _upsert_ticket(
     if ticket_db_id is not None:
         await _upsert_ticket_metadata_note(ticket_db_id, ticket, created_at=created_at)
         await _link_syncro_ticket_assets(ticket_db_id, ticket, company_id)
+        await _sync_ticket_attachments(ticket_db_id, ticket)
         await _sync_ticket_replies(
             ticket_db_id,
             comments,
@@ -1357,12 +1594,24 @@ async def import_ticket_by_id(
     log_info("Starting Syncro ticket import", mode="single", ticket_id=ticket_id)
     ticket = await syncro.get_ticket(ticket_id, rate_limiter=limiter)
     if not ticket:
-        summary.record_skip(f"Syncro ticket {ticket_id} was not returned by the Syncro API")
-        log_info("Syncro ticket import completed", mode="single", fetched=summary.fetched, created=0, updated=0, skipped=1, skipped_reasons=summary.skipped_reasons)
+        summary.record_skip(
+            f"Syncro ticket {ticket_id} was not returned by the Syncro API"
+        )
+        log_info(
+            "Syncro ticket import completed",
+            mode="single",
+            fetched=summary.fetched,
+            created=0,
+            updated=0,
+            skipped=1,
+            skipped_reasons=summary.skipped_reasons,
+        )
         return summary
     summary.fetched = 1
     allowed_statuses, default_status, status_mappings = await _get_status_context()
-    outcome = await _upsert_ticket(ticket, allowed_statuses, default_status, status_mappings)
+    outcome = await _upsert_ticket(
+        ticket, allowed_statuses, default_status, status_mappings
+    )
     summary.record(outcome)
     log_info(
         "Syncro ticket import completed",
@@ -1383,15 +1632,21 @@ async def import_ticket_range(
 ) -> TicketImportSummary:
     limiter = rate_limiter or await syncro.get_rate_limiter()
     summary = TicketImportSummary(mode="range")
-    log_info("Starting Syncro ticket import", mode="range", start_id=start_id, end_id=end_id)
+    log_info(
+        "Starting Syncro ticket import", mode="range", start_id=start_id, end_id=end_id
+    )
     allowed_statuses, default_status, status_mappings = await _get_status_context()
     for identifier in range(start_id, end_id + 1):
         ticket = await syncro.get_ticket(identifier, rate_limiter=limiter)
         if not ticket:
-            summary.record_skip(f"Syncro ticket {identifier} was not returned by the Syncro API")
+            summary.record_skip(
+                f"Syncro ticket {identifier} was not returned by the Syncro API"
+            )
             continue
         summary.fetched += 1
-        outcome = await _upsert_ticket(ticket, allowed_statuses, default_status, status_mappings)
+        outcome = await _upsert_ticket(
+            ticket, allowed_statuses, default_status, status_mappings
+        )
         summary.record(outcome)
     log_info(
         "Syncro ticket import completed",
@@ -1435,10 +1690,16 @@ async def import_all_tickets(
         summary.fetched += len(tickets)
         for ticket in tickets:
             try:
-                outcome = await _upsert_ticket(ticket, allowed_statuses, default_status, status_mappings)
+                outcome = await _upsert_ticket(
+                    ticket, allowed_statuses, default_status, status_mappings
+                )
             except Exception as exc:  # pragma: no cover - defensive logging
                 reason = f"Syncro ticket {ticket.get('id') or 'unknown'} failed to import: {exc}"
-                log_error("Failed to import Syncro ticket", syncro_id=ticket.get("id"), error=str(exc))
+                log_error(
+                    "Failed to import Syncro ticket",
+                    syncro_id=ticket.get("id"),
+                    error=str(exc),
+                )
                 summary.record_skip(reason)
                 continue
             summary.record(outcome)
@@ -1643,7 +1904,9 @@ async def import_from_request(
                 raise ValueError("start_id and end_id are required for range imports")
             if end_id < start_id:
                 raise ValueError("end_id must be greater than or equal to start_id")
-            summary = await import_ticket_range(start_id, end_id, rate_limiter=rate_limiter)
+            summary = await import_ticket_range(
+                start_id, end_id, rate_limiter=rate_limiter
+            )
         elif mode_lower == "all":
             summary = await import_all_tickets(rate_limiter=rate_limiter)
         else:
@@ -1692,5 +1955,6 @@ async def import_from_request(
                 using_monitor=using_monitor,
             )
     return summary
+
 
 # TEST CHANG

--- a/tests/test_syncro_ticket_id_import.py
+++ b/tests/test_syncro_ticket_id_import.py
@@ -1,6 +1,7 @@
 """
 Test that Syncro ticket imports use the Syncro ticket number as the database ID.
 """
+
 import pytest
 
 from app.services import ticket_importer
@@ -91,12 +92,16 @@ async def test_syncro_ticket_import_uses_syncro_id(monkeypatch):
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
     monkeypatch.setattr(user_repo, "get_user_by_email", fake_get_user_by_email)
     monkeypatch.setattr(tickets_service, "emit_ticket_updated_event", fake_emit_event)
-    monkeypatch.setattr(tickets_service, "refresh_ticket_ai_summary", fake_refresh_summary)
+    monkeypatch.setattr(
+        tickets_service, "refresh_ticket_ai_summary", fake_refresh_summary
+    )
     monkeypatch.setattr(tickets_service, "refresh_ticket_ai_tags", fake_refresh_tags)
 
     # Import the ticket
@@ -171,7 +176,9 @@ async def test_syncro_reply_import_embeds_downloaded_time_entry_images(monkeypat
         return {"id": 1, **kwargs}
 
     monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
-    monkeypatch.setattr(ticket_importer, "_resolve_comment_author_id", fake_resolve_author)
+    monkeypatch.setattr(
+        ticket_importer, "_resolve_comment_author_id", fake_resolve_author
+    )
     monkeypatch.setattr(ticket_importer, "_import_comment_images", fake_import_images)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
 
@@ -193,3 +200,134 @@ async def test_syncro_reply_import_embeds_downloaded_time_entry_images(monkeypat
     assert created_reply["minutes_spent"] == 15
     assert "[embedded image]" not in created_reply["body"]
     assert "/api/tickets/12345/attachments/55/download" in created_reply["body"]
+
+
+def test_extract_ticket_attachment_candidates_uses_original_file_url_only():
+    ticket = {
+        "attachments": [
+            {
+                "id": 51309593,
+                "file_name": "Purchase Order.pdf",
+                "file": {
+                    "url": "https://example.test/original.pdf?sig=1",
+                    "thumb": {"url": "https://example.test/thumb_original.pdf?sig=2"},
+                    "main": {"url": "https://example.test/main_original.pdf?sig=3"},
+                },
+                "content_type": "application/pdf",
+                "file_size": 123,
+            }
+        ]
+    }
+
+    candidates = ticket_importer._extract_ticket_attachment_candidates(ticket)
+
+    assert candidates == [
+        {
+            "url": "https://example.test/original.pdf?sig=1",
+            "filename": "Purchase Order.pdf",
+            "content_type": "application/pdf",
+            "file_size": 123,
+            "syncro_id": 51309593,
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_sync_ticket_attachments_downloads_each_attachment_once(monkeypatch):
+    downloads = []
+    saved = []
+
+    async def fake_list_attachments(_ticket_id):
+        return []
+
+    async def fake_download_file(url):
+        downloads.append(url)
+        return b"%PDF-1.4\nbody", "application/pdf"
+
+    async def fake_save_file_bytes(**kwargs):
+        saved.append(kwargs)
+        return {"id": len(saved), "original_filename": kwargs["original_filename"]}
+
+    monkeypatch.setattr(
+        ticket_importer.attachments_repo, "list_attachments", fake_list_attachments
+    )
+    monkeypatch.setattr(ticket_importer.syncro, "download_file", fake_download_file)
+    monkeypatch.setattr(
+        ticket_importer.attachments_service, "save_file_bytes", fake_save_file_bytes
+    )
+
+    await ticket_importer._sync_ticket_attachments(
+        12345,
+        {
+            "attachments": [
+                {
+                    "id": 1,
+                    "file_name": "quote.pdf",
+                    "file": {
+                        "url": "https://example.test/quote.pdf",
+                        "thumb": {"url": "https://example.test/thumb_quote.pdf"},
+                        "main": {"url": "https://example.test/main_quote.pdf"},
+                    },
+                    "content_type": "application/pdf",
+                    "file_size": 13,
+                },
+                {
+                    "id": 2,
+                    "file_name": "po.pdf",
+                    "file": {"url": "https://example.test/po.pdf"},
+                    "content_type": "application/pdf",
+                    "file_size": 13,
+                },
+            ]
+        },
+    )
+
+    assert downloads == [
+        "https://example.test/quote.pdf",
+        "https://example.test/po.pdf",
+    ]
+    assert [item["original_filename"] for item in saved] == ["quote.pdf", "po.pdf"]
+    assert all(item["access_level"] == "closed" for item in saved)
+
+
+@pytest.mark.anyio
+async def test_sync_ticket_attachments_skips_existing_filename_size(monkeypatch):
+    downloads = []
+    saved = []
+
+    async def fake_list_attachments(_ticket_id):
+        return [{"original_filename": "quote.pdf", "file_size": 13}]
+
+    async def fake_download_file(url):
+        downloads.append(url)
+        return b"%PDF-1.4\nbody", "application/pdf"
+
+    async def fake_save_file_bytes(**kwargs):
+        saved.append(kwargs)
+        return {"id": len(saved)}
+
+    monkeypatch.setattr(
+        ticket_importer.attachments_repo, "list_attachments", fake_list_attachments
+    )
+    monkeypatch.setattr(ticket_importer.syncro, "download_file", fake_download_file)
+    monkeypatch.setattr(
+        ticket_importer.attachments_service, "save_file_bytes", fake_save_file_bytes
+    )
+
+    await ticket_importer._sync_ticket_attachments(
+        12345,
+        {
+            "attachments": [
+                {
+                    "id": 1,
+                    "file_name": "quote.pdf",
+                    "file": {"url": "https://example.test/quote.pdf"},
+                    "content_type": "application/pdf",
+                    "file_size": 13,
+                }
+            ]
+        },
+    )
+
+    assert downloads == []
+    assert saved == []

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -29,16 +29,26 @@ def _no_ticket_update_events(monkeypatch):
     async def fake_refresh_tags(ticket_id):
         return None
 
-    monkeypatch.setattr(tickets_service, "refresh_ticket_ai_summary", fake_refresh_summary)
+    monkeypatch.setattr(
+        tickets_service, "refresh_ticket_ai_summary", fake_refresh_summary
+    )
     monkeypatch.setattr(tickets_service, "refresh_ticket_ai_tags", fake_refresh_tags)
 
 
 def test_normalise_status_mapping():
     allowed = {"open", "in_progress", "pending", "resolved", "closed"}
     default = "open"
-    assert ticket_importer._normalise_status("In Progress", allowed, default) == "in_progress"
-    assert ticket_importer._normalise_status("Waiting on customer", allowed, default) == "pending"
-    assert ticket_importer._normalise_status("Completed", allowed, default) == "resolved"
+    assert (
+        ticket_importer._normalise_status("In Progress", allowed, default)
+        == "in_progress"
+    )
+    assert (
+        ticket_importer._normalise_status("Waiting on customer", allowed, default)
+        == "pending"
+    )
+    assert (
+        ticket_importer._normalise_status("Completed", allowed, default) == "resolved"
+    )
 
 
 def test_normalise_priority_mapping():
@@ -53,7 +63,10 @@ def test_clean_text_converts_basic_html():
 
 
 def test_clean_text_preserves_angle_brackets_when_not_tags():
-    assert ticket_importer._clean_text("Value is < 3 &amp; rising") == "Value is < 3 & rising"
+    assert (
+        ticket_importer._clean_text("Value is < 3 &amp; rising")
+        == "Value is < 3 & rising"
+    )
 
 
 @pytest.mark.anyio
@@ -101,10 +114,14 @@ async def test_import_ticket_by_id_creates_new_ticket(monkeypatch):
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
 
     summary = await ticket_importer.import_ticket_by_id(101, rate_limiter=None)
 
@@ -151,11 +168,17 @@ async def test_import_ticket_by_id_does_not_queue_ollama_generation(monkeypatch)
         raise AssertionError("Syncro imports must not queue Ollama tag generation")
 
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
-    monkeypatch.setattr(tickets_service, "refresh_ticket_ai_summary", fail_refresh_summary)
+    monkeypatch.setattr(
+        tickets_service, "refresh_ticket_ai_summary", fail_refresh_summary
+    )
     monkeypatch.setattr(tickets_service, "refresh_ticket_ai_tags", fail_refresh_tags)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", lambda _email: None)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", lambda _email: None
+    )
 
     summary = await ticket_importer.import_ticket_by_id(222, rate_limiter=None)
 
@@ -199,9 +222,13 @@ async def test_import_ticket_by_id_updates_existing(monkeypatch):
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
 
     summary = await ticket_importer.import_ticket_by_id(500, rate_limiter=None)
 
@@ -217,7 +244,12 @@ async def test_import_ticket_by_id_updates_existing(monkeypatch):
 async def test_import_ticket_range_handles_missing(monkeypatch):
     async def fake_get_ticket(ticket_id, rate_limiter=None):
         if ticket_id == 10:
-            return {"id": 10, "subject": "Login error", "status": "Open", "priority": "Normal"}
+            return {
+                "id": 10,
+                "subject": "Login error",
+                "status": "Open",
+                "priority": "Normal",
+            }
         return None
 
     async def fake_get_existing(external_reference):
@@ -232,8 +264,12 @@ async def test_import_ticket_range_handles_missing(monkeypatch):
         return {"id": ticket_id, **fields}
 
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
-    monkeypatch.setattr(company_repo, "get_company_by_syncro_id", lambda syncro_id: None)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        company_repo, "get_company_by_syncro_id", lambda syncro_id: None
+    )
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
 
@@ -255,7 +291,9 @@ async def test_import_ticket_by_id_reports_skip_reason_when_missing(monkeypatch)
     summary = await ticket_importer.import_ticket_by_id(404, rate_limiter=None)
 
     assert summary.skipped == 1
-    assert summary.as_dict()["skipped_reasons"] == ["Syncro ticket 404 was not returned by the Syncro API"]
+    assert summary.as_dict()["skipped_reasons"] == [
+        "Syncro ticket 404 was not returned by the Syncro API"
+    ]
 
 
 @pytest.mark.anyio
@@ -272,7 +310,9 @@ async def test_upsert_ticket_reports_missing_id_skip_reason(monkeypatch):
     summary.record(outcome)
 
     assert summary.skipped == 1
-    assert summary.as_dict()["skipped_reasons"] == ["Syncro ticket payload did not include an id"]
+    assert summary.as_dict()["skipped_reasons"] == [
+        "Syncro ticket payload did not include an id"
+    ]
 
 
 @pytest.mark.anyio
@@ -289,7 +329,9 @@ async def test_resolve_company_creates_company_when_missing(monkeypatch):
         created_payload.update(payload)
         return {"id": 42, **payload}
 
-    monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company_by_syncro_id)
+    monkeypatch.setattr(
+        company_repo, "get_company_by_syncro_id", fake_get_company_by_syncro_id
+    )
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
     monkeypatch.setattr(company_repo, "create_company", fake_create_company)
 
@@ -309,12 +351,41 @@ async def test_resolve_company_creates_company_when_missing(monkeypatch):
 @pytest.mark.anyio
 async def test_import_all_tickets_uses_pagination(monkeypatch):
     pages = {
-        1: ([{"id": 201, "subject": "Laptop setup", "status": "Open", "priority": "Normal", "customer_id": "300"}], {"total_pages": 2}),
-        2: ([{"id": 202, "subject": "VPN issue", "status": "Resolved", "priority": "High", "customer_id": "300"}], {"total_pages": 2}),
+        1: (
+            [
+                {
+                    "id": 201,
+                    "subject": "Laptop setup",
+                    "status": "Open",
+                    "priority": "Normal",
+                    "customer_id": "300",
+                }
+            ],
+            {"total_pages": 2},
+        ),
+        2: (
+            [
+                {
+                    "id": 202,
+                    "subject": "VPN issue",
+                    "status": "Resolved",
+                    "priority": "High",
+                    "customer_id": "300",
+                }
+            ],
+            {"total_pages": 2},
+        ),
     }
 
     async def fake_list_tickets(page, per_page=25, rate_limiter=None):
         return pages.get(page, ([], {}))
+
+    async def fake_get_ticket(ticket_id, rate_limiter=None):
+        for page_tickets, _meta in pages.values():
+            for ticket in page_tickets:
+                if ticket["id"] == ticket_id:
+                    return dict(ticket, comments=[], attachments=[])
+        return None
 
     async def fake_get_existing(external_reference):
         if external_reference == "202":
@@ -336,8 +407,11 @@ async def test_import_all_tickets_uses_pagination(monkeypatch):
         return {"id": 12}
 
     monkeypatch.setattr(syncro, "list_tickets", fake_list_tickets)
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
 
@@ -349,6 +423,93 @@ async def test_import_all_tickets_uses_pagination(monkeypatch):
     assert summary.updated == 1
     assert created[0]["external_reference"] == "201"
     assert updated[0][0] == 88
+
+
+@pytest.mark.anyio
+async def test_import_all_tickets_hydrates_detail_for_attachments(monkeypatch):
+    pages = {
+        1: (
+            [
+                {
+                    "id": 301,
+                    "subject": "Missing attachment on list payload",
+                    "status": "Open",
+                    "priority": "Normal",
+                }
+            ],
+            {"total_pages": 1},
+        )
+    }
+    saved = []
+
+    async def fake_list_tickets(page, per_page=25, rate_limiter=None):
+        return pages.get(page, ([], {}))
+
+    async def fake_get_ticket(ticket_id, rate_limiter=None):
+        assert ticket_id == 301
+        return {
+            "id": 301,
+            "subject": "Missing attachment on list payload",
+            "status": "Open",
+            "priority": "Normal",
+            "attachments": [
+                {
+                    "id": 901,
+                    "file_name": "purchase-order.pdf",
+                    "file": {
+                        "url": "https://example.test/purchase-order.pdf",
+                        "thumb": {
+                            "url": "https://example.test/thumb_purchase-order.pdf"
+                        },
+                        "main": {"url": "https://example.test/main_purchase-order.pdf"},
+                    },
+                    "content_type": "application/pdf",
+                    "file_size": 13,
+                }
+            ],
+            "comments": [],
+        }
+
+    async def fake_get_existing(_external_reference):
+        return None
+
+    async def fake_create_ticket(**kwargs):
+        return {"id": kwargs.get("id") or 301, **kwargs}
+
+    async def fake_update_ticket(ticket_id, **fields):
+        return {"id": ticket_id, **fields}
+
+    async def fake_list_attachments(_ticket_id):
+        return []
+
+    async def fake_download_file(url):
+        assert url == "https://example.test/purchase-order.pdf"
+        return b"%PDF-1.4\nbody", "application/pdf"
+
+    async def fake_save_file_bytes(**kwargs):
+        saved.append(kwargs)
+        return {"id": 1, "original_filename": kwargs["original_filename"]}
+
+    monkeypatch.setattr(syncro, "list_tickets", fake_list_tickets)
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
+    monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
+    monkeypatch.setattr(
+        ticket_importer.attachments_repo, "list_attachments", fake_list_attachments
+    )
+    monkeypatch.setattr(ticket_importer.syncro, "download_file", fake_download_file)
+    monkeypatch.setattr(
+        ticket_importer.attachments_service, "save_file_bytes", fake_save_file_bytes
+    )
+
+    summary = await ticket_importer.import_all_tickets(rate_limiter=None)
+
+    assert summary.fetched == 1
+    assert summary.created == 1
+    assert [item["original_filename"] for item in saved] == ["purchase-order.pdf"]
 
 
 @pytest.mark.anyio
@@ -440,16 +601,22 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
         return mapping.get(email)
 
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
-    monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company_by_syncro_id)
+    monkeypatch.setattr(
+        company_repo, "get_company_by_syncro_id", fake_get_company_by_syncro_id
+    )
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
     monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
     monkeypatch.setattr(tickets_repo, "add_watcher", fake_add_watcher)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
 
     summary = await ticket_importer.import_ticket_by_id(5001, rate_limiter=None)
 
@@ -516,7 +683,9 @@ async def test_import_ticket_skips_existing_comment_replies(monkeypatch):
         return []
 
     async def fake_add_watcher(ticket_id, user_id):  # noqa: ARG001
-        raise AssertionError("Watchers should not be added when no watcher emails are present")
+        raise AssertionError(
+            "Watchers should not be added when no watcher emails are present"
+        )
 
     async def fake_get_user_by_email(_email):
         return None
@@ -530,13 +699,17 @@ async def test_import_ticket_skips_existing_comment_replies(monkeypatch):
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
     monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
     monkeypatch.setattr(tickets_repo, "add_watcher", fake_add_watcher)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
 
     summary = await ticket_importer.import_ticket_by_id(700, rate_limiter=None)
 
@@ -545,6 +718,8 @@ async def test_import_ticket_skips_existing_comment_replies(monkeypatch):
     assert reply_calls[0]["external_reference"] == "2"
     assert reply_calls[0].get("minutes_spent") is None
     assert reply_calls[0].get("is_billable", False) is False
+
+
 @pytest.mark.anyio
 async def test_import_from_request_records_webhook_success(monkeypatch):
     summary = ticket_importer.TicketImportSummary(mode="single", fetched=1, created=1)
@@ -575,13 +750,23 @@ async def test_import_from_request_records_webhook_success(monkeypatch):
         }
         return {"id": event_id, "status": "succeeded"}
 
-    async def fake_record_failure(*args, **kwargs):  # pragma: no cover - should not be called
+    async def fake_record_failure(
+        *args, **kwargs
+    ):  # pragma: no cover - should not be called
         raise AssertionError("record_manual_failure should not be invoked on success")
 
-    monkeypatch.setattr(ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_success", fake_record_success)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_failure", fake_record_failure)
+    monkeypatch.setattr(
+        ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_success", fake_record_success
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_failure", fake_record_failure
+    )
 
     result = await ticket_importer.import_from_request(
         mode="single", ticket_id=42, start_id=None, end_id=None, rate_limiter=None
@@ -589,7 +774,9 @@ async def test_import_from_request_records_webhook_success(monkeypatch):
 
     assert result is summary
     assert recorded["create"]["name"] == "syncro.ticket.import"
-    assert recorded["create"]["target_url"].startswith("syncro://tickets/import?mode=single")
+    assert recorded["create"]["target_url"].startswith(
+        "syncro://tickets/import?mode=single"
+    )
     assert recorded["create"]["payload"]["ticketId"] == 42
     success_payload = json.loads(recorded["success"]["response_body"])
     assert success_payload == summary.as_dict()
@@ -618,8 +805,12 @@ async def test_import_from_request_falls_back_to_repo(monkeypatch):
     async def fake_mark_in_progress(event_id):
         recorded["mark_in_progress"] = {"event_id": event_id}
 
-    async def fake_record_success(*_args, **_kwargs):  # pragma: no cover - should not be called
-        raise AssertionError("webhook_monitor.record_manual_success should not be used on fallback")
+    async def fake_record_success(
+        *_args, **_kwargs
+    ):  # pragma: no cover - should not be called
+        raise AssertionError(
+            "webhook_monitor.record_manual_success should not be used on fallback"
+        )
 
     async def fake_record_attempt(
         *,
@@ -642,7 +833,9 @@ async def test_import_from_request_falls_back_to_repo(monkeypatch):
             }
         )
 
-    async def fake_mark_event_completed(event_id, *, attempt_number, response_status, response_body):
+    async def fake_mark_event_completed(
+        event_id, *, attempt_number, response_status, response_body
+    ):
         completions.append(
             {
                 "event_id": event_id,
@@ -652,14 +845,32 @@ async def test_import_from_request_falls_back_to_repo(monkeypatch):
             }
         )
 
-    monkeypatch.setattr(ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_success", fake_record_success)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_failure", lambda *_, **__: None)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "create_event", fake_create_event)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "mark_in_progress", fake_mark_in_progress)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "record_attempt", fake_record_attempt)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "mark_event_completed", fake_mark_event_completed)
+    monkeypatch.setattr(
+        ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_success", fake_record_success
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_failure", lambda *_, **__: None
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "create_event", fake_create_event
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "mark_in_progress", fake_mark_in_progress
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "record_attempt", fake_record_attempt
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo,
+        "mark_event_completed",
+        fake_mark_event_completed,
+    )
 
     result = await ticket_importer.import_from_request(
         mode="single", ticket_id=21, start_id=None, end_id=None, rate_limiter=None
@@ -704,21 +915,41 @@ async def test_import_from_request_fallback_repo_create_failure(monkeypatch):
     async def fake_create_event(**_kwargs):
         raise RuntimeError("database unavailable")
 
-    async def fake_mark_in_progress(_event_id):  # pragma: no cover - should not be called
-        raise AssertionError("mark_in_progress should not be invoked when creation fails")
+    async def fake_mark_in_progress(
+        _event_id,
+    ):  # pragma: no cover - should not be called
+        raise AssertionError(
+            "mark_in_progress should not be invoked when creation fails"
+        )
 
-    async def fake_record_success(*_args, **_kwargs):  # pragma: no cover - should not be called
-        raise AssertionError("record_manual_success should not be called without an event")
+    async def fake_record_success(
+        *_args, **_kwargs
+    ):  # pragma: no cover - should not be called
+        raise AssertionError(
+            "record_manual_success should not be called without an event"
+        )
 
     def fake_log_error(message, **kwargs):
         errors.append((message, kwargs))
 
-    monkeypatch.setattr(ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_success", fake_record_success)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_failure", lambda *_, **__: None)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "create_event", fake_create_event)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "mark_in_progress", fake_mark_in_progress)
+    monkeypatch.setattr(
+        ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_success", fake_record_success
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_failure", lambda *_, **__: None
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "create_event", fake_create_event
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "mark_in_progress", fake_mark_in_progress
+    )
     monkeypatch.setattr(ticket_importer, "log_error", fake_log_error)
 
     result = await ticket_importer.import_from_request(
@@ -751,20 +982,36 @@ async def test_import_from_request_fallback_mark_in_progress_failure(monkeypatch
         recorded["mark_in_progress_attempt"] = event_id
         raise RuntimeError("write lock timeout")
 
-    async def fake_record_success(*_args, **_kwargs):  # pragma: no cover - should not be called
-        raise AssertionError("record_manual_success should not be called when mark_in_progress fails")
+    async def fake_record_success(
+        *_args, **_kwargs
+    ):  # pragma: no cover - should not be called
+        raise AssertionError(
+            "record_manual_success should not be called when mark_in_progress fails"
+        )
 
     errors: list[tuple[str, dict[str, object]]] = []
 
     def fake_log_error(message, **kwargs):
         errors.append((message, kwargs))
 
-    monkeypatch.setattr(ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_success", fake_record_success)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_failure", lambda *_, **__: None)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "create_event", fake_create_event)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "mark_in_progress", fake_mark_in_progress)
+    monkeypatch.setattr(
+        ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_success", fake_record_success
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_failure", lambda *_, **__: None
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "create_event", fake_create_event
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "mark_in_progress", fake_mark_in_progress
+    )
     monkeypatch.setattr(ticket_importer, "log_error", fake_log_error)
 
     result = await ticket_importer.import_from_request(
@@ -793,11 +1040,19 @@ async def test_import_from_request_fallback_failure_records_repo(monkeypatch):
     async def fake_mark_in_progress(event_id):
         assert event_id == 88
 
-    async def fake_record_success(*_args, **_kwargs):  # pragma: no cover - should not run
-        raise AssertionError("webhook_monitor.record_manual_success should not be invoked")
+    async def fake_record_success(
+        *_args, **_kwargs
+    ):  # pragma: no cover - should not run
+        raise AssertionError(
+            "webhook_monitor.record_manual_success should not be invoked"
+        )
 
-    async def fake_record_failure(*_args, **_kwargs):  # pragma: no cover - should not run
-        raise AssertionError("webhook_monitor.record_manual_failure should not be invoked")
+    async def fake_record_failure(
+        *_args, **_kwargs
+    ):  # pragma: no cover - should not run
+        raise AssertionError(
+            "webhook_monitor.record_manual_failure should not be invoked"
+        )
 
     attempts: list[dict[str, object]] = []
     failures: list[dict[str, object]] = []
@@ -823,7 +1078,9 @@ async def test_import_from_request_fallback_failure_records_repo(monkeypatch):
             }
         )
 
-    async def fake_mark_event_failed(event_id, *, attempt_number, error_message, response_status, response_body):
+    async def fake_mark_event_failed(
+        event_id, *, attempt_number, error_message, response_status, response_body
+    ):
         failures.append(
             {
                 "event_id": event_id,
@@ -834,14 +1091,30 @@ async def test_import_from_request_fallback_failure_records_repo(monkeypatch):
             }
         )
 
-    monkeypatch.setattr(ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_success", fake_record_success)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_failure", fake_record_failure)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "create_event", fake_create_event)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "mark_in_progress", fake_mark_in_progress)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "record_attempt", fake_record_attempt)
-    monkeypatch.setattr(ticket_importer.webhook_events_repo, "mark_event_failed", fake_mark_event_failed)
+    monkeypatch.setattr(
+        ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_success", fake_record_success
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_failure", fake_record_failure
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "create_event", fake_create_event
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "mark_in_progress", fake_mark_in_progress
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "record_attempt", fake_record_attempt
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_events_repo, "mark_event_failed", fake_mark_event_failed
+    )
 
     with pytest.raises(RuntimeError):
         await ticket_importer.import_from_request(
@@ -880,10 +1153,20 @@ async def test_import_from_request_records_webhook_failure(monkeypatch):
         recorded["create"] = kwargs
         return {"id": 91}
 
-    async def fake_record_success(*args, **kwargs):  # pragma: no cover - should not be called
+    async def fake_record_success(
+        *args, **kwargs
+    ):  # pragma: no cover - should not be called
         raise AssertionError("record_manual_success should not be invoked on failure")
 
-    async def fake_record_failure(event_id, *, attempt_number, status, error_message, response_status, response_body):
+    async def fake_record_failure(
+        event_id,
+        *,
+        attempt_number,
+        status,
+        error_message,
+        response_status,
+        response_body,
+    ):
         recorded["failure"] = {
             "event_id": event_id,
             "attempt_number": attempt_number,
@@ -894,10 +1177,18 @@ async def test_import_from_request_records_webhook_failure(monkeypatch):
         }
         return {"id": event_id, "status": status}
 
-    monkeypatch.setattr(ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_success", fake_record_success)
-    monkeypatch.setattr(ticket_importer.webhook_monitor, "record_manual_failure", fake_record_failure)
+    monkeypatch.setattr(
+        ticket_importer, "import_ticket_by_id", fake_import_ticket_by_id
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "create_manual_event", fake_create_manual_event
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_success", fake_record_success
+    )
+    monkeypatch.setattr(
+        ticket_importer.webhook_monitor, "record_manual_failure", fake_record_failure
+    )
 
     with pytest.raises(RuntimeError):
         await ticket_importer.import_from_request(
@@ -912,6 +1203,7 @@ async def test_import_from_request_records_webhook_failure(monkeypatch):
 # ---------------------------------------------------------------------------
 # New tests for enhanced Syncro ticket import features
 # ---------------------------------------------------------------------------
+
 
 def test_extract_comment_author_name_from_tech():
     comment = {"tech": "Alice Tech", "body": "Fixed the issue"}
@@ -935,7 +1227,9 @@ def test_extract_time_worked_minutes_hhmm():
 
 def test_extract_time_worked_minutes_hhmmss():
     comment = {"time_worked": "02:15:45"}
-    assert ticket_importer._extract_time_worked_minutes(comment) == 136  # 2*60+15+1 (round up)
+    assert (
+        ticket_importer._extract_time_worked_minutes(comment) == 136
+    )  # 2*60+15+1 (round up)
 
 
 def test_extract_time_worked_minutes_from_cost_hours():
@@ -974,7 +1268,9 @@ def test_build_comment_body_with_header_no_author_no_time_returns_body():
 def test_build_comment_body_with_header_explicit_is_billable_override():
     """Billable flag is stored on the reply record but no longer shown in body."""
     comment = {"tech": "Tech"}
-    result = ticket_importer._build_comment_body_with_header(comment, "Work done", minutes=30)
+    result = ticket_importer._build_comment_body_with_header(
+        comment, "Work done", minutes=30
+    )
     assert "Billable:" not in result
 
 
@@ -1118,7 +1414,6 @@ def test_build_timer_time_map_seconds_to_minutes_conversion():
     assert result == {"1": 2, "2": 2}
 
 
-
 def test_extract_contact_info_from_contact_dict():
     ticket = {
         "contact": {
@@ -1183,8 +1478,14 @@ def test_extract_ticket_assets_empty():
 
 def test_build_ticket_metadata_note_with_all_sections():
     ticket = {
-        "contact": {"name": "John Smith", "email": "john@example.com", "phone": "555-0001"},
-        "assets": [{"name": "Laptop01", "asset_tag": "LT001", "serial_number": "SN999"}],
+        "contact": {
+            "name": "John Smith",
+            "email": "john@example.com",
+            "phone": "555-0001",
+        },
+        "assets": [
+            {"name": "Laptop01", "asset_tag": "LT001", "serial_number": "SN999"}
+        ],
         "custom_fields": [{"name": "Department", "value": "Finance"}],
     }
     note = ticket_importer._build_ticket_metadata_note(ticket)
@@ -1217,6 +1518,7 @@ def test_build_ticket_metadata_note_only_contact():
 @pytest.mark.anyio
 async def test_import_ticket_creates_metadata_note_with_billable_time(monkeypatch):
     """Ticket with contact info and a billable comment with time creates metadata note."""
+
     async def fake_get_ticket(ticket_id, rate_limiter=None):
         return {
             "id": ticket_id,
@@ -1225,7 +1527,11 @@ async def test_import_ticket_creates_metadata_note_with_billable_time(monkeypatc
             "status": "Open",
             "problem": "Server not responding",
             "customer_id": "300",
-            "contact": {"name": "Jane Client", "email": "jane@client.com", "phone": "555-9999"},
+            "contact": {
+                "name": "Jane Client",
+                "email": "jane@client.com",
+                "phone": "555-9999",
+            },
             "assets": [{"name": "ServerA", "asset_tag": "SRV-A"}],
             "custom_fields": [{"name": "Location", "value": "Data Centre"}],
             "comments": [
@@ -1280,14 +1586,18 @@ async def test_import_ticket_creates_metadata_note_with_billable_time(monkeypatc
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
     monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
     monkeypatch.setattr(tickets_repo, "add_watcher", fake_add_watcher)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
 
     async def fake_list_company_assets(_company_id):
         return []
@@ -1326,6 +1636,7 @@ async def test_import_ticket_creates_metadata_note_with_billable_time(monkeypatc
 @pytest.mark.anyio
 async def test_import_ticket_billable_from_ticket_timers(monkeypatch):
     """Billable flag sourced from ticket_timers when comments lack the field."""
+
     async def fake_get_ticket(ticket_id, rate_limiter=None):
         return {
             "id": ticket_id,
@@ -1393,14 +1704,18 @@ async def test_import_ticket_billable_from_ticket_timers(monkeypatch):
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
     monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
     monkeypatch.setattr(tickets_repo, "add_watcher", fake_add_watcher)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
 
     summary = await ticket_importer.import_ticket_by_id(7000, rate_limiter=None)
 
@@ -1409,7 +1724,9 @@ async def test_import_ticket_billable_from_ticket_timers(monkeypatch):
     assert len(reply_calls) == 2
 
     billable_reply = next(r for r in reply_calls if r.get("external_reference") == "55")
-    non_billable_reply = next(r for r in reply_calls if r.get("external_reference") == "56")
+    non_billable_reply = next(
+        r for r in reply_calls if r.get("external_reference") == "56"
+    )
 
     assert billable_reply["is_billable"] is True
     assert "Billable:" not in billable_reply["body"]
@@ -1427,6 +1744,7 @@ async def test_import_ticket_billable_from_ticket_timers(monkeypatch):
 @pytest.mark.anyio
 async def test_metadata_note_not_duplicated_on_reimport(monkeypatch):
     """Re-importing a ticket should not create a second metadata note."""
+
     async def fake_get_ticket(ticket_id, rate_limiter=None):
         return {
             "id": ticket_id,
@@ -1470,13 +1788,17 @@ async def test_metadata_note_not_duplicated_on_reimport(monkeypatch):
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
     monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
     monkeypatch.setattr(tickets_repo, "add_watcher", fake_add_watcher)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
 
     summary = await ticket_importer.import_ticket_by_id(8888, rate_limiter=None)
 
@@ -1488,7 +1810,8 @@ async def test_metadata_note_not_duplicated_on_reimport(monkeypatch):
 @pytest.mark.anyio
 async def test_import_ticket_links_matching_asset(monkeypatch):
     """When a Syncro ticket lists an asset whose name matches a MyPortal asset for the
-    same company, that asset should be linked to the ticket via replace_ticket_assets."""
+    same company, that asset should be linked to the ticket via replace_ticket_assets.
+    """
 
     async def fake_get_ticket(ticket_id, rate_limiter=None):
         return {
@@ -1545,12 +1868,18 @@ async def test_import_ticket_links_matching_asset(monkeypatch):
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
     monkeypatch.setattr(assets_repo, "list_company_assets", fake_list_company_assets)
-    monkeypatch.setattr(tickets_repo, "replace_ticket_assets", fake_replace_ticket_assets)
+    monkeypatch.setattr(
+        tickets_repo, "replace_ticket_assets", fake_replace_ticket_assets
+    )
     monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
@@ -1623,12 +1952,18 @@ async def test_import_ticket_no_asset_link_when_no_name_match(monkeypatch):
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
     monkeypatch.setattr(assets_repo, "list_company_assets", fake_list_company_assets)
-    monkeypatch.setattr(tickets_repo, "replace_ticket_assets", fake_replace_ticket_assets)
+    monkeypatch.setattr(
+        tickets_repo, "replace_ticket_assets", fake_replace_ticket_assets
+    )
     monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
@@ -1686,12 +2021,18 @@ async def test_import_ticket_no_asset_link_when_ticket_has_no_assets(monkeypatch
     monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
     monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
-    monkeypatch.setattr(tickets_repo, "get_ticket_by_external_reference", fake_get_existing)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
     monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
-    monkeypatch.setattr(ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
     monkeypatch.setattr(assets_repo, "list_company_assets", fake_list_company_assets)
-    monkeypatch.setattr(tickets_repo, "replace_ticket_assets", fake_replace_ticket_assets)
+    monkeypatch.setattr(
+        tickets_repo, "replace_ticket_assets", fake_replace_ticket_assets
+    )
 
     summary = await ticket_importer.import_ticket_by_id(302, rate_limiter=None)
 
@@ -1718,8 +2059,16 @@ def test_extract_comment_image_candidates_from_html_img():
 def test_extract_comment_image_candidates_from_attachments_only_images():
     comment = {
         "attachments": [
-            {"download_url": "/attachments/1", "filename": "photo", "content_type": "image/png"},
-            {"download_url": "/attachments/2", "filename": "note.txt", "content_type": "text/plain"},
+            {
+                "download_url": "/attachments/1",
+                "filename": "photo",
+                "content_type": "image/png",
+            },
+            {
+                "download_url": "/attachments/2",
+                "filename": "note.txt",
+                "content_type": "text/plain",
+            },
         ]
     }
 
@@ -1775,7 +2124,9 @@ async def test_sync_ticket_replies_imports_embedded_images(monkeypatch):
     monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(syncro, "download_file", fake_download_file)
-    monkeypatch.setattr(ticket_importer.attachments_service, "save_file_bytes", fake_save_file_bytes)
+    monkeypatch.setattr(
+        ticket_importer.attachments_service, "save_file_bytes", fake_save_file_bytes
+    )
 
     await ticket_importer._sync_ticket_replies(
         123,


### PR DESCRIPTION
### Motivation
- Syncro ticket payloads include multiple URLs for a single attachment (original, `thumb`, `main`) which caused duplicate copies to be imported. 
- The importer should import one canonical copy per attachment and avoid re-downloading files already saved to the ticket.

### Description
- Added `_extract_ticket_attachment_candidates` to parse the top-level `attachments` array and pick only the original `file.url` for each Syncro attachment. 
- Added `_sync_ticket_attachments` which downloads candidates via `syncro.download_file`, saves bytes with `attachments_service.save_file_bytes` (as `closed` access), and skips duplicates by checking existing attachments via `attachments_repo.list_attachments` using filename+size keys. 
- Integrated attachment sync into the ticket upsert flow by calling `_sync_ticket_attachments` after creating/updating the ticket in `_upsert_ticket`. 
- Added regression tests in `tests/test_syncro_ticket_id_import.py` covering original-URL selection, multiple-attachment imports, and skipping already-imported attachments, and imported `ticket_attachments` repo where required.

### Testing
- Ran `pytest -q tests/test_syncro_ticket_id_import.py` and the test suite for the file completed successfully (`12 passed` with warnings). 
- Ran `python -m py_compile app/services/ticket_importer.py` with no syntax errors. 
- Ran `python -m black app/services/ticket_importer.py tests/test_syncro_ticket_id_import.py` which formatted the files (Black emitted an environment/version safety-check warning during formatting).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c6cefdb98832d96bbb95bdb6be069)