### PR TITLE
Prevent AI description replacement from changing ticket status

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -816,7 +816,7 @@ async def admin_replace_ticket_description(ticket_id: int, request: Request):
 
     sanitized = sanitize_rich_text(str((updated or {}).get("description") or ""))
 
-    await tickets_service.emit_ticket_updated_event(
+    await tickets_service.emit_ticket_details_updated_event(
         ticket_id,
         actor_type="technician",
         actor=current_user,

--- a/tests/test_ticket_access.py
+++ b/tests/test_ticket_access.py
@@ -1189,6 +1189,8 @@ def test_admin_replace_ticket_description_returns_json(monkeypatch, active_sessi
         return {"id": ticket_id, "ai_summary": "First line\r\nSecond line"}
 
     update_mock = AsyncMock(return_value={"id": 55, "description": "First line\nSecond line"})
+    updated_event_mock = AsyncMock()
+    details_updated_event_mock = AsyncMock()
 
     def fake_sanitize(value: str) -> SimpleNamespace:
         return SimpleNamespace(html=f"<p>{value}</p>", text_content=value)
@@ -1196,6 +1198,12 @@ def test_admin_replace_ticket_description_returns_json(monkeypatch, active_sessi
     monkeypatch.setattr(main_module, "_require_helpdesk_page", fake_require_helpdesk)
     monkeypatch.setattr(main_module.tickets_repo, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(main_module.tickets_service, "update_ticket_description", update_mock)
+    monkeypatch.setattr(main_module.tickets_service, "emit_ticket_updated_event", updated_event_mock)
+    monkeypatch.setattr(
+        main_module.tickets_service,
+        "emit_ticket_details_updated_event",
+        details_updated_event_mock,
+    )
     monkeypatch.setattr(main_module, "sanitize_rich_text", fake_sanitize)
     monkeypatch.setattr(session_manager, "load_session", AsyncMock(return_value=active_session))
 
@@ -1219,6 +1227,12 @@ def test_admin_replace_ticket_description_returns_json(monkeypatch, active_sessi
     assert payload["descriptionHtml"] == "<p>First line\nSecond line</p>"
     assert payload["descriptionText"] == "First line\nSecond line"
     update_mock.assert_awaited_once_with(55, "First line\nSecond line")
+    updated_event_mock.assert_not_awaited()
+    details_updated_event_mock.assert_awaited_once_with(
+        55,
+        actor_type="technician",
+        actor={"id": 71, "email": "helper@example.com", "is_super_admin": False},
+    )
 
 
 def test_admin_replace_ticket_description_requires_summary(monkeypatch, active_session):


### PR DESCRIPTION
### Motivation
- Replacing a ticket description from the AI Summary should not trigger automations that treat the change as a general ticket update (which can change ticket status); the intent is to record a description/details change only.

### Description
- Changed the AI Summary replace-description endpoint to emit `tickets.details_updated` via `emit_ticket_details_updated_event` instead of `tickets.updated` via `emit_ticket_updated_event` in `app/features/tickets/admin_routes.py`.
- Added a regression test in `tests/test_ticket_access.py` to assert the replace-description flow does not call `emit_ticket_updated_event` and does call `emit_ticket_details_updated_event` with the correct actor metadata.

### Testing
- Compiled the modified files with `python -m py_compile app/features/tickets/admin_routes.py tests/test_ticket_access.py` which succeeded.
- Attempted to run the two new/updated tests with `pytest tests/test_ticket_access.py::test_admin_replace_ticket_description_returns_json tests/test_ticket_access.py::test_admin_replace_ticket_description_requires_summary`, but test collection failed due to a missing system `libmagic` dependency in the environment (blocking automated pytest execution).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c82dfebac8332b7516c020710ec87)