### PR TITLE
Improve cron calendar timeline readability and overlapping events

### DIFF
--- a/app/static/js/cron_calendar.js
+++ b/app/static/js/cron_calendar.js
@@ -2,10 +2,10 @@
   const root = document.querySelector('[data-cron-calendar]');
   if (!root) return;
 
-  const DISPLAY_MINUTES = 5;
-  const DAY_START_HOUR = 5;
-  const DAY_END_HOUR = 23;
-  const HOUR_HEIGHT = 64;
+  const DISPLAY_MINUTES = 1;
+  const DAY_START_HOUR = 0;
+  const DAY_END_HOUR = 24;
+  const HOUR_HEIGHT = 96;
   const state = { view: 'week', anchor: new Date(), events: [], search: '', includeInactive: false };
   const grid = root.querySelector('[data-calendar-grid]');
   const rangeLabel = root.querySelector('[data-calendar-range]');
@@ -25,6 +25,26 @@
   function formatHour(hour) { const d = new Date(); d.setHours(hour, 0, 0, 0); return new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).format(d).replace(' ', ''); }
   function minutesSinceStart(date) { return (date.getHours() - DAY_START_HOUR) * 60 + date.getMinutes(); }
   function isSameDay(left, right) { return startOfDay(left).getTime() === startOfDay(right).getTime(); }
