### PR TITLE
Support watcher email list variables

### DIFF
--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -198,6 +198,24 @@ def _normalise_actions(actions: Any) -> list[dict[str, Any]]:
     return normalised
 
 
+def _project_sequence_field(value: Sequence[Any], field: str) -> str | None:
+    projected: list[str] = []
+    for item in value:
+        item_value: Any = None
+        if isinstance(item, Mapping):
+            item_value = item.get(field)
+        elif not isinstance(item, (str, bytes, bytearray)):
+            item_value = getattr(item, field, None)
+        if item_value is None:
+            continue
+        rendered = str(item_value).strip()
+        if rendered:
+            projected.append(rendered)
+    if not projected:
+        return None
+    return ", ".join(projected)
+
+
 def _resolve_context_value(context: Mapping[str, Any] | None, path: str) -> Any:
     if not context or not path:
         return None
@@ -209,7 +227,10 @@ def _resolve_context_value(context: Mapping[str, Any] | None, path: str) -> Any:
             try:
                 index = int(segment)
             except (TypeError, ValueError):
-                return None
+                current = _project_sequence_field(current, segment)
+                if current is None:
+                    return None
+                continue
             if index < 0 or index >= len(current):
                 return None
             current = current[index]

--- a/app/services/message_templates.py
+++ b/app/services/message_templates.py
@@ -6,6 +6,7 @@ from html import escape as html_escape
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from threading import RLock
+from collections.abc import Sequence
 from typing import Any, Mapping
 
 from loguru import logger
@@ -45,11 +46,36 @@ _REDIS_CACHE_KEY = "message-templates:records"
 _TOKEN_PATTERN = re.compile(r"{{\s*([a-zA-Z0-9_.-]+)\s*}}")
 
 
+def _project_sequence_field(value: Sequence[Any], field: str) -> str | None:
+    projected: list[str] = []
+    for item in value:
+        item_value: Any = None
+        if isinstance(item, Mapping):
+            item_value = item.get(field)
+        elif not isinstance(item, (str, bytes, bytearray)):
+            item_value = getattr(item, field, None)
+        if item_value is None:
+            continue
+        rendered = str(item_value).strip()
+        if rendered:
+            projected.append(rendered)
+    if not projected:
+        return None
+    return ", ".join(projected)
+
+
 def _resolve_context_value(context: Mapping[str, Any], path: str) -> Any:
     current: Any = context
     for part in path.split("."):
         if isinstance(current, Mapping):
             current = current.get(part)
+        elif isinstance(current, Sequence) and not isinstance(current, (str, bytes, bytearray)):
+            try:
+                index = int(part)
+            except (TypeError, ValueError):
+                current = _project_sequence_field(current, part)
+            else:
+                current = current[index] if 0 <= index < len(current) else None
         else:
             current = getattr(current, part, None)
         if current is None:

--- a/app/services/system_variables.py
+++ b/app/services/system_variables.py
@@ -203,6 +203,23 @@ def _safe_environment_variables() -> dict[str, str]:
     return safe
 
 
