### PR TITLE
Update admin ticket detail layout: reorder fields, surface requester phone, move Category/External Reference

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8656,6 +8656,19 @@ async def _load_ticket_stored_related_items(ticket_id: int, *, limit: int = 12) 
     return items
 
 
+def _format_ticket_requester_phone(phone_number: Any) -> str | None:
+    digits = re.sub(r"\D+", "", str(phone_number or ""))
+    if not digits:
+        return None
+    if digits.startswith("61") and len(digits) == 11:
+        digits = f"0{digits[2:]}"
+    if len(digits) == 10:
+        return f"{digits[:4]} {digits[4:7]} {digits[7:]}"
+    if len(digits) == 11:
+        return f"{digits[:5]} {digits[5:8]} {digits[8:]}"
+    return str(phone_number or "").strip() or None
+
+
 async def _render_ticket_detail(
     request: Request,
     user: dict[str, Any],
@@ -9020,6 +9033,34 @@ async def _render_ticket_detail(
 
         requester_options.sort(key=_requester_sort_key)
 
+    ticket_requester_phone_display: str | None = None
+    requester_staff_id = ticket.get("requester_staff_id")
+    requester_user_id = ticket.get("requester_id")
+    def _same_identifier(left: Any, right: Any) -> bool:
+        if left is None or right is None:
+            return False
+        try:
+            return int(left) == int(right)
+        except (TypeError, ValueError):
+            return str(left) == str(right)
+
+    for requester_option in requester_options:
+        if (
+            _same_identifier(requester_option.get("staff_id"), requester_staff_id)
+            or _same_identifier(requester_option.get("user_id"), requester_user_id)
+            or _same_identifier(requester_option.get("id"), requester_user_id)
+        ):
+            ticket_requester_phone_display = _format_ticket_requester_phone(
+                requester_option.get("mobile_phone")
+            )
+            break
+    if ticket_requester_phone_display is None:
+        requester_record = user_lookup.get(ticket.get("requester_id"))
+        if requester_record:
+            ticket_requester_phone_display = _format_ticket_requester_phone(
+                requester_record.get("mobile_phone")
+            )
+
     default_priorities = ["urgent", "high", "normal", "low"]
     current_priority = str(ticket.get("priority") or "normal")
     seen_priorities: set[str] = set()
@@ -9167,6 +9208,7 @@ async def _render_ticket_detail(
         "ticket_company_options": companies,
         "ticket_user_options": technician_users,
         "ticket_requester_options": requester_options,
+        "ticket_requester_phone_display": ticket_requester_phone_display,
         "ticket_watcher_staff_options": watcher_staff_options,
         "ticket_mention_staff_options": ticket_mention_staff_options,
         "ticket_priority_options": priority_options,

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -138,6 +138,17 @@
                 </select>
               </div>
               <div class="form-field">
+                <label class="form-label" for="ticket-company-detail">Company</label>
+                <select id="ticket-company-detail" name="companyId" class="form-input">
+                  <option value="">Not linked</option>
+                  {% for company_option in ticket_company_options %}
+                    <option value="{{ company_option.id }}" {% if company_option.id == ticket.company_id %}selected{% endif %}>
+                      {{ company_option.name }}
+                    </option>
+                  {% endfor %}
+                </select>
+              </div>
+              <div class="form-field">
                 <label class="form-label" for="ticket-requester-detail">Requester</label>
                 <select
                   id="ticket-requester-detail"
@@ -169,6 +180,10 @@
                 </p>
               </div>
               <div class="form-field">
+                <span class="form-label">Requester phone</span>
+                <p class="form-help">{{ ticket_requester_phone_display or '—' }}</p>
+              </div>
+              <div class="form-field">
                 <label class="form-label" for="ticket-assigned-detail">Assigned to</label>
                 <select id="ticket-assigned-detail" name="assignedUserId" class="form-input">
                   <option value="">Unassigned</option>
@@ -178,39 +193,6 @@
                     </option>
                   {% endfor %}
                 </select>
-              </div>
-              <div class="form-field">
-                <label class="form-label" for="ticket-company-detail">Company</label>
-                <select id="ticket-company-detail" name="companyId" class="form-input">
-                  <option value="">Not linked</option>
-                  {% for company_option in ticket_company_options %}
-                    <option value="{{ company_option.id }}" {% if company_option.id == ticket.company_id %}selected{% endif %}>
-                      {{ company_option.name }}
-                    </option>
-                  {% endfor %}
-                </select>
-              </div>
-              <div class="form-field">
-                <label class="form-label" for="ticket-category-detail">Category</label>
-                <input
-                  id="ticket-category-detail"
-                  name="category"
-                  class="form-input"
-                  maxlength="64"
-                  value="{{ ticket.category or '' }}"
-                  placeholder="Networking, onboarding, escalation…"
-                />
-              </div>
-              <div class="form-field">
-                <label class="form-label" for="ticket-reference-detail">External reference</label>
-                <input
-                  id="ticket-reference-detail"
-                  name="externalReference"
-                  class="form-input"
-                  maxlength="128"
-                  value="{{ ticket.external_reference or '' }}"
-                  placeholder="Syncro ID or external case"
-                />
               </div>
               <div class="form-actions">
                 <button type="submit" class="button button--primary">Save changes</button>
@@ -307,6 +289,34 @@
                 <div class="definition-list__item">
                   <dt>Module</dt>
                   <dd>{{ ticket_module.name if ticket_module else (ticket.module_slug or '—') }}</dd>
+                </div>
+                <div class="definition-list__item">
+                  <dt><label class="form-label" for="ticket-category-detail">Category</label></dt>
+                  <dd>
+                    <input
+                      id="ticket-category-detail"
+                      name="category"
+                      form="ticket-details-form"
+                      class="form-input"
+                      maxlength="64"
+                      value="{{ ticket.category or '' }}"
+                      placeholder="Networking, onboarding, escalation…"
+                    />
+                  </dd>
+                </div>
+                <div class="definition-list__item">
+                  <dt><label class="form-label" for="ticket-reference-detail">External reference</label></dt>
+                  <dd>
+                    <input
+                      id="ticket-reference-detail"
+                      name="externalReference"
+                      form="ticket-details-form"
+                      class="form-input"
+                      maxlength="128"
+                      value="{{ ticket.external_reference or '' }}"
+                      placeholder="Syncro ID or external case"
+                    />
+                  </dd>
                 </div>
                 {% if ticket_assets %}
                   <div class="definition-list__item">


### PR DESCRIPTION
### Motivation
- Make the admin ticket edit UI match the requested field order and surface the requester's phone number for quick technician access.
- Keep Category and External Reference editable but visually grouped under Additional Details to reduce clutter in the primary Ticket Details area.
- Present the requester's phone in the easy-to-scan local formats `NNNN NNN NNN` or `NNNNN NNN NNN`, converting `+61` style numbers to local notation for convenience.

### Description
- Reordered the Ticket Details form so fields render in the sequence Subject, Status, Priority, Company, Requester, Requester phone (read-only text), and Assigned To by updating `app/templates/admin/ticket_detail.html`.
- Added a phone formatting helper `_format_ticket_requester_phone` to `app/main.py` that normalizes digits, converts `61` prefixed mobiles to leading `0`, and formats 10- and 11-digit numbers into `NNNN NNN NNN` or `NNNNN NNN NNN` respectively.
- Looked up the requester's mobile number from `ticket_requester_options` or the `user_lookup` and passed `ticket_requester_phone_display` into the template context so the phone is shown as plain text for technicians.
- Moved the Category and External Reference inputs into the Additional Details section and kept them associated with the existing save form by using `form="ticket-details-form"` on those inputs so they are submitted with the Ticket Details form.

### Testing
- Ran `python -m py_compile app/main.py` to verify there are no syntax errors and it passed successfully.
- Confirmed file changes do not trigger `git diff --check` issues (no whitespace/conflict markers found).
- Ran `pytest tests/test_admin_ticket_detail.py -q` which was blocked by a missing system dependency (`libmagic`) in the environment, preventing full test execution. Please run the test suite in an environment with `libmagic` installed to validate template rendering and context values.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a503d186194832d8aeb0bf069927604)