### PR TITLE
Add Syncro destination recipients as ticket watchers

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -1278,14 +1278,33 @@ def _extract_destination_emails(comment: dict[str, Any]) -> set[str]:
     return emails
 
 
-def _gather_comment_watchers(comments: list[dict[str, Any]]) -> set[str]:
+def _gather_comment_watchers(
+    comments: list[dict[str, Any]],
+    *,
+    excluded_emails: Collection[str] | None = None,
+) -> set[str]:
     watchers: dict[str, str] = {}
+    excluded = {email.lower() for email in (excluded_emails or []) if email}
     for comment in comments:
         for email in _extract_destination_emails(comment):
             key = email.lower()
+            if key in excluded:
+                continue
             if key not in watchers:
                 watchers[key] = email
     return set(watchers.values())
+
+
+def _gather_technician_emails(comments: list[dict[str, Any]]) -> set[str]:
+    emails: set[str] = set()
+    for comment in comments:
+        tech = _clean_text(comment.get("tech"))
+        if tech and tech.lower() == "customer-reply":
+            continue
+        email = _extract_comment_author_email(comment)
+        if email:
+            emails.add(email)
+    return emails
 
 
 def _should_comment_be_internal(comment: dict[str, Any]) -> bool:
@@ -1538,16 +1557,11 @@ async def _sync_ticket_watchers(
     comments: list[dict[str, Any]],
     contact_email: str | None,
 ) -> None:
-    watchers = _gather_comment_watchers(comments)
+    excluded_emails = {"support@hawkinsitsolutions.com.au"}
     if contact_email:
-        watchers = {
-            email for email in watchers if email.lower() != contact_email.lower()
-        }
-    watchers = {
-        email
-        for email in watchers
-        if email.lower() != "support@hawkinsitsolutions.com.au"
-    }
+        excluded_emails.add(contact_email)
+    excluded_emails.update(_gather_technician_emails(comments))
+    watchers = _gather_comment_watchers(comments, excluded_emails=excluded_emails)
     if not watchers:
         return
     try:
@@ -1564,12 +1578,24 @@ async def _sync_ticket_watchers(
         for watcher in existing
         if watcher.get("user_id") is not None
     }
+    existing_emails = {
+        str(watcher["email"]).lower()
+        for watcher in existing
+        if watcher.get("email") is not None
+    }
     for email in sorted(watchers, key=lambda value: value.lower()):
+        email_key = email.lower()
         user_id = await _resolve_user_id_by_email(email)
-        if user_id is None or user_id in existing_ids:
-            continue
+        if user_id is not None:
+            if user_id in existing_ids:
+                continue
+            add_kwargs: dict[str, Any] = {"user_id": user_id}
+        else:
+            if email_key in existing_emails:
+                continue
+            add_kwargs = {"email": email}
         try:
-            await tickets_repo.add_watcher(ticket_id, user_id)
+            await tickets_repo.add_watcher(ticket_id, **add_kwargs)
         except Exception as exc:  # pragma: no cover - defensive logging
             log_error(
                 "Failed to add ticket watcher",
@@ -1578,7 +1604,10 @@ async def _sync_ticket_watchers(
                 error=str(exc),
             )
             continue
-        existing_ids.add(user_id)
+        if user_id is not None:
+            existing_ids.add(user_id)
+        else:
+            existing_emails.add(email_key)
 
 
 async def _resolve_company_id(ticket: dict[str, Any]) -> int | None:

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -745,6 +745,7 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
                     "destination_emails": [
                         "customer@example.com",
                         "tech@example.com",
+                        "manager@example.com",
                     ],
                     "created_at": "2025-01-01T08:00:00Z",
                 },
@@ -807,13 +808,14 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
         recorded_recipients.append(kwargs)
         return len(kwargs.get("to") or [])
 
-    async def fake_add_watcher(ticket_id, user_id):
-        added_watchers.append((ticket_id, user_id))
+    async def fake_add_watcher(ticket_id, user_id=None, email=None):
+        added_watchers.append((ticket_id, user_id, email))
 
     async def fake_get_user_by_email(email):
         mapping = {
             "customer@example.com": {"id": 21},
             "tech@example.com": {"id": 31},
+            "manager@example.com": {"id": 41},
         }
         return mapping.get(email)
 
@@ -868,12 +870,58 @@ async def test_import_ticket_syncs_comments_and_watchers(monkeypatch):
     assert reply_calls[2].get("minutes_spent") is None
     assert reply_calls[2].get("is_billable", False) is False
     assert [call["to"] for call in recorded_recipients] == [
-        ["customer@example.com", "tech@example.com"],
+        ["customer@example.com", "manager@example.com", "tech@example.com"],
         ["support@hawkinsitsolutions.com.au", "tech@example.com"],
     ]
     assert all(call["tracking_id"] is None for call in recorded_recipients)
     # The ticket ID should now be 5001, not 400
-    assert added_watchers == [(5001, 31)]
+    assert added_watchers == [(5001, 41, None)]
+
+
+@pytest.mark.anyio
+async def test_syncro_destination_email_without_user_is_added_as_email_watcher(monkeypatch):
+    async def fake_list_watchers(ticket_id):  # noqa: ARG001
+        return []
+
+    added_watchers = []
+
+    async def fake_add_watcher(ticket_id, user_id=None, email=None):
+        added_watchers.append((ticket_id, user_id, email))
+
+    async def fake_get_user_by_email(_email):
+        return None
+
+    monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
+    monkeypatch.setattr(tickets_repo, "add_watcher", fake_add_watcher)
+    monkeypatch.setattr(
+        ticket_importer.user_repo, "get_user_by_email", fake_get_user_by_email
+    )
+
+    await ticket_importer._sync_ticket_watchers(
+        7001,
+        [
+            {
+                "tech": "customer-reply",
+                "email_sender": "requester@example.com",
+                "destination_emails": [
+                    "requester@example.com",
+                    "external@example.com",
+                ],
+            },
+            {
+                "tech": "agent",
+                "email_sender": "tech@example.com",
+                "destination_emails": [
+                    "tech@example.com",
+                    "support@hawkinsitsolutions.com.au",
+                    "external@example.com",
+                ],
+            },
+        ],
+        contact_email="requester@example.com",
+    )
+
+    assert added_watchers == [(7001, None, "external@example.com")]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- Ensure any email addresses listed in Syncro `destination_emails` (except the requester, the technician author, and the configured support mailbox) become ticket Watchers when importing Syncro tickets.

### Description
- Add `excluded_emails` support to `_gather_comment_watchers` and introduce `_gather_technician_emails` to detect and exclude technician author addresses from `destination_emails` processing in `app/services/ticket_importer.py`.
- Update `_sync_ticket_watchers` to build an exclusion set (support mailbox, requester, and technician authors) and to add remaining recipients by resolving a portal user or falling back to an email-only watcher via `tickets_repo.add_watcher` with `user_id` or `email` as appropriate.
- Normalize/deduplicate destination recipients before adding and avoid duplicating watchers already present on the ticket.
- Update `tests/test_ticket_importer.py` to cover: resolved user watchers, exclusion of requester/technician/support mailbox, and creation of email-only watchers when no portal user exists.

### Testing
- Ran `python -m py_compile app/services/ticket_importer.py tests/test_ticket_importer.py` which succeeded.
- Ran `ruff check app/services/ticket_importer.py tests/test_ticket_importer.py` which passed with no issues.
- Attempted `pytest tests/test_ticket_importer.py -q` but collection failed due to missing system `libmagic` (dependency of `python-magic`) in the test environment, so the updated tests could not be executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ccd5daf18833289348600abff4a14)