### PR TITLE
Use Syncro timer `recorded` flag for billable import

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -706,8 +706,10 @@ def _resolve_comment_billable(
 
     Checks the ticket_timers mapping first (keyed by comment ID) because
     Syncro stores the authoritative billable flag on the labor log (timer)
-    entry rather than on the comment object itself.  Falls back to the
-    comment's own fields when no timer entry exists for this comment.
+    entry rather than on the comment object itself. Syncro indicates whether
+    the technician charged the time with the timer's recorded value. Falls
+    back to the comment's own fields when no timer entry exists for this
+    comment.
     """
     if timer_billable:
         comment_id = comment.get("id")
@@ -723,7 +725,7 @@ def _resolve_comment_billable(
 
 
 def _build_timer_billable_map(ticket: dict[str, Any]) -> dict[str, bool]:
-    """Build a {comment_id_str: billable} mapping from ticket_timers."""
+    """Build a {comment_id_str: billable} mapping from timer recorded values."""
     timers = ticket.get("ticket_timers")
     if not isinstance(timers, list):
         return {}
@@ -734,9 +736,7 @@ def _build_timer_billable_map(ticket: dict[str, Any]) -> dict[str, bool]:
         comment_id = timer.get("comment_id")
         if comment_id is None:
             continue
-        billable = timer.get("billable")
-        if billable is not None:
-            result[str(comment_id)] = _coerce_bool(billable)
+        result[str(comment_id)] = _coerce_bool(timer.get("recorded"))
     return result
 
 

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -1550,8 +1550,8 @@ def test_resolve_comment_billable_no_timer_match():
 def test_build_timer_billable_map_basic():
     ticket = {
         "ticket_timers": [
-            {"id": 1, "comment_id": 10, "billable": True},
-            {"id": 2, "comment_id": 20, "billable": False},
+            {"id": 1, "comment_id": 10, "recorded": True},
+            {"id": 2, "comment_id": 20, "recorded": False},
         ]
     }
     result = ticket_importer._build_timer_billable_map(ticket)
@@ -1561,9 +1561,9 @@ def test_build_timer_billable_map_basic():
 def test_build_timer_billable_map_coerces_string_values():
     ticket = {
         "ticket_timers": [
-            {"id": 1, "comment_id": 10, "billable": "false"},
-            {"id": 2, "comment_id": 20, "billable": "true"},
-            {"id": 3, "comment_id": 30, "billable": "0"},
+            {"id": 1, "comment_id": 10, "recorded": "false"},
+            {"id": 2, "comment_id": 20, "recorded": "true"},
+            {"id": 3, "comment_id": 30, "recorded": "0"},
         ]
     }
     result = ticket_importer._build_timer_billable_map(ticket)
@@ -1573,12 +1573,24 @@ def test_build_timer_billable_map_coerces_string_values():
 def test_build_timer_billable_map_skips_null_comment_id():
     ticket = {
         "ticket_timers": [
-            {"id": 1, "comment_id": None, "billable": True},
-            {"id": 2, "comment_id": 5, "billable": True},
+            {"id": 1, "comment_id": None, "recorded": True},
+            {"id": 2, "comment_id": 5, "recorded": True},
         ]
     }
     result = ticket_importer._build_timer_billable_map(ticket)
     assert result == {"5": True}
+
+
+def test_build_timer_billable_map_ignores_timer_billable_field():
+    ticket = {
+        "ticket_timers": [
+            {"id": 1, "comment_id": 10, "billable": True, "recorded": False},
+            {"id": 2, "comment_id": 20, "billable": False, "recorded": True},
+            {"id": 3, "comment_id": 30, "billable": True},
+        ]
+    }
+    result = ticket_importer._build_timer_billable_map(ticket)
+    assert result == {"10": False, "20": True, "30": False}
 
 
 def test_build_timer_billable_map_no_timers():


### PR DESCRIPTION
### Motivation
- Syncro stores the technician-charged indicator on the timer as a `recorded` value, but the importer previously relied on the timer's `billable` field which caused imported time to be incorrectly marked billable.

### Description
- Use the timer `recorded` value when building the timer-to-comment billable map in `app.services.ticket_importer._build_timer_billable_map` so imported replies reflect whether the tech actually charged the time.
- Clarify the _resolve_comment_billable docstring to explain that Syncro's `recorded` is the authoritative "charged" flag.
- Update unit tests in `tests/test_ticket_importer.py` to use `ticket_timers[].recorded` fixtures, add `test_build_timer_billable_map_ignores_timer_billable_field`, and adjust existing tests to assert proper boolean/string coercion of `recorded` values.

### Testing
- Ran `python -m py_compile app/services/ticket_importer.py tests/test_ticket_importer.py` which succeeded.
- Attempted `pytest tests/test_ticket_importer.py -q` but collection failed due to environment missing `libmagic` (`ImportError: failed to find libmagic`).
- Performed local static checks (`git diff --check`) and validated the module compiles prior to test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cc8fc68108332b2e5daf4b2092978)