### PR TITLE
Add @mentions to ticket replies (UI + backend watcher auto-add)

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -73,6 +73,50 @@ def _main():
     return main_module
 
 
+def _parse_mentioned_user_ids(form: Mapping[str, Any]) -> list[int]:
+    raw_values: list[Any] = []
+    getlist = getattr(form, "getlist", None)
+    if callable(getlist):
+        raw_values.extend(getlist("mentionedUserIds"))
+    else:
+        raw_values.append(form.get("mentionedUserIds"))
+    user_ids: list[int] = []
+    seen: set[int] = set()
+    for raw in raw_values:
+        for token in str(raw or "").replace(";", ",").split(","):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                user_id = int(token)
+            except (TypeError, ValueError):
+                continue
+            if user_id > 0 and user_id not in seen:
+                seen.add(user_id)
+                user_ids.append(user_id)
+    return user_ids
+
+
+async def _valid_mentioned_user_ids(ticket: Mapping[str, Any] | dict[str, Any], requested_ids: list[int]) -> list[int]:
+    if not requested_ids:
+        return []
+    try:
+        company_id = int(ticket.get("company_id")) if ticket.get("company_id") is not None else None
+    except (TypeError, ValueError, AttributeError):
+        company_id = None
+    if company_id is None:
+        return []
+    allowed_ids: set[int] = set()
+    for staff_user in await staff_repo.list_enabled_staff_users(company_id):
+        try:
+            user_id = int(staff_user.get("user_id")) if staff_user.get("user_id") is not None else None
+        except (TypeError, ValueError):
+            user_id = None
+        if user_id is not None:
+            allowed_ids.add(user_id)
+    return [user_id for user_id in requested_ids if user_id in allowed_ids]
+
+
 def _strip_external_links(text: str) -> str:
     return re.sub(r"https?://\S+|www\.\S+", " ", text or "")
 
@@ -1549,6 +1593,9 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
             is_billable=is_billable,
             labour_type_id=labour_type_id,
         )
+        mentioned_user_ids = await _valid_mentioned_user_ids(ticket, _parse_mentioned_user_ids(form))
+        if mentioned_user_ids:
+            await tickets_repo.bulk_add_watchers(ticket_id, mentioned_user_ids)
         attachments = form.getlist("attachments")
         if attachments:
             for attachment in attachments:

--- a/app/features/tickets/portal_routes.py
+++ b/app/features/tickets/portal_routes.py
@@ -17,6 +17,8 @@ from ``app.main`` and the existing service modules; see the pack
 
 from __future__ import annotations
 
+from typing import Any, Mapping
+
 from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 
@@ -24,6 +26,7 @@ from app.core.logging import log_error
 from app.features.tickets.form_helpers import get_last_form_value
 from app.security.flash import flash_redirect
 from app.repositories import ticket_views as ticket_views_repo
+from app.repositories import staff as staff_repo
 from app.repositories import tickets as tickets_repo
 from app.services import ticket_attachments as attachments_service
 from app.services import tickets as tickets_service
@@ -31,6 +34,50 @@ from app.services.sanitization import sanitize_rich_text
 
 
 router = APIRouter(tags=["Tickets"])
+
+
+def _parse_mentioned_user_ids(form) -> list[int]:
+    raw_values: list[object] = []
+    getlist = getattr(form, "getlist", None)
+    if callable(getlist):
+        raw_values.extend(getlist("mentionedUserIds"))
+    else:
+        raw_values.append(form.get("mentionedUserIds"))
+    user_ids: list[int] = []
+    seen: set[int] = set()
+    for raw in raw_values:
+        for token in str(raw or "").replace(";", ",").split(","):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                user_id = int(token)
+            except (TypeError, ValueError):
+                continue
+            if user_id > 0 and user_id not in seen:
+                seen.add(user_id)
+                user_ids.append(user_id)
+    return user_ids
+
+
+async def _valid_mentioned_user_ids(ticket: Mapping[str, Any] | dict[str, Any], requested_ids: list[int]) -> list[int]:
+    if not requested_ids:
+        return []
+    try:
+        company_id = int(ticket.get("company_id")) if ticket.get("company_id") is not None else None
+    except (TypeError, ValueError, AttributeError):
+        company_id = None
+    if company_id is None:
+        return []
+    allowed_ids: set[int] = set()
+    for staff_user in await staff_repo.list_enabled_staff_users(company_id):
+        try:
+            user_id = int(staff_user.get("user_id")) if staff_user.get("user_id") is not None else None
+        except (TypeError, ValueError):
+            user_id = None
+        if user_id is not None:
+            allowed_ids.add(user_id)
+    return [user_id for user_id in requested_ids if user_id in allowed_ids]
 
 
 def _main():
