### PR TITLE
Move admin ticket attachments below Assets

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -478,65 +478,6 @@
             </article>
           {% endif %}
 
-          <details class="card card--panel card-collapsible" {% if not ticket_attachments %}open{% endif %}>
-            <summary class="card__header card__header--collapsible">
-              <h2 class="card__title">Attachments</h2>
-              <div class="card__collapsible-meta">
-                {% if ticket_attachments %}<span class="badge badge--muted">{{ ticket_attachments|length }}</span>{% endif %}
-                <span class="card__toggle-icon" aria-hidden="true"></span>
-              </div>
-            </summary>
-            <div class="card-collapsible__content card__body">
-              <div
-                class="attachments-grid"
-                data-attachments-grid
-                data-ticket-id="{{ ticket.id }}"
-              >
-                {% for attachment in ticket_attachments %}
-                  <article class="attachment-card" data-attachment-id="{{ attachment.id }}">
-                    <div class="attachment-card__icon" aria-hidden="true">📎</div>
-                    <div class="attachment-card__content">
-                      <div class="attachment-card__header">
-                        <p class="attachment-card__name">
-                          <a
-                            href="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download"
-                            title="{{ attachment.original_filename or attachment.filename }}"
-                          >
-                            {{ attachment.original_filename or attachment.filename }}
-                          </a>
-                        </p>
-                        <div class="attachment-card__actions">
-                          <button
-                            type="button"
-                            class="button button--ghost button--small attachment-card__action"
-                            data-remove-attachment
-                            data-attachment-id="{{ attachment.id }}"
-                            aria-label="Remove attachment"
-                          >
-                            Remove
-                          </button>
-                        </div>
-                      </div>
-                      <p class="attachment-card__meta">
-                        {{ attachment.file_size | filesizeformat }}
-                        {% if attachment.uploaded_iso %}
-                          · <span data-utc="{{ attachment.uploaded_iso }}"></span>
-                        {% endif %}
-                      </p>
-                    </div>
-                  </article>
-                {% endfor %}
-              </div>
-              <p
-                class="card__empty"
-                data-attachments-empty
-                {% if ticket_attachments %}hidden{% endif %}
-              >
-                No attachments have been added yet.
-              </p>
-            </div>
-          </details>
-
           <details
             class="card card--panel card-collapsible ticket-related"
             data-ticket-related
@@ -969,6 +910,65 @@
                 <button type="submit" class="button button--primary" form="ticket-details-form">Save asset changes</button>
               </div>
               </div>
+            </div>
+          </details>
+
+          <details class="card card--panel card-collapsible" {% if not ticket_attachments %}open{% endif %}>
+            <summary class="card__header card__header--collapsible">
+              <h2 class="card__title">Attachments</h2>
+              <div class="card__collapsible-meta">
+                {% if ticket_attachments %}<span class="badge badge--muted">{{ ticket_attachments|length }}</span>{% endif %}
+                <span class="card__toggle-icon" aria-hidden="true"></span>
+              </div>
+            </summary>
+            <div class="card-collapsible__content card__body">
+              <div
+                class="attachments-grid"
+                data-attachments-grid
+                data-ticket-id="{{ ticket.id }}"
+              >
+                {% for attachment in ticket_attachments %}
+                  <article class="attachment-card" data-attachment-id="{{ attachment.id }}">
+                    <div class="attachment-card__icon" aria-hidden="true">📎</div>
+                    <div class="attachment-card__content">
+                      <div class="attachment-card__header">
+                        <p class="attachment-card__name">
+                          <a
+                            href="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download"
+                            title="{{ attachment.original_filename or attachment.filename }}"
+                          >
+                            {{ attachment.original_filename or attachment.filename }}
+                          </a>
+                        </p>
+                        <div class="attachment-card__actions">
+                          <button
+                            type="button"
+                            class="button button--ghost button--small attachment-card__action"
+                            data-remove-attachment
+                            data-attachment-id="{{ attachment.id }}"
+                            aria-label="Remove attachment"
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      </div>
+                      <p class="attachment-card__meta">
+                        {{ attachment.file_size | filesizeformat }}
+                        {% if attachment.uploaded_iso %}
+                          · <span data-utc="{{ attachment.uploaded_iso }}"></span>
+                        {% endif %}
+                      </p>
+                    </div>
+                  </article>
+                {% endfor %}
+              </div>
+              <p
+                class="card__empty"
+                data-attachments-empty
+                {% if ticket_attachments %}hidden{% endif %}
+              >
+                No attachments have been added yet.
+              </p>
             </div>
           </details>
 


### PR DESCRIPTION
### Motivation
- Reorder the admin ticket detail page so the Attachments panel appears directly after the Assets panel to match the desired UI flow.

### Description
- Moved the Attachments block in `app/templates/admin/ticket_detail.html` to sit immediately below the Assets panel while preserving the existing attachment markup, download links, remove actions, metadata display, and empty-state behavior.

### Testing
- Verified the modified template compiles by loading it with Jinja2 using `python - <<'PY'\nfrom jinja2 import Environment, FileSystemLoader\nEnvironment(loader=FileSystemLoader('app/templates')).get_template('admin/ticket_detail.html')\nprint('template ok')\nPY`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4f1b04527c832da746c7aaef3862a5)