### PR TITLE
Persist inline data-uri images as ticket attachments

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -1397,7 +1397,6 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
     form = await request.form()
     body_value = form.get("body", "")
     body_raw = str(body_value) if isinstance(body_value, str) else ""
-    sanitized_body = sanitize_rich_text(body_raw)
     is_internal = str(form.get("isInternal", "")).lower() in {"1", "true", "on", "yes"}
     minutes_input_raw = form.get("minutesSpent", "")
     minutes_input = str(minutes_input_raw).strip() if isinstance(minutes_input_raw, str) else ""
@@ -1468,14 +1467,6 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
         default_labour = await labour_types_service.get_default_labour_type()
         if default_labour:
             labour_type_id = default_labour.get("id")
-    if not sanitized_body.has_rich_content:
-        return await main_module._render_ticket_detail(
-            request,
-            current_user,
-            ticket_id=ticket_id,
-            error_message="Enter a reply before submitting.",
-            status_code=status.HTTP_400_BAD_REQUEST,
-        )
     ticket = await tickets_repo.get_ticket(ticket_id)
     if not ticket:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
@@ -1506,6 +1497,38 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
             current_user,
             ticket_id=ticket_id,
             error_message="Cannot add replies to a billed ticket. This ticket has been invoiced and closed.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        author_id_for_inline = current_user.get("id")
