### PR TITLE
Add bulk-redistribute action for scheduled tasks (backend, UI, tests)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5778,6 +5778,9 @@ async def admin_bulk_delete_scheduled_tasks(request: Request):
     response = RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
     set_flash(response, redirect_message, "success")
     return response
+
+
+@app.post("/admin/scheduled-tasks/bulk-rename", response_class=HTMLResponse)
 async def admin_bulk_rename_scheduled_tasks(request: Request):
     current_user, redirect = await _require_super_admin_page(request)
     if redirect:
@@ -5852,6 +5855,83 @@ async def admin_bulk_rename_scheduled_tasks(request: Request):
     response = RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
     set_flash(response, redirect_message, "success")
     return response
+
+
+@app.post("/admin/scheduled-tasks/bulk-redistribute", response_class=HTMLResponse)
+async def admin_bulk_redistribute_scheduled_tasks(request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    form = await request.form()
+    raw_ids = form.getlist("taskIds")
+    task_ids: list[int] = []
+    seen: set[int] = set()
+    for raw in raw_ids:
+        try:
+            identifier = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if identifier <= 0 or identifier in seen:
+            continue
+        seen.add(identifier)
+        task_ids.append(identifier)
+
+    if not task_ids:
+        return flash_redirect("/admin/scheduled-tasks", "Select at least one task to redistribute.", "error")
+
+    try:
+        hour = int(str(form.get("redistributeHour") or "").strip())
+    except (TypeError, ValueError):
+        return flash_redirect("/admin/scheduled-tasks", "Enter an hour between 0 and 23.", "error")
+
+    if hour < 0 or hour > 23:
+        return flash_redirect("/admin/scheduled-tasks", "Enter an hour between 0 and 23.", "error")
+
+    redistributed_count = 0
+    for offset, task_id in enumerate(task_ids):
+        task = await scheduled_tasks_repo.get_task(task_id)
+        if not task:
+            continue
+        fields = str(task.get("cron") or "").split()
+        if len(fields) < 5:
+            log_warning(
+                "Skipped scheduled task cron redistribution due to invalid cron",
+                task_id=task_id,
+                cron=task.get("cron"),
+            )
+            continue
+        scheduled_hour = (hour + (offset // 60)) % 24
+        scheduled_minute = offset % 60
+        fields[0] = str(scheduled_minute)
+        fields[1] = str(scheduled_hour)
+        await scheduled_tasks_repo.update_task_cron(task_id, " ".join(fields))
+        redistributed_count += 1
+
+    if redistributed_count:
+        await scheduler_service.refresh()
+
+    log_info(
+        "Scheduled tasks bulk redistributed",
+        redistributed_count=redistributed_count,
+        redistribute_hour=hour,
+        redistributed_by=current_user.get("id") if current_user else None,
+        task_ids=task_ids,
+    )
+
+    message_suffix = "task" if redistributed_count == 1 else "tasks"
+    redirect_message = f"Redistributed {redistributed_count} {message_suffix} to run from {hour:02d}:00 UTC."
+    if redistributed_count < len(task_ids):
+        redirect_message = f"{redirect_message} Some selected tasks were not found or had invalid cron expressions."
+
+    show_inactive_raw = form.get("show_inactive")
+    show_inactive_param = "1" if show_inactive_raw else ""
+    base_url = "/admin/scheduled-tasks"
+    redirect_url = f"{base_url}?show_inactive={show_inactive_param}" if show_inactive_param else base_url
+    response = RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
+    set_flash(response, redirect_message, "success")
+    return response
+
 # ---------------------------------------------------------------------------
 
 

--- a/app/repositories/scheduled_tasks.py
+++ b/app/repositories/scheduled_tasks.py
@@ -241,6 +241,14 @@ async def rename_task(task_id: int, name: str) -> None:
     )
 
 
+async def update_task_cron(task_id: int, cron: str) -> None:
+    """Update only the cron expression of a scheduled task."""
+    await db.execute(
+        "UPDATE scheduled_tasks SET cron = %s WHERE id = %s",
+        (cron, task_id),
+    )
+
+
 async def set_task_active(task_id: int, active: bool) -> dict[str, Any] | None:
     await db.execute(
         "UPDATE scheduled_tasks SET active = %s WHERE id = %s",

--- a/app/static/js/scheduled_task_columns.js
+++ b/app/static/js/scheduled_task_columns.js
@@ -150,8 +150,11 @@
     const selectAll = document.querySelector('[data-scheduled-tasks-select-all]');
     const deleteBtn = document.querySelector('[data-scheduled-tasks-bulk-action="delete"]');
     const renameBtn = document.querySelector('[data-scheduled-tasks-bulk-action="rename"]');
+    const redistributeBtn = document.querySelector('[data-scheduled-tasks-bulk-action="redistribute"]');
     const deleteForm = document.querySelector('[data-scheduled-tasks-bulk-form="delete"]');
     const renameForm = document.querySelector('[data-scheduled-tasks-bulk-form="rename"]');
+    const redistributeForm = document.querySelector('[data-scheduled-tasks-bulk-form="redistribute"]');
+    const redistributeHourInput = document.querySelector('[data-scheduled-tasks-redistribute-hour]');
     const countLabel = document.getElementById('scheduled-tasks-bulk-count');
 
     const getRowCheckboxes = () =>
@@ -185,6 +188,10 @@
         renameBtn.disabled = count === 0;
         renameBtn.hidden = false;
       }
+      if (redistributeBtn) {
+        redistributeBtn.disabled = count === 0;
+        redistributeBtn.hidden = false;
+      }
       if (countLabel) {
         countLabel.textContent = `(${count})`;
         countLabel.hidden = count === 0;
@@ -202,17 +209,20 @@
         }
       }
 
-      // Mirror checked checkboxes into the rename form so it also receives taskIds
-      if (renameForm) {
-        renameForm.querySelectorAll('input[name="taskIds"]').forEach((el) => el.remove());
+      // Mirror checked checkboxes into forms that do not own the row checkboxes.
+      [renameForm, redistributeForm].forEach((form) => {
+        if (!form) {
+          return;
+        }
+        form.querySelectorAll('input[name="taskIds"]').forEach((el) => el.remove());
         selected.forEach((cb) => {
           const input = document.createElement('input');
           input.type = 'hidden';
           input.name = 'taskIds';
           input.value = cb.value;
-          renameForm.appendChild(input);
+          form.appendChild(input);
         });
-      }
+      });
     };
 
     if (selectAll) {
@@ -276,6 +286,34 @@
           return;
         }
         renameForm.submit();