+def _project_sequence_field(value: Sequence[Any], field: str) -> str | None:
+    projected: list[str] = []
+    for item in value:
+        item_value: Any = None
+        if isinstance(item, Mapping):
+            item_value = item.get(field)
+        elif not isinstance(item, (str, bytes, bytearray)):
+            item_value = getattr(item, field, None)
+        if item_value is None:
+            continue
+        rendered = _stringify(item_value).strip()
+        if rendered:
+            projected.append(rendered)
+    if not projected:
+        return None
+    return ", ".join(projected)
+
 def _flatten_context_tokens(
     value: Any,
     path: list[str],
@@ -232,6 +249,16 @@ def _flatten_context_tokens(
         if identifier in seen:
             return
         seen.add(identifier)
+        aggregate_fields: set[str] = set()
+        for item in value:
+            if isinstance(item, Mapping):
+                aggregate_fields.update(key for key in item if isinstance(key, str))
+        for field in sorted(aggregate_fields):
+            projected = _project_sequence_field(value, field)
+            if projected is not None:
+                aggregate_token_name = "_".join(segment.upper() for segment in [*path, field] if segment)
+                if aggregate_token_name:
+                    tokens.setdefault(aggregate_token_name, projected)
         for index, item in enumerate(value):
             _flatten_context_tokens(
                 item,

--- a/app/services/value_templates.py
+++ b/app/services/value_templates.py
@@ -162,6 +162,24 @@ _FIELD_ALIASES: dict[str, str] = {
 }
 
 
+def _project_sequence_field(value: Sequence[Any], field: str) -> str | None:
+    projected: list[str] = []
+    for item in value:
+        item_value: Any = None
+        if isinstance(item, Mapping):
+            item_value = item.get(field)
+        elif not isinstance(item, (str, bytes, bytearray)):
+            item_value = getattr(item, field, None)
+        if item_value is None:
+            continue
+        rendered = str(item_value).strip()
+        if rendered:
+            projected.append(rendered)
+    if not projected:
+        return None
+    return ", ".join(projected)
+
+
 def _resolve_context_value(context: Mapping[str, Any] | None, path: str) -> Any:
     if not context or not path:
         return None
@@ -176,7 +194,10 @@ def _resolve_context_value(context: Mapping[str, Any] | None, path: str) -> Any:
             try:
                 index = int(segment)
             except (TypeError, ValueError):
-                return None
+                current = _project_sequence_field(current, segment)
+                if current is None:
+                    return None
+                continue
             if index < 0 or index >= len(current):
                 return None
             current = current[index]

--- a/docs/wiki/administration/Automation Variables.md
+++ b/docs/wiki/administration/Automation Variables.md
@@ -25,6 +25,8 @@ paths now available include:
 - `ticket.category`, `ticket.priority`, and `ticket.external_reference`
 - `ticket.ai_tags` for AI-generated categorisation
 - `ticket.watchers_count` for the number of subscribed users
+- `ticket.watchers.email` for a comma-separated list of every watcher email,
+  which is useful when populating an email CC field for multiple watchers
 - `ticket.watchers[0].email` (and subsequent indexes) for individual watcher
   details
 - `ticket.latest_reply.body` and `ticket.latest_reply.author_email` for the most
@@ -50,7 +52,9 @@ filters can react to specific sources. The following actor types are emitted:
 
 Arrays such as `ticket.watchers` can be indexed numerically. For example,
 matching `ticket.watchers[0].email` allows a workflow to react when the first
-watcher is a specific address.
+watcher is a specific address. Referencing a field directly on an array, such
+as `ticket.watchers.email`, projects that field from each watcher and returns a
+comma-separated list like `watcher.one@example.com, watcher.two@example.com`.
 
 ## Template tokens
 
@@ -70,6 +74,7 @@ emails or webhook requests). Newly added tokens include:
 | `{{ TICKET_EXTERNAL_REFERENCE }}` | External system identifier such as an RMM ticket number. |
 | `{{ TICKET_AI_TAGS_0 }}` ... | AI-generated tags (indexed for each tag). |
 | `{{ TICKET_WATCHERS_COUNT }}` | Number of watchers subscribed to the ticket. |
+| `{{ TICKET_WATCHERS_EMAIL }}` | Comma-separated list of all watcher email addresses. |
 | `{{ TICKET_WATCHERS_0_EMAIL }}` ... | Indexed watcher email addresses. |
 | `{{ TICKET_WATCHERS_0_USER_EMAIL }}` ... | Indexed watcher user profile email values. |
 | `{{ TICKET_WATCHER_EMAILS_0 }}` ... | Flattened list of watcher emails for quick iteration. |

--- a/docs/wiki/administration/Email Template Variables.md
+++ b/docs/wiki/administration/Email Template Variables.md
@@ -31,6 +31,7 @@ When configuring email notifications in automation actions, you can use the foll
 
 ### Watchers
 - `{{ticket.watcher_emails}}` - Array of watcher email addresses
+- `{{ticket.watchers.email}}` - Comma-separated list of all watcher email addresses, useful for CC fields
 - `{{ticket.watchers_count}}` - Number of watchers
 
 ### Timestamps

--- a/tests/test_system_variables_service.py
+++ b/tests/test_system_variables_service.py
@@ -79,10 +79,22 @@ def test_system_variables_filter_sensitive_env(monkeypatch):
                         "email": "watcher@example.com",
                         "display_name": "Casey Lee",
                     },
+                },
+                {
+                    "id": 78,
+                    "ticket_id": 321,
+                    "user_id": 16,
+                    "email": "second.watcher@example.com",
+                    "display_name": "Morgan Reed",
+                    "user": {
+                        "id": 16,
+                        "email": "second.watcher@example.com",
+                        "display_name": "Morgan Reed",
+                    },
                 }
             ],
