### PR TITLE
Add encrypted ticket reply draft cookie cache

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -1785,6 +1785,13 @@ button.header-title-menu__link,
   gap: var(--space-gap-base);
 }
 
+.card__title-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
 .card__header--stacked {
   flex-direction: column;
   align-items: stretch;

--- a/app/static/js/ticket_reply_cache.js
+++ b/app/static/js/ticket_reply_cache.js
@@ -1,0 +1,204 @@
+(function () {
+  const DB_NAME = 'myportal-ticket-reply-cache';
+  const DB_STORE = 'keys';
+  const DB_VERSION = 1;
+  const KEY_ID = 'ticket-reply-cookie-key-v1';
+  const COOKIE_PREFIX = 'mp_ticket_reply_';
+  const MAX_AGE_SECONDS = 7 * 24 * 60 * 60;
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  function base64UrlEncode(buffer) {
+    const bytes = new Uint8Array(buffer);
+    let binary = '';
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  }
+
+  function base64UrlDecode(value) {
+    const padded = value.replace(/-/g, '+').replace(/_/g, '/') + '==='.slice((value.length + 3) % 4);
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  }
+
+  function openKeyDatabase() {
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        request.result.createObjectStore(DB_STORE);
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async function getKey() {
+    const database = await openKeyDatabase();
+    const existingKey = await new Promise((resolve, reject) => {
+      const transaction = database.transaction(DB_STORE, 'readonly');
+      const request = transaction.objectStore(DB_STORE).get(KEY_ID);
+      request.onsuccess = () => resolve(request.result || null);
+      request.onerror = () => reject(request.error);
+    });
+    if (existingKey) {
+      database.close();
+      return existingKey;
+    }
+    const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']);
+    await new Promise((resolve, reject) => {
+      const transaction = database.transaction(DB_STORE, 'readwrite');
+      transaction.objectStore(DB_STORE).put(key, KEY_ID);
+      transaction.oncomplete = resolve;
+      transaction.onerror = () => reject(transaction.error);
+    });
+    database.close();
+    return key;
+  }
+
+  async function encryptReply(replyHtml, cookieName) {
+    const key = await getKey();
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv, additionalData: encoder.encode(cookieName) },
+      key,
+      encoder.encode(replyHtml),
+    );
+    return `v1.${base64UrlEncode(iv)}.${base64UrlEncode(ciphertext)}`;
+  }
+
+  async function decryptReply(payload, cookieName) {
+    const parts = String(payload || '').split('.');
+    if (parts.length !== 3 || parts[0] !== 'v1') {
+      return '';
+    }
+    const key = await getKey();
+    const plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: base64UrlDecode(parts[1]), additionalData: encoder.encode(cookieName) },
+      key,
+      base64UrlDecode(parts[2]),
+    );
+    return decoder.decode(plaintext);
+  }
+
+  function cookieNameForForm(form) {
+    const ticketId = form.getAttribute('data-ticket-reply-cache-ticket-id') || form.dataset.ticketId || 'unknown';
+    const scope = form.action && form.action.includes('/admin/') ? 'admin' : 'portal';
+    return `${COOKIE_PREFIX}${scope}_${encodeURIComponent(ticketId)}`.replace(/[^A-Za-z0-9_%.-]/g, '_');
+  }
+
+  function readCookie(name) {
+    return document.cookie.split('; ').find((row) => row.startsWith(`${name}=`))?.slice(name.length + 1) || '';
+  }
+
+  function writeCookie(name, value) {
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${name}=${encodeURIComponent(value)}; Max-Age=${MAX_AGE_SECONDS}; Path=${window.location.pathname}; SameSite=Strict${secure}`;
+  }
+
+  function deleteCookie(name) {
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${name}=; Max-Age=0; Path=${window.location.pathname}; SameSite=Strict${secure}`;
+  }
+
+  function getReplyHtml(surface, hidden) {
+    const html = surface ? surface.innerHTML.replace(/\u200B/g, '').trim() : hidden.value.trim();
+    return html || '';
+  }
+
+  function isReplyEmpty(surface, hidden) {
+    const text = surface ? surface.textContent.replace(/\u200B/g, '').trim() : hidden.value.trim();
+    return !text && !getReplyHtml(surface, hidden);
+  }
+
+  function applyReply(surface, hidden, html) {
+    if (surface) {
+      surface.innerHTML = html;
+      surface.dispatchEvent(new Event('input', { bubbles: true }));
+      surface.focus({ preventScroll: true });
+    }
+    hidden.value = html;
+    hidden.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  function debounce(callback, delay) {
+    let timeoutId;
+    return (...args) => {
+      window.clearTimeout(timeoutId);
+      timeoutId = window.setTimeout(() => callback(...args), delay);
+    };
+  }
+
+  function initForm(form) {
+    if (!window.crypto?.subtle || !window.indexedDB) {
+      return;
+    }
+    const editor = form.querySelector('[data-rich-text-editor]');
+    const surface = editor?.querySelector('[data-rich-text-content]') || null;
+    const hidden = form.querySelector('[data-rich-text-value]');
+    if (!(hidden instanceof HTMLTextAreaElement || hidden instanceof HTMLInputElement)) {
+      return;
+    }
+    const cookieName = cookieNameForForm(form);
+    const loadButton = document.querySelector(`[data-ticket-reply-cache-load][data-ticket-reply-cache-target="${form.id}"]`);
+
+    const refreshButton = () => {
+      if (loadButton) {
+        loadButton.hidden = !readCookie(cookieName) || !isReplyEmpty(surface, hidden);
+      }
+    };
+
+    const save = debounce(async () => {
+      const html = getReplyHtml(surface, hidden);
+      if (!html) {
+        deleteCookie(cookieName);
+        refreshButton();
+        return;
+      }
+      try {
+        writeCookie(cookieName, await encryptReply(html, cookieName));
+      } catch (error) {
+        console.warn('Unable to cache encrypted ticket reply.', error);
+      }
+      refreshButton();
+    }, 500);
+
+    ['input', 'blur'].forEach((eventName) => {
+      (surface || hidden).addEventListener(eventName, save);
+      hidden.addEventListener(eventName, save);
+    });
+    editor?.querySelectorAll('[data-rich-text-button]').forEach((button) => {
+      button.addEventListener('click', () => window.setTimeout(save, 0));
+    });
+
+    loadButton?.addEventListener('click', async (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      try {
+        const cached = await decryptReply(decodeURIComponent(readCookie(cookieName)), cookieName);
+        if (cached && isReplyEmpty(surface, hidden)) {
+          applyReply(surface, hidden, cached);
+        }
+      } catch (error) {
+        console.warn('Unable to load encrypted ticket reply cache.', error);
+        deleteCookie(cookieName);
+      }
+      refreshButton();
+    });
+
+    form.addEventListener('submit', () => {
+      deleteCookie(cookieName);
+    });
+
+    refreshButton();
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-ticket-reply-cache]').forEach(initForm);
+  });
+})();

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -977,13 +977,16 @@
         <div class="management__column management__column--activity">
           <details class="card card--panel card-collapsible" open>
             <summary class="card__header card__header--collapsible">
