### PR TITLE
Record per-message decisions for M365 mail sync and show results in admin UI

### DIFF
--- a/app/features/m365_mail/admin_routes.py
+++ b/app/features/m365_mail/admin_routes.py
@@ -41,6 +41,7 @@ async def _render_m365_mail_dashboard(
     editing_account_id: int | None = None,
     success_message: str | None = None,
     error_message: str | None = None,
+    sync_result: dict[str, Any] | None = None,
     status_code: int = status.HTTP_200_OK,
 ) -> HTMLResponse:
     main_module = _main()
@@ -61,6 +62,7 @@ async def _render_m365_mail_dashboard(
         "companies": companies,
         "success_message": success_message,
         "error_message": error_message,
+        "sync_result": sync_result,
     }
     response = await main_module._render_template("admin/m365_mail.html", request, user, extra=extra)
     response.status_code = status_code
@@ -298,19 +300,53 @@ async def admin_sync_m365_mail_account(account_id: int, request: Request):
     status_value = str(result.get("status") or "").lower()
     processed = int(result.get("processed") or 0)
     error_count = len(result.get("errors") or [])
+    message_actions = result.get("message_actions") or []
+    created_count = sum(1 for action in message_actions if action.get("outcome") == "created_new_ticket")
+    attached_count = sum(1 for action in message_actions if action.get("outcome") == "attached_to_existing_ticket")
+    ignored_count = sum(1 for action in message_actions if action.get("outcome") == "ignored")
+    detail_summary = (
+        f" Created {created_count}, attached {attached_count}, ignored {ignored_count}."
+        if message_actions
+        else ""
+    )
     if status_value in {"error"}:
         message = result.get("error") or "Office 365 mail synchronisation failed."
-        return flash_redirect("/admin/modules/m365-mail", message, "error")
+        return await _render_m365_mail_dashboard(
+            request,
+            current_user,
+            error_message=message,
+            sync_result=result,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
     if status_value == "skipped":
         message = result.get("reason") or "Office 365 mail synchronisation skipped."
-        return flash_redirect("/admin/modules/m365-mail", message, "error")
+        return await _render_m365_mail_dashboard(
+            request,
+            current_user,
+            error_message=message,
+            sync_result=result,
+        )
     if status_value == "completed_with_errors" and error_count:
-        first_error = (result.get("errors") or [{}])[0].get("error") or "Office 365 mail sync completed with errors."
+        first_error = (
+            (result.get("errors") or [{}])[0].get("error")
+            or "Office 365 mail sync completed with errors."
+        )
         if processed:
             first_error = f"{first_error} ({processed} message{'s' if processed != 1 else ''} imported.)"
-        return flash_redirect("/admin/modules/m365-mail", first_error, "error")
-    message = f"Office 365 mail sync imported {processed} message{'s' if processed != 1 else ''}."
-    return flash_redirect("/admin/modules/m365-mail", message, "success")
+        first_error = f"{first_error}{detail_summary}"
+        return await _render_m365_mail_dashboard(
+            request,
+            current_user,
+            error_message=first_error,
+            sync_result=result,
+        )
+    message = f"Office 365 mail sync imported {processed} message{'s' if processed != 1 else ''}.{detail_summary}"
+    return await _render_m365_mail_dashboard(
+        request,
+        current_user,
+        success_message=message,
+        sync_result=result,
+    )
 
 
 @router.get("/admin/modules/m365-mail/accounts/{account_id}/authorize")

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -815,6 +815,13 @@ async def sync_account(account_id: int) -> dict[str, Any]:
 
     processed = 0
     errors: list[dict[str, Any]] = []
+    message_actions: list[dict[str, Any]] = []
+
+    def _remember_message_action(action: dict[str, Any]) -> None:
+        """Capture and emit a detailed per-message import decision."""
+        action = {key: value for key, value in action.items() if value is not None}
+        message_actions.append(action)
+        log_info("M365 mailbox import message decision", **action)
 
     try:
         # Build the messages URL
@@ -947,10 +954,34 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                 internet_msg_id = msg.get("internetMessageId") or msg_id
 
                 if not msg_id:
+                    _remember_message_action({
+                        "account_id": account_id,
+                        "mailbox": upn,
+                        "folder": folder,
+                        "outcome": "ignored",
+                        "reason": "missing_graph_message_id",
+                    })
                     continue
+
+                message_log_base = {
+                    "account_id": account_id,
+                    "mailbox": upn,
+                    "folder": folder,
+                    "message_id": msg_id,
+                    "internet_message_id": internet_msg_id,
+                    "conversation_id": msg.get("conversationId"),
+                    "subject": msg.get("subject") or f"Email from {upn}",
+                    "is_read": bool(msg.get("isRead", False)),
+                    "received_at": msg.get("receivedDateTime"),
+                }
 
                 # Skip already-read messages when only processing unread
                 if process_unread_only and msg.get("isRead", False):
+                    _remember_message_action({
+                        **message_log_base,
+                        "outcome": "ignored",
+                        "reason": "already_read",
+                    })
                     continue
 
                 # Check if already processed
@@ -959,6 +990,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                     # A previous run may have successfully imported the message but
                     # failed while marking it read.  Avoid duplicate ticket activity,
                     # but still repair the mailbox read state on subsequent syncs.
+                    read_state_repaired = False
                     if mark_as_read and not msg.get("isRead", False):
                         try:
                             patch_url = (
@@ -966,12 +998,20 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                 f"{quote(msg_id, safe='')}"
                             )
                             await _graph_patch(access_token, patch_url, {"isRead": True})
+                            read_state_repaired = True
                         except Exception:  # pragma: no cover - Graph API errors
                             log_error(
                                 "Unable to mark already-imported M365 message as read",
                                 account_id=account_id,
                                 message_id=msg_id,
                             )
+                    _remember_message_action({
+                        **message_log_base,
+                        "outcome": "ignored",
+                        "reason": "already_imported",
+                        "ticket_id": existing_message.get("ticket_id"),
+                        "read_state_repaired": read_state_repaired,
+                    })
                     continue
 
                 # Extract message details
@@ -1030,11 +1070,12 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                         message_id=internet_msg_id,
                     )
                     if not _evaluate_filter(filter_rule, context):
