### PR TITLE
Add ticket automation audit trail modal

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import re
 from collections.abc import Sequence
+from datetime import datetime, timezone
 from typing import Any, Mapping
 from urllib.parse import urlsplit
 
@@ -33,6 +34,7 @@ from app.core.logging import log_debug, log_error, log_info
 from app.features.tickets.form_helpers import get_last_form_value
 from app.security.flash import flash_redirect
 from app.repositories import assets as assets_repo
+from app.repositories import automations as automation_repo
 from app.repositories import companies as company_repo
 from app.repositories import company_memberships as membership_repo
 from app.repositories import staff as staff_repo
@@ -298,6 +300,40 @@ async def admin_ticket_detail(
     )
 
 
+
+@router.get("/admin/tickets/{ticket_id:int}/automation-history", response_class=JSONResponse)
+async def admin_ticket_automation_history(
+    ticket_id: int,
+    request: Request,
+    limit: int = Query(default=200, ge=1, le=1000),
+):
+    main_module = _main()
+    _, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not permitted")
+    ticket = await tickets_repo.get_ticket(ticket_id)
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
+
+    rows = await automation_repo.list_history_for_ticket(ticket_id, limit=limit)
+
+    def encode(value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.astimezone(timezone.utc).isoformat()
+        if isinstance(value, Mapping):
+            return {str(k): encode(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [encode(item) for item in value]
+        return value
+
+    return JSONResponse({
+        "ticket": {
+            "id": ticket_id,
+            "ticket_number": ticket.get("ticket_number"),
+            "subject": ticket.get("subject"),
+        },
+        "history": [encode(row) for row in rows],
+    })
 
 @router.post("/admin/tickets/{ticket_id:int}/related/rescan", response_class=JSONResponse)
 async def admin_rescan_ticket_related(ticket_id: int, request: Request):

--- a/app/repositories/automations.py
+++ b/app/repositories/automations.py
@@ -485,3 +485,19 @@ async def list_history(automation_id: int, *, limit: int = 200) -> list[Automati
         (automation_id, limit),
     )
     return [_normalise_history(row) for row in rows]
+
+
+async def list_history_for_ticket(ticket_id: int, *, limit: int = 200) -> list[AutomationHistoryRecord]:
+    await _ensure_connection()
+    rows = await db.fetch_all(
+        """
+        SELECT history.*, automations.name AS automation_name
+        FROM automation_history AS history
+        LEFT JOIN automations ON automations.id = history.automation_id
+        WHERE history.ticket_id = %s
+        ORDER BY history.occurred_at DESC, history.id DESC
+        LIMIT %s
+        """,
+        (ticket_id, limit),
+    )
+    return [_normalise_history(row) for row in rows]

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -2268,6 +2268,87 @@
     updateButton();
   }
 
+
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function formatAutomationHistoryDate(value) {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return String(value);
+    return date.toLocaleString();
+  }
+
+  function formatAutomationHistoryJson(value) {
+    if (value === null || value === undefined || value === '') return '—';
+    if (typeof value === 'string') return escapeHtml(value);
+    try {
+      return escapeHtml(JSON.stringify(value, null, 2));
+    } catch (error) {
+      return escapeHtml(String(value));
+    }
+  }
+
+  function renderAutomationHistoryRows(tbody, rows) {
+    if (!tbody) return;
+    if (!Array.isArray(rows) || rows.length === 0) {
+      tbody.innerHTML = '<tr><td colspan="6" class="table__empty">No automation audit trail has been recorded for this ticket yet.</td></tr>';
+      return;
+    }
+    tbody.innerHTML = rows.map((item) => {
+      const automation = item.automation_name || (item.automation_id ? `#${item.automation_id}` : '—');
+      const action = item.action_name || item.action_module || '—';
+      const details = item.error_message || item.result_payload || null;
+      return `
+        <tr>
+          <td data-label="When" data-column-key="occurred_at">${escapeHtml(formatAutomationHistoryDate(item.occurred_at))}</td>
+          <td data-label="Automation" data-column-key="automation">${escapeHtml(automation)}</td>
+          <td data-label="Action" data-column-key="action">${escapeHtml(action)}</td>
+          <td data-label="Status" data-column-key="status">${escapeHtml(item.status || 'unknown')}</td>
+          <td data-label="Previous values" data-column-key="previous"><code>${formatAutomationHistoryJson(item.previous_values)}</code></td>
+          <td data-label="Details" data-column-key="details"><code>${formatAutomationHistoryJson(details)}</code></td>
+        </tr>`;
+    }).join('');
+  }
+
+  function initialiseAutomationHistoryModal() {
+    const modal = document.getElementById('ticket-automation-history-modal');
+    const tbody = document.querySelector('[data-ticket-automation-history-rows]');
+    const openButton = document.querySelector('[data-ticket-automation-history-open]');
+    if (!modal || !tbody || !openButton) return;
+
+    const closeModal = () => { modal.hidden = true; };
+    const openModal = () => { modal.hidden = false; };
+
+    document.querySelectorAll('[data-ticket-automation-history-close]').forEach((button) => {
+      button.addEventListener('click', closeModal);
+    });
+
+    openButton.addEventListener('click', async () => {
+      const ticketId = openButton.getAttribute('data-ticket-id');
+      if (!ticketId) return;
+      tbody.innerHTML = '<tr><td colspan="6" class="table__empty">Loading automation audit trail…</td></tr>';
+      openModal();
+      try {
+        const response = await fetch(`/admin/tickets/${encodeURIComponent(ticketId)}/automation-history`, {
+          headers: { Accept: 'application/json' },
+          credentials: 'same-origin',
+        });
+        if (!response.ok) throw new Error(`Request failed with ${response.status}`);
+        const payload = await response.json();
+        renderAutomationHistoryRows(tbody, payload.history || []);
+      } catch (error) {
+        tbody.innerHTML = `<tr><td colspan="6" class="table__empty">Unable to load automation audit trail: ${escapeHtml(error.message)}</td></tr>`;
+      }
+    });
+  }
+
   function ready() {
     const messageWrappers = document.querySelectorAll('[data-timeline-message]');
 
@@ -2291,6 +2372,7 @@
     initTicketRelated();
     convertUtcElements();
     initialiseBookingModal();
+    initialiseAutomationHistoryModal();
   }
 
   function initialiseBookingModal() {

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -6,6 +6,7 @@
 
 {% block header_actions %}
   {{ page_header_actions([
+    {"label": "Audit Trail", "type": "button", "attrs": {"data-ticket-automation-history-open": true, "data-ticket-id": ticket.id}},
     {"label": "All tickets", "type": "link", "href": "/admin/tickets"}
   ]) }}
 {% endblock %}
@@ -1508,6 +1509,42 @@
           <button type="submit" class="button button--primary" data-recording-time-submit>Save changes</button>
         </div>
       </form>
+    </div>
+  </div>
+
+
+  <div class="modal" id="ticket-automation-history-modal" role="dialog" aria-modal="true" aria-labelledby="ticket-automation-history-title" hidden>
+    <div class="modal__backdrop" data-ticket-automation-history-close></div>
+    <div class="modal__panel modal__panel--wide">
+      <header class="modal__header">
+        <h2 class="modal__title" id="ticket-automation-history-title">Ticket automation audit trail</h2>
+        <button type="button" class="modal__close" data-ticket-automation-history-close aria-label="Close">×</button>
+      </header>
+      <div class="modal__body">
+        <p class="card__subtitle">Automation actions recorded against ticket #{{ ticket.ticket_number or ticket.id }}.</p>
+        <div class="management__toolbar">
+          <div class="management__toolbar-search">
+            <input type="search" class="form-input" placeholder="Filter audit trail" aria-label="Filter ticket automation audit trail" data-table-filter="ticket-automation-history-table" />
+          </div>
+        </div>
+        <div class="table-wrapper">
+          <table class="table" id="ticket-automation-history-table" data-table data-table-id="ticket-automation-history">
+            <thead>
+              <tr>
+                <th scope="col" data-sort="string" data-column-key="occurred_at">When</th>
+                <th scope="col" data-sort="string" data-column-key="automation">Automation</th>
+                <th scope="col" data-sort="string" data-column-key="action">Action</th>
+                <th scope="col" data-sort="string" data-column-key="status">Status</th>
+                <th scope="col" data-sort="string" data-column-key="previous">Previous values</th>
+                <th scope="col" data-sort="string" data-column-key="details">Details</th>
+              </tr>
+            </thead>
+            <tbody data-ticket-automation-history-rows>
+              <tr><td colspan="6" class="table__empty">Open the audit trail to load automation history.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
### Motivation
- Make automation activity easier to inspect for a specific ticket by surfacing automation audit history directly from the ticket detail page instead of requiring navigation to the global Automations UI.

### Description
- Add an `Audit Trail` action to the ticket header and a modal to display ticket-scoped automation history (markup in `app/templates/admin/ticket_detail.html`).
- Add a ticket-scoped JSON endpoint `GET /admin/tickets/{ticket_id}/automation-history` that enforces helpdesk access and returns encoded history rows (handler in `app/features/tickets/admin_routes.py`).
- Add repository support to fetch automation history by ticket via `list_history_for_ticket` and include `automation_name` from the `automations` table (`app/repositories/automations.py`).
- Add client-side logic to `app/static/js/ticket_detail.js` to open the modal, fetch `/admin/tickets/{id}/automation-history`, render rows safely (escaping/formatting dates and JSON) and show loading/empty/error states.

### Testing
- Ran `python -m compileall app/features/tickets/admin_routes.py app/repositories/automations.py` which succeeded. 
- Ran `pytest tests/test_admin_ticket_detail.py -q` which failed during collection due to missing system dependency (`libmagic`), preventing full test execution against the updated code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c814acea08332936ca04024ebcccc)