### PR TITLE
Fix admin ticket requester label rendering

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7887,6 +7887,19 @@ def _format_attachment_uploaded_iso(uploaded_at: datetime | None) -> str | None:
     return uploaded_dt.isoformat()
 
 
+def _format_user_label(user_record: Mapping[str, Any] | None) -> str:
+    """Build a safe display label for a user or staff-like record."""
+    if not isinstance(user_record, Mapping):
+        return "System"
+    first = str(user_record.get("first_name") or "").strip()
+    last = str(user_record.get("last_name") or "").strip()
+    name_parts = [part for part in (first, last) if part]
+    if name_parts:
+        return " ".join(name_parts)
+    email = str(user_record.get("email") or "").strip()
+    return email or "System"
+
+
 async def _render_portal_ticket_detail(
     request: Request,
     user: dict[str, Any],

--- a/tests/test_admin_ticket_detail.py
+++ b/tests/test_admin_ticket_detail.py
@@ -98,7 +98,20 @@ async def test_render_ticket_detail_with_tactical_module_and_ai_tags(monkeypatch
         "list_users_with_permission",
         AsyncMock(return_value=[]),
     )
-    monkeypatch.setattr(main.staff_repo, "list_enabled_staff_users", AsyncMock(return_value=[]))
+    requester_staff_options = [
+        {
+            "id": 2,
+            "user_id": 2,
+            "first_name": "Requester",
+            "last_name": "Example",
+            "email": "requester@example.com",
+        }
+    ]
+    monkeypatch.setattr(
+        main.staff_repo,
+        "list_enabled_staff_users",
+        AsyncMock(return_value=requester_staff_options),
+    )
     monkeypatch.setattr(main.assets_repo, "list_company_assets", AsyncMock(return_value=[]))
     monkeypatch.setattr(
         main.knowledge_base_repo,
@@ -143,6 +156,9 @@ async def test_render_ticket_detail_with_tactical_module_and_ai_tags(monkeypatch
     assert captured["extra"]["relevant_kb_articles"] == relevant_kb_articles
     # Verify tactical base URL was extracted correctly
     assert captured["extra"]["tacticalrmm_base_url"] == "https://tactical.example.com"
+    assert captured["extra"]["ticket_mention_staff_options"] == [
+        {"id": 2, "label": "Requester Example", "email": "requester@example.com"}
+    ]
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation
- Prevent runtime `NameError` when admin ticket detail rendering references `_format_user_label` for requester/staff records by providing a module-level helper.
- Ensure admin ticket mention/staff option labels are formatted consistently (prefer full name, fallback to email) so UI shows human-friendly labels.

### Description
- Add a new helper `def _format_user_label(user_record: Mapping[str, Any] | None) -> str` in `app/main.py` that returns a full name when `first_name`/`last_name` exist, falls back to `email`, and returns `"System"` for non-mapping inputs. 
- Update `tests/test_admin_ticket_detail.py` to include a mocked enabled staff user in `list_enabled_staff_users` and assert that `ticket_mention_staff_options` contains the expected formatted label.

### Testing
- Ran `python -m py_compile app/main.py tests/test_admin_ticket_detail.py` which completed successfully. 
- Attempted `pytest tests/test_admin_ticket_detail.py -q` but test collection failed due to a missing system dependency: `libmagic` (ImportError from the `magic` Python package), so the full pytest run was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4f9f328778832d9776b703df6dfd96)