### PR TITLE
Fix merge tickets modal styling

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -4341,6 +4341,113 @@ dialog.modal:not([open]) {
   display: none;
 }
 
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.42);
+}
+
+.modal__dialog {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  width: min(92vw, 44rem);
+  max-height: min(86vh, 48rem);
+  overflow: hidden;
+  color: #f8fafc;
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.98), rgba(15, 23, 42, 0.98));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1rem;
+  box-shadow: 0 30px 80px -24px rgba(2, 6, 23, 0.95), 0 0 0 1px rgba(15, 23, 42, 0.7);
+}
+
+.modal__dialog .modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-gap-base);
+  padding: calc(var(--space-gap-roomy) * 1.25) calc(var(--space-gap-roomy) * 1.5) var(--space-gap-base);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.modal__dialog .modal__header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  line-height: 1.25;
+}
+
+.modal__dialog .modal__body {
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-gap-roomy) calc(var(--space-gap-roomy) * 1.5);
+}
+
+.modal__dialog .modal__body p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.modal__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-gap-tight);
+  padding: var(--space-gap-base) calc(var(--space-gap-roomy) * 1.5) calc(var(--space-gap-roomy) * 1.25);
+  border-top: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.72);
+}
+
+.ticket-merge-list {
+  display: grid;
+  gap: var(--space-gap-tight);
+}
+
+.ticket-merge-list__item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-gap-tight);
+  padding: var(--space-gap-base);
+  color: #e2e8f0;
+  background: rgba(15, 23, 42, 0.76);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 0.75rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  cursor: pointer;
+}
+
+.ticket-merge-list__item:hover,
+.ticket-merge-list__item:focus-within {
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(30, 41, 59, 0.86);
+}
+
+.ticket-merge-list__item input {
+  margin-top: 0.2rem;
+  accent-color: #38bdf8;
+  flex: 0 0 auto;
+}
+
+@media (max-width: 640px) {
+  .modal {
+    padding: var(--space-gap-base);
+  }
+
+  .modal__dialog {
+    width: 100%;
+    max-height: calc(100vh - (var(--space-gap-base) * 2));
+  }
+
+  .modal__dialog .modal__header,
+  .modal__dialog .modal__body,
+  .modal__footer {
+    padding-left: var(--space-gap-base);
+    padding-right: var(--space-gap-base);
+  }
+}
+
 .modal__content {
   background: rgba(15, 23, 42, 0.95);
   border-radius: 1rem;


### PR DESCRIPTION
### Motivation
- The merge tickets modal was rendering without a backdrop, visible dialog container, borders, or proper layout, making it hard to use on the tickets page.
- The intent is to present the merge UI as an accessible, focused dialog with a backdrop, clear header/body/footer, and readable merge choices.

### Description
- Add an explicit `.modal__backdrop` rule to ensure the overlay fills the viewport behind the dialog and dims the page.  
- Introduce a `.modal__dialog` container with background, border, rounded corners, shadow, constrained viewport sizing, and internal scroll handling.  
- Add header/body/footer layout styles for dialogs to position the title, close control, explanatory copy, and action buttons consistently.  
- Style merge choice rows via `.ticket-merge-list` and `.ticket-merge-list__item` with padding, borders, hover/focus states, radio alignment, and responsive adjustments for small screens.

### Testing
- Ran `python -m compileall app` to validate Python modules and build sanity; the command completed successfully.  
- Ran a small selector verification script to confirm the new CSS selectors (`.modal__dialog`, `.modal__backdrop`, `.ticket-merge-list__item`, `@media (max-width: 640px)`) are present and it passed.  
- Performed static checks via `git diff --check` to ensure no whitespace/index issues and found no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4db6c16990832d896d86f3d8edb9d1)