### PR TITLE
Skip unchanged Syncro ticket imports

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -207,8 +207,16 @@ def _normalise_ticket(row: dict[str, Any]) -> TicketRecord:
     for key in ("id", "company_id", "requester_id", "requester_staff_id", "assigned_user_id", "merged_into_ticket_id", "split_from_ticket_id"):
         if key in record and record[key] is not None:
             record[key] = int(record[key])
-    for key in ("created_at", "updated_at", "closed_at", "status_changed_at", "ai_summary_updated_at"):
-        record[key] = _make_aware(record.get(key))
+    for key in (
+        "created_at",
+        "updated_at",
+        "closed_at",
+        "status_changed_at",
+        "ai_summary_updated_at",
+        "syncro_updated_at",
+    ):
+        if key in record:
+            record[key] = _make_aware(record.get(key))
     record["ai_tags"] = _deserialise_tags(record.get("ai_tags"))
     record["ai_tags_updated_at"] = _make_aware(record.get("ai_tags_updated_at"))
     return record
@@ -382,6 +390,7 @@ async def create_ticket(
         "ai_tags_updated_at": None,
         "created_at": None,
         "updated_at": None,
+        "syncro_updated_at": None,
         "closed_at": None,
     }
     return _normalise_ticket(fallback_row)

--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -228,6 +228,40 @@ def _parse_datetime(value: Any) -> datetime | None:
     return parsed.replace(tzinfo=timezone.utc)
 
 
