### PR TITLE
Prevent duplicate tray form tickets (idempotency + locking)

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -14,6 +14,8 @@ The websocket handler ``/ws/tray/{device_uid}`` is registered in
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import html as _html
 import json
 import secrets
@@ -427,6 +429,7 @@ async def get_ticket_questions(
 async def tray_submit_ticket(
     payload: TrayTicketSubmitRequest,
     request: Request,
+    external_reference: str | None = None,
 ) -> TrayTicketSubmitResponse:
     """Create a support ticket submitted via the tray icon.
 
@@ -535,7 +538,7 @@ async def tray_submit_ticket(
         status=status_value,
         category=None,
         module_slug=None,
-        external_reference=None,
+        external_reference=external_reference,
         trigger_automations=True,
         initial_reply_author_id=requester_id,
         requester_email=normalised_email if requester_id is None else None,
@@ -680,6 +683,16 @@ async def tray_submit_syncro_ticket(
 
 
 _TICKET_TOKEN_TTL_SECONDS = 300
+_TICKET_FORM_SUBMISSION_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _ticket_form_submission_reference(session: dict[str, Any], token: str) -> str:
+    """Return a stable idempotency reference for one tray ticket form token."""
+
+    sid = str(session.get("sid") or "").strip()
+    if not sid:
+        sid = hashlib.sha256(token.encode("utf-8")).hexdigest()[:32]
+    return f"tray-form:{sid}"
 
 
 def _issue_ticket_form_token(device: dict[str, Any], mode: str) -> tuple[str, str]:
@@ -692,6 +705,7 @@ def _issue_ticket_form_token(device: dict[str, Any], mode: str) -> tuple[str, st
             "device_id": int(device["id"]),
             "mode": "syncro" if mode == "syncro" else "myportal",
             "csrf": csrf,
+            "sid": secrets.token_urlsafe(18),
             "exp": exp,
         }
     )
@@ -946,11 +960,28 @@ async def tray_ticket_form_submit(request: Request) -> HTMLResponse:
     class _NoAuthRequest:
         headers: dict[str, str] = {}
 
+    submission_ref = _ticket_form_submission_reference(session, token)
+    lock = _TICKET_FORM_SUBMISSION_LOCKS.setdefault(submission_ref, asyncio.Lock())
+
     try:
-        if str(session.get("mode")) == "syncro":
-            result = await tray_submit_syncro_ticket(payload, _NoAuthRequest())
-        else:
-            result = await tray_submit_ticket(payload, _NoAuthRequest())
+        async with lock:
+            if str(session.get("mode")) == "syncro":
+                result = await tray_submit_syncro_ticket(payload, _NoAuthRequest())
+            else:
+                existing_ticket = await tickets_repo.get_ticket_by_external_reference(
+                    submission_ref
+                )
+                if existing_ticket:
+                    result = TrayTicketSubmitResponse(
+                        ticket_id=int(existing_ticket["id"]),
+                        ticket_number=existing_ticket.get("ticket_number"),
+                    )
+                else:
+                    result = await tray_submit_ticket(
+                        payload,
+                        _NoAuthRequest(),
+                        external_reference=submission_ref,
+                    )
     except HTTPException as exc:
         detail = (
             exc.detail
@@ -969,6 +1000,10 @@ async def tray_ticket_form_submit(request: Request) -> HTMLResponse:
             ),
             status_code=exc.status_code if exc.status_code < 500 else 200,
         )
+    finally:
+        if not lock.locked():
+            _TICKET_FORM_SUBMISSION_LOCKS.pop(submission_ref, None)
+
     ticket_number = result.ticket_number or (
         f"#{result.ticket_id}" if result.ticket_id else ""
     )

--- a/tests/test_tray_app.py
+++ b/tests/test_tray_app.py
@@ -1237,3 +1237,98 @@ def test_empty_chat_message_mentions_matrix_client_app():
     assert expected in popup_template
     assert "No messages yet. Say hello!" not in room_template
     assert "No messages yet. Say hello!" not in popup_template
+
+
+def _stub_magic_module():
+    import sys
+    import types
+
+    if "magic" not in sys.modules:
+        magic_stub = types.ModuleType("magic")
+        magic_stub.from_buffer = lambda *_args, **_kwargs: "application/octet-stream"
+        sys.modules["magic"] = magic_stub
+
+
+def test_ticket_form_submission_reference_uses_sid_and_legacy_token_hash():
+    _stub_magic_module()
+    from app.api.routes.tray import _ticket_form_submission_reference
+
+    assert (
+        _ticket_form_submission_reference({"sid": "abc123"}, "token-one")
+        == "tray-form:abc123"
+    )
+    legacy_one = _ticket_form_submission_reference({}, "token-one")
+    legacy_two = _ticket_form_submission_reference({}, "token-one")
+    assert legacy_one == legacy_two
+    assert legacy_one.startswith("tray-form:")
+    assert legacy_one != _ticket_form_submission_reference({}, "token-two")
+
+
+def test_tray_submit_ticket_passes_external_reference(monkeypatch, run):
+    _stub_magic_module()
+    from app.api.routes import tray as tray_routes
+    from app.schemas.tray import TrayTicketSubmitRequest
+
+    async def fake_get_device_by_uid(uid):
+        return {
+            "id": 1,
+            "device_uid": uid,
+            "company_id": None,
+            "asset_id": None,
+            "status": "active",
+        }
+
+    async def fake_get_user_by_email(email):
+        return None
+
+    async def fake_get_questions_for_company(company_id):
+        return []
+
+    async def fake_resolve_status_or_default(status):
+        return "open"
+
+    captured = {}
+
+    async def fake_create_ticket(**kwargs):
+        captured.update(kwargs)
+        return {"id": 77, "ticket_number": "TKT-77"}
+
+    monkeypatch.setattr(
+        tray_routes.tray_repo, "get_device_by_uid", fake_get_device_by_uid
+    )
+    monkeypatch.setattr(
+        tray_routes.users_repo, "get_user_by_email", fake_get_user_by_email
+    )
+    monkeypatch.setattr(
+        tray_routes.tq_service,
+        "get_questions_for_company",
+        fake_get_questions_for_company,
+    )
+    monkeypatch.setattr(
+        tray_routes.tickets_service,
+        "resolve_status_or_default",
+        fake_resolve_status_or_default,
+    )
+    monkeypatch.setattr(
+        tray_routes.tickets_service, "create_ticket", fake_create_ticket
+    )
+
+    class RequestWithoutAuth:
+        headers = {}
+
+    result = run(
+        tray_routes.tray_submit_ticket(
+            TrayTicketSubmitRequest(
+                device_uid="device-1",
+                name="Alice",
+                email="alice@example.com",
+                subject="Help",
+                description="Please help",
+            ),
+            RequestWithoutAuth(),
+            external_reference="tray-form:test-ref",
+        )
+    )
+
+    assert result.ticket_id == 77
+    assert captured["external_reference"] == "tray-form:test-ref"


### PR DESCRIPTION
### Motivation
- Submissions from the tray ticket form could be double-posted (e.g. rapid retry / duplicate POST) and result in two separate MyPortal tickets for the same user action.

### Description
- Add a stable submission identifier to tray ticket form tokens by embedding a `sid` and provide a legacy fallback hash via `_ticket_form_submission_reference` in `app/api/routes/tray.py`.
- Serialize tray form processing with a per-submission async lock (`_TICKET_FORM_SUBMISSION_LOCKS`) and check `tickets_repo.get_ticket_by_external_reference` before creating a new ticket to avoid duplicates.
- Propagate the idempotency reference into ticket creation by passing `external_reference` to `tickets_service.create_ticket` so retries can be detected.
- Add regression tests to `tests/test_tray_app.py`: `test_ticket_form_submission_reference_uses_sid_and_legacy_token_hash` and `test_tray_submit_ticket_passes_external_reference` to verify reference generation and propagation.

### Testing
- `python -m py_compile app/api/routes/tray.py tests/test_tray_app.py` succeeded.
- Focused tests `pytest -q tests/test_tray_app.py::test_ticket_form_submission_reference_uses_sid_and_legacy_token_hash tests/test_tray_app.py::test_tray_submit_ticket_passes_external_reference` were executed and passed.
- Running the full tray test suite (`pytest -q tests/test_tray_app.py`) in this environment produced import errors (missing system `libmagic`) unrelated to the tray-form idempotency changes, so full-suite verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4efa027788832d9b128d162be6d8f2)