+      });
+    }
+
+    // Handle redistribute button click — prompt for hour then submit the form
+    if (redistributeBtn && redistributeForm && redistributeHourInput) {
+      redistributeBtn.addEventListener('click', () => {
+        uncheckHiddenCheckboxes();
+        const selected = getVisibleCheckboxes().filter((cb) => cb.checked);
+        const count = selected.length;
+        if (!count) {
+          return;
+        }
+        const rawHour = window.prompt('Enter the UTC hour for the selected tasks to start running (0-23):', '0');
+        if (rawHour === null) {
+          return;
+        }
+        const hour = Number.parseInt(rawHour.trim(), 10);
+        if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+          window.alert('Enter an hour between 0 and 23.');
+          return;
+        }
+        const noun = count === 1 ? 'task' : 'tasks';
+        const message = `Redistribute ${count} selected ${noun} from ${String(hour).padStart(2, '0')}:00 UTC, one minute apart?`;
+        if (!window.confirm(message)) {
+          return;
+        }
+        redistributeHourInput.value = String(hour);
+        redistributeForm.submit();
       });
     }
 

--- a/app/templates/admin/scheduled_tasks.html
+++ b/app/templates/admin/scheduled_tasks.html
@@ -57,6 +57,17 @@
       >
         <span>Rename selected</span>
       </button>
