### PR TITLE
Fix cron calendar timezone scheduling

### DIFF
--- a/app/api/routes/scheduler.py
+++ b/app/api/routes/scheduler.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from app.api.dependencies.auth import require_super_admin
 from app.api.dependencies.database import require_database
+from app.core.config import get_settings
 from app.core.logging import log_info
 from app.repositories import scheduled_tasks as scheduled_tasks_repo
 from app.repositories import webhook_events as webhook_events_repo
@@ -39,7 +40,9 @@ async def list_tasks(
     return [ScheduledTaskResponse.model_validate(record) for record in records]
 
 
-@router.post("/tasks", response_model=ScheduledTaskResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/tasks", response_model=ScheduledTaskResponse, status_code=status.HTTP_201_CREATED
+)
 async def create_task(
     payload: ScheduledTaskCreate,
     _: None = Depends(require_database),
@@ -73,7 +76,9 @@ async def get_task(
 ) -> ScheduledTaskResponse:
     task = await scheduled_tasks_repo.get_task(task_id)
     if not task:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
     return ScheduledTaskResponse.model_validate(task)
 
 
@@ -86,12 +91,12 @@ async def update_task(
 ) -> ScheduledTaskResponse:
     existing = await scheduled_tasks_repo.get_task(task_id)
     if not existing:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
     updates = payload.model_dump(exclude_unset=True, by_alias=False)
     merged = existing | {
-        key: value
-        for key, value in updates.items()
-        if value is not None
+        key: value for key, value in updates.items() if value is not None
     }
     raw_max_retries = merged.get("max_retries")
     raw_retry_backoff = merged.get("retry_backoff_seconds")
@@ -121,7 +126,9 @@ async def delete_task(
 ) -> None:
     existing = await scheduled_tasks_repo.get_task(task_id)
     if not existing:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
     await scheduled_tasks_repo.delete_task(task_id)
     await scheduler_service.refresh()
     return None
@@ -136,7 +143,9 @@ async def activate_task(
 ) -> ScheduledTaskResponse:
     existing = await scheduled_tasks_repo.get_task(task_id)
     if not existing:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
     updated = await scheduled_tasks_repo.set_task_active(task_id, payload.active)
     await scheduler_service.refresh()
     return ScheduledTaskResponse.model_validate(updated)
@@ -151,13 +160,19 @@ async def preview_task(
 ) -> ScheduledTaskPreviewResponse:
     existing = await scheduled_tasks_repo.get_task(task_id)
     if not existing:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
     response.headers["Cache-Control"] = "no-store"
     preview = await scheduled_task_preview.preview_task(existing)
     return ScheduledTaskPreviewResponse.model_validate(preview)
 
 
-@router.post("/tasks/{task_id}/run", response_model=RunTaskResponse, status_code=status.HTTP_202_ACCEPTED)
+@router.post(
+    "/tasks/{task_id}/run",
+    response_model=RunTaskResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
 async def run_task_now(
     task_id: int,
     _: None = Depends(require_database),
@@ -165,7 +180,9 @@ async def run_task_now(
 ) -> RunTaskResponse:
     existing = await scheduled_tasks_repo.get_task(task_id)
     if not existing:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
     await scheduler_service.run_now(task_id)
     return RunTaskResponse()
 
@@ -180,7 +197,9 @@ async def list_task_runs(
 ) -> list[ScheduledTaskRunResponse]:
     existing = await scheduled_tasks_repo.get_task(task_id)
     if not existing:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Task not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Task not found"
+        )
     response.headers["Cache-Control"] = "no-store"
     runs = await scheduled_tasks_repo.list_recent_runs(task_ids=[task_id], limit=limit)
     return [ScheduledTaskRunResponse.model_validate(run) for run in runs]
@@ -195,9 +214,20 @@ async def list_calendar_events(
     _: None = Depends(require_database),
     __: dict[str, Any] = Depends(require_super_admin),
 ) -> list[ScheduledTaskCalendarEventResponse]:
-    tasks = await scheduled_tasks_repo.list_calendar_tasks(include_inactive=include_inactive)
-    events = cron_calendar.build_calendar_events(tasks, start=start, end=end, limit=limit)
-    return [ScheduledTaskCalendarEventResponse.model_validate(event) for event in events]
+    tasks = await scheduled_tasks_repo.list_calendar_tasks(
+        include_inactive=include_inactive
+    )
+    settings = get_settings()
+    events = cron_calendar.build_calendar_events(
+        tasks,
+        start=start,
+        end=end,
+        limit=limit,
+        timezone_name=settings.default_timezone,
+    )
+    return [
+        ScheduledTaskCalendarEventResponse.model_validate(event) for event in events
+    ]
 
 
 @router.get("/webhooks", response_model=list[WebhookEventResponse])
@@ -211,7 +241,9 @@ async def list_webhook_events(
     return [WebhookEventResponse.model_validate(event) for event in events]
 
 
-@router.get("/webhooks/{event_id}/attempts", response_model=list[WebhookEventAttemptResponse])
+@router.get(
+    "/webhooks/{event_id}/attempts", response_model=list[WebhookEventAttemptResponse]
+)
 async def list_webhook_attempts(
     event_id: int,
     limit: int = Query(default=20, ge=1, le=200),
@@ -220,7 +252,9 @@ async def list_webhook_attempts(
 ) -> list[WebhookEventAttemptResponse]:
     event = await webhook_events_repo.get_event(event_id)
     if not event:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
+        )
     attempts = await webhook_events_repo.list_attempts(event_id, limit=limit)
     return [WebhookEventAttemptResponse.model_validate(attempt) for attempt in attempts]
 
@@ -233,7 +267,9 @@ async def retry_webhook_event(
 ) -> WebhookEventResponse:
     event = await webhook_monitor.force_retry(event_id)
     if not event:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
+        )
     return WebhookEventResponse.model_validate(event)
 
 
@@ -258,7 +294,9 @@ async def delete_webhook_event(
 ) -> None:
     event = await webhook_events_repo.get_event(event_id)
     if not event:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Event not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Event not found"
+        )
     if str(event.get("status") or "").lower() == "in_progress":
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/app/services/cron_calendar.py
+++ b/app/services/cron_calendar.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import CroniterBadCronError, croniter
 
@@ -14,15 +15,30 @@ def _as_utc(value: datetime) -> datetime:
     return value.astimezone(timezone.utc)
 
 
+def _resolve_timezone(timezone_name: str | None) -> tzinfo:
+    if not timezone_name:
+        return timezone.utc
+    try:
+        return ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError:
+        return timezone.utc
+
+
 def build_calendar_events(
     tasks: list[dict[str, Any]],
     *,
     start: datetime,
     end: datetime,
     limit: int = _MAX_EVENTS,
+    timezone_name: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Expand cron-based scheduled tasks into UTC calendar event instances."""
+    """Expand cron-based scheduled tasks into UTC calendar event instances.
 
+    Cron expressions are interpreted in the configured scheduler timezone, while
+    returned event timestamps remain UTC ISO-8601 values for browser display.
+    """
+
+    schedule_timezone = _resolve_timezone(timezone_name)
     start_utc = _as_utc(start)
     end_utc = _as_utc(end)
     if end_utc <= start_utc:
@@ -35,7 +51,9 @@ def build_calendar_events(
         if not cron_expression:
             continue
         try:
-            iterator = croniter(cron_expression, start_utc)
+            iterator = croniter(
+                cron_expression, start_utc.astimezone(schedule_timezone)
+            )
         except (CroniterBadCronError, ValueError, KeyError):
             continue
 
@@ -51,7 +69,9 @@ def build_calendar_events(
                 {
                     "id": f"task-{task.get('id')}-{next_run_utc.isoformat()}",
                     "task_id": int(task.get("id") or 0),
-                    "title": str(task.get("name") or task.get("command") or "Scheduled task"),
+                    "title": str(
+                        task.get("name") or task.get("command") or "Scheduled task"
+                    ),
                     "command": str(task.get("command") or ""),
                     "cron": cron_expression,
                     "company_id": task.get("company_id"),

--- a/app/templates/admin/cron_calendar.html
+++ b/app/templates/admin/cron_calendar.html
@@ -38,7 +38,7 @@
       </div>
       <div>
         <h2 class="card__title" data-calendar-range>Loading…</h2>
-        <p class="card__subtitle"><span data-calendar-count>0</span> scheduled task runs shown. Times are converted from UTC to your browser timezone.</p>
+        <p class="card__subtitle"><span data-calendar-count>0</span> scheduled task runs shown. Times are scheduled in the configured CRON_TIMEZONE and displayed in your browser timezone.</p>
       </div>
     </div>
 

--- a/tests/test_cron_calendar.py
+++ b/tests/test_cron_calendar.py
@@ -3,7 +3,9 @@ from datetime import datetime, timezone
 import importlib.util
 from pathlib import Path
 
-spec = importlib.util.spec_from_file_location("cron_calendar", Path("app/services/cron_calendar.py"))
+spec = importlib.util.spec_from_file_location(
+    "cron_calendar", Path("app/services/cron_calendar.py")
+)
 cron_calendar = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(cron_calendar)
@@ -51,3 +53,37 @@ def test_build_calendar_events_skips_invalid_cron():
     )
 
     assert events == []
+
+
+def test_build_calendar_events_uses_configured_cron_timezone():
+    events = build_calendar_events(
+        [
+            {
+                "id": 3,
+                "name": "Evening Brisbane job",
+                "command": "sync_staff",
+                "cron": "1 18 * * *",
+                "company_id": None,
+                "company_name": "All companies",
+                "active": True,
+            }
+        ],
+        start=datetime(2026, 7, 7, tzinfo=timezone.utc),
+        end=datetime(2026, 7, 8, tzinfo=timezone.utc),
+        timezone_name="Australia/Brisbane",
+    )
+
+    assert len(events) == 1
+    assert events[0]["start"] == "2026-07-07T08:01:00+00:00"
+
+
+def test_build_calendar_events_falls_back_to_utc_for_invalid_timezone():
+    events = build_calendar_events(
+        [{"id": 4, "name": "UTC fallback", "cron": "1 18 * * *", "active": True}],
+        start=datetime(2026, 7, 7, tzinfo=timezone.utc),
+        end=datetime(2026, 7, 8, tzinfo=timezone.utc),
+        timezone_name="Invalid/Timezone",
+    )
+
+    assert len(events) == 1
+    assert events[0]["start"] == "2026-07-07T18:01:00+00:00"


### PR DESCRIPTION
### Motivation
- Calendar previews expanded cron expressions as UTC regardless of the configured scheduler timezone, causing scheduled times (e.g. `1 18 * * *` in `Australia/Brisbane`) to appear at the wrong UTC offset. 
- The scheduler's configured `CRON_TIMEZONE` (`settings.default_timezone`) must be used when interpreting cron expressions so displayed times match the server/scheduler expectation.

### Description
- Updated `app/services/cron_calendar.py` to accept an optional `timezone_name` parameter, resolve it with `zoneinfo.ZoneInfo` (falling back to UTC on error), and evaluate cron iteration in that timezone before converting run times to UTC for output. 
- Wired the scheduler API in `app/api/routes/scheduler.py` to pass the configured scheduler timezone via `get_settings().default_timezone` into `cron_calendar.build_calendar_events`. 
- Clarified the calendar helper text in `app/templates/admin/cron_calendar.html` to state times are scheduled using `CRON_TIMEZONE` and displayed in the browser timezone. 
- Added regression tests in `tests/test_cron_calendar.py` to verify Australia/Brisbane scheduling and invalid-timezone fallback behavior.

### Testing
- Ran `pytest tests/test_cron_calendar.py -q`, which passed (`4 passed`).
- Compiled changed modules with `python -m compileall app/services/cron_calendar.py app/api/routes/scheduler.py`, which succeeded.
- Formatting/consistency checks (Black / automatic reformat) were applied as part of the change and the test suite passed afterwards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4de30db0d4832da652cf673101e718)