-                        log_info(
-                            "Skipping M365 message because it did not match the configured filter",
-                            account_id=account_id,
-                            message_id=msg_id,
-                        )
+                        _remember_message_action({
+                            **message_log_base,
+                            "from_address": from_address,
+                            "outcome": "ignored",
+                            "reason": "filter_not_matched",
+                        })
                         continue
 
                 # Check sync_known_only
@@ -1042,19 +1083,20 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                 if sync_known_only:
                     from_email_addresses = _extract_email_addresses(from_header)
                     if not from_email_addresses:
-                        log_info(
-                            "Skipping M365 message because no valid sender email address found",
-                            account_id=account_id,
-                            message_id=msg_id,
-                        )
+                        _remember_message_action({
+                            **message_log_base,
+                            "from_address": from_address,
+                            "outcome": "ignored",
+                            "reason": "no_valid_sender_email",
+                        })
                         continue
                     if not await _is_any_email_address_known(from_email_addresses):
-                        log_info(
-                            "Skipping M365 message from unknown sender",
-                            account_id=account_id,
-                            message_id=msg_id,
-                            from_address=from_address,
-                        )
+                        _remember_message_action({
+                            **message_log_base,
+                            "from_address": from_address,
+                            "outcome": "ignored",
+                            "reason": "unknown_sender",
+                        })
                         continue
 
                 # Resolve ticket entities
@@ -1122,6 +1164,13 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                 except Exception as exc:  # pragma: no cover - defensive logging
                     error_text = str(exc)
                     errors.append({"message_id": msg_id, "error": error_text})
+                    _remember_message_action({
+                        **message_log_base,
+                        "from_address": from_address if "from_address" in locals() else None,
+                        "outcome": "error",
+                        "reason": "ticket_create_or_match_failed",
+                        "error": error_text,
+                    })
                     await _record_message(
                         account_id=int(account_id),
                         uid=msg_id,
@@ -1138,6 +1187,8 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                     continue
 
                 ticket_id = ticket.get("id") if isinstance(ticket, Mapping) else None
+                reply_added = False
+                reply_outcome: str | None = None
                 if isinstance(ticket_id, int):
                     # Add reply to existing ticket
                     if not is_new_ticket:
@@ -1146,7 +1197,6 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                         if sanitized.has_rich_content:
                             reply_created_at = received_at or datetime.now(timezone.utc)
                             reply_author_id = requester_id if requester_id is not None else None
-                            reply_added = False
                             try:
                                 await tickets_repo.create_reply(
                                     ticket_id=int(ticket_id),
@@ -1164,6 +1214,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                     ticket_id=ticket_id,
                                 )
                             except Exception as exc:  # pragma: no cover - defensive logging
+                                reply_outcome = "failed_to_add_reply"
                                 log_error(
                                     "Failed to add M365 email reply to ticket",
                                     account_id=account_id,
@@ -1174,6 +1225,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
 
                             # Trigger ticket updated event for email replies
                             if reply_added:
+                                reply_outcome = "reply_added"
                                 try:
                                     actor_info: dict[str, Any] | None = None
                                     if reply_author_id is not None:
@@ -1190,6 +1242,8 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                         ticket_id=ticket_id,
                                         error=str(exc),
                                     )
+                        else:
+                            reply_outcome = "ignored_empty_reply_body"
 
                     # Fetch and save attachments if any
                     if msg.get("hasAttachments"):
@@ -1208,6 +1262,22 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                 ticket_id=ticket_id,
                                 error=str(exc),
                             )
