### PR TITLE
Fix M365 mail delegated 403 fallback

### DIFF
--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -50,7 +50,8 @@ _403_ERROR_MESSAGE = (
     "policy, the mailbox does not exist, or the enterprise app has not been "
     "granted access. Verify that the enterprise app has Mail.ReadWrite "
     "application permission and that no Exchange Online access policies "
-    "are blocking access, then retry the sync."
+    "are blocking access. A Global Administrator may need to grant admin "
+    "consent or update Exchange application access policies, then retry the sync."
 )
 
 # Delegated OAuth scope for the per-account sign-in flow.  Mail.ReadWrite
@@ -852,26 +853,6 @@ async def sync_account(account_id: int) -> dict[str, Any]:
             try:
                 data = await _graph_get(access_token, full_url)
             except M365Error as exc:
-                if exc.http_status == 403 and using_unread_filter and not unread_filter_fallback_attempted:
-                    # Older tenants or restricted shared-mailbox policies may reject
-                    # filtered message queries.  Fall back to the previous full-folder
-                    # scan rather than failing the sync outright.
-                    unread_filter_fallback_attempted = True
-                    using_unread_filter = False
-                    fallback_params = dict(query_params)
-                    fallback_params.pop("$filter", None)
-                    fallback_params["$orderby"] = "receivedDateTime asc"
-                    full_url = messages_url + "?" + urlencode(
-                        fallback_params,
-                        quote_via=quote,
-                        safe="$,",
-                    )
-                    log_info(
-                        "M365 unread filter was denied; falling back to full mailbox scan",
-                        account_id=account_id,
-                        upn=upn,
-                    )
-                    continue
                 if exc.http_status == 403 and using_delegated and not delegated_fallback_attempted:
                     # Delegated token lacks access to this mailbox.
                     # Fall back to client_credentials (app-level permissions)
@@ -892,6 +873,13 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                 int(auth_company_id), force_client_credentials=True
                             )
                             using_delegated = False
+                            # Retry the exact failed query with app-only permissions.
+                            # A delegated 403 usually means the signed-in user cannot
+                            # access the target/shared mailbox; it does not prove that
+                            # the unread OData filter is unsupported.  Keeping the
+                            # unread-filter URL avoids falling back to an expensive
+                            # full-folder scan that can miss new unread messages in
+                            # large mailboxes or time out under scheduler pressure.
                             continue
                         except Exception as fb_exc:
                             log_error(
@@ -909,6 +897,33 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                         )
                     })
                     break
+                if (
+                    exc.http_status == 403
+                    and using_unread_filter
+                    and not unread_filter_fallback_attempted
+                    and not delegated_fallback_attempted
+                ):
+                    # Older tenants or restricted shared-mailbox policies may reject
+                    # filtered message queries.  Only use this fallback after any
+                    # delegated-token fallback has been exhausted, otherwise an
+                    # auth failure from the signed-in user can force app-only syncs
+                    # into slow full-folder scans.
+                    unread_filter_fallback_attempted = True
+                    using_unread_filter = False
+                    fallback_params = dict(query_params)
+                    fallback_params.pop("$filter", None)
+                    fallback_params["$orderby"] = "receivedDateTime asc"
+                    full_url = messages_url + "?" + urlencode(
+                        fallback_params,
+                        quote_via=quote,
+                        safe="$,",
+                    )
+                    log_info(
+                        "M365 unread filter was denied; falling back to full mailbox scan",
+                        account_id=account_id,
+                        upn=upn,
+                    )
+                    continue
                 if exc.http_status == 403 and not using_delegated:
                     log_error(
                         "Failed to fetch messages from M365 mailbox",

--- a/tests/test_m365_mail_delegated_auth.py
+++ b/tests/test_m365_mail_delegated_auth.py
@@ -336,5 +336,48 @@ async def test_sync_delegated_403_fallback_then_client_creds_also_403(monkeypatc
     assert "403 Forbidden" in result["errors"][0]["error"]
     assert call_count["graph_get"] == 2
     assert call_count["acquire"] == 1
+
+
 async def _coro(val):
     return val
+
+
+async def test_sync_delegated_403_retries_unread_filter_with_client_credentials(monkeypatch):
+    """Delegated mailbox access failures should not disable the unread filter.
+
+    Shared mailboxes often deny the signed-in user's delegated token while the
+    tenant app token can still read the mailbox.  The app-token retry should use
+    the same unread-filtered query instead of switching to a full mailbox scan.
+    """
+    from app.services.m365 import M365Error
+
+    account = _fake_account(company_id=5, refresh_token="enc:refresh", tenant_id="tenant-123")
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(m365_mail.mail_repo, "get_account", lambda _: _coro(account))
+
+    async def fake_acquire_delegated(acct):
+        return "delegated-token"
+
+    async def fake_acquire_token(company_id, **kwargs):
+        assert company_id == 5
+        return "client-creds-token"
+
+    seen_urls: list[tuple[str, str]] = []
+
+    async def fake_graph_get(token, url):
+        seen_urls.append((token, url))
+        if token == "delegated-token":
+            raise M365Error("Forbidden", http_status=403)
+        assert token == "client-creds-token"
+        return {"value": [], "@odata.nextLink": None}
+
+    monkeypatch.setattr(m365_mail, "_acquire_delegated_access_token", fake_acquire_delegated)
+    monkeypatch.setattr(m365_mail.m365_service, "acquire_access_token", fake_acquire_token)
+    monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
+
+    result = await m365_mail.sync_account(1)
+
+    assert result["status"] == "succeeded"
+    assert [token for token, _url in seen_urls] == ["delegated-token", "client-creds-token"]
+    assert all("$filter=isRead%20eq%20false" in url for _token, url in seen_urls)
+    assert all("$orderby=receivedDateTime%20asc" not in url for _token, url in seen_urls)


### PR DESCRIPTION
### Motivation
- Avoid unnecessary full-mailbox scans when a delegated user token gets a 403 by retrying the same unread-filtered Graph query using app-only `client_credentials` instead of immediately falling back to a full-folder scan.
- Make the 403 guidance more actionable by calling out admin consent / Exchange application access policy remediation.

### Description
- Reordered 403 handling in `app/services/m365_mail.py` so a delegated-token 403 triggers a retry with `client_credentials` while preserving the original unread-filtered URL (keeps `$filter=isRead eq false`), and only after app-only unread-filter failures do we fall back to a full mailbox scan. (`sync_account` error handling.)
- Improved `_403_ERROR_MESSAGE` in `app/services/m365_mail.py` to explicitly mention that a Global Administrator may need to grant admin consent or update Exchange application access policies.
- Added a regression test `test_sync_delegated_403_retries_unread_filter_with_client_credentials` to `tests/test_m365_mail_delegated_auth.py` to assert the unread-filtered query is preserved across delegated->client_credentials fallback.

### Testing
- Compiled the modified module with `python3 -m py_compile app/services/m365_mail.py` (success).
- Ran unit tests: `pytest -q tests/test_m365_mail_delegated_auth.py tests/test_m365_mail_sync_403.py` and observed all tests in those files passed (previous failing cases fixed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dfb40a47883328cea30ae55ffd5c1)