### PR TITLE
Add cron calendar UI, API and backend to preview scheduled task runs

### DIFF
--- a/app/api/routes/scheduler.py
+++ b/app/api/routes/scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
@@ -16,12 +17,13 @@ from app.schemas.scheduler import (
     ScheduledTaskResponse,
     ScheduledTaskPreviewResponse,
     ScheduledTaskRunResponse,
+    ScheduledTaskCalendarEventResponse,
     ScheduledTaskUpdate,
     WebhookEventAttemptResponse,
     WebhookEventResponse,
     WebhookEventsBulkDeleteResponse,
 )
-from app.services import scheduled_task_preview, webhook_monitor
+from app.services import cron_calendar, scheduled_task_preview, webhook_monitor
 from app.services.scheduler import scheduler_service
 
 router = APIRouter(prefix="/scheduler", tags=["Scheduler"])
@@ -180,6 +182,20 @@ async def list_task_runs(
     response.headers["Cache-Control"] = "no-store"
     runs = await scheduled_tasks_repo.list_recent_runs(task_ids=[task_id], limit=limit)
     return [ScheduledTaskRunResponse.model_validate(run) for run in runs]
+
+
+@router.get("/calendar", response_model=list[ScheduledTaskCalendarEventResponse])
+async def list_calendar_events(
+    start: datetime,
+    end: datetime,
+    include_inactive: bool = False,
+    limit: int = Query(default=1000, ge=1, le=1000),
+    _: None = Depends(require_database),
+    __: dict[str, Any] = Depends(require_super_admin),
+) -> list[ScheduledTaskCalendarEventResponse]:
+    tasks = await scheduled_tasks_repo.list_calendar_tasks(include_inactive=include_inactive)
+    events = cron_calendar.build_calendar_events(tasks, start=start, end=end, limit=limit)
+    return [ScheduledTaskCalendarEventResponse.model_validate(event) for event in events]
 
 
 @router.get("/webhooks", response_model=list[WebhookEventResponse])

--- a/app/main.py
+++ b/app/main.py
@@ -5605,6 +5605,15 @@ async def admin_roles(request: Request):
     return await _render_template("admin/roles.html", request, current_user, extra=extra)
 
 
+@app.get("/admin/cron-calendar", response_class=HTMLResponse)
+async def admin_cron_calendar(request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+    extra = {"title": "Cron Calendar"}
+    return await _render_template("admin/cron_calendar.html", request, current_user, extra=extra)
+
+
 @app.get("/admin/automation", response_class=HTMLResponse)
 async def admin_automation(request: Request, show_inactive: bool = Query(default=False)):
     return RedirectResponse(url="/admin/scheduled-tasks", status_code=status.HTTP_301_MOVED_PERMANENTLY)

--- a/app/repositories/scheduled_tasks.py
+++ b/app/repositories/scheduled_tasks.py
@@ -93,6 +93,31 @@ async def list_tasks(include_inactive: bool = False) -> list[dict[str, Any]]:
     return [_normalise_task(row) for row in rows]
 
 
+async def list_calendar_tasks(include_inactive: bool = False) -> list[dict[str, Any]]:
+    """Return scheduled tasks with company names for calendar previews."""
+    where = "" if include_inactive else "WHERE t.active = 1"
+    rows = await db.fetch_all(
+        f"""
+        SELECT
+            t.*,
+            c.name AS company_name
+        FROM scheduled_tasks AS t
+        LEFT JOIN companies AS c ON c.id = t.company_id
+        {where}
+        ORDER BY t.name ASC
+        """,
+    )
+    tasks: list[dict[str, Any]] = []
+    for row in rows:
+        task = _normalise_task(row)
+        if task.get("company_id") is None:
+            task["company_name"] = "All companies"
+        elif not task.get("company_name"):
+            task["company_name"] = f"Company #{task['company_id']}"
+        tasks.append(task)
+    return tasks
+
+
 async def list_active_tasks() -> list[dict[str, Any]]:
     return await list_tasks(include_inactive=False)
 

--- a/app/schemas/scheduler.py
+++ b/app/schemas/scheduler.py
@@ -88,6 +88,24 @@ class ScheduledTaskRunResponse(BaseModel):
     }
 
 
+class ScheduledTaskCalendarEventResponse(BaseModel):
+    id: str
+    task_id: int = Field(serialization_alias="taskId")
+    title: str
+    command: str
+    cron: str
+    company_id: int | None = Field(default=None, serialization_alias="companyId")
+    company_name: str = Field(serialization_alias="companyName")
+    active: bool
+    start: datetime
+    url: str
+    last_status: str | None = Field(default=None, serialization_alias="lastStatus")
+
+    model_config = {
+        "populate_by_name": True,
+    }
+
+
 class WebhookEventResponse(BaseModel):
     id: int
     name: str

--- a/app/services/cron_calendar.py
+++ b/app/services/cron_calendar.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from croniter import CroniterBadCronError, croniter
+
+_MAX_EVENTS = 1000
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def build_calendar_events(
+    tasks: list[dict[str, Any]],
+    *,
+    start: datetime,
+    end: datetime,
+    limit: int = _MAX_EVENTS,
+) -> list[dict[str, Any]]:
+    """Expand cron-based scheduled tasks into UTC calendar event instances."""
+
+    start_utc = _as_utc(start)
+    end_utc = _as_utc(end)
+    if end_utc <= start_utc:
+        return []
+
+    capped_limit = max(1, min(limit, _MAX_EVENTS))
+    events: list[dict[str, Any]] = []
+    for task in tasks:
+        cron_expression = str(task.get("cron") or "").strip()
+        if not cron_expression:
+            continue
+        try:
+            iterator = croniter(cron_expression, start_utc)
+        except (CroniterBadCronError, ValueError, KeyError):
+            continue
+
+        while len(events) < capped_limit:
+            try:
+                next_run = iterator.get_next(datetime)
+            except (CroniterBadCronError, ValueError, KeyError):
+                break
+            next_run_utc = _as_utc(next_run)
+            if next_run_utc >= end_utc:
+                break
+            events.append(
+                {
+                    "id": f"task-{task.get('id')}-{next_run_utc.isoformat()}",
+                    "task_id": int(task.get("id") or 0),
+                    "title": str(task.get("name") or task.get("command") or "Scheduled task"),
+                    "command": str(task.get("command") or ""),
+                    "cron": cron_expression,
+                    "company_id": task.get("company_id"),
+                    "company_name": task.get("company_name") or "All companies",
+                    "active": bool(task.get("active")),
+                    "start": next_run_utc.isoformat(),
+                    "url": f"/admin/scheduled-tasks?taskId={task.get('id')}",
+                    "last_status": task.get("last_status"),
+                }
+            )
+        if len(events) >= capped_limit:
+            break
+    events.sort(key=lambda event: (event["start"], event["title"]))
+    return events

--- a/app/static/js/cron_calendar.js
+++ b/app/static/js/cron_calendar.js
@@ -1,0 +1,105 @@
+(function () {
+  const root = document.querySelector('[data-cron-calendar]');
+  if (!root) return;
+
+  const state = { view: 'day', anchor: new Date(), events: [], search: '', includeInactive: false };
+  const grid = root.querySelector('[data-calendar-grid]');
+  const rangeLabel = root.querySelector('[data-calendar-range]');
+  const countLabel = root.querySelector('[data-calendar-count]');
+  const statusBox = root.querySelector('[data-calendar-status]');
+  const searchInput = root.querySelector('[data-calendar-search]');
+  const inactiveInput = root.querySelector('[data-calendar-inactive]');
+
+  function startOfDay(date) { const d = new Date(date); d.setHours(0, 0, 0, 0); return d; }
+  function addDays(date, days) { const d = new Date(date); d.setDate(d.getDate() + days); return d; }
+  function startOfWeek(date) { const d = startOfDay(date); d.setDate(d.getDate() - d.getDay()); return d; }
+  function startOfMonth(date) { return new Date(date.getFullYear(), date.getMonth(), 1); }
+  function addMonths(date, months) { return new Date(date.getFullYear(), date.getMonth() + months, 1); }
+  function escapeHtml(value) { return String(value || '').replace(/[&<>'"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[c])); }
+  function formatDate(date, opts) { return new Intl.DateTimeFormat(undefined, opts).format(date); }
+  function formatTime(date) { return new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' }).format(date); }
+
+  function rangeForView() {
+    if (state.view === 'month') { const start = startOfMonth(state.anchor); return { start, end: addMonths(start, 1) }; }
+    if (state.view === 'week') { const start = startOfWeek(state.anchor); return { start, end: addDays(start, 7) }; }
+    if (state.view === 'list') { const start = startOfDay(state.anchor); return { start, end: addDays(start, 30) }; }
+    const start = startOfDay(state.anchor); return { start, end: addDays(start, 1) };
+  }
+
+  function setStatus(message, isError) {
+    statusBox.hidden = !message;
+    statusBox.textContent = message || '';
+    statusBox.classList.toggle('card--danger', Boolean(isError));
+  }
+
+  async function loadEvents() {
+    const { start, end } = rangeForView();
+    rangeLabel.textContent = `${formatDate(start, { dateStyle: 'medium' })} – ${formatDate(addDays(end, -1), { dateStyle: 'medium' })}`;
+    setStatus('Loading scheduled tasks…', false);
+    const params = new URLSearchParams({ start: start.toISOString(), end: end.toISOString(), include_inactive: state.includeInactive ? 'true' : 'false', limit: '1000' });
+    try {
+      const response = await fetch(`/scheduler/calendar?${params}`, { credentials: 'same-origin', headers: { Accept: 'application/json' } });
+      if (!response.ok) throw new Error(`Calendar request failed (${response.status})`);
+      state.events = await response.json();
+      setStatus('', false);
+      render();
+    } catch (error) {
+      state.events = [];
+      setStatus(error.message || 'Unable to load scheduled task calendar.', true);
+      render();
+    }
+  }
+
+  function filteredEvents() {
+    const term = state.search.trim().toLowerCase();
+    if (!term) return state.events;
+    return state.events.filter(event => [event.title, event.command, event.cron, event.companyName].some(value => String(value || '').toLowerCase().includes(term)));
+  }
+
+  function eventHtml(event) {
+    const startsAt = new Date(event.start);
+    return `<a class="cron-calendar__event" href="${escapeHtml(event.url)}">
+      <strong>${escapeHtml(event.title)}</strong>
+      <span class="cron-calendar__event-meta"><span>${formatTime(startsAt)}</span><span>${escapeHtml(event.companyName)}</span><code>${escapeHtml(event.cron)}</code><span>${escapeHtml(event.command)}</span>${event.active ? '' : '<span>Inactive</span>'}</span>
+    </a>`;
+  }
+
+  function renderPeriod(label, events) {
+    return `<section class="cron-calendar__period"><div class="cron-calendar__period-header">${escapeHtml(label)}</div><div class="cron-calendar__events">${events.length ? events.map(eventHtml).join('') : '<p class="cron-calendar__empty">No scheduled runs.</p>'}</div></section>`;
+  }
+
+  function render() {
+    const events = filteredEvents();
+    countLabel.textContent = String(events.length);
+    grid.className = `cron-calendar__grid cron-calendar__grid--${state.view}`;
+    const { start } = rangeForView();
+    if (state.view === 'day') {
+      grid.innerHTML = renderPeriod(formatDate(start, { weekday: 'long', dateStyle: 'full' }), events);
+      return;
+    }
+    if (state.view === 'list') {
+      const byDay = new Map();
+      events.forEach(event => { const key = formatDate(new Date(event.start), { dateStyle: 'full' }); byDay.set(key, [...(byDay.get(key) || []), event]); });
+      grid.innerHTML = byDay.size ? Array.from(byDay.entries()).map(([label, items]) => renderPeriod(label, items)).join('') : renderPeriod('Upcoming 30 days', []);
+      return;
+    }
+    const days = state.view === 'week' ? 7 : new Date(start.getFullYear(), start.getMonth() + 1, 0).getDate();
+    grid.innerHTML = Array.from({ length: days }, (_, idx) => {
+      const day = addDays(start, idx);
+      const items = events.filter(event => startOfDay(new Date(event.start)).getTime() === day.getTime());
+      return renderPeriod(formatDate(day, { weekday: 'short', month: 'short', day: 'numeric' }), items);
+    }).join('');
+  }
+
+  document.querySelectorAll('[data-calendar-view]').forEach(button => button.addEventListener('click', () => {
+    state.view = button.dataset.calendarView;
+    document.querySelectorAll('[data-calendar-view]').forEach(btn => { btn.classList.toggle('button--primary', btn === button); btn.classList.toggle('button--ghost', btn !== button); });
+    loadEvents();
+  }));
+  root.querySelector('[data-calendar-prev]').addEventListener('click', () => { state.anchor = state.view === 'month' ? addMonths(state.anchor, -1) : addDays(state.anchor, state.view === 'week' ? -7 : state.view === 'list' ? -30 : -1); loadEvents(); });
+  root.querySelector('[data-calendar-next]').addEventListener('click', () => { state.anchor = state.view === 'month' ? addMonths(state.anchor, 1) : addDays(state.anchor, state.view === 'week' ? 7 : state.view === 'list' ? 30 : 1); loadEvents(); });
+  root.querySelector('[data-calendar-today]').addEventListener('click', () => { state.anchor = new Date(); loadEvents(); });
+  searchInput.addEventListener('input', () => { state.search = searchInput.value || ''; render(); });
+  inactiveInput.addEventListener('change', () => { state.includeInactive = inactiveInput.checked; loadEvents(); });
+  loadEvents();
+}());

--- a/app/templates/admin/cron_calendar.html
+++ b/app/templates/admin/cron_calendar.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+{% block header_title %}<span class="header__title-text">{{ title | default('Cron Calendar') }}</span>{% endblock %}
+
+{% block header_actions %}
+  <a class="button button--ghost" href="/admin/scheduled-tasks">Manage scheduled tasks</a>
+  <div class="button-group" role="group" aria-label="Calendar views">
+    <button class="button button--primary" type="button" data-calendar-view="day">Day</button>
+    <button class="button button--ghost" type="button" data-calendar-view="week">Week</button>
+    <button class="button button--ghost" type="button" data-calendar-view="month">Month</button>
+    <button class="button button--ghost" type="button" data-calendar-view="list">List</button>
+  </div>
+{% endblock %}
+
+{% block content %}
+<div class="management management--single cron-calendar" data-cron-calendar>
+  <section class="management__content">
+    <header class="management__header">
+      <div>
+        <h1 class="management__title">Cron Calendar</h1>
+        <p class="management__subtitle">Review upcoming scheduled task runs in your local timezone before planning new automation windows.</p>
+      </div>
+      <form class="management__filters" data-calendar-filters>
+        <label class="form-field">
+          <span class="form-label">Filter</span>
+          <input class="form-input" type="search" placeholder="Task, command, company, cron" data-calendar-search />
+        </label>
+        <label class="form-checkbox-label">
+          <input class="form-checkbox" type="checkbox" data-calendar-inactive />
+          <span class="form-checkbox-text">Show inactive tasks</span>
+        </label>
+      </form>
+    </header>
+
+    <div class="card card--panel cron-calendar__toolbar">
+      <div class="cron-calendar__nav">
+        <button class="button button--ghost" type="button" data-calendar-prev>Previous</button>
+        <button class="button button--ghost" type="button" data-calendar-today>Today</button>
+        <button class="button button--ghost" type="button" data-calendar-next>Next</button>
+      </div>
+      <div>
+        <h2 class="card__title" data-calendar-range>Loading…</h2>
+        <p class="card__subtitle"><span data-calendar-count>0</span> scheduled task runs shown. Times are converted from UTC to your browser timezone.</p>
+      </div>
+    </div>
+
+    <div class="card card--panel cron-calendar__status" data-calendar-status hidden></div>
+    <div class="cron-calendar__grid" data-calendar-grid aria-live="polite"></div>
+  </section>
+</div>
+{% endblock %}
+
+{% block extra_head %}
+<style>
+  .button-group { display: inline-flex; gap: .35rem; flex-wrap: wrap; }
+  .cron-calendar__toolbar { display: flex; justify-content: space-between; gap: 1rem; align-items: center; margin-bottom: 1rem; }
+  .cron-calendar__nav { display: flex; gap: .5rem; flex-wrap: wrap; }
+  .cron-calendar__grid { display: grid; gap: .75rem; max-height: calc(100vh - 18rem); overflow: auto; }
+  .cron-calendar__period { border: 1px solid var(--border-color, #d8dee9); border-radius: .75rem; background: var(--surface-color, #fff); min-height: 8rem; overflow: hidden; }
+  .cron-calendar__period-header { padding: .65rem .85rem; font-weight: 700; background: var(--surface-muted, #f8fafc); border-bottom: 1px solid var(--border-color, #d8dee9); }
+  .cron-calendar__events { display: grid; gap: .5rem; padding: .65rem; }
+  .cron-calendar__event { display: grid; gap: .25rem; border-left: .25rem solid var(--primary-color, #2563eb); padding: .55rem .65rem; background: color-mix(in srgb, var(--primary-color, #2563eb) 8%, transparent); border-radius: .5rem; text-decoration: none; color: inherit; }
+  .cron-calendar__event-meta { display: flex; gap: .5rem; flex-wrap: wrap; font-size: .82rem; color: var(--text-muted, #64748b); }
+  .cron-calendar__empty { padding: 1rem; color: var(--text-muted, #64748b); }
+  .cron-calendar__grid--month { grid-template-columns: repeat(7, minmax(9rem, 1fr)); }
+  .cron-calendar__grid--week { grid-template-columns: repeat(7, minmax(10rem, 1fr)); }
+  .cron-calendar__grid--day, .cron-calendar__grid--list { grid-template-columns: 1fr; }
+  @media (max-width: 900px) { .cron-calendar__grid--month, .cron-calendar__grid--week { grid-template-columns: 1fr; } .cron-calendar__toolbar { align-items: stretch; flex-direction: column; } }
+</style>
+<script src="{{ static_url('/static/js/cron_calendar.js') }}" defer></script>
+{% endblock %}

--- a/app/templates/admin/scheduled_tasks.html
+++ b/app/templates/admin/scheduled_tasks.html
@@ -2,6 +2,7 @@
 {% block header_title %}<span class="header__title-text">{{ title | default('Scheduled Tasks') }}</span>{% endblock %}
 
 {% block header_actions %}
+  <a class="button button--ghost" href="/admin/cron-calendar">Schedule calendar</a>
   <button
     type="button"
     class="button button--primary"

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -544,6 +544,14 @@
                 </a>
               </li>
               <li class="menu__item">
+                <a href="/admin/cron-calendar" {% if current_path.startswith('/admin/cron-calendar') %}aria-current="page"{% endif %}>
+                  <span class="menu__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false"><path d="M7 2h2v2h6V2h2v2h3a1 1 0 0 1 1 1v15a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a1 1 0 0 1 1-1h3V2zm12 8H5v10h14V10zM5 6v2h14V6H5zm2 6h3v3H7v-3zm5 0h3v3h-3v-3z"/></svg>
+                  </span>
+                  <span class="menu__label">Schedule</span>
+                </a>
+              </li>
+              <li class="menu__item">
                 <a href="/admin/backup-jobs" {% if current_path.startswith('/admin/backup-jobs') %}aria-current="page"{% endif %}>
                   <span class="menu__icon" aria-hidden="true">
                     <svg viewBox="0 0 24 24" focusable="false"><path d="M12 3a8 4 0 0 1 8 4v10a8 4 0 0 1-16 0V7a8 4 0 0 1 8-4zm-6 4c0 1.1 2.69 2 6 2s6-.9 6-2-2.69-2-6-2-6 .9-6 2zm0 3.5V13c0 1.1 2.69 2 6 2s6-.9 6-2v-2.5c-1.36.95-3.7 1.5-6 1.5s-4.64-.55-6-1.5zm0 4.5v2c0 1.1 2.69 2 6 2s6-.9 6-2v-2c-1.36.95-3.7 1.5-6 1.5s-4.64-.55-6-1.5z"/></svg>

--- a/tests/test_cron_calendar.py
+++ b/tests/test_cron_calendar.py
@@ -1,0 +1,53 @@
+from datetime import datetime, timezone
+
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("cron_calendar", Path("app/services/cron_calendar.py"))
+cron_calendar = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(cron_calendar)
+build_calendar_events = cron_calendar.build_calendar_events
+
+
+def test_build_calendar_events_expands_cron_in_utc_order():
+    tasks = [
+        {
+            "id": 1,
+            "name": "Nightly sync",
+            "command": "sync_staff",
+            "cron": "0 0 * * *",
+            "company_id": None,
+            "company_name": "All companies",
+            "active": True,
+        },
+        {
+            "id": 2,
+            "name": "Morning mail",
+            "command": "sync_m365_mailboxes",
+            "cron": "30 6 * * *",
+            "company_id": 4,
+            "company_name": "Example Co",
+            "active": True,
+        },
+    ]
+
+    events = build_calendar_events(
+        tasks,
+        start=datetime(2026, 7, 7, tzinfo=timezone.utc),
+        end=datetime(2026, 7, 8, tzinfo=timezone.utc),
+    )
+
+    assert [event["title"] for event in events] == ["Morning mail"]
+    assert events[0]["start"] == "2026-07-07T06:30:00+00:00"
+    assert events[0]["company_name"] == "Example Co"
+
+
+def test_build_calendar_events_skips_invalid_cron():
+    events = build_calendar_events(
+        [{"id": 1, "name": "Broken", "cron": "not a cron", "active": True}],
+        start=datetime(2026, 7, 7, tzinfo=timezone.utc),
+        end=datetime(2026, 7, 8, tzinfo=timezone.utc),
+    )
+
+    assert events == []


### PR DESCRIPTION
### Motivation
- Provide a way to preview upcoming scheduled task runs by expanding cron expressions into calendar events so admins can review automation timing before scheduling changes.

### Description
- Added a new cron expansion service `app/services/cron_calendar.py` that exposes `build_calendar_events` to expand cron expressions into UTC event instances and caps results with a limit.
- Exposed a new admin page and UI via `GET /admin/cron-calendar`, the template `app/templates/admin/cron_calendar.html`, and the client script `app/static/js/cron_calendar.js` to render day/week/month/list views and filtering.
- Added API support `GET /scheduler/calendar` in `app/api/routes/scheduler.py`, a response schema `ScheduledTaskCalendarEventResponse` in `app/schemas/scheduler.py`, and a repository helper `list_calendar_tasks` in `app/repositories/scheduled_tasks.py` to fetch tasks with company names.
- Integrated the calendar entry points into the UI by adding a menu item in `app/templates/base.html` and a link from `app/templates/admin/scheduled_tasks.html`.

### Testing
- Added unit tests in `tests/test_cron_calendar.py` that exercise `build_calendar_events` for normal cron expansion and invalid cron handling, and ran `pytest tests/test_cron_calendar.py`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ce808ccf8832d9c8175eac2b42275)