### PR TITLE
Add Force reimport action for M365 mail sync history

### DIFF
--- a/app/features/m365_mail/admin_routes.py
+++ b/app/features/m365_mail/admin_routes.py
@@ -43,7 +43,6 @@ async def _render_m365_mail_dashboard(
     error_message: str | None = None,
     sync_result: dict[str, Any] | None = None,
     status_code: int = status.HTTP_200_OK,
-    sync_result: dict[str, Any] | None = None,
 ) -> HTMLResponse:
     main_module = _main()
     accounts = await m365_mail_service.list_accounts()
@@ -290,6 +289,45 @@ async def admin_delete_m365_mail_account(account_id: int, request: Request):
     label = account.get("name") if account else f"#{account_id}"
     message = f"Mailbox {label} deleted."
     return flash_redirect("/admin/modules/m365-mail", message, "success")
+
+
+@router.post("/admin/modules/m365-mail/accounts/{account_id}/messages/force-import", response_class=HTMLResponse)
+async def admin_force_import_m365_mail_message(account_id: int, request: Request):
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return redirect
+    form = await request.form()
+    message_uid = str(form.get("messageUid") or "").strip()
+    try:
+        result = await m365_mail_service.force_reimport_message(account_id, message_uid)
+    except (LookupError, ValueError) as exc:
+        return flash_redirect("/admin/modules/m365-mail", str(exc), "error")
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log_error(
+            "Failed to force M365 message reimport",
+            account_id=account_id,
+            message_uid=message_uid,
+            error=str(exc),
+        )
+        return flash_redirect(
+            "/admin/modules/m365-mail",
+            "Unable to force import that Office 365 mailbox message.",
+            "error",
+        )
+    account = result.get("account") or {}
+    label = account.get("name") or account.get("user_principal_name") or f"Mailbox {account_id}"
+    unread_note = (
+        " The message was also marked unread so the unread-only sync can pick it up."
+        if result.get("marked_unread")
+        else ""
+    )
+    if result.get("mark_unread_error"):
+        unread_note = " The import record was cleared, but the message could not be marked unread."
+    return flash_redirect(
+        "/admin/modules/m365-mail",
+        f"{label} will force import the selected email on the next sync cycle.{unread_note}",
+        "success",
+    )
 
 
 @router.post("/admin/modules/m365-mail/accounts/{account_id}/sync", response_class=HTMLResponse)

--- a/app/repositories/m365_mail_accounts.py
+++ b/app/repositories/m365_mail_accounts.py
@@ -238,6 +238,16 @@ async def get_message(account_id: int, message_uid: str) -> dict[str, Any] | Non
     return _normalise_message(row) if row else None
 
 
+async def delete_message(account_id: int, message_uid: str) -> None:
+    await db.execute(
+        """
+        DELETE FROM m365_mail_account_messages
+        WHERE account_id = %s AND message_uid = %s
+        """,
+        (account_id, message_uid),
+    )
+
+
 async def upsert_message(
     *,
     account_id: int,

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -408,6 +408,67 @@ async def clone_account(account_id: int) -> dict[str, Any]:
     return enrich_account_response(account)
 
 
+async def _acquire_access_token_for_mail_account(account: Mapping[str, Any]) -> str:
+    if _account_has_delegated_tokens(account):
+        return await _acquire_delegated_access_token(account)
+    auth_company_id = _int_or_none(account.get("company_id"))
+    if auth_company_id is None:
+        provisioned = await m365_repo.list_provisioned_company_ids()
+        if provisioned:
+            auth_company_id = min(provisioned)
+    if auth_company_id is None:
+        raise ValueError("No Microsoft 365 credentials configured.")
+    return await m365_service.acquire_access_token(
+        int(auth_company_id), force_client_credentials=True
+    )
+
+
+async def force_reimport_message(account_id: int, message_uid: str) -> dict[str, Any]:
+    """Forget a previously imported Graph message so a future sync can import it again."""
+    normalized_uid = (message_uid or "").strip()
+    if not normalized_uid:
+        raise ValueError("Message id is required.")
+
+    account = await mail_repo.get_account(account_id)
+    if not account:
+        raise LookupError("Mailbox account not found.")
+
+    existing = await mail_repo.get_message(account_id, normalized_uid)
+    if not existing:
+        raise LookupError("Imported message record not found.")
+
+    await mail_repo.delete_message(account_id, normalized_uid)
+    marked_unread = False
+    mark_unread_error: str | None = None
+
+    if bool(account.get("process_unread_only")):
+        try:
+            access_token = await _acquire_access_token_for_mail_account(account)
+            upn = str(account.get("user_principal_name") or "")
+            patch_url = (
+                f"{_GRAPH_BASE}/users/{quote(upn, safe='')}/messages/"
+                f"{quote(normalized_uid, safe='')}"
+            )
+            await _graph_patch(access_token, patch_url, {"isRead": False})
+            marked_unread = True
+        except Exception as exc:  # pragma: no cover - depends on live Graph access
+            mark_unread_error = str(exc)
+            log_error(
+                "Unable to mark force-reimported M365 message as unread",
+                account_id=account_id,
+                message_id=normalized_uid,
+                error=mark_unread_error,
+            )
+
+    return {
+        "account": enrich_account_response(account),
+        "message_uid": normalized_uid,
+        "deleted": True,
+        "marked_unread": marked_unread,
+        "mark_unread_error": mark_unread_error,
+    }
+
+
 async def delete_account(account_id: int) -> None:
     from app.services.scheduler import scheduler_service
 

--- a/app/templates/admin/m365_mail.html
+++ b/app/templates/admin/m365_mail.html
@@ -367,6 +367,7 @@
                     <th scope="col">From</th>
                     <th scope="col">Result</th>
                     <th scope="col">Ticket / reason</th>
+                    <th scope="col">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -395,6 +396,19 @@
                           {{ action.reason|replace('_', ' ') }}
                         {% elif action.error %}
                           <span class="text-danger">{{ action.error }}</span>
+                        {% else %}
+                          —
+                        {% endif %}
+                      </td>
+                      <td>
+                        {% if action.reason == 'already_imported' and action.message_id %}
+                          <form action="/admin/modules/m365-mail/accounts/{{ sync_account.id }}/messages/force-import" method="post" class="inline-form" onsubmit="return confirm('Force import this email again during the next sync cycle?');">
+                            {% if csrf_token %}
+                              <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+                            {% endif %}
+                            <input type="hidden" name="messageUid" value="{{ action.message_id }}" />
+                            <button type="submit" class="button button--small button--ghost">Force import next sync</button>
+                          </form>
                         {% else %}
                           —
                         {% endif %}

--- a/tests/test_m365_mail_service.py
+++ b/tests/test_m365_mail_service.py
@@ -1512,3 +1512,62 @@ async def test_sync_account_marks_already_imported_unread_message_as_read(monkey
             {"isRead": True},
         )
     ]
