### PR TITLE
Fix AI ticket response parsing

### DIFF
--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -1602,6 +1602,44 @@ def _parse_json_candidate(candidate: str) -> tuple[str | None, str | None] | Non
     return candidate, None
 
 
+def _extract_chat_completion_content(payload: Any) -> Any:
+    """Return assistant message content from OpenAI-compatible chat responses.
+
+    Several Ollama-compatible gateways return the whole chat completion object as
+    the module response instead of only ``choices[0].message.content``.  The
+    ticket importers need the actual assistant content so summary, resolution,
+    and tag JSON can be parsed reliably.
+    """
+
+    if isinstance(payload, Mapping):
+        choices = payload.get("choices")
+        if isinstance(choices, Sequence) and not isinstance(choices, (str, bytes, bytearray)):
+            for choice in choices:
+                if not isinstance(choice, Mapping):
+                    continue
+                message = choice.get("message")
+                if isinstance(message, Mapping):
+                    content = message.get("content")
+                    if content is not None:
+                        return content
+                text = choice.get("text")
+                if text is not None:
+                    return text
+        return payload
+
+    if isinstance(payload, str):
+        text = payload.strip()
+        if not text:
+            return payload
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return payload
+        extracted = _extract_chat_completion_content(parsed)
+        return extracted if extracted is not parsed else payload
+
+    return payload
+
 def _normalise_model_response_text(value: Any) -> str:
     """Return model text in a parseable plain-text form.
 
@@ -1622,6 +1660,7 @@ def _normalise_model_response_text(value: Any) -> str:
 
 
 def _extract_summary_fields(payload: Any) -> tuple[str | None, str | None]:
+    payload = _extract_chat_completion_content(payload)
     if isinstance(payload, Mapping):
         direct_summary = payload.get("summary")
         direct_resolution = payload.get("resolution") or payload.get("resolution_label") or payload.get("status")
@@ -1705,6 +1744,8 @@ async def _extract_tags(payload: Any, ticket: Mapping[str, Any], replies: list[M
     external_ref_tokens = _extract_external_reference_tokens(ticket, replies or [])
     combined_exclusions = excluded_tags | external_ref_tokens
     
+    payload = _extract_chat_completion_content(payload)
+
     tags = _normalise_tag_list(payload, combined_exclusions)
     if tags:
         return _finalise_tags(tags, ticket, combined_exclusions)
@@ -1734,6 +1775,14 @@ def _normalise_tag_list(source: Any, excluded_tags: set[str] | None = None) -> l
                 return _normalise_tag_list(source[key], excluded_tags)
         return []
     if isinstance(source, str):
+        cleaned = _strip_wrapped_block(_normalise_model_response_text(source))
+        if cleaned and cleaned != source.strip():
+            try:
+                parsed = json.loads(cleaned)
+            except json.JSONDecodeError:
+                source = cleaned
+            else:
+                return _normalise_tag_list(parsed, excluded_tags)
         segments = [segment.strip() for segment in re.split(r"[,\n;]+", source) if segment.strip()]
         iterable: Iterable[str] = segments
     elif isinstance(source, Iterable) and not isinstance(source, (bytes, bytearray)):

--- a/tests/test_ticket_ai_summary_service.py
+++ b/tests/test_ticket_ai_summary_service.py
@@ -1,4 +1,5 @@
 from typing import Any
+import json
 import sys
 from types import SimpleNamespace
 
@@ -283,3 +284,45 @@ def test_strip_conversation_noise_removes_email_headers():
     assert "Date:" not in cleaned
     assert "Actual message body line one." in cleaned
     assert "Another line." in cleaned
+
+
+def test_extract_summary_fields_from_openai_chat_completion_json_string():
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "```json\n{\"summary\": \"CHKDSK found errors on BJP-DC-02.\", \"resolution\": \"Likely In Progress\"}\n```",
+                }
+            }
+        ],
+        "model": "gemma4:e2b",
+    }
+
+    summary, resolution = tickets_service._extract_summary_fields(json.dumps(payload))
+
+    assert summary == "CHKDSK found errors on BJP-DC-02."
+    assert resolution == "Likely In Progress"
+
+
+@pytest.mark.anyio
+async def test_extract_tags_from_openai_chat_completion_json_string(monkeypatch):
+    async def fake_excluded_tags():
+        return set()
+
+    monkeypatch.setattr(tickets_service, "get_all_excluded_tags", fake_excluded_tags)
+    payload = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "```json\n{\"tags\": [\"disk-verification\", \"chkdsk-scan\", \"server-health\"]}\n```",
+                }
+            }
+        ],
+        "model": "gemma4:e2b",
+    }
+
+    tags = await tickets_service._extract_tags(json.dumps(payload), {"subject": "BJPSC - Verify"}, [])
+
+    assert tags[:3] == ["disk-verification", "chkdsk-scan", "server-health"]


### PR DESCRIPTION
### Motivation
- AI-generated ticket summaries and tags were sometimes parsed from the raw module response object instead of the assistant message content, causing incorrect imports (e.g. wrappers like `json` becoming tags) and wrong resolution/status assignment.
- The change improves robustness for integrations that return full OpenAI-style chat completion objects (with `choices[...].message.content`) or HTML-wrapped JSON.

### Description
- Added `_extract_chat_completion_content(payload: Any)` to extract assistant message content from OpenAI-compatible chat completion responses and recursively handle JSON-encoded strings.
- Updated `_extract_summary_fields` to run the payload through the chat-completion extractor before extracting `summary` and `resolution` fields.
- Updated `_extract_tags` / tag processing to extract chat-completion content first and to parse fenced/HTML-normalised JSON prior to the fallback line/comma splitting so wrappers like `json` are not treated as tags.
- Added regression tests to `tests/test_ticket_ai_summary_service.py` that cover chat-completion JSON strings for both summary/resolution parsing and tag extraction.

### Testing
- Executed `pytest -q tests/test_ticket_ai_summary_service.py`, which ran the updated and existing tests and resulted in all tests passing (`12 passed`, test file run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c801a1ff4832d8467c8d08317f4cc)