### PR TITLE
Add minute offset to scheduled task redistribution

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5888,6 +5888,14 @@ async def admin_bulk_redistribute_scheduled_tasks(request: Request):
     if hour < 0 or hour > 23:
         return flash_redirect("/admin/scheduled-tasks", "Enter an hour between 0 and 23.", "error")
 
+    try:
+        minute_offset = int(str(form.get("redistributeOffset") or "0").strip())
+    except (TypeError, ValueError):
+        return flash_redirect("/admin/scheduled-tasks", "Enter a starting minute offset between 0 and 59.", "error")
+
+    if minute_offset < 0 or minute_offset > 59:
+        return flash_redirect("/admin/scheduled-tasks", "Enter a starting minute offset between 0 and 59.", "error")
+
     redistributed_count = 0
     for offset, task_id in enumerate(task_ids):
         task = await scheduled_tasks_repo.get_task(task_id)
@@ -5901,8 +5909,9 @@ async def admin_bulk_redistribute_scheduled_tasks(request: Request):
                 cron=task.get("cron"),
             )
             continue
-        scheduled_hour = (hour + (offset // 60)) % 24
-        scheduled_minute = offset % 60
+        total_minutes = minute_offset + offset
+        scheduled_hour = (hour + (total_minutes // 60)) % 24
+        scheduled_minute = total_minutes % 60
         fields[0] = str(scheduled_minute)
         fields[1] = str(scheduled_hour)
         await scheduled_tasks_repo.update_task_cron(task_id, " ".join(fields))
@@ -5915,12 +5924,13 @@ async def admin_bulk_redistribute_scheduled_tasks(request: Request):
         "Scheduled tasks bulk redistributed",
         redistributed_count=redistributed_count,
         redistribute_hour=hour,
+        redistribute_offset=minute_offset,
         redistributed_by=current_user.get("id") if current_user else None,
         task_ids=task_ids,
     )
 
     message_suffix = "task" if redistributed_count == 1 else "tasks"
-    redirect_message = f"Redistributed {redistributed_count} {message_suffix} to run from {hour:02d}:00 UTC."
+    redirect_message = f"Redistributed {redistributed_count} {message_suffix} to run from {hour:02d}:{minute_offset:02d} UTC."
     if redistributed_count < len(task_ids):
         redirect_message = f"{redirect_message} Some selected tasks were not found or had invalid cron expressions."
 

--- a/app/static/js/scheduled_task_columns.js
+++ b/app/static/js/scheduled_task_columns.js
@@ -155,6 +155,7 @@
     const renameForm = document.querySelector('[data-scheduled-tasks-bulk-form="rename"]');
     const redistributeForm = document.querySelector('[data-scheduled-tasks-bulk-form="redistribute"]');
     const redistributeHourInput = document.querySelector('[data-scheduled-tasks-redistribute-hour]');
+    const redistributeOffsetInput = document.querySelector('[data-scheduled-tasks-redistribute-offset]');
     const countLabel = document.getElementById('scheduled-tasks-bulk-count');
 
     const getRowCheckboxes = () =>
@@ -289,8 +290,8 @@
       });
     }
 
-    // Handle redistribute button click — prompt for hour then submit the form
-    if (redistributeBtn && redistributeForm && redistributeHourInput) {
+    // Handle redistribute button click — prompt for hour and offset then submit the form
+    if (redistributeBtn && redistributeForm && redistributeHourInput && redistributeOffsetInput) {
       redistributeBtn.addEventListener('click', () => {
         uncheckHiddenCheckboxes();
         const selected = getVisibleCheckboxes().filter((cb) => cb.checked);
@@ -307,12 +308,22 @@
           window.alert('Enter an hour between 0 and 23.');
           return;
         }
+        const rawOffset = window.prompt('Enter the starting minute offset for the selected tasks (0-59):', '0');
+        if (rawOffset === null) {
+          return;
+        }
+        const offset = Number.parseInt(rawOffset.trim(), 10);
+        if (!Number.isInteger(offset) || offset < 0 || offset > 59) {
+          window.alert('Enter a starting minute offset between 0 and 59.');
+          return;
+        }
         const noun = count === 1 ? 'task' : 'tasks';
-        const message = `Redistribute ${count} selected ${noun} from ${String(hour).padStart(2, '0')}:00 UTC, one minute apart?`;
+        const message = `Redistribute ${count} selected ${noun} from ${String(hour).padStart(2, '0')}:${String(offset).padStart(2, '0')} UTC, one minute apart?`;
         if (!window.confirm(message)) {
           return;
         }
         redistributeHourInput.value = String(hour);
+        redistributeOffsetInput.value = String(offset);
         redistributeForm.submit();
       });
     }

--- a/app/templates/admin/scheduled_tasks.html
+++ b/app/templates/admin/scheduled_tasks.html
@@ -126,6 +126,7 @@
     >
       {% include "partials/csrf.html" %}
       <input type="hidden" name="redistributeHour" data-scheduled-tasks-redistribute-hour />
