### PR TITLE
Fix email reply automation actor detection

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -1694,12 +1694,15 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                         # This allows automations to fire when requestor/watcher replies via email
                         if reply_added:
                             try:
-                                actor_info: dict[str, Any] | None = None
+                                actor_info: dict[str, Any] = {}
                                 if reply_author_id is not None:
-                                    actor_info = {"id": reply_author_id}
+                                    actor_info["id"] = reply_author_id
+                                if from_email_addr:
+                                    actor_info["email"] = from_email_addr
+                                    actor_info["display_name"] = from_email_addr
                                 await tickets_service.emit_ticket_updated_event(
                                     ticket_id,
-                                    actor=actor_info,
+                                    actor=actor_info or None,
                                 )
                             except Exception as exc:  # pragma: no cover - defensive logging
                                 log_error(

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -529,14 +529,15 @@ async def _enrich_ticket_context(ticket: Mapping[str, Any]) -> TicketRecord:
         user_id = watcher.get("user_id")
         resolved_user = await _resolve_user_snapshot(user_value, user_id)
         snapshot = _build_user_snapshot(resolved_user)
+        watcher_email = snapshot.get("email") if snapshot else watcher.get("email")
         entry: dict[str, Any] = {
             "id": watcher.get("id"),
             "ticket_id": watcher.get("ticket_id"),
             "user_id": watcher.get("user_id"),
             "created_at": watcher.get("created_at"),
             "user": snapshot,
-            "email": snapshot.get("email") if snapshot else None,
-            "display_name": snapshot.get("display_name") if snapshot else None,
+            "email": str(watcher_email).strip() if watcher_email else None,
+            "display_name": snapshot.get("display_name") if snapshot else watcher.get("email"),
         }
         if entry["email"]:
             watcher_emails.append(entry["email"])
@@ -595,16 +596,25 @@ def _normalise_ticket_update_actor(value: str | None) -> str | None:
     return None
 
 
+def _normalise_email_for_compare(value: Any) -> str | None:
+    if value is None:
+        return None
+    candidate = str(value).strip().lower()
+    return candidate or None
+
+
 def _auto_detect_ticket_update_actor(
     ticket: Mapping[str, Any],
     actor: Mapping[str, Any] | None,
 ) -> str:
     actor_id = None
+    actor_email = None
     if isinstance(actor, Mapping):
         try:
             actor_id = int(actor.get("id")) if actor.get("id") is not None else None
         except (TypeError, ValueError):
             actor_id = None
+        actor_email = _normalise_email_for_compare(actor.get("email"))
     if actor_id is not None:
         requester_id = ticket.get("requester_id")
         if requester_id is not None and actor_id == requester_id:
@@ -623,6 +633,18 @@ def _auto_detect_ticket_update_actor(
                 except (TypeError, ValueError):
                     continue
                 if watcher_user_id_int == actor_id:
+                    return "watcher"
+    if actor_email:
+        requester_email = _normalise_email_for_compare(ticket.get("requester_email"))
+        if requester_email and actor_email == requester_email:
+            return "requester"
+        watchers = ticket.get("watchers")
+        if isinstance(watchers, Sequence):
+            for watcher in watchers:
+                if not isinstance(watcher, Mapping):
+                    continue
+                watcher_email = _normalise_email_for_compare(watcher.get("email"))
+                if watcher_email and actor_email == watcher_email:
                     return "watcher"
     return "system"
 

--- a/tests/test_ticket_details_updated_event.py
+++ b/tests/test_ticket_details_updated_event.py
@@ -139,3 +139,105 @@ async def test_emit_ticket_updated_event_fires_tickets_updated(monkeypatch):
     assert events_fired == ["tickets.updated"], (
         f"Expected ['tickets.updated'], got {events_fired}"
     )
+
+@pytest.mark.anyio
+async def test_emit_ticket_updated_event_detects_email_only_watcher(monkeypatch):
+    """Email-only ticket watchers should be detected as watcher actors."""
+    captured: dict[str, Any] = {}
+
+    async def fake_get_ticket(ticket_id: int) -> dict[str, Any]:
+        return {
+            "id": ticket_id,
+            "subject": "Test",
+            "status": "open",
+            "priority": "normal",
+            "company_id": None,
+            "requester_id": None,
+            "assigned_user_id": None,
+        }
+
+    async def fake_get_company(company_id: int) -> None:
+        return None
+
+    async def fake_get_user(user_id: int) -> None:
+        return None
+
+    async def fake_list_watchers(ticket_id: int) -> list[dict[str, Any]]:
+        return [{"id": 7, "ticket_id": ticket_id, "user_id": None, "email": "Watcher@Example.com"}]
+
+    async def fake_list_replies(ticket_id: int, include_internal: bool = True) -> list:
+        return []
+
+    async def fake_handle_event(event: str, context: dict[str, Any]) -> None:
+        captured["event"] = event
+        captured["context"] = context
+
+    from app.repositories import tickets as tickets_repo
+    from app.repositories import companies as company_repo
+    from app.repositories import users as user_repo
+
+    monkeypatch.setattr(tickets_repo, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
+    monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
+    monkeypatch.setattr(company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
+
+    await tickets_service.emit_ticket_updated_event(
+        1,
+        actor={"email": "watcher@example.com", "display_name": "watcher@example.com"},
+    )
+
+    assert captured["event"] == "tickets.updated"
+    assert captured["context"]["ticket_update"]["actor_type"] == "watcher"
+    assert captured["context"]["ticket_update"]["actor_user_email"] == "watcher@example.com"
+    assert captured["context"]["ticket"]["watcher_emails"] == ["Watcher@Example.com"]
+
+
+@pytest.mark.anyio
+async def test_emit_ticket_updated_event_detects_requester_by_email(monkeypatch):
+    """Requester email actors should not fall back to system when no user id is present."""
+    captured: dict[str, Any] = {}
+
+    async def fake_get_ticket(ticket_id: int) -> dict[str, Any]:
+        return {
+            "id": ticket_id,
+            "subject": "Test",
+            "status": "open",
+            "priority": "normal",
+            "company_id": None,
+            "requester_id": 42,
+            "assigned_user_id": None,
+        }
+
+    async def fake_get_company(company_id: int) -> None:
+        return None
+
+    async def fake_get_user(user_id: int) -> dict[str, Any] | None:
+        if user_id == 42:
+            return {"id": 42, "email": "requester@example.com", "first_name": "Req", "last_name": "User"}
+        return None
+
+    async def fake_list_watchers(ticket_id: int) -> list:
+        return []
+
+    async def fake_list_replies(ticket_id: int, include_internal: bool = True) -> list:
+        return []
+
+    async def fake_handle_event(event: str, context: dict[str, Any]) -> None:
+        captured["context"] = context
+
+    from app.repositories import tickets as tickets_repo
+    from app.repositories import companies as company_repo
+    from app.repositories import users as user_repo
+
+    monkeypatch.setattr(tickets_repo, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
+    monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
+    monkeypatch.setattr(company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
+
+    await tickets_service.emit_ticket_updated_event(1, actor={"email": "REQUESTER@example.com"})
+
+    assert captured["context"]["ticket_update"]["actor_type"] == "requester"


### PR DESCRIPTION
### Motivation
- IMAP-imported email replies without a local user id were being treated as the `System` actor, preventing automations from recognizing requester or watcher replies.
- Email-only watcher addresses were not consistently preserved in the ticket automation context, which broke filters and actor matching that rely on watcher emails.

### Description
- Include sender metadata (`email` and `display_name`) when emitting `tickets.updated` for IMAP email replies in `app/services/imap.py` so replies without a `user_id` carry an actor identity.
- Preserve email-only watcher addresses in the enriched ticket context by populating `watcher_emails` and ensuring `watchers` entries keep `email` and a sensible `display_name` in `app/services/tickets.py`.
- Add `_normalise_email_for_compare` and update `_auto_detect_ticket_update_actor` to detect `requester` or `watcher` by normalized email when the actor has no numeric `id` in `app/services/tickets.py`.
- Add unit tests to `tests/test_ticket_details_updated_event.py` to cover email-only watcher detection and requester-by-email actor detection.

### Testing
- Ran `python -m py_compile app/services/tickets.py app/services/imap.py tests/test_ticket_details_updated_event.py` which succeeded.
- Ran `git diff --check` to ensure no whitespace/patch issues and found none.
- Ran `pytest -q tests/test_ticket_details_updated_event.py` but collection failed in this environment because the system `libmagic` library required by `python-magic` is missing, so the new tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ded89e4788332b4220bbb5f335396)