### PR TITLE
Keep Xero OAuth tokens refreshed via background keepalive task

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -357,6 +357,9 @@ XERO_BILLABLE_STATUSES=resolved, closed
 TICKET_INVOICED_STATUS=closed
 XERO_LINE_ITEM_TEMPLATE=Ticket {ticket_id}: {ticket_subject} {labour_suffix} {requester_name} ({labour_duration})
 XERO_AUTO_CREATE_PRODUCTS=true
+# Background keepalive interval for refreshing/revalidating Xero OAuth tokens.
+# Defaults to 86400 seconds (24 hours); values below 3600 are raised to 3600.
+XERO_TOKEN_KEEPALIVE_INTERVAL_SECONDS=86400
 
 # ChatGPT MCP integration
 CHATGPT_MCP_SHARED_SECRET=

--- a/app/main.py
+++ b/app/main.py
@@ -2738,6 +2738,7 @@ async def on_startup() -> None:
             log_info("BCP default template bootstrapped")
 
     await scheduler_service.start()
+    modules_service.start_xero_token_keepalive()
     global _rag_relationship_stop, _rag_relationship_tasks
     _rag_relationship_stop = asyncio.Event()
     _rag_relationship_tasks = []
@@ -2797,6 +2798,7 @@ async def on_shutdown() -> None:
     if _feature_pack_watcher is not None:
         await _feature_pack_watcher.stop()
     await feature_registry.unload_all()
+    await modules_service.stop_xero_token_keepalive()
     await scheduler_service.stop()
     await db.disconnect()
     log_info("Application shutdown")

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -47,6 +47,9 @@ _TACTICALRMM_DEFAULT_CALLS_PER_SECOND = 1.0
 
 _XERO_TOKEN_REFRESH_LOCK = asyncio.Lock()
 _XERO_TOKEN_EXPIRY_BUFFER = timedelta(minutes=5)
+_XERO_TOKEN_KEEPALIVE_TASK: asyncio.Task[Any] | None = None
+_XERO_TOKEN_KEEPALIVE_DEFAULT_INTERVAL_SECONDS = 24 * 60 * 60
+_XERO_TOKEN_KEEPALIVE_MIN_INTERVAL_SECONDS = 60 * 60
 
 
 # Module slug constants
@@ -350,6 +353,95 @@ async def acquire_xero_access_token() -> str:
             return cached_token
 
         return await refresh_xero_access_token()