-            "watchers_count": 1,
-            "watcher_emails": ["watcher@example.com"],
+            "watchers_count": 2,
+            "watcher_emails": ["watcher@example.com", "second.watcher@example.com"],
             "latest_reply": {
                 "id": 555,
                 "ticket_id": 321,
@@ -122,8 +134,10 @@ def test_system_variables_include_ticket_tokens(ticket):
     assert variables["TICKET_CATEGORY"] == "hardware"
     assert variables["TICKET_PRIORITY"] == "high"
     assert variables["TICKET_EXTERNAL_REFERENCE"] == "RMM-42"
-    assert variables["TICKET_WATCHERS_COUNT"] == "1"
+    assert variables["TICKET_WATCHERS_COUNT"] == "2"
+    assert variables["TICKET_WATCHERS_EMAIL"] == "watcher@example.com, second.watcher@example.com"
     assert variables["TICKET_WATCHERS_0_EMAIL"] == "watcher@example.com"
     assert variables["TICKET_WATCHERS_0_USER_EMAIL"] == "watcher@example.com"
+    assert variables["TICKET_WATCHERS_1_EMAIL"] == "second.watcher@example.com"
     assert variables["TICKET_LATEST_REPLY_BODY"] == "We rebooted the printer."
     assert variables["TICKET_LATEST_REPLY_AUTHOR_EMAIL"] == "tech@example.com"

--- a/tests/test_ticket_automation_variables.py
+++ b/tests/test_ticket_automation_variables.py
@@ -37,6 +37,10 @@ async def test_ticket_variables_are_rendered_in_automation_payload():
                 "id": 5,
                 "name": "Acme Corp",
             },
+            "watchers": [
+                {"email": "watcher.one@example.com", "display_name": "Watcher One"},
+                {"email": "watcher.two@example.com", "display_name": "Watcher Two"},
+            ],
         }
     }
     
@@ -48,6 +52,7 @@ async def test_ticket_variables_are_rendered_in_automation_payload():
         ("Subject: {{ticket.subject}}", "Subject: Printer is broken"),
         ("Requester: {{ticket.requester.email}}", "Requester: user@example.com"),
         ("Company: {{ticket.company.name}}", "Company: Acme Corp"),
+        ("CC: {{ticket.watchers.email}}", "CC: watcher.one@example.com, watcher.two@example.com"),
         
         # Complex payload
         (


### PR DESCRIPTION
### Motivation
- Allow templates and automation filters to reference a projected list of watcher fields (e.g. `ticket.watchers.email`) so callers can populate CC fields with all watcher addresses.
- Provide a flattened uppercase token for automation payloads (`TICKET_WATCHERS_EMAIL`) so watcher lists are available when rendering system variables.
- Keep existing numeric indexing (`ticket.watchers[0].email`) behaviour while adding convenient array-field projection.

### Description
- Added a small projection helper `_project_sequence_field` and integrated it into `_resolve_context_value` in `app/services/value_templates.py`, `app/services/automations.py`, and `app/services/message_templates.py` so dotted lookups like `ticket.watchers.email` return a comma-separated string of emails when the intermediate node is a list/sequence.
- Extended `_flatten_context_tokens` in `app/services/system_variables.py` to project sequence fields and emit uppercase aggregate tokens such as `TICKET_WATCHERS_EMAIL` when flattening the `ticket` context.
- Updated documentation to describe the new `ticket.watchers.email` path and `TICKET_WATCHERS_EMAIL` token in `docs/wiki/administration/Automation Variables.md` and `docs/wiki/administration/Email Template Variables.md`.
- Added regression tests to cover the new behaviour in `tests/test_ticket_automation_variables.py` and `tests/test_system_variables_service.py` (examples of `{{ticket.watchers.email}}` and `TICKET_WATCHERS_EMAIL`).

### Testing
- Ran static compilation checks with `python -m py_compile app/services/system_variables.py app/services/value_templates.py app/services/automations.py app/services/message_templates.py` and they succeeded.
- Executed the focused test suite with `pytest tests/test_system_variables_service.py tests/test_ticket_automation_variables.py` after installing `libmagic1` to satisfy test environment dependencies, resulting in all tests passing (`6 passed`).
- Verified the new templates/filters render expected comma-separated watcher lists and that existing indexed watcher tokens still work via the added unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e4d162b0c832d9965d29b47a2e966)