### PR TITLE
Fix Syncro ticket conversation attribution

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -21,6 +21,7 @@ from app.repositories import webhook_events as webhook_events_repo
 from app.services.sanitization import sanitize_rich_text
 from app.services import (
     syncro,
+    email_recipients,
     ticket_attachments as attachments_service,
     tickets as tickets_service,
     webhook_monitor,
@@ -1264,6 +1265,8 @@ async def _resolve_user_id_by_email(email: str | None) -> int | None:
 
 def _extract_comment_author_email(comment: dict[str, Any]) -> str | None:
     for key in (
+        "email_sender",
+        "emailSender",
         "user_email",
         "userEmail",
         "author_email",
@@ -1282,6 +1285,9 @@ def _extract_comment_author_email(comment: dict[str, Any]) -> str | None:
         email = _normalise_email(comment.get(key))
         if email:
             return email
+    tech_email = _normalise_email(comment.get("tech"))
+    if tech_email:
+        return tech_email
     for key in ("user", "author", "created_by", "creator"):
         nested = comment.get(key)
         if isinstance(nested, dict):
@@ -1301,6 +1307,13 @@ async def _resolve_comment_author_id(
 ) -> int | None:
     tech = _clean_text(comment.get("tech"))
     if tech and tech.lower() == "customer-reply":
+        email = _extract_comment_author_email(comment)
+        if email:
+            key = email.lower()
+            if key not in cache:
+                cache[key] = await _resolve_user_id_by_email(email)
+            if cache[key] is not None:
+                return cache[key]
         if requester_id is not None:
             return requester_id
         if contact_email:
@@ -1316,6 +1329,36 @@ async def _resolve_comment_author_id(
     if key not in cache:
         cache[key] = await _resolve_user_id_by_email(email)
     return cache[key]
+
+
+async def _record_imported_reply_recipients(
+    reply: dict[str, Any] | None,
+    comment: dict[str, Any],
+    sent_at: datetime | None,
+) -> None:
+    """Persist Syncro destination_emails as ticket reply recipients."""
+    reply_id = (reply or {}).get("id")
+    if reply_id is None:
+        return
+    recipients = sorted(
+        _extract_destination_emails(comment), key=lambda value: value.lower()
+    )
+    if not recipients:
+        return
+    try:
+        await email_recipients.record_recipients(
+            reply_id=int(reply_id),
+            tracking_id=None,
+            smtp2go_message_id=None,
+            to=recipients,
+            sent_at=sent_at,
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log_error(
+            "Failed to record imported Syncro reply recipients",
+            reply_id=reply_id,
+            error=str(exc),
+        )
 
 
 async def _sync_ticket_replies(
@@ -1381,7 +1424,7 @@ async def _sync_ticket_replies(
         enhanced_body = _build_comment_body_with_header(
             comment, body_with_images, minutes=minutes_spent
         )
-        await tickets_repo.create_reply(
+        reply = await tickets_repo.create_reply(
             ticket_id=ticket_id,
             author_id=author_id,
             body=enhanced_body,
@@ -1391,6 +1434,7 @@ async def _sync_ticket_replies(
             external_reference=external_ref,
             created_at=created_at,
         )
+        await _record_imported_reply_recipients(reply, comment, created_at)
         if external_ref:
             known_refs.add(external_ref)
 

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -613,6 +613,7 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
                     "subject": "Initial Issue",
                     "body": "Customer message",
                     "tech": "customer-reply",
+                    "email_sender": "customer@example.com",
                     "hidden": False,
                     "destination_emails": [
                         "customer@example.com",
@@ -624,7 +625,7 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
                     "id": 2,
                     "body": "Internal update",
                     "tech": "agent",
-                    "user_email": "tech@example.com",
+                    "email_sender": "tech@example.com",
                     "hidden": True,
                     "destination_emails": [
                         "tech@example.com",
@@ -673,6 +674,11 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
         return []
 
     added_watchers = []
+    recorded_recipients = []
+
+    async def fake_record_recipients(**kwargs):
+        recorded_recipients.append(kwargs)
+        return len(kwargs.get("to") or [])
 
     async def fake_add_watcher(ticket_id, user_id):
         added_watchers.append((ticket_id, user_id))
@@ -700,6 +706,9 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
     monkeypatch.setattr(tickets_repo, "add_watcher", fake_add_watcher)
     monkeypatch.setattr(
         ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
+    monkeypatch.setattr(
+        ticket_importer.email_recipients, "record_recipients", fake_record_recipients
     )
 
     summary = await ticket_importer.import_ticket_by_id(5001, rate_limiter=None)
@@ -730,6 +739,11 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
     assert reply_calls[2]["author_id"] == 31
     assert reply_calls[2].get("minutes_spent") is None
     assert reply_calls[2].get("is_billable", False) is False
+    assert [call["to"] for call in recorded_recipients] == [
+        ["customer@example.com", "tech@example.com"],
+        ["support@hawkinsitsolutions.com.au", "tech@example.com"],
+    ]
+    assert all(call["tracking_id"] is None for call in recorded_recipients)
     # The ticket ID should now be 5001, not 400
     assert added_watchers == [(5001, 31)]
 


### PR DESCRIPTION
### Motivation
- Imported Syncro conversation items were being attributed to the generic "System" or the requester instead of the actual user who made the update, and `destination_emails` were not persisted per-reply.
- Preserve original sender and recipient context so conversation history, reply authorship, and per-recipient tracking are accurate for imported tickets.

### Description
- Update `app/services/ticket_importer.py` to import the `email_recipients` service and record per-reply recipients via `email_recipients.record_recipients` using Syncro's `destination_emails`.
- Prefer `email_sender` / `emailSender` when resolving a comment author email in `_extract_comment_author_email`, and treat email-like `tech` values as an author-email fallback.
- When `tech` is `customer-reply`, attempt to resolve a user id from the extracted sender email before falling back to the ticket requester or contact email in `_resolve_comment_author_id`.
- After creating a reply, persist the imported reply recipients by adding a new helper `async def _record_imported_reply_recipients(...)` and invoke it from `_sync_ticket_replies`.
- Update `tests/test_ticket_importer.py` to exercise the new behavior (use `email_sender` fields, assert correct author ids, and assert recorded recipients are saved).

### Testing
- Ran `python -m py_compile app/services/ticket_importer.py tests/test_ticket_importer.py` to verify syntax; the check succeeded.
- Installed `libmagic1` (needed by tests) and ran `pytest tests/test_ticket_importer.py -q`, resulting in the test file passing (tests exercised the new attribution and recipient recording behavior) and overall test run completed successfully (71 passed for the whole suite when executed earlier).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c75c33cc8832db060d8d503c4d14c)