### PR TITLE
Improve email ticket deduplication for external senders

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -1227,16 +1227,22 @@ async def _find_existing_ticket_for_reply(
             params.extend([requester_id, requester_id])
         elif from_email:
             # If no requester_id but we have an email, check watchers by email
+            # and email-created ticket descriptions that captured the sender in
+            # the leading "From:" line. External senders often do not have a
+            # local user record, so the description fallback prevents repeated
+            # Office 365/IMAP imports with the same sender + subject from opening
+            # duplicate tickets.
             query += """
                 AND (
                     EXISTS (
-                        SELECT 1 FROM users ru 
+                        SELECT 1 FROM users ru
                         WHERE ru.id = t.requester_id AND LOWER(ru.email) = LOWER(%s)
                     )
                     OR LOWER(u.email) = LOWER(%s)
+                    OR LOWER(COALESCE(t.description, '')) LIKE LOWER(%s)
                 )
             """
-            params.extend([from_email, from_email])
+            params.extend([from_email, from_email, f"%{from_email}%"])
         else:
             # No way to match sender, can't reliably determine if this is a reply
             return None

--- a/tests/test_email_ticket_replies.py
+++ b/tests/test_email_ticket_replies.py
@@ -265,6 +265,50 @@ class TestFindExistingTicket:
         assert result["id"] == 2
         assert result["subject"] == "Network Connection Issue"
 
+
+    async def test_find_ticket_by_subject_and_sender_in_description(self, monkeypatch):
+        """External sender tickets can be matched without a local requester user."""
+        from app.core import database
+        from app.services import imap
+
+        captured: dict[str, object] = {}
+
+        async def mock_fetch_all(query, params):
+            captured["query"] = query
+            captured["params"] = params
+            if "ticket_number" in query:
+                return []
+            return [
+                {
+                    "id": 12,
+                    "ticket_number": "25006",
+                    "subject": "We have moved Support requests to Ideagen Luminate",
+                    "description": "From: Ideagen Support <support@ideagen.example>\n\nHello",
+                    "status": "open",
+                    "requester_id": None,
+                    "company_id": 3,
+                    "created_at": None,
+                    "updated_at": None,
+                    "closed_at": None,
+                    "ai_summary_updated_at": None,
+                    "ai_tags": None,
+                    "ai_tags_updated_at": None,
+                }
+            ]
+
+        monkeypatch.setattr(database.db, "fetch_all", mock_fetch_all)
+
+        result = await imap._find_existing_ticket_for_reply(
+            subject="We have moved Support requests to Ideagen Luminate",
+            from_email="support@ideagen.example",
+            requester_id=None,
+        )
+
+        assert result is not None
+        assert result["id"] == 12
+        assert "COALESCE(t.description" in str(captured["query"])
+        assert "%support@ideagen.example%" in captured["params"]
+
     async def test_find_ticket_by_in_reply_to_header(self, monkeypatch):
         """Test finding ticket by matching Message-ID references."""
 


### PR DESCRIPTION
### Motivation
- Office 365/IMAP imports were creating duplicate tickets when repeated messages came from external senders that do not have a local requester account. 
- Enhance matching so the system makes reasonable attempts to match incoming emails to existing open tickets when the sender address appears in a ticket created from an email description.

### Description
- Extend the IMAP reply-ticket matching query in `app/services/imap.py` to also consider `LOWER(COALESCE(t.description, '')) LIKE LOWER(%s)` when `from_email` is present and no local `requester_id` is known, passing `"%{from_email}%"` as a parameter. 
- This allows matching tickets where the original email-created ticket stored the sender in the leading `From:` line of the description, preventing duplicate tickets for the same subject+sender.
- Add a regression test `test_find_ticket_by_subject_and_sender_in_description` in `tests/test_email_ticket_replies.py` covering the external-sender scenario.

### Testing
- Ran static compile checks with `python -m py_compile app/services/imap.py tests/test_email_ticket_replies.py` and they succeeded. 
- Ran the focused test suite with `pytest tests/test_email_ticket_replies.py::TestFindExistingTicket -q` and all tests passed (`9 passed`). 
- The added test `TestFindExistingTicket::test_find_ticket_by_subject_and_sender_in_description` passed, verifying the new matching behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cd21d5fcc83329fd1c1bd7232323b)