+
+
+async def test_force_reimport_message_deletes_import_record_and_marks_unread(monkeypatch):
+    account = {
+        "id": 9,
+        "company_id": 5,
+        "user_principal_name": "user@example.com",
+        "process_unread_only": True,
+    }
+    deleted: list[tuple[int, str]] = []
+    patched: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_get_account(account_id: int):
+        return account
+
+    async def fake_get_message(account_id: int, message_uid: str):
+        return {"status": "imported", "message_uid": message_uid}
+
+    async def fake_delete_message(account_id: int, message_uid: str):
+        deleted.append((account_id, message_uid))
+
+    async def fake_acquire_token(company_id, **kwargs):
+        return "token"
+
+    async def fake_graph_patch(access_token: str, url: str, payload: dict[str, object]):
+        patched.append((url, payload))
+        return {}
+
+    monkeypatch.setattr(m365_mail.mail_repo, "get_account", fake_get_account)
+    monkeypatch.setattr(m365_mail.mail_repo, "get_message", fake_get_message)
+    monkeypatch.setattr(m365_mail.mail_repo, "delete_message", fake_delete_message)
+    monkeypatch.setattr(m365_mail.m365_service, "acquire_access_token", fake_acquire_token)
+    monkeypatch.setattr(m365_mail, "_graph_patch", fake_graph_patch)
+
+    result = await m365_mail.force_reimport_message(9, " message/id ")
+
+    assert result["deleted"] is True
+    assert result["marked_unread"] is True
+    assert deleted == [(9, "message/id")]
+    assert patched == [
+        (
+            "https://graph.microsoft.com/v1.0/users/user%40example.com/messages/message%2Fid",
+            {"isRead": False},
+        )
+    ]
+
+
+async def test_force_reimport_message_requires_existing_record(monkeypatch):
+    async def fake_get_account(account_id: int):
+        return {"id": account_id}
+
+    async def fake_get_message(account_id: int, message_uid: str):
+        return None
+
+    monkeypatch.setattr(m365_mail.mail_repo, "get_account", fake_get_account)
+    monkeypatch.setattr(m365_mail.mail_repo, "get_message", fake_get_message)
+
+    with pytest.raises(LookupError):
+        await m365_mail.force_reimport_message(9, "missing")


### PR DESCRIPTION
### Motivation
- Administrators need a way to re-import emails that were skipped as `already_imported` but are not visible in the UI, so MyPortal can forget the previous import and pick them up on the next sync.
- When mailboxes are configured to only process unread messages, the reimport should also try to mark the message unread in Microsoft Graph so the next sync cycle can include it.

### Description
- Added an `Actions` column and a `Force import next sync` inline form/button to the sync history modal template at `app/templates/admin/m365_mail.html` to allow per-message reimport requests.
- Added an admin POST endpoint `POST /admin/modules/m365-mail/accounts/{account_id}/messages/force-import` in `app/features/m365_mail/admin_routes.py` which accepts `messageUid` and flashes success/error messages.
- Implemented `force_reimport_message(account_id, message_uid)` in `app/services/m365_mail.py` to validate the account and stored message record, delete the stored import record via the repo, and when appropriate attempt to mark the Graph message unread; also added helper `_acquire_access_token_for_mail_account` to obtain an access token for the mailbox when needed.
- Added `delete_message(account_id, message_uid)` to `app/repositories/m365_mail_accounts.py` to remove the stored imported-message row.
- Added unit tests for the new behavior in `tests/test_m365_mail_service.py` covering successful deletion + marking unread and missing-record handling.

### Testing
- Verified modules compile with `python -m compileall app/features/m365_mail/admin_routes.py app/services/m365_mail.py app/repositories/m365_mail_accounts.py tests/test_m365_mail_service.py` which succeeded. 
- Ran `pytest -q tests/test_m365_mail_service.py` but test collection failed due to the environment missing the `libmagic` system dependency (`ImportError: failed to find libmagic`), so the new tests could not be executed to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e03acb50c8332a60dc58f2eeb9893)