### PR TITLE
Fix email blocklist admin template context

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -295,11 +295,12 @@ async def admin_email_blocklist_page(request: Request, search: str | None = Quer
     entries = await email_blocklist_repo.list_entries(search=search, limit=500, offset=0, sort="email", direction="asc")
     for entry in entries:
         entry["updated_iso"] = _iso_utc(entry.get("updated_at"))
-    return main_module.templates.TemplateResponse(
+    return await main_module._render_template(
         "admin/email_blocklist.html",
-        {
-            "request": request,
-            "current_user": current_user,
+        request,
+        current_user,
+        extra={
+            "title": "Email blocklist",
             "entries": entries,
             "search": search or "",
         },

--- a/tests/test_email_blocklist.py
+++ b/tests/test_email_blocklist.py
@@ -35,3 +35,59 @@ async def test_filter_allowed_removes_blocklisted_addresses(monkeypatch):
 def test_normalize_email_rejects_invalid_address():
     with pytest.raises(ValueError):
         email_blocklist.normalize_email("not-an-email")
+
+
+@pytest.mark.anyio
+async def test_admin_email_blocklist_page_uses_base_template_context(monkeypatch):
+    """Regression: page rendering must include base context such as plausible_config."""
+    from fastapi import Request
+    from fastapi.responses import HTMLResponse
+
+    from app import main as main_module
+    from app.features.tickets import admin_routes
+
+    async def fake_require_helpdesk_page(request: Request):
+        return {"id": 1, "email": "admin@example.com", "is_super_admin": True}, None
+
+    async def fake_list_entries(**kwargs):
+        return [
+            {
+                "id": 1,
+                "email": "blocked@example.com",
+                "source": "manual",
+                "updated_at": None,
+            }
+        ]
+
+    captured = {}
+
+    async def fake_render_template(template_name, request, user, *, extra=None):
+        captured["template_name"] = template_name
+        captured["user"] = user
+        captured["extra"] = extra or {}
+        return HTMLResponse("ok")
+
+    monkeypatch.setattr(main_module, "_require_helpdesk_page", fake_require_helpdesk_page)
+    monkeypatch.setattr(main_module, "_render_template", fake_render_template)
+    monkeypatch.setattr(email_blocklist, "list_entries", fake_list_entries)
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/admin/tickets/email-blocklist",
+        "headers": [],
+        "query_string": b"",
+        "server": ("testserver", 80),
+        "scheme": "http",
+        "client": ("testclient", 50000),
+    }
+    request = Request(scope)
+
+    response = await admin_routes.admin_email_blocklist_page(request, search=None)
+
+    assert response.status_code == 200
+    assert captured["template_name"] == "admin/email_blocklist.html"
+    assert captured["user"]["is_super_admin"] is True
+    assert captured["extra"]["title"] == "Email blocklist"
+    assert captured["extra"]["search"] == ""
+    assert captured["extra"]["entries"][0]["updated_iso"] is None


### PR DESCRIPTION
### Motivation
- Prevent Jinja errors and ensure standard page globals (e.g. `plausible_config`, CSRF/session data and layout flags) are present when rendering the email blocklist admin page.
- Unify rendering to use the shared base-context helper so the page receives the same application-wide context as other admin pages.
- Add a regression test to lock in the expected behavior and prevent future regressions.

### Description
- Replace the direct `TemplateResponse` call in `app/features/tickets/admin_routes.py` with the shared `await main_module._render_template(...)` helper and pass `extra` context including `title`, `entries`, and `search` so base context values are included.
- Add a regression test `test_admin_email_blocklist_page_uses_base_template_context` to `tests/test_email_blocklist.py` which asserts the route uses the shared renderer and that the page-specific extras (including `entries` / `search`) are passed through.
- Kept existing POST handler behavior unchanged; the change only affects how the GET page is rendered.

### Testing
- Ran `pytest -q tests/test_email_blocklist.py` which completed with `3 passed`.
- Performed bytecode validation with `python -m py_compile app/features/tickets/admin_routes.py tests/test_email_blocklist.py` which succeeded.
- Resolved a test environment dependency (`libmagic1`) to allow full test collection and assertions to run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dc95f3cf4832db1914a891b0cd3cc)