@@ -338,6 +385,10 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
             minutes_spent=None,
             is_billable=False,
         )
+        if has_helpdesk_access or is_super_admin:
+            mentioned_user_ids = await _valid_mentioned_user_ids(ticket, _parse_mentioned_user_ids(form))
+            if mentioned_user_ids:
+                await tickets_repo.bulk_add_watchers(ticket_id, mentioned_user_ids)
         if reply_status:
             await tickets_repo.set_ticket_status(ticket_id, reply_status)
 

--- a/app/main.py
+++ b/app/main.py
@@ -8215,6 +8215,28 @@ async def _render_portal_ticket_detail(
                 "email": watcher.get("email"),
             })
 
+    ticket_mention_staff_options: list[dict[str, Any]] = []
+    if has_helpdesk_access or is_super_admin:
+        try:
+            ticket_company_id = int(ticket.get("company_id")) if ticket.get("company_id") is not None else None
+        except (TypeError, ValueError):
+            ticket_company_id = None
+        if ticket_company_id is not None:
+            for staff_user in await staff_repo.list_enabled_staff_users(ticket_company_id):
+                user_id_value = staff_user.get("user_id")
+                if user_id_value is None:
+                    continue
+                try:
+                    user_id_int = int(user_id_value)
+                except (TypeError, ValueError):
+                    continue
+                label = _format_user_label(staff_user) or str(staff_user.get("email") or "").strip()
+                ticket_mention_staff_options.append({
+                    "id": user_id_int,
+                    "label": label,
+                    "email": str(staff_user.get("email") or "").strip(),
+                })
+
     # Get ticket attachments
     attachment_records: list[Mapping[str, Any]] = []
     try:
