### PR TITLE
Fix M365 mailbox subfolder imports

### DIFF
--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -627,8 +627,10 @@ async def _resolve_mail_folder_identifier(
     """Resolve a mailbox folder display name to a Graph folder ID when needed."""
     folder_path = (folder or "").strip()
 
-    async def _resolve_top_level(folder_name: str) -> str:
-        if folder_name.lower() in _WELL_KNOWN_MAIL_FOLDERS or _looks_like_graph_folder_id(folder_name):
+    async def _resolve_top_level(folder_name: str, *, prefer_display_name_lookup: bool = False) -> str:
+        if _looks_like_graph_folder_id(folder_name):
+            return folder_name
+        if folder_name.lower() in _WELL_KNOWN_MAIL_FOLDERS and not prefer_display_name_lookup:
             return folder_name
 
         # OData string literal escaping (single-quote doubling); urlencode then handles
@@ -650,6 +652,9 @@ async def _resolve_mail_folder_identifier(
             folder_id = folders[0].get("id")
             if folder_id:
                 return folder_id
+
+        if folder_name.lower() in _WELL_KNOWN_MAIL_FOLDERS:
+            return folder_name
 
         raise M365Error(f"Mail folder '{folder_name}' not found or inaccessible", http_status=404)
 
@@ -699,8 +704,14 @@ async def _resolve_mail_folder_identifier(
             http_status=400,
         )
     if len(segments) > 1:
-        # Resolve the first segment against the root, then walk child folders for the rest
-        parent_identifier = await _resolve_top_level(segments[0])
+        # Resolve the first segment against the root, then walk child folders for the rest.
+        # Prefer a concrete folder ID for nested paths (including well-known parents
+        # like Inbox) because some tenants reject child-folder queries that use a
+        # well-known folder name as the parent path segment.
+        parent_identifier = await _resolve_top_level(
+            segments[0],
+            prefer_display_name_lookup=True,
+        )
         for child_name in segments[1:]:
             parent_identifier = await _resolve_child_folder(parent_identifier, child_name)
 

--- a/tests/test_m365_mail_service.py
+++ b/tests/test_m365_mail_service.py
@@ -466,7 +466,11 @@ async def test_sync_account_resolves_subfolder(monkeypatch):
     async def fake_graph_get(access_token: str, url: str):
         decoded = unquote(url)
         graph_calls.append(decoded)
-        if "childFolders?" in decoded:
+        if "/mailFolders?" in decoded:
+            assert "displayName eq 'Inbox'" in decoded
+            return {"value": [{"id": "inbox-folder-id"}]}
+        if "/mailFolders/inbox-folder-id/childFolders?" in decoded:
+            assert "displayName eq 'Support'" in decoded
             return {"value": [{"id": "child-folder-id"}]}
         if "/mailFolders/child-folder-id/messages?" in decoded:
             return {"value": []}
@@ -489,13 +493,15 @@ async def test_sync_account_resolves_subfolder(monkeypatch):
 
     assert result["status"] == "succeeded"
     assert graph_calls, "Expected at least one Graph request"
-    expected_call_count = 2  # child folder lookup + messages fetch
-    assert len(graph_calls) == expected_call_count, "Expected child folder lookup, then messages fetch"
-    first_call, second_call = graph_calls
-    assert "childFolders?" in first_call
-    assert "/mailFolders/Inbox/childFolders?" in first_call
-    assert "displayName eq 'Support'" in first_call
-    assert "/mailFolders/child-folder-id/messages?" in second_call
+    expected_call_count = 3  # parent lookup + child folder lookup + messages fetch
+    assert len(graph_calls) == expected_call_count, "Expected parent lookup, child folder lookup, then messages fetch"
+    first_call, second_call, third_call = graph_calls
+    assert "/mailFolders?" in first_call
+    assert "displayName eq 'Inbox'" in first_call
+    assert "childFolders?" in second_call
+    assert "/mailFolders/inbox-folder-id/childFolders?" in second_call
+    assert "displayName eq 'Support'" in second_call
+    assert "/mailFolders/child-folder-id/messages?" in third_call
 
 
 async def test_sync_account_errors_on_empty_folder_segment(monkeypatch):
@@ -572,7 +578,10 @@ async def test_sync_account_resolves_multi_level_nested_folders(monkeypatch):
     async def fake_graph_get(access_token: str, url: str):
         decoded = unquote(url)
         graph_calls.append(decoded)
-        if "/mailFolders/Inbox/childFolders?" in decoded:
+        if "/mailFolders?" in decoded:
+            assert "displayName eq 'Inbox'" in decoded
+            return {"value": [{"id": "inbox-folder-id"}]}
+        if "/mailFolders/inbox-folder-id/childFolders?" in decoded:
             assert "displayName eq 'Team'" in decoded
             return {"value": [{"id": "team-folder-id"}]}
         if "/mailFolders/team-folder-id/childFolders?" in decoded:
@@ -598,11 +607,13 @@ async def test_sync_account_resolves_multi_level_nested_folders(monkeypatch):
     result = await m365_mail.sync_account(1)
 
     assert result["status"] == "succeeded"
-    expected_call_count = 3  # two child lookups + messages fetch
+    expected_call_count = 4  # parent lookup + two child lookups + messages fetch
     assert len(graph_calls) == expected_call_count
-    assert "childFolders?" in graph_calls[0]
+    assert "/mailFolders?" in graph_calls[0]
+    assert "displayName eq 'Inbox'" in graph_calls[0]
     assert "childFolders?" in graph_calls[1]
-    assert "/mailFolders/support-folder-id/messages?" in graph_calls[2]
+    assert "childFolders?" in graph_calls[2]
+    assert "/mailFolders/support-folder-id/messages?" in graph_calls[3]
 
 
 async def test_sync_account_escapes_folder_name(monkeypatch):


### PR DESCRIPTION
### Motivation
- Nested mailbox folder paths like `Inbox/Test` were failing because Graph child-folder queries used a well-known parent name (e.g. `Inbox`) instead of a concrete Graph folder ID which some tenants reject. 

### Description
- Update `_resolve_mail_folder_identifier` to resolve the top-level segment to a concrete Graph folder ID when the configured folder contains multiple segments, by adding a `prefer_display_name_lookup` flag and preferring ID-based parent lookups for nested paths. 
- Preserve existing shortcut behavior for single-folder syncs by still returning well-known folder names (e.g. `Inbox`) when appropriate and falling back to those names if a display-name lookup returns no ID. 
- Adjust tests in `tests/test_m365_mail_service.py` to assert that nested paths perform a parent `mailFolders` lookup (display-name -> ID) before issuing `childFolders` and `messages` requests. 

### Testing
- Ran `python3 -m py_compile app/services/m365_mail.py` which succeeded. 
- Ran `git diff --check` which reported no whitespace/format issues. 
- Attempted targeted pytest run for the updated folder-resolution tests (`tests/test_m365_mail_service.py::test_sync_account_resolves_subfolder` and `::test_sync_account_resolves_multi_level_nested_folders`) but execution was blocked by a missing system dependency (`libmagic`) in the environment so the tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e0513b7908332a13b481325798fab)