### PR TITLE
Add 'Import Billable Time Entries as Already Billed' option for Syncro ticket imports

### DIFF
--- a/app/features/syncro/routes.py
+++ b/app/features/syncro/routes.py
@@ -15,8 +15,13 @@ from app.core.logging import log_error, log_info
 from app.features.staff.helpers import _load_staff_context
 from app.schemas.tickets import SyncroTicketImportRequest
 from app.services import background as background_tasks
-from app.services import company_importer, modules as modules_service, staff_importer, ticket_importer, tickets as tickets_service
-
+from app.services import (
+    company_importer,
+    modules as modules_service,
+    staff_importer,
+    ticket_importer,
+    tickets as tickets_service,
+)
 
 router = APIRouter(tags=["Syncro"])
 settings = get_settings()
@@ -120,7 +125,9 @@ async def admin_syncro_ticket_import_page(
     )
 
 
-@router.post("/admin/tickets/syncro-import/status-mappings", response_class=HTMLResponse)
+@router.post(
+    "/admin/tickets/syncro-import/status-mappings", response_class=HTMLResponse
+)
 async def update_syncro_ticket_status_mappings(request: Request):
     current_user, redirect = await _main()._require_super_admin_page(request)
     if redirect:
@@ -134,10 +141,15 @@ async def update_syncro_ticket_status_mappings(request: Request):
     form = await request.form()
     syncro_statuses = form.getlist("syncroStatus")
     myportal_statuses = form.getlist("myportalStatus")
-    allowed_statuses = {definition.tech_status for definition in await tickets_service.list_status_definitions()}
+    allowed_statuses = {
+        definition.tech_status
+        for definition in await tickets_service.list_status_definitions()
+    }
     mappings: list[dict[str, str]] = []
     seen: set[str] = set()
-    for syncro_status_raw, myportal_status_raw in zip(syncro_statuses, myportal_statuses, strict=False):
+    for syncro_status_raw, myportal_status_raw in zip(
+        syncro_statuses, myportal_statuses, strict=False
+    ):
         syncro_status = str(syncro_status_raw or "").strip()
         myportal_status = str(myportal_status_raw or "").strip().lower()
         if not syncro_status and not myportal_status:
@@ -153,7 +165,9 @@ async def update_syncro_ticket_status_mappings(request: Request):
         if key in seen:
             continue
         seen.add(key)
-        mappings.append({"syncro_status": syncro_status[:128], "myportal_status": myportal_status})
+        mappings.append(
+            {"syncro_status": syncro_status[:128], "myportal_status": myportal_status}
+        )
     existing_settings = dict((module.get("settings") or {}))
     existing_settings["ticket_status_mappings"] = mappings
     await modules_service.update_module("syncro", settings=existing_settings)
@@ -183,7 +197,9 @@ async def route_import_syncro_contacts(request: Request):
             detail="Syncro module is disabled",
         )
     payload = await request.json()
-    syncro_company_id = payload.get("syncroCompanyId") or payload.get("syncro_company_id")
+    syncro_company_id = payload.get("syncroCompanyId") or payload.get(
+        "syncro_company_id"
+    )
     if not syncro_company_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -294,6 +310,7 @@ async def route_import_syncro_tickets(request: Request):
         ticket_id=import_request.ticket_id,
         start_id=import_request.start_id,
         end_id=import_request.end_id,
+        import_billable_time_as_billed=import_request.import_billable_time_as_billed,
         request_path=str(request.url),
     )
     try:
@@ -302,6 +319,7 @@ async def route_import_syncro_tickets(request: Request):
             ticket_id=import_request.ticket_id,
             start_id=import_request.start_id,
             end_id=import_request.end_id,
+            mark_billable_time_as_billed=import_request.import_billable_time_as_billed,
         )
     except ValueError as exc:
         raise HTTPException(

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -265,6 +265,13 @@ class SyncroTicketImportRequest(BaseModel):
         validation_alias=AliasChoices("endId", "end_id"),
         ge=1,
     )
