### PR TITLE
Queue Tactical RMM updates for all non-revoked outdated tray devices

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6155,16 +6155,17 @@ async def admin_tray_bulk_update_outdated_devices(request: Request):
             "error",
         )
 
-    devices = await tray_repo.list_devices(status="active")
+    devices = await tray_repo.list_devices()
     outdated_devices = [
         device
         for device in devices
-        if _is_tray_agent_outdated(device.get("agent_version"), latest_tray_version)
+        if device.get("status") != "revoked"
+        and _is_tray_agent_outdated(device.get("agent_version"), latest_tray_version)
     ]
     if not outdated_devices:
         return flash_redirect(
             "/admin/tray/devices",
-            "No active tray devices are outdated.",
+            "No linked tray devices are outdated.",
             "info",
         )
 
@@ -6206,7 +6207,7 @@ async def admin_tray_bulk_update_outdated_devices(request: Request):
         await tray_repo.mark_command_delivered(command_id)
         started_count += 1
 
-    message = f"Started Tactical RMM update script for {started_count} outdated tray device(s)."
+    message = f"Queued Tactical RMM update script for {started_count} outdated tray device(s)."
     if skipped_count or failed_count:
         message += f" Skipped {skipped_count}; failed {failed_count}."
     category = "success" if started_count else "warning"

--- a/app/templates/admin/tray/devices.html
+++ b/app/templates/admin/tray/devices.html
@@ -47,12 +47,12 @@
               type="submit"
               class="button button--primary"
               {% if not selected_update_script_id or not outdated_device_count %}disabled{% endif %}
-              data-confirm="Run the selected Tactical RMM update script on all active tray devices with an older agent version than the server tray app release?"
+              data-confirm="Queue the selected Tactical RMM update script for all non-revoked tray devices with an older agent version than the server tray app release?"
             >
               Update all outdated agents
             </button>
             <span class="form-help">
-              {{ outdated_device_count }} active tray {{ 'device is' if outdated_device_count == 1 else 'devices are' }} older than {{ tray_release.version or 'the loaded release' }}.
+              {{ outdated_device_count }} linked tray {{ 'device is' if outdated_device_count == 1 else 'devices are' }} older than {{ tray_release.version or 'the loaded release' }}.
             </span>
           </div>
         </form>

--- a/tests/test_tray_devices_page.py
+++ b/tests/test_tray_devices_page.py
@@ -351,7 +351,7 @@ async def test_issue_chat_token_rejects_closed_explicit_room(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_tray_bulk_update_outdated_devices_runs_for_outdated_linked_assets(monkeypatch):
+async def test_tray_bulk_update_outdated_devices_runs_for_outdated_linked_assets_regardless_of_active_status(monkeypatch):
     import app.repositories.assets as assets_repo
     import app.repositories.tray as tray_repo
     from app.services import tacticalrmm as tacticalrmm_service
@@ -377,7 +377,8 @@ async def test_tray_bulk_update_outdated_devices_runs_for_outdated_linked_assets
             return_value=[
                 {"id": 1, "status": "active", "agent_version": "1.0.0", "asset_id": 10},
                 {"id": 2, "status": "active", "agent_version": "2.0.0", "asset_id": 20},
-                {"id": 3, "status": "active", "agent_version": None, "asset_id": 30},
+                {"id": 3, "status": "offline", "agent_version": None, "asset_id": 30},
+                {"id": 4, "status": "revoked", "agent_version": "1.0.0", "asset_id": 40},
             ]
         ),
     )
@@ -399,7 +400,7 @@ async def test_tray_bulk_update_outdated_devices_runs_for_outdated_linked_assets
 
     assert response.status_code == 303
     assert response.headers["location"] == "/admin/tray/devices"
-    tray_repo.list_devices.assert_awaited_once_with(status="active")
+    tray_repo.list_devices.assert_awaited_once_with()
     assert run_mock.await_count == 2
     run_mock.assert_any_await("agent-10", 99)
     run_mock.assert_any_await("agent-30", 99)


### PR DESCRIPTION
### Motivation
- Outdated agent updates were only targeting devices with `status == "active"`, causing non-active but linked devices to be ignored while still queuing nothing for revoked devices.
- The intent is to queue Tactical RMM update tasks for any linked tray device that is outdated except revoked devices, matching operator expectations for RMM-driven updates.

### Description
- Removed the `status="active"` filter when loading tray devices and instead filter out `status == "revoked"` in `admin_tray_bulk_update_outdated_devices` in `app/main.py`.
- Changed the user-facing messaging to reflect that updates are being queued rather than started and refer to "linked"/"non-revoked" devices in `app/main.py` and `app/templates/admin/tray/devices.html`.
- Updated the admin UI confirmation/help text to match the new behavior in `app/templates/admin/tray/devices.html`.
- Updated the tray device page test in `tests/test_tray_devices_page.py` to include offline/non-active devices and ensure revoked devices are skipped, and to assert `tray_repo.list_devices.assert_awaited_once_with()`.

### Testing
- `python3 -m py_compile app/main.py` succeeded to validate syntax.
- Attempted `pytest tests/test_tray_devices_page.py -q`, but test collection failed due to a missing system dependency required by `python-magic` (`libmagic`), blocking full test run (error during collection: `ImportError: failed to find libmagic`).
- The modified unit test was run locally in the test invocation attempt and expects the code to call `tray_repo.list_devices()` (no `status` param) and to queue two updates for the provided fixtures, but results could not be verified end-to-end due to the environment dependency failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e2b61a5108332ac6ba1aaa7308a70)