### PR TITLE
Prune empty M365 mail sync history

### DIFF
--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -854,25 +854,35 @@ async def _record_sync_history_safe(
 ) -> None:
     message_actions = list(result.get("message_actions") or [])
     errors = list(result.get("errors") or [])
+    processed = int(result.get("processed") or 0)
+    created_count = sum(
+        1 for action in message_actions if action.get("outcome") == "created_new_ticket"
+    )
+    attached_count = sum(
+        1
+        for action in message_actions
+        if action.get("outcome") == "attached_to_existing_ticket"
+    )
+    ignored_count = sum(
+        1 for action in message_actions if action.get("outcome") == "ignored"
+    )
+    error_count = len(errors)
+    if not any((processed, created_count, attached_count, ignored_count, error_count)):
+        log_info(
+            "Skipping empty M365 mail sync history record",
+            account_id=account_id,
+            status=_normalise_string(result.get("status"), default="unknown"),
+        )
+        return
     try:
         await mail_repo.record_sync_history(
             account_id=int(account_id),
             status=_normalise_string(result.get("status"), default="unknown"),
-            processed=int(result.get("processed") or 0),
-            created_count=sum(
-                1
-                for action in message_actions
-                if action.get("outcome") == "created_new_ticket"
-            ),
-            attached_count=sum(
-                1
-                for action in message_actions
-                if action.get("outcome") == "attached_to_existing_ticket"
-            ),
-            ignored_count=sum(
-                1 for action in message_actions if action.get("outcome") == "ignored"
-            ),
-            error_count=len(errors),
+            processed=processed,
+            created_count=created_count,
+            attached_count=attached_count,
+            ignored_count=ignored_count,
+            error_count=error_count,
             errors=errors,
             message_actions=message_actions,
             started_at=started_at,

--- a/migrations/293_purge_empty_m365_mail_sync_history.sql
+++ b/migrations/293_purge_empty_m365_mail_sync_history.sql
@@ -1,0 +1,9 @@
+-- Remove historical M365 mail sync entries that did not process any messages.
+-- Future empty sync runs are skipped in application code.
+
+DELETE FROM m365_mail_sync_history
+WHERE COALESCE(processed, 0) = 0
+  AND COALESCE(created_count, 0) = 0
+  AND COALESCE(attached_count, 0) = 0
+  AND COALESCE(ignored_count, 0) = 0
+  AND COALESCE(error_count, 0) = 0;

--- a/tests/test_m365_mail_sync_403.py
+++ b/tests/test_m365_mail_sync_403.py
@@ -1,4 +1,5 @@
 """Tests for 403 error handling in M365 mail sync_account."""
+
 from __future__ import annotations
 from typing import Any
 import pytest
@@ -7,37 +8,60 @@ from app.services.m365 import M365Error
 
 pytestmark = pytest.mark.anyio("asyncio")
 
+
 @pytest.fixture
 def anyio_backend() -> str:
     return "asyncio"
 
+
 def _fake_account(company_id: int | None = 5) -> dict[str, Any]:
-    return {"id": 1, "active": True, "company_id": company_id, "user_principal_name": "user@example.com", "folder": "Inbox", "process_unread_only": True, "mark_as_read": True}
+    return {
+        "id": 1,
+        "active": True,
+        "company_id": company_id,
+        "user_principal_name": "user@example.com",
+        "folder": "Inbox",
+        "process_unread_only": True,
+        "mark_as_read": True,
+    }
+
 
 def _patch_common(monkeypatch):
     monkeypatch.setattr(m365_mail.system_state, "is_restart_pending", lambda: False)
+
     async def fake_get_module(slug: str, *, redact: bool = True):
         return {"enabled": True}
+
     async def fake_get_account(account_id: int):
         return _fake_account()
+
     async def fake_update_account(account_id, **fields):
         return None
+
     async def fake_acquire_delegated_token(company_id):
         return None
+
     monkeypatch.setattr(m365_mail.modules_service, "get_module", fake_get_module)
     monkeypatch.setattr(m365_mail.mail_repo, "get_account", fake_get_account)
     monkeypatch.setattr(m365_mail.mail_repo, "update_account", fake_update_account)
-    monkeypatch.setattr(m365_mail.m365_service, "acquire_delegated_token", fake_acquire_delegated_token)
+    monkeypatch.setattr(
+        m365_mail.m365_service, "acquire_delegated_token", fake_acquire_delegated_token
+    )
 
 
 async def test_sync_account_403_returns_actionable_error(monkeypatch):
     """A 403 from Graph should surface a clear actionable error message."""
     _patch_common(monkeypatch)
+
     async def fake_acquire_token(company_id, **kwargs):
         return "fake-token"
+
     async def fake_graph_get(access_token: str, url: str):
         raise M365Error("Microsoft Graph request failed (403)", http_status=403)
-    monkeypatch.setattr(m365_mail.m365_service, "acquire_access_token", fake_acquire_token)
+
+    monkeypatch.setattr(
+        m365_mail.m365_service, "acquire_access_token", fake_acquire_token
+    )
     monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
     result = await m365_mail.sync_account(1)
     assert result["status"] == "completed_with_errors"
@@ -51,11 +75,16 @@ async def test_sync_account_403_returns_actionable_error(monkeypatch):
 async def test_sync_account_403_non_403_error_not_intercepted(monkeypatch):
     """Non-403 errors should propagate normally."""
     _patch_common(monkeypatch)
+
     async def fake_acquire_token(company_id, **kwargs):
         return "fake-token"
+
     async def fake_graph_get(access_token: str, url: str):
         raise M365Error("Microsoft Graph request failed (500)", http_status=500)
-    monkeypatch.setattr(m365_mail.m365_service, "acquire_access_token", fake_acquire_token)
+
+    monkeypatch.setattr(
+        m365_mail.m365_service, "acquire_access_token", fake_acquire_token
+    )
     monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
     result = await m365_mail.sync_account(1)
     assert result["status"] == "completed_with_errors"
@@ -68,12 +97,17 @@ async def test_sync_uses_unread_filter_param_in_graph_url(monkeypatch):
     """Unread-only sync asks Graph for unread messages instead of scanning the whole folder."""
     _patch_common(monkeypatch)
     captured_urls: list[str] = []
+
     async def fake_acquire_token(company_id, **kwargs):
         return "fake-token"
+
     async def fake_graph_get(access_token: str, url: str):
         captured_urls.append(url)
         return {"value": [], "@odata.nextLink": None}
-    monkeypatch.setattr(m365_mail.m365_service, "acquire_access_token", fake_acquire_token)
+
+    monkeypatch.setattr(
+        m365_mail.m365_service, "acquire_access_token", fake_acquire_token
+    )
     monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
     result = await m365_mail.sync_account(1)
     assert result["status"] == "succeeded"
@@ -84,17 +118,60 @@ async def test_sync_uses_unread_filter_param_in_graph_url(monkeypatch):
 async def test_sync_read_message_skipped_when_process_unread_only(monkeypatch):
     """Messages with isRead=True must be skipped client-side."""
     _patch_common(monkeypatch)
+
     async def fake_acquire_token(company_id, **kwargs):
         return "fake-token"
+
     async def fake_graph_get(access_token: str, url: str):
-        return {"value": [{"id": "msg-read", "internetMessageId": "<r@e.com>", "subject": "R", "body": {"content": "b"}, "from": {"emailAddress": {"address": "a@b.com", "name": "A"}}, "toRecipients": [], "ccRecipients": [], "bccRecipients": [], "replyTo": [], "internetMessageHeaders": [], "isRead": True, "receivedDateTime": "2026-01-01T10:00:00Z", "hasAttachments": False, "conversationId": "c1"}, {"id": "msg-unread", "internetMessageId": "<u@e.com>", "subject": "U", "body": {"content": "b"}, "from": {"emailAddress": {"address": "b@c.com", "name": "B"}}, "toRecipients": [], "ccRecipients": [], "bccRecipients": [], "replyTo": [], "internetMessageHeaders": [], "isRead": False, "receivedDateTime": "2026-01-01T11:00:00Z", "hasAttachments": False, "conversationId": "c2"}]}
+        return {
+            "value": [
+                {
+                    "id": "msg-read",
+                    "internetMessageId": "<r@e.com>",
+                    "subject": "R",
+                    "body": {"content": "b"},
+                    "from": {"emailAddress": {"address": "a@b.com", "name": "A"}},
+                    "toRecipients": [],
+                    "ccRecipients": [],
+                    "bccRecipients": [],
+                    "replyTo": [],
+                    "internetMessageHeaders": [],
+                    "isRead": True,
+                    "receivedDateTime": "2026-01-01T10:00:00Z",
+                    "hasAttachments": False,
+                    "conversationId": "c1",
+                },
+                {
+                    "id": "msg-unread",
+                    "internetMessageId": "<u@e.com>",
+                    "subject": "U",
+                    "body": {"content": "b"},
+                    "from": {"emailAddress": {"address": "b@c.com", "name": "B"}},
+                    "toRecipients": [],
+                    "ccRecipients": [],
+                    "bccRecipients": [],
+                    "replyTo": [],
+                    "internetMessageHeaders": [],
+                    "isRead": False,
+                    "receivedDateTime": "2026-01-01T11:00:00Z",
+                    "hasAttachments": False,
+                    "conversationId": "c2",
+                },
+            ]
+        }
+
     visited: list[str] = []
+
     async def fake_get_message(account_id, message_uid):
         visited.append(message_uid)
         return {"status": "imported"}
+
     async def fake_update_account(account_id, **fields):
         return None
-    monkeypatch.setattr(m365_mail.m365_service, "acquire_access_token", fake_acquire_token)
+
+    monkeypatch.setattr(
+        m365_mail.m365_service, "acquire_access_token", fake_acquire_token
+    )
     monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
     monkeypatch.setattr(m365_mail.mail_repo, "get_message", fake_get_message)
     monkeypatch.setattr(m365_mail.mail_repo, "update_account", fake_update_account)
@@ -118,7 +195,9 @@ async def test_sync_unread_filter_403_falls_back_to_full_scan(monkeypatch):
             raise M365Error("Microsoft Graph request failed (403)", http_status=403)
         return {"value": [], "@odata.nextLink": None}
 
-    monkeypatch.setattr(m365_mail.m365_service, "acquire_access_token", fake_acquire_token)
+    monkeypatch.setattr(
+        m365_mail.m365_service, "acquire_access_token", fake_acquire_token
+    )
     monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
 
     result = await m365_mail.sync_account(1)
@@ -128,3 +207,55 @@ async def test_sync_unread_filter_403_falls_back_to_full_scan(monkeypatch):
     assert "$filter=isRead%20eq%20false" in captured_urls[0]
     assert "$filter" not in captured_urls[1]
     assert "$orderby" in captured_urls[1]
+
+
+async def test_empty_sync_history_is_not_recorded(monkeypatch):
+    """Sync runs with no imported, created, attached, ignored, or errored messages are omitted."""
+    recorded: list[dict[str, Any]] = []
+
+    async def fake_record_sync_history(**kwargs):
+        recorded.append(kwargs)
+
+    monkeypatch.setattr(
+        m365_mail.mail_repo, "record_sync_history", fake_record_sync_history
+    )
+
+    await m365_mail._record_sync_history_safe(
+        account_id=1,
+        started_at=m365_mail.datetime.now(m365_mail.timezone.utc),
+        result={
+            "status": "succeeded",
+            "processed": 0,
+            "message_actions": [],
+            "errors": [],
+        },
+    )
+
+    assert recorded == []
+
+
+async def test_non_empty_sync_history_is_recorded(monkeypatch):
+    """Sync history is retained once at least one message is processed or errored."""
+    recorded: list[dict[str, Any]] = []
+
+    async def fake_record_sync_history(**kwargs):
+        recorded.append(kwargs)
+
+    monkeypatch.setattr(
+        m365_mail.mail_repo, "record_sync_history", fake_record_sync_history
+    )
+
+    await m365_mail._record_sync_history_safe(
+        account_id=1,
+        started_at=m365_mail.datetime.now(m365_mail.timezone.utc),
+        result={
+            "status": "succeeded",
+            "processed": 1,
+            "message_actions": [{"outcome": "ignored"}],
+            "errors": [],
+        },
+    )
+
+    assert len(recorded) == 1
+    assert recorded[0]["processed"] == 1
+    assert recorded[0]["ignored_count"] == 1


### PR DESCRIPTION
### Motivation
- Avoid cluttering the `m365_mail_sync_history` table with empty runs where no messages were processed or acted upon (Imported/Created/Attached/Ignored/Errors all zero).

### Description
- Update `_record_sync_history_safe` in `app/services/m365_mail.py` to compute `processed`, `created_count`, `attached_count`, `ignored_count`, and `error_count`, and to skip persisting history when all these counts are zero.
- Add migration `migrations/293_purge_empty_m365_mail_sync_history.sql` which deletes existing empty history rows at startup. 
- Add regression tests in `tests/test_m365_mail_sync_403.py` that assert empty runs are not recorded and non-empty runs are recorded. 

### Testing
- `python -m py_compile app/services/m365_mail.py tests/test_m365_mail_sync_403.py` succeeded. 
- Executed a SQLite migration smoke test by applying `migrations/293_purge_empty_m365_mail_sync_history.sql` against an in-memory DB which removed the empty row as expected. 
- Running `pytest -q tests/test_m365_mail_sync_403.py` failed during collection due to a missing system dependency (`libmagic`) in the environment, so full test execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4f4fae5010832d9ffe8c1d6c395b4f)