### PR TITLE
Avoid duplicate initial replies on Syncro import

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -1704,6 +1704,7 @@ async def _upsert_ticket(
             ticket_number=ticket_number,
             trigger_automations=False,
             send_creation_notification=False,
+            record_initial_reply=False,
             id=ticket_id_to_use,
         )
         created_id = created.get("id")

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -1277,6 +1277,7 @@ async def create_ticket(
     id: int | None = None,
     requester_email: str | None = None,
     send_creation_notification: bool = True,
+    record_initial_reply: bool = True,
 ) -> TicketRecord:
     """Create a ticket and emit the corresponding automation event."""
 
@@ -1318,6 +1319,7 @@ async def create_ticket(
     if (
         isinstance(ticket_id, int)
         and ticket_id > 0
+        and record_initial_reply
         and isinstance(original_description, str)
         and original_description
     ):

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -137,6 +137,7 @@ async def test_import_ticket_by_id_creates_new_ticket(monkeypatch):
     assert created_calls["requester_id"] is None
     assert created_calls["module_slug"] == "syncro"
     assert created_calls["trigger_automations"] is False
+    assert created_calls["record_initial_reply"] is False
     # Now the ticket ID should match the Syncro ticket number
     assert created_calls["id"] == 101
     assert update_calls[0][0] == 101
@@ -718,6 +719,7 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
     assert created_call["company_id"] == 8
     assert created_call["requester_id"] == 21
     assert created_call["description"] == "Customer message"
+    assert created_call["record_initial_reply"] is False
     # Verify the ticket ID was set to 5001 from the number
     assert created_call["id"] == 5001
     # 1 metadata note + 2 comments


### PR DESCRIPTION
### Motivation
- Prevent Syncro-imported tickets from getting the initial issue recorded twice: once by `create_ticket` and again when importing Syncro comments, so the Syncro comment history is the single source of truth in the ticket timeline.

### Description
- Added a `record_initial_reply: bool = True` parameter to `tickets_service.create_ticket` in `app/services/tickets.py` and gated the automatic creation of the initial reply on that flag. 
- Updated the Syncro importer in `app/services/ticket_importer.py` to call `create_ticket(..., record_initial_reply=False)` for newly imported Syncro tickets. 
- Added regression assertions in `tests/test_ticket_importer.py` to verify Syncro imports explicitly opt out of recording the initial reply.

### Testing
- Compiled modified modules with `python -m compileall app/services/tickets.py app/services/ticket_importer.py tests/test_ticket_importer.py` which succeeded. 
- Ran targeted tests with `pytest -q tests/test_ticket_importer.py::test_import_ticket_by_id_creates_new_ticket tests/test_ticket_importer.py::test_import_ticket_syncs_comments_and_watchers tests/test_tickets_service_create.py` and received all tests passing (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c770b4760832d87659e1efbba0f24)