### PR TITLE
Stop adding technicians as ticket watchers on reply

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -1575,8 +1575,7 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
                         ticket_id=ticket_id,
                     )
                     has_failed_attachments = True
-        if isinstance(author_id, int):
-            await tickets_repo.add_watcher(ticket_id, author_id)
+        # Technicians should not be automatically added as ticket watchers when replying.
         await tickets_repo.set_ticket_status(ticket_id, reply_status)
         await tickets_service.refresh_ticket_ai_summary(ticket_id)
         await tickets_service.refresh_ticket_ai_tags(ticket_id)

--- a/tests/test_admin_ticket_detail.py
+++ b/tests/test_admin_ticket_detail.py
@@ -263,7 +263,8 @@ async def test_admin_reply_saves_attachments(monkeypatch):
     monkeypatch.setattr(main.tickets_repo, "create_reply", AsyncMock(return_value=None))
     set_status_mock = AsyncMock(return_value={"id": 3, "status": "pending"})
     monkeypatch.setattr(main.tickets_repo, "set_ticket_status", set_status_mock)
-    monkeypatch.setattr(main.tickets_repo, "add_watcher", AsyncMock(return_value=None))
+    add_watcher_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(main.tickets_repo, "add_watcher", add_watcher_mock)
     monkeypatch.setattr(main.tickets_service, "refresh_ticket_ai_summary", AsyncMock(return_value=None))
     monkeypatch.setattr(main.tickets_service, "refresh_ticket_ai_tags", AsyncMock(return_value=None))
     monkeypatch.setattr(main.tickets_service, "broadcast_ticket_event", AsyncMock(return_value=None))
@@ -278,6 +279,7 @@ async def test_admin_reply_saves_attachments(monkeypatch):
     assert response.status_code == status.HTTP_303_SEE_OTHER
     assert "/admin/tickets/3" in response.headers.get("location", "")
     assert set_status_mock.await_args.args == (3, "pending")
+    add_watcher_mock.assert_not_awaited()
     assert save_mock.await_count == 1
     called_args = save_mock.await_args.kwargs
     assert called_args["ticket_id"] == 3


### PR DESCRIPTION
### Motivation
- Prevent technicians from being automatically appended as ticket watchers when they post a reply in the admin ticket UI, so replies do not change watcher membership unintentionally.

### Description
- Removed the automatic call to `tickets_repo.add_watcher(...)` in the admin reply flow in `app/features/tickets/admin_routes.py` so replying technicians are not added as watchers.
- Updated `tests/test_admin_ticket_detail.py` to inject a mocked `add_watcher` and assert `add_watcher` is `assert_not_awaited()` to cover the regression.
- Minor code comment added explaining the behavioral change in the reply handler.

### Testing
- Successfully compiled the modified files with `python -m py_compile app/features/tickets/admin_routes.py tests/test_admin_ticket_detail.py`.
- Running `pytest tests/test_admin_ticket_detail.py -q` was attempted but blocked by an environment dependency error: `ImportError: failed to find libmagic. Check your installation`, so full test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4efbef6274832d977dfda5d2ff742b)