### PR TITLE
Always render Next ticket number handler and add regression test

### DIFF
--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -1116,26 +1116,24 @@
   <script src="{{ static_url('/static/js/ticket_columns.js') }}" defer></script>
   <script src="{{ static_url('/static/js/admin.js') }}" defer></script>
 
-  {% if show_next_ticket_number %}
-    <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        const button = document.querySelector('[data-next-ticket-number-open]');
-        const form = document.querySelector('[data-next-ticket-number-form]');
-        const input = document.querySelector('[data-next-ticket-number-input]');
-        if (!button || !form || !input) return;
-        button.addEventListener('click', () => {
-          const currentValue = button.getAttribute('data-current-next-ticket-number') || '';
-          const value = window.prompt('Enter the next ticket number to use for newly-created tickets.', currentValue);
-          if (value === null) return;
-          const cleaned = value.trim();
-          if (!/^\d+$/.test(cleaned) || Number(cleaned) <= 0) {
-            window.alert('Enter a positive whole number.');
-            return;
-          }
-          input.value = cleaned;
-          form.requestSubmit();
-        });
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const button = document.querySelector('[data-next-ticket-number-open]');
+      const form = document.querySelector('[data-next-ticket-number-form]');
+      const input = document.querySelector('[data-next-ticket-number-input]');
+      if (!button || !form || !input) return;
+      button.addEventListener('click', () => {
+        const currentValue = button.getAttribute('data-current-next-ticket-number') || '';
+        const value = window.prompt('Enter the next ticket number to use for newly-created tickets.', currentValue);
+        if (value === null) return;
+        const cleaned = value.trim();
+        if (!/^\d+$/.test(cleaned) || Number(cleaned) <= 0) {
+          window.alert('Enter a positive whole number.');
+          return;
+        }
+        input.value = cleaned;
+        form.requestSubmit();
       });
-    </script>
-  {% endif %}
+    });
+  </script>
 {% endblock %}

--- a/changes/b96a0066-dbfb-4372-b23f-f934fb9a7598.json
+++ b/changes/b96a0066-dbfb-4372-b23f-f934fb9a7598.json
@@ -1,0 +1,7 @@
+{
+  "guid": "b96a0066-dbfb-4372-b23f-f934fb9a7598",
+  "occurred_at": "2026-07-07T03:59:21Z",
+  "change_type": "fix",
+  "summary": "Fix Next ticket number menu action on ticket workspace",
+  "content_hash": "da5c3b5a5e5b4d06b7da414a9540c439df517264ab97b1b0d719e6374875bd58"
+}

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -27,6 +27,17 @@ def test_columns_toggle_button_present():
     assert '>Columns<' in html
 
 
+def test_next_ticket_number_handler_is_always_rendered():
+    """The menu item handler must not depend on header-block scoped Jinja variables."""
+    html = _template_html()
+    script_index = html.index("data-next-ticket-number-open")
+    scripts_block_index = html.index("{% block scripts %}")
+    handler_index = html.index("form.requestSubmit();")
+
+    assert script_index < scripts_block_index < handler_index
+    assert "{% if show_next_ticket_number %}\n    <script>" not in html
+
+
 def test_column_panel_present():
     """The column customisation panel should be rendered."""
     html = _template_html()


### PR DESCRIPTION
### Motivation
- Fix the header "Next ticket number" menu item which did nothing when clicked because its click handler was conditionally omitted by a header-scoped Jinja `if` block.
- Ensure the UI action is available to client-side code while still being safe when the button/form are absent.

### Description
- Move the Next ticket number click handler out of the `{% if show_next_ticket_number %}` block so the script is always rendered in `app/templates/admin/tickets.html` while keeping the defensive `if (!button || !form || !input) return;` no-op behavior.
- Add a regression test `test_next_ticket_number_handler_is_always_rendered` in `tests/test_ticket_column_customisation.py` that asserts the handler is present in the `scripts` block and not gated by the header-only Jinja conditional.
- Add a change-log entry file under `changes/` describing the fix.

### Testing
- Ran `pytest tests/test_ticket_column_customisation.py` which executed the updated tests and resulted in 11 passed tests (all tests in that file passed).
- The updated template and test were validated by the test suite run and no failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c793bf9b4832da9a933f593731b9c)