### PR TITLE
Suppress tray heartbeat logs unless verbose logging enabled

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -213,6 +213,8 @@ SWAGGER_UI_URL=/docs
 # be downgraded to GET by the proxy's HTTP→HTTPS redirect.
 PUBLIC_BASE_URL=
 OPNFORM_BASE_URL=
+# Set true to emit DEBUG-level verbose logs, including high-frequency tray heartbeat events.
+VERBOSE_LOGGING=false
 # Main application log file. Receives INFO-and-above server events in addition
 # to journald/stdout, one entry per line, including the feature pack field for filtering.
 # Set empty to disable the file sink.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -301,6 +301,14 @@ class Settings(BaseSettings):
         default=None,
         validation_alias=AliasChoices("OPNFORM_BASE_URL", "OPNFORM_URL"),
     )
+    verbose_logging: bool = Field(
+        default=False,
+        validation_alias="VERBOSE_LOGGING",
+        description=(
+            "Enable verbose DEBUG-level request and access logging, including "
+            "high-frequency tray heartbeat events."
+        ),
+    )
     app_log_path: Path | None = Field(
         default=Path("/var/log/myportal/myportal.log"),
         validation_alias="APP_LOG_PATH",

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from contextvars import ContextVar
 from datetime import date, datetime, time, timezone
@@ -8,6 +9,8 @@ from pathlib import Path
 from typing import Any
 
 from loguru import logger
+
+TRAY_HEARTBEAT_PATH = "/api/tray/heartbeat"
 
 
 # Context variables that carry per-request state into every log line emitted
@@ -126,9 +129,12 @@ def configure_logging() -> None:
         record["message"] = str(record["message"]).replace("\r", "\\r").replace("\n", "\\n")
         return file_log_format + "\n"
 
-    logger.add(sink=lambda msg: print(msg, end=""), format=_format_console_record)
-
     settings = get_settings()
+    log_level = "DEBUG" if settings.verbose_logging else "INFO"
+
+    logger.add(sink=lambda msg: print(msg, end=""), format=_format_console_record, level=log_level)
+    _configure_uvicorn_access_logging(verbose=settings.verbose_logging)
+
     app_log_path = getattr(settings, "app_log_path", None)
     if app_log_path:
         app_log_path = app_log_path.expanduser()
@@ -140,7 +146,7 @@ def configure_logging() -> None:
                 logger.add(
                     str(app_log_path),
                     format=_format_file_record,
-                    level="INFO",
+                    level=log_level,
                     encoding="utf-8",
                     enqueue=True,
                     rotation=rotation,
@@ -196,6 +202,30 @@ def configure_logging() -> None:
                 logger.warning(
                     f"ERROR LOG FILE DISABLED - unable to open file path={error_log_path} error={exc}"
                 )
+
+
+class _UvicornHeartbeatAccessFilter(logging.Filter):
+    """Hide noisy tray heartbeat access logs unless verbose logging is enabled."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            rendered = record.getMessage()
+        except Exception:  # pragma: no cover - defensive logging hook
+            rendered = str(getattr(record, "msg", ""))
+        return TRAY_HEARTBEAT_PATH not in rendered
+
+
+def _configure_uvicorn_access_logging(*, verbose: bool) -> None:
+    """Apply endpoint-specific filtering to uvicorn's own access logger."""
+
+    access_logger = logging.getLogger("uvicorn.access")
+    access_logger.filters = [
+        existing
+        for existing in access_logger.filters
+        if not isinstance(existing, _UvicornHeartbeatAccessFilter)
+    ]
+    if not verbose:
+        access_logger.addFilter(_UvicornHeartbeatAccessFilter())
 
 
 def _coerce_optional(value: Any) -> Any:

--- a/app/security/request_logger.py
+++ b/app/security/request_logger.py
@@ -8,6 +8,7 @@ from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.core.logging import (
+    TRAY_HEARTBEAT_PATH,
     log_debug,
     log_error,
     log_info,
@@ -15,7 +16,6 @@ from app.core.logging import (
     set_request_context,
 )
 from app.core.log_redaction import redact_headers
-from app.core.logging import log_debug, log_error, log_info
 from app.security.client_ip import get_client_ip
 
 
@@ -88,7 +88,10 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         duration = time.time() - start_time
 
         # Log response
-        log_function = log_error if response.status_code >= 500 else log_info
+        if path == TRAY_HEARTBEAT_PATH and response.status_code < 500:
+            log_function = log_debug
+        else:
+            log_function = log_error if response.status_code >= 500 else log_info
         message = (
             "Request completed with server error"
             if response.status_code >= 500

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -114,3 +114,64 @@ def test_blank_application_log_path_disables_file_sink():
         settings = Settings()
 
     assert settings.app_log_path is None
+
+
+def test_uvicorn_access_filter_suppresses_heartbeat_when_not_verbose():
+    """Normal logging hides uvicorn's high-frequency tray heartbeat access entries."""
+    import logging
+
+    from app.core.logging import _configure_uvicorn_access_logging
+
+    access_logger = logging.getLogger("uvicorn.access")
+    original_filters = list(access_logger.filters)
+    try:
+        _configure_uvicorn_access_logging(verbose=False)
+        heartbeat_record = logging.LogRecord(
+            "uvicorn.access",
+            logging.INFO,
+            __file__,
+            1,
+            '%s - "%s %s HTTP/%s" %d',
+            ("127.0.0.1:1234", "POST", "/api/tray/heartbeat", "1.1", 200),
+            None,
+        )
+        normal_record = logging.LogRecord(
+            "uvicorn.access",
+            logging.INFO,
+            __file__,
+            1,
+            '%s - "%s %s HTTP/%s" %d',
+            ("127.0.0.1:1234", "GET", "/api/ping", "1.1", 200),
+            None,
+        )
+
+        assert not access_logger.filter(heartbeat_record)
+        assert access_logger.filter(normal_record)
+    finally:
+        access_logger.filters = original_filters
+
+
+def test_uvicorn_access_filter_allows_heartbeat_when_verbose():
+    """Verbose logging leaves uvicorn access logs unfiltered for troubleshooting."""
+    import logging
+
+    from app.core.logging import _configure_uvicorn_access_logging
+
+    access_logger = logging.getLogger("uvicorn.access")
+    original_filters = list(access_logger.filters)
+    try:
+        _configure_uvicorn_access_logging(verbose=False)
+        _configure_uvicorn_access_logging(verbose=True)
+        heartbeat_record = logging.LogRecord(
+            "uvicorn.access",
+            logging.INFO,
+            __file__,
+            1,
+            '%s - "%s %s HTTP/%s" %d',
+            ("127.0.0.1:1234", "POST", "/api/tray/heartbeat", "1.1", 200),
+            None,
+        )
+
+        assert access_logger.filter(heartbeat_record)
+    finally:
+        access_logger.filters = original_filters

--- a/tests/test_request_logging_middleware.py
+++ b/tests/test_request_logging_middleware.py
@@ -62,3 +62,59 @@ def test_request_id_survives_exception_path() -> None:
     assert response.status_code == 500
     assert response.headers['X-Request-ID'] == 'req-explode'
     assert response.json()['request_id'] == 'req-explode'
+
+
+def test_tray_heartbeat_completion_logs_at_debug(monkeypatch) -> None:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    @app.post('/api/tray/heartbeat')
+    async def tray_heartbeat():
+        return {'status': 'ok'}
+
+    calls: list[tuple[str, str, dict]] = []
+
+    def fake_debug(message: str, **meta):
+        calls.append(('debug', message, meta))
+
+    def fake_info(message: str, **meta):
+        calls.append(('info', message, meta))
+
+    monkeypatch.setattr('app.security.request_logger.log_debug', fake_debug)
+    monkeypatch.setattr('app.security.request_logger.log_info', fake_info)
+
+    client = TestClient(app)
+    response = client.post('/api/tray/heartbeat')
+
+    assert response.status_code == 200
+    assert calls
+    assert calls[-1][0] == 'debug'
+    assert calls[-1][1] == 'Request completed'
+
+
+def test_regular_request_completion_logs_at_info(monkeypatch) -> None:
+    app = FastAPI()
+    app.add_middleware(RequestLoggingMiddleware)
+
+    @app.get('/api/ping')
+    async def ping():
+        return {'status': 'ok'}
+
+    calls: list[tuple[str, str, dict]] = []
+
+    def fake_debug(message: str, **meta):
+        calls.append(('debug', message, meta))
+
+    def fake_info(message: str, **meta):
+        calls.append(('info', message, meta))
+
+    monkeypatch.setattr('app.security.request_logger.log_debug', fake_debug)
+    monkeypatch.setattr('app.security.request_logger.log_info', fake_info)
+
+    client = TestClient(app)
+    response = client.get('/api/ping')
+
+    assert response.status_code == 200
+    assert calls
+    assert calls[-1][0] == 'info'
+    assert calls[-1][1] == 'Request completed'


### PR DESCRIPTION
### Motivation
- Reduce noise in server logs by hiding high-frequency tray heartbeat entries from normal INFO-level logs while preserving them for debugging when verbose logging is explicitly enabled.

### Description
- Add a `VERBOSE_LOGGING` boolean setting (`Settings.verbose_logging`) and a corresponding `.env.example` entry to control verbose/DEBUG logging behavior. 
- Make the console/file application sinks default to `INFO` and switch to `DEBUG` when `VERBOSE_LOGGING=true`.
- Introduce `TRAY_HEARTBEAT_PATH` and change `RequestLoggingMiddleware` so successful `/api/tray/heartbeat` completions are logged at `DEBUG` instead of `INFO`, while errors remain at `ERROR`.
- Add a `_UvicornHeartbeatAccessFilter` and `_configure_uvicorn_access_logging()` to suppress `uvicorn.access` records that contain `/api/tray/heartbeat` unless verbose logging is enabled.
- Add tests covering heartbeat request logging behavior and the uvicorn access-log filtering.

### Testing
- Installed system dependency with `apt-get update && apt-get install -y libmagic1` to satisfy test environment requirements and reran the test suite.
- Ran the focused tests with `SESSION_SECRET=test-secret TOTP_ENCRYPTION_KEY=test-totp-key pytest tests/test_request_logging_middleware.py tests/test_logging.py -q` and the test run succeeded (`19 passed`, with warnings unrelated to the change).
- Verified code compiles and the new logging filter behaves as expected by exercising `_configure_uvicorn_access_logging()` in unit tests which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dfe0050848332b9adc0dacb6d7a38)