### PR TITLE
Show Office 365 mailbox sync details modal

### DIFF
--- a/app/features/m365_mail/admin_routes.py
+++ b/app/features/m365_mail/admin_routes.py
@@ -42,6 +42,7 @@ async def _render_m365_mail_dashboard(
     success_message: str | None = None,
     error_message: str | None = None,
     status_code: int = status.HTTP_200_OK,
+    sync_result: dict[str, Any] | None = None,
 ) -> HTMLResponse:
     main_module = _main()
     accounts = await m365_mail_service.list_accounts()
@@ -61,6 +62,7 @@ async def _render_m365_mail_dashboard(
         "companies": companies,
         "success_message": success_message,
         "error_message": error_message,
+        "sync_result": sync_result,
     }
     response = await main_module._render_template("admin/m365_mail.html", request, user, extra=extra)
     response.status_code = status_code
@@ -307,20 +309,38 @@ async def admin_sync_m365_mail_account(account_id: int, request: Request):
         if message_actions
         else ""
     )
+    account = await m365_mail_service.get_account(account_id)
     if status_value in {"error"}:
         message = result.get("error") or "Office 365 mail synchronisation failed."
-        return flash_redirect("/admin/modules/m365-mail", message, "error")
-    if status_value == "skipped":
+        message_type = "error"
+    elif status_value == "skipped":
         message = result.get("reason") or "Office 365 mail synchronisation skipped."
-        return flash_redirect("/admin/modules/m365-mail", message, "error")
-    if status_value == "completed_with_errors" and error_count:
+        message_type = "error"
+    elif status_value == "completed_with_errors" and error_count:
         first_error = (result.get("errors") or [{}])[0].get("error") or "Office 365 mail sync completed with errors."
         if processed:
             first_error = f"{first_error} ({processed} message{'s' if processed != 1 else ''} imported.)"
-        first_error = f"{first_error}{detail_summary}"
-        return flash_redirect("/admin/modules/m365-mail", first_error, "error")
-    message = f"Office 365 mail sync imported {processed} message{'s' if processed != 1 else ''}.{detail_summary}"
-    return flash_redirect("/admin/modules/m365-mail", message, "success")
+        message = f"{first_error}{detail_summary}"
+        message_type = "error"
+    else:
+        message = f"Office 365 mail sync imported {processed} message{'s' if processed != 1 else ''}.{detail_summary}"
+        message_type = "success"
+    return await _render_m365_mail_dashboard(
+        request,
+        current_user,
+        success_message=message if message_type == "success" else None,
+        error_message=message if message_type == "error" else None,
+        sync_result={
+            **result,
+            "account": account,
+            "created_count": created_count,
+            "attached_count": attached_count,
+            "ignored_count": ignored_count,
+            "processed": processed,
+            "message": message,
+            "message_type": message_type,
+        },
+    )
 
 
 @router.get("/admin/modules/m365-mail/accounts/{account_id}/authorize")

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -1020,11 +1020,17 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                 account_id=account_id,
                                 message_id=msg_id,
                             )
+                    existing_ticket_id = existing_message.get("ticket_id")
+                    existing_ticket = None
+                    if isinstance(existing_ticket_id, int):
+                        existing_ticket = await tickets_repo.get_ticket(existing_ticket_id)
                     _remember_message_action({
                         **message_log_base,
                         "outcome": "ignored",
                         "reason": "already_imported",
-                        "ticket_id": existing_message.get("ticket_id"),
+                        "ticket_id": existing_ticket_id,
+                        "ticket_number": existing_ticket.get("ticket_number") if isinstance(existing_ticket, Mapping) else None,
+                        "ticket_subject": existing_ticket.get("subject") if isinstance(existing_ticket, Mapping) else None,
                         "read_state_repaired": read_state_repaired,
                     })
                     continue

--- a/app/templates/admin/m365_mail.html
+++ b/app/templates/admin/m365_mail.html
@@ -224,4 +224,97 @@
       </div>
     </section>
   </div>