+
+
+def _get_xero_token_keepalive_interval_seconds() -> int:
+    """Return how often the background Xero OAuth keepalive should run."""
+    raw_value = str(os.getenv("XERO_TOKEN_KEEPALIVE_INTERVAL_SECONDS", "")).strip()
+    if not raw_value:
+        return _XERO_TOKEN_KEEPALIVE_DEFAULT_INTERVAL_SECONDS
+    try:
+        interval = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid XERO_TOKEN_KEEPALIVE_INTERVAL_SECONDS value; using default",
+            value=raw_value,
+            default=_XERO_TOKEN_KEEPALIVE_DEFAULT_INTERVAL_SECONDS,
+        )
+        return _XERO_TOKEN_KEEPALIVE_DEFAULT_INTERVAL_SECONDS
+    if interval < _XERO_TOKEN_KEEPALIVE_MIN_INTERVAL_SECONDS:
+        logger.warning(
+            "XERO_TOKEN_KEEPALIVE_INTERVAL_SECONDS below minimum; using minimum",
+            value=raw_value,
+            minimum=_XERO_TOKEN_KEEPALIVE_MIN_INTERVAL_SECONDS,
+        )
+        return _XERO_TOKEN_KEEPALIVE_MIN_INTERVAL_SECONDS
+    return interval
+
+
+async def _xero_token_keepalive_once() -> bool:
+    """Refresh/revalidate Xero OAuth when the module has enough credentials.
+
+    Xero access tokens are short lived and refresh tokens are rotated on use. If
+    the integration is idle for an extended period, an unused refresh token can
+    expire before the next scheduled sync. Running this keepalive periodically
+    keeps the stored refresh token current without requiring admins to revisit
+    the OAuth connect flow.
+    """
+    module = await get_module(XERO_MODULE_SLUG, redact=False)
+    if not module or not module.get("enabled", True):
+        return False
+
+    credentials = await get_xero_credentials()
+    if not credentials:
+        return False
+
+    required_fields = ("client_id", "client_secret", "refresh_token")
+    if not all(str(credentials.get(field) or "").strip() for field in required_fields):
+        return False
+
+    await acquire_xero_access_token()
+    return True
+
+
+async def _xero_token_keepalive_loop() -> None:
+    interval_seconds = _get_xero_token_keepalive_interval_seconds()
+    logger.info(
+        "Started Xero OAuth token keepalive task",
+        interval_seconds=interval_seconds,
+    )
+    try:
+        while True:
+            try:
+                refreshed = await _xero_token_keepalive_once()
+                if refreshed:
+                    logger.info("Xero OAuth token keepalive completed")
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("Xero OAuth token keepalive failed", error=str(exc))
+            await asyncio.sleep(interval_seconds)
+    finally:
+        logger.info("Stopped Xero OAuth token keepalive task")
+
+
+def start_xero_token_keepalive() -> None:
+    """Start the background Xero OAuth keepalive task if not already running."""
+    global _XERO_TOKEN_KEEPALIVE_TASK
+    if _XERO_TOKEN_KEEPALIVE_TASK and not _XERO_TOKEN_KEEPALIVE_TASK.done():
+        return
+    _XERO_TOKEN_KEEPALIVE_TASK = asyncio.create_task(_xero_token_keepalive_loop())
+
+
+async def stop_xero_token_keepalive() -> None:
+    """Stop the background Xero OAuth keepalive task."""
+    global _XERO_TOKEN_KEEPALIVE_TASK
+    task = _XERO_TOKEN_KEEPALIVE_TASK
+    if not task:
+        return
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    _XERO_TOKEN_KEEPALIVE_TASK = None
 
 
 def _merge_settings(

--- a/tests/test_xero_module.py
+++ b/tests/test_xero_module.py
@@ -1213,6 +1213,63 @@ async def test_acquire_xero_access_token_rechecks_cache_after_refresh_lock(monke
     refresh.assert_not_awaited()
 
 
+@pytest.mark.anyio("asyncio")
+async def test_xero_token_keepalive_refreshes_configured_module(monkeypatch):
+    module = {"enabled": True, "settings": {}}
+    credentials = {
+        "client_id": "xero-client",
+        "client_secret": "xero-secret",
+        "refresh_token": "refresh-token",
+    }
+    acquire = AsyncMock(return_value="fresh-access-token")
+
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        assert slug == modules_service.XERO_MODULE_SLUG
+        assert redact is False
+        return module
+
+    async def fake_get_xero_credentials():
+        return credentials
+
+    monkeypatch.setattr(modules_service, "get_module", fake_get_module)
+    monkeypatch.setattr(modules_service, "get_xero_credentials", fake_get_xero_credentials)
+    monkeypatch.setattr(modules_service, "acquire_xero_access_token", acquire)
+
+    assert await modules_service._xero_token_keepalive_once() is True
+    acquire.assert_awaited_once()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_xero_token_keepalive_skips_incomplete_credentials(monkeypatch):
+    acquire = AsyncMock(return_value="fresh-access-token")
+
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        return {"enabled": True, "settings": {}}
+
+    async def fake_get_xero_credentials():
+        return {
+            "client_id": "xero-client",
+            "client_secret": "xero-secret",
+            "refresh_token": "",
+        }
+
+    monkeypatch.setattr(modules_service, "get_module", fake_get_module)
+    monkeypatch.setattr(modules_service, "get_xero_credentials", fake_get_xero_credentials)
+    monkeypatch.setattr(modules_service, "acquire_xero_access_token", acquire)
+
+    assert await modules_service._xero_token_keepalive_once() is False
+    acquire.assert_not_awaited()
+
+
+def test_xero_token_keepalive_interval_uses_safe_minimum(monkeypatch):
+    monkeypatch.setenv("XERO_TOKEN_KEEPALIVE_INTERVAL_SECONDS", "5")
+
+    assert (
+        modules_service._get_xero_token_keepalive_interval_seconds()
+        == modules_service._XERO_TOKEN_KEEPALIVE_MIN_INTERVAL_SECONDS
+    )
+
+
 def test_xero_line_item_template_env_overrides_stored_settings(monkeypatch):
     monkeypatch.setenv(
         "XERO_LINE_ITEM_TEMPLATE",


### PR DESCRIPTION
### Motivation
- Xero access tokens expire quickly and refresh tokens are rotated, causing scheduled syncs to fail if the integration is idle and an admin does not re-authorise at `/xero/connect`.
- Ensure the integration remains usable without manual re-authorization by proactively keeping tokens current.

### Description
- Add a background Xero OAuth keepalive task in `app/services/modules.py` that periodically runs `acquire_xero_access_token()` for the configured Xero module when credentials are present.  
- Make the interval configurable via `XERO_TOKEN_KEEPALIVE_INTERVAL_SECONDS` with a sensible default of 24 hours and a minimum enforced of 1 hour.  
- Start the keepalive on application startup and stop it cleanly on shutdown by invoking `start_xero_token_keepalive()` and `stop_xero_token_keepalive()` from `app/main.py`.  
- Document the new environment variable in `.env.example` and add unit tests in `tests/test_xero_module.py` that cover successful keepalive execution, skipping when credentials are incomplete, and minimum-interval enforcement.

### Testing
- Ran a syntax/compile check with `python -m py_compile app/services/modules.py app/main.py`, which succeeded.  
- Executed a diff/check to validate changes; no structural issues were reported.  
- Attempted to run the new tests with `pytest tests/test_xero_module.py`, but test collection was blocked by missing system dependencies (`libmagic`) in the environment.  
- Running tests under the project virtualenv was blocked by a missing runtime dependency (`aiosqlite`), so full test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dbe2e94d0832d980827aec96a0ac2)