@@ -8301,6 +8323,7 @@ async def _render_portal_ticket_detail(
         "assigned_user": assigned_record,
         "ticket_replies": timeline_entries,
         "ticket_watchers": watchers,
+        "ticket_mention_staff_options": ticket_mention_staff_options,
         "ticket_attachments": formatted_attachments,
         "ticket_assets": ticket_assets,
         "ticket_status_definitions": [
@@ -8950,6 +8973,17 @@ async def _render_ticket_detail(
         # Get all enabled staff for the company as watcher options
         watcher_staff_options = await staff_repo.list_enabled_staff_users(ticket_company_id)
 
+
+    ticket_mention_staff_options = [
+        {
+            "id": int(option.get("user_id")),
+            "label": _format_user_label(option) or str(option.get("email") or "").strip(),
+            "email": str(option.get("email") or "").strip(),
+        }
+        for option in watcher_staff_options
+        if option.get("user_id") is not None
+    ]
+
     current_requester_id = ticket.get("requester_id")
     if isinstance(current_requester_id, int):
         existing_ids = {
@@ -9121,6 +9155,7 @@ async def _render_ticket_detail(
         "ticket_user_options": technician_users,
         "ticket_requester_options": requester_options,
         "ticket_watcher_staff_options": watcher_staff_options,
+        "ticket_mention_staff_options": ticket_mention_staff_options,
         "ticket_priority_options": priority_options,
         "ticket_return_url": request.url.path,
         "ticket_assets": ticket_assets,

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10814,3 +10814,48 @@ a.stat-strip__stat:focus-visible {
     flex-direction: column;
   }
 }
+
+.ticket-mention-menu {
+  position: absolute;
+  z-index: 30;
+  width: min(24rem, 100%);
+  max-height: 16rem;
+  overflow-y: auto;
+  padding: 0.35rem;
+  border: 1px solid var(--color-border, rgba(148, 163, 184, 0.35));
+  border-radius: 0.75rem;
+  background: var(--color-surface, #ffffff);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
+}
+
+.rich-text-editor:has(.ticket-mention-menu) {
+  position: relative;
+}
+
+.ticket-mention-menu__item {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.55rem 0.7rem;
+  border: 0;
+  border-radius: 0.55rem;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.ticket-mention-menu__item:hover,
+.ticket-mention-menu__item.is-active {
+  background: var(--color-primary-soft, rgba(37, 99, 235, 0.12));
+}
+
+.ticket-mention-menu__name {
+  font-weight: 700;
+}
+
+.ticket-mention-menu__email {
+  color: var(--color-text-muted, #64748b);
+  font-size: 0.85rem;
+}

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -2422,6 +2422,164 @@
     });
   }
 
+
+
+  function initialiseTicketMentions() {
+    document.querySelectorAll('[data-ticket-mention-users]').forEach((editor) => {
+      const surface = editor.querySelector('[data-rich-text-content]');
+      const form = editor.closest('form');
+      const hidden = form ? form.querySelector('[data-ticket-mention-user-ids]') : null;
+      if (!(surface instanceof HTMLElement) || !(hidden instanceof HTMLInputElement)) {
+        return;
+      }
+
+      let users = [];
+      try {
+        users = JSON.parse(editor.getAttribute('data-ticket-mention-users') || '[]');
+      } catch (error) {
+        users = [];
+      }
+      users = users
+        .map((user) => ({
+          id: Number(user.id),
+          label: String(user.label || user.email || '').trim(),
+          email: String(user.email || '').trim(),
+        }))
+        .filter((user) => Number.isInteger(user.id) && user.id > 0 && user.label);
+      if (!users.length) {
+        return;
+      }
+
+      const selected = new Set();
+      const menu = document.createElement('div');
+      menu.className = 'ticket-mention-menu';
+      menu.setAttribute('role', 'listbox');
+      menu.hidden = true;
+      editor.appendChild(menu);
+
+      let activeIndex = 0;
+      let currentRange = null;
+      let currentQuery = '';
+
+      function syncHidden() {
+        hidden.value = Array.from(selected).join(',');
+      }
+
+      function getMentionContext() {
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0 || !surface.contains(selection.anchorNode)) {
+          return null;
+        }
+        const range = selection.getRangeAt(0).cloneRange();
+        const prefixRange = range.cloneRange();
+        prefixRange.selectNodeContents(surface);
+        prefixRange.setEnd(range.endContainer, range.endOffset);
+        const text = prefixRange.toString();
+        const match = text.match(/(^|\s)@([\p{L}\p{N}._'-]{0,40})$/u);
+        if (!match) {
+          return null;
+        }
+        return { query: match[2].toLowerCase(), length: match[2].length + 1 };
+      }
+
+      function matchingUsers(query) {
+        return users.filter((user) => {
+          const haystack = `${user.label} ${user.email}`.toLowerCase();
+          return haystack.includes(query);
+        }).slice(0, 8);
+      }
+
+      function positionMenu() {
+        const rect = surface.getBoundingClientRect();
+        menu.style.left = '0px';
+        menu.style.top = `${rect.height + 6}px`;
+      }
+
+      function hideMenu() {
+        menu.hidden = true;
+        menu.innerHTML = '';
+        currentRange = null;
+      }
+
+      function renderMenu(matches) {
+        if (!matches.length) {
+          hideMenu();
+          return;
+        }
+        activeIndex = Math.min(activeIndex, matches.length - 1);
+        menu.innerHTML = matches.map((user, index) => `
+          <button type="button" class="ticket-mention-menu__item${index === activeIndex ? ' is-active' : ''}" data-mention-index="${index}" role="option" aria-selected="${index === activeIndex ? 'true' : 'false'}">
+            <span class="ticket-mention-menu__name"></span>
+            <span class="ticket-mention-menu__email"></span>
+          </button>
+        `).join('');
+        menu.querySelectorAll('[data-mention-index]').forEach((button) => {
+          const user = matches[Number(button.getAttribute('data-mention-index'))];
+          button.querySelector('.ticket-mention-menu__name').textContent = user.label;
+          button.querySelector('.ticket-mention-menu__email').textContent = user.email;
+          button.addEventListener('mousedown', (event) => {
+            event.preventDefault();
+            confirmMention(user);
+          });
+        });
+        menu.hidden = false;
+        positionMenu();
+      }
+
+      function updateMenu() {
+        const context = getMentionContext();
+        if (!context) {
+          hideMenu();
+          return;
+        }
+        currentQuery = context.query;
+        const selection = window.getSelection();
+        currentRange = selection && selection.rangeCount ? selection.getRangeAt(0).cloneRange() : null;
+        renderMenu(matchingUsers(currentQuery));
+      }
+
+      function confirmMention(user) {
+        if (!currentRange) {
+          return;
+        }
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(currentRange);
+        if (selection.modify) {
+          for (let i = 0; i < currentQuery.length + 1; i += 1) {
+            selection.modify('extend', 'backward', 'character');
+          }
+        }
+        document.execCommand('insertText', false, `@${user.label} `);
+        selected.add(user.id);
+        syncHidden();
+        surface.dispatchEvent(new Event('input', { bubbles: true }));
+        hideMenu();
+      }
+
+      surface.addEventListener('input', updateMenu);
+      surface.addEventListener('keyup', updateMenu);
+      surface.addEventListener('blur', () => window.setTimeout(hideMenu, 150));
+      surface.addEventListener('keydown', (event) => {
+        if (menu.hidden) {
+          return;
+        }
+        const matches = matchingUsers(currentQuery);
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+          event.preventDefault();
+          activeIndex = (activeIndex + (event.key === 'ArrowDown' ? 1 : -1) + matches.length) % matches.length;
+          renderMenu(matches);
+        } else if (event.key === 'Enter') {
+          event.preventDefault();
+          confirmMention(matches[activeIndex]);
+        } else if (event.key === 'Escape') {
+          event.preventDefault();
+          hideMenu();
+        }
+      });
+    });
+  }
+
   function ready() {
     const messageWrappers = document.querySelectorAll('[data-timeline-message]');
 
@@ -2442,6 +2600,7 @@
     initialiseRequesterSelector();
     initialiseTaskManagement();
     initialiseWatcherManagement();
+    initialiseTicketMentions();
     initialiseAttachmentActions();
     initTicketRelated();
     convertUtcElements();

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -995,6 +995,7 @@
                 <div
                   class="rich-text-editor"
                   data-rich-text-editor
+                  data-ticket-mention-users='{{ ticket_mention_staff_options | tojson | e }}'
                   aria-labelledby="ticket-reply-label"
                 >
                   <div class="rich-text-editor__toolbar" role="toolbar" aria-label="Formatting options">
@@ -1092,6 +1093,7 @@
                     aria-multiline="true"
                     data-placeholder="Write your reply..."
                   ></div>
+                  <input type="hidden" name="mentionedUserIds" data-ticket-mention-user-ids />
                   <textarea
                     name="body"
                     class="rich-text-editor__fallback"

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -324,6 +324,7 @@
                     <div
                       class="rich-text-editor"
                       data-rich-text-editor
+                      data-ticket-mention-users='{{ ticket_mention_staff_options | default([]) | tojson | e }}'
                       aria-labelledby="ticket-reply-label"
                     >
                       <div class="rich-text-editor__toolbar" role="toolbar" aria-label="Formatting options">
@@ -422,6 +423,7 @@
                         data-placeholder="Write your reply..."
                       >{{ reply_body }}</div>
                     </div>
+                    <input type="hidden" name="mentionedUserIds" data-ticket-mention-user-ids />
                     <textarea
                       id="ticket-reply-body-hidden"
                       name="body"


### PR DESCRIPTION
### Motivation
- Provide technicians a fast way to mention staff in ticket replies using `@name` and automatically subscribe mentioned staff as ticket watchers when a reply is sent.
- Keep mention suggestions scoped to enabled staff for the ticket's company and validate IDs server-side to avoid privilege escalation or invalid watcher additions.

### Description
- Add server-side mention support: parse submitted `mentionedUserIds`, validate them against enabled company staff, and call `tickets_repo.bulk_add_watchers` when saving replies in both admin and portal flows (`app/features/tickets/admin_routes.py`, `app/features/tickets/portal_routes.py`).
- Expose mention candidates to templates by adding `ticket_mention_staff_options` into ticket detail contexts (`app/main.py`) for both portal and admin pages.
- Wire the rich-text reply forms to submit selected mentions via a hidden input `mentionedUserIds` in templates (`app/templates/admin/ticket_detail.html`, `app/templates/tickets/detail.html`).
- Implement client-side mention UX: suggestion popdown, keyboard navigation, enter/click to confirm, and hidden-ID syncing in `app/static/js/ticket_detail.js` (`initialiseTicketMentions`).
- Add styles for the mention popdown in `app/static/css/app.css`.
- Sanity and security: only technicians/super-admins see mention suggestion payloads, and backend validates requested IDs are allowed for the ticket company before adding watchers.

### Testing
- Ran byte-compile on modified files with `python3 -m compileall app/features/tickets/admin_routes.py app/features/tickets/portal_routes.py app/main.py` which succeeded.
- Ran `pytest tests/test_tickets_dashboard_api.py -q` but collection failed due to a missing system dependency (`libmagic`) in the environment, so full automated tests were blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4f4c548994832da232c66c038a3b69)