+      <input type="hidden" name="redistributeOffset" data-scheduled-tasks-redistribute-offset />
       {% if show_inactive %}<input type="hidden" name="show_inactive" value="1" />{% endif %}
     </form>
 

--- a/tests/test_admin_scheduled_tasks_page.py
+++ b/tests/test_admin_scheduled_tasks_page.py
@@ -187,6 +187,7 @@ def test_scheduled_tasks_page_renders_tasks(super_admin_context, monkeypatch):
     assert 'data-task-create' in header_html
     assert 'Redistribute selected' in header_html
     assert 'data-scheduled-tasks-bulk-action="redistribute"' in header_html
+    assert 'data-scheduled-tasks-redistribute-offset' in html
 
 
 def test_scheduled_tasks_page_offers_rag_control_commands(super_admin_context, monkeypatch):
@@ -674,6 +675,78 @@ def test_bulk_redistribute_scheduled_tasks_rolls_into_later_hours(super_admin_co
     assert updated[61] == "0 0 * * *"
     assert updated[62] == "1 0 * * *"
     assert refreshed is True
+
+
+def test_bulk_redistribute_scheduled_tasks_uses_minute_offset(super_admin_context, csrf_session, monkeypatch):
+    """Bulk redistribute starts at the requested minute offset and rolls over hours."""
+    updated: dict[int, str] = {}
+    refreshed = False
+
+    async def fake_get_task(task_id):
+        return {"id": task_id, "cron": "15 4 * * *"}
+
+    async def fake_update_task_cron(task_id, cron):
+        updated[task_id] = cron
+
+    async def fake_refresh():
+        nonlocal refreshed
+        refreshed = True
+
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "get_task", fake_get_task)
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "update_task_cron", fake_update_task_cron)
+    monkeypatch.setattr(main_module.scheduler_service, "refresh", fake_refresh)
+    request = _make_post_request("/admin/scheduled-tasks/bulk-redistribute")
+
+    async def fake_form():
+        return FormData(
+            [
+                ("taskIds", "1"),
+                ("taskIds", "2"),
+                ("taskIds", "3"),
+                ("redistributeHour", "9"),
+                ("redistributeOffset", "58"),
+                ("_csrf", csrf_session.csrf_token),
+            ]
+        )
+
+    monkeypatch.setattr(request, "form", fake_form)
+
+    response = asyncio.run(main_module.admin_bulk_redistribute_scheduled_tasks(request))
+
+    assert response.status_code == 303
+    assert updated == {
+        1: "58 9 * * *",
+        2: "59 9 * * *",
+        3: "0 10 * * *",
+    }
+    assert refreshed is True
+
+
+def test_bulk_redistribute_rejects_invalid_offset(super_admin_context, csrf_session, monkeypatch):
+    """Bulk redistribute validates the requested minute offset before updating tasks."""
+    update_mock = AsyncMock()
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "update_task_cron", update_mock)
+    request = _make_post_request("/admin/scheduled-tasks/bulk-redistribute")
+
+    async def fake_form():
+        return FormData(
+            [
+                ("taskIds", "1"),
+                ("redistributeHour", "9"),
+                ("redistributeOffset", "60"),
+                ("_csrf", csrf_session.csrf_token),
+            ]
+        )
+
+    monkeypatch.setattr(request, "form", fake_form)
+
+    response = asyncio.run(main_module.admin_bulk_redistribute_scheduled_tasks(request))
+
+    assert response.status_code == 303
+    update_mock.assert_not_called()
+    flash_cookie = response.headers.get("set-cookie", "")
+    assert "_flash=" in flash_cookie
+    assert "error" in flash_cookie
 
 
 def test_bulk_redistribute_rejects_invalid_hour(super_admin_context, csrf_session, monkeypatch):


### PR DESCRIPTION
### Motivation
- Allow the scheduled-tasks bulk "Redistribute selected" action to start assigning minutes from an arbitrary starting minute instead of always from 00, so batches can begin at any minute and still space tasks one minute apart.

### Description
- Added a hidden `redistributeOffset` input to the bulk redistribute form so the UI can submit a starting minute offset. (`app/templates/admin/scheduled_tasks.html`)
- Updated the bulk action UI to prompt for a starting minute offset, validate it as `0-59`, include it in the confirmation message, and submit it with the redistribute form. (`app/static/js/scheduled_task_columns.js`)
- Updated the server handler to parse and validate `redistributeOffset` (defaulting to `0`), apply the offset when calculating minutes/hours with rollover, and include the offset in logs and the success flash message. (`app/main.py`)
- Added tests to assert the hidden offset input exists, that redistribution respects the minute offset and rolls into later hours, and that invalid offsets are rejected. (`tests/test_admin_scheduled_tasks_page.py`)

### Testing
- `python -m py_compile app/main.py tests/test_admin_scheduled_tasks_page.py` succeeded with no syntax errors. 
- `node --check app/static/js/scheduled_task_columns.js` succeeded with no JS syntax errors. 
- `python -m pytest tests/test_admin_scheduled_tasks_page.py -q` was attempted but test collection failed due to a missing system dependency required by `python-magic` (`libmagic`), so the new tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e16ff76548332bf725d9e759a9528)