### PR TITLE
Converge mailbox read state for already-imported messages and add M365 unread-filtering with 403 fallback

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -1452,6 +1452,18 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                 continue
             existing_message = await imap_repo.get_message(int(account_id), uid)
             if existing_message and existing_message.get("status") == "imported":
+                # A prior sync may have imported the ticket but failed to update the
+                # mailbox flag.  Do not re-import it, but still converge the mailbox
+                # state so imported messages are not left unread forever.
+                if mark_as_read:
+                    try:
+                        mailbox.uid("store", raw_uid, "+FLAGS", "(\\Seen)")
+                    except Exception:  # pragma: no cover - IMAP flag errors
+                        log_error(
+                            "Unable to mark already-imported IMAP message as read",
+                            account_id=account_id,
+                            uid=uid,
+                        )
                 continue
             # Use BODY.PEEK so that fetching the message does not set the \\Seen flag
             # before the ticket import succeeds.

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -827,25 +827,51 @@ async def sync_account(account_id: int) -> dict[str, Any]:
         messages_url = f"{_GRAPH_BASE}/users/{quote(upn, safe='')}/mailFolders/{quote(folder_identifier, safe='')}/messages"
         query_params = {
             "$top": "50",
-            "$orderby": "receivedDateTime asc",
             "$select": (
                 "id,subject,body,from,toRecipients,ccRecipients,bccRecipients,"
                 "replyTo,internetMessageHeaders,internetMessageId,isRead,receivedDateTime,"
                 "hasAttachments,conversationId"
             ),
         }
-        # Note: $filter is intentionally omitted. Combining $filter=isRead eq false
-        # with $orderby on the messages endpoint returns ErrorAccessDenied (403) for
-        # shared mailboxes and service accounts in certain Exchange Online configurations.
-        # Unread filtering is applied client-side using the isRead field from $select.
+        using_unread_filter = process_unread_only
+        if using_unread_filter:
+            # Ask Graph for unread messages directly.  Scanning a whole mailbox and
+            # filtering client-side can miss unread mail in large folders when the
+            # sync job exits, times out, or is interrupted before it has walked every
+            # page of already-read messages.  Do not combine this with $orderby:
+            # some Exchange Online/shared-mailbox configurations reject that shape.
+            query_params["$filter"] = "isRead eq false"
+        else:
+            query_params["$orderby"] = "receivedDateTime asc"
         full_url = messages_url + "?" + urlencode(query_params, quote_via=quote, safe="$,")
 
         # Paginate through all messages
         delegated_fallback_attempted = False
+        unread_filter_fallback_attempted = False
         while full_url:
             try:
                 data = await _graph_get(access_token, full_url)
             except M365Error as exc:
+                if exc.http_status == 403 and using_unread_filter and not unread_filter_fallback_attempted:
+                    # Older tenants or restricted shared-mailbox policies may reject
+                    # filtered message queries.  Fall back to the previous full-folder
+                    # scan rather than failing the sync outright.
+                    unread_filter_fallback_attempted = True
+                    using_unread_filter = False
+                    fallback_params = dict(query_params)
+                    fallback_params.pop("$filter", None)
+                    fallback_params["$orderby"] = "receivedDateTime asc"
+                    full_url = messages_url + "?" + urlencode(
+                        fallback_params,
+                        quote_via=quote,
+                        safe="$,",
+                    )
+                    log_info(
+                        "M365 unread filter was denied; falling back to full mailbox scan",
+                        account_id=account_id,
+                        upn=upn,
+                    )
+                    continue
                 if exc.http_status == 403 and using_delegated and not delegated_fallback_attempted:
                     # Delegated token lacks access to this mailbox.
                     # Fall back to client_credentials (app-level permissions)
@@ -930,6 +956,22 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                 # Check if already processed
                 existing_message = await mail_repo.get_message(int(account_id), msg_id)
                 if existing_message and existing_message.get("status") == "imported":
+                    # A previous run may have successfully imported the message but
+                    # failed while marking it read.  Avoid duplicate ticket activity,
+                    # but still repair the mailbox read state on subsequent syncs.
+                    if mark_as_read and not msg.get("isRead", False):
+                        try:
+                            patch_url = (
+                                f"{_GRAPH_BASE}/users/{quote(upn, safe='')}/messages/"
+                                f"{quote(msg_id, safe='')}"
+                            )
+                            await _graph_patch(access_token, patch_url, {"isRead": True})
+                        except Exception:  # pragma: no cover - Graph API errors
+                            log_error(
+                                "Unable to mark already-imported M365 message as read",
+                                account_id=account_id,
+                                message_id=msg_id,
+                            )
                     continue
 
                 # Extract message details
@@ -1179,7 +1221,10 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                 # Mark as read if configured
                 if mark_as_read and is_unread:
                     try:
