### PR TITLE
Fix email ticket requester resolution

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -438,12 +438,16 @@ def _extract_record_id(record: Any) -> int | None:
     return _int_or_none(getattr(record, "id", None))
 
 
+def _normalise_email_address(email_address: str | None) -> str:
+    return (email_address or "").strip().lower()
+
+
 def _extract_email_addresses(from_header: str | None) -> list[str]:
     if not from_header:
         return []
     addresses = []
     for _name, email_address in getaddresses([from_header]):
-        candidate = (email_address or "").strip()
+        candidate = _normalise_email_address(email_address)
         if candidate:
             addresses.append(candidate)
     return addresses
@@ -532,6 +536,20 @@ async def _resolve_ticket_entities(
     default_company_id: int | None = None,
 ) -> tuple[int | None, int | None]:
     email_addresses = _extract_email_addresses(from_header)
+
+    checked_users: set[str] = set()
+    for email_address in email_addresses:
+        if email_address in checked_users:
+            continue
+        checked_users.add(email_address)
+        user = await users_repo.get_user_by_email(email_address)
+        requester_id = _extract_record_id(user)
+        if requester_id is not None:
+            user_company_id = _int_or_none(
+                user.get("company_id") if isinstance(user, Mapping) else None
+            )
+            return user_company_id or _int_or_none(default_company_id), requester_id
+
     seen_domains: set[str] = set()
 
     for email_address in email_addresses:
@@ -1635,6 +1653,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                         category="email",
                         module_slug="imap",
                         external_reference=message_id,
+                        initial_reply_author_id=requester_id,
                         requester_email=from_email_addr if requester_id is None else None,
                     )
                     is_new_ticket = True

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -1410,6 +1410,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                             category="email",
                             module_slug=_MODULE_SLUG,
                             external_reference=internet_msg_id,
+                            initial_reply_author_id=requester_id,
                             requester_email=(
                                 from_email_addr if requester_id is None else None
                             ),

--- a/tests/test_imap_service.py
+++ b/tests/test_imap_service.py
@@ -24,6 +24,12 @@ def test_extract_body_prefers_html_over_plain_text():
     assert "Plain text body" not in body
 
 
+def test_extract_email_addresses_normalises_case():
+    assert imap._extract_email_addresses("Sender <Sender@Example.COM>") == [
+        "sender@example.com"
+    ]
+
+
 def test_extract_body_inlines_cid_images():
     root = MIMEMultipart("related")
     alternative = MIMEMultipart("alternative")
@@ -408,6 +414,8 @@ async def test_sync_account_imports_email_successfully(monkeypatch):
         return None
 
     async def fake_get_user_by_email(email: str):
+        if email == "sender@example.com":
+            return {"id": 42, "company_id": 24}
         return None
 
     class SuccessMailbox:
@@ -429,7 +437,7 @@ async def test_sync_account_imports_email_successfully(monkeypatch):
                 return "OK", [b"10"]
             if command == "fetch":
                 raw_message = (
-                    b"From: Sender <sender@example.com>\r\n"
+                    b"From: Sender <Sender@Example.com>\r\n"
                     b"Subject: Help me with this\r\n"
                     b"Message-ID: <msg-10@example.com>\r\n"
                     b"\r\n"
@@ -469,6 +477,10 @@ async def test_sync_account_imports_email_successfully(monkeypatch):
     assert created_tickets, "Expected a ticket to be created"
     assert created_tickets[0]["subject"] == "Help me with this"
     assert created_tickets[0]["module_slug"] == "imap"
+    assert created_tickets[0]["requester_id"] == 42
+    assert created_tickets[0]["company_id"] == 24
+    assert created_tickets[0]["initial_reply_author_id"] == 42
+    assert created_tickets[0]["requester_email"] is None
 
     assert recorded_messages, "Expected message to be recorded"
     assert recorded_messages[-1]["status"] == "imported"


### PR DESCRIPTION
### Motivation
- Incoming mail was not reliably setting the ticket `requester` when the sender matched an existing portal user, in part due to case differences in header addresses.
- New tickets created from IMAP and M365 mail needed the initial email reply author set to the resolved requester so automations and audit events use the correct actor.

### Description
- Normalize sender addresses by adding `_normalise_email_address` and using it in `_extract_email_addresses` so addresses are compared case-insensitively (`app/services/imap.py`).
- Resolve existing portal users before falling back to company-domain and staff matching inside `_resolve_ticket_entities` so the sender is used as `requester` when present (`app/services/imap.py`).
- Pass `initial_reply_author_id=requester_id` into `tickets_service.create_ticket` for both IMAP and Microsoft 365 mailbox flows so the created ticket’s initial reply is authored by the resolved requester (`app/services/imap.py`, `app/services/m365_mail.py`).
- Add/adjust IMAP regression coverage for mixed-case sender headers and asserts for `requester_id`, `company_id`, `initial_reply_author_id`, and `requester_email` in `tests/test_imap_service.py`.

### Testing
- Verified Python syntax/compilation with `python -m py_compile` for the modified modules and tests, and it succeeded.
- Ran `git diff --check` style checks on the change and there were no whitespace/diff issues.
- Attempted to run `pytest -q tests/test_imap_service.py` but the environment prevented full test execution due to missing native/system dependencies (`libmagic`) and missing venv package `aiosqlite` which blocked test collection; therefore the full test run could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e4ba28404832d9ec8c3b7c5a4987f)