+
+  function layoutTimelineEvents(events) {
+    const sorted = [...events].sort((left, right) => new Date(left.start) - new Date(right.start));
+    const active = [];
+    return sorted.map(event => {
+      const startsAt = new Date(event.start);
+      const endsAt = new Date(startsAt.getTime() + DISPLAY_MINUTES * 60000);
+      for (let idx = active.length - 1; idx >= 0; idx -= 1) {
+        if (active[idx].end <= startsAt) active.splice(idx, 1);
+      }
+      const usedColumns = new Set(active.map(item => item.column));
+      let column = 0;
+      while (usedColumns.has(column)) column += 1;
+      const entry = { event, startsAt, endsAt, end: endsAt, column, clusterSize: column + 1 };
+      active.push(entry);
+      const clusterSize = Math.max(...active.map(item => item.column), column) + 1;
+      active.forEach(item => { item.clusterSize = Math.max(item.clusterSize, clusterSize); });
+      return entry;
+    });
+  }
 
   function rangeForView() {
     if (state.view === 'month') { const start = startOfMonth(state.anchor); return { start, end: addMonths(start, 1) }; }
@@ -84,7 +104,7 @@
 
   function renderTimeline(days) {
     const events = filteredEvents();
-    const totalHours = DAY_END_HOUR - DAY_START_HOUR + 1;
+    const totalHours = DAY_END_HOUR - DAY_START_HOUR;
     const timelineHeight = totalHours * HOUR_HEIGHT;
     const dayList = Array.from({ length: days }, (_, idx) => addDays(days === 7 ? startOfWeek(state.anchor) : startOfDay(state.anchor), idx));
     const now = new Date();
@@ -95,13 +115,14 @@
       <div class="cron-calendar__day-headings">${dayList.map(day => `<div class="cron-calendar__day-heading${isSameDay(day, now) ? ' is-today' : ''}"><span>${formatDate(day, { weekday: 'short' })}</span><strong>${formatDate(day, { day: '2-digit' })}</strong></div>`).join('')}</div>
       <div class="cron-calendar__time-axis">${Array.from({ length: totalHours }, (_, idx) => `<span>${formatHour(DAY_START_HOUR + idx)}</span>`).join('')}</div>
       <div class="cron-calendar__day-columns">${dayList.map(day => {
-        const items = events.filter(event => isSameDay(new Date(event.start), day));
-        return `<div class="cron-calendar__day-column${isSameDay(day, now) ? ' is-today' : ''}">${items.map(event => {
-          const startsAt = new Date(event.start);
-          const endsAt = new Date(startsAt.getTime() + DISPLAY_MINUTES * 60000);
-          const top = Math.max(0, Math.min(timelineHeight - 28, (minutesSinceStart(startsAt) / 60) * HOUR_HEIGHT));
-          const height = Math.max(28, (DISPLAY_MINUTES / 60) * HOUR_HEIGHT);
-          return `<a class="cron-calendar__timeline-event" href="${escapeHtml(event.url)}" style="top:${top}px;height:${height}px" title="${escapeHtml(event.title)} ${formatTime(startsAt)} - ${formatTime(endsAt)}">
+        const items = layoutTimelineEvents(events.filter(event => isSameDay(new Date(event.start), day)));
+        return `<div class="cron-calendar__day-column${isSameDay(day, now) ? ' is-today' : ''}">${items.map(item => {
+          const { event, startsAt, endsAt, column, clusterSize } = item;
+          const top = Math.max(0, Math.min(timelineHeight - 36, (minutesSinceStart(startsAt) / 60) * HOUR_HEIGHT));
+          const height = Math.max(36, (DISPLAY_MINUTES / 60) * HOUR_HEIGHT);
+          const width = `calc(${100 / clusterSize}% - .3rem)`;
+          const left = `calc(${(100 / clusterSize) * column}% + .15rem)`;
+          return `<a class="cron-calendar__timeline-event" href="${escapeHtml(event.url)}" style="top:${top}px;height:${height}px;left:${left};width:${width}" title="${escapeHtml(event.title)} ${formatTime(startsAt)} - ${formatTime(endsAt)}">
             <strong>${escapeHtml(event.title)}</strong><span>${formatTime(startsAt)} - ${formatTime(endsAt)}</span>
           </a>`;
         }).join('')}</div>`;

--- a/app/templates/admin/cron_calendar.html
+++ b/app/templates/admin/cron_calendar.html
@@ -56,7 +56,7 @@
   .cron-calendar .management__content { min-height: 0; }
   .cron-calendar__toolbar { display: flex; justify-content: space-between; gap: 1rem; align-items: center; margin-bottom: 1rem; }
   .cron-calendar__nav { display: flex; gap: .5rem; flex-wrap: wrap; }
-  .cron-calendar__grid { display: grid; gap: .75rem; max-height: calc(100vh - 18rem); overflow: auto; }
+  .cron-calendar__grid { display: grid; gap: .75rem; max-height: calc(100vh - 18rem); min-height: 24rem; overflow: auto; }
   .cron-calendar__period { border: 1px solid var(--border-color, #d8dee9); border-radius: .75rem; background: var(--surface-color, #fff); min-height: 8rem; overflow: hidden; }
   .cron-calendar__period-header { padding: .65rem .85rem; font-weight: 700; background: var(--surface-muted, #f8fafc); border-bottom: 1px solid var(--border-color, #d8dee9); }
   .cron-calendar__events { display: grid; gap: .5rem; padding: .65rem; }
@@ -66,18 +66,18 @@
   .cron-calendar__grid--month { grid-template-columns: repeat(7, minmax(9rem, 1fr)); }
   .cron-calendar__grid--list { grid-template-columns: 1fr; }
   .cron-calendar__grid--timeline { display: block; border: 1px solid var(--border-color, #d8dee9); border-radius: .85rem; background: var(--surface-color, #fff); overflow: auto; }
-  .cron-calendar__timeline { display: grid; grid-template-columns: 4.5rem minmax(55rem, 1fr); grid-template-rows: 3rem var(--calendar-timeline-height); min-width: 62rem; }
+  .cron-calendar__timeline { display: grid; grid-template-columns: 4.5rem minmax(78rem, 1fr); grid-template-rows: 3rem var(--calendar-timeline-height); min-width: 84rem; }
   .cron-calendar__corner { position: sticky; left: 0; top: 0; z-index: 5; background: var(--surface-color, #fff); border-right: 1px solid var(--border-color, #d8dee9); border-bottom: 1px solid var(--border-color, #d8dee9); }
-  .cron-calendar__day-headings { position: sticky; top: 0; z-index: 4; display: grid; grid-auto-columns: minmax(12rem, 1fr); grid-auto-flow: column; background: var(--surface-color, #fff); border-bottom: 1px solid var(--border-color, #d8dee9); }
+  .cron-calendar__day-headings { position: sticky; top: 0; z-index: 4; display: grid; grid-auto-columns: minmax(14rem, 1fr); grid-auto-flow: column; background: var(--surface-color, #fff); border-bottom: 1px solid var(--border-color, #d8dee9); }
   .cron-calendar__day-heading { display: inline-flex; align-items: center; justify-content: center; gap: .4rem; border-right: 1px solid var(--border-color, #d8dee9); color: var(--text-muted, #64748b); font-size: .78rem; text-transform: uppercase; }
   .cron-calendar__day-heading strong { display: inline-grid; min-width: 1.45rem; min-height: 1.45rem; place-items: center; border-radius: 999px; color: var(--text-color, #111827); }
   .cron-calendar__day-heading.is-today strong { color: #fff; background: var(--primary-color, #2563eb); }
-  .cron-calendar__time-axis { position: sticky; left: 0; z-index: 3; display: grid; grid-template-rows: repeat(19, var(--calendar-hour-height)); background: var(--surface-color, #fff); border-right: 1px solid var(--border-color, #d8dee9); }
+  .cron-calendar__time-axis { position: sticky; left: 0; z-index: 3; display: grid; grid-template-rows: repeat(24, var(--calendar-hour-height)); background: var(--surface-color, #fff); border-right: 1px solid var(--border-color, #d8dee9); }
   .cron-calendar__time-axis span { transform: translateY(-.45rem); padding-right: .5rem; text-align: right; color: var(--text-muted, #64748b); font-size: .78rem; }
-  .cron-calendar__day-columns { display: grid; grid-auto-columns: minmax(12rem, 1fr); grid-auto-flow: column; min-height: var(--calendar-timeline-height); background-image: repeating-linear-gradient(to bottom, transparent 0, transparent calc(var(--calendar-hour-height) - 1px), var(--border-color, #d8dee9) calc(var(--calendar-hour-height) - 1px), var(--border-color, #d8dee9) var(--calendar-hour-height)); }
+  .cron-calendar__day-columns { display: grid; grid-auto-columns: minmax(14rem, 1fr); grid-auto-flow: column; min-height: var(--calendar-timeline-height); background-image: repeating-linear-gradient(to bottom, transparent 0, transparent calc(var(--calendar-hour-height) - 1px), var(--border-color, #d8dee9) calc(var(--calendar-hour-height) - 1px), var(--border-color, #d8dee9) var(--calendar-hour-height)); }
   .cron-calendar__day-column { position: relative; border-right: 1px solid var(--border-color, #d8dee9); min-height: var(--calendar-timeline-height); }
   .cron-calendar__day-column.is-today { background: color-mix(in srgb, var(--primary-color, #2563eb) 4%, transparent); }
-  .cron-calendar__timeline-event { position: absolute; left: .15rem; right: .15rem; display: grid; align-content: start; gap: .1rem; overflow: hidden; border-left: .2rem solid var(--accent-color, #ec4899); border-radius: .2rem; padding: .2rem .35rem; background: color-mix(in srgb, var(--surface-muted, #f1f5f9) 90%, var(--primary-color, #2563eb)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-color, #d8dee9) 70%, transparent); color: var(--text-color, #111827); font-size: .72rem; line-height: 1.15; text-decoration: none; }
+  .cron-calendar__timeline-event { position: absolute; left: .15rem; width: calc(100% - .3rem); display: grid; align-content: start; gap: .1rem; overflow: hidden; border-left: .2rem solid var(--accent-color, #ec4899); border-radius: .35rem; padding: .25rem .4rem; background: color-mix(in srgb, var(--surface-muted, #f1f5f9) 90%, var(--primary-color, #2563eb)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-color, #d8dee9) 70%, transparent); color: var(--text-color, #111827); font-size: .78rem; line-height: 1.2; text-decoration: none; }
   .cron-calendar__timeline-event strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .cron-calendar__timeline-event span { color: var(--text-muted, #64748b); }
   @media (max-width: 900px) { .cron-calendar__grid--month { grid-template-columns: 1fr; } .cron-calendar__toolbar { align-items: stretch; flex-direction: column; } .cron-calendar__timeline { grid-template-columns: 3.75rem minmax(42rem, 1fr); min-width: 46rem; } }


### PR DESCRIPTION
### Motivation
- The cron calendar timeline displayed runs as short, cramped blocks making items unreadable and the view hard to scroll through for a full day. 
- Overlapping scheduled items were stacked on top of each other which hid information. 
- The display granularity needed to be 1 minute for more accurate visual placement of short scheduled runs.

### Description
- Updated `app/static/js/cron_calendar.js` to render runs as 1-minute items by setting `DISPLAY_MINUTES = 1` and to expand the visible range to a full 24-hour timeline with `DAY_START_HOUR = 0`, `DAY_END_HOUR = 24`, and increased `HOUR_HEIGHT` for larger time slots. 
- Added `layoutTimelineEvents` to compute event columns and cluster sizes so overlapping events are laid out side-by-side and rendered with calculated `left` and `width` styles. 
- Adjusted timeline rendering math to use the computed columns and increased minimum `top`/`height` values for better readability. 
- Updated `app/templates/admin/cron_calendar.html` styles to make the timeline more scrollable and readable by increasing timeline/min-width and day column sizes, switching to a 24-row time axis, and improving event styling (padding, radius, font-size, spacing).

### Testing
- Ran JavaScript syntax check with `node --check app/static/js/cron_calendar.js`, which succeeded. 
- Compiled Python modules with `python -m compileall app`, which succeeded. 
- Verified repository checks with `git diff --check`, which reported no issues. 
- Ran `pytest tests/test_health_endpoints.py -q` which failed during import due to a missing system dependency (`libmagic`) in the execution environment, so full test suite validation was blocked. 
- Screenshot capture was not performed because no browser/screenshot tooling is available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dcbe987b8832d84c4ad2dc6cff08c)