### PR TITLE
Add ticket un-bill cutoff tool

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -48,6 +48,7 @@ from app.services import labour_types as labour_types_service
 from app.services import ticket_attachments as attachments_service
 from app.services import rag_retrieval
 from app.services import tickets as tickets_service
+from app.services import unbill_tickets as unbill_tickets_service
 from app.services import tray as tray_service
 from app.services.sanitization import sanitize_rich_text
 
@@ -65,14 +66,10 @@ _RELATED_STOP_WORDS = {
 }
 
 
-
 def _main():
     from app import main as main_module
 
     return main_module
-
-
-
 
 
 def _strip_external_links(text: str) -> str:
@@ -300,7 +297,6 @@ async def admin_ticket_detail(
     )
 
 
-
 @router.get("/admin/tickets/{ticket_id:int}/automation-history", response_class=JSONResponse)
 async def admin_ticket_automation_history(
     ticket_id: int,
@@ -437,6 +433,26 @@ async def admin_update_next_ticket_number(request: Request):
         log_debug("Failed to update ticket AUTO_INCREMENT from admin setting", error=str(exc))
     return flash_redirect("/admin/tickets", f"Next ticket number set to {next_ticket_number}.", "success")
 
+
+@router.post("/admin/tickets/unbill-older-than", response_class=HTMLResponse)
+async def admin_unbill_tickets_older_than(request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        return redirect
+    if not current_user.get("is_super_admin"):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Super admin access required")
+
+    form = await request.form()
+    raw_cutoff = str(form.get("cutoffDate", "")).strip()
+    try:
+        cutoff_date = unbill_tickets_service.parse_unbill_cutoff_date(raw_cutoff)
+    except ValueError as exc:
+        return flash_redirect("/admin/tickets", str(exc), "error")
+
+    result = await unbill_tickets_service.unbill_tickets_older_than(cutoff_date)
+    level = "success" if result.get("status") == "succeeded" else "info"
+    return flash_redirect("/admin/tickets", str(result.get("summary") or "Ticket un-bill completed."), level)
 
 @router.post("/admin/tickets", response_class=HTMLResponse)
 async def admin_create_ticket(request: Request):

--- a/app/repositories/ticket_billed_time_entries.py
+++ b/app/repositories/ticket_billed_time_entries.py
@@ -155,3 +155,15 @@ async def rename_invoice_number(
         """,
         (new_invoice_number, old_invoice_number, company_id),
     )
+
+
+async def delete_entries_for_tickets(ticket_ids: list[int]) -> int:
+    """Delete billed-time markers for the supplied tickets and return affected rows."""
+    clean_ids = sorted({int(ticket_id) for ticket_id in ticket_ids if ticket_id})
+    if not clean_ids:
+        return 0
+    placeholders = ", ".join(["%s"] * len(clean_ids))
+    return await db.execute_rowcount(
+        f"DELETE FROM ticket_billed_time_entries WHERE ticket_id IN ({placeholders})",
+        tuple(clean_ids),
+    )

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -776,7 +776,6 @@ async def count_tickets_for_user(
     return int(row["count"]) if row else 0
 
 
-
 async def count_tickets(
     *,
     status: str | None = None,
@@ -993,6 +992,40 @@ async def replace_ticket_assets(ticket_id: int, asset_ids: Iterable[int]) -> lis
 
     return await list_ticket_assets(ticket_id)
 
+
+async def list_billed_tickets_older_than(cutoff: datetime, *, limit: int = 10000) -> list[TicketRecord]:
+    """Return billed, unmerged tickets created before the supplied UTC cutoff."""
+    rows = await db.fetch_all(
+        """
+        SELECT *
+        FROM tickets
+        WHERE merged_into_ticket_id IS NULL
+          AND created_at < %s
+          AND (billed_at IS NOT NULL OR COALESCE(TRIM(xero_invoice_number), '') <> '')
+        ORDER BY created_at ASC, id ASC
+        LIMIT %s
+        """,
+        (cutoff, int(max(1, limit))),
+    )
+    return [_normalise_ticket(row) for row in rows]
+
+
+async def clear_ticket_billing_fields(ticket_ids: list[int]) -> int:
+    """Clear ticket-level billing markers for the supplied tickets."""
+    clean_ids = sorted({int(ticket_id) for ticket_id in ticket_ids if ticket_id})
+    if not clean_ids:
+        return 0
+    placeholders = ", ".join(["%s"] * len(clean_ids))
+    return await db.execute_rowcount(
+        f"""
+        UPDATE tickets
+        SET xero_invoice_number = NULL,
+            billed_at = NULL,
+            updated_at = %s
+        WHERE id IN ({placeholders})
+        """,
+        (datetime.now(timezone.utc), *clean_ids),
+    )
 
 async def update_ticket(ticket_id: int, **fields: Any) -> TicketRecord | None:
     if not fields:
@@ -1794,7 +1827,6 @@ async def merge_tickets(
     target_ticket = await get_ticket(target_ticket_id)
 
     return target_ticket, source_ticket_ids, moved_count
-
 
 
 async def list_merged_child_tickets(parent_ticket_id: int) -> list[TicketRecord]:

--- a/app/services/unbill_tickets.py
+++ b/app/services/unbill_tickets.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from app.repositories import ticket_billed_time_entries as billed_time_repo
+from app.repositories import tickets as tickets_repo
+
+_DATE_FORMAT = "%Y%m%d"
+_MAX_TICKETS_PER_RUN = 10000
+
+
+def parse_unbill_cutoff_date(value: str) -> datetime:
+    """Parse a yyyyMMdd cutoff date as the start of that UTC day."""
+    cleaned = (value or "").strip()
+    if not cleaned:
+        raise ValueError("Enter a cutoff date in yyyyMMdd format.")
+    if len(cleaned) != 8 or not cleaned.isdigit():
+        raise ValueError("Cutoff date must use yyyyMMdd format, for example 20240131.")
+    try:
+        parsed = datetime.strptime(cleaned, _DATE_FORMAT)
+    except ValueError as exc:
+        raise ValueError("Enter a valid cutoff date in yyyyMMdd format.") from exc
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def _ticket_label(ticket: Mapping[str, Any]) -> str:
+    ticket_number = str(ticket.get("ticket_number") or "").strip()
+    subject = str(ticket.get("subject") or "").strip()
+    if ticket_number and subject:
+        return f"Ticket #{ticket_number}: {subject}"
+    if subject:
+        return subject
+    return f"Ticket #{ticket.get('id')}"
+
+
+async def preview_unbill_tickets(cutoff_date: datetime) -> dict[str, Any]:
+    """Preview billed tickets created before the UTC cutoff date."""
+    tickets = await tickets_repo.list_billed_tickets_older_than(
+        cutoff_date,
+        limit=_MAX_TICKETS_PER_RUN,
+    )
+    items = [
+        {
+            "type": "ticket",
+            "id": int(ticket["id"]),
+            "label": _ticket_label(ticket),
+            "createdAt": ticket.get("created_at"),
+            "billedAt": ticket.get("billed_at"),
+            "invoiceNumber": ticket.get("xero_invoice_number"),
+            "action": "Remove ticket billing markers and billed time-entry records",
+        }
+        for ticket in tickets
+        if ticket.get("id")
+    ]
+    return {
+        "status": "ready" if items else "skipped",
+        "command": "unbill_tickets",
+        "cutoffDate": cutoff_date.date().isoformat(),
+        "summary": (
+            f"{len(items)} billed ticket{'s' if len(items) != 1 else ''} created before "
+            f"{cutoff_date.date().isoformat()} will be un-billed."
+            if items else f"No billed tickets created before {cutoff_date.date().isoformat()} were found."
+        ),
+        "totals": {"ticketCount": len(items)},
+        "items": items,
+    }
+
+
+async def unbill_tickets_older_than(cutoff_date: datetime) -> dict[str, Any]:
+    """Remove billing markers from billed tickets created before the cutoff date."""
+    preview = await preview_unbill_tickets(cutoff_date)
+    ticket_ids = [int(item["id"]) for item in preview.get("items", []) if item.get("id")]
+    if not ticket_ids:
+        return preview
+    deleted_entries = await billed_time_repo.delete_entries_for_tickets(ticket_ids)
+    cleared_tickets = await tickets_repo.clear_ticket_billing_fields(ticket_ids)
+    return {
+        **preview,
+        "status": "succeeded" if cleared_tickets else "skipped",
+        "unbilledTickets": cleared_tickets,
+        "deletedBilledTimeEntries": deleted_entries,
+        "summary": (
+            f"Un-billed {cleared_tickets} ticket{'s' if cleared_tickets != 1 else ''} and removed "
+            f"{deleted_entries} billed time entr{'ies' if deleted_entries != 1 else 'y'}."
+        ),
+    }

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -7,8 +7,9 @@
   {% set show_labour_type_editor = is_super_admin %}
   {% set show_tag_exclusions = is_super_admin %}
   {% set show_next_ticket_number = is_super_admin %}
+  {% set show_unbill_tickets = is_super_admin %}
   {% set can_merge_tickets = is_helpdesk_technician | default(false) %}
-  {% set show_ticket_tools = show_ticket_automations or show_syncro_import or show_ticket_status_editor or show_labour_type_editor or show_next_ticket_number or show_tag_exclusions or can_bulk_delete_tickets or can_merge_tickets %}
+  {% set show_ticket_tools = show_ticket_automations or show_syncro_import or show_ticket_status_editor or show_labour_type_editor or show_next_ticket_number or show_unbill_tickets or show_tag_exclusions or can_bulk_delete_tickets or can_merge_tickets %}
   <div class="header-title-menu">
     <span class="header-title-menu__label">Ticketing workspace</span>
     <button
@@ -81,6 +82,18 @@
               </button>
             </li>
           {% endif %}
+          {% if show_unbill_tickets %}
+            <li class="header-title-menu__item" role="none">
+              <button
+                type="button"
+                class="header-title-menu__link"
+                role="menuitem"
+                data-unbill-tickets-open
+              >
+                Un-bill tickets
+              </button>
+            </li>
+          {% endif %}
           {% if show_tag_exclusions %}
             <li class="header-title-menu__item" role="none">
               <a href="/admin/tag-exclusions" class="header-title-menu__link" role="menuitem">AI tag exclusions</a>
@@ -126,6 +139,14 @@
     <form action="/admin/tickets/next-number" method="post" data-next-ticket-number-form hidden>
       {% include "partials/csrf.html" %}
       <input type="hidden" name="nextTicketNumber" value="" data-next-ticket-number-input />
+    </form>
+  {% endif %}
+
+
+  {% if show_unbill_tickets %}
+    <form action="/admin/tickets/unbill-older-than" method="post" data-unbill-tickets-form hidden>
+      {% include "partials/csrf.html" %}
+      <input type="hidden" name="cutoffDate" value="" data-unbill-tickets-date-input />
     </form>
   {% endif %}
 
@@ -1131,6 +1152,26 @@
           window.alert('Enter a positive whole number.');
           return;
         }
+        input.value = cleaned;
+        form.requestSubmit();
+      });
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const button = document.querySelector('[data-unbill-tickets-open]');
+      const form = document.querySelector('[data-unbill-tickets-form]');
+      const input = document.querySelector('[data-unbill-tickets-date-input]');
+      if (!button || !form || !input) return;
+      button.addEventListener('click', () => {
+        const value = window.prompt('Enter the cutoff date in yyyyMMdd format. Billed tickets created before this UTC date will be un-billed.');
+        if (value === null) return;
+        const cleaned = value.trim();
+        if (!/^\d{8}$/.test(cleaned)) {
+          window.alert('Enter the date in yyyyMMdd format, for example 20240131.');
+          return;
+        }
+        const confirmed = window.confirm(`Un-bill billed tickets created before ${cleaned}? This removes ticket billing markers and billed time-entry records.`);
+        if (!confirmed) return;
         input.value = cleaned;
         form.requestSubmit();
       });

--- a/tests/test_unbill_tickets.py
+++ b/tests/test_unbill_tickets.py
@@ -1,0 +1,48 @@
+from datetime import timezone
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+def _load_unbill_tickets_module():
+    app_module = sys.modules.setdefault("app", types.ModuleType("app"))
+    repos_module = types.ModuleType("app.repositories")
+    repos_module.ticket_billed_time_entries = types.SimpleNamespace()
+    repos_module.tickets = types.SimpleNamespace()
+    sys.modules["app.repositories"] = repos_module
+    services_module = types.ModuleType("app.services")
+    sys.modules["app.services"] = services_module
+    app_module.repositories = repos_module
+    app_module.services = services_module
+
+    spec = importlib.util.spec_from_file_location(
+        "unbill_tickets_under_test",
+        Path(__file__).resolve().parents[1] / "app" / "services" / "unbill_tickets.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+unbill_tickets = _load_unbill_tickets_module()
+
+
+def test_parse_unbill_cutoff_date_accepts_yyyymmdd_as_utc_start():
+    parsed = unbill_tickets.parse_unbill_cutoff_date("20240131")
+
+    assert parsed.year == 2024
+    assert parsed.month == 1
+    assert parsed.day == 31
+    assert parsed.hour == 0
+    assert parsed.minute == 0
+    assert parsed.tzinfo == timezone.utc
+
+
+@pytest.mark.parametrize("value", ["", "2024-01-31", "202401", "20240231", "abcdefgh"])
+def test_parse_unbill_cutoff_date_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        unbill_tickets.parse_unbill_cutoff_date(value)


### PR DESCRIPTION
### Motivation
- Provide a safe admin action to un-bill tickets created before a supplied cutoff date so billing markers and billed time-entry records can be reverted in bulk. 
- The action must be restricted to super-admins and accept a compact `yyyyMMdd` cutoff date format to match automation/operator workflows.

### Description
- Added a new service `app/services/unbill_tickets.py` that parses `yyyyMMdd` cutoff dates (as UTC day-start), previews matching billed tickets, and un-bills them by clearing ticket billing fields and removing billed time-entry markers. 
- Added repository helpers `list_billed_tickets_older_than` and `clear_ticket_billing_fields` in `app/repositories/tickets.py` and `delete_entries_for_tickets` in `app/repositories/ticket_billed_time_entries.py` to perform the DB operations. 
- Added a POST handler `POST /admin/tickets/unbill-older-than` in `app/features/tickets/admin_routes.py` enforcing helpdesk access and super-admin permission, validating the `yyyyMMdd` input and returning a flash message with the result. 
- Updated the admin tickets template `app/templates/admin/tickets.html` to expose a super-admin-only "Un-bill tickets" menu item, include a CSRF-protected hidden form, and client-side prompt/confirmation logic that accepts `yyyyMMdd` and submits the form. 
- Added regression tests `tests/test_unbill_tickets.py` covering cutoff-date parsing and validation.

### Testing
- Ran compilation checks with `python -m compileall app/services/unbill_tickets.py app/repositories/ticket_billed_time_entries.py app/repositories/tickets.py app/features/tickets/admin_routes.py` and they compiled successfully. 
- Executed the new unit tests with `pytest tests/test_unbill_tickets.py` and all tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cfdcb3d0c832db2aa1d85bf4f8436)