### PR TITLE
Restore ticket dashboard attached columns

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -327,6 +327,38 @@ async def get_ticket_dashboard(
         include_reference_data=False,
     )
     rows: list[TicketDashboardRow] = []
+    ticket_ids: list[int] = []
+    for ticket in state.tickets:
+        identifier = ticket.get("id")
+        try:
+            numeric_id = int(identifier)
+        except (TypeError, ValueError):
+            continue
+        ticket_ids.append(numeric_id)
+
+    automation_lookup = await tickets_repo.get_automation_filter_context_by_ticket_ids(ticket_ids) if ticket_ids else {}
+    dashboard_now = datetime.now(timezone.utc)
+
+    def _display_name(record: dict | None) -> str | None:
+        if not isinstance(record, dict):
+            return None
+        name = " ".join(
+            part
+            for part in (
+                str(record.get("first_name") or "").strip(),
+                str(record.get("last_name") or "").strip(),
+            )
+            if part
+        )
+        return name or str(record.get("email") or "").strip() or None
+
+    def _age_hours(value: datetime | None) -> int | None:
+        if not isinstance(value, datetime):
+            return None
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return int((dashboard_now - value.astimezone(timezone.utc)).total_seconds() // 3600)
+
     for ticket in state.tickets:
         identifier = ticket.get("id")
         try:
@@ -335,6 +367,19 @@ async def get_ticket_dashboard(
             continue
         company_record = state.company_lookup.get(ticket.get("company_id"))
         assigned_record = state.user_lookup.get(ticket.get("assigned_user_id"))
+        requester_record = state.user_lookup.get(ticket.get("requester_id"))
+        automation_data = automation_lookup.get(numeric_id, {})
+        created_at = ticket.get("created_at")
+        updated_at = ticket.get("updated_at")
+        status_changed_at = ticket.get("status_changed_at") or created_at
+        latest_reply_at = automation_data.get("latest_reply_at")
+        requester_label = (
+            ticket.get("requester_label")
+            or _display_name(requester_record)
+            or ticket.get("requester_email")
+        )
+        assigned_display_name = _display_name(assigned_record)
+        ai_tags = ticket.get("ai_tags") if isinstance(ticket.get("ai_tags"), list) else []
         rows.append(
             TicketDashboardRow(
                 id=numeric_id,
@@ -347,10 +392,38 @@ async def get_ticket_dashboard(
                 assigned_user_email=(assigned_record or {}).get("email")
                 if isinstance(assigned_record, dict)
                 else None,
+                assigned_user_display_name=assigned_display_name,
                 module_slug=ticket.get("module_slug"),
                 requester_id=ticket.get("requester_id"),
-                updated_at=ticket.get("updated_at"),
+                requester_email=ticket.get("requester_email")
+                or ((requester_record or {}).get("email") if isinstance(requester_record, dict) else None),
+                requester_label=requester_label,
+                requester_display_name=ticket.get("requester_display_name") or requester_label,
+                category=ticket.get("category"),
+                external_reference=ticket.get("external_reference"),
+                created_at=created_at,
+                updated_at=updated_at,
+                closed_at=ticket.get("closed_at"),
                 status_changed_at=ticket.get("status_changed_at"),
+                ai_resolution_state=ticket.get("ai_resolution_state"),
+                ai_tags=ai_tags,
+                billable_minutes=int(automation_data.get("billable_minutes") or 0),
+                non_billable_minutes=int(automation_data.get("non_billable_minutes") or 0),
+                has_attachments=bool(automation_data.get("has_attachments")),
+                attachment_count=int(automation_data.get("attachment_count") or 0),
+                has_tasks=bool(automation_data.get("has_tasks")),
+                task_count=int(automation_data.get("task_count") or 0),
+                has_open_tasks=bool(automation_data.get("has_open_tasks")),
+                open_task_count=int(automation_data.get("open_task_count") or 0),
+                labels=ai_tags,
+                age_days=(_age_hours(created_at) // 24) if _age_hours(created_at) is not None else None,
+                updated_age_hours=_age_hours(updated_at),
+                in_status_age_hours=_age_hours(status_changed_at),
+                last_reply_age_hours=_age_hours(latest_reply_at),
+                latest_reply_is_internal=automation_data.get("latest_reply_is_internal")
+                if automation_data.get("latest_reply_id")
+                else None,
+                latest_reply_kind=automation_data.get("latest_reply_kind"),
             )
         )
     filters = TicketSearchFilters(

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -141,10 +141,35 @@ class TicketDashboardRow(BaseModel):
     company_name: Optional[str] = None
     assigned_user_id: Optional[int] = None
     assigned_user_email: Optional[str] = None
+    assigned_user_display_name: Optional[str] = None
     module_slug: Optional[str] = None
     requester_id: Optional[int] = None
+    requester_email: Optional[str] = None
+    requester_label: Optional[str] = None
+    requester_display_name: Optional[str] = None
+    category: Optional[str] = None
+    external_reference: Optional[str] = None
+    created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+    closed_at: Optional[datetime] = None
     status_changed_at: Optional[datetime] = None
+    ai_resolution_state: Optional[str] = None
+    ai_tags: list[str] = Field(default_factory=list)
+    billable_minutes: int = 0
+    non_billable_minutes: int = 0
+    has_attachments: bool = False
+    attachment_count: int = 0
+    has_tasks: bool = False
+    task_count: int = 0
+    has_open_tasks: bool = False
+    open_task_count: int = 0
+    labels: list[str] = Field(default_factory=list)
+    age_days: Optional[int] = None
+    updated_age_hours: Optional[int] = None
+    in_status_age_hours: Optional[int] = None
+    last_reply_age_hours: Optional[int] = None
+    latest_reply_is_internal: Optional[bool] = None
+    latest_reply_kind: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/tests/test_tickets_dashboard_api.py
+++ b/tests/test_tickets_dashboard_api.py
@@ -11,6 +11,7 @@ from app.main import app
 from app.main import automations_service, change_log_service, modules_service, scheduler_service
 from app.core.database import db
 from app.services import tickets as tickets_service
+from app.repositories import tickets as tickets_repo
 from app.security.session import SessionData, session_manager
 
 
@@ -64,7 +65,11 @@ def test_ticket_dashboard_endpoint(monkeypatch):
                 "assigned_user_id": 22,
                 "module_slug": None,
                 "requester_id": 12,
+                "requester_email": "requester@example.com",
+                "requester_label": "Riley Requester",
+                "created_at": datetime(2024, 4, 30, 9, 30, tzinfo=timezone.utc),
                 "updated_at": datetime(2024, 5, 1, 9, 30, tzinfo=timezone.utc),
+                "ai_tags": ["printer"],
             }
         ],
         total=1,
@@ -81,11 +86,30 @@ def test_ticket_dashboard_endpoint(monkeypatch):
         companies=[{"id": 301, "name": "Acme Corp"}],
         technicians=[{"id": 22, "email": "tech@example.com"}],
         company_lookup={301: {"id": 301, "name": "Acme Corp"}},
-        user_lookup={22: {"id": 22, "email": "tech@example.com"}},
+        user_lookup={22: {"id": 22, "email": "tech@example.com", "first_name": "Taylor", "last_name": "Tech"}},
     )
 
     load_state_mock = AsyncMock(return_value=sample_state)
+    automation_context_mock = AsyncMock(
+        return_value={
+            41: {
+                "billable_minutes": 15,
+                "non_billable_minutes": 5,
+                "attachment_count": 2,
+                "has_attachments": True,
+                "task_count": 3,
+                "has_tasks": True,
+                "open_task_count": 1,
+                "has_open_tasks": True,
+                "latest_reply_id": 99,
+                "latest_reply_at": datetime(2024, 5, 1, 10, 30, tzinfo=timezone.utc),
+                "latest_reply_is_internal": False,
+                "latest_reply_kind": "message",
+            }
+        }
+    )
     monkeypatch.setattr(tickets_service, "load_dashboard_state", load_state_mock)
+    monkeypatch.setattr(tickets_repo, "get_automation_filter_context_by_ticket_ids", automation_context_mock)
 
     app.dependency_overrides[require_helpdesk_technician] = lambda: {"id": 1, "is_super_admin": True}
     try:
@@ -101,11 +125,26 @@ def test_ticket_dashboard_endpoint(monkeypatch):
     assert payload["filters"]["module_slug"] == "ops"
     assert payload["items"][0]["company_name"] == "Acme Corp"
     assert payload["items"][0]["assigned_user_email"] == "tech@example.com"
+    assert payload["items"][0]["assigned_user_display_name"] == "Taylor Tech"
+    assert payload["items"][0]["requester_email"] == "requester@example.com"
+    assert payload["items"][0]["requester_display_name"] == "Riley Requester"
+    assert payload["items"][0]["billable_minutes"] == 15
+    assert payload["items"][0]["non_billable_minutes"] == 5
+    assert payload["items"][0]["has_attachments"] is True
+    assert payload["items"][0]["attachment_count"] == 2
+    assert payload["items"][0]["has_tasks"] is True
+    assert payload["items"][0]["task_count"] == 3
+    assert payload["items"][0]["has_open_tasks"] is True
+    assert payload["items"][0]["open_task_count"] == 1
+    assert payload["items"][0]["labels"] == ["printer"]
+    assert payload["items"][0]["latest_reply_is_internal"] is False
+    assert payload["items"][0]["latest_reply_kind"] == "message"
 
     load_state_mock.assert_awaited_once()
     kwargs = load_state_mock.await_args.kwargs
     assert kwargs["status_filter"] == ["open"]
     assert kwargs["module_filter"] == "ops"
+    automation_context_mock.assert_awaited_once_with([41])
 
 
 def test_list_ticket_statuses_endpoint(monkeypatch):


### PR DESCRIPTION
### Motivation
- Server-side filtering/autoload for the tickets table stopped populating the client-side attached columns (requester, attachments, tasks, labels, ages, latest-reply data), causing blank or default values after refresh.
- The dashboard endpoint needs to return the same aggregate automation/context values used by the server-rendered table so the client-side table can show attached columns when filters are applied server-side.

### Description
- Expand the `TicketDashboardRow` schema to include requester and assignee display fields, attachment/task aggregates, AI labels, age/updated/last-reply metrics, and related metadata used by the tickets table. (`app/schemas/tickets.py`)
- Update `/api/tickets/dashboard` to collect ticket IDs, call `tickets_repo.get_automation_filter_context_by_ticket_ids(...)`, compute display names and age calculations, and populate the enriched fields on each returned dashboard row. (`app/api/routes/tickets.py`)
- Populate requester/assignee emails and display names, AI tags/labels, billable/non-billable minutes, attachment/task counts and flags, latest-reply metadata, and created/closed/updated timestamps in the dashboard rows so attached columns are preserved after server-side filtering. (`app/api/routes/tickets.py`)
- Add/adjust test coverage to assert the new dashboard payload fields and to mock the automation context lookup used to hydrate the rows. (`tests/test_tickets_dashboard_api.py`)

### Testing
- Ran `python3 -m py_compile app/api/routes/tickets.py app/schemas/tickets.py tests/test_tickets_dashboard_api.py` which succeeded. 
- Ran `python3 -m pytest tests/test_tickets_dashboard_api.py::test_ticket_dashboard_endpoint -q` which passed and validated the new dashboard fields. 
- Ran `python3 -m pytest tests/test_tickets_dashboard_api.py -q` which exercised the updated tests but produced 2 failures in unrelated, preexisting assertions (`test_replace_ticket_statuses_endpoint_handles_errors` and `test_build_ticket_status_payloads_marks_new_default`), while the new dashboard assertions passed; these failures appear outside the scope of the dashboard changes and will need separate investigation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e4c19512c832db4b8e13189613a84)