-              <h2 class="card__title">Add a reply</h2>
+              <div class="card__title-group">
+                <h2 class="card__title">Add a reply</h2>
+                <button type="button" class="button button--secondary button--small" data-ticket-reply-cache-load data-ticket-reply-cache-target="ticket-reply-form" hidden>Load Previous Reply</button>
+              </div>
               <div class="card__collapsible-meta">
                 <span class="card__toggle-icon" aria-hidden="true"></span>
               </div>
             </summary>
             <div class="card-collapsible__content">
-            <form action="/admin/tickets/{{ ticket.id }}/replies" method="post" class="form card__form ticket-reply-form" enctype="multipart/form-data">
+            <form id="ticket-reply-form" action="/admin/tickets/{{ ticket.id }}/replies" method="post" class="form card__form ticket-reply-form" enctype="multipart/form-data" data-ticket-reply-cache data-ticket-reply-cache-ticket-id="{{ ticket.id }}">
               {% if csrf_token %}
                 <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
               {% endif %}
@@ -1557,6 +1560,7 @@
   <script src="{{ static_url('/static/js/suneditor.min.js') }}"></script>
   <script src="{{ static_url('/static/js/admin.js') }}" defer></script>
   <script src="{{ static_url('/static/js/rich_text_editor.js') }}" defer></script>
