### PR TITLE
Fix Syncro ticket requester import

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from app.core.logging import log_error, log_info
 from app.repositories import assets as assets_repo
+from app.repositories import staff as staff_repo
 from app.repositories import companies as company_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import ticket_attachments as attachments_repo
@@ -1307,6 +1308,29 @@ async def _resolve_user_id_by_email(email: str | None) -> int | None:
         return None
 
 
+async def _resolve_staff_id_by_email(
+    email: str | None, company_id: int | None
+) -> int | None:
+    if not email or company_id is None:
+        return None
+    try:
+        staff = await staff_repo.get_staff_by_company_and_email(company_id, email)
+    except RuntimeError as exc:  # pragma: no cover - defensive logging
+        log_error(
+            "Failed to resolve staff requester from email",
+            email=email,
+            company_id=company_id,
+            error=str(exc),
+        )
+        return None
+    if not staff or staff.get("id") is None:
+        return None
+    try:
+        return int(staff["id"])
+    except (TypeError, ValueError):
+        return None
+
+
 def _extract_comment_author_email(comment: dict[str, Any]) -> str | None:
     for key in (
         "email_sender",
@@ -1719,6 +1743,11 @@ async def _upsert_ticket(
             status = default_status
 
     company_id = await _resolve_company_id(ticket)
+    requester_staff_id = (
+        None
+        if requester_id is not None
+        else await _resolve_staff_id_by_email(contact_email, company_id)
+    )
 
     existing = await tickets_repo.get_ticket_by_external_reference(external_reference)
     description_value: str | None = description or None
@@ -1735,6 +1764,7 @@ async def _upsert_ticket(
             "priority": priority,
             "ticket_number": ticket_number,
             "requester_id": requester_id,
+            "requester_staff_id": requester_staff_id,
         }
         if category_value is not None:
             updates["category"] = category_value
@@ -1763,6 +1793,7 @@ async def _upsert_ticket(
             subject=subject,
             description=description_value,
             requester_id=requester_id,
+            requester_staff_id=requester_staff_id,
             company_id=company_id,
             assigned_user_id=None,
             priority=priority,

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -145,6 +145,131 @@ async def test_import_ticket_by_id_creates_new_ticket(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_import_ticket_by_id_uses_staff_requester_when_no_portal_user(monkeypatch):
+    async def fake_get_ticket(ticket_id, rate_limiter=None):  # noqa: ARG001
+        return {
+            "id": 512,
+            "subject": "VPN issue",
+            "status": "New",
+            "problem": "Cannot connect",
+            "customer_id": "200",
+            "contact": {"email": "staff.requester@example.com"},
+        }
+
+    async def fake_get_company(syncro_id):
+        assert syncro_id == "200"
+        return {"id": 7}
+
+    async def fake_get_company_by_name(_name):
+        return None
+
+    async def fake_get_existing(_external_reference):
+        return None
+
+    created_calls = {}
+
+    async def fake_create_ticket(**kwargs):
+        created_calls.update(kwargs)
+        return {"id": kwargs.get("id") or 512, **kwargs}
+
+    async def fake_update_ticket(ticket_id, **fields):
+        return {"id": ticket_id, **fields}
+
+    async def fake_get_user_by_email(email):
+        assert email == "staff.requester@example.com"
+        return None
+
+    async def fake_get_staff_by_company_and_email(company_id, email):
+        assert company_id == 7
+        assert email == "staff.requester@example.com"
+        return {"id": 44}
+
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
+    monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
+    monkeypatch.setattr(tickets_service, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
+    monkeypatch.setattr(
+        ticket_importer.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
+    )
+
+    summary = await ticket_importer.import_ticket_by_id(512, rate_limiter=None)
+
+    assert summary.created == 1
+    assert created_calls["requester_id"] is None
+    assert created_calls["requester_staff_id"] == 44
+
+
+@pytest.mark.anyio
+async def test_import_ticket_by_id_updates_existing_staff_requester(monkeypatch):
+    async def fake_get_ticket(ticket_id, rate_limiter=None):  # noqa: ARG001
+        return {
+            "id": 513,
+            "subject": "Laptop issue",
+            "status": "New",
+            "problem": "Blue screen",
+            "customer_id": "201",
+            "contact": {"email": "staff.requester@example.com"},
+        }
+
+    async def fake_get_existing(external_reference):
+        return {"id": 99, "external_reference": external_reference}
+
+    async def fake_get_company(syncro_id):
+        assert syncro_id == "201"
+        return {"id": 8}
+
+    async def fake_get_company_by_name(_name):
+        return None
+
+    update_calls = []
+
+    async def fake_update_ticket(ticket_id, **fields):
+        update_calls.append((ticket_id, fields))
+        return {"id": ticket_id, **fields}
+
+    async def fake_get_user_by_email(email):
+        assert email == "staff.requester@example.com"
+        return None
+
+    async def fake_get_staff_by_company_and_email(company_id, email):
+        assert company_id == 8
+        assert email == "staff.requester@example.com"
+        return {"id": 45}
+
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
+    monkeypatch.setattr(company_repo, "get_company_by_syncro_id", fake_get_company)
+    monkeypatch.setattr(company_repo, "get_company_by_name", fake_get_company_by_name)
+    monkeypatch.setattr(tickets_repo, "update_ticket", fake_update_ticket)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
+    monkeypatch.setattr(
+        ticket_importer.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
+    )
+
+    summary = await ticket_importer.import_ticket_by_id(513, rate_limiter=None)
+
+    assert summary.updated == 1
+    assert update_calls[0][0] == 99
+    assert update_calls[0][1]["requester_id"] is None
+    assert update_calls[0][1]["requester_staff_id"] == 45
+
+
+@pytest.mark.anyio
 async def test_import_ticket_by_id_does_not_queue_ollama_generation(monkeypatch):
     async def fake_get_ticket(ticket_id, rate_limiter=None):
         return {


### PR DESCRIPTION
### Motivation
- Syncro-imported tickets were not associating a staff requester when the Syncro contact email matched a company staff record but no portal user existed. This left some imported tickets without the correct requester information. 
- Ensure imported tickets persist the resolved staff requester on both new ticket creation and updates so internal workflows and notifications behave correctly.

### Description
- Added an import of the staff repository with `from app.repositories import staff as staff_repo` and implemented `async def _resolve_staff_id_by_email(email, company_id) -> int | None` to find a company staff record by email. 
- Use the new resolver when `requester_id` is `None` to compute `requester_staff_id`, and persist `requester_staff_id` on existing ticket updates and when creating new tickets by passing it into `tickets_service.create_ticket` and `tickets_repo.update_ticket`. 
- Added regression tests `test_import_ticket_by_id_uses_staff_requester_when_no_portal_user` and `test_import_ticket_by_id_updates_existing_staff_requester` to cover new and updated import flows assigning `requester_staff_id`.

### Testing
- Ran static check: `python -m py_compile app/services/ticket_importer.py tests/test_ticket_importer.py` — succeeded. 
- Ran targeted unit tests: `pytest -q tests/test_ticket_importer.py::test_import_ticket_by_id_uses_staff_requester_when_no_portal_user tests/test_ticket_importer.py::test_import_ticket_by_id_updates_existing_staff_requester tests/test_ticket_importer.py::test_import_ticket_by_id_creates_new_ticket -q` — all passed. 
- Ran the full file: `pytest -q tests/test_ticket_importer.py -q` — the targeted requester tests passed but the full suite produced failures (7 failing tests) unrelated to the requester change, stemming from existing `import_from_request` test stubs and one billable-time assertion; those failures were not caused by the staff-requester logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cc70450588332a0e2317d9520577c)