### PR TITLE
Fix AI ticket summary JSON parsing

### DIFF
--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -1602,6 +1602,25 @@ def _parse_json_candidate(candidate: str) -> tuple[str | None, str | None] | Non
     return candidate, None
 
 
+def _normalise_model_response_text(value: Any) -> str:
+    """Return model text in a parseable plain-text form.
+
+    Some integrations pass model output through HTML-oriented formatting before the
+    ticket summary parser sees it.  Convert common line-break markup back to text
+    so JSON such as ``{<br />"summary": ...}`` is parsed instead of displayed to
+    technicians.
+    """
+
+    text = str(value).strip() if value is not None else ""
+    if not text:
+        return ""
+    text = html.unescape(text)
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"</(p|div|li|tr|td|th|tbody|thead|ul|ol)>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", "", text)
+    return text.strip()
+
+
 def _extract_summary_fields(payload: Any) -> tuple[str | None, str | None]:
     if isinstance(payload, Mapping):
         direct_summary = payload.get("summary")
@@ -1622,7 +1641,7 @@ def _extract_summary_fields(payload: Any) -> tuple[str | None, str | None]:
     else:
         payload_text = payload
 
-    text = str(payload_text).strip() if payload_text is not None else ""
+    text = _normalise_model_response_text(payload_text)
     if not text:
         return None, None
 

--- a/tests/test_ticket_ai_summary_service.py
+++ b/tests/test_ticket_ai_summary_service.py
@@ -1,6 +1,16 @@
 from typing import Any
+import sys
+from types import SimpleNamespace
 
 import pytest
+
+sys.modules.setdefault(
+    "magic",
+    SimpleNamespace(
+        Magic=lambda *args, **kwargs: None,
+        from_buffer=lambda *args, **kwargs: "application/octet-stream",
+    ),
+)
 
 from app.services import tickets as tickets_service
 
@@ -164,6 +174,24 @@ def test_extract_summary_fields_from_triple_quoted_block():
 
     assert summary == "Still working"
     assert resolution == "Likely In Progress"
+
+
+def test_extract_summary_fields_from_html_line_break_json():
+    payload = '{<br />"summary": "Executed CHKDSK verification successfully.",<br />"resolution": "Likely Resolved"<br />}'
+
+    summary, resolution = tickets_service._extract_summary_fields(payload)
+
+    assert summary == "Executed CHKDSK verification successfully."
+    assert resolution == "Likely Resolved"
+
+
+def test_extract_summary_fields_from_html_escaped_json():
+    payload = '{&lt;br /&gt;&quot;summary&quot;: &quot;Disk scan completed.&quot;,&lt;br /&gt;&quot;resolution&quot;: &quot;Likely Resolved&quot;&lt;br /&gt;}'
+
+    summary, resolution = tickets_service._extract_summary_fields(payload)
+
+    assert summary == "Disk scan completed."
+    assert resolution == "Likely Resolved"
 
 
 def test_render_prompt_ignores_signatures_and_reply_markers():


### PR DESCRIPTION
### Motivation
- AI model integrations sometimes return output wrapped with HTML markup or escaped entities which caused raw JSON to be displayed to technicians instead of being parsed. 
- The goal is to normalize model output into plain text so the existing JSON/wrapper parsing and resolution mapping behave correctly.

### Description
- Add helper ` _normalise_model_response_text` in `app/services/tickets.py` to unescape HTML entities, convert `<br />` and common closing block tags to newlines, and strip remaining tags. 
- Update `_extract_summary_fields` to run model payloads through ` _normalise_model_response_text` before wrapper and JSON parsing so JSON like `{<br />"summary": ...}` is parsed rather than shown. 
- Add regression tests in `tests/test_ticket_ai_summary_service.py` that cover HTML `<br />` JSON payloads and HTML-escaped JSON payloads returning `Likely Resolved`. 
- Add a local `magic` test stub in the test module to allow these focused unit tests to run in environments missing `libmagic`.

### Testing
- Ran `pytest -q tests/test_ticket_ai_summary_service.py` and all tests in that file passed (`10 passed`). 
- The new tests verify parsed `summary` and `resolution` for markdown-wrapped, triple-quoted, HTML line-break, and HTML-escaped JSON payloads and confirmed resolution normalization to `likely_resolved` where appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c7a41015c832db4046192fd205d0c)