+  <script src="{{ static_url('/static/js/ticket_reply_cache.js') }}" defer></script>
   <script src="{{ static_url('/static/js/ticket_detail.js') }}" defer></script>
   <script src="{{ static_url('/static/js/email_recipients.js') }}" defer></script>
   <script>

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -310,11 +310,14 @@
 
           <article class="card card--panel">
             <header class="card__header">
-              <h2 class="card__title">Reply</h2>
+              <div class="card__title-group">
+                <h2 class="card__title">Reply</h2>
+                <button type="button" class="button button--secondary button--small" data-ticket-reply-cache-load data-ticket-reply-cache-target="ticket-reply-form" hidden>Load Previous Reply</button>
+              </div>
             </header>
             <div class="card__body">
               {% if can_reply %}
-                <form action="/tickets/{{ ticket.id }}/replies" method="post" class="form" novalidate enctype="multipart/form-data" data-ticket-reply-form>
+                <form id="ticket-reply-form" action="/tickets/{{ ticket.id }}/replies" method="post" class="form" novalidate enctype="multipart/form-data" data-ticket-reply-form data-ticket-reply-cache data-ticket-reply-cache-ticket-id="{{ ticket.id }}">
                   {% include "partials/csrf.html" %}
                   <div class="form-field">
                     <span class="form-label" id="ticket-reply-label">Message</span>
@@ -645,6 +648,7 @@
   {{ super() }}
   <script src="{{ static_url('/static/js/tables.js') }}" defer></script>
   <script src="{{ static_url('/static/js/rich_text_editor.js') }}" defer></script>
+  <script src="{{ static_url('/static/js/ticket_reply_cache.js') }}" defer></script>
   <script src="{{ static_url('/static/js/ticket_detail.js') }}" defer></script>
   <script src="{{ static_url('/static/js/email_recipients.js') }}" defer></script>
   {% if matrix_chat_enabled and not ticket_chat_room and is_requester %}


### PR DESCRIPTION
### Motivation
- Remember technician reply drafts on the workstation so text is not lost if they navigate away or the browser crashes. 
- Ensure cached drafts are not readable in plain text on disk and expire automatically after 7 days or when the reply is posted.
- Provide an affordance to restore a cached draft only when the reply box is empty via a contextual “Load Previous Reply” button.

### Description
- Added `app/static/js/ticket_reply_cache.js` which encrypts draft HTML with `AES-GCM` (using `crypto.subtle`), keeps the non-extractable key in `IndexedDB`, and stores ciphertext in a `SameSite=Strict` cookie with a 7-day `Max-Age` and `Secure` when appropriate.
- Wire-up changes to ticket templates: added an inline `Load Previous Reply` button and `id="ticket-reply-form"` plus `data-ticket-reply-cache` and `data-ticket-reply-cache-ticket-id` attributes in `app/templates/admin/ticket_detail.html` and `app/templates/tickets/detail.html`, and included the new script in both pages.
- Added layout CSS `.card__title-group` in `app/static/css/app.css` so the new button aligns with existing card headers.
- Client behaviour: drafts are auto-saved (debounced 500ms) on input/toolbar interaction, the load button only appears when a cached draft exists and the reply box is empty, the draft cookie is deleted when the reply form is submitted, and cached drafts are decrypted and applied securely when loaded.

### Testing
- Ran JavaScript syntax check with `node --check app/static/js/ticket_reply_cache.js` and it passed.
- Compiled Python modules under `app/features/tickets` with `python3 -m compileall app/features/tickets` and there were no syntax errors.
- Ran repository style/sanity check with `git diff --check` and no whitespace/diff issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4f1811c210832da52e9c785cbb4201)