### PR TITLE
Fix cron calendar timeline slot density

### DIFF
--- a/app/static/js/cron_calendar.js
+++ b/app/static/js/cron_calendar.js
@@ -3,9 +3,12 @@
   if (!root) return;
 
   const DISPLAY_MINUTES = 1;
+  const VISUAL_DURATION_MINUTES = 6;
+  const MINUTE_SLOTS_PER_HOUR = 60;
+  const MINUTE_SLOT_HEIGHT = 6;
   const DAY_START_HOUR = 0;
   const DAY_END_HOUR = 24;
-  const HOUR_HEIGHT = 96;
+  const HOUR_HEIGHT = MINUTE_SLOTS_PER_HOUR * MINUTE_SLOT_HEIGHT;
   const state = { view: 'week', anchor: new Date(), events: [], search: '', includeInactive: false };
   const grid = root.querySelector('[data-calendar-grid]');
   const rangeLabel = root.querySelector('[data-calendar-range]');
@@ -32,13 +35,17 @@
     return sorted.map(event => {
       const startsAt = new Date(event.start);
       const endsAt = new Date(startsAt.getTime() + DISPLAY_MINUTES * 60000);
+      const visualEndsAt = new Date(startsAt.getTime() + VISUAL_DURATION_MINUTES * 60000);
       for (let idx = active.length - 1; idx >= 0; idx -= 1) {
         if (active[idx].end <= startsAt) active.splice(idx, 1);
       }
+      // The timeline uses one vertical slot per minute.  Events are visually
+      // taller than one minute so titles remain readable, so keep nearby
+      // entries active for their rendered height to prevent visual overlap.
       const usedColumns = new Set(active.map(item => item.column));
       let column = 0;
       while (usedColumns.has(column)) column += 1;
-      const entry = { event, startsAt, endsAt, end: endsAt, column, clusterSize: column + 1 };
+      const entry = { event, startsAt, endsAt, end: visualEndsAt, column, clusterSize: column + 1 };
       active.push(entry);
       const clusterSize = Math.max(...active.map(item => item.column), column) + 1;
       active.forEach(item => { item.clusterSize = Math.max(item.clusterSize, clusterSize); });
@@ -118,8 +125,8 @@
         const items = layoutTimelineEvents(events.filter(event => isSameDay(new Date(event.start), day)));
         return `<div class="cron-calendar__day-column${isSameDay(day, now) ? ' is-today' : ''}">${items.map(item => {
           const { event, startsAt, endsAt, column, clusterSize } = item;
-          const top = Math.max(0, Math.min(timelineHeight - 36, (minutesSinceStart(startsAt) / 60) * HOUR_HEIGHT));
-          const height = Math.max(36, (DISPLAY_MINUTES / 60) * HOUR_HEIGHT);
+          const top = Math.max(0, Math.min(timelineHeight - MINUTE_SLOT_HEIGHT, (minutesSinceStart(startsAt) / 60) * HOUR_HEIGHT));
+          const height = Math.max(MINUTE_SLOT_HEIGHT, (VISUAL_DURATION_MINUTES / 60) * HOUR_HEIGHT);
           const width = `calc(${100 / clusterSize}% - .3rem)`;
           const left = `calc(${(100 / clusterSize) * column}% + .15rem)`;
           return `<a class="cron-calendar__timeline-event" href="${escapeHtml(event.url)}" style="top:${top}px;height:${height}px;left:${left};width:${width}" title="${escapeHtml(event.title)} ${formatTime(startsAt)} - ${formatTime(endsAt)}">


### PR DESCRIPTION
### Motivation
- The daily and weekly cron calendar had insufficient vertical resolution causing closely scheduled tasks to visually overlap. 
- The goal is to provide minute-level placement (60 slots per hour) so events can be positioned without collision. 
- Preserve the existing one-minute scheduled-run semantics shown in labels and tooltips while improving layout readability.

### Description
- Add `VISUAL_DURATION_MINUTES`, `MINUTE_SLOTS_PER_HOUR`, and `MINUTE_SLOT_HEIGHT` constants and compute `HOUR_HEIGHT` as `MINUTE_SLOTS_PER_HOUR * MINUTE_SLOT_HEIGHT` in `app/static/js/cron_calendar.js` to establish 60 time slots per hour. 
- Use a `visualEndsAt` (based on `VISUAL_DURATION_MINUTES`) for collision/column calculations while keeping `DISPLAY_MINUTES` for the actual scheduled-run `endsAt` shown to users. 
- Adjust collision window and rendered event `top`/`height` calculations to use the new minute-slot sizing so nearby runs are kept active for their rendered height and laid out into columns instead of overlapping. 
- Added explanatory comments and preserved existing event label/tool-tip formatting.

### Testing
- Ran `node --check app/static/js/cron_calendar.js` which succeeded. 
- Ran `python -m pytest tests/test_cron_calendar.py` which succeeded (2 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ddc5cb828832d9f05d6e2be3dc862)