### PR TITLE
Admin: bulk update outdated tray agents via Tactical RMM

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -787,6 +787,28 @@ app.add_middleware(
 templates = Jinja2Templates(directory=str(templates_config.template_path))
 
 
+def _parse_tray_agent_version(value: str | None) -> tuple[int, int, int]:
+    raw = (value or "").strip()
+    if not raw:
+        return (0, 0, 0)
+    if raw.startswith(("v", "V")):
+        raw = raw[1:]
+    numeric = re.split(r"[-+]", raw, maxsplit=1)[0]
+    parts = [part.strip() for part in numeric.split(".") if part.strip()]
+    nums: list[int] = []
+    for part in parts[:3]:
+        nums.append(int(part) if part.isdigit() else 0)
+    while len(nums) < 3:
+        nums.append(0)
+    return nums[0], nums[1], nums[2]
+
+
+def _is_tray_agent_outdated(agent_version: str | None, latest_version: str | None) -> bool:
+    if not (latest_version or "").strip():
+        return False
+    return _parse_tray_agent_version(agent_version) < _parse_tray_agent_version(latest_version)
+
+
 def _static_url(path: str) -> str:
     """Generate cache-busted URL for static files.
     
@@ -5980,12 +6002,21 @@ async def admin_tray_devices_page(
     if current_user.get("is_super_admin"):
         trmm_scripts, trmm_scripts_error = await _get_tray_trmm_scripts_for_form()
         selected_update_script_id = await site_settings_repo.get_tray_update_trmm_script_id()
+    tray_release = tray_installer_service.get_cached_latest_release_info()
+    latest_tray_version = tray_release.get("version") if isinstance(tray_release, dict) else None
+    outdated_device_count = sum(
+        1
+        for device in devices
+        if device.get("status") != "revoked"
+        and _is_tray_agent_outdated(device.get("agent_version"), latest_tray_version)
+    )
     extra = {
         "title": "Tray devices",
         "devices": devices,
         "filters": {"search": search or "", "status": status or ""},
         "matrix_enabled": settings.matrix_enabled,
-        "tray_release": tray_installer_service.get_cached_latest_release_info(),
+        "tray_release": tray_release,
+        "outdated_device_count": outdated_device_count,
         "trmm_scripts": trmm_scripts,
         "trmm_scripts_error": trmm_scripts_error,
         "selected_update_script_id": selected_update_script_id,
@@ -6095,6 +6126,91 @@ async def admin_tray_update_device(device_id: int, request: Request):
         "Tactical RMM update script started for the tray device.",
         "success",
     )
+
+
+@app.post("/admin/tray/devices/bulk-update-outdated", response_class=HTMLResponse)
+async def admin_tray_bulk_update_outdated_devices(request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+    from app.repositories import assets as assets_repo
+    from app.repositories import tray as tray_repo
+    from app.services import tacticalrmm as tacticalrmm_service
+    from app.services import tray_installer as tray_installer_service
+
+    script_id = await site_settings_repo.get_tray_update_trmm_script_id()
+    if not script_id:
+        return flash_redirect(
+            "/admin/tray/devices",
+            "Select a Tactical RMM script before running tray updates.",
+            "error",
+        )
+
+    tray_release = tray_installer_service.get_cached_latest_release_info()
+    latest_tray_version = tray_release.get("version") if isinstance(tray_release, dict) else None
+    if not latest_tray_version:
+        return flash_redirect(
+            "/admin/tray/devices",
+            "The latest tray app release is not loaded, so outdated devices cannot be determined.",
+            "error",
+        )
+
+    devices = await tray_repo.list_devices(status="active")
+    outdated_devices = [
+        device
+        for device in devices
+        if _is_tray_agent_outdated(device.get("agent_version"), latest_tray_version)
+    ]
+    if not outdated_devices:
+        return flash_redirect(
+            "/admin/tray/devices",
+            "No active tray devices are outdated.",
+            "info",
+        )
+
+    started_count = 0
+    skipped_count = 0
+    failed_count = 0
+    for device in outdated_devices:
+        asset_id = device.get("asset_id")
+        if not asset_id:
+            skipped_count += 1
+            continue
+        asset = await assets_repo.get_asset_by_id(int(asset_id))
+        tactical_agent_id = str((asset or {}).get("tactical_asset_id") or "").strip()
+        if not tactical_agent_id:
+            skipped_count += 1
+            continue
+        payload = {
+            "type": "tacticalrmm_script",
+            "purpose": "tray_update",
+            "script_id": script_id,
+            "tactical_agent_id": tactical_agent_id,
+            "latest_tray_version": latest_tray_version,
+            "current_agent_version": device.get("agent_version"),
+        }
+        command_id = await tray_repo.log_command(
+            device_id=int(device["id"]),
+            command="trmm_update_script",
+            payload_json=json.dumps(payload),
+            initiated_by_user_id=current_user.get("id") if current_user else None,
+            status="queued",
+        )
+        try:
+            result = await tacticalrmm_service.run_script_on_agent(tactical_agent_id, script_id)
+        except Exception as exc:  # pragma: no cover - external integration availability
+            failed_count += 1
+            await tray_repo.mark_command_delivered(command_id, error=str(exc))
+            continue
+        payload["tactical_rmm_response"] = result.get("response")
+        await tray_repo.mark_command_delivered(command_id)
+        started_count += 1
+
+    message = f"Started Tactical RMM update script for {started_count} outdated tray device(s)."
+    if skipped_count or failed_count:
+        message += f" Skipped {skipped_count}; failed {failed_count}."
+    category = "success" if started_count else "warning"
+    return flash_redirect("/admin/tray/devices", message, category)
 
 
 @app.post("/admin/tray/devices/{device_id}/revoke", response_class=HTMLResponse)

--- a/app/templates/admin/tray/devices.html
+++ b/app/templates/admin/tray/devices.html
@@ -40,6 +40,22 @@
             <button type="submit" class="button button--primary">Save update script</button>
           </div>
         </form>
+        <form method="post" action="/admin/tray/devices/bulk-update-outdated" class="form-stack">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+          <div class="form-field form-field--actions">
+            <button
+              type="submit"
+              class="button button--primary"
+              {% if not selected_update_script_id or not outdated_device_count %}disabled{% endif %}
+              data-confirm="Run the selected Tactical RMM update script on all active tray devices with an older agent version than the server tray app release?"
+            >
+              Update all outdated agents
+            </button>
+            <span class="form-help">
+              {{ outdated_device_count }} active tray {{ 'device is' if outdated_device_count == 1 else 'devices are' }} older than {{ tray_release.version or 'the loaded release' }}.
+            </span>
+          </div>
+        </form>
       {% endif %}
       <div class="info-grid info-grid--compact" aria-label="Tray release loaded on this server">
         <div class="info-grid__item">

--- a/tests/test_tray_devices_page.py
+++ b/tests/test_tray_devices_page.py
@@ -348,3 +348,90 @@ async def test_issue_chat_token_rejects_closed_explicit_room(monkeypatch):
     assert exc.value.status_code == 409
     assert exc.value.detail == "Chat room is closed"
     create_token_mock.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_tray_bulk_update_outdated_devices_runs_for_outdated_linked_assets(monkeypatch):
+    import app.repositories.assets as assets_repo
+    import app.repositories.tray as tray_repo
+    from app.services import tacticalrmm as tacticalrmm_service
+    from app.services import tray_installer as tray_installer_service
+
+    monkeypatch.setattr(
+        main, "_require_super_admin_page", AsyncMock(return_value=({"id": 1}, None))
+    )
+    monkeypatch.setattr(
+        main.site_settings_repo,
+        "get_tray_update_trmm_script_id",
+        AsyncMock(return_value=99),
+    )
+    monkeypatch.setattr(
+        tray_installer_service,
+        "get_cached_latest_release_info",
+        lambda: {"version": "2.0.0"},
+    )
+    monkeypatch.setattr(
+        tray_repo,
+        "list_devices",
+        AsyncMock(
+            return_value=[
+                {"id": 1, "status": "active", "agent_version": "1.0.0", "asset_id": 10},
+                {"id": 2, "status": "active", "agent_version": "2.0.0", "asset_id": 20},
+                {"id": 3, "status": "active", "agent_version": None, "asset_id": 30},
+            ]
+        ),
+    )
+
+    async def fake_get_asset_by_id(asset_id: int):
+        return {"id": asset_id, "tactical_asset_id": f"agent-{asset_id}"}
+
+    monkeypatch.setattr(assets_repo, "get_asset_by_id", fake_get_asset_by_id)
+    log_mock = AsyncMock(side_effect=[101, 102])
+    monkeypatch.setattr(tray_repo, "log_command", log_mock)
+    mark_mock = AsyncMock()
+    monkeypatch.setattr(tray_repo, "mark_command_delivered", mark_mock)
+    run_mock = AsyncMock(return_value={"response": {"ok": True}})
+    monkeypatch.setattr(tacticalrmm_service, "run_script_on_agent", run_mock)
+
+    response = await main.admin_tray_bulk_update_outdated_devices(
+        _make_request("/admin/tray/devices/bulk-update-outdated")
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/admin/tray/devices"
+    tray_repo.list_devices.assert_awaited_once_with(status="active")
+    assert run_mock.await_count == 2
+    run_mock.assert_any_await("agent-10", 99)
+    run_mock.assert_any_await("agent-30", 99)
+    assert log_mock.await_count == 2
+    assert mark_mock.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_tray_bulk_update_outdated_devices_requires_loaded_release(monkeypatch):
+    import app.repositories.tray as tray_repo
+    from app.services import tray_installer as tray_installer_service
+
+    monkeypatch.setattr(
+        main, "_require_super_admin_page", AsyncMock(return_value=({"id": 1}, None))
+    )
+    monkeypatch.setattr(
+        main.site_settings_repo,
+        "get_tray_update_trmm_script_id",
+        AsyncMock(return_value=99),
+    )
+    monkeypatch.setattr(
+        tray_installer_service,
+        "get_cached_latest_release_info",
+        lambda: {"version": None},
+    )
+    list_mock = AsyncMock(return_value=[])
+    monkeypatch.setattr(tray_repo, "list_devices", list_mock)
+
+    response = await main.admin_tray_bulk_update_outdated_devices(
+        _make_request("/admin/tray/devices/bulk-update-outdated")
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/admin/tray/devices"
+    list_mock.assert_not_called()


### PR DESCRIPTION
### Motivation
- Allow administrators to schedule the configured Tactical RMM update script against all enrolled tray devices that are running an older tray agent version, removing the need to trigger updates per-device. 
- Provide safe guardrails so bulk updates only run when a Tactical RMM script is selected and the server tray release is loaded.

### Description
- Add server-side tray agent version parsing and comparison helpers (`_parse_tray_agent_version`, `_is_tray_agent_outdated`) in `app/main.py` to detect devices with older agent versions. 
- Compute and expose `outdated_device_count` on the `/admin/tray/devices` page for active, non-revoked devices compared to the loaded tray release. 
- Add a new super-admin endpoint `POST /admin/tray/devices/bulk-update-outdated` that validates a saved Tactical RMM script and loaded release, filters active outdated devices, skips devices missing linked Tactical agent IDs, logs commands via `tray_repo.log_command`, and invokes `tacticalrmm_service.run_script_on_agent` for each eligible device. 
- Add an admin UI action (button) to `app/templates/admin/tray/devices.html` to trigger the bulk update, disabled until a script is selected and at least one outdated device exists. 
- Add tests in `tests/test_tray_devices_page.py` covering successful scheduling for outdated linked assets and the guardrail when the release is not loaded.

### Testing
- Ran `python -m py_compile app/main.py`, which succeeded. 
- Ran the new unit tests with `pytest -q tests/test_tray_devices_page.py::test_tray_bulk_update_outdated_devices_runs_for_outdated_linked_assets tests/test_tray_devices_page.py::test_tray_bulk_update_outdated_devices_requires_loaded_release`, which passed. 
- Running the entire `tests/test_tray_devices_page.py` surfaced an unrelated pre-existing failure in `test_tray_chat_popup_reuses_existing_open_room_from_unbound_token` due to `RuntimeError: Database pool not initialised`, so the full file run is not green (failure is unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e1c031f088332b933c36dbaba3000)