### PR TITLE
Expand webhook_event_attempts request/headers to LONGTEXT to avoid Data too long errors

### DIFF
--- a/migrations/294_expand_webhook_attempt_request_body.sql
+++ b/migrations/294_expand_webhook_attempt_request_body.sql
@@ -1,0 +1,13 @@
+-- Expand webhook attempt request logging columns so large webhook payloads do not
+-- fail with MySQL error 1406 (Data too long for column 'request_body').
+-- SQLite stores these as TEXT dynamically and ignores unsupported MODIFY syntax
+-- through the migration runner's compatibility handling.
+
+ALTER TABLE webhook_event_attempts
+  MODIFY COLUMN request_body LONGTEXT NULL;
+
+ALTER TABLE webhook_event_attempts
+  MODIFY COLUMN request_headers LONGTEXT NULL;
+
+ALTER TABLE webhook_event_attempts
+  MODIFY COLUMN response_headers LONGTEXT NULL;

--- a/tests/test_webhook_request_body_migration.py
+++ b/tests/test_webhook_request_body_migration.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_webhook_request_body_migration_expands_attempt_logging_columns():
+    migration = Path("migrations/294_expand_webhook_attempt_request_body.sql")
+
+    assert migration.exists()
+    sql = migration.read_text(encoding="utf-8")
+
+    assert "MODIFY COLUMN request_body LONGTEXT NULL" in sql
+    assert "MODIFY COLUMN request_headers LONGTEXT NULL" in sql
+    assert "MODIFY COLUMN response_headers LONGTEXT NULL" in sql


### PR DESCRIPTION
### Motivation
- Prevent MySQL `1406 Data too long for column 'request_body'` errors when large webhook payloads or headers are logged by increasing the storage capacity for webhook attempt columns.

### Description
- Add migration `migrations/294_expand_webhook_attempt_request_body.sql` which changes `webhook_event_attempts.request_body`, `request_headers`, and `response_headers` to `LONGTEXT` for MySQL compatibility while remaining safe for SQLite via the migration runner.
- Add a regression test `tests/test_webhook_request_body_migration.py` that asserts the migration file exists and contains the expected `MODIFY COLUMN ... LONGTEXT` statements.

### Testing
- Ran `pytest tests/test_webhook_request_body_migration.py`, which passed.
- Attempted to run a broader webhook test set (including `tests/test_incoming_webhook_logging.py`, `tests/test_webhook_events_repository.py`, `tests/test_webhook_timeout.py`, `tests/test_webhook_monitor_cleanup.py`), but collection failed due to a missing system dependency (`libmagic`) required by `python-magic` in the test environment; these runs were blocked and not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4fa24bb7c4832d9c7fee72ee78e31d)