### PR TITLE
Prevent stale Syncro ticket overwrites

### DIFF
--- a/app/services/ticket_importer.py
+++ b/app/services/ticket_importer.py
@@ -293,6 +293,28 @@ def _syncro_ticket_is_unchanged(
     return syncro_updated_at <= last_imported_syncro_updated_at
 
 
+def _syncro_ticket_is_older_than_local_copy(
+    ticket: dict[str, Any], existing: dict[str, Any] | None
+) -> bool:
+    """Return true when importing would overwrite fresher MyPortal ticket data."""
+
+    if not existing:
+        return False
+    syncro_updated_at = _ticket_updated_at(ticket)
+    if syncro_updated_at is None:
+        return False
+    local_updated_at = _parse_datetime(existing.get("updated_at"))
+    if local_updated_at is None:
+        return False
+    return local_updated_at > syncro_updated_at
+
+
+def _newer_local_copy_skip_reason(syncro_id: Any) -> str:
+    return (
+        f"Syncro ticket {syncro_id} is older than the MyPortal ticket and was not imported"
+    )
+
+
 def _normalise_comment_comparison_text(value: str | None) -> str:
     """Return comment text normalised for rich-preview/body comparisons."""
 
@@ -1815,6 +1837,8 @@ async def _upsert_ticket(
 
     if existing and _syncro_ticket_is_unchanged(ticket, existing):
         return f"skipped: Syncro ticket {external_reference} has not changed since last import"
+    if existing and _syncro_ticket_is_older_than_local_copy(ticket, existing):
+        return f"skipped: {_newer_local_copy_skip_reason(external_reference)}"
 
     if existing:
         updates: dict[str, Any] = {
@@ -2068,6 +2092,8 @@ async def import_all_tickets(
             )
             if _syncro_ticket_is_unchanged(ticket, existing):
                 outcome = f"skipped: Syncro ticket {syncro_id} has not changed since last import"
+            elif _syncro_ticket_is_older_than_local_copy(ticket, existing):
+                outcome = f"skipped: {_newer_local_copy_skip_reason(syncro_id)}"
             else:
                 ticket_detail = await _fetch_ticket_detail_for_import(
                     ticket, rate_limiter=limiter

--- a/tests/test_ticket_importer.py
+++ b/tests/test_ticket_importer.py
@@ -406,7 +406,7 @@ async def test_import_ticket_by_id_skips_existing_when_syncro_updated_at_unchang
 
 
 @pytest.mark.anyio
-async def test_import_ticket_by_id_updates_existing_when_syncro_updated_at_newer(
+async def test_import_ticket_by_id_skips_existing_when_myportal_updated_at_is_newer(
     monkeypatch,
 ):
     async def fake_get_ticket(ticket_id, rate_limiter=None):
@@ -424,6 +424,46 @@ async def test_import_ticket_by_id_updates_existing_when_syncro_updated_at_newer
             "external_reference": external_reference,
             "syncro_updated_at": "2025-01-02T10:45:00Z",
             "updated_at": "2025-01-05T09:00:00Z",
+        }
+
+    async def fail_update_ticket(*args, **kwargs):
+        raise AssertionError("Older Syncro tickets should not update MyPortal")
+
+    monkeypatch.setattr(syncro, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(
+        tickets_repo, "get_ticket_by_external_reference", fake_get_existing
+    )
+    monkeypatch.setattr(tickets_repo, "update_ticket", fail_update_ticket)
+
+    summary = await ticket_importer.import_ticket_by_id(500, rate_limiter=None)
+
+    assert summary.updated == 0
+    assert summary.created == 0
+    assert summary.skipped == 1
+    assert summary.skipped_reasons == [
+        "Syncro ticket 500 is older than the MyPortal ticket and was not imported"
+    ]
+
+
+@pytest.mark.anyio
+async def test_import_ticket_by_id_updates_existing_when_syncro_is_newer_than_myportal(
+    monkeypatch,
+):
+    async def fake_get_ticket(ticket_id, rate_limiter=None):
+        return {
+            "id": ticket_id,
+            "subject": "Network outage",
+            "priority": "Critical",
+            "status": "Resolved",
+            "updated_at": "2025-01-05T10:45:00Z",
+        }
+
+    async def fake_get_existing(external_reference):
+        return {
+            "id": 99,
+            "external_reference": external_reference,
+            "syncro_updated_at": "2025-01-02T10:45:00Z",
+            "updated_at": "2025-01-03T09:00:00Z",
         }
 
     update_calls = []
@@ -446,9 +486,9 @@ async def test_import_ticket_by_id_updates_existing_when_syncro_updated_at_newer
     assert summary.updated == 1
     assert (
         update_calls[0][1]["syncro_updated_at"].isoformat()
-        == "2025-01-03T10:45:00+00:00"
+        == "2025-01-05T10:45:00+00:00"
     )
-    assert update_calls[0][1]["updated_at"].isoformat() == "2025-01-03T10:45:00+00:00"
+    assert update_calls[0][1]["updated_at"].isoformat() == "2025-01-05T10:45:00+00:00"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation

- Prevent Syncro ticket imports from overwriting MyPortal tickets that have been updated more recently in the portal.

### Description

- Add `_syncro_ticket_is_older_than_local_copy` to compare Syncro `updated_at` with the local ticket `updated_at`.  
- Add `_newer_local_copy_skip_reason` to provide a consistent skip message.  
- Short-circuit imports in `_upsert_ticket` and `import_all_tickets` to skip when the MyPortal copy is newer rather than updating it.  
- Update `tests/test_ticket_importer.py` to cover the new skip behaviour and to assert existing behaviour when Syncro is newer.

### Testing

- Ran `pytest tests/test_ticket_importer.py -k "syncro_updated_at_unchanged or myportal_updated_at_is_newer or syncro_is_newer_than_myportal"` after ensuring system dependency `libmagic1` was available, and the selected tests passed.  
- Verified `python -m py_compile app/services/ticket_importer.py tests/test_ticket_importer.py` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dc785b18c832d896e41e4e8def885)