### PR TITLE
Fix reply status split button submission

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -1154,14 +1154,15 @@
               </div>
               <div class="form-actions">
                 <div class="ticket-reply-submit" data-ticket-reply-submit>
-                  <button type="submit" name="replyStatus" value="{{ ticket_reply_default_status }}" class="button button--primary ticket-reply-submit__primary">Post reply</button>
+                  <input type="hidden" name="replyStatus" value="{{ ticket_reply_default_status }}" data-ticket-reply-status-input />
+                  <button type="submit" class="button button--primary ticket-reply-submit__primary">Post reply</button>
                   <details class="ticket-reply-submit__status-menu">
                     <summary class="button button--primary ticket-reply-submit__toggle" aria-label="Post reply with a selected ticket status">
                       <span aria-hidden="true">▾</span>
                     </summary>
                     <div class="ticket-reply-submit__menu" role="menu" aria-label="Post reply and set status">
                       {% for status_definition in ticket_status_definitions %}
-                        <button type="submit" name="replyStatus" value="{{ status_definition.tech_status }}" class="ticket-reply-submit__menu-item" role="menuitem">
+                        <button type="submit" value="{{ status_definition.tech_status }}" class="ticket-reply-submit__menu-item" role="menuitem" onclick="this.form.querySelector('[data-ticket-reply-status-input]').value = this.value;">
                           {{ status_definition.tech_label }}
                         </button>
                       {% endfor %}

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -446,14 +446,15 @@
                   <div class="form-actions">
                     {% if has_helpdesk_access or is_super_admin %}
                       <div class="ticket-reply-submit" data-ticket-reply-submit>
-                        <button type="submit" name="replyStatus" value="{{ ticket_reply_default_status }}" class="button button--primary ticket-reply-submit__primary">Post reply</button>
+                        <input type="hidden" name="replyStatus" value="{{ ticket_reply_default_status }}" data-ticket-reply-status-input />
+                        <button type="submit" class="button button--primary ticket-reply-submit__primary">Post reply</button>
                         <details class="ticket-reply-submit__status-menu">
                           <summary class="button button--primary ticket-reply-submit__toggle" aria-label="Post reply with a selected ticket status">
                             <span aria-hidden="true">▾</span>
                           </summary>
                           <div class="ticket-reply-submit__menu" role="menu" aria-label="Post reply and set status">
                             {% for status_definition in ticket_status_definitions %}
-                              <button type="submit" name="replyStatus" value="{{ status_definition.tech_status }}" class="ticket-reply-submit__menu-item" role="menuitem">
+                              <button type="submit" value="{{ status_definition.tech_status }}" class="ticket-reply-submit__menu-item" role="menuitem" onclick="this.form.querySelector('[data-ticket-reply-status-input]').value = this.value;">
                                 {{ status_definition.tech_label }}
                               </button>
                             {% endfor %}


### PR DESCRIPTION
### Motivation
- The reply split-button was not sending the technician-selected status to the server and instead always submitted the configured default status, causing replies to be saved with the wrong ticket status.

### Description
- Add a hidden `replyStatus` input to the reply forms in `app/templates/tickets/detail.html` and `app/templates/admin/ticket_detail.html` so one authoritative field carries the status value.
- Update the status menu buttons to clear their `name` attribute and set the hidden field via `onclick` before submitting so the selected status is what the backend receives, with no backend code changes required.

### Testing
- Ran `pytest tests -q`, but automated test collection was blocked due to a missing system dependency (`libmagic`) required by `python-magic`, so tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4df07cb2e48332b5f6db912877a89f)