### PR TITLE
Prefix Trello ticket external references

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -1044,39 +1044,43 @@ async def add_reply(
 
     # Push public replies on Trello-linked tickets back to the Trello card as comments
     if not reply.get("is_internal") and ticket_payload.get("module_slug") == "trello":
-        card_id = str(ticket_payload.get("external_reference") or "").strip()
-        if card_id:
-            try:
-                from app.repositories import companies as company_repo
-                from app.services import trello as trello_service
+        try:
+            from app.repositories import companies as company_repo
+            from app.services import trello as trello_service
 
-                trello_company: dict[str, Any] | None = None
-                trello_company_id = ticket_payload.get("company_id")
-                if trello_company_id is not None:
-                    try:
-                        trello_company = await company_repo.get_company_by_id(
-                            int(trello_company_id)
-                        )
-                    except (TypeError, ValueError):
-                        pass
-                first_name = str(current_user.get("first_name") or "").strip()
-                last_name = str(current_user.get("last_name") or "").strip()
-                author_parts = [p for p in (first_name, last_name) if p]
-                author_display = (
-                    " ".join(author_parts)
-                    if author_parts
-                    else str(current_user.get("email") or "Staff")
-                )
-                await trello_service.post_reply_comment(
-                    card_id,
-                    author_display,
-                    sanitised_reply_payload.html,
-                    company=trello_company,
-                )
-            except Exception as exc:
-                logger.debug(
-                    "Trello reply sync failed for ticket {}: {}", ticket_id, exc
-                )
+            card_id = trello_service.card_id_from_external_reference(
+                ticket_payload.get("external_reference")
+            )
+            if not card_id:
+                return reply
+
+            trello_company: dict[str, Any] | None = None
+            trello_company_id = ticket_payload.get("company_id")
+            if trello_company_id is not None:
+                try:
+                    trello_company = await company_repo.get_company_by_id(
+                        int(trello_company_id)
+                    )
+                except (TypeError, ValueError):
+                    pass
+            first_name = str(current_user.get("first_name") or "").strip()
+            last_name = str(current_user.get("last_name") or "").strip()
+            author_parts = [p for p in (first_name, last_name) if p]
+            author_display = (
+                " ".join(author_parts)
+                if author_parts
+                else str(current_user.get("email") or "Staff")
+            )
+            await trello_service.post_reply_comment(
+                card_id,
+                author_display,
+                sanitised_reply_payload.html,
+                company=trello_company,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Trello reply sync failed for ticket {}: {}", ticket_id, exc
+            )
 
     # IMPORTANT: never store the reply body in the audit log. We capture only
     # metadata (id, author, visibility, length) so admins can confirm a reply

--- a/app/api/routes/trello.py
+++ b/app/api/routes/trello.py
@@ -321,7 +321,7 @@ async def _handle_create_card(
             status="open",
             category=None,
             module_slug=trello_service.TRELLO_MODULE_SLUG,
-            external_reference=card_id,
+            external_reference=trello_service.card_external_reference(card_id),
             trigger_automations=True,
         )
     except Exception as exc:

--- a/app/services/trello.py
+++ b/app/services/trello.py
@@ -17,6 +17,7 @@ TRELLO_API_BASE = "https://api.trello.com/1"
 # Prefix added to every comment MyPortal posts to Trello.  The webhook handler
 # skips incoming comments that carry this prefix to prevent feedback loops.
 MYPORTAL_COMMENT_PREFIX = "[MyPortal]"
+TRELLO_EXTERNAL_REFERENCE_PREFIX = "trello:"
 
 _REQUEST_TIMEOUT = httpx.Timeout(15.0, connect=5.0)
 
@@ -340,9 +341,43 @@ async def get_company_for_board(board_id: str) -> dict[str, Any] | None:
     return row
 
 
+def card_external_reference(card_id: str) -> str:
+    """Return the canonical ticket external reference for a Trello card ID."""
+    card_id = str(card_id or "").strip()
+    if card_id.startswith(TRELLO_EXTERNAL_REFERENCE_PREFIX):
+        return card_id
+    return f"{TRELLO_EXTERNAL_REFERENCE_PREFIX}{card_id}"
+
+
+def card_id_from_external_reference(external_reference: Any) -> str | None:
+    """Extract a Trello card ID from a ticket external reference.
+
+    Trello ticket references are stored as ``trello:<card_id>`` so automation
+    rules can target Trello-specific references. Legacy tickets may still carry
+    only the raw card ID; callers that already know the ticket belongs to the
+    Trello module can fall back to that value.
+    """
+    value = str(external_reference or "").strip()
+    if not value:
+        return None
+    if value.startswith(TRELLO_EXTERNAL_REFERENCE_PREFIX):
+        card_id = value[len(TRELLO_EXTERNAL_REFERENCE_PREFIX):].strip()
+        return card_id or None
+    return value
+
+
 async def find_ticket_for_card(card_id: str) -> dict[str, Any] | None:
-    """Return the MyPortal ticket whose ``external_reference`` matches *card_id*."""
-    return await tickets_repo.get_ticket_by_external_reference(card_id)
+    """Return the MyPortal ticket linked to a Trello card ID."""
+    canonical_ref = card_external_reference(card_id)
+    ticket = await tickets_repo.get_ticket_by_external_reference(canonical_ref)
+    if ticket:
+        return ticket
+    # Backward compatibility for tickets created before Trello references were
+    # namespaced. This can be removed after legacy data has been migrated.
+    legacy_card_id = str(card_id or "").strip()
+    if legacy_card_id and legacy_card_id != canonical_ref:
+        return await tickets_repo.get_ticket_by_external_reference(legacy_card_id)
+    return None
 
 
 async def post_ticket_created_comment(

--- a/tests/test_trello_create_ticket_description.py
+++ b/tests/test_trello_create_ticket_description.py
@@ -65,8 +65,18 @@ def test_handle_create_card_fetches_full_card_and_creates_ticket_with_link(monke
 
         assert created_payload["subject"] == "Full card title"
         assert created_payload["company_id"] == 42
-        assert created_payload["external_reference"] == "card-1"
+        assert created_payload["external_reference"] == "trello:card-1"
         assert "https://trello.com/c/full-card" in created_payload["description"]
         assert "Full card body" in created_payload["description"]
 
     asyncio.run(run_test())
+
+
+def test_trello_external_reference_helpers():
+    from app.services import trello as trello_service
+
+    assert trello_service.card_external_reference("card-1") == "trello:card-1"
+    assert trello_service.card_external_reference("trello:card-1") == "trello:card-1"
+    assert trello_service.card_id_from_external_reference("trello:card-1") == "card-1"
+    assert trello_service.card_id_from_external_reference("card-1") == "card-1"
+    assert trello_service.card_id_from_external_reference("") is None


### PR DESCRIPTION
### Motivation
- Make Trello-linked tickets have a predictable, namespaced `external_reference` (`trello:<card_id>`) so admins and automations can target Trello references reliably. 
- Preserve backwards compatibility so existing tickets that stored raw card IDs continue to be found. 
- Ensure outbound sync to Trello uses the raw card ID when posting comments.

### Description
- Add `TRELLO_EXTERNAL_REFERENCE_PREFIX = "trello:"` and helper functions `card_external_reference` and `card_id_from_external_reference` in `app/services/trello.py`. 
- Update `find_ticket_for_card` to first look up `trello:<card_id>` and fall back to legacy raw card ID when necessary in `app/services/trello.py`. 
- Store namespaced references for newly imported Trello cards by passing `external_reference=trello_service.card_external_reference(card_id)` when creating tickets in `app/api/routes/trello.py`. 
- Update reply sync in `app/api/routes/tickets.py` to extract the raw Trello card ID via `trello_service.card_id_from_external_reference(...)` before calling Trello APIs. 
- Update tests in `tests/test_trello_create_ticket_description.py` to assert the new `trello:` namespaced external reference and add unit checks for the new helper functions.

### Testing
- Successfully type-checked/compiled the modified modules with `python -m py_compile app/services/trello.py app/api/routes/trello.py app/api/routes/tickets.py`. 
- Ran `python -m pytest tests/test_trello_create_ticket_description.py`, but collection failed due to a missing system dependency causing `ImportError: failed to find libmagic` in the test environment, so the test could not be executed to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5038cd1a20832d886d747a5cc7f690)