### PR TITLE
Preserve full Syncro ticket comment bodies

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -263,27 +263,70 @@ def _syncro_ticket_is_unchanged(
     return syncro_updated_at <= last_imported_syncro_updated_at
 
 
+def _normalise_comment_comparison_text(value: str | None) -> str:
+    """Return comment text normalised for rich-preview/body comparisons."""
+
+    if not value:
+        return ""
+    return re.sub(r"\s+", " ", value).strip().casefold()
+
+
+def _append_full_plain_body_to_rich_preview(
+    rich_html: str, rich_text: str, plain_body: str | None
+) -> str:
+    """Ensure a truncated Syncro rich preview is supplemented with full text.
+
+    Syncro's ``rich_text_preview`` can preserve useful HTML, including images,
+    but it is sometimes only a preview of the full comment.  When the plain
+    ``body`` contains additional text, keep the rich preview and append the full
+    body as escaped preformatted text so no ticket content is lost.
+    """
+
+    if not plain_body:
+        return rich_html
+
+    normalised_rich = _normalise_comment_comparison_text(rich_text)
+    normalised_plain = _normalise_comment_comparison_text(plain_body)
+    if not normalised_plain or normalised_plain in normalised_rich:
+        return rich_html
+
+    escaped_body = escape(plain_body)
+    return (
+        f"{rich_html}"
+        '<hr />'
+        '<div class="syncro-full-body">'
+        '<p><strong>Full ticket body from Syncro:</strong></p>'
+        f"<pre>{escaped_body}</pre>"
+        '</div>'
+    )
+
+
 def _extract_comment_body(comment: dict[str, Any]) -> str | None:
     """Return the best available formatted Syncro comment body.
 
     Syncro comments can include ``rich_text_preview`` with the original HTML
-    formatting and inline image tags, while ``body`` may be a plain-text
-    preview such as ``[embedded image]``.  Prefer the rich HTML field when it
-    is present, then fall back to legacy body-like fields.
+    formatting and inline image tags, while ``body`` contains the full plain
+    text.  Keep useful rich content when it is present, but append the full
+    plain-text body whenever the rich preview is truncated so the import never
+    loses ticket content.
     """
+
+    plain_body = _clean_text(
+        comment.get("body")
+        or comment.get("comment")
+        or comment.get("text")
+        or comment.get("content")
+    )
     for rich_key in ("rich_text_preview", "richTextPreview"):
         rich_body = comment.get(rich_key)
         if rich_body is not None:
             text = unescape(str(rich_body).replace("\r\n", "\n")).replace("\xa0", " ")
             sanitized = sanitize_rich_text(text)
             if sanitized.has_rich_content:
-                return sanitized.html
-    return _clean_text(
-        comment.get("body")
-        or comment.get("comment")
-        or comment.get("text")
-        or comment.get("content")
-    )
+                return _append_full_plain_body_to_rich_preview(
+                    sanitized.html, sanitized.text_content, plain_body
+                )
+    return plain_body
 
 
 _IMAGE_MIME_TYPES = {

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -2144,13 +2144,28 @@ async def test_import_ticket_no_asset_link_when_ticket_has_no_assets(monkeypatch
 
 def test_extract_comment_body_prefers_rich_text_preview():
     comment = {
-        "body": "Plain body [embedded image]",
+        "body": "Formatted",
         "rich_text_preview": '<p>Formatted</p><img src="https://example.test/image.png">',
     }
 
     assert ticket_importer._extract_comment_body(comment) == (
         '<p>Formatted</p><img src="https://example.test/image.png">'
     )
+
+
+def test_extract_comment_body_appends_full_body_when_rich_text_preview_is_truncated():
+    comment = {
+        "body": "First line\nSecond line\nThird line with <unsafe> markers",
+        "rich_text_preview": "<p>First line<br/>Second...</p><img src=\"https://example.test/image.png\">",
+    }
+
+    result = ticket_importer._extract_comment_body(comment)
+
+    assert result is not None
+    assert '<p>First line<br>Second...</p>' in result
+    assert '<img src="https://example.test/image.png">' in result
+    assert "Full ticket body from Syncro" in result
+    assert "First line\nSecond line\nThird line with  markers" in result
 
 
 def test_append_imported_image_markup_replaces_syncro_img_src():


### PR DESCRIPTION
### Motivation
- Syncro's `rich_text_preview` may contain useful HTML and inline images but is sometimes a truncated preview that omits part of the full plain-text comment, causing imported tickets to lose content.
- The importer should keep the formatted preview when useful while ensuring the full original body is preserved when the preview is incomplete.

### Description
- Added `_normalise_comment_comparison_text` to produce a casefolded, whitespace-normalised comparison string for rich-preview vs plain-body checks.
- Added `_append_full_plain_body_to_rich_preview` which appends the escaped full plain-text body (inside a `<pre>` block with an explanatory header) to preserved rich HTML when the rich preview is detected as truncated.
- Updated `_extract_comment_body` to compute `plain_body` first, prefer sanitized `rich_text_preview` when it contains rich content, and call the new append helper to avoid losing text while retaining images/formatting; fall back to the cleaned plain body when no rich content exists (file: `app/services/ticket_importer.py`).
- Added a regression test `test_extract_comment_body_appends_full_body_when_rich_text_preview_is_truncated` and adjusted `test_extract_comment_body_prefers_rich_text_preview` to verify both behaviors (file: `tests/test_ticket_importer.py`).

### Testing
- Ran `python -m py_compile app/services/ticket_importer.py tests/test_ticket_importer.py` which completed successfully.
- Ran `pytest -q tests/test_ticket_importer.py -q` and all tests in that file passed, including the new truncated-preview regression test and the rich-preview preference test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c7b6017a0832d949eed910b7c01ee)