### PR TITLE
Remove Month view and improve Cron Calendar list readability

### DIFF
--- a/app/static/js/cron_calendar.js
+++ b/app/static/js/cron_calendar.js
@@ -20,8 +20,6 @@
   function startOfDay(date) { const d = new Date(date); d.setHours(0, 0, 0, 0); return d; }
   function addDays(date, days) { const d = new Date(date); d.setDate(d.getDate() + days); return d; }
   function startOfWeek(date) { const d = startOfDay(date); d.setDate(d.getDate() - d.getDay()); return d; }
-  function startOfMonth(date) { return new Date(date.getFullYear(), date.getMonth(), 1); }
-  function addMonths(date, months) { return new Date(date.getFullYear(), date.getMonth() + months, 1); }
   function escapeHtml(value) { return String(value || '').replace(/[&<>'"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[c])); }
   function formatDate(date, opts) { return new Intl.DateTimeFormat(undefined, opts).format(date); }
   function formatTime(date) { return new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' }).format(date); }
@@ -54,7 +52,6 @@
   }
 
   function rangeForView() {
-    if (state.view === 'month') { const start = startOfMonth(state.anchor); return { start, end: addMonths(start, 1) }; }
     if (state.view === 'week') { const start = startOfWeek(state.anchor); return { start, end: addDays(start, 7) }; }
     if (state.view === 'list') { const start = startOfDay(state.anchor); return { start, end: addDays(start, 30) }; }
     const start = startOfDay(state.anchor); return { start, end: addDays(start, 1) };
@@ -142,19 +139,12 @@
     if (state.view === 'day' || state.view === 'week') { renderTimeline(state.view === 'week' ? 7 : 1); return; }
     countLabel.textContent = String(events.length);
     grid.className = `cron-calendar__grid cron-calendar__grid--${state.view}`;
-    const { start } = rangeForView();
-    if (state.view === 'list') {
-      const byDay = new Map();
-      events.forEach(event => { const key = formatDate(new Date(event.start), { dateStyle: 'full' }); byDay.set(key, [...(byDay.get(key) || []), event]); });
-      grid.innerHTML = byDay.size ? Array.from(byDay.entries()).map(([label, items]) => renderPeriod(label, items)).join('') : renderPeriod('Upcoming 30 days', []);
-      return;
-    }
-    const days = new Date(start.getFullYear(), start.getMonth() + 1, 0).getDate();
-    grid.innerHTML = Array.from({ length: days }, (_, idx) => {
-      const day = addDays(start, idx);
-      const items = events.filter(event => isSameDay(new Date(event.start), day));
-      return renderPeriod(formatDate(day, { weekday: 'short', month: 'short', day: 'numeric' }), items);
-    }).join('');
+    const byDay = new Map();
+    events.forEach(event => {
+      const key = formatDate(new Date(event.start), { dateStyle: 'full' });
+      byDay.set(key, [...(byDay.get(key) || []), event]);
+    });
+    grid.innerHTML = byDay.size ? Array.from(byDay.entries()).map(([label, items]) => renderPeriod(label, items)).join('') : renderPeriod('Upcoming 30 days', []);
   }
 
   document.querySelectorAll('[data-calendar-view]').forEach(button => {
@@ -166,8 +156,8 @@
       loadEvents();
     });
   });
-  root.querySelector('[data-calendar-prev]').addEventListener('click', () => { state.anchor = state.view === 'month' ? addMonths(state.anchor, -1) : addDays(state.anchor, state.view === 'week' ? -7 : state.view === 'list' ? -30 : -1); loadEvents(); });
-  root.querySelector('[data-calendar-next]').addEventListener('click', () => { state.anchor = state.view === 'month' ? addMonths(state.anchor, 1) : addDays(state.anchor, state.view === 'week' ? 7 : state.view === 'list' ? 30 : 1); loadEvents(); });
+  root.querySelector('[data-calendar-prev]').addEventListener('click', () => { state.anchor = addDays(state.anchor, state.view === 'week' ? -7 : state.view === 'list' ? -30 : -1); loadEvents(); });
+  root.querySelector('[data-calendar-next]').addEventListener('click', () => { state.anchor = addDays(state.anchor, state.view === 'week' ? 7 : state.view === 'list' ? 30 : 1); loadEvents(); });
   root.querySelector('[data-calendar-today]').addEventListener('click', () => { state.anchor = new Date(); loadEvents(); });
   searchInput.addEventListener('input', () => { state.search = searchInput.value || ''; render(); });
   inactiveInput.addEventListener('change', () => { state.includeInactive = inactiveInput.checked; loadEvents(); });

--- a/app/templates/admin/cron_calendar.html
+++ b/app/templates/admin/cron_calendar.html
@@ -6,7 +6,6 @@
   <div class="button-group" role="group" aria-label="Calendar views">
     <button class="button button--ghost" type="button" data-calendar-view="day">Day</button>
     <button class="button button--primary" type="button" data-calendar-view="week">Week</button>
-    <button class="button button--ghost" type="button" data-calendar-view="month">Month</button>
     <button class="button button--ghost" type="button" data-calendar-view="list">List</button>
   </div>
 {% endblock %}
@@ -60,10 +59,11 @@
   .cron-calendar__period { border: 1px solid var(--border-color, #d8dee9); border-radius: .75rem; background: var(--surface-color, #fff); min-height: 8rem; overflow: hidden; }
   .cron-calendar__period-header { padding: .65rem .85rem; font-weight: 700; background: var(--surface-muted, #f8fafc); border-bottom: 1px solid var(--border-color, #d8dee9); }
   .cron-calendar__events { display: grid; gap: .5rem; padding: .65rem; }
-  .cron-calendar__event { display: grid; gap: .25rem; border-left: .25rem solid var(--primary-color, #2563eb); padding: .55rem .65rem; background: color-mix(in srgb, var(--primary-color, #2563eb) 8%, transparent); border-radius: .5rem; text-decoration: none; color: inherit; }
-  .cron-calendar__event-meta { display: flex; gap: .5rem; flex-wrap: wrap; font-size: .82rem; color: var(--text-muted, #64748b); }
+  .cron-calendar__event { display: grid; gap: .25rem; border-left: .25rem solid var(--primary-color, #2563eb); padding: .55rem .65rem; background: color-mix(in srgb, var(--primary-color, #2563eb) 8%, #ffffff); border-radius: .5rem; text-decoration: none; color: var(--cron-calendar-event-text, #0f172a); }
+  .cron-calendar__event strong { color: var(--cron-calendar-event-title, #0f172a); }
+  .cron-calendar__event-meta { display: flex; gap: .5rem; flex-wrap: wrap; font-size: .82rem; color: var(--cron-calendar-event-muted, #475569); }
+  .cron-calendar__event-meta code { color: var(--cron-calendar-event-code, #334155); }
   .cron-calendar__empty { padding: 1rem; color: var(--text-muted, #64748b); }
-  .cron-calendar__grid--month { grid-template-columns: repeat(7, minmax(9rem, 1fr)); }
   .cron-calendar__grid--list { grid-template-columns: 1fr; }
   .cron-calendar__grid--timeline { display: block; border: 1px solid var(--border-color, #d8dee9); border-radius: .85rem; background: var(--surface-color, #fff); overflow: auto; }
   .cron-calendar__timeline { display: grid; grid-template-columns: 4.5rem minmax(78rem, 1fr); grid-template-rows: 3rem var(--calendar-timeline-height); min-width: 84rem; }
@@ -80,7 +80,7 @@
   .cron-calendar__timeline-event { position: absolute; left: .15rem; width: calc(100% - .3rem); display: grid; align-content: start; gap: .1rem; overflow: hidden; border-left: .2rem solid var(--accent-color, #ec4899); border-radius: .35rem; padding: .25rem .4rem; background: color-mix(in srgb, var(--surface-muted, #f1f5f9) 90%, var(--primary-color, #2563eb)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-color, #d8dee9) 70%, transparent); color: var(--text-color, #111827); font-size: .78rem; line-height: 1.2; text-decoration: none; }
   .cron-calendar__timeline-event strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .cron-calendar__timeline-event span { color: var(--text-muted, #64748b); }
-  @media (max-width: 900px) { .cron-calendar__grid--month { grid-template-columns: 1fr; } .cron-calendar__toolbar { align-items: stretch; flex-direction: column; } .cron-calendar__timeline { grid-template-columns: 3.75rem minmax(42rem, 1fr); min-width: 46rem; } }
+  @media (max-width: 900px) { .cron-calendar__toolbar { align-items: stretch; flex-direction: column; } .cron-calendar__timeline { grid-template-columns: 3.75rem minmax(42rem, 1fr); min-width: 46rem; } }
 </style>
 <script src="{{ static_url('/static/js/cron_calendar.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- The Cron Calendar month view was redundant and the list view had poor text contrast, making scheduled tasks hard to read. 
- Simplify client-side calendar logic by removing month-specific rendering and navigation to reduce complexity and potential bugs. 
- Improve accessibility and visual clarity of list cards so titles, cron expressions and metadata are readable across themes.

### Description
- Removed the `Month` button from the calendar view selector in `app/templates/admin/cron_calendar.html` and removed month-related CSS rules. 
- Removed month-range helpers and references (`startOfMonth`, `addMonths`, and `state.view === 'month'` branches) from `app/static/js/cron_calendar.js` and updated prev/next handlers to no longer special-case month navigation. 
- Simplified List rendering so it always groups events by full-day label for the upcoming 30-day window instead of attempting a month grid. 
- Updated list card styling in `app/templates/admin/cron_calendar.html` to use explicit readable foreground/background variables (`--cron-calendar-event-text`, `--cron-calendar-event-title`, `--cron-calendar-event-muted`, `--cron-calendar-event-code`) and a light event background to ensure good contrast.

### Testing
- Ran `node --check app/static/js/cron_calendar.js` and the JS passed syntax checks. 
- Searched for leftover month references with `rg -n "data-calendar-view=\"month\"|state\.view === 'month'|addMonths|startOfMonth|cron-calendar__grid--month"` and confirmed no matches. 
- Ran `git diff --check` to ensure no whitespace/formatting issues. 
- Attempted to start the app to capture a screenshot, but app startup failed in the container due to a missing system dependency (`libmagic`), so an in-browser screenshot could not be taken.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4de0b299fc832d9b6d37215dfe7d28)