+      <button
+        type="button"
+        class="header-menu__item"
+        role="menuitem"
+        id="scheduled-tasks-bulk-redistribute-btn"
+        form="scheduled-tasks-bulk-redistribute-form"
+        data-scheduled-tasks-bulk-action="redistribute"
+        disabled
+      >
+        <span>Redistribute selected</span>
+      </button>
     </div>
   </div>
 {% endblock %}
@@ -102,6 +113,19 @@
       hidden
     >
       {% include "partials/csrf.html" %}
+      {% if show_inactive %}<input type="hidden" name="show_inactive" value="1" />{% endif %}
+    </form>
+
+    {# Hidden bulk-redistribute form #}
+    <form
+      id="scheduled-tasks-bulk-redistribute-form"
+      method="post"
+      action="/admin/scheduled-tasks/bulk-redistribute"
+      data-scheduled-tasks-bulk-form="redistribute"
+      hidden
+    >
+      {% include "partials/csrf.html" %}
+      <input type="hidden" name="redistributeHour" data-scheduled-tasks-redistribute-hour />
       {% if show_inactive %}<input type="hidden" name="show_inactive" value="1" />{% endif %}
     </form>
 

--- a/tests/test_admin_scheduled_tasks_page.py
+++ b/tests/test_admin_scheduled_tasks_page.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
@@ -184,6 +185,8 @@ def test_scheduled_tasks_page_renders_tasks(super_admin_context, monkeypatch):
     assert 'id="scheduled-tasks-bulk-actions-menu"' in header_html
     assert ">Manage Tasks<" not in header_html
     assert 'data-task-create' in header_html
+    assert 'Redistribute selected' in header_html
+    assert 'data-scheduled-tasks-bulk-action="redistribute"' in header_html
 
 
 def test_scheduled_tasks_page_offers_rag_control_commands(super_admin_context, monkeypatch):
@@ -581,6 +584,113 @@ async def test_bulk_rename_no_ids(super_admin_context, csrf_session, monkeypatch
 
     assert response.status_code == 303
     assert "error=" not in response.headers["location"]
+    flash_cookie = response.headers.get("set-cookie", "")
+    assert "_flash=" in flash_cookie
+    assert "error" in flash_cookie
+
+
+def test_bulk_redistribute_scheduled_tasks(super_admin_context, csrf_session, monkeypatch):
+    """Bulk redistribute updates cron minutes one minute apart at the requested hour."""
+    updated: dict[int, str] = {}
+    refreshed = False
+
+    async def fake_get_task(task_id):
+        tasks = {
+            1: {"id": 1, "cron": "15 4 * * *"},
+            2: {"id": 2, "cron": "30 5 * * 1"},
+            3: {"id": 3, "cron": "45 6 * * * extra"},
+        }
+        return tasks.get(task_id)
+
+    async def fake_update_task_cron(task_id, cron):
+        updated[task_id] = cron
+
+    async def fake_refresh():
+        nonlocal refreshed
+        refreshed = True
+
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "get_task", fake_get_task)
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "update_task_cron", fake_update_task_cron)
+    monkeypatch.setattr(main_module.scheduler_service, "refresh", fake_refresh)
+    request = _make_post_request("/admin/scheduled-tasks/bulk-redistribute")
+
+    async def fake_form():
+        return FormData(
+            [
+                ("taskIds", "1"),
+                ("taskIds", "2"),
+                ("taskIds", "3"),
+                ("redistributeHour", "9"),
+                ("_csrf", csrf_session.csrf_token),
+            ]
+        )
+
+    monkeypatch.setattr(request, "form", fake_form)
+
+    response = asyncio.run(main_module.admin_bulk_redistribute_scheduled_tasks(request))
+
+    assert response.status_code == 303
+    assert updated == {
+        1: "0 9 * * *",
+        2: "1 9 * * 1",
+        3: "2 9 * * * extra",
+    }
+    assert refreshed is True
+
+
+def test_bulk_redistribute_scheduled_tasks_rolls_into_later_hours(super_admin_context, csrf_session, monkeypatch):
+    """Bulk redistribute keeps spacing tasks one minute apart beyond the first hour."""
+    updated: dict[int, str] = {}
+    refreshed = False
+
+    async def fake_get_task(task_id):
+        return {"id": task_id, "cron": "15 4 * * *"}
+
+    async def fake_update_task_cron(task_id, cron):
+        updated[task_id] = cron
+
+    async def fake_refresh():
+        nonlocal refreshed
+        refreshed = True
+
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "get_task", fake_get_task)
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "update_task_cron", fake_update_task_cron)
+    monkeypatch.setattr(main_module.scheduler_service, "refresh", fake_refresh)
+    request = _make_post_request("/admin/scheduled-tasks/bulk-redistribute")
+
+    async def fake_form():
+        entries = [("taskIds", str(task_id)) for task_id in range(1, 63)]
+        entries.extend([("redistributeHour", "23"), ("_csrf", csrf_session.csrf_token)])
+        return FormData(entries)
+
+    monkeypatch.setattr(request, "form", fake_form)
+
+    response = asyncio.run(main_module.admin_bulk_redistribute_scheduled_tasks(request))
+
+    assert response.status_code == 303
+    assert len(updated) == 62
+    assert updated[1] == "0 23 * * *"
+    assert updated[60] == "59 23 * * *"
+    assert updated[61] == "0 0 * * *"
+    assert updated[62] == "1 0 * * *"
+    assert refreshed is True
+
+
+def test_bulk_redistribute_rejects_invalid_hour(super_admin_context, csrf_session, monkeypatch):
+    """Bulk redistribute validates the requested hour before updating tasks."""
+    update_mock = AsyncMock()
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "update_task_cron", update_mock)
+    request = _make_post_request("/admin/scheduled-tasks/bulk-redistribute")
+
+    async def fake_form():
+        return FormData([("taskIds", "1"), ("redistributeHour", "24"), ("_csrf", csrf_session.csrf_token)])
+
+    monkeypatch.setattr(request, "form", fake_form)
+
+    response = asyncio.run(main_module.admin_bulk_redistribute_scheduled_tasks(request))
+
+    assert response.status_code == 303
+    update_mock.assert_not_called()
     flash_cookie = response.headers.get("set-cookie", "")
     assert "_flash=" in flash_cookie
     assert "error" in flash_cookie


