### PR TITLE
Fix inbound email reply author attribution

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -1297,6 +1297,59 @@ async def _find_existing_ticket_for_reply(
     return None
 
 
+async def _resolve_existing_reply_author_id(
+    ticket: Mapping[str, Any],
+    from_email: str | None,
+    requester_id: int | None,
+) -> int | None:
+    """Resolve the local user who authored an inbound reply to an existing ticket.
+
+    Mailboxes can match a reply by message-id or ticket number even when the
+    initial sender lookup did not produce a requester_id (for example when the
+    sender is a watcher, or when the display address casing/format differs).
+    In that case, look at the matched ticket requester and watchers so the
+    conversation entry and automation actor are the customer instead of System.
+    """
+
+    if requester_id is not None:
+        return requester_id
+
+    ticket_id = _int_or_none(ticket.get("id"))
+    normalised_email = _normalise_string(from_email).lower()
+    if ticket_id is None or not normalised_email:
+        return None
+
+    ticket_requester_id = _int_or_none(ticket.get("requester_id"))
+    if ticket_requester_id is not None:
+        try:
+            requester = await users_repo.get_user_by_id(ticket_requester_id)
+        except Exception:  # pragma: no cover - defensive lookup
+            requester = None
+        if requester and _normalise_string(requester.get("email")).lower() == normalised_email:
+            return ticket_requester_id
+
+    try:
+        watchers = await tickets_repo.list_watchers(ticket_id)
+    except Exception:  # pragma: no cover - defensive lookup
+        watchers = []
+
+    for watcher in watchers:
+        watcher_user_id = _int_or_none(watcher.get("user_id"))
+        watcher_email = _normalise_string(watcher.get("email")).lower()
+        if watcher_user_id is not None:
+            try:
+                watcher_user = await users_repo.get_user_by_id(watcher_user_id)
+            except Exception:  # pragma: no cover - defensive lookup
+                watcher_user = None
+            watcher_email = _normalise_string(
+                watcher_user.get("email") if watcher_user else watcher_email
+            ).lower()
+        if watcher_email == normalised_email:
+            return watcher_user_id
+
+    return None
+
+
 async def _record_message(
     *,
     account_id: int,
@@ -1693,8 +1746,11 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                     sanitized = sanitize_rich_text(conversation_source)
                     if sanitized.has_rich_content:
                         reply_created_at = received_at or datetime.now(timezone.utc)
-                        # Determine the author - use requester_id if available
-                        reply_author_id = requester_id if requester_id is not None else None
+                        reply_author_id = await _resolve_existing_reply_author_id(
+                            ticket,
+                            from_email_addr,
+                            requester_id,
+                        )
                         reply_added = False
                         try:
                             await tickets_repo.create_reply(

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -30,6 +30,7 @@ from app.services.imap import (
     _extract_email_addresses,
     _extract_message_ids,
     _find_existing_ticket_for_reply,
+    _resolve_existing_reply_author_id,
     _int_or_none,
     _is_any_email_address_known,
     _normalise_bool,
@@ -1471,8 +1472,10 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                         sanitized = sanitize_rich_text(conversation_source)
                         if sanitized.has_rich_content:
                             reply_created_at = received_at or datetime.now(timezone.utc)
-                            reply_author_id = (
-                                requester_id if requester_id is not None else None
+                            reply_author_id = await _resolve_existing_reply_author_id(
+                                ticket,
+                                from_email_addr,
+                                requester_id,
                             )
                             try:
                                 await tickets_repo.create_reply(
@@ -1508,12 +1511,15 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                             if reply_added:
                                 reply_outcome = "reply_added"
                                 try:
-                                    actor_info: dict[str, Any] | None = None
+                                    actor_info: dict[str, Any] = {}
                                     if reply_author_id is not None:
-                                        actor_info = {"id": reply_author_id}
+                                        actor_info["id"] = reply_author_id
+                                    if from_email_addr:
+                                        actor_info["email"] = from_email_addr
+                                        actor_info["display_name"] = from_email_addr
                                     await tickets_service.emit_ticket_updated_event(
                                         ticket_id,
-                                        actor=actor_info,
+                                        actor=actor_info or None,
                                     )
                                 except (
                                     Exception

--- a/tests/test_imap_service.py
+++ b/tests/test_imap_service.py
@@ -1006,3 +1006,57 @@ async def test_sync_account_marks_already_imported_unread_message_as_read(monkey
     assert result["processed"] == 0
     assert ("store", (b"42", "+FLAGS", "(\\Seen)")) in mailbox.commands
     assert not any(command == "fetch" for command, _args in mailbox.commands)
+
+
+async def test_resolve_existing_reply_author_id_matches_ticket_requester(monkeypatch):
+    async def fake_get_user_by_id(user_id: int):
+        assert user_id == 42
+        return {"id": 42, "email": "Requester@Example.com"}
+
+    async def fake_list_watchers(ticket_id: int):
+        raise AssertionError("watchers should not be queried after requester match")
+
+    monkeypatch.setattr(imap.users_repo, "get_user_by_id", fake_get_user_by_id)
+    monkeypatch.setattr(imap.tickets_repo, "list_watchers", fake_list_watchers)
+
+    author_id = await imap._resolve_existing_reply_author_id(
+        {"id": 10, "requester_id": 42},
+        "requester@example.com",
+        None,
+    )
+
+    assert author_id == 42
+
+
+async def test_resolve_existing_reply_author_id_matches_ticket_watcher(monkeypatch):
+    async def fake_get_user_by_id(user_id: int):
+        if user_id == 42:
+            return {"id": 42, "email": "requester@example.com"}
+        if user_id == 77:
+            return {"id": 77, "email": "Watcher@Example.com"}
+        raise AssertionError(f"unexpected user id {user_id}")
+
+    async def fake_list_watchers(ticket_id: int):
+        assert ticket_id == 10
+        return [{"ticket_id": 10, "user_id": 77, "email": None}]
+
+    monkeypatch.setattr(imap.users_repo, "get_user_by_id", fake_get_user_by_id)
+    monkeypatch.setattr(imap.tickets_repo, "list_watchers", fake_list_watchers)
+
+    author_id = await imap._resolve_existing_reply_author_id(
+        {"id": 10, "requester_id": 42},
+        "watcher@example.com",
+        None,
+    )
+
+    assert author_id == 77
+
+
+async def test_resolve_existing_reply_author_id_preserves_resolved_requester_id():
+    author_id = await imap._resolve_existing_reply_author_id(
+        {"id": 10, "requester_id": 42},
+        "someone@example.com",
+        99,
+    )
+
+    assert author_id == 99


### PR DESCRIPTION
### Motivation
- Inbound email replies were sometimes recorded as coming from System when the original sender lookup did not produce a `requester_id`, causing automations that target the requester or watchers to misfire.

### Description
- Add `async def _resolve_existing_reply_author_id(...)` in `app/services/imap.py` to resolve the local user for inbound replies by checking the matched ticket requester and ticket watchers by email.
- Use the new resolver when creating replies in IMAP and Microsoft 365 mail sync so `ticket_replies.author_id` is set to the requester or watcher where applicable (`app/services/imap.py`, `app/services/m365_mail.py`).
- Enrich the M365 automation actor payload with sender `email` and `display_name` so automations can evaluate email-based actors (`app/services/m365_mail.py`).
- Add regression tests in `tests/test_imap_service.py` covering requester match, watcher match, and preserving an already-resolved requester id.

### Testing
- `python3 -m py_compile app/services/imap.py app/services/m365_mail.py` — succeeded.
- New unit tests for the resolver ran: `pytest -q tests/test_imap_service.py::test_resolve_existing_reply_author_id_matches_ticket_requester tests/test_imap_service.py::test_resolve_existing_reply_author_id_matches_ticket_watcher tests/test_imap_service.py::test_resolve_existing_reply_author_id_preserves_resolved_requester_id` — all passed.
- Broader run `pytest -q tests/test_imap_service.py tests/test_email_ticket_replies.py` required system dependency `libmagic1` to be installed; after installing this, tests revealed one pre-existing unrelated failure (`test_resolve_ticket_entities_matches_company_and_staff`) which predates these changes and was observed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4ee2caa0c4832dafe1c3460ad4eac9)