### PR TITLE
Equal-width columns for ticket detail view at high resolutions

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5202,6 +5202,10 @@ dialog.modal:not([open]) {
 }
 
 @media (min-width: 961px) and (max-width: 1799px) {
+  .management__body--ticket-detail {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .management__column--details {
     grid-column: 1;
     grid-row: 1;
@@ -5216,6 +5220,10 @@ dialog.modal:not([open]) {
 @media (min-width: 1800px) {
   .management__body--columns {
     grid-template-columns: minmax(280px, 320px) minmax(360px, 1fr) minmax(0, 1fr);
+  }
+
+  .management__body--ticket-detail-two-column {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .management__column-group--main {

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -86,7 +86,7 @@
         </div>
       </header>
 
-      <div class="management__body management__body--columns">
+      <div class="management__body management__body--columns management__body--ticket-detail management__body--ticket-detail-admin">
         <div class="management__column management__column--details">
           <details class="card card--panel card-collapsible">
             <summary class="card__header card__header--collapsible">

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -20,7 +20,7 @@
           <a class="button button--ghost" href="/tickets">Back to tickets</a>
         </div>
       </header>
-      <div class="management__body management__body--columns">
+      <div class="management__body management__body--columns management__body--ticket-detail management__body--ticket-detail-two-column">
         <div class="management__column management__column--details">
           <details class="card card--panel card-collapsible" open>
             <summary class="card__header card__header--collapsible">


### PR DESCRIPTION
### Motivation
- The ticket detail page should present the left and right columns sharing available width equally in the high-resolution two-column layout. 
- Preserve the existing wider admin three-column breakpoint while applying a ticket-detail specific two-column behavior so other management grids are unaffected.

### Description
- Added ticket-detail layout markers to the customer and admin ticket detail templates by adding `management__body--ticket-detail` and narrow two-column modifiers in `app/templates/tickets/detail.html` and `app/templates/admin/ticket_detail.html`.
- Updated `app/static/css/app.css` to provide ticket-detail-specific grid rules so the two columns use `repeat(2, minmax(0, 1fr))` between `961px` and `1799px`, and applied a two-column variant at very wide screens while retaining the admin three-column rules at `>=1800px`.
- Changes are scoped to the ticket detail pages to avoid impacting other management grids or layouts.

### Testing
- Ran `git diff --check` to validate no whitespace or diff issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cd00ad11883328442443e57fe5805)