### PR TITLE
Add Smart Attachment Removal automation action

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -987,6 +987,14 @@ _ALWAYS_ON_TICKET_ACTION_MODULES: tuple[dict[str, Any], ...] = (
         "settings": {},
         "enabled": True,
     },
+    {
+        "slug": "smart-attachment-removal",
+        "name": "Smart Attachment Removal",
+        "description": "Remove duplicate ticket attachments by comparing file hashes and deleting redundant copies from storage.",
+        "icon": "🧹",
+        "settings": {},
+        "enabled": True,
+    },
 )
 _ALWAYS_ON_TICKET_ACTION_MODULE_SLUGS = {
     module["slug"] for module in _ALWAYS_ON_TICKET_ACTION_MODULES
@@ -2230,6 +2238,27 @@ _ACTION_PAYLOAD_SCHEMAS: dict[str, dict[str, Any]] = {
             {"name": "author_id", "label": "Author ID", "type": "string"},
         ],
     },
+    "smart-attachment-removal": {
+        "fields": [
+            {
+                "name": "ticket_id",
+                "label": "Ticket ID",
+                "type": "string",
+                "placeholder": "{{ticket.id}}",
+            },
+            {
+                "name": "hash_algorithm",
+                "label": "Hash algorithm",
+                "type": "string",
+                "enum": ["sha256", "md5"],
+            },
+            {
+                "name": "dry_run",
+                "label": "Dry run",
+                "type": "boolean",
+            },
+        ],
+    },
     "whisperx": {
         "fields": [
             {"name": "ticket_id", "label": "Ticket ID", "type": "string"},
@@ -2450,6 +2479,7 @@ async def trigger_module(
         "update-ticket-description": _invoke_update_ticket_description,
         "reprocess-ai": _invoke_reprocess_ai,
         "add-ticket-reply": _invoke_add_ticket_reply,
+        "smart-attachment-removal": _invoke_smart_attachment_removal,
         "whisperx": _invoke_whisperx,
         "password-pusher": _invoke_password_pusher,
         "hudu": _validate_hudu,
@@ -5688,6 +5718,138 @@ async def _invoke_add_ticket_reply(
             "is_internal": is_internal,
         },
     )
+
+
+def _resolve_ticket_id_from_payload(payload: Mapping[str, Any]) -> int:
+    """Resolve a ticket id from an action payload or automation context."""
+
+    raw_context = payload.get("context")
+    context = raw_context if isinstance(raw_context, Mapping) else {}
+    ticket_id = payload.get("ticket_id")
+    if ticket_id is None:
+        ticket_id = context.get("ticket_id")
+    if ticket_id is None:
+        ticket_context = context.get("ticket")
+        if isinstance(ticket_context, Mapping):
+            ticket_id = ticket_context.get("id")
+    if ticket_id is None:
+        raise ValueError("ticket_id is required")
+    try:
+        ticket_id_int = int(ticket_id)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("ticket_id must be a valid integer") from exc
+    if ticket_id_int <= 0:
+        raise ValueError("ticket_id must be a positive integer")
+    return ticket_id_int
+
+
+async def _invoke_smart_attachment_removal(
+    settings: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    *,
+    event_future: asyncio.Future[int | None] | None = None,
+) -> dict[str, Any]:
+    """Remove duplicate ticket attachments by comparing content hashes."""
+
+    from app.repositories import tickets as tickets_repo
+    from app.repositories import ticket_attachments as attachments_repo
+    from app.services import ticket_attachments as attachments_service
+
+    ticket_id = _resolve_ticket_id_from_payload(payload)
+    existing = await tickets_repo.get_ticket(ticket_id)
+    if not existing:
+        raise ValueError(f"Ticket {ticket_id} not found")
+
+    algorithm = str(payload.get("hash_algorithm") or "sha256").strip().lower()
+    if algorithm not in {"sha256", "md5"}:
+        raise ValueError("hash_algorithm must be one of: sha256, md5")
+    dry_run = bool(payload.get("dry_run", False))
+
+    attachments = await attachments_repo.list_attachments(ticket_id)
+    seen: dict[str, dict[str, Any]] = {}
+    duplicates: list[dict[str, Any]] = []
+    missing_files: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+
+    for attachment in attachments:
+        filename = str(attachment.get("filename") or "").strip()
+        attachment_id = attachment.get("id")
+        if not filename or attachment_id is None:
+            errors.append(
+                {
+                    "attachment_id": attachment_id,
+                    "error": "Attachment record has no stored filename",
+                }
+            )
+            continue
+        file_path = attachments_service.get_attachment_file_path(filename)
+        if not file_path.exists() or not file_path.is_file():
+            missing_files.append(
+                {
+                    "attachment_id": attachment_id,
+                    "filename": filename,
+                    "original_filename": attachment.get("original_filename"),
+                }
+            )
+            continue
+        digest = hashlib.new(algorithm)
+        try:
+            with open(file_path, "rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        except OSError as exc:
+            errors.append(
+                {
+                    "attachment_id": attachment_id,
+                    "filename": filename,
+                    "error": str(exc),
+                }
+            )
+            continue
+        file_hash = digest.hexdigest()
+        original = seen.get(file_hash)
+        if original is None:
+            seen[file_hash] = attachment
+            continue
+        duplicate_entry = {
+            "attachment_id": attachment_id,
+            "original_attachment_id": original.get("id"),
+            "filename": filename,
+            "original_filename": attachment.get("original_filename"),
+            "hash": file_hash,
+        }
+        duplicates.append(duplicate_entry)
+        if dry_run:
+            continue
+        try:
+            await attachments_service.delete_attachment_file(attachment)
+        except Exception as exc:  # pragma: no cover - defensive per-file guard
+            duplicate_entry["deleted"] = False
+            duplicate_entry["error"] = str(exc)
+            errors.append(
+                {
+                    "attachment_id": attachment_id,
+                    "filename": filename,
+                    "error": str(exc),
+                }
+            )
+        else:
+            duplicate_entry["deleted"] = True
+
+    removed = sum(1 for entry in duplicates if entry.get("deleted"))
+    return {
+        "status": "succeeded" if not errors else "partial",
+        "ticket_id": ticket_id,
+        "hash_algorithm": algorithm,
+        "dry_run": dry_run,
+        "scanned": len(attachments),
+        "unique": len(seen),
+        "duplicates_found": len(duplicates),
+        "removed": 0 if dry_run else removed,
+        "missing_files": missing_files,
+        "duplicates": duplicates,
+        "errors": errors,
+    }
 
 
 # Audio MIME types accepted for WhisperX transcription

--- a/tests/test_ticket_automation_actions.py
+++ b/tests/test_ticket_automation_actions.py
@@ -164,6 +164,102 @@ async def test_invoke_update_ticket_missing_ticket_id():
 
 
 @pytest.mark.asyncio
+async def test_smart_attachment_removal_deletes_duplicate_files(monkeypatch, tmp_path):
+    """Duplicate attachment files are removed from storage and the attachment list."""
+    from app.repositories import tickets as tickets_repo
+    from app.repositories import ticket_attachments as attachments_repo
+    from app.services import ticket_attachments as attachments_service
+
+    attachments = [
+        {
+            "id": 1,
+            "ticket_id": 10,
+            "filename": "first.png",
+            "original_filename": "logo.png",
+        },
+        {
+            "id": 2,
+            "ticket_id": 10,
+            "filename": "duplicate.png",
+            "original_filename": "logo-copy.png",
+        },
+        {
+            "id": 3,
+            "ticket_id": 10,
+            "filename": "unique.png",
+            "original_filename": "diagram.png",
+        },
+    ]
+    (tmp_path / "first.png").write_bytes(b"same-image-bytes")
+    (tmp_path / "duplicate.png").write_bytes(b"same-image-bytes")
+    (tmp_path / "unique.png").write_bytes(b"different-image-bytes")
+
+    monkeypatch.setattr(tickets_repo, "get_ticket", AsyncMock(return_value={"id": 10}))
+    monkeypatch.setattr(
+        attachments_repo, "list_attachments", AsyncMock(return_value=attachments)
+    )
+    monkeypatch.setattr(
+        attachments_service,
+        "get_attachment_file_path",
+        lambda filename: tmp_path / filename,
+    )
+    delete_mock = AsyncMock()
+    monkeypatch.setattr(attachments_service, "delete_attachment_file", delete_mock)
+
+    result = await modules._invoke_smart_attachment_removal(
+        {},
+        {"context": {"ticket": {"id": 10}}},
+        event_future=None,
+    )
+
+    assert result["status"] == "succeeded"
+    assert result["scanned"] == 3
+    assert result["unique"] == 2
+    assert result["duplicates_found"] == 1
+    assert result["removed"] == 1
+    delete_mock.assert_awaited_once_with(attachments[1])
+
+
+@pytest.mark.asyncio
+async def test_smart_attachment_removal_dry_run_preserves_duplicates(monkeypatch, tmp_path):
+    """Dry runs report duplicates without deleting attachment files."""
+    from app.repositories import tickets as tickets_repo
+    from app.repositories import ticket_attachments as attachments_repo
+    from app.services import ticket_attachments as attachments_service
+
+    attachments = [
+        {"id": 1, "ticket_id": 10, "filename": "a.png", "original_filename": "a.png"},
+        {"id": 2, "ticket_id": 10, "filename": "b.png", "original_filename": "b.png"},
+    ]
+    (tmp_path / "a.png").write_bytes(b"signature")
+    (tmp_path / "b.png").write_bytes(b"signature")
+
+    monkeypatch.setattr(tickets_repo, "get_ticket", AsyncMock(return_value={"id": 10}))
+    monkeypatch.setattr(
+        attachments_repo, "list_attachments", AsyncMock(return_value=attachments)
+    )
+    monkeypatch.setattr(
+        attachments_service,
+        "get_attachment_file_path",
+        lambda filename: tmp_path / filename,
+    )
+    delete_mock = AsyncMock()
+    monkeypatch.setattr(attachments_service, "delete_attachment_file", delete_mock)
+
+    result = await modules._invoke_smart_attachment_removal(
+        {},
+        {"ticket_id": 10, "hash_algorithm": "md5", "dry_run": True},
+        event_future=None,
+    )
+
+    assert result["status"] == "succeeded"
+    assert result["hash_algorithm"] == "md5"
+    assert result["duplicates_found"] == 1
+    assert result["removed"] == 0
+    delete_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_invoke_update_ticket_description(monkeypatch, mock_webhook_monitor, mock_record_success):
     """Test that update-ticket-description module changes description."""
     from app.services import tickets as tickets_service


### PR DESCRIPTION
### Motivation
- Reduce ticket storage bloat and remove redundant attachments (e.g. repeated email signature images) by providing an admin-configurable automation that compares file hashes and deletes duplicate files and their DB records.

### Description
- Added an always-on automation action `smart-attachment-removal` to the modules registry so it can be selected in event automations (`app/services/modules.py`).
- Defined the action payload schema with `ticket_id`, `hash_algorithm` (`sha256` or `md5`), and `dry_run` options (`app/services/modules.py`).
- Implemented `_resolve_ticket_id_from_payload` to resolve ticket id from payload or automation context and `_invoke_smart_attachment_removal` which scans attachments, computes per-file hashes, retains the first occurrence, and removes duplicates using the existing `attachments_service.delete_attachment_file` (which deletes DB record and server file). The handler supports dry-run and returns a detailed report (`scanned`, `unique`, `duplicates_found`, `removed`, `missing_files`, `errors`).
- Registered the new handler in the `trigger_module` dispatcher and added regression tests covering duplicate deletion and dry-run behavior (`tests/test_ticket_automation_actions.py`).

### Testing
- Compiled the modified file with `python -m compileall app/services/modules.py` which succeeded.
- Ran the module tests with `pytest tests/test_ticket_automation_actions.py -q` and all tests in that file passed (`17 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4f657e70b8832da9b8df0d39ce768c)