### PR TITLE
Fix unbill automation ticket pagination

### DIFF
--- a/app/services/unbill_time_entries.py
+++ b/app/services/unbill_time_entries.py
@@ -21,36 +21,54 @@ def _display_ticket_label(ticket: Mapping[str, Any]) -> str:
 
 
 async def preview_unbill_time_entries(company_id: int | None = None, *, limit: int = 1000) -> dict[str, Any]:
-    """Preview billable, unbilled time entries that would be excluded from invoices."""
-    tickets = await tickets_repo.list_tickets(company_id=company_id, limit=limit)
+    """Preview billable, unbilled time entries that would be excluded from invoices.
+
+    Tickets are read in pages so the automation covers every ticket for the
+    selected customer instead of only the first repository page.  The ``limit``
+    argument controls the page size, matching the existing scheduled-task batch
+    behaviour without silently capping the total customer scan.
+    """
+    page_size = max(1, int(limit or 1000))
+    offset = 0
     items: list[dict[str, Any]] = []
     total_minutes = 0
-    for ticket in tickets:
-        ticket_id = ticket.get("id")
-        if not ticket_id:
-            continue
-        unbilled_ids = await billed_time_repo.get_unbilled_reply_ids(int(ticket_id))
-        if not unbilled_ids:
-            continue
-        replies = await tickets_repo.list_replies(int(ticket_id), include_internal=True)
-        for reply in replies:
-            reply_id = reply.get("id")
-            if reply_id not in unbilled_ids or not reply.get("is_billable"):
+    while True:
+        tickets = await tickets_repo.list_tickets(
+            company_id=company_id,
+            limit=page_size,
+            offset=offset,
+        )
+        if not tickets:
+            break
+        for ticket in tickets:
+            ticket_id = ticket.get("id")
+            if not ticket_id:
                 continue
-            minutes = invoice_generator_service._coerce_minutes(reply.get("minutes_spent"))
-            if minutes <= 0:
+            unbilled_ids = await billed_time_repo.get_unbilled_reply_ids(int(ticket_id))
+            if not unbilled_ids:
                 continue
-            total_minutes += minutes
-            items.append({
-                "type": "time_entry",
-                "id": int(reply_id),
-                "ticketId": int(ticket_id),
-                "label": _display_ticket_label(ticket),
-                "minutes": minutes,
-                "hours": str(invoice_generator_service._minutes_to_hours(minutes)),
-                "labourType": reply.get("labour_type_name") or reply.get("labour_type_code"),
-                "action": "Mark this billable time entry as already billed so invoice generation skips it",
-            })
+            replies = await tickets_repo.list_replies(int(ticket_id), include_internal=True)
+            for reply in replies:
+                reply_id = reply.get("id")
+                if reply_id not in unbilled_ids or not reply.get("is_billable"):
+                    continue
+                minutes = invoice_generator_service._coerce_minutes(reply.get("minutes_spent"))
+                if minutes <= 0:
+                    continue
+                total_minutes += minutes
+                items.append({
+                    "type": "time_entry",
+                    "id": int(reply_id),
+                    "ticketId": int(ticket_id),
+                    "label": _display_ticket_label(ticket),
+                    "minutes": minutes,
+                    "hours": str(invoice_generator_service._minutes_to_hours(minutes)),
+                    "labourType": reply.get("labour_type_name") or reply.get("labour_type_code"),
+                    "action": "Mark this billable time entry as already billed so invoice generation skips it",
+                })
+        if len(tickets) < page_size:
+            break
+        offset += page_size
     return {
         "status": "ready" if items else "skipped",
         "command": "unbill_time_entries",

--- a/tests/test_scheduled_task_preview.py
+++ b/tests/test_scheduled_task_preview.py
@@ -198,8 +198,8 @@ def test_generate_invoice_preview_resolves_requester_name_for_template(monkeypat
 
 
 def test_unbill_time_entries_preview_lists_billable_unbilled_entries(monkeypatch):
-    async def fake_tickets(company_id, limit):
-        return [{"id": 42, "ticket_number": "T-42", "subject": "AYCE support"}]
+    async def fake_tickets(company_id, limit, offset=0):
+        return [{"id": 42, "ticket_number": "T-42", "subject": "AYCE support"}] if offset == 0 else []
 
     async def fake_unbilled(ticket_id):
         return {100}
@@ -220,3 +220,37 @@ def test_unbill_time_entries_preview_lists_billable_unbilled_entries(monkeypatch
     assert preview["totals"] == {"timeEntryCount": 1, "minutes": 45}
     assert preview["items"][0]["label"] == "Ticket #T-42: AYCE support"
     assert preview["items"][0]["action"].startswith("Mark this billable time entry")
+
+
+def test_unbill_time_entries_preview_scans_all_ticket_pages(monkeypatch):
+    async def fake_tickets(company_id, limit, offset=0):
+        pages = {
+            0: [{"id": 42, "ticket_number": "T-42", "subject": "First page"}],
+            1: [{"id": 84, "ticket_number": "T-84", "subject": "Second page"}],
+        }
+        return pages.get(offset, [])
+
+    async def fake_unbilled(ticket_id):
+        return {ticket_id * 10}
+
+    async def fake_replies(ticket_id, include_internal):
+        return [
+            {
+                "id": ticket_id * 10,
+                "is_billable": True,
+                "minutes_spent": 30,
+                "labour_type_name": "Remote Support",
+            }
+        ]
+
+    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.tickets_repo, "list_tickets", fake_tickets)
+    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled)
+    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.tickets_repo, "list_replies", fake_replies)
+
+    preview = asyncio.run(
+        scheduled_task_preview.unbill_time_entries_service.preview_unbill_time_entries(1, limit=1)
+    )
+
+    assert preview["status"] == "ready"
+    assert preview["totals"] == {"timeEntryCount": 2, "minutes": 60}
+    assert [item["ticketId"] for item in preview["items"]] == [42, 84]


### PR DESCRIPTION
### Motivation
- The Un-Bill Time Entries preview only scanned the first repository page of tickets for a company, causing billable time entries on later pages to be skipped.

### Description
- Update `preview_unbill_time_entries` in `app/services/unbill_time_entries.py` to page through tickets using `limit` as a `page_size` and an `offset` loop until no more pages are returned.
- Preserve existing logic that checks `get_unbilled_reply_ids`, `is_billable`, and positive `minutes_spent` while aggregating `items` and `totals` across pages.
- Add a regression test `test_unbill_time_entries_preview_scans_all_ticket_pages` and adapt the existing `list_tickets` test mocks to accept an `offset` in `tests/test_scheduled_task_preview.py` to exercise pagination.
- No database migrations or API changes were made.

### Testing
- Ran `pytest tests/test_scheduled_task_preview.py -q` and the test file passed (`8 passed`, `108 warnings`).
- Ran `python -m py_compile app/services/unbill_time_entries.py tests/test_scheduled_task_preview.py` with no syntax errors.
- New regression test verifies the preview collects billable unbilled time entries from multiple ticket pages and aggregates totals accordingly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ce3f719a4832d9c97066af148b8c6)