### PR TITLE
Fix unbill time entries to clear billable flags

### DIFF
--- a/app/repositories/ticket_billed_time_entries.py
+++ b/app/repositories/ticket_billed_time_entries.py
@@ -167,3 +167,15 @@ async def delete_entries_for_tickets(ticket_ids: list[int]) -> int:
         f"DELETE FROM ticket_billed_time_entries WHERE ticket_id IN ({placeholders})",
         tuple(clean_ids),
     )
+
+
+async def delete_entries_for_replies(reply_ids: list[int]) -> int:
+    """Delete billed-time markers for the supplied replies and return affected rows."""
+    clean_ids = sorted({int(reply_id) for reply_id in reply_ids if reply_id})
+    if not clean_ids:
+        return 0
+    placeholders = ", ".join(["%s"] * len(clean_ids))
+    return await db.execute_rowcount(
+        f"DELETE FROM ticket_billed_time_entries WHERE reply_id IN ({placeholders})",
+        tuple(clean_ids),
+    )

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -488,6 +488,54 @@ async def list_tickets(
     return [_normalise_ticket(row) for row in rows]
 
 
+async def list_billable_time_entries(
+    *,
+    company_id: int | None = None,
+    limit: int | None = 1000,
+    offset: int = 0,
+) -> list[TicketRecord]:
+    """Return billable ticket replies with positive tracked time.
+
+    This query scans time entries directly instead of paging through tickets so
+    bulk un-billing catches entries on closed, billed, or otherwise filtered
+    tickets that still contribute to billable-time reports.
+    """
+    where = [
+        "tr.is_billable = 1",
+        "tr.minutes_spent IS NOT NULL",
+        "tr.minutes_spent > 0",
+    ]
+    params: list[Any] = []
+    if company_id is not None:
+        where.append("t.company_id = %s")
+        params.append(int(company_id))
+    query_parts = [
+        "SELECT tr.*, t.ticket_number, t.subject, t.company_id, lt.name AS labour_type_name, lt.code AS labour_type_code",
+        "FROM ticket_replies tr",
+        "INNER JOIN tickets t ON t.id = tr.ticket_id",
+        "LEFT JOIN ticket_labour_types lt ON lt.id = tr.labour_type_id",
+        "WHERE " + " AND ".join(where),
+        "ORDER BY tr.created_at ASC, tr.id ASC",
+    ]
+    if limit is not None:
+        query_parts.append("LIMIT %s OFFSET %s")
+        params.extend([int(max(1, limit)), int(max(0, offset))])
+    rows = await db.fetch_all("\n".join(query_parts), tuple(params))
+    return [dict(row) for row in rows]
+
+
+async def mark_replies_non_billable(reply_ids: Sequence[int]) -> int:
+    """Clear the billable flag for the supplied replies and return affected rows."""
+    clean_ids = sorted({int(reply_id) for reply_id in reply_ids if reply_id})
+    if not clean_ids:
+        return 0
+    placeholders = ", ".join(["%s"] * len(clean_ids))
+    return await db.execute_rowcount(
+        f"UPDATE ticket_replies SET is_billable = 0 WHERE is_billable = 1 AND id IN ({placeholders})",
+        tuple(clean_ids),
+    )
+
+
 async def list_tickets_for_automation_scan(*, limit: int = 1000) -> list[TicketRecord]:
     """Return recent ticket records with reply timestamps for scheduled automations.
 

--- a/app/services/unbill_time_entries.py
+++ b/app/services/unbill_time_entries.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any, Mapping
 
 from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import tickets as tickets_repo
 from app.services import invoice_generator as invoice_generator_service
-
-_UNBILLED_INVOICE_NUMBER = "UNBILLED_BY_AUTOMATION"
 
 
 def _display_ticket_label(ticket: Mapping[str, Any]) -> str:
@@ -21,52 +18,44 @@ def _display_ticket_label(ticket: Mapping[str, Any]) -> str:
 
 
 async def preview_unbill_time_entries(company_id: int | None = None, *, limit: int = 1000) -> dict[str, Any]:
-    """Preview billable, unbilled time entries that would be excluded from invoices.
+    """Preview billable time entries that will be made non-billable.
 
-    Tickets are read in pages so the automation covers every ticket for the
-    selected customer instead of only the first repository page.  The ``limit``
-    argument controls the page size, matching the existing scheduled-task batch
-    behaviour without silently capping the total customer scan.
+    Time entries are read directly from ``ticket_replies`` in pages so the
+    automation matches billable-time reports and does not miss entries on
+    already-billed, closed, merged, or otherwise filtered tickets.
     """
     page_size = max(1, int(limit or 1000))
     offset = 0
     items: list[dict[str, Any]] = []
     total_minutes = 0
     while True:
-        tickets = await tickets_repo.list_tickets(
+        replies = await tickets_repo.list_billable_time_entries(
             company_id=company_id,
             limit=page_size,
             offset=offset,
         )
-        if not tickets:
+        if not replies:
             break
-        for ticket in tickets:
-            ticket_id = ticket.get("id")
-            if not ticket_id:
+        for reply in replies:
+            reply_id = reply.get("id")
+            ticket_id = reply.get("ticket_id")
+            if not reply_id or not ticket_id:
                 continue
-            unbilled_ids = await billed_time_repo.get_unbilled_reply_ids(int(ticket_id))
-            if not unbilled_ids:
+            minutes = invoice_generator_service._coerce_minutes(reply.get("minutes_spent"))
+            if minutes <= 0:
                 continue
-            replies = await tickets_repo.list_replies(int(ticket_id), include_internal=True)
-            for reply in replies:
-                reply_id = reply.get("id")
-                if reply_id not in unbilled_ids or not reply.get("is_billable"):
-                    continue
-                minutes = invoice_generator_service._coerce_minutes(reply.get("minutes_spent"))
-                if minutes <= 0:
-                    continue
-                total_minutes += minutes
-                items.append({
-                    "type": "time_entry",
-                    "id": int(reply_id),
-                    "ticketId": int(ticket_id),
-                    "label": _display_ticket_label(ticket),
-                    "minutes": minutes,
-                    "hours": str(invoice_generator_service._minutes_to_hours(minutes)),
-                    "labourType": reply.get("labour_type_name") or reply.get("labour_type_code"),
-                    "action": "Mark this billable time entry as already billed so invoice generation skips it",
-                })
-        if len(tickets) < page_size:
+            total_minutes += minutes
+            items.append({
+                "type": "time_entry",
+                "id": int(reply_id),
+                "ticketId": int(ticket_id),
+                "label": _display_ticket_label(reply),
+                "minutes": minutes,
+                "hours": str(invoice_generator_service._minutes_to_hours(minutes)),
+                "labourType": reply.get("labour_type_name") or reply.get("labour_type_code"),
+                "action": "Clear the billable flag and remove any billed-time marker for this time entry",
+            })
+        if len(replies) < page_size:
             break
         offset += page_size
     return {
@@ -74,8 +63,8 @@ async def preview_unbill_time_entries(company_id: int | None = None, *, limit: i
         "command": "unbill_time_entries",
         "company_id": company_id,
         "summary": (
-            f"{len(items)} billable time entr{'y' if len(items) == 1 else 'ies'} will be marked as already billed."
-            if items else "No billable, unbilled time entries were found."
+            f"{len(items)} billable time entr{'y' if len(items) == 1 else 'ies'} will be made non-billable."
+            if items else "No billable time entries were found."
         ),
         "totals": {"timeEntryCount": len(items), "minutes": total_minutes},
         "items": items,
@@ -83,19 +72,17 @@ async def preview_unbill_time_entries(company_id: int | None = None, *, limit: i
 
 
 async def unbill_time_entries(company_id: int | None = None, *, limit: int = 1000) -> dict[str, Any]:
-    """Mark billable, unbilled time entries as billed without creating invoices."""
+    """Make billable time entries non-billable and clear billed-time markers."""
     preview = await preview_unbill_time_entries(company_id, limit=limit)
     reply_ids = [int(item["id"]) for item in preview.get("items", []) if item.get("id")]
     if not reply_ids:
         return preview
-    marked = await billed_time_repo.mark_replies_billed(
-        reply_ids,
-        xero_invoice_number=_UNBILLED_INVOICE_NUMBER,
-        billed_at=datetime.now(timezone.utc),
-    )
+    removed_markers = await billed_time_repo.delete_entries_for_replies(reply_ids)
+    updated = await tickets_repo.mark_replies_non_billable(reply_ids)
     return {
         **preview,
-        "status": "succeeded" if marked else "skipped",
-        "markedTimeEntries": marked,
-        "summary": f"Marked {marked} billable time entr{'y' if marked == 1 else 'ies'} as already billed.",
+        "status": "succeeded" if updated else "skipped",
+        "unbilledTimeEntries": updated,
+        "removedBilledTimeMarkers": removed_markers,
+        "summary": f"Made {updated} time entr{'y' if updated == 1 else 'ies'} non-billable and removed {removed_markers} billed-time marker{'s' if removed_markers != 1 else ''}.",
     }

--- a/tests/test_scheduled_task_preview.py
+++ b/tests/test_scheduled_task_preview.py
@@ -197,55 +197,32 @@ def test_generate_invoice_preview_resolves_requester_name_for_template(monkeypat
     assert preview["items"][0]["xeroDescription"] == "Ticket 42: Broken printer - Jane Requester"
 
 
-def test_unbill_time_entries_preview_lists_billable_unbilled_entries(monkeypatch):
-    async def fake_tickets(company_id, limit, offset=0):
-        return [{"id": 42, "ticket_number": "T-42", "subject": "AYCE support"}] if offset == 0 else []
-
-    async def fake_unbilled(ticket_id):
-        return {100}
-
-    async def fake_replies(ticket_id, include_internal):
+def test_unbill_time_entries_preview_lists_billable_entries(monkeypatch):
+    async def fake_entries(company_id, limit, offset=0):
         return [
-            {"id": 100, "is_billable": True, "minutes_spent": 45, "labour_type_name": "Remote Support"},
-            {"id": 101, "is_billable": True, "minutes_spent": 30, "labour_type_name": "Remote Support"},
-        ]
+            {"id": 100, "ticket_id": 42, "ticket_number": "T-42", "subject": "AYCE support", "is_billable": True, "minutes_spent": 45, "labour_type_name": "Remote Support"},
+            {"id": 101, "ticket_id": 42, "ticket_number": "T-42", "subject": "AYCE support", "is_billable": True, "minutes_spent": 30, "labour_type_name": "Remote Support"},
+        ] if offset == 0 else []
 
-    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.tickets_repo, "list_tickets", fake_tickets)
-    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled)
-    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.tickets_repo, "list_replies", fake_replies)
+    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.tickets_repo, "list_billable_time_entries", fake_entries)
 
     preview = asyncio.run(scheduled_task_preview.preview_task({"command": "unbill_time_entries", "company_id": 1}))
 
     assert preview["status"] == "ready"
-    assert preview["totals"] == {"timeEntryCount": 1, "minutes": 45}
+    assert preview["totals"] == {"timeEntryCount": 2, "minutes": 75}
     assert preview["items"][0]["label"] == "Ticket #T-42: AYCE support"
-    assert preview["items"][0]["action"].startswith("Mark this billable time entry")
+    assert preview["items"][0]["action"].startswith("Clear the billable flag")
 
 
 def test_unbill_time_entries_preview_scans_all_ticket_pages(monkeypatch):
-    async def fake_tickets(company_id, limit, offset=0):
+    async def fake_entries(company_id, limit, offset=0):
         pages = {
-            0: [{"id": 42, "ticket_number": "T-42", "subject": "First page"}],
-            1: [{"id": 84, "ticket_number": "T-84", "subject": "Second page"}],
+            0: [{"id": 420, "ticket_id": 42, "ticket_number": "T-42", "subject": "First page", "minutes_spent": 30, "labour_type_name": "Remote Support"}],
+            1: [{"id": 840, "ticket_id": 84, "ticket_number": "T-84", "subject": "Second page", "minutes_spent": 30, "labour_type_name": "Remote Support"}],
         }
         return pages.get(offset, [])
 
-    async def fake_unbilled(ticket_id):
-        return {ticket_id * 10}
-
-    async def fake_replies(ticket_id, include_internal):
-        return [
-            {
-                "id": ticket_id * 10,
-                "is_billable": True,
-                "minutes_spent": 30,
-                "labour_type_name": "Remote Support",
-            }
-        ]
-
-    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.tickets_repo, "list_tickets", fake_tickets)
-    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled)
-    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.tickets_repo, "list_replies", fake_replies)
+    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.tickets_repo, "list_billable_time_entries", fake_entries)
 
     preview = asyncio.run(
         scheduled_task_preview.unbill_time_entries_service.preview_unbill_time_entries(1, limit=1)

--- a/tests/test_unbill_time_entries.py
+++ b/tests/test_unbill_time_entries.py
@@ -1,0 +1,97 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+
+def _load_module():
+    app_module = sys.modules.setdefault("app", types.ModuleType("app"))
+    repos_module = types.ModuleType("app.repositories")
+    repos_module.ticket_billed_time_entries = types.SimpleNamespace()
+    repos_module.tickets = types.SimpleNamespace()
+    services_module = types.ModuleType("app.services")
+    invoice_generator = types.SimpleNamespace(
+        _coerce_minutes=lambda value: int(value or 0),
+        _minutes_to_hours=lambda minutes: round(minutes / 60, 2),
+    )
+    services_module.invoice_generator = invoice_generator
+    sys.modules["app.repositories"] = repos_module
+    sys.modules["app.services"] = services_module
+    app_module.repositories = repos_module
+    app_module.services = services_module
+
+    spec = importlib.util.spec_from_file_location(
+        "unbill_time_entries_under_test",
+        Path(__file__).resolve().parents[1] / "app" / "services" / "unbill_time_entries.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_preview_reads_billable_entries_directly():
+    module = _load_module()
+
+    async def fake_entries(company_id, limit, offset=0):
+        assert company_id == 7
+        pages = {
+            0: [
+                {
+                    "id": 10,
+                    "ticket_id": 100,
+                    "ticket_number": "T-100",
+                    "subject": "Billed work",
+                    "minutes_spent": 60,
+                    "labour_type_code": "REMOTE",
+                }
+            ],
+            1: [
+                {
+                    "id": 11,
+                    "ticket_id": 101,
+                    "ticket_number": "T-101",
+                    "subject": "Closed work",
+                    "minutes_spent": 30,
+                    "labour_type_name": "Onsite",
+                }
+            ],
+        }
+        return pages.get(offset, [])
+
+    module.tickets_repo.list_billable_time_entries = fake_entries
+
+    preview = asyncio.run(module.preview_unbill_time_entries(7, limit=1))
+
+    assert preview["status"] == "ready"
+    assert preview["totals"] == {"timeEntryCount": 2, "minutes": 90}
+    assert [item["id"] for item in preview["items"]] == [10, 11]
+    assert preview["items"][0]["action"].startswith("Clear the billable flag")
+
+
+def test_unbill_clears_billed_markers_then_billable_flags():
+    module = _load_module()
+    calls = []
+
+    async def fake_preview(company_id, limit=1000):
+        return {"status": "ready", "items": [{"id": 10}, {"id": 11}]}
+
+    async def fake_delete(reply_ids):
+        calls.append(("delete", list(reply_ids)))
+        return 1
+
+    async def fake_mark(reply_ids):
+        calls.append(("mark", list(reply_ids)))
+        return 2
+
+    module.preview_unbill_time_entries = fake_preview
+    module.billed_time_repo.delete_entries_for_replies = fake_delete
+    module.tickets_repo.mark_replies_non_billable = fake_mark
+
+    result = asyncio.run(module.unbill_time_entries(7))
+
+    assert calls == [("delete", [10, 11]), ("mark", [10, 11])]
+    assert result["status"] == "succeeded"
+    assert result["unbilledTimeEntries"] == 2
+    assert result["removedBilledTimeMarkers"] == 1


### PR DESCRIPTION
### Motivation
- The `unbill_time_entries` automation was missing many billable entries because it paged tickets and relied on `get_unbilled_reply_ids` rather than scanning billable replies directly. 
- The goal is to ensure bulk un-billing matches billable-time reports and to actually remove billed markers / clear billable flags so reports reflect the change.

### Description
- Added `list_billable_time_entries` and `mark_replies_non_billable` to `app/repositories/tickets.py` to page and update billable `ticket_replies` directly. 
- Added `delete_entries_for_replies` to `app/repositories/ticket_billed_time_entries.py` to remove billed-time markers referencing specific reply IDs. 
- Reworked `app/services/unbill_time_entries.py` so `preview_unbill_time_entries` reads replies via `list_billable_time_entries` and `unbill_time_entries` now calls `delete_entries_for_replies` and `mark_replies_non_billable` to remove billed markers and clear the `is_billable` flag. 
- Updated scheduled-task preview tests to expect scanning of reply entries and added `tests/test_unbill_time_entries.py` with focused regression tests for preview and execution behavior. 

### Testing
- Ran `pytest tests/test_unbill_time_entries.py` and the new regression tests passed (`2 passed`).
- Compiled modified modules using `python -m py_compile app/services/unbill_time_entries.py app/repositories/tickets.py app/repositories/ticket_billed_time_entries.py` and compilation succeeded. 
- Attempted `pytest tests/test_scheduled_task_preview.py` but collection failed due to a missing native dependency (`ImportError: failed to find libmagic`), so those full tests were blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4db21b76d4832dbe2e646fb424bbdf)