### PR TITLE
Throttle unavailable RAG relationship evaluator

### DIFF
--- a/app/repositories/rag_relationships.py
+++ b/app/repositories/rag_relationships.py
@@ -178,6 +178,13 @@ async def complete_queue_item(queue_id: int, status: str) -> None:
     )
 
 
+async def reset_queue_item(queue_id: int, note: str | None = None) -> None:
+    await db.execute(
+        "UPDATE rag_relationship_queue SET status = 'PENDING', started_at = NULL, last_error = ? WHERE id = ?",
+        ((note or "")[:2000], queue_id),
+    )
+
+
 async def fail_queue_item(queue_id: int, error: str, *, max_retries: int) -> None:
     row = (
         await db.fetch_one(

--- a/app/services/rag_relationships.py
+++ b/app/services/rag_relationships.py
@@ -50,6 +50,47 @@ _MATCH_ORDER = {
 }
 
 
+_EVALUATOR_BACKOFF_SECONDS = 60.0
+_evaluator_retry_after = 0.0
+_last_unavailable_log_at = 0.0
+
+
+class RelationshipEvaluatorUnavailable(RuntimeError):
+    """Raised when the configured relationship LLM cannot currently run."""
+
+
+def _relationship_evaluator_unavailable_reason(response: Any) -> str | None:
+    if not isinstance(response, Mapping):
+        return None
+    status = str(response.get("status") or "").lower()
+    if status not in {"error", "failed", "skipped"}:
+        return None
+    return str(
+        response.get("last_error")
+        or response.get("error")
+        or response.get("reason")
+        or "module did not complete"
+    )
+
+
+def _set_evaluator_backoff(reason: str) -> None:
+    global _evaluator_retry_after, _last_unavailable_log_at
+    now = time.monotonic()
+    _evaluator_retry_after = max(
+        _evaluator_retry_after, now + _EVALUATOR_BACKOFF_SECONDS
+    )
+    if now - _last_unavailable_log_at >= _EVALUATOR_BACKOFF_SECONDS:
+        logger.warning(
+            "RAG relationship evaluator unavailable; pausing relationship jobs briefly: {}",
+            reason,
+        )
+        _last_unavailable_log_at = now
+
+
+def _evaluator_in_backoff() -> bool:
+    return time.monotonic() < _evaluator_retry_after
+
+
 def utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
@@ -239,7 +280,11 @@ async def evaluate_next_batch(*, limit: int | None = None) -> int:
     settings = get_settings()
     if not settings.enable_background_relationships:
         return 0
-    if await rel_repo.matching_paused():
+    if await rel_repo.matching_paused() or _evaluator_in_backoff():
+        return 0
+    evaluator_module = await modules_service.get_module("ollama", redact=False)
+    if not evaluator_module or not evaluator_module.get("enabled"):
+        _set_evaluator_backoff("Ollama module disabled or not configured")
         return 0
     jobs = await rel_repo.claim_jobs(limit or settings.rag_relationship_batch_size)
     processed = 0
@@ -248,6 +293,12 @@ async def evaluate_next_batch(*, limit: int | None = None) -> int:
     async def _one(job: Mapping[str, Any]) -> None:
         nonlocal processed
         async with semaphore:
+            if _evaluator_in_backoff():
+                await rel_repo.reset_queue_item(
+                    int(job["id"]),
+                    "Relationship evaluator unavailable: backoff active",
+                )
+                return
             started = time.perf_counter()
             try:
                 source = await rel_repo.get_document_with_content(
@@ -272,16 +323,11 @@ async def evaluate_next_batch(*, limit: int | None = None) -> int:
                     },
                     background=False,
                 )
-                if isinstance(response, Mapping) and str(
-                    response.get("status") or ""
-                ).lower() in {"error", "failed", "skipped"}:
-                    reason = (
-                        response.get("last_error")
-                        or response.get("error")
-                        or response.get("reason")
-                        or "module did not complete"
-                    )
-                    raise RuntimeError(f"Relationship evaluator unavailable: {reason}")
+                unavailable_reason = _relationship_evaluator_unavailable_reason(
+                    response
+                )
+                if unavailable_reason:
+                    raise RelationshipEvaluatorUnavailable(unavailable_reason)
                 raw = _relationship_response_payload(response)
                 parsed = parse_relationship_response(
                     raw, min_score=settings.rag_relationship_min_score
@@ -297,6 +343,12 @@ async def evaluate_next_batch(*, limit: int | None = None) -> int:
                 )
                 await rel_repo.complete_queue_item(int(job["id"]), "completed")
                 processed += 1
+            except RelationshipEvaluatorUnavailable as exc:
+                reason = str(exc) or "module did not complete"
+                _set_evaluator_backoff(reason)
+                await rel_repo.reset_queue_item(
+                    int(job["id"]), f"Relationship evaluator unavailable: {reason}"
+                )
             except Exception as exc:
                 await rel_repo.fail_queue_item(int(job["id"]), str(exc), max_retries=5)
                 logger.warning("RAG relationship job failed: {}", exc)

--- a/tests/test_rag_relationships.py
+++ b/tests/test_rag_relationships.py
@@ -162,3 +162,124 @@ async def test_set_matching_paused_quotes_reserved_key_column_for_sqlite(monkeyp
     assert "INSERT INTO rag_matching_state (`key`, value, updated_at)" in query
     assert "ON CONFLICT(`key`)" in query
     assert params == ("1",)
+
+
+def test_relationship_evaluator_unavailable_reason_includes_skipped_reason():
+    from app.services.rag_relationships import (
+        _relationship_evaluator_unavailable_reason,
+    )
+
+    assert (
+        _relationship_evaluator_unavailable_reason(
+            {"status": "skipped", "reason": "Module disabled", "module": "ollama"}
+        )
+        == "Module disabled"
+    )
+    assert _relationship_evaluator_unavailable_reason({"status": "succeeded"}) is None
+
+
+@pytest.mark.anyio
+async def test_evaluate_next_batch_does_not_claim_jobs_when_ollama_disabled(
+    monkeypatch,
+):
+    from app.services import rag_relationships
+
+    claimed = False
+
+    async def fake_matching_paused():
+        return False
+
+    async def fake_get_module(slug, *, redact=True):
+        assert slug == "ollama"
+        return {"slug": "ollama", "enabled": False}
+
+    async def fake_claim_jobs(limit):
+        nonlocal claimed
+        claimed = True
+        return []
+
+    monkeypatch.setattr(rag_relationships, "_evaluator_retry_after", 0.0)
+    monkeypatch.setattr(
+        rag_relationships.rel_repo, "matching_paused", fake_matching_paused
+    )
+    monkeypatch.setattr(
+        rag_relationships.modules_service, "get_module", fake_get_module
+    )
+    monkeypatch.setattr(rag_relationships.rel_repo, "claim_jobs", fake_claim_jobs)
+
+    assert await rag_relationships.evaluate_next_batch(limit=1) == 0
+    assert claimed is False
+    assert rag_relationships._evaluator_retry_after > 0
+
+
+@pytest.mark.anyio
+async def test_evaluate_next_batch_requeues_evaluator_failures_without_retry_increment(
+    monkeypatch,
+):
+    from app.services import rag_relationships
+
+    reset_calls: list[tuple[int, str]] = []
+    failed_calls: list[tuple[int, str]] = []
+
+    async def fake_matching_paused():
+        return False
+
+    async def fake_get_module(slug, *, redact=True):
+        return {"slug": slug, "enabled": True}
+
+    async def fake_claim_jobs(limit):
+        return [{"id": 9, "source_document_id": 1, "target_document_id": 2}]
+
+    async def fake_get_document_with_content(document_id):
+        return {
+            "id": document_id,
+            "source_type": "knowledge_base",
+            "source_id": document_id,
+            "title": f"Doc {document_id}",
+            "content": "content",
+            "content_hash": f"hash-{document_id}",
+        }
+
+    async def fake_relationship_current(source_id, target_id):
+        return False
+
+    async def fake_trigger_module(*args, **kwargs):
+        return {"status": "failed", "last_error": "connection refused"}
+
+    async def fake_reset_queue_item(queue_id, note=None):
+        reset_calls.append((queue_id, note or ""))
+
+    async def fake_fail_queue_item(queue_id, error, *, max_retries):
+        failed_calls.append((queue_id, error))
+
+    monkeypatch.setattr(rag_relationships, "_evaluator_retry_after", 0.0)
+    monkeypatch.setattr(
+        rag_relationships.rel_repo, "matching_paused", fake_matching_paused
+    )
+    monkeypatch.setattr(
+        rag_relationships.modules_service, "get_module", fake_get_module
+    )
+    monkeypatch.setattr(rag_relationships.rel_repo, "claim_jobs", fake_claim_jobs)
+    monkeypatch.setattr(
+        rag_relationships.rel_repo,
+        "get_document_with_content",
+        fake_get_document_with_content,
+    )
+    monkeypatch.setattr(
+        rag_relationships.rel_repo, "relationship_current", fake_relationship_current
+    )
+    monkeypatch.setattr(
+        rag_relationships.modules_service, "trigger_module", fake_trigger_module
+    )
+    monkeypatch.setattr(
+        rag_relationships.rel_repo, "reset_queue_item", fake_reset_queue_item
+    )
+    monkeypatch.setattr(
+        rag_relationships.rel_repo, "fail_queue_item", fake_fail_queue_item
+    )
+
+    assert await rag_relationships.evaluate_next_batch(limit=1) == 0
+    assert reset_calls == [
+        (9, "Relationship evaluator unavailable: connection refused")
+    ]
+    assert failed_calls == []


### PR DESCRIPTION
### Motivation
- Prevent noisy repeated warnings and wasted retries when the configured RAG relationship evaluator (Ollama/OpenAI-compatible) is temporarily unavailable by pausing relationship processing briefly and requeuing affected jobs.

### Description
- Add an in-memory backoff for the relationship evaluator with helper functions `_relationship_evaluator_unavailable_reason`, `_set_evaluator_backoff`, and `_evaluator_in_backoff` in `app/services/rag_relationships.py` to rate-limit warnings and pause processing.
- Perform an Ollama preflight (`modules_service.get_module("ollama")`) before claiming work so workers do not pull queue rows when the evaluator is disabled or not configured.
- Treat `error|failed|skipped` module responses as evaluator unavailability by raising `RelationshipEvaluatorUnavailable`, set backoff, and requeue the job without consuming retry attempts.
- Add `reset_queue_item` to `app/repositories/rag_relationships.py` to reset a queue item to `PENDING` with a `last_error` note, and update `evaluate_next_batch` to use it when the evaluator is unavailable.
- Add regression tests in `tests/test_rag_relationships.py` that validate the unavailable-reason detection, disabled-module preflight behavior, and that evaluator failures requeue without incrementing retries.

### Testing
- `python -m py_compile app/services/rag_relationships.py app/repositories/rag_relationships.py tests/test_rag_relationships.py` succeeded.
- Code was formatted with `black` and `git diff --check` reported no issues.
- `pytest -q tests/test_rag_relationships.py` could not be completed in this environment because the test run failed during app import due to a missing system dependency (`libmagic`) required by `python-magic`, so the new tests were added but could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a503994d3e8832d82ea1888007383da)