### PR DESCRIPTION
### Motivation
- Provide an admin action to redistribute selected scheduled tasks so they start at a given UTC hour spaced one minute apart to reduce thundering runs.
- Make the operation available from the scheduled tasks management UI and ensure the scheduler reloads when cron expressions change.

### Description
- Add a POST endpoint `admin_bulk_redistribute_scheduled_tasks` in `app/main.py` that validates selected `taskIds` and `redistributeHour`, computes minute/hour offsets, updates each task cron, and calls `scheduler_service.refresh()` when changes occur.
- Add `update_task_cron(task_id, cron)` to `app/repositories/scheduled_tasks.py` to update only the `cron` column for a task.
- Extend the scheduled tasks UI in `app/templates/admin/scheduled_tasks.html` with a hidden bulk-redistribute form and a new `Redistribute selected` button, and update `app/static/js/scheduled_task_columns.js` to prompt for an hour, mirror selected `taskIds` into the redistribute form, and submit it.
- Add automated tests in `tests/test_admin_scheduled_tasks_page.py` covering successful redistribution, rolling into later hours, and validation of invalid hours, and adjust an existing page rendering test to assert the new UI element.

### Testing
- Ran the scheduled tasks page tests in `tests/test_admin_scheduled_tasks_page.py`, including `test_bulk_redistribute_scheduled_tasks`, `test_bulk_redistribute_scheduled_tasks_rolls_into_later_hours`, and `test_bulk_redistribute_rejects_invalid_hour`, and they passed.
- Existing page rendering and bulk-rename related tests in the same test module were also run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e06273f94833290674459a7401591)