+  {% if sync_result %}
+    {% set sync_account = sync_result.account or {} %}
+    {% set sync_actions = sync_result.message_actions or [] %}
+    <div class="modal" id="m365-mail-sync-details-modal" role="dialog" aria-modal="true" aria-labelledby="m365-mail-sync-details-title">
+      <div class="modal__dialog modal__dialog--wide">
+        <button type="button" class="modal__close" data-modal-close aria-label="Close sync details">
+          <span aria-hidden="true">&times;</span>
+          <span class="visually-hidden">Close sync details</span>
+        </button>
+        <h2 class="modal__title" id="m365-mail-sync-details-title">Office 365 mailbox sync details</h2>
+        <div class="modal__body stack-sm">
+          <p class="text-muted">
+            {{ sync_result.message }}
+            {% if sync_account.name or sync_account.user_principal_name %}
+              Mailbox: <strong>{{ sync_account.name or sync_account.user_principal_name }}</strong>.
+            {% endif %}
+          </p>
+          <div class="stats-grid stats-grid--compact">
+            <div class="stat-card"><span class="stat-card__label">Created</span><strong>{{ sync_result.created_count or 0 }}</strong></div>
+            <div class="stat-card"><span class="stat-card__label">Appended</span><strong>{{ sync_result.attached_count or 0 }}</strong></div>
+            <div class="stat-card"><span class="stat-card__label">Ignored</span><strong>{{ sync_result.ignored_count or 0 }}</strong></div>
+            <div class="stat-card"><span class="stat-card__label">Errors</span><strong>{{ (sync_result.errors or [])|length }}</strong></div>
+          </div>
+          {% if sync_actions %}
+            <div class="table-wrapper">
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th scope="col">Received</th>
+                    <th scope="col">Subject</th>
+                    <th scope="col">From</th>
+                    <th scope="col">Result</th>
+                    <th scope="col">Ticket / reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for action in sync_actions %}
+                    <tr>
+                      <td>{{ action.received_at or '—' }}</td>
+                      <td>{{ action.subject or '(no subject)' }}</td>
+                      <td>{{ action.from_address or '—' }}</td>
+                      <td>
+                        {% if action.outcome == 'created_new_ticket' %}
+                          <span class="badge badge--success">New ticket</span>
+                        {% elif action.outcome == 'attached_to_existing_ticket' %}
+                          <span class="badge badge--info">Appended</span>
+                        {% elif action.outcome == 'ignored' %}
+                          <span class="badge badge--secondary">Ignored</span>
+                        {% else %}
+                          <span class="badge badge--warning">{{ action.outcome|replace('_', ' ')|title }}</span>
+                        {% endif %}
+                      </td>
+                      <td>
+                        {% if action.ticket_id %}
+                          <a href="/admin/tickets/{{ action.ticket_id }}">#{{ action.ticket_number or action.ticket_id }}</a>
+                          {% if action.ticket_subject %}<div class="table__meta">{{ action.ticket_subject }}</div>{% endif %}
+                          {% if action.reply_outcome %}<div class="table__meta">{{ action.reply_outcome|replace('_', ' ') }}</div>{% endif %}
+                        {% elif action.reason %}
+                          {{ action.reason|replace('_', ' ') }}
+                        {% elif action.error %}
+                          <span class="text-danger">{{ action.error }}</span>
+                        {% else %}
+                          —
+                        {% endif %}
+                      </td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% else %}
+            <p class="text-muted">No mailbox messages were returned for this sync run.</p>
+          {% endif %}
+          {% if sync_result.errors %}
+            <h3 class="card__subtitle">Sync errors</h3>
+            <ul>
+              {% for err in sync_result.errors %}
+                <li class="text-danger">{{ err.error or err }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    <script>
+      document.addEventListener('click', function (event) {
+        if (event.target.closest('[data-modal-close]')) {
+          document.getElementById('m365-mail-sync-details-modal')?.setAttribute('hidden', '');
+        }
+      });
+    </script>
+  {% endif %}
+
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Replace the ephemeral toast-only feedback for ad-hoc mailbox syncs with an in-page modal so administrators can inspect full sync results per mailbox run. 
- Surface every import decision (created ticket, appended reply, ignored message or error) rather than only summarising the most recent outcome. 
- Provide actionable context for ignored messages by showing the ticket number/subject when available or the reason an email was skipped. 

### Description
- Update the admin sync handler to render the mailbox dashboard with a `sync_result` payload instead of redirecting with only a flash message, surfaced via `admin_sync_m365_mail_account` and `_render_m365_mail_dashboard` in `app/features/m365_mail/admin_routes.py`. 
- Add a sync details modal in `app/templates/admin/m365_mail.html` that displays summary stats and a row-per-message table with `received_at`, `subject`, `from`, `result`, and `ticket / reason` columns. 
- Enrich per-message actions for already-imported messages in `app/services/m365_mail.py` by resolving the existing ticket (when present) and attaching `ticket_id`, `ticket_number`, and `ticket_subject` to the recorded `message_action`. 
- Include aggregate counts (`created_count`, `attached_count`, `ignored_count`, `processed`) and propagate the original `message_actions` into the template context so the modal can enumerate every import decision. 

### Testing
- Ran `python -m py_compile app/features/m365_mail/admin_routes.py app/services/m365_mail.py` which succeeded. 
- Ran `pytest -q tests/test_m365_mail_service.py` which failed during collection due to the environment missing the system `libmagic` library required by `python-magic` (test collection error, not related to the changes themselves).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e00cf21048332b4463575f8f8e02e)