### PR TITLE
Embed M365 inline images in imported tickets

### DIFF
--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -4,7 +4,7 @@ import base64
 import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, unquote, urlencode
 
 import httpx
 
@@ -38,6 +38,7 @@ from app.services.imap import (
     _normalise_string,
     _resolve_ticket_entities,
     _save_email_attachment,
+    _CID_REFERENCE_PATTERN,
     _ticket_is_closed,
 )
 
@@ -933,6 +934,13 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                 subject = msg.get("subject") or f"Email from {upn}"
                 body_content = msg.get("body", {})
                 body = body_content.get("content") or ""
+                if msg.get("hasAttachments") and body:
+                    body = await _embed_graph_inline_images(
+                        access_token=access_token,
+                        upn=upn,
+                        message_id=msg_id,
+                        html_body=body,
+                    )
 
                 from_data = msg.get("from", {})
                 from_email_data = from_data.get("emailAddress", {})
@@ -1194,6 +1202,82 @@ async def sync_account(account_id: int) -> dict[str, Any]:
     )
     status_value = "succeeded" if not errors else "completed_with_errors"
     return {"status": status_value, "processed": processed, "errors": errors}
+
+
+async def _embed_graph_inline_images(
+    *,
+    access_token: str,
+    upn: str,
+    message_id: str,
+    html_body: str,
+) -> str:
+    """Replace Graph ``cid:`` image references with safe data URIs.
+
+    Microsoft Graph returns inline email images as file attachments with
+    ``isInline`` and ``contentId`` metadata.  The ticket body otherwise keeps
+    ``cid:...`` references that browsers render as broken placeholders, so fetch
+    the matching inline images and embed them directly in the imported HTML.
+    """
+    if not html_body or "cid:" not in html_body.lower():
+        return html_body
+
+    message_id_encoded = quote(message_id, safe="")
+    url = f"{_GRAPH_BASE}/users/{quote(upn, safe='')}/messages/{message_id_encoded}/attachments"
+    try:
+        data = await _graph_get(access_token, url)
+    except Exception:
+        return html_body
+
+    inline_images: dict[str, tuple[str, bytes]] = {}
+    for attachment in data.get("value") or []:
+        if attachment.get("@odata.type") != "#microsoft.graph.fileAttachment":
+            continue
+        if not attachment.get("isInline"):
+            continue
+
+        content_type = str(attachment.get("contentType") or "").lower()
+        if not content_type.startswith("image/"):
+            continue
+
+        content_id = str(attachment.get("contentId") or "").strip().strip("<>")
+        if not content_id:
+            continue
+
+        payload: bytes | None = None
+        content_bytes_b64 = attachment.get("contentBytes") or ""
+        if content_bytes_b64:
+            try:
+                payload = base64.b64decode(content_bytes_b64)
+            except Exception:
+                payload = None
+
+        attachment_id = str(attachment.get("id") or "").strip()
+        if payload is None and attachment_id:
+            value_url = (
+                f"{_GRAPH_BASE}/users/{quote(upn, safe='')}/messages/{message_id_encoded}"
+                f"/attachments/{quote(attachment_id, safe='')}/$value"
+            )
+            try:
+                payload = await _graph_get_bytes(access_token, value_url)
+            except Exception:
+                payload = None
+
+        if payload:
+            inline_images[content_id.lower()] = (content_type, payload)
+
+    if not inline_images:
+        return html_body
+
+    def _replace_cid(match):
+        cid_value = unquote((match.group(1) or "").strip().strip("<>"))
+        resource = inline_images.get(cid_value.lower())
+        if not resource:
+            return match.group(0)
+        content_type, payload = resource
+        encoded = base64.b64encode(payload).decode("ascii")
+        return f"data:{content_type};base64,{encoded}"
+
+    return _CID_REFERENCE_PATTERN.sub(_replace_cid, html_body)
 
 
 async def _save_graph_attachments(

--- a/tests/test_m365_mail_service.py
+++ b/tests/test_m365_mail_service.py
@@ -1190,6 +1190,75 @@ async def test_sync_account_matches_existing_ticket(monkeypatch):
     assert len(replies_added) == 1
     assert replies_added[0]["ticket_id"] == 50
 
+async def test_embed_graph_inline_images_replaces_cid_with_data_uri(monkeypatch):
+    async def fake_graph_get(access_token: str, url: str):
+        return {
+            "value": [
+                {
+                    "@odata.type": "#microsoft.graph.fileAttachment",
+                    "id": "att-inline",
+                    "name": "image001.png",
+                    "contentType": "image/png",
+                    "contentId": "image001@example.com",
+                    "contentBytes": "cG5nLWJ5dGVz",
+                    "isInline": True,
+                }
+            ]
+        }
+
+    async def fake_graph_get_bytes(access_token: str, url: str):
+        raise AssertionError("contentBytes should avoid $value fetch")
+
+    monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
+    monkeypatch.setattr(m365_mail, "_graph_get_bytes", fake_graph_get_bytes)
+
+    body = await m365_mail._embed_graph_inline_images(
+        access_token="token",
+        upn="user@example.com",
+        message_id="msg-1",
+        html_body='<p>Screenshot</p><img src="cid:image001@example.com">',
+    )
+
+    assert "cid:image001@example.com" not in body
+    assert 'src="data:image/png;base64,cG5nLWJ5dGVz"' in body
+
+
+async def test_embed_graph_inline_images_fetches_value_when_content_bytes_missing(monkeypatch):
+    value_urls: list[str] = []
+
+    async def fake_graph_get(access_token: str, url: str):
+        return {
+            "value": [
+                {
+                    "@odata.type": "#microsoft.graph.fileAttachment",
+                    "id": "att inline/1",
+                    "name": "photo.jpg",
+                    "contentType": "image/jpeg",
+                    "contentId": "photo@cid",
+                    "isInline": True,
+                }
+            ]
+        }
+
+    async def fake_graph_get_bytes(access_token: str, url: str):
+        value_urls.append(url)
+        return b"jpeg-bytes"
+
+    monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
+    monkeypatch.setattr(m365_mail, "_graph_get_bytes", fake_graph_get_bytes)
+
+    body = await m365_mail._embed_graph_inline_images(
+        access_token="token",
+        upn="user@example.com",
+        message_id="AAMkAGI2/ABC==",
+        html_body="<img src='cid:photo%40cid'>",
+    )
+
+    assert "data:image/jpeg;base64,anBlZy1ieXRlcw==" in body
+    assert value_urls
+    assert "AAMkAGI2%2FABC%3D%3D" in value_urls[0]
+    assert "att%20inline%2F1" in value_urls[0]
+
 
 async def test_save_graph_attachments_fetches_value_when_content_bytes_missing(monkeypatch):
     """Attachments are saved even when Graph list response omits contentBytes."""


### PR DESCRIPTION
### Motivation

- Office 365 (Microsoft Graph) mail imports created tickets with broken `cid:` image placeholders because inline images were not being embedded into ticket HTML.  This change ensures inline images are preserved when importing messages.

### Description

- Call `await _embed_graph_inline_images(...)` from `sync_account` to replace `cid:` references before ticket creation or reply handling. 
- Add `_embed_graph_inline_images` which fetches inline file attachments from Graph, decodes `contentBytes` or falls back to the attachment `$value` endpoint, and replaces `cid:` references with `data:` URIs.
- Reuse the IMAP module's `_CID_REFERENCE_PATTERN` and add safe URL-encoding/decoding of message and attachment IDs using `quote`/`unquote` so Graph paths remain valid.
- Add regression tests to `tests/test_m365_mail_service.py` that verify direct `contentBytes` embedding and the `$value` fallback including encoded message/attachment ID handling.

### Testing

- `python -m py_compile app/services/m365_mail.py tests/test_m365_mail_service.py` succeeded. 
- `pytest -q tests/test_m365_mail_service.py -q` was attempted but test collection failed due to the environment missing the `libmagic` native dependency, preventing full test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dc1233cec832da77aa4b14509cd1d)