### PR TITLE
Calendar: timeline week view and 5-minute task blocks

### DIFF
--- a/app/static/js/cron_calendar.js
+++ b/app/static/js/cron_calendar.js
@@ -2,7 +2,11 @@
   const root = document.querySelector('[data-cron-calendar]');
   if (!root) return;
 
-  const state = { view: 'day', anchor: new Date(), events: [], search: '', includeInactive: false };
+  const DISPLAY_MINUTES = 5;
+  const DAY_START_HOUR = 5;
+  const DAY_END_HOUR = 23;
+  const HOUR_HEIGHT = 64;
+  const state = { view: 'week', anchor: new Date(), events: [], search: '', includeInactive: false };
   const grid = root.querySelector('[data-calendar-grid]');
   const rangeLabel = root.querySelector('[data-calendar-range]');
   const countLabel = root.querySelector('[data-calendar-count]');
@@ -18,6 +22,9 @@
   function escapeHtml(value) { return String(value || '').replace(/[&<>'"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[c])); }
   function formatDate(date, opts) { return new Intl.DateTimeFormat(undefined, opts).format(date); }
   function formatTime(date) { return new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' }).format(date); }
+  function formatHour(hour) { const d = new Date(); d.setHours(hour, 0, 0, 0); return new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).format(d).replace(' ', ''); }
+  function minutesSinceStart(date) { return (date.getHours() - DAY_START_HOUR) * 60 + date.getMinutes(); }
+  function isSameDay(left, right) { return startOfDay(left).getTime() === startOfDay(right).getTime(); }
 
   function rangeForView() {
     if (state.view === 'month') { const start = startOfMonth(state.anchor); return { start, end: addMonths(start, 1) }; }
@@ -32,9 +39,15 @@
     statusBox.classList.toggle('card--danger', Boolean(isError));
   }
 
+  function updateRangeLabel() {
+    const { start, end } = rangeForView();
+    if (state.view === 'day') rangeLabel.textContent = formatDate(start, { dateStyle: 'medium' });
+    else rangeLabel.textContent = `${formatDate(start, { month: 'short', day: 'numeric' })} - ${formatDate(addDays(end, -1), { month: 'short', day: 'numeric', year: 'numeric' })}`;
+  }
+
   async function loadEvents() {
     const { start, end } = rangeForView();
-    rangeLabel.textContent = `${formatDate(start, { dateStyle: 'medium' })} – ${formatDate(addDays(end, -1), { dateStyle: 'medium' })}`;
+    updateRangeLabel();
     setStatus('Loading scheduled tasks…', false);
     const params = new URLSearchParams({ start: start.toISOString(), end: end.toISOString(), include_inactive: state.includeInactive ? 'true' : 'false', limit: '1000' });
     try {
@@ -58,9 +71,10 @@
 
   function eventHtml(event) {
     const startsAt = new Date(event.start);
+    const endsAt = new Date(startsAt.getTime() + DISPLAY_MINUTES * 60000);
     return `<a class="cron-calendar__event" href="${escapeHtml(event.url)}">
       <strong>${escapeHtml(event.title)}</strong>
-      <span class="cron-calendar__event-meta"><span>${formatTime(startsAt)}</span><span>${escapeHtml(event.companyName)}</span><code>${escapeHtml(event.cron)}</code><span>${escapeHtml(event.command)}</span>${event.active ? '' : '<span>Inactive</span>'}</span>
+      <span class="cron-calendar__event-meta"><span>${formatTime(startsAt)} - ${formatTime(endsAt)}</span><span>${escapeHtml(event.companyName)}</span><code>${escapeHtml(event.cron)}</code><span>${escapeHtml(event.command)}</span>${event.active ? '' : '<span>Inactive</span>'}</span>
     </a>`;
   }
 
@@ -68,34 +82,62 @@
     return `<section class="cron-calendar__period"><div class="cron-calendar__period-header">${escapeHtml(label)}</div><div class="cron-calendar__events">${events.length ? events.map(eventHtml).join('') : '<p class="cron-calendar__empty">No scheduled runs.</p>'}</div></section>`;
   }
 
+  function renderTimeline(days) {
+    const events = filteredEvents();
+    const totalHours = DAY_END_HOUR - DAY_START_HOUR + 1;
+    const timelineHeight = totalHours * HOUR_HEIGHT;
+    const dayList = Array.from({ length: days }, (_, idx) => addDays(days === 7 ? startOfWeek(state.anchor) : startOfDay(state.anchor), idx));
+    const now = new Date();
+    countLabel.textContent = String(events.length);
+    grid.className = `cron-calendar__grid cron-calendar__grid--timeline cron-calendar__grid--${state.view}`;
+    grid.innerHTML = `<div class="cron-calendar__timeline" style="--calendar-hour-height:${HOUR_HEIGHT}px;--calendar-timeline-height:${timelineHeight}px">
+      <div class="cron-calendar__corner" aria-hidden="true"></div>
+      <div class="cron-calendar__day-headings">${dayList.map(day => `<div class="cron-calendar__day-heading${isSameDay(day, now) ? ' is-today' : ''}"><span>${formatDate(day, { weekday: 'short' })}</span><strong>${formatDate(day, { day: '2-digit' })}</strong></div>`).join('')}</div>
+      <div class="cron-calendar__time-axis">${Array.from({ length: totalHours }, (_, idx) => `<span>${formatHour(DAY_START_HOUR + idx)}</span>`).join('')}</div>
+      <div class="cron-calendar__day-columns">${dayList.map(day => {
+        const items = events.filter(event => isSameDay(new Date(event.start), day));
+        return `<div class="cron-calendar__day-column${isSameDay(day, now) ? ' is-today' : ''}">${items.map(event => {
+          const startsAt = new Date(event.start);
+          const endsAt = new Date(startsAt.getTime() + DISPLAY_MINUTES * 60000);
+          const top = Math.max(0, Math.min(timelineHeight - 28, (minutesSinceStart(startsAt) / 60) * HOUR_HEIGHT));
+          const height = Math.max(28, (DISPLAY_MINUTES / 60) * HOUR_HEIGHT);
+          return `<a class="cron-calendar__timeline-event" href="${escapeHtml(event.url)}" style="top:${top}px;height:${height}px" title="${escapeHtml(event.title)} ${formatTime(startsAt)} - ${formatTime(endsAt)}">
+            <strong>${escapeHtml(event.title)}</strong><span>${formatTime(startsAt)} - ${formatTime(endsAt)}</span>
+          </a>`;
+        }).join('')}</div>`;
+      }).join('')}</div>
+    </div>`;
+  }
+
   function render() {
     const events = filteredEvents();
+    if (state.view === 'day' || state.view === 'week') { renderTimeline(state.view === 'week' ? 7 : 1); return; }
     countLabel.textContent = String(events.length);
     grid.className = `cron-calendar__grid cron-calendar__grid--${state.view}`;
     const { start } = rangeForView();
-    if (state.view === 'day') {
-      grid.innerHTML = renderPeriod(formatDate(start, { weekday: 'long', dateStyle: 'full' }), events);
-      return;
-    }
     if (state.view === 'list') {
       const byDay = new Map();
       events.forEach(event => { const key = formatDate(new Date(event.start), { dateStyle: 'full' }); byDay.set(key, [...(byDay.get(key) || []), event]); });
       grid.innerHTML = byDay.size ? Array.from(byDay.entries()).map(([label, items]) => renderPeriod(label, items)).join('') : renderPeriod('Upcoming 30 days', []);
       return;
     }
-    const days = state.view === 'week' ? 7 : new Date(start.getFullYear(), start.getMonth() + 1, 0).getDate();
+    const days = new Date(start.getFullYear(), start.getMonth() + 1, 0).getDate();
     grid.innerHTML = Array.from({ length: days }, (_, idx) => {
       const day = addDays(start, idx);
-      const items = events.filter(event => startOfDay(new Date(event.start)).getTime() === day.getTime());
+      const items = events.filter(event => isSameDay(new Date(event.start), day));
       return renderPeriod(formatDate(day, { weekday: 'short', month: 'short', day: 'numeric' }), items);
     }).join('');
   }
 
-  document.querySelectorAll('[data-calendar-view]').forEach(button => button.addEventListener('click', () => {
-    state.view = button.dataset.calendarView;
-    document.querySelectorAll('[data-calendar-view]').forEach(btn => { btn.classList.toggle('button--primary', btn === button); btn.classList.toggle('button--ghost', btn !== button); });
-    loadEvents();
-  }));
+  document.querySelectorAll('[data-calendar-view]').forEach(button => {
+    const active = button.dataset.calendarView === state.view;
+    button.classList.toggle('button--primary', active); button.classList.toggle('button--ghost', !active);
+    button.addEventListener('click', () => {
+      state.view = button.dataset.calendarView;
+      document.querySelectorAll('[data-calendar-view]').forEach(btn => { btn.classList.toggle('button--primary', btn === button); btn.classList.toggle('button--ghost', btn !== button); });
+      loadEvents();
+    });
+  });
   root.querySelector('[data-calendar-prev]').addEventListener('click', () => { state.anchor = state.view === 'month' ? addMonths(state.anchor, -1) : addDays(state.anchor, state.view === 'week' ? -7 : state.view === 'list' ? -30 : -1); loadEvents(); });
   root.querySelector('[data-calendar-next]').addEventListener('click', () => { state.anchor = state.view === 'month' ? addMonths(state.anchor, 1) : addDays(state.anchor, state.view === 'week' ? 7 : state.view === 'list' ? 30 : 1); loadEvents(); });
   root.querySelector('[data-calendar-today]').addEventListener('click', () => { state.anchor = new Date(); loadEvents(); });

--- a/app/templates/admin/cron_calendar.html
+++ b/app/templates/admin/cron_calendar.html
@@ -4,8 +4,8 @@
 {% block header_actions %}
   <a class="button button--ghost" href="/admin/scheduled-tasks">Manage scheduled tasks</a>
   <div class="button-group" role="group" aria-label="Calendar views">
-    <button class="button button--primary" type="button" data-calendar-view="day">Day</button>
-    <button class="button button--ghost" type="button" data-calendar-view="week">Week</button>
+    <button class="button button--ghost" type="button" data-calendar-view="day">Day</button>
+    <button class="button button--primary" type="button" data-calendar-view="week">Week</button>
     <button class="button button--ghost" type="button" data-calendar-view="month">Month</button>
     <button class="button button--ghost" type="button" data-calendar-view="list">List</button>
   </div>
@@ -52,6 +52,8 @@
 {% block extra_head %}
 <style>
   .button-group { display: inline-flex; gap: .35rem; flex-wrap: wrap; }
+  .cron-calendar { min-height: 0; }
+  .cron-calendar .management__content { min-height: 0; }
   .cron-calendar__toolbar { display: flex; justify-content: space-between; gap: 1rem; align-items: center; margin-bottom: 1rem; }
   .cron-calendar__nav { display: flex; gap: .5rem; flex-wrap: wrap; }
   .cron-calendar__grid { display: grid; gap: .75rem; max-height: calc(100vh - 18rem); overflow: auto; }
@@ -62,9 +64,23 @@
   .cron-calendar__event-meta { display: flex; gap: .5rem; flex-wrap: wrap; font-size: .82rem; color: var(--text-muted, #64748b); }
   .cron-calendar__empty { padding: 1rem; color: var(--text-muted, #64748b); }
   .cron-calendar__grid--month { grid-template-columns: repeat(7, minmax(9rem, 1fr)); }
-  .cron-calendar__grid--week { grid-template-columns: repeat(7, minmax(10rem, 1fr)); }
-  .cron-calendar__grid--day, .cron-calendar__grid--list { grid-template-columns: 1fr; }
-  @media (max-width: 900px) { .cron-calendar__grid--month, .cron-calendar__grid--week { grid-template-columns: 1fr; } .cron-calendar__toolbar { align-items: stretch; flex-direction: column; } }
+  .cron-calendar__grid--list { grid-template-columns: 1fr; }
+  .cron-calendar__grid--timeline { display: block; border: 1px solid var(--border-color, #d8dee9); border-radius: .85rem; background: var(--surface-color, #fff); overflow: auto; }
+  .cron-calendar__timeline { display: grid; grid-template-columns: 4.5rem minmax(55rem, 1fr); grid-template-rows: 3rem var(--calendar-timeline-height); min-width: 62rem; }
+  .cron-calendar__corner { position: sticky; left: 0; top: 0; z-index: 5; background: var(--surface-color, #fff); border-right: 1px solid var(--border-color, #d8dee9); border-bottom: 1px solid var(--border-color, #d8dee9); }
+  .cron-calendar__day-headings { position: sticky; top: 0; z-index: 4; display: grid; grid-auto-columns: minmax(12rem, 1fr); grid-auto-flow: column; background: var(--surface-color, #fff); border-bottom: 1px solid var(--border-color, #d8dee9); }
+  .cron-calendar__day-heading { display: inline-flex; align-items: center; justify-content: center; gap: .4rem; border-right: 1px solid var(--border-color, #d8dee9); color: var(--text-muted, #64748b); font-size: .78rem; text-transform: uppercase; }
+  .cron-calendar__day-heading strong { display: inline-grid; min-width: 1.45rem; min-height: 1.45rem; place-items: center; border-radius: 999px; color: var(--text-color, #111827); }
+  .cron-calendar__day-heading.is-today strong { color: #fff; background: var(--primary-color, #2563eb); }
+  .cron-calendar__time-axis { position: sticky; left: 0; z-index: 3; display: grid; grid-template-rows: repeat(19, var(--calendar-hour-height)); background: var(--surface-color, #fff); border-right: 1px solid var(--border-color, #d8dee9); }
+  .cron-calendar__time-axis span { transform: translateY(-.45rem); padding-right: .5rem; text-align: right; color: var(--text-muted, #64748b); font-size: .78rem; }
+  .cron-calendar__day-columns { display: grid; grid-auto-columns: minmax(12rem, 1fr); grid-auto-flow: column; min-height: var(--calendar-timeline-height); background-image: repeating-linear-gradient(to bottom, transparent 0, transparent calc(var(--calendar-hour-height) - 1px), var(--border-color, #d8dee9) calc(var(--calendar-hour-height) - 1px), var(--border-color, #d8dee9) var(--calendar-hour-height)); }
+  .cron-calendar__day-column { position: relative; border-right: 1px solid var(--border-color, #d8dee9); min-height: var(--calendar-timeline-height); }
+  .cron-calendar__day-column.is-today { background: color-mix(in srgb, var(--primary-color, #2563eb) 4%, transparent); }
+  .cron-calendar__timeline-event { position: absolute; left: .15rem; right: .15rem; display: grid; align-content: start; gap: .1rem; overflow: hidden; border-left: .2rem solid var(--accent-color, #ec4899); border-radius: .2rem; padding: .2rem .35rem; background: color-mix(in srgb, var(--surface-muted, #f1f5f9) 90%, var(--primary-color, #2563eb)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-color, #d8dee9) 70%, transparent); color: var(--text-color, #111827); font-size: .72rem; line-height: 1.15; text-decoration: none; }
+  .cron-calendar__timeline-event strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .cron-calendar__timeline-event span { color: var(--text-muted, #64748b); }
+  @media (max-width: 900px) { .cron-calendar__grid--month { grid-template-columns: 1fr; } .cron-calendar__toolbar { align-items: stretch; flex-direction: column; } .cron-calendar__timeline { grid-template-columns: 3.75rem minmax(42rem, 1fr); min-width: 46rem; } }
 </style>
 <script src="{{ static_url('/static/js/cron_calendar.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Update the scheduled tasks calendar to match the provided timeline-style layout for easier planning and density visibility.
- Make each scheduled task visually occupy a small, consistent duration so simultaneous runs are easier to spot.

### Description
- Default the calendar view to `week` and toggle active view button state in `app/templates/admin/cron_calendar.html`.
- Add a timeline rendering mode to `app/static/js/cron_calendar.js` with hour rows, sticky day headers, a horizontal day column layout, and responsive scrolling.
- Introduce display constants (`DISPLAY_MINUTES = 5`, timeline hours, and sizing) and render every event as a 5-minute block in timeline/day views while showing the 5-minute time range in list views.
- Update CSS in the template to support the timeline layout and event block styling (sticky headers, time axis, event positioning).

### Testing
- Ran `python3 -m pytest tests/test_cron_calendar.py` and all tests passed (2 passed). 
- Verified JavaScript syntax with `node --check app/static/js/cron_calendar.js` which succeeded. 
- Generated a UI screenshot (Playwright with mocked data) and verified `/tmp/cron-calendar-view.png` exists to confirm the visual timeline rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dc0233ae0832da4c0abd226a17f3c)