### PR TITLE
Fix MSI workflow ProductVersion definition

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -94,9 +94,23 @@ jobs:
         shell: pwsh
         run: |
           $binDir = (Resolve-Path dist\windows).Path
+          $version = "${{ github.event.release.tag_name || inputs.tag_name || github.ref_name }}"
+          $msiVersion = ($version -replace '^v', '' -replace '[^0-9.].*$', '')
+          if ([string]::IsNullOrWhiteSpace($msiVersion)) {
+            $msiVersion = '0.0.0'
+          }
+          $versionParts = @($msiVersion.Split('.') | ForEach-Object {
+            if ($_ -match '^\d+$') { [int]$_ } else { 0 }
+          })
+          while ($versionParts.Count -lt 3) {
+            $versionParts += 0
+          }
+          $msiVersion = ($versionParts[0..2] -join '.')
+
           wix build -acceptEula wix7 installer\windows\myportal-tray.wxs `
             -arch x64 `
             -d "BinDir=$binDir" `
+            -d "ProductVersion=$msiVersion" `
             -o dist\windows\myportal-tray.msi
 
       - name: Upload MSI to release


### PR DESCRIPTION
### Motivation

- The WiX build failed with an undefined preprocessor variable `$(var.ProductVersion)` because the MSI `ProductVersion` was not being passed into `wix build` from the CI inputs/tags. 
- The workflow needs a WiX-compatible three-part numeric MSI version derived from the release tag/ref so Windows Installer upgrade rules are satisfied.

### Description

- Updated ` .github/workflows/build-msi.yml` to compute a normalized three-part numeric MSI version from the release tag, `workflow_dispatch` input, or ref name and fall back to `0.0.0` when empty. 
- The PowerShell snippet strips a leading `v`, removes non-numeric suffixes, coerces non-numeric segments to `0`, ensures exactly three numeric fields, and joins them into `X.Y.Z`.
- Passed the computed value into `wix build` via `-d "ProductVersion=$msiVersion"` so the WiX source `$(var.ProductVersion)` is defined at build time.

### Testing

- Ran a Python assertion that verified the workflow now includes `-d "ProductVersion=$msiVersion"` and that the WiX source still references `$(var.ProductVersion)`, which succeeded. 
- Attempted a PowerShell normalization check with `pwsh` but it was skipped in the Linux container because `pwsh` was not available. 
- Ran `git diff --check` which passed with no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4df1136d708332a5666c8b959aa744)