+def _ticket_updated_at(ticket: dict[str, Any]) -> datetime | None:
+    return _parse_datetime(
+        ticket.get("updated_at")
+        or ticket.get("updated_on")
+        or ticket.get("updated")
+        or ticket.get("updated_at_utc")
+    )
+
+
+def _existing_syncro_updated_at(existing: dict[str, Any]) -> datetime | None:
+    """Return the last Syncro update timestamp stored for an imported ticket.
+
+    Older imports predate ``syncro_updated_at`` and stored Syncro's
+    ``updated_at`` in the main ticket timestamp, so fall back to that value once.
+    """
+    return _parse_datetime(existing.get("syncro_updated_at")) or _parse_datetime(
+        existing.get("updated_at")
+    )
+
+
+def _syncro_ticket_is_unchanged(
+    ticket: dict[str, Any], existing: dict[str, Any] | None
+) -> bool:
+    if not existing:
+        return False
+    syncro_updated_at = _ticket_updated_at(ticket)
+    if syncro_updated_at is None:
+        return False
+    last_imported_syncro_updated_at = _existing_syncro_updated_at(existing)
+    if last_imported_syncro_updated_at is None:
+        return False
+    return syncro_updated_at <= last_imported_syncro_updated_at
+
+
 def _extract_comment_body(comment: dict[str, Any]) -> str | None:
     """Return the best available formatted Syncro comment body.
 
@@ -1554,12 +1588,7 @@ async def _upsert_ticket(
         or ticket.get("created")
         or ticket.get("created_at_utc")
     )
-    updated_at = _parse_datetime(
-        ticket.get("updated_at")
-        or ticket.get("updated_on")
-        or ticket.get("updated")
-        or ticket.get("updated_at_utc")
-    )
+    updated_at = _ticket_updated_at(ticket)
     closed_at = _parse_datetime(
         ticket.get("resolved_at")
         or ticket.get("closed_at")
@@ -1582,6 +1611,9 @@ async def _upsert_ticket(
     description_value: str | None = description or None
     category_value: str | None = category or None
 
+    if existing and _syncro_ticket_is_unchanged(ticket, existing):
+        return f"skipped: Syncro ticket {external_reference} has not changed since last import"
+
     if existing:
         updates: dict[str, Any] = {
             "subject": subject,
@@ -1601,6 +1633,7 @@ async def _upsert_ticket(
             updates["created_at"] = created_at
         if updated_at is not None:
             updates["updated_at"] = updated_at
+            updates["syncro_updated_at"] = updated_at
         await tickets_repo.update_ticket(int(existing["id"]), **updates)
         await tickets_service.emit_ticket_updated_event(
             int(existing["id"]),
@@ -1637,6 +1670,7 @@ async def _upsert_ticket(
                 timestamp_updates["created_at"] = created_at
             if updated_at is not None:
                 timestamp_updates["updated_at"] = updated_at
+                timestamp_updates["syncro_updated_at"] = updated_at
             if closed_at is not None:
                 timestamp_updates["closed_at"] = closed_at
             await tickets_repo.update_ticket(int(created_id), **timestamp_updates)
@@ -1801,12 +1835,21 @@ async def import_all_tickets(
         summary.fetched += len(tickets)
         for ticket in tickets:
             try:
-                ticket_detail = await _fetch_ticket_detail_for_import(
-                    ticket, rate_limiter=limiter
+                syncro_id = ticket.get("id")
+                existing = (
+                    await tickets_repo.get_ticket_by_external_reference(str(syncro_id))
+                    if syncro_id is not None
+                    else None
                 )
-                outcome = await _upsert_ticket(
-                    ticket_detail, allowed_statuses, default_status, status_mappings
-                )
+                if _syncro_ticket_is_unchanged(ticket, existing):
+                    outcome = f"skipped: Syncro ticket {syncro_id} has not changed since last import"
+                else:
+                    ticket_detail = await _fetch_ticket_detail_for_import(
+                        ticket, rate_limiter=limiter
+                    )
+                    outcome = await _upsert_ticket(
+                        ticket_detail, allowed_statuses, default_status, status_mappings
+                    )
             except Exception as exc:  # pragma: no cover - defensive logging
                 reason = f"Syncro ticket {ticket.get('id') or 'unknown'} failed to import: {exc}"
                 log_error(

--- a/migrations/290_ticket_syncro_updated_at.sql
+++ b/migrations/290_ticket_syncro_updated_at.sql
@@ -1,0 +1,3 @@
+-- Track the last Syncro updated_at value imported for each ticket.
+ALTER TABLE tickets ADD COLUMN syncro_updated_at DATETIME(6) NULL;
+CREATE INDEX idx_tickets_syncro_updated_at ON tickets(syncro_updated_at);

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -241,6 +241,90 @@ async def test_import_ticket_by_id_updates_existing(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_import_ticket_by_id_skips_existing_when_syncro_updated_at_unchanged(monkeypatch):
+    async def fake_get_ticket(ticket_id, rate_limiter=None):
+        return {
+            "id": ticket_id,
+            "subject": "Network outage",
+            "status": "Resolved",
+            "updated_at": "2025-01-02T10:45:00Z",
+        }
+
+    async def fake_get_existing(external_reference):
+        return {
+            "id": 99,
+            "external_reference": external_reference,
+            "syncro_updated_at": "2025-01-02T10:45:00Z",
+            "updated_at": "2025-01-05T09:00:00Z",
+        }
+
+    async def fail_update_ticket(*args, **kwargs):
+        raise AssertionError("Unchanged Syncro tickets should not update MyPortal")
+
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
+    monkeypatch.setattr(tickets_repo, "update_ticket", fail_update_ticket)
+
+    summary = await ticket_importer.import_ticket_by_id(500, rate_limiter=None)
+
+    assert summary.updated == 0
+    assert summary.created == 0
+    assert summary.skipped == 1
+    assert summary.skipped_reasons == [
+        "Syncro ticket 500 has not changed since last import"
+    ]
+
+
+@pytest.mark.anyio
+async def test_import_ticket_by_id_updates_existing_when_syncro_updated_at_newer(monkeypatch):
+    async def fake_get_ticket(ticket_id, rate_limiter=None):
+        return {
+            "id": ticket_id,
+            "subject": "Network outage",
+            "priority": "Critical",
+            "status": "Resolved",
+            "updated_at": "2025-01-03T10:45:00Z",
+        }
+
+    async def fake_get_existing(external_reference):
+        return {
+            "id": 99,
+            "external_reference": external_reference,
+            "syncro_updated_at": "2025-01-02T10:45:00Z",
+            "updated_at": "2025-01-05T09:00:00Z",
+        }
+
+    update_calls = []
+
+    async def fake_update_ticket(ticket_id, **fields):
+        update_calls.append((ticket_id, fields))
+        return {"id": ticket_id, **fields}
+
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
+    monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", lambda _email: None
+    )
+
+    summary = await ticket_importer.import_ticket_by_id(500, rate_limiter=None)
+
+    assert summary.updated == 1
+    assert (
+        update_calls[0][1]["syncro_updated_at"].isoformat()
+        == "2025-01-03T10:45:00+00:00"
+    )
+    assert (
+        update_calls[0][1]["updated_at"].isoformat()
+        == "2025-01-03T10:45:00+00:00"
+    )
+
+
+@pytest.mark.anyio
 async def test_import_ticket_range_handles_missing(monkeypatch):
     async def fake_get_ticket(ticket_id, rate_limiter=None):
         if ticket_id == 10:


### PR DESCRIPTION
### Motivation
- Prevent repeated imports/updates for Syncro tickets that have not changed by tracking and comparing Syncro `updated_at` values before touching MyPortal records.

### Description
- Add a new DB migration `migrations/290_ticket_syncro_updated_at.sql` to add `tickets.syncro_updated_at` and an index for efficient comparisons.
- Return and normalise the new `syncro_updated_at` field in ticket records so it is available as a UTC-aware datetime. (`app/repositories/tickets.py`).
- Implement helpers `_ticket_updated_at`, `_existing_syncro_updated_at`, and `_syncro_ticket_is_unchanged` to parse Syncro timestamps and decide if an import is necessary. (`app/services/ticket_importer.py`).
- Change `_upsert_ticket` to skip updating existing MyPortal tickets when the incoming Syncro `updated_at` is not newer, and to persist `syncro_updated_at` whenever a ticket is created or updated from Syncro. (`app/services/ticket_importer.py`).
- Optimise `import_all_tickets` to avoid hydrating full ticket details when the list payload demonstrates the ticket is unchanged. (`app/services/ticket_importer.py`).
- Add regression tests to verify unchanged tickets are skipped and newer Syncro updates are applied. (`tests/test_ticket_importer.py`).

### Testing
- Compiled modified modules with `python -m py_compile app/services/ticket_importer.py app/repositories/tickets.py` and it succeeded. 
- Ran `python -m pytest tests/test_ticket_importer.py -q` and all tests passed (71 passed, 0 failed). 
- Ran `git diff --check` to ensure no trailing whitespace or diff-check issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c73081940832d9daa603ff7a3ca27)