### PR TITLE
Fix tray MSI upgrades and uninstall metadata

### DIFF
--- a/tray/Makefile
+++ b/tray/Makefile
@@ -20,6 +20,10 @@
 ##   make clean
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "0.0.0-dev")
+# Windows Installer versions must be numeric and use at most three fields for
+# upgrade comparisons. Keep the app-facing VERSION unchanged, but normalize the
+# MSI ProductVersion so every tagged build produces a valid ARP/upgrade version.
+MSI_VERSION ?= $(shell printf '%s' '$(VERSION)' | sed -E 's/^v//; s/[^0-9.].*//; s/^$$/0.0.0/' | awk -F. '{printf "%d.%d.%d", $$1, ($$2==""?0:$$2), ($$3==""?0:$$3)}')
 LDFLAGS  := -X 'github.com/bradhawkins85/myportal-tray/internal/updater.AgentVersion=$(VERSION)'
 DIST     := dist
 
@@ -163,6 +167,7 @@ build-msi: build-windows
 	        wix build -acceptEula wix7 installer/windows/myportal-tray.wxs \
 	            -arch x64 \
 	            -d BinDir=$(CURDIR)/$(DIST)/windows \
+	            -d ProductVersion=$(MSI_VERSION) \
 	            -o $(DIST)/windows/myportal-tray.msi ;; \
 	    *) \
 	        echo "Skipping MSI build: WiX only supports Windows hosts (host: $(HOST_OS))."; \

--- a/tray/installer/windows/myportal-tray.wxs
+++ b/tray/installer/windows/myportal-tray.wxs
@@ -22,7 +22,7 @@
   <Package
     Name="MyPortal Tray"
     Manufacturer="MyPortal"
-    Version="!(bind.FileVersion.ServiceExe)"
+    Version="$(var.ProductVersion)"
     UpgradeCode="A3E7F4C2-8B1D-4F5E-9A2C-1D6E3B7F8A4C"
     Scope="perMachine">
 
@@ -30,8 +30,22 @@
       Description="MyPortal Helpdesk Tray Application"
       Keywords="MyPortal;Helpdesk;Tray" />
 
-    <!-- Prevent downgrade -->
-    <MajorUpgrade DowngradeErrorMessage="A newer version is already installed." />
+    <!--
+      Configure a major-upgrade package. ProductCode is generated for each MSI
+      while UpgradeCode stays stable so Windows Installer can find and remove
+      prior installs. AllowSameVersionUpgrades covers rebuilds where only the
+      fourth/metadata version segment changed because MSI compares only the
+      first three numeric fields.
+    -->
+    <MajorUpgrade
+      AllowSameVersionUpgrades="yes"
+      DowngradeErrorMessage="A newer version is already installed." />
+
+    <!-- Add Programs and Features metadata so Windows records uninstall information. -->
+    <Property Id="ARPCONTACT" Value="MyPortal" />
+    <Property Id="ARPHELPLINK" Value="https://github.com/bradhawkins85/MyPortal" />
+    <Property Id="ARPURLINFOABOUT" Value="https://github.com/bradhawkins85/MyPortal" />
+    <Property Id="ARPNOREPAIR" Value="yes" />
 
     <!-- Allow MSI properties on the command line -->
     <Property Id="MYPORTAL_URL" Secure="yes" />
@@ -53,7 +67,7 @@
         <RegistryKey Root="HKLM" Key="Software\MyPortal\Tray" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
           <RegistryValue Type="string" Name="PortalURL"   Value="[MYPORTAL_URL]" />
           <RegistryValue Type="string" Name="EnrolToken"  Value="[ENROL_TOKEN]" />
-          <RegistryValue Type="string" Name="AutoUpdate"  Value="[AUTO_UPDATE]" />
+          <RegistryValue Type="string" Name="AutoUpdate"  Value="[AUTO_UPDATE]" KeyPath="yes" />
         </RegistryKey>
       </Component>
     </ComponentGroup>


### PR DESCRIPTION
### Motivation
- MSI builds were not producing Windows Installer-compatible product versions and therefore failed to upgrade when a prior install existed.
- The installer did not reliably write Programs and Features / ARP uninstall metadata and a proper registry key path for uninstall tracking.

### Description
- Normalize the build `VERSION` into a three-field Windows Installer `MSI_VERSION` and expose it via `-d ProductVersion=$(MSI_VERSION)` when invoking WiX in `tray/Makefile`.
- Switch the WiX package `Version` to `$(var.ProductVersion)` so the MSI uses the normalized ProductVersion instead of the executable file version.
- Configure `<MajorUpgrade>` with `AllowSameVersionUpgrades="yes"` to allow upgrades when only non-MSI-visible metadata (fourth segment) changes.
- Add ARP/Programs-and-Features properties (`ARPCONTACT`, `ARPHELPLINK`, `ARPURLINFOABOUT`, `ARPNOREPAIR`) and set the registry `AutoUpdate` value as the `KeyPath` so uninstall information is recorded in Windows.

### Testing
- Parsed the modified WiX XML with `python3` (`xml.etree.ElementTree.parse`) and it succeeded.
- Verified the Makefile invocation with `make -C tray -n build-msi VERSION=v1.2.3-4-gabcdef` produced a `-d ProductVersion=1.2.3` argument to the WiX build.
- Ran tray unit tests with `GOFLAGS='-tags=nowebview' go test -count=1 ./...` and all Go tests passed under the `nowebview` build tag.
- `make -C tray test` in this Linux environment still fails due to a missing system dependency (`ayatana-appindicator3-0.1`) required to build the systray UI, which is an environment constraint rather than a code issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dec7a5a08832dac5dd35aa8d343a7)