+    import_billable_time_as_billed: bool = Field(
+        default=False,
+        alias="importBillableTimeAsBilled",
+        validation_alias=AliasChoices(
+            "importBillableTimeAsBilled", "import_billable_time_as_billed"
+        ),
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -300,7 +307,9 @@ class TicketTaskCreate(BaseModel):
 
 
 class TicketTaskUpdate(BaseModel):
-    task_name: Optional[str] = Field(default=None, min_length=1, max_length=255, alias="taskName")
+    task_name: Optional[str] = Field(
+        default=None, min_length=1, max_length=255, alias="taskName"
+    )
     is_completed: Optional[bool] = Field(default=None, alias="isCompleted")
     sort_order: Optional[int] = Field(default=None, alias="sortOrder")
 
@@ -327,6 +336,7 @@ class TicketTaskListResponse(BaseModel):
 
 class TicketViewFilters(BaseModel):
     """Filters that can be applied to ticket views"""
+
     status: Optional[list[str]] = None
     priority: Optional[list[str]] = None
     company_id: Optional[list[int]] = None
@@ -339,6 +349,7 @@ class TicketViewFilters(BaseModel):
 
 class TicketViewCreate(BaseModel):
     """Request to create a new saved ticket view"""
+
     name: str = Field(..., min_length=1, max_length=128)
     description: Optional[str] = None
     filters: Optional[TicketViewFilters] = None
@@ -353,6 +364,7 @@ class TicketViewCreate(BaseModel):
 
 class TicketViewUpdate(BaseModel):
     """Request to update an existing saved ticket view"""
+
     name: Optional[str] = Field(default=None, min_length=1, max_length=128)
     description: Optional[str] = None
     filters: Optional[TicketViewFilters] = None
@@ -367,6 +379,7 @@ class TicketViewUpdate(BaseModel):
 
 class TicketViewModel(BaseModel):
     """Saved ticket view model"""
+
     id: int
     user_id: int
     name: str
@@ -385,11 +398,13 @@ class TicketViewModel(BaseModel):
 
 class TicketViewListResponse(BaseModel):
     """Response containing list of ticket views"""
+
     items: list[TicketViewModel] = Field(default_factory=list)
 
 
 class TicketAttachmentAccessLevel(str, Enum):
     """Access levels for ticket attachments"""
+
     OPEN = "open"  # Accessible via URL without login
     CLOSED = "closed"  # Requires login, accessible by requester, watchers, technicians
     RESTRICTED = "restricted"  # Only accessible by helpdesk technicians
@@ -397,16 +412,21 @@ class TicketAttachmentAccessLevel(str, Enum):
 
 class TicketAttachmentCreate(BaseModel):
     """Schema for creating a ticket attachment"""
-    access_level: TicketAttachmentAccessLevel = Field(default=TicketAttachmentAccessLevel.CLOSED)
+
+    access_level: TicketAttachmentAccessLevel = Field(
+        default=TicketAttachmentAccessLevel.CLOSED
+    )
 
 
 class TicketAttachmentUpdate(BaseModel):
     """Schema for updating a ticket attachment"""
+
     access_level: Optional[TicketAttachmentAccessLevel] = None
 
 
 class TicketAttachment(BaseModel):
     """Schema for ticket attachment response"""
+
     id: int
     ticket_id: int
     filename: str
@@ -422,17 +442,24 @@ class TicketAttachment(BaseModel):
 
 class TicketAttachmentListResponse(BaseModel):
     """Response containing list of ticket attachments"""
+
     items: list[TicketAttachment] = Field(default_factory=list)
 
 
 class TicketSplitRequest(BaseModel):
     """Request to split selected replies into a new ticket"""
-    reply_ids: list[int] = Field(..., min_length=1, description="List of reply IDs to move to new ticket")
-    new_subject: str = Field(..., min_length=1, max_length=255, description="Subject for the new ticket")
+
+    reply_ids: list[int] = Field(
+        ..., min_length=1, description="List of reply IDs to move to new ticket"
+    )
+    new_subject: str = Field(
+        ..., min_length=1, max_length=255, description="Subject for the new ticket"
+    )
 
 
 class TicketSplitResponse(BaseModel):
     """Response after splitting a ticket"""
+
     original_ticket: TicketResponse
     new_ticket: TicketResponse
     moved_reply_count: int
@@ -440,12 +467,18 @@ class TicketSplitResponse(BaseModel):
 
 class TicketMergeRequest(BaseModel):
     """Request to merge multiple tickets into one"""
-    ticket_ids: list[int] = Field(..., min_length=2, description="List of ticket IDs to merge (at least 2)")
-    target_ticket_id: int = Field(..., description="ID of the ticket to merge into (must be in ticket_ids)")
+
+    ticket_ids: list[int] = Field(
+        ..., min_length=2, description="List of ticket IDs to merge (at least 2)"
+    )
+    target_ticket_id: int = Field(
+        ..., description="ID of the ticket to merge into (must be in ticket_ids)"
+    )
 
 
 class TicketMergeResponse(BaseModel):
     """Response after merging tickets"""
+
     merged_ticket: TicketResponse
     merged_ticket_ids: list[int] = Field(description="IDs of tickets that were merged")
     moved_reply_count: int

--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -16,6 +16,7 @@ from app.repositories import assets as assets_repo
 from app.repositories import companies as company_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import ticket_attachments as attachments_repo
+from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import users as user_repo
 from app.repositories import webhook_events as webhook_events_repo
 from app.services.sanitization import sanitize_rich_text
@@ -293,11 +294,11 @@ def _append_full_plain_body_to_rich_preview(
     escaped_body = escape(plain_body)
     return (
         f"{rich_html}"
-        '<hr />'
+        "<hr />"
         '<div class="syncro-full-body">'
-        '<p><strong>Full ticket body from Syncro:</strong></p>'
+        "<p><strong>Full ticket body from Syncro:</strong></p>"
         f"<pre>{escaped_body}</pre>"
-        '</div>'
+        "</div>"
     )
 
 
@@ -1412,6 +1413,7 @@ async def _sync_ticket_replies(
     contact_email: str | None,
     timer_billable: dict[str, bool] | None = None,
     timer_time: dict[str, int] | None = None,
+    mark_billable_time_as_billed: bool = False,
 ) -> None:
     if not comments:
         return
@@ -1478,6 +1480,28 @@ async def _sync_ticket_replies(
             created_at=created_at,
         )
         await _record_imported_reply_recipients(reply, comment, created_at)
+        if (
+            mark_billable_time_as_billed
+            and is_billable
+            and minutes_spent
+            and minutes_spent > 0
+        ):
+            reply_id = (reply or {}).get("id")
+            if reply_id is not None:
+                try:
+                    await billed_time_repo.create_billed_time_entry(
+                        ticket_id=ticket_id,
+                        reply_id=int(reply_id),
+                        xero_invoice_number="SYNCRO-IMPORT-ALREADY-BILLED",
+                        minutes_billed=int(minutes_spent),
+                    )
+                except Exception as exc:  # pragma: no cover - defensive logging
+                    log_error(
+                        "Failed to mark imported Syncro billable time as already billed",
+                        ticket_id=ticket_id,
+                        reply_id=reply_id,
+                        error=str(exc),
+                    )
         if external_ref:
             known_refs.add(external_ref)
 
@@ -1645,6 +1669,8 @@ async def _upsert_ticket(
     allowed_statuses: Collection[str],
     default_status: str,
     status_mappings: dict[str, str] | None = None,
+    *,
+    mark_billable_time_as_billed: bool = False,
 ) -> str:
     status_choices = set(allowed_statuses)
     syncro_id = ticket.get("id")
@@ -1778,6 +1804,7 @@ async def _upsert_ticket(
             contact_email=contact_email,
             timer_billable=timer_billable,
             timer_time=timer_time,
+            mark_billable_time_as_billed=mark_billable_time_as_billed,
         )
         await _sync_ticket_watchers(ticket_db_id, comments, contact_email)
 
@@ -1788,6 +1815,7 @@ async def import_ticket_by_id(
     ticket_id: int,
     *,
     rate_limiter: syncro.AsyncRateLimiter | None = None,
+    mark_billable_time_as_billed: bool = False,
 ) -> TicketImportSummary:
     limiter = rate_limiter or await syncro.get_rate_limiter()
     summary = TicketImportSummary(mode="single")
@@ -1810,7 +1838,11 @@ async def import_ticket_by_id(
     summary.fetched = 1
     allowed_statuses, default_status, status_mappings = await _get_status_context()
     outcome = await _upsert_ticket(
-        ticket, allowed_statuses, default_status, status_mappings
+        ticket,
+        allowed_statuses,
+        default_status,
+        status_mappings,
+        mark_billable_time_as_billed=mark_billable_time_as_billed,
     )
     summary.record(outcome)
     log_info(
@@ -1829,6 +1861,7 @@ async def import_ticket_range(
     end_id: int,
     *,
     rate_limiter: syncro.AsyncRateLimiter | None = None,
+    mark_billable_time_as_billed: bool = False,
 ) -> TicketImportSummary:
     limiter = rate_limiter or await syncro.get_rate_limiter()
     summary = TicketImportSummary(mode="range")
@@ -1845,7 +1878,11 @@ async def import_ticket_range(
             continue
         summary.fetched += 1
         outcome = await _upsert_ticket(
-            ticket, allowed_statuses, default_status, status_mappings
+            ticket,
+            allowed_statuses,
+            default_status,
+            status_mappings,
+            mark_billable_time_as_billed=mark_billable_time_as_billed,
         )
         summary.record(outcome)
     log_info(
@@ -1909,6 +1946,7 @@ async def _fetch_ticket_detail_for_import(
 async def import_all_tickets(
     *,
     rate_limiter: syncro.AsyncRateLimiter | None = None,
+    mark_billable_time_as_billed: bool = False,
 ) -> TicketImportSummary:
     limiter = rate_limiter or await syncro.get_rate_limiter()
     summary = TicketImportSummary(mode="all")
@@ -1936,7 +1974,11 @@ async def import_all_tickets(
                         ticket, rate_limiter=limiter
                     )
                     outcome = await _upsert_ticket(
-                        ticket_detail, allowed_statuses, default_status, status_mappings
+                        ticket_detail,
+                        allowed_statuses,
+                        default_status,
+                        status_mappings,
+                        mark_billable_time_as_billed=mark_billable_time_as_billed,
                     )
             except Exception as exc:  # pragma: no cover - defensive logging
                 reason = f"Syncro ticket {ticket.get('id') or 'unknown'} failed to import: {exc}"
@@ -1988,6 +2030,7 @@ async def import_from_request(
     start_id: int | None = None,
     end_id: int | None = None,
     rate_limiter: syncro.AsyncRateLimiter | None = None,
+    mark_billable_time_as_billed: bool = False,
 ) -> TicketImportSummary:
     mode_lower = mode.lower()
     payload: dict[str, Any] = {"mode": mode_lower}
@@ -1997,6 +2040,8 @@ async def import_from_request(
         payload["startId"] = start_id
     if end_id is not None:
         payload["endId"] = end_id
+    if mark_billable_time_as_billed:
+        payload["importBillableTimeAsBilled"] = True
 
     event_id: int | None = None
     using_monitor: bool = False
@@ -2143,17 +2188,27 @@ async def import_from_request(
         if mode_lower == "single":
             if ticket_id is None:
                 raise ValueError("ticket_id is required for single imports")
-            summary = await import_ticket_by_id(ticket_id, rate_limiter=rate_limiter)
+            summary = await import_ticket_by_id(
+                ticket_id,
+                rate_limiter=rate_limiter,
+                mark_billable_time_as_billed=mark_billable_time_as_billed,
+            )
         elif mode_lower == "range":
             if start_id is None or end_id is None:
                 raise ValueError("start_id and end_id are required for range imports")
             if end_id < start_id:
                 raise ValueError("end_id must be greater than or equal to start_id")
             summary = await import_ticket_range(
-                start_id, end_id, rate_limiter=rate_limiter
+                start_id,
+                end_id,
+                rate_limiter=rate_limiter,
+                mark_billable_time_as_billed=mark_billable_time_as_billed,
             )
         elif mode_lower == "all":
-            summary = await import_all_tickets(rate_limiter=rate_limiter)
+            summary = await import_all_tickets(
+                rate_limiter=rate_limiter,
+                mark_billable_time_as_billed=mark_billable_time_as_billed,
+            )
         else:
             raise ValueError("mode must be one of 'single', 'range', or 'all'")
     except Exception as exc:

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -528,6 +528,7 @@
         }
         const payload = { mode };
         const formData = new FormData(form);
+        payload.importBillableTimeAsBilled = formData.get('importBillableTimeAsBilled') === 'on';
 
         const parseInteger = (value, errorMessage) => {
           const parsed = Number(value);

--- a/app/templates/admin/syncro_ticket_import.html
+++ b/app/templates/admin/syncro_ticket_import.html
@@ -131,6 +131,13 @@
                 <label class="form-label" for="syncro-ticket-id">Syncro ticket ID</label>
                 <input id="syncro-ticket-id" name="ticketId" class="form-input" type="number" min="1" step="1" required {% if not is_configured %}disabled{% endif %} />
               </div>
+              <div class="form-field form-field--checkbox">
+                <label class="checkbox-option">
+                  <input name="importBillableTimeAsBilled" type="checkbox" {% if not is_configured %}disabled{% endif %} />
+                  <span>Import billable time entries as already billed</span>
+                </label>
+                <p class="form-help">Billable imported time remains visible for reporting, but MyPortal records it in billed-time tracking so it is excluded from future billing.</p>
+              </div>
               <div class="form-actions">
                 <button type="submit" class="button button--primary" {% if not is_configured %}disabled{% endif %}>Import ticket</button>
               </div>
@@ -150,6 +157,13 @@
                   <input id="syncro-ticket-end" name="endId" class="form-input" type="number" min="1" step="1" required {% if not is_configured %}disabled{% endif %} />
                 </div>
               </div>
+              <div class="form-field form-field--checkbox">
+                <label class="checkbox-option">
+                  <input name="importBillableTimeAsBilled" type="checkbox" {% if not is_configured %}disabled{% endif %} />
+                  <span>Import billable time entries as already billed</span>
+                </label>
+                <p class="form-help">Billable imported time remains visible for reporting, but MyPortal records it in billed-time tracking so it is excluded from future billing.</p>
+              </div>
               <div class="form-actions">
                 <button type="submit" class="button" {% if not is_configured %}disabled{% endif %}>Import range</button>
               </div>
@@ -158,6 +172,13 @@
               <div>
                 <h3 class="card__title">Full account import</h3>
                 <p class="card__subtitle text-muted">Iterate through all Syncro tickets using paginated requests.</p>
+              </div>
+              <div class="form-field form-field--checkbox">
+                <label class="checkbox-option">
+                  <input name="importBillableTimeAsBilled" type="checkbox" {% if not is_configured %}disabled{% endif %} />
+                  <span>Import billable time entries as already billed</span>
+                </label>
+                <p class="form-help">Billable imported time remains visible for reporting, but MyPortal records it in billed-time tracking so it is excluded from future billing.</p>
               </div>
               <div class="form-actions">
                 <button type="submit" class="button button--ghost" {% if not is_configured %}disabled{% endif %}>Import all tickets</button>

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -242,7 +242,9 @@ async def test_import_ticket_by_id_updates_existing(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_import_ticket_by_id_skips_existing_when_syncro_updated_at_unchanged(monkeypatch):
+async def test_import_ticket_by_id_skips_existing_when_syncro_updated_at_unchanged(
+    monkeypatch,
+):
     async def fake_get_ticket(ticket_id, rate_limiter=None):
         return {
             "id": ticket_id,
@@ -279,7 +281,9 @@ async def test_import_ticket_by_id_skips_existing_when_syncro_updated_at_unchang
 
 
 @pytest.mark.anyio
-async def test_import_ticket_by_id_updates_existing_when_syncro_updated_at_newer(monkeypatch):
+async def test_import_ticket_by_id_updates_existing_when_syncro_updated_at_newer(
+    monkeypatch,
+):
     async def fake_get_ticket(ticket_id, rate_limiter=None):
         return {
             "id": ticket_id,
@@ -319,10 +323,7 @@ async def test_import_ticket_by_id_updates_existing_when_syncro_updated_at_newer
         update_calls[0][1]["syncro_updated_at"].isoformat()
         == "2025-01-03T10:45:00+00:00"
     )
-    assert (
-        update_calls[0][1]["updated_at"].isoformat()
-        == "2025-01-03T10:45:00+00:00"
-    )
+    assert update_calls[0][1]["updated_at"].isoformat() == "2025-01-03T10:45:00+00:00"
 
 
 @pytest.mark.anyio
@@ -2156,13 +2157,13 @@ def test_extract_comment_body_prefers_rich_text_preview():
 def test_extract_comment_body_appends_full_body_when_rich_text_preview_is_truncated():
     comment = {
         "body": "First line\nSecond line\nThird line with <unsafe> markers",
-        "rich_text_preview": "<p>First line<br/>Second...</p><img src=\"https://example.test/image.png\">",
+        "rich_text_preview": '<p>First line<br/>Second...</p><img src="https://example.test/image.png">',
     }
 
     result = ticket_importer._extract_comment_body(comment)
 
     assert result is not None
-    assert '<p>First line<br>Second...</p>' in result
+    assert "<p>First line<br>Second...</p>" in result
     assert '<img src="https://example.test/image.png">' in result
     assert "Full ticket body from Syncro" in result
     assert "First line\nSecond line\nThird line with  markers" in result
@@ -2297,3 +2298,60 @@ async def test_sync_ticket_replies_imports_embedded_images(monkeypatch):
     assert attachment_calls[0]["original_filename"] == "screen.png"
     assert attachment_calls[0]["mime_type"] == "image/png"
     assert attachment_calls[0]["access_level"] == "closed"
+
+
+@pytest.mark.anyio
+async def test_sync_ticket_replies_can_mark_imported_billable_time_as_billed(
+    monkeypatch,
+):
+    async def fake_list_replies(ticket_id):
+        assert ticket_id == 123
+        return []
+
+    async def fake_create_reply(**kwargs):
+        return {"id": 456, **kwargs}
+
+    billed_calls = []
+
+    async def fake_create_billed_time_entry(**kwargs):
+        billed_calls.append(kwargs)
+        return {"id": 1, **kwargs}
+
+    monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
+    monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
+    monkeypatch.setattr(
+        ticket_importer.billed_time_repo,
+        "create_billed_time_entry",
+        fake_create_billed_time_entry,
+    )
+
+    async def fake_import_comment_images(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(
+        ticket_importer, "_import_comment_images", fake_import_comment_images
+    )
+
+    await ticket_importer._sync_ticket_replies(
+        123,
+        [
+            {
+                "id": "syncro-comment-1",
+                "body": "Worked on billing setup",
+                "minutes_spent": 45,
+                "is_billable": True,
+            }
+        ],
+        requester_id=None,
+        contact_email=None,
+        mark_billable_time_as_billed=True,
+    )
+
+    assert billed_calls == [
+        {
+            "ticket_id": 123,
+            "reply_id": 456,
+            "xero_invoice_number": "SYNCRO-IMPORT-ALREADY-BILLED",
+            "minutes_billed": 45,
+        }
+    ]


### PR DESCRIPTION
### Motivation
- Some Syncro-imported time entries should not be billed again by MyPortal and must be flagged on import so they are excluded from future invoicing.
- Provide an admin-facing toggle to mark imported billable time as already billed for single, range, and full-account Syncro imports.

### Description
- Add `importBillableTimeAsBilled` to the `SyncroTicketImportRequest` schema and propagate it through the route into the import workflow as `mark_billable_time_as_billed`.
- Add a checkbox to the Syncro import forms (single, range, all) and include the flag in the JSON payload from `app/static/js/admin.js`.
- Update `app/services/ticket_importer.py` to accept the flag and, when set, record each imported billable reply in `ticket_billed_time_entries` using `ticket_billed_time_entries.create_billed_time_entry` with the marker invoice number `SYNCRO-IMPORT-ALREADY-BILLED`.
- Add a unit test (`tests/test_ticket_importer.py`) that verifies a billable Syncro reply is recorded as billed when the flag is enabled.

### Testing
- Successfully type-checked/compiled modified modules with `python3 -m py_compile app/services/ticket_importer.py app/schemas/tickets.py app/features/syncro/routes.py`.
- Added and ran a focused unit test invocation `pytest tests/test_ticket_importer.py::test_sync_ticket_replies_can_mark_imported_billable_time_as_billed`, but collection/execution was blocked by the test environment missing the `libmagic` system library required by `python-magic` (so full pytest run could not complete in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4c85cb110083329c10bfb8a083d669)