+
+                _remember_message_action({
+                    **message_log_base,
+                    "from_address": from_address,
+                    "requester_id": requester_id,
+                    "company_id": ticket_company_id,
+                    "outcome": "created_new_ticket" if is_new_ticket else "attached_to_existing_ticket",
+                    "ticket_id": int(ticket_id) if isinstance(ticket_id, int) else None,
+                    "ticket_number": ticket.get("ticket_number") if isinstance(ticket, Mapping) else None,
+                    "ticket_subject": ticket.get("subject") if isinstance(ticket, Mapping) else None,
+                    "reply_added": reply_added,
+                    "reply_outcome": reply_outcome,
+                    "has_attachments": bool(msg.get("hasAttachments")),
+                    "matched_by_related_message_ids": bool(related_message_ids),
+                    "related_message_ids": related_message_ids[:10] if related_message_ids else None,
+                })
 
                 await _record_message(
                     account_id=int(account_id),
@@ -1241,14 +1311,31 @@ async def sync_account(account_id: int) -> dict[str, Any]:
         int(account_id),
         last_synced_at=datetime.now(timezone.utc),
     )
+    created_count = sum(
+        1 for action in message_actions if action.get("outcome") == "created_new_ticket"
+    )
+    attached_count = sum(
+        1 for action in message_actions if action.get("outcome") == "attached_to_existing_ticket"
+    )
+    ignored_count = sum(
+        1 for action in message_actions if action.get("outcome") == "ignored"
+    )
     log_info(
         "M365 mail synchronisation completed",
         account_id=account_id,
         processed=processed,
         errors=len(errors),
+        created=created_count,
+        attached=attached_count,
+        ignored=ignored_count,
     )
     status_value = "succeeded" if not errors else "completed_with_errors"
-    return {"status": status_value, "processed": processed, "errors": errors}
+    return {
+        "status": status_value,
+        "processed": processed,
+        "errors": errors,
+        "message_actions": message_actions,
+    }
 
 
 async def _embed_graph_inline_images(

--- a/app/templates/admin/m365_mail.html
+++ b/app/templates/admin/m365_mail.html
@@ -118,6 +118,116 @@
       </header>
 
       <div class="management__body">
+
+        {% if sync_result %}
+          {% set sync_actions = sync_result.message_actions or [] %}
+          <section class="panel" aria-labelledby="m365-sync-results-heading">
+            <div class="panel__header">
+              <div>
+                <h2 class="panel__title" id="m365-sync-results-heading">Latest Office 365 mailbox sync details</h2>
+                <p class="panel__subtitle">
+                  Status: <strong>{{ sync_result.status or 'unknown' }}</strong> ·
+                  Imported: <strong>{{ sync_result.processed or 0 }}</strong> ·
+                  Decisions shown: <strong>{{ sync_actions|length }}</strong>
+                </p>
+              </div>
+            </div>
+            {% if sync_result.errors %}
+              <div class="alert alert--error" role="alert">
+                <strong>Sync issues</strong>
+                <ul>
+                  {% for item in sync_result.errors %}
+                    <li>{{ item.error or item }}</li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% endif %}
+            {% if sync_actions %}
+              <div class="table-wrapper">
+                <table class="table" id="m365-mail-sync-results-table" data-table data-table-id="m365-mail-sync-results">
+                  <thead>
+                    <tr>
+                      <th scope="col" data-sort="string" data-column-key="outcome">Outcome</th>
+                      <th scope="col" data-sort="string" data-column-key="reason">Reason / reply</th>
+                      <th scope="col" data-sort="string" data-column-key="message">Mailbox message</th>
+                      <th scope="col" data-sort="string" data-column-key="sender">Sender</th>
+                      <th scope="col" data-sort="string" data-column-key="ticket">Ticket</th>
+                      <th scope="col" data-sort="string" data-column-key="matching">Matching details</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for action in sync_actions %}
+                      <tr>
+                        <td data-column-key="outcome">
+                          <span class="badge {% if action.outcome == 'created_new_ticket' %}badge--success{% elif action.outcome == 'attached_to_existing_ticket' %}badge--info{% elif action.outcome == 'ignored' %}badge--muted{% elif action.outcome == 'error' %}badge--danger{% else %}badge--warning{% endif %}">
+                            {{ (action.outcome or 'unknown')|replace('_', ' ')|title }}
+                          </span>
+                        </td>
+                        <td data-column-key="reason">
+                          {{ (action.reason or action.reply_outcome or '—')|replace('_', ' ') }}
+                          {% if action.error %}
+                            <div class="table__meta">{{ action.error }}</div>
+                          {% endif %}
+                        </td>
+                        <td data-column-key="message">
+                          <strong>{{ action.subject or 'No subject' }}</strong>
+                          <div class="table__meta">Graph: <code>{{ action.message_id or '—' }}</code></div>
+                          <div class="table__meta">Internet: <code>{{ action.internet_message_id or '—' }}</code></div>
+                          {% if action.received_at %}
+                            <div class="table__meta">Received: {{ action.received_at }}</div>
+                          {% endif %}
+                        </td>
+                        <td data-column-key="sender">
+                          {{ action.from_address or '—' }}
+                          {% if action.mailbox %}
+                            <div class="table__meta">Mailbox: {{ action.mailbox }}</div>
+                          {% endif %}
+                        </td>
+                        <td data-column-key="ticket">
+                          {% if action.ticket_id %}
+                            <a href="/admin/tickets/{{ action.ticket_id }}">#{{ action.ticket_number or action.ticket_id }}</a>
+                            {% if action.ticket_subject %}
+                              <div class="table__meta">{{ action.ticket_subject }}</div>
+                            {% endif %}
+                            {% if action.reply_added is not none %}
+                              <div class="table__meta">Reply added: {{ 'yes' if action.reply_added else 'no' }}</div>
+                            {% endif %}
+                          {% else %}
+                            —
+                          {% endif %}
+                        </td>
+                        <td data-column-key="matching">
+                          {% if action.matched_by_related_message_ids %}
+                            Related message IDs matched
+                          {% elif action.read_state_repaired %}
+                            Already imported; read state repaired
+                          {% elif action.has_attachments %}
+                            Attachments present
+                          {% else %}
+                            —
+                          {% endif %}
+                          {% if action.related_message_ids %}
+                            <details>
+                              <summary>Related IDs</summary>
+                              <ul>
+                                {% for related_id in action.related_message_ids %}
+                                  <li><code>{{ related_id }}</code></li>
+                                {% endfor %}
+                              </ul>
+                            </details>
+                          {% endif %}
+                        </td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            {% else %}
+              <p class="empty-state">No mailbox messages were evaluated during this sync.</p>
+            {% endif %}
+          </section>
+        {% endif %}
+
         <div class="table-wrapper">
           <table class="table" id="m365-mail-accounts-table" data-table data-table-id="m365-mail-accounts">
             <thead>
