### PR TITLE
Persist ticket detail section state

### DIFF
--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -1,4 +1,77 @@
 (function () {
+
+  const TICKET_SECTION_STATE_STORAGE_KEY = 'myportal.admin.ticketDetail.sectionState.v1';
+
+  function readTicketSectionState() {
+    try {
+      const raw = window.localStorage.getItem(TICKET_SECTION_STATE_STORAGE_KEY);
+      if (!raw) {
+        return {};
+      }
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+    } catch (error) {
+      console.warn('Unable to read ticket section preferences:', error);
+      return {};
+    }
+  }
+
+  function writeTicketSectionState(state) {
+    try {
+      window.localStorage.setItem(TICKET_SECTION_STATE_STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.warn('Unable to save ticket section preferences:', error);
+    }
+  }
+
+  function getTicketSectionStateKey(details, index) {
+    if (!(details instanceof HTMLDetailsElement)) {
+      return '';
+    }
+
+    const explicitKey = details.getAttribute('data-ticket-section-state-key');
+    if (explicitKey && explicitKey.trim()) {
+      return explicitKey.trim();
+    }
+
+    const title = details.querySelector('summary .card__title, summary h2, summary h3, summary');
+    const label = title ? title.textContent.replace(/\s+/g, ' ').trim().toLowerCase() : '';
+    const slug = label.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    return slug || `section-${index + 1}`;
+  }
+
+  function initialisePersistentTicketSections() {
+    const sections = Array.from(document.querySelectorAll('details.card-collapsible'));
+    if (!sections.length || !window.localStorage) {
+      return;
+    }
+
+    const state = readTicketSectionState();
+
+    sections.forEach((section, index) => {
+      if (!(section instanceof HTMLDetailsElement)) {
+        return;
+      }
+
+      const key = getTicketSectionStateKey(section, index);
+      if (!key) {
+        return;
+      }
+
+      section.setAttribute('data-ticket-section-state-key', key);
+
+      if (Object.prototype.hasOwnProperty.call(state, key)) {
+        section.open = state[key] === true;
+      }
+
+      section.addEventListener('toggle', () => {
+        const latestState = readTicketSectionState();
+        latestState[key] = section.open;
+        writeTicketSectionState(latestState);
+      });
+    });
+  }
+
   function getLineHeightPx(element) {
     const computed = window.getComputedStyle(element);
     const lineHeight = parseFloat(computed.lineHeight);
@@ -2361,6 +2434,7 @@
       initialiseTimelineMessage(wrapper, toggle);
     });
 
+    initialisePersistentTicketSections();
     initialiseTicketSplit();
     initialiseReplyTimeEditing();
     initialiseCallRecordingTimeEditing();


### PR DESCRIPTION
### Motivation
- Ensure admin ticket detail page respects technicians' preferred expand/collapse state for sections (e.g. Assets) across page refreshes and when switching tickets. 

### Description
- Added persistent section state handling to `app/static/js/ticket_detail.js` using `localStorage` under the key `myportal.admin.ticketDetail.sectionState.v1` and helper functions `readTicketSectionState`, `writeTicketSectionState`, `getTicketSectionStateKey`, and `initialisePersistentTicketSections`.
- Section identity is derived from an explicit `data-ticket-section-state-key` when present or a slugified summary title fallback to provide stable, human-readable keys.
- Restores saved open/closed state early in the page `ready()` flow (before other ticket initializers) and attaches `toggle` listeners to update the saved map when sections are expanded/collapsed.
- Only boolean open/closed preferences are stored (no ticket content or PII), and failures to read/write storage are handled with non-blocking warnings.

### Testing
- Ran `python -m compileall app` and it completed successfully.
- Ran `node --check app/static/js/ticket_detail.js` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4f16f180e8832da9296c2e34bb60b2)