### PR TITLE
Add event automation simulation and processing for ticket-scoped automations

### DIFF
--- a/app/api/routes/automations.py
+++ b/app/api/routes/automations.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, status
 
 from app.api.dependencies.auth import require_super_admin
 from app.repositories import automations as automation_repo
@@ -155,6 +155,41 @@ async def preview_scheduled_ticket_automation(
         status_code = status.HTTP_400_BAD_REQUEST if "Only scheduled" in message else status.HTTP_404_NOT_FOUND
         raise HTTPException(status_code=status_code, detail=message) from exc
     return AutomationTicketPreviewResponse(**result)
+
+
+@router.get("/{automation_id}/simulate", response_model=AutomationTicketPreviewResponse)
+async def simulate_event_ticket_automation(
+    automation_id: int,
+    limit: int = Query(default=1000, ge=1, le=5000),
+    current_user: dict = Depends(require_super_admin),
+) -> AutomationTicketPreviewResponse:
+    try:
+        result = await automation_service.simulate_event_ticket_automation_by_id(automation_id, limit=limit)
+    except ValueError as exc:
+        message = str(exc)
+        status_code = status.HTTP_400_BAD_REQUEST if "Only" in message else status.HTTP_404_NOT_FOUND
+        raise HTTPException(status_code=status_code, detail=message) from exc
+    return AutomationTicketPreviewResponse(**result)
+
+
+@router.post("/{automation_id}/simulate/process", response_model=dict[str, object])
+async def process_event_ticket_simulation(
+    automation_id: int,
+    ticket_ids: list[int] = Body(default_factory=list),
+    limit: int = Query(default=1000, ge=1, le=5000),
+    current_user: dict = Depends(require_super_admin),
+) -> dict[str, object]:
+    try:
+        result = await automation_service.process_event_ticket_simulation_by_id(
+            automation_id,
+            ticket_ids=ticket_ids,
+            limit=limit,
+        )
+    except ValueError as exc:
+        message = str(exc)
+        status_code = status.HTTP_400_BAD_REQUEST if "Only" in message else status.HTTP_404_NOT_FOUND
+        raise HTTPException(status_code=status_code, detail=message) from exc
+    return result
 
 
 @router.get("/{automation_id}/runs", response_model=list[AutomationRunResponse])

--- a/app/features/automations/handlers.py
+++ b/app/features/automations/handlers.py
@@ -595,6 +595,58 @@ async def admin_preview_automation(automation_id: int, request: Request, limit: 
     return await _main()._render_template("admin/automations_preview.html", request, current_user, extra=extra)
 
 
+
+
+async def admin_simulate_automation(automation_id: int, request: Request, limit: int = Query(default=1000, ge=1, le=5000)):
+    from app.repositories import automations as automation_repo
+    from app.services import automations as automations_service
+
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return redirect
+    automation = await automation_repo.get_automation(automation_id)
+    if not automation:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+    try:
+        preview = await automations_service.simulate_event_ticket_automation(automation, limit=limit)
+    except ValueError as exc:
+        return flash_redirect("/admin/automations", str(exc), "error")
+    extra = {
+        "title": f"Simulate automation #{automation_id}",
+        "automation": automation,
+        "preview": preview,
+        "limit": limit,
+        "is_simulation": True,
+    }
+    return await _main()._render_template("admin/automations_preview.html", request, current_user, extra=extra)
+
+
+async def admin_process_simulated_automation(automation_id: int, request: Request):
+    from app.services import automations as automations_service
+
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return redirect
+    form = await request.form()
+    ticket_ids = [int(value) for value in form.getlist("ticket_ids") if str(value).isdigit()]
+    try:
+        limit = int(form.get("limit") or 1000)
+    except (TypeError, ValueError):
+        limit = 1000
+    try:
+        result = await automations_service.process_event_ticket_simulation_by_id(
+            automation_id,
+            ticket_ids=ticket_ids,
+            limit=limit,
+        )
+    except ValueError as exc:
+        return flash_redirect("/admin/automations", str(exc), "error")
+    message = (
+        f"Simulated automation {automation_id} processed {result.get('matched', 0)} ticket(s): "
+        f"{result.get('succeeded', 0)} succeeded, {result.get('failed', 0)} failed."
+    )
+    return flash_redirect(f"/admin/automations/{automation_id}/simulate", message, "success")
+
 async def admin_execute_automation(automation_id: int, request: Request):
     from app.services import automations as automations_service
 

--- a/app/features/automations/routes.py
+++ b/app/features/automations/routes.py
@@ -40,6 +40,18 @@ router.add_api_route(
     response_class=HTMLResponse,
 )
 router.add_api_route(
+    "/admin/automations/{automation_id}/simulate",
+    handlers.admin_simulate_automation,
+    methods=["GET"],
+    response_class=HTMLResponse,
+)
+router.add_api_route(
+    "/admin/automations/{automation_id}/simulate/process",
+    handlers.admin_process_simulated_automation,
+    methods=["POST"],
+    response_class=HTMLResponse,
+)
+router.add_api_route(
     "/admin/automations/{automation_id}/edit",
     handlers.admin_edit_automation_page,
     methods=["GET"],

--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -735,20 +735,13 @@ async def _invoke_automation_actions_for_context(
     return {"status": "skipped", "reason": "No action module configured"}, None
 
 
-async def preview_scheduled_ticket_automation(
+async def _scan_tickets_for_automation(
     automation: Mapping[str, Any],
     *,
     limit: int = 1000,
+    preview: bool = True,
 ) -> dict[str, Any]:
-    """Return tickets that would be actioned by a scheduled ticket automation.
-
-    This mirrors the scheduled ticket scan path but never invokes automation
-    actions, so admins can safely inspect the next run impact before enabling
-    or manually executing an automation.
-    """
-
-    if str(automation.get("kind") or "").strip().lower() != "scheduled":
-        raise ValueError("Only scheduled automations can be previewed")
+    """Scan recent tickets against an automation's filter JSON without actions."""
 
     now = datetime.now(timezone.utc)
     raw_filters = automation.get("trigger_filters")
@@ -771,12 +764,13 @@ async def preview_scheduled_ticket_automation(
                 "actor_type": "automation",
                 "actor_label": "Automation",
                 "actor_user": None,
+                "simulated_event": automation.get("trigger_event"),
             },
             "schedule": {
                 "automation_id": automation.get("id"),
                 "automation_name": automation.get("name"),
                 "checked_at": now.isoformat(),
-                "preview": True,
+                "preview": preview,
             },
         }
         if not _filters_match(filters, context):
@@ -786,12 +780,13 @@ async def preview_scheduled_ticket_automation(
         match["last_activity_at"] = ticket_context.get("last_activity_at")
         match["age_days"] = ticket_context.get("age_days")
         match["last_activity_age_days"] = ticket_context.get("last_activity_age_days")
+        match["automation_context"] = context
         matches.append(match)
 
     return {
         "automation_id": automation.get("id"),
         "automation_name": automation.get("name"),
-        "mode": "scheduled_ticket_preview",
+        "mode": "event_ticket_simulation" if str(automation.get("kind") or "").strip().lower() == "event" else "scheduled_ticket_preview",
         "checked_at": now,
         "scan_limit": scan_limit,
         "scanned": len(scanned),
@@ -800,12 +795,98 @@ async def preview_scheduled_ticket_automation(
     }
 
 
+async def preview_scheduled_ticket_automation(
+    automation: Mapping[str, Any],
+    *,
+    limit: int = 1000,
+) -> dict[str, Any]:
+    """Return tickets that would be actioned by a scheduled ticket automation."""
+
+    if str(automation.get("kind") or "").strip().lower() != "scheduled":
+        raise ValueError("Only scheduled automations can be previewed")
+    return await _scan_tickets_for_automation(automation, limit=limit, preview=True)
+
+
+async def simulate_event_ticket_automation(
+    automation: Mapping[str, Any],
+    *,
+    limit: int = 1000,
+) -> dict[str, Any]:
+    """Return tickets an event automation would affect when simulated."""
+
+    if str(automation.get("kind") or "").strip().lower() != "event":
+        raise ValueError("Only event automations can be simulated")
+    event_name = str(automation.get("trigger_event") or "").strip()
+    if event_name and not event_name.startswith("tickets.") and not event_name.startswith("ticket."):
+        raise ValueError("Only ticket event automations can be simulated against tickets")
+    return await _scan_tickets_for_automation(automation, limit=limit, preview=True)
+
+
 async def preview_scheduled_ticket_automation_by_id(automation_id: int, *, limit: int = 1000) -> dict[str, Any]:
     automation = await automation_repo.get_automation(automation_id)
     if not automation:
         raise ValueError(f"Automation {automation_id} not found")
     return await preview_scheduled_ticket_automation(automation, limit=limit)
 
+
+
+
+async def simulate_event_ticket_automation_by_id(automation_id: int, *, limit: int = 1000) -> dict[str, Any]:
+    automation = await automation_repo.get_automation(automation_id)
+    if not automation:
+        raise ValueError(f"Automation {automation_id} not found")
+    return await simulate_event_ticket_automation(automation, limit=limit)
+
+
+async def process_event_ticket_simulation_by_id(
+    automation_id: int,
+    *,
+    ticket_ids: Sequence[int] | None = None,
+    limit: int = 1000,
+) -> dict[str, Any]:
+    automation = await automation_repo.get_automation(automation_id)
+    if not automation:
+        raise ValueError(f"Automation {automation_id} not found")
+    simulation = await simulate_event_ticket_automation(automation, limit=limit)
+    requested_ids: set[int] = set()
+    for ticket_id in ticket_ids or []:
+        try:
+            clean_id = int(ticket_id)
+        except (TypeError, ValueError):
+            continue
+        if clean_id > 0:
+            requested_ids.add(clean_id)
+    matched_tickets = simulation.get("tickets") if isinstance(simulation, Mapping) else []
+    if requested_ids:
+        matched_tickets = [ticket for ticket in matched_tickets if int(ticket.get("id") or 0) in requested_ids]
+
+    succeeded = 0
+    failed = 0
+    results: list[dict[str, Any]] = []
+    for ticket in matched_tickets if isinstance(matched_tickets, list) else []:
+        context = ticket.get("automation_context") if isinstance(ticket, Mapping) else None
+        action_result, action_error = await _invoke_automation_actions_for_context(automation, context=context)
+        result_entry: dict[str, Any] = {
+            "ticket_id": ticket.get("id"),
+            "status": "failed" if action_error else "succeeded",
+            "result": action_result,
+        }
+        if action_error:
+            failed += 1
+            result_entry["error"] = action_error
+        else:
+            succeeded += 1
+        results.append(result_entry)
+
+    return {
+        "mode": "event_ticket_simulation_process",
+        "scanned": simulation.get("scanned", 0),
+        "matched": len(matched_tickets) if isinstance(matched_tickets, list) else 0,
+        "succeeded": succeeded,
+        "failed": failed,
+        "skipped": max(0, int(simulation.get("matched", 0)) - (len(matched_tickets) if isinstance(matched_tickets, list) else 0)),
+        "results": results,
+    }
 
 async def _execute_scheduled_ticket_automation(automation: Mapping[str, Any]) -> dict[str, Any]:
     """Run a scheduled automation once for each ticket matching its filters."""

--- a/app/templates/admin/automations.html
+++ b/app/templates/admin/automations.html
@@ -125,6 +125,10 @@
                           <li class="header-title-menu__item" role="none">
                             <a class="header-title-menu__link" role="menuitem" href="/admin/automations/{{ automation.id }}/preview">Preview tickets</a>
                           </li>
+                          {% elif automation.kind == 'event' %}
+                          <li class="header-title-menu__item" role="none">
+                            <a class="header-title-menu__link" role="menuitem" href="/admin/automations/{{ automation.id }}/simulate">Simulate</a>
+                          </li>
                           {% endif %}
                           <li class="header-title-menu__item" role="none">
                             <form action="/admin/automations/{{ automation.id }}/execute" method="post" class="inline-form">

--- a/app/templates/admin/automations_preview.html
+++ b/app/templates/admin/automations_preview.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% from "macros/header.html" import page_header_actions %}
 
-{% block header_title %}Automation preview{% endblock %}
+{% block header_title %}{{ 'Automation simulation' if is_simulation else 'Automation preview' }}{% endblock %}
 
 {% block header_actions %}
   {{ page_header_actions([
@@ -15,14 +15,18 @@
     <section class="management__content">
       <header class="management__header">
         <div>
-          <p class="eyebrow">Scheduled ticket automation</p>
+          <p class="eyebrow">{{ 'Event automation simulation' if is_simulation else 'Scheduled ticket automation' }}</p>
           <h1 class="page-title">{{ automation.name }}</h1>
-          <p class="page-subtitle">Preview the tickets that will be actioned the next time this automation runs. No actions are executed from this page.</p>
+          {% if is_simulation %}
+            <p class="page-subtitle">Simulate this event automation against recent tickets using its filters. Review the matches, then process the automation against the selected tickets only.</p>
+          {% else %}
+            <p class="page-subtitle">Preview the tickets that will be actioned the next time this automation runs. No actions are executed from this page.</p>
+          {% endif %}
         </div>
         <form method="get" class="management__filters">
           <label class="form-label" for="preview-limit">Scan limit</label>
           <input id="preview-limit" name="limit" type="number" min="1" max="5000" class="form-input" value="{{ limit }}" />
-          <button type="submit" class="button">Refresh preview</button>
+          <button type="submit" class="button">{{ 'Refresh simulation' if is_simulation else 'Refresh preview' }}</button>
         </form>
       </header>
 
@@ -37,8 +41,8 @@
             <p class="stat-card__value">{{ preview.matched }}</p>
           </article>
           <article class="stat-card">
-            <h3 class="stat-card__title">Next run</h3>
-            <p class="stat-card__value stat-card__value--small">{{ automation.next_run_at.astimezone().strftime('%Y-%m-%d %H:%M') if automation.next_run_at else '—' }}</p>
+            <h3 class="stat-card__title">{{ 'Trigger event' if is_simulation else 'Next run' }}</h3>
+            <p class="stat-card__value stat-card__value--small">{{ automation.trigger_event if is_simulation else (automation.next_run_at.astimezone().strftime('%Y-%m-%d %H:%M') if automation.next_run_at else '—') }}</p>
           </article>
           <article class="stat-card">
             <h3 class="stat-card__title">Checked</h3>
@@ -51,6 +55,17 @@
             <input type="search" class="form-input" placeholder="Filter preview tickets" aria-label="Filter preview tickets" data-table-filter="automation-preview-table" />
           </div>
         </div>
+
+        {% if is_simulation and preview.tickets %}
+          <form method="post" action="/admin/automations/{{ automation.id }}/simulate/process" class="management__toolbar" onsubmit="return confirm('Process this automation against the matched tickets?');">
+            {% include "partials/csrf.html" %}
+            <input type="hidden" name="limit" value="{{ limit }}" />
+            {% for ticket in preview.tickets %}
+              <input type="hidden" name="ticket_ids" value="{{ ticket.id }}" />
+            {% endfor %}
+            <button type="submit" class="button button--primary">Process automation against {{ preview.matched }} matched ticket{{ '' if preview.matched == 1 else 's' }}</button>
+          </form>
+        {% endif %}
 
         <div class="table-wrapper">
           <table class="table" id="automation-preview-table" data-table data-table-id="automation-preview">

--- a/tests/test_automations_feature_pack.py
+++ b/tests/test_automations_feature_pack.py
@@ -17,6 +17,8 @@ EXPECTED = {
     ("GET", "/admin/automations/create/event"),
     ("POST", "/admin/automations"),
     ("GET", "/admin/automations/{automation_id}/preview"),
+    ("GET", "/admin/automations/{automation_id}/simulate"),
+    ("POST", "/admin/automations/{automation_id}/simulate/process"),
     ("GET", "/admin/automations/{automation_id}/edit"),
     ("POST", "/admin/automations/{automation_id}"),
     ("POST", "/admin/automations/{automation_id}/status"),
@@ -78,16 +80,18 @@ def test_automations_pack_owns_handlers():
     )
     assert automation_routes.router.routes[3].endpoint == automation_handlers.admin_create_automation
     assert automation_routes.router.routes[4].endpoint == automation_handlers.admin_preview_automation
-    assert automation_routes.router.routes[5].endpoint == automation_handlers.admin_edit_automation_page
-    assert automation_routes.router.routes[6].endpoint == automation_handlers.admin_update_automation
+    assert automation_routes.router.routes[5].endpoint == automation_handlers.admin_simulate_automation
+    assert automation_routes.router.routes[6].endpoint == automation_handlers.admin_process_simulated_automation
+    assert automation_routes.router.routes[7].endpoint == automation_handlers.admin_edit_automation_page
+    assert automation_routes.router.routes[8].endpoint == automation_handlers.admin_update_automation
     assert (
-        automation_routes.router.routes[7].endpoint
+        automation_routes.router.routes[9].endpoint
         == automation_handlers.admin_update_automation_status
     )
-    assert automation_routes.router.routes[8].endpoint == automation_handlers.admin_automation_history
-    assert automation_routes.router.routes[9].endpoint == automation_handlers.admin_execute_automation
-    assert automation_routes.router.routes[10].endpoint == automation_handlers.admin_clone_automation
-    assert automation_routes.router.routes[11].endpoint == automation_handlers.admin_delete_automation
+    assert automation_routes.router.routes[10].endpoint == automation_handlers.admin_automation_history
+    assert automation_routes.router.routes[11].endpoint == automation_handlers.admin_execute_automation
+    assert automation_routes.router.routes[12].endpoint == automation_handlers.admin_clone_automation
+    assert automation_routes.router.routes[13].endpoint == automation_handlers.admin_delete_automation
 
 
 def test_automations_pack_loads_and_reloads_cleanly():

--- a/tests/test_automations_service.py
+++ b/tests/test_automations_service.py
@@ -973,3 +973,75 @@ async def test_preview_scheduled_ticket_automation_returns_matches_without_actio
     assert result["matched"] == 1
     assert result["tickets"][0]["id"] == 10
     assert result["tickets"][0]["ticket_number"] == "T-10"
+
+
+@pytest.mark.anyio
+async def test_simulate_event_ticket_automation_processes_selected_matches(monkeypatch):
+    scanned_tickets = [
+        {
+            "id": 20,
+            "ticket_number": "T-20",
+            "status": "open",
+            "subject": "Matching ticket",
+            "created_at": datetime.now(timezone.utc) - timedelta(days=3),
+            "updated_at": datetime.now(timezone.utc) - timedelta(days=2),
+            "latest_reply_at": None,
+        },
+        {
+            "id": 21,
+            "ticket_number": "T-21",
+            "status": "closed",
+            "subject": "Filtered ticket",
+            "created_at": datetime.now(timezone.utc) - timedelta(days=3),
+            "updated_at": datetime.now(timezone.utc) - timedelta(days=2),
+            "latest_reply_at": None,
+        },
+    ]
+    automation = {
+        "id": 13,
+        "name": "Simulate ticket updates",
+        "kind": "event",
+        "trigger_event": "tickets.updated",
+        "trigger_filters": {"match": {"ticket.status": "open"}},
+        "action_module": "test-module",
+        "action_payload": {},
+    }
+    triggered = []
+
+    async def fake_get_automation(automation_id):
+        assert automation_id == 13
+        return automation
+
+    async def fake_list_tickets_for_automation_scan(*, limit: int = 1000):
+        assert limit == 50
+        return scanned_tickets
+
+    async def fake_enrich(ticket):
+        return dict(ticket)
+
+    async def fake_trigger_module(module_slug, payload, *, background=False):
+        triggered.append((module_slug, payload, background))
+        return {"status": "succeeded"}
+
+    async def fake_record_action_history(*args, **kwargs):
+        return None
+
+    from app.services import tickets as tickets_service
+
+    monkeypatch.setattr(automations_service.automation_repo, "get_automation", fake_get_automation)
+    monkeypatch.setattr(automations_service.tickets_repo, "list_tickets_for_automation_scan", fake_list_tickets_for_automation_scan)
+    monkeypatch.setattr(tickets_service, "_enrich_ticket_context", fake_enrich)
+    monkeypatch.setattr(automations_service.modules_service, "trigger_module", fake_trigger_module)
+    monkeypatch.setattr(automations_service, "_record_action_history", fake_record_action_history)
+
+    simulation = await automations_service.simulate_event_ticket_automation_by_id(13, limit=50)
+    assert simulation["mode"] == "event_ticket_simulation"
+    assert simulation["matched"] == 1
+    assert simulation["tickets"][0]["id"] == 20
+    assert triggered == []
+
+    result = await automations_service.process_event_ticket_simulation_by_id(13, ticket_ids=[20], limit=50)
+    assert result["matched"] == 1
+    assert result["succeeded"] == 1
+    assert triggered[0][0] == "test-module"
+    assert triggered[0][1]["context"]["ticket"]["id"] == 20


### PR DESCRIPTION
### Motivation
- Provide admins a way to simulate event-driven automations against recent tickets using the automation's filters so they can inspect matches without executing actions. 
- Allow admins to optionally process a simulation's matched tickets (selected matches) so actions can be invoked only after review. 
- Reuse the scheduled-preview ticket-scanning logic to avoid duplicating filter evaluation and to ensure secure, deterministic processing.

### Description
- Added a shared scanner `_scan_tickets_for_automation` in `app/services/automations.py` and new helpers `simulate_event_ticket_automation`, `simulate_event_ticket_automation_by_id`, and `process_event_ticket_simulation_by_id` to return matched tickets and to process selected matches by invoking the automation's actions against each ticket context. 
- Kept simulation read-only by default and attached an `automation_context` to each matched ticket so processing reuses the same context when the admin opts to process matches. 
- Added admin HTML endpoints and handlers: `admin_simulate_automation` and `admin_process_simulated_automation` in `app/features/automations/handlers.py` and wired them into the feature pack routes in `app/features/automations/routes.py`. 
- Exposed API endpoints under `/api/automations` in `app/api/routes/automations.py` for `GET /{automation_id}/simulate` and `POST /{automation_id}/simulate/process` with appropriate validation and super-admin guard. 
- Updated UI: added a `Simulate` action for event automations in `app/templates/admin/automations.html` and adapted the existing preview template `app/templates/admin/automations_preview.html` to support simulation mode (`is_simulation`) and a CSRF-protected form to process matched tickets. 
- Added regression tests and adjusted feature-pack expectations in `tests/test_automations_feature_pack.py` and added `test_simulate_event_ticket_automation_processes_selected_matches` to `tests/test_automations_service.py` to cover scanning and processing behavior.

### Testing
- Compiled the modified modules with `python3 -m compileall app/services/automations.py app/features/automations/handlers.py app/features/automations/routes.py app/api/routes/automations.py` and there were no syntax errors. 
- Ran targeted pytest checks with `pytest tests/test_automations_feature_pack.py tests/test_automations_service.py::test_preview_scheduled_ticket_automation_returns_matches_without_actions tests/test_automations_service.py::test_simulate_event_ticket_automation_processes_selected_matches -q` and they passed (targeted run produced passing tests). 
- Note: the repository-wide test run required the `libmagic1` system package to import `magic`; after installing that dependency the targeted tests above passed (warnings unrelated to these changes were emitted by the test run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4f1b44c9b0832d827e26d9cfcdb6fc)