### PR TITLE
Suppress closed chat tray notifications

### DIFF
--- a/app/services/tray_chat_notifications.py
+++ b/app/services/tray_chat_notifications.py
@@ -52,6 +52,8 @@ async def notify_tray_device_of_chat_message(
         tray_device_id = 0
     if tray_device_id <= 0:
         return False
+    if str(room.get("status") or "").strip().lower() == "closed":
+        return False
     if _is_from_tray_device(message, tray_device_id):
         return False
 

--- a/tests/test_tray_chat_notifications.py
+++ b/tests/test_tray_chat_notifications.py
@@ -67,6 +67,21 @@ async def test_notify_tray_device_of_chat_message_sends_incoming_technician_repl
 
 
 @pytest.mark.anyio("asyncio")
+async def test_notify_tray_device_of_chat_message_skips_closed_room(monkeypatch):
+    async def fail_get_device_by_id(device_id: int):  # pragma: no cover - should not be called
+        raise AssertionError("closed room messages should not resolve devices")
+
+    monkeypatch.setattr(tray_chat_notifications.tray_repo, "get_device_by_id", fail_get_device_by_id)
+
+    delivered = await tray_chat_notifications.notify_tray_device_of_chat_message(
+        room={"id": 42, "tray_device_id": 7, "status": "closed"},
+        message={"sender_matrix_id": "@bot:example", "body": "This chat has been closed."},
+    )
+
+    assert delivered is False
+
+
+@pytest.mark.anyio("asyncio")
 async def test_notify_tray_device_of_chat_message_skips_own_tray_message(monkeypatch):
     async def fail_get_device_by_id(device_id: int):  # pragma: no cover - should not be called
         raise AssertionError("own tray messages should not resolve devices")


### PR DESCRIPTION
### Motivation
- Prevent end users from receiving tray notifications that prompt opening a blank chat when the chat room has already been closed by a technician or bot.

### Description
- Return early from `notify_tray_device_of_chat_message` when `room["status"]` is `"closed"` to skip sending tray notifications for closed rooms.
- Add `test_notify_tray_device_of_chat_message_skips_closed_room` to `tests/test_tray_chat_notifications.py` to cover the regression.

### Testing
- Ran `python -m py_compile app/services/tray_chat_notifications.py tests/test_tray_chat_notifications.py` which succeeded.
- Ran `pytest tests/test_tray_chat_notifications.py` but it could not complete in this environment due to a missing system dependency (`libmagic`) causing an ImportError.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4df5a699148332a61368edd1ccd7b7)