+        if not isinstance(author_id_for_inline, int):
+            try:
+                author_id_for_inline = int(author_id_for_inline)
+            except (TypeError, ValueError, AttributeError):
+                author_id_for_inline = None
+        body_raw, _inline_attachments = await attachments_service.persist_inline_images_for_ticket_body(
+            ticket_id,
+            body_raw,
+            access_level="closed",
+            uploaded_by_user_id=author_id_for_inline,
+        )
+    except (ValueError, IOError) as exc:
+        log_error("Failed to save inline image attachment", ticket_id=ticket_id, error=str(exc))
+        return await main_module._render_ticket_detail(
+            request,
+            current_user,
+            ticket_id=ticket_id,
+            error_message="Unable to save one of the images in the reply. Please try a smaller supported image.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    sanitized_body = sanitize_rich_text(body_raw)
+    if not sanitized_body.has_rich_content:
+        return await main_module._render_ticket_detail(
+            request,
+            current_user,
+            ticket_id=ticket_id,
+            error_message="Enter a reply before submitting.",
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/app/features/tickets/portal_routes.py
+++ b/app/features/tickets/portal_routes.py
@@ -279,6 +279,27 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
 
     form = await request.form()
     body = str(form.get("body") or "").strip()
+    try:
+        body, _inline_attachments = await attachments_service.persist_inline_images_for_ticket_body(
+            ticket_id,
+            body,
+            access_level="closed",
+            uploaded_by_user_id=user_id,
+        )
+    except (ValueError, IOError) as exc:
+        log_error(
+            "Failed to save inline image attachment",
+            ticket_id=ticket_id,
+            error=str(exc),
+        )
+        return await main_module._render_portal_ticket_detail(
+            request,
+            user,
+            ticket_id=ticket_id,
+            error_message="We couldn't save one of the images in your reply. Please try a smaller supported image.",
+            reply_body=body,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
     sanitized_body = sanitize_rich_text(body)
     if not sanitized_body.has_rich_content:
         return await main_module._render_portal_ticket_detail(

--- a/app/services/ticket_attachments.py
+++ b/app/services/ticket_attachments.py
@@ -1,7 +1,10 @@
 """Service for handling ticket attachment file operations."""
 from __future__ import annotations
 
+import base64
+import binascii
 import os
+import re
 import secrets
 from pathlib import Path
 from typing import Any
@@ -48,6 +51,16 @@ ALLOWED_MIME_TYPES = {
 
 # Number of bytes to read from the start of a file for MIME sniffing.
 _MAGIC_HEADER_BYTES = 2048
+_INLINE_IMAGE_DATA_URI_PATTERN = re.compile(
+    r'(<img\b[^>]*?\bsrc=["\\\'])data:(image/[a-zA-Z0-9.+-]+);base64,([^"\\\']+)(["\\\'][^>]*>)',
+    re.IGNORECASE,
+)
+_INLINE_IMAGE_EXTENSIONS = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/gif": "gif",
+    "image/webp": "webp",
+}
 
 
 def _get_upload_directory() -> Path:
@@ -260,6 +273,63 @@ async def save_file_bytes(
         if file_path.exists():
             file_path.unlink()
         raise
+
+
+async def persist_inline_images_for_ticket_body(
+    ticket_id: int,
+    body: str,
+    *,
+    access_level: str,
+    uploaded_by_user_id: int | None,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Persist base64 inline ``<img>`` data URIs and rewrite them to downloads.
+
+    Rich-text editors commonly paste screenshots as ``data:image/...;base64``
+    URLs. Storing those data URIs directly in ``ticket_replies.body`` can exceed
+    MySQL ``TEXT`` limits or packet limits, causing reply saves to fail. This
+    helper turns supported raster images into regular ticket attachments and
+    replaces the image ``src`` with the authenticated attachment download URL.
+    """
+
+    if not body or "data:image/" not in body.lower():
+        return body, []
+
+    created_attachments: list[dict[str, Any]] = []
+
+    async def _save_match(match: re.Match[str]) -> str:
+        prefix, mime_type_raw, encoded_raw, suffix = match.groups()
+        mime_type = mime_type_raw.lower()
+        extension = _INLINE_IMAGE_EXTENSIONS.get(mime_type)
+        if not extension:
+            # Leave unsupported image data URIs for the sanitizer/validator path.
+            return match.group(0)
+
+        encoded = re.sub(r"\s+", "", encoded_raw)
+        try:
+            contents = base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError):
+            return match.group(0)
+
+        attachment = await save_file_bytes(
+            ticket_id=ticket_id,
+            contents=contents,
+            original_filename=f"inline-image.{extension}",
+            mime_type=mime_type,
+            access_level=access_level,
+            uploaded_by_user_id=uploaded_by_user_id,
+        )
+        created_attachments.append(attachment)
+        attachment_id = attachment.get("id")
+        return f'{prefix}/api/tickets/{ticket_id}/attachments/{attachment_id}/download{suffix}'
+
+    rewritten_parts: list[str] = []
+    last_index = 0
+    for match in _INLINE_IMAGE_DATA_URI_PATTERN.finditer(body):
+        rewritten_parts.append(body[last_index:match.start()])
+        rewritten_parts.append(await _save_match(match))
+        last_index = match.end()
+    rewritten_parts.append(body[last_index:])
+    return "".join(rewritten_parts), created_attachments
 
 
 async def delete_attachment_file(attachment: dict[str, Any]) -> None:

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -1,3 +1,8 @@
+import base64
+
+import pytest
+
+from app.services import ticket_attachments as ticket_attachments_service
 from app.services.sanitization import sanitize_rich_text
 
 
@@ -68,3 +73,38 @@ def test_sanitize_rich_text_keeps_non_quoted_header_like_content():
     assert "voice mail from" in result.html
     assert "Duration" in result.html
     assert "Received" in result.html
+
+
+@pytest.mark.asyncio
+async def test_persist_inline_images_for_ticket_body_saves_data_uri(monkeypatch, tmp_path):
+    png_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+    )
+    created = []
+
+    monkeypatch.setattr(ticket_attachments_service, "_get_upload_directory", lambda: tmp_path)
+
+    async def fake_create_attachment(**kwargs):
+        record = {"id": 42, **kwargs}
+        created.append(record)
+        return record
+
+    monkeypatch.setattr(ticket_attachments_service.attachments_repo, "create_attachment", fake_create_attachment)
+
+    body = f'<p>Screenshot</p><img src="data:image/png;base64,{base64.b64encode(png_bytes).decode()}" alt="shot">'
+
+    rewritten, attachments = await ticket_attachments_service.persist_inline_images_for_ticket_body(
+        123,
+        body,
+        access_level="closed",
+        uploaded_by_user_id=7,
+    )
+
+    assert "data:image" not in rewritten
+    assert 'src="/api/tickets/123/attachments/42/download"' in rewritten
+    assert attachments == created
+    assert created[0]["ticket_id"] == 123
+    assert created[0]["original_filename"] == "inline-image.png"
+    assert created[0]["access_level"] == "closed"
+    assert created[0]["uploaded_by_user_id"] == 7
+    assert (tmp_path / created[0]["filename"]).read_bytes() == png_bytes


### PR DESCRIPTION
### Motivation
- Users could not post ticket replies when the reply body contained pasted inline images (`data:image/...;base64`) because the large data URIs could cause reply saves to fail or exceed DB/packet limits.
- Convert inline base64 images into real attachment files so reply bodies remain small and attachments benefit from existing access controls and download endpoints.
- Restrict the conversion to supported raster types to avoid introducing new attack vectors or storing executable/vector formats.

### Description
- Added `persist_inline_images_for_ticket_body` to `app/services/ticket_attachments.py` which detects inline `data:image/...;base64` `<img>` tags, decodes and validates supported raster image types, saves them via the existing attachment pipeline (`save_file_bytes` / `attachments_repo.create_attachment`), and rewrites the `src` to the authenticated download URL `/api/tickets/{ticket_id}/attachments/{attachment_id}/download`.
- Introduced `_INLINE_IMAGE_DATA_URI_PATTERN` and `_INLINE_IMAGE_EXTENSIONS` and small helper decoding/validation logic in `app/services/ticket_attachments.py` and kept allowed mime checks aligned with `ALLOWED_MIME_TYPES`.
- Integrated conversion into portal and admin reply flows by calling `persist_inline_images_for_ticket_body` before sanitisation in `app/features/tickets/portal_routes.py` and `app/features/tickets/admin_routes.py`, with defensive exception handling and user-facing validation messages when inline image persistence fails.
- Added a regression test `test_persist_inline_images_for_ticket_body_saves_data_uri` to `tests/test_sanitization.py` that asserts a base64 PNG is saved, the reply HTML is rewritten, and the created attachment record/bytes are as expected.

### Testing
- Ran static checks/compilation: `python -m py_compile app/services/ticket_attachments.py app/features/tickets/portal_routes.py app/features/tickets/admin_routes.py tests/test_sanitization.py` which succeeded.
- Attempted to run the new unit test: `pytest -q tests/test_sanitization.py`, but test collection failed due to the environment lacking the `libmagic` shared library required by `python-magic` (import error); this blocks execution of the attachment-saving test in the current CI/container environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dcd506bd8832daf3d797b4484caa9)