### PR TITLE
Process newest Syncro tickets first during full import

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -240,6 +240,34 @@ def _ticket_updated_at(ticket: dict[str, Any]) -> datetime | None:
     )
 
 
+
+def _syncro_ticket_sort_key(ticket: dict[str, Any]) -> tuple[datetime, int]:
+    """Return a descending-sort key for processing the freshest Syncro work first."""
+
+    timestamp = (
+        _ticket_updated_at(ticket)
+        or _parse_datetime(
+            ticket.get("created_at")
+            or ticket.get("created_on")
+            or ticket.get("created")
+            or ticket.get("created_at_utc")
+        )
+        or datetime.min.replace(tzinfo=timezone.utc)
+    )
+    try:
+        ticket_id = int(ticket.get("id") or 0)
+    except (TypeError, ValueError):
+        ticket_id = 0
+    return timestamp, ticket_id
+
+
+def _sort_syncro_tickets_newest_first(
+    tickets: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Order Syncro tickets by most recent change, falling back to id ordering."""
+
+    return sorted(tickets, key=_syncro_ticket_sort_key, reverse=True)
+
 def _existing_syncro_updated_at(existing: dict[str, Any]) -> datetime | None:
     """Return the last Syncro update timestamp stored for an imported ticket.
 
@@ -2017,47 +2045,50 @@ async def import_all_tickets(
     allowed_statuses, default_status, status_mappings = await _get_status_context()
     page = 1
     total_pages: int | None = None
+    tickets_to_process: list[dict[str, Any]] = []
     while True:
         tickets, meta = await syncro.list_tickets(page=page, rate_limiter=limiter)
         if not tickets:
             break
         summary.fetched += len(tickets)
-        for ticket in tickets:
-            try:
-                syncro_id = ticket.get("id")
-                existing = (
-                    await tickets_repo.get_ticket_by_external_reference(str(syncro_id))
-                    if syncro_id is not None
-                    else None
-                )
-                if _syncro_ticket_is_unchanged(ticket, existing):
-                    outcome = f"skipped: Syncro ticket {syncro_id} has not changed since last import"
-                else:
-                    ticket_detail = await _fetch_ticket_detail_for_import(
-                        ticket, rate_limiter=limiter
-                    )
-                    outcome = await _upsert_ticket(
-                        ticket_detail,
-                        allowed_statuses,
-                        default_status,
-                        status_mappings,
-                        mark_billable_time_as_billed=mark_billable_time_as_billed,
-                    )
-            except Exception as exc:  # pragma: no cover - defensive logging
-                reason = f"Syncro ticket {ticket.get('id') or 'unknown'} failed to import: {exc}"
-                log_error(
-                    "Failed to import Syncro ticket",
-                    syncro_id=ticket.get("id"),
-                    error=str(exc),
-                )
-                summary.record_skip(reason)
-                continue
-            summary.record(outcome)
+        tickets_to_process.extend(tickets)
         if total_pages is None:
             total_pages = _extract_total_pages(meta)
         if total_pages is not None and page >= total_pages:
             break
         page += 1
+
+    for ticket in _sort_syncro_tickets_newest_first(tickets_to_process):
+        try:
+            syncro_id = ticket.get("id")
+            existing = (
+                await tickets_repo.get_ticket_by_external_reference(str(syncro_id))
+                if syncro_id is not None
+                else None
+            )
+            if _syncro_ticket_is_unchanged(ticket, existing):
+                outcome = f"skipped: Syncro ticket {syncro_id} has not changed since last import"
+            else:
+                ticket_detail = await _fetch_ticket_detail_for_import(
+                    ticket, rate_limiter=limiter
+                )
+                outcome = await _upsert_ticket(
+                    ticket_detail,
+                    allowed_statuses,
+                    default_status,
+                    status_mappings,
+                    mark_billable_time_as_billed=mark_billable_time_as_billed,
+                )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            reason = f"Syncro ticket {ticket.get('id') or 'unknown'} failed to import: {exc}"
+            log_error(
+                "Failed to import Syncro ticket",
+                syncro_id=ticket.get("id"),
+                error=str(exc),
+            )
+            summary.record_skip(reason)
+            continue
+        summary.record(outcome)
     log_info(
         "Syncro ticket import completed",
         mode="all",

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -636,6 +636,82 @@ async def test_import_all_tickets_uses_pagination(monkeypatch):
     assert updated[0][0] == 88
 
 
+
+@pytest.mark.anyio
+async def test_import_all_tickets_processes_most_recent_changes_first(monkeypatch):
+    pages = {
+        1: (
+            [
+                {
+                    "id": 401,
+                    "subject": "Older page one ticket",
+                    "status": "Open",
+                    "priority": "Normal",
+                    "updated_at": "2024-01-02T10:00:00Z",
+                    "comments": [],
+                    "attachments": [],
+                },
+                {
+                    "id": 402,
+                    "subject": "Newest page one ticket",
+                    "status": "Open",
+                    "priority": "Normal",
+                    "updated_at": "2024-01-04T10:00:00Z",
+                    "comments": [],
+                    "attachments": [],
+                },
+            ],
+            {"total_pages": 2},
+        ),
+        2: (
+            [
+                {
+                    "id": 403,
+                    "subject": "Newest overall ticket",
+                    "status": "Open",
+                    "priority": "Normal",
+                    "updated_at": "2024-01-05T10:00:00Z",
+                    "comments": [],
+                    "attachments": [],
+                },
+                {
+                    "id": 404,
+                    "subject": "Oldest overall ticket",
+                    "status": "Open",
+                    "priority": "Normal",
+                    "updated_at": "2024-01-01T10:00:00Z",
+                    "comments": [],
+                    "attachments": [],
+                },
+            ],
+            {"total_pages": 2},
+        ),
+    }
+    processed: list[int] = []
+
+    async def fake_list_tickets(page, per_page=25, rate_limiter=None):
+        return pages.get(page, ([], {}))
+
+    async def fake_get_existing(_external_reference):
+        return None
+
+    async def fake_upsert_ticket(ticket, *args, **kwargs):
+        processed.append(ticket["id"])
+        return "created"
+
+    monkeypatch.setattr(syncro, "list_tickets", fake_list_tickets)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
+    monkeypatch.setattr(ticket_importer, "_upsert_ticket", fake_upsert_ticket)
+
+    summary = await ticket_importer.import_all_tickets(rate_limiter=None)
+
+    assert summary.fetched == 4
+    assert summary.created == 4
+    assert processed == [403, 402, 401, 404]
+
+
 @pytest.mark.anyio
 async def test_import_all_tickets_hydrates_detail_for_attachments(monkeypatch):
     pages = {


### PR DESCRIPTION
### Motivation
- Ensure the Full account Syncro ticket import processes the most recently changed tickets first rather than relying on paginated list order.
- Prevent older pages from causing stale ordering so recent updates are handled promptly and deterministically.

### Description
- Collect all paginated Syncro ticket summaries into `tickets_to_process` before processing during `import_all_tickets`.
- Add `_syncro_ticket_sort_key` and `_sort_syncro_tickets_newest_first` helpers to order tickets by `updated_at` (falling back to created timestamp and ticket id) and process newest-first.
- Replace the per-page processing loop with a post-pagination loop that processes tickets in newest-change-first order.
- Add a regression test `test_import_all_tickets_processes_most_recent_changes_first` in `tests/test_ticket_importer.py` to assert the processing order across pages.

### Testing
- Ran `python -m py_compile app/services/ticket_importer.py tests/test_ticket_importer.py` and compilation succeeded.
- Ran `pytest -q tests/test_ticket_importer.py -q` and the test suite for that file (including the new regression test) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cd59d7b60832dadc706840ab929ed)