-                        patch_url = f"{_GRAPH_BASE}/users/{quote(upn, safe='')}/messages/{msg_id}"
+                        patch_url = (
+                            f"{_GRAPH_BASE}/users/{quote(upn, safe='')}/messages/"
+                            f"{quote(msg_id, safe='')}"
+                        )
                         await _graph_patch(access_token, patch_url, {"isRead": True})
                     except Exception:  # pragma: no cover - Graph API errors
                         log_error(

--- a/tests/test_imap_service.py
+++ b/tests/test_imap_service.py
@@ -932,3 +932,65 @@ async def test_sync_account_reports_search_error(monkeypatch):
     assert result["errors"]
     assert "Unable to search mailbox" in result["errors"][0]["error"]
     assert mailbox.logged_out
+
+
+async def test_sync_account_marks_already_imported_unread_message_as_read(monkeypatch):
+    monkeypatch.setattr(imap.system_state, "is_restart_pending", lambda: False)
+
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        return {"enabled": True}
+
+    async def fake_get_account(account_id: int):
+        return {
+            "id": account_id,
+            "host": "mail.example.com",
+            "port": 993,
+            "username": "inbox",
+            "password_encrypted": "encrypted",
+            "folder": "INBOX",
+            "process_unread_only": True,
+            "mark_as_read": True,
+            "active": True,
+        }
+
+    async def fake_get_message(account_id: int, uid: str):
+        return {"status": "imported"}
+
+    async def fake_update_account(account_id: int, **payload):
+        return None
+
+    class AlreadyImportedMailbox:
+        def __init__(self) -> None:
+            self.commands: list[tuple[str, tuple[object, ...]]] = []
+
+        def login(self, username: str, password: str) -> None:
+            pass
+
+        def select(self, folder: str, readonly: bool = False):
+            return "OK", []
+
+        def uid(self, command: str, *args):
+            self.commands.append((command, args))
+            if command == "search":
+                return "OK", [b"42"]
+            if command == "store":
+                return "OK", []
+            raise AssertionError(f"Unexpected command {command!r}")
+
+        def logout(self) -> None:
+            pass
+
+    mailbox = AlreadyImportedMailbox()
+    monkeypatch.setattr(imap.imaplib, "IMAP4_SSL", lambda host, port: mailbox)
+    monkeypatch.setattr(imap.modules_service, "get_module", fake_get_module)
+    monkeypatch.setattr(imap.imap_repo, "get_account", fake_get_account)
+    monkeypatch.setattr(imap.imap_repo, "get_message", fake_get_message)
+    monkeypatch.setattr(imap.imap_repo, "update_account", fake_update_account)
+    monkeypatch.setattr(imap, "decrypt_secret", lambda value: "password")
+
+    result = await imap.sync_account(5)
+
+    assert result["status"] == "succeeded"
+    assert result["processed"] == 0
+    assert ("store", (b"42", "+FLAGS", "(\\Seen)")) in mailbox.commands
+    assert not any(command == "fetch" for command, _args in mailbox.commands)

--- a/tests/test_m365_mail_service.py
+++ b/tests/test_m365_mail_service.py
@@ -1446,3 +1446,69 @@ def test_m365_mail_account_response_schema():
 
     assert response.id == 1
     assert response.user_principal_name == "user@example.com"
+
+
+async def test_sync_account_marks_already_imported_unread_message_as_read(monkeypatch):
+    monkeypatch.setattr(m365_mail.system_state, "is_restart_pending", lambda: False)
+
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        return {"enabled": True}
+
+    async def fake_get_account(account_id: int):
+        return {
+            "id": account_id,
+            "active": True,
+            "company_id": 5,
+            "user_principal_name": "user@example.com",
+            "folder": "Inbox",
+            "process_unread_only": True,
+            "mark_as_read": True,
+            "filter_query": None,
+            "sync_known_only": False,
+        }
+
+    async def fake_acquire_token(company_id, **kwargs):
+        return "fake-access-token"
+
+    async def fake_graph_get(access_token: str, url: str):
+        return {
+            "value": [
+                {
+                    "id": "message/id with spaces",
+                    "internetMessageId": "<message@example.com>",
+                    "isRead": False,
+                    "subject": "Already imported",
+                }
+            ]
+        }
+
+    async def fake_get_message(account_id: int, message_uid: str):
+        return {"status": "imported"}
+
+    patched: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_graph_patch(access_token: str, url: str, payload: dict[str, object]):
+        patched.append((url, payload))
+        return {}
+
+    async def fake_update_account(account_id: int, **fields):
+        return None
+
+    monkeypatch.setattr(m365_mail.modules_service, "get_module", fake_get_module)
+    monkeypatch.setattr(m365_mail.mail_repo, "get_account", fake_get_account)
+    monkeypatch.setattr(m365_mail.m365_service, "acquire_access_token", fake_acquire_token)
+    monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
+    monkeypatch.setattr(m365_mail, "_graph_patch", fake_graph_patch)
+    monkeypatch.setattr(m365_mail.mail_repo, "get_message", fake_get_message)
+    monkeypatch.setattr(m365_mail.mail_repo, "update_account", fake_update_account)
+
+    result = await m365_mail.sync_account(8)
+
+    assert result["status"] == "succeeded"
+    assert result["processed"] == 0
+    assert patched == [
+        (
+            "https://graph.microsoft.com/v1.0/users/user%40example.com/messages/message%2Fid%20with%20spaces",
+            {"isRead": True},
+        )
+    ]

--- a/tests/test_m365_mail_sync_403.py
+++ b/tests/test_m365_mail_sync_403.py
@@ -64,8 +64,8 @@ async def test_sync_account_403_non_403_error_not_intercepted(monkeypatch):
     assert "500" in error_msg
 
 
-async def test_sync_no_filter_param_in_graph_url(monkeypatch):
-    """The Graph API request must NOT include $filter=isRead eq false."""
+async def test_sync_uses_unread_filter_param_in_graph_url(monkeypatch):
+    """Unread-only sync asks Graph for unread messages instead of scanning the whole folder."""
     _patch_common(monkeypatch)
     captured_urls: list[str] = []
     async def fake_acquire_token(company_id, **kwargs):
@@ -77,8 +77,8 @@ async def test_sync_no_filter_param_in_graph_url(monkeypatch):
     monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
     result = await m365_mail.sync_account(1)
     assert result["status"] == "succeeded"
-    assert "$filter" not in captured_urls[0], f"$filter found in URL: {captured_urls[0]}"
-    assert "$orderby" in captured_urls[0]
+    assert "$filter=isRead%20eq%20false" in captured_urls[0], captured_urls[0]
+    assert "$orderby" not in captured_urls[0]
 
 
 async def test_sync_read_message_skipped_when_process_unread_only(monkeypatch):
@@ -102,3 +102,29 @@ async def test_sync_read_message_skipped_when_process_unread_only(monkeypatch):
     assert "msg-read" not in visited
     assert "msg-unread" in visited
     assert result["status"] == "succeeded"
+
+
+async def test_sync_unread_filter_403_falls_back_to_full_scan(monkeypatch):
+    """A tenant that denies unread filtering should still sync via the full-folder scan."""
+    _patch_common(monkeypatch)
+    captured_urls: list[str] = []
+
+    async def fake_acquire_token(company_id, **kwargs):
+        return "fake-token"
+
+    async def fake_graph_get(access_token: str, url: str):
+        captured_urls.append(url)
+        if "$filter" in url:
+            raise M365Error("Microsoft Graph request failed (403)", http_status=403)
+        return {"value": [], "@odata.nextLink": None}
+
+    monkeypatch.setattr(m365_mail.m365_service, "acquire_access_token", fake_acquire_token)
+    monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
+
+    result = await m365_mail.sync_account(1)
+
+    assert result["status"] == "succeeded"
+    assert len(captured_urls) == 2
+    assert "$filter=isRead%20eq%20false" in captured_urls[0]
+    assert "$filter" not in captured_urls[1]
+    assert "$orderby" in captured_urls[1]


### PR DESCRIPTION
### Motivation

- Avoid re-importing messages that were already imported but left unread in the mailbox by previous sync failures, and ensure mailbox read state is converged when `mark_as_read` is enabled.
- Improve Microsoft 365 sync efficiency for unread-only runs by requesting unread messages from Graph where possible, while falling back to a full-folder scan for tenants that reject filtered queries.

### Description

- IMAP: If an existing message has `status == "imported"` the sync now skips re-import and, when `mark_as_read` is true, attempts to set the `\Seen` flag via `mailbox.uid("store", raw_uid, "+FLAGS", "(\Seen)")` and logs errors on failure.
- M365: When `process_unread_only` is set the code now uses `"$filter=isRead eq false"` in the Graph query and omits `"$orderby"`, and falls back to the previous `"$orderby=receivedDateTime asc"` full-folder scan if Graph returns a 403 for that filtered request.
- M365: When an existing message is already recorded as `imported` but remains unread in the mailbox and `mark_as_read` is true, the sync will attempt to patch the message with `{"isRead": True}` via `_graph_patch` to repair read state, logging errors defensively.
- Minor URL/quoting and formatting adjustments were made to ensure message IDs and UPNs are properly quoted when building Graph URLs.

### Testing

- Added and ran `tests/test_imap_service.py::test_sync_account_marks_already_imported_unread_message_as_read`, which verifies the IMAP `store` command is issued for already-imported unread messages, and it passed.
- Added and ran `tests/test_m365_mail_service.py::test_sync_account_marks_already_imported_unread_message_as_read`, which verifies the Graph `PATCH` is invoked for already-imported unread M365 messages, and it passed.
- Updated and ran M365 Graph URL tests in `tests/test_m365_mail_sync_403.py`, including `test_sync_uses_unread_filter_param_in_graph_url` and the new `test_sync_unread_filter_403_falls_back_to_full_scan`, which verify use of `$filter` for unread-only syncs and fallback behavior on 403, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4df461243c8332924a0b60d4cbd47a)