@@ -161,7 +271,7 @@
                       {% if account.auth_status == 'signed_in' %}
                         <span class="badge badge--success">Signed in</span>
                       {% elif account.auth_status == 'company_credentials' %}
-                        <span class="badge badge--secondary">Company</span>
+                        <span class="badge badge--muted">Company</span>
                       {% else %}
                         <span class="badge badge--warning">Not configured</span>
                       {% endif %}
@@ -174,7 +284,7 @@
                       {% endif %}
                     </td>
                     <td data-column-key="status">
-                      <span class="badge {{ 'badge--success' if account.active else 'badge--secondary' }}">
+                      <span class="badge {{ 'badge--success' if account.active else 'badge--muted' }}">
                         {{ 'Active' if account.active else 'Paused' }}
                       </span>
                     </td>


### PR DESCRIPTION
### Motivation

- Provide detailed per-message visibility for Office 365 mailbox synchronisation so operators can inspect why messages were created, attached, ignored, or errored.  
- Avoid losing diagnostic context on sync failures by rendering results in the admin page instead of always using flash redirects.

### Description

- Add a `message_actions` collection and helper `_remember_message_action` to `sync_account` to capture a compact, logged record for each message processed, and include it in the sync result.  
- Instrument the sync flow to record outcomes such as `ignored`, `created_new_ticket`, `attached_to_existing_ticket`, and `error`, including reasons and metadata (message ids, mailbox, ticket info, reply outcome, etc.).  
- Aggregate created/attached/ignored counts, include them in logs, and return `message_actions` in the sync result payload.  
- Update admin routes to pass `sync_result` into the dashboard and render the admin page with detailed results (and appropriate status codes) instead of always redirecting on errors/skips/success.  
- Add a UI panel in the `admin/m365_mail.html` template that displays sync status, errors, summary counts, and a detailed table of per-message actions; also adjust a couple of badge styles (`company` and paused state) for visual consistency.

### Testing

- Ran the automated test suite with `pytest -q`; all tests passed.  
- Ran linters/types (`flake8`, `mypy`) locally; no failures reported.  
- Exercised the M365 mail sync integration scenario via existing integration tests (`pytest tests/integration -q`); assertions covering sync result shape and logging passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4dfaa2689c8332b1876d3003c961f8)