### PR TITLE
Add next run column to scheduled tasks

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -174,6 +174,7 @@ from app.services import audit as audit_service
 from app.services import background as background_tasks
 from app.services import automations as automations_service
 from app.services import change_log as change_log_service
+from app.services import cron_calendar as cron_calendar_service
 from app.services import company_domains
 from app.services import company_access
 from app.services import dashboard as dashboard_service
@@ -5649,6 +5650,10 @@ async def admin_scheduled_tasks(
     for task in tasks:
         serialised_task = _serialise_mapping(task)
         serialised_task["last_run_iso"] = _to_iso(task.get("last_run_at"))
+        next_run = cron_calendar_service.calculate_next_run(
+            task, timezone_name=settings.default_timezone
+        )
+        serialised_task["next_run_iso"] = _to_iso(next_run)
         raw_company_id = task.get("company_id")
         company_key: int | None = None
         if raw_company_id is not None:

--- a/app/services/cron_calendar.py
+++ b/app/services/cron_calendar.py
@@ -24,6 +24,32 @@ def _resolve_timezone(timezone_name: str | None) -> tzinfo:
         return timezone.utc
 
 
+def calculate_next_run(
+    task: dict[str, Any],
+    *,
+    reference: datetime | None = None,
+    timezone_name: str | None = None,
+) -> datetime | None:
+    """Return the next UTC datetime for a cron-based scheduled task.
+
+    Cron expressions are interpreted in the configured scheduler timezone so
+    the admin table mirrors when the background scheduler will fire tasks.
+    Invalid or empty cron expressions return ``None`` instead of raising.
+    """
+
+    cron_expression = str(task.get("cron") or "").strip()
+    if not cron_expression:
+        return None
+
+    schedule_timezone = _resolve_timezone(timezone_name)
+    reference_utc = _as_utc(reference or datetime.now(timezone.utc))
+    try:
+        iterator = croniter(cron_expression, reference_utc.astimezone(schedule_timezone))
+        return _as_utc(iterator.get_next(datetime))
+    except (CroniterBadCronError, ValueError, KeyError):
+        return None
+
+
 def build_calendar_events(
     tasks: list[dict[str, Any]],
     *,

--- a/app/templates/admin/scheduled_tasks.html
+++ b/app/templates/admin/scheduled_tasks.html
@@ -184,6 +184,10 @@
                   <span class="form-checkbox-text">Calendar</span>
                 </label>
                 <label class="form-checkbox-label">
+                  <input type="checkbox" class="scheduled-task-column-toggle" data-column="next-run" checked />
+                  <span class="form-checkbox-text">Next run</span>
+                </label>
+                <label class="form-checkbox-label">
                   <input type="checkbox" class="scheduled-task-column-toggle" data-column="last-run" checked />
                   <span class="form-checkbox-text">Last run</span>
                 </label>
@@ -217,6 +221,7 @@
               <th scope="col" data-sort="string" data-column="cron" data-column-key="schedule">Schedule</th>
               <th scope="col" data-sort="string" data-column="active" data-column-key="active">Active</th>
               <th scope="col" data-sort="string" data-column="calendar" data-column-key="calendar">Calendar</th>
+              <th scope="col" data-sort="date" data-column="next-run" data-column-key="next_run">Next Run</th>
               <th scope="col" data-sort="date" data-column="last-run" data-column-key="last_run">Last run</th>
               <th scope="col" data-sort="string" data-column="status" data-column-key="status">Status</th>
               <th scope="col" class="table__actions" data-column-key="actions">Actions</th>
@@ -257,6 +262,13 @@
                   </td>
                   <td data-label="Calendar" data-column="calendar" data-column-key="calendar">
                     <span class="tag {{ 'tag--muted' if task.exclude_from_calendar else 'tag--success' }}">{{ 'Hidden' if task.exclude_from_calendar else 'Shown' }}</span>
+                  </td>
+                  <td data-label="Next Run" data-column="next-run" data-value="{{ task.next_run_iso or '' }}" data-column-key="next_run">
+                    {% if task.next_run_iso %}
+                      <span data-utc="{{ task.next_run_iso }}"></span>
+                    {% else %}
+                      <span class="text-muted">Invalid schedule</span>
+                    {% endif %}
                   </td>
                   <td data-label="Last run" data-column="last-run" data-value="{{ task.last_run_iso or '' }}" data-column-key="last_run">
                     {% if task.last_run_iso %}
@@ -310,7 +322,7 @@
               {% endfor %}
             {% else %}
               <tr>
-                <td colspan="11" class="table__empty">
+                <td colspan="12" class="table__empty">
                   {% if show_inactive %}
                     No scheduled tasks configured yet.
                   {% else %}

--- a/tests/test_cron_calendar.py
+++ b/tests/test_cron_calendar.py
@@ -10,6 +10,7 @@ cron_calendar = importlib.util.module_from_spec(spec)
 assert spec.loader is not None
 spec.loader.exec_module(cron_calendar)
 build_calendar_events = cron_calendar.build_calendar_events
+calculate_next_run = cron_calendar.calculate_next_run
 
 
 def test_build_calendar_events_expands_cron_in_utc_order():
@@ -87,3 +88,21 @@ def test_build_calendar_events_falls_back_to_utc_for_invalid_timezone():
 
     assert len(events) == 1
     assert events[0]["start"] == "2026-07-07T18:01:00+00:00"
+
+
+def test_calculate_next_run_returns_utc_timestamp_for_configured_timezone():
+    next_run = calculate_next_run(
+        {"cron": "1 18 * * *"},
+        reference=datetime(2026, 7, 7, tzinfo=timezone.utc),
+        timezone_name="Australia/Brisbane",
+    )
+
+    assert next_run is not None
+    assert next_run.isoformat() == "2026-07-07T08:01:00+00:00"
+
+
+def test_calculate_next_run_returns_none_for_invalid_cron():
+    assert calculate_next_run(
+        {"cron": "not a cron"},
+        reference=datetime(2026, 7, 7, tzinfo=timezone.utc),
+    ) is None


### PR DESCRIPTION
### Motivation
- Help admins plan and coordinate automations by showing a sortable, chronological "Next Run" timestamp for each scheduled task. 
- Surface invalid cron expressions in the UI instead of failing, so admins can spot misconfigured schedules.

### Description
- Added `calculate_next_run(task, *, reference=None, timezone_name=None)` to `app/services/cron_calendar.py` to compute the next UTC run time for a task or return `None` for empty/invalid cron expressions. 
- Populated each task with `next_run_iso` in the admin handler at `/admin/scheduled-tasks` using the configured scheduler timezone via `settings.default_timezone`. 
- Updated `app/templates/admin/scheduled_tasks.html` to add a column-toggleable, date-sortable "Next Run" column that emits the ISO timestamp as a `data-value` and displays `Invalid schedule` when `next_run_iso` is missing, and adjusted the table `colspan`. 
- Added unit coverage for `calculate_next_run` in `tests/test_cron_calendar.py` to verify timezone handling and invalid-cron behaviour.

### Testing
- Ran `pytest -q tests/test_cron_calendar.py`, which passed (6 tests). 
- Ran `python -m compileall app/services/cron_calendar.py app/main.py`, which succeeded. 
- Attempted `pytest -q tests/test_admin_scheduled_tasks_page.py::test_scheduled_tasks_page_renders_tasks`, but collection failed due to a missing system library dependency (`libmagic`) causing `ImportError: failed to find libmagic`, so the admin page render test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e17f232408332aea161dbba500cb3)