### PR TITLE
Add sorting to tray devices table

### DIFF
--- a/app/templates/admin/tray/devices.html
+++ b/app/templates/admin/tray/devices.html
@@ -83,26 +83,26 @@
     </header>
     <div class="card__body card__body--table">
       {% if devices %}
-        <table class="data-table">
+        <table class="data-table" data-table data-table-id="tray-devices">
           <thead>
             <tr>
-              <th scope="col">Hostname</th>
-              <th scope="col">Status</th>
-              <th scope="col">OS</th>
-              <th scope="col">Console user</th>
-              <th scope="col">Last seen</th>
-              <th scope="col">Agent</th>
+              <th scope="col" data-sort="string">Hostname</th>
+              <th scope="col" data-sort="string">Status</th>
+              <th scope="col" data-sort="string">OS</th>
+              <th scope="col" data-sort="string">Console user</th>
+              <th scope="col" data-sort="date">Last seen</th>
+              <th scope="col" data-sort="string">Agent</th>
               <th scope="col" class="data-table__col--actions">Actions</th>
             </tr>
           </thead>
           <tbody>
             {% for device in devices %}
               <tr>
-                <td>
+                <td data-value="{{ (device.hostname or device.device_uid or '')|lower }}">
                   <strong>{{ device.hostname or device.device_uid }}</strong>
                   <div class="data-table__sub">{{ device.device_uid }}</div>
                 </td>
-                <td>
+                <td data-value="{{ device.status or '' }}">
                   {% if device.status == 'active' %}
                     <span class="status status--success">Active</span>
                   {% elif device.status == 'pending' %}
@@ -111,16 +111,16 @@
                     <span class="status status--danger">Revoked</span>
                   {% endif %}
                 </td>
-                <td>{{ device.os or '—' }} {{ device.os_version or '' }}</td>
-                <td>{{ device.console_user or '—' }}</td>
-                <td>
+                <td data-value="{{ ((device.os or '') ~ ' ' ~ (device.os_version or ''))|trim|lower }}">{{ device.os or '—' }} {{ device.os_version or '' }}</td>
+                <td data-value="{{ (device.console_user or '')|lower }}">{{ device.console_user or '—' }}</td>
+                <td data-value="{{ device.last_seen_utc or '' }}">
                   {% if device.last_seen_utc %}
                     <span data-utc="{{ device.last_seen_utc }}">{{ device.last_seen_utc }}</span>
                   {% else %}
                     —
                   {% endif %}
                 </td>
-                <td>{{ device.agent_version or '—' }}</td>
+                <td data-value="{{ (device.agent_version or '')|lower }}">{{ device.agent_version or '—' }}</td>
                 <td class="data-table__col--actions">
                   {% if device.status != 'revoked' %}
                     {% if current_user.is_super_admin %}
@@ -161,4 +161,5 @@
   </section>
 </div>
 
+<script src="{{ static_url('/static/js/tables.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Improve usability of the Tray devices admin page by enabling client-side sorting so technicians can quickly order devices by hostname, status, OS, last-seen time, and agent.

### Description
- Enable the shared sortable table behavior by adding `data-table` and a stable table id `tray-devices` to the devices table in `app/templates/admin/tray/devices.html`.
- Mark columns as sortable and set sort types for columns by adding `data-sort="string"` or `data-sort="date"` to the relevant `<th>` elements.
- Add normalized `data-value` attributes for hostname/device UID, status, OS+version, console user, last-seen timestamp, and agent version so the shared `tables.js` sorts consistently.
- Load the shared `tables.js` on the tray devices page by including the script via `static_url('/static/js/tables.js')`.

### Testing
- Ran an automated verification script (`python - <<'PY' ... PY`) to assert the sorting markup and `data-value` attributes are present, which succeeded.
- Ran `git diff --check` to validate the working tree for whitespace/format issues, which succeeded.
- Ran `pytest tests/test_tray_devices_page.py`, which failed during test collection due to a missing system dependency (`libmagic`) required by the test environment, so full test execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e1a400b0c8332ae84a93af06af373)