### PR TITLE
Fallback sanitization for inbound email replies and attachment-only reply bodies

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -10,6 +10,7 @@ import secrets
 from datetime import datetime, timezone
 from email.header import decode_header, make_header
 from email.utils import getaddresses, parsedate_to_datetime
+from html import escape
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -334,6 +335,63 @@ def _evaluate_filter(rule: Mapping[str, Any], context: Mapping[str, Any]) -> boo
         if any(_evaluate_filter(child, context) for child in none_group):
             return False
     return True
+
+
+def _sanitize_inbound_reply_body(value: str | None):
+    """Sanitize inbound email reply content without dropping real body text.
+
+    ``sanitize_rich_text`` trims quoted email headers before cleaning. Some
+    mailbox providers can deliver the current reply wrapped in header-like text,
+    which may leave an empty sanitized result even though the message had body
+    text. Fall back to escaped plain text so existing-ticket replies are still
+    recorded safely in the conversation history.
+    """
+
+    sanitized = sanitize_rich_text(value)
+    if sanitized.has_rich_content:
+        return sanitized
+
+    raw_text = (value or "").strip()
+    if not raw_text:
+        return sanitized
+
+    escaped_body = escape(raw_text).replace("\r\n", "\n").replace("\r", "\n")
+    escaped_body = escaped_body.replace("\n", "<br />")
+    return type(sanitized)(
+        html=escaped_body,
+        text_content=raw_text,
+        has_rich_content=True,
+    )
+
+
+def _build_attachment_only_reply_body(
+    *,
+    from_address: str | None = None,
+    subject: str | None = None,
+) -> str:
+    """Build a safe conversation entry when an inbound reply only has attachments.
+
+    Some mail clients and Graph/IMAP payloads contain no usable text body once
+    quoted history, signatures, and unsafe markup are removed.  If the message
+    still has attachments, add a concise public reply so the ticket conversation
+    records that the customer replied instead of only showing new files.
+    """
+
+    details: list[str] = []
+    sender = _normalise_string(from_address)
+    if sender:
+        details.append(f"<strong>From:</strong> {escape(sender)}")
+    reply_subject = _normalise_string(subject)
+    if reply_subject:
+        details.append(f"<strong>Subject:</strong> {escape(reply_subject)}")
+
+    detail_html = ""
+    if details:
+        detail_html = "<br />" + "<br />".join(details)
+    return (
+        "<p>Email reply received with attachment(s), but no message body was "
+        f"available after sanitisation.{detail_html}</p>"
+    )
 
 
 def _extract_domains(addresses: list[str]) -> list[str]:
@@ -1743,8 +1801,15 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                 # For new tickets, create_ticket already adds the initial reply
                 if not is_new_ticket:
                     conversation_source = body or ""
-                    sanitized = sanitize_rich_text(conversation_source)
-                    if sanitized.has_rich_content:
+                    sanitized = _sanitize_inbound_reply_body(conversation_source)
+                    has_attachment_reply = bool(email_attachments)
+                    reply_body = sanitized.html
+                    if not sanitized.has_rich_content and has_attachment_reply:
+                        reply_body = _build_attachment_only_reply_body(
+                            from_address=from_address,
+                            subject=subject,
+                        )
+                    if sanitized.has_rich_content or has_attachment_reply:
                         reply_created_at = received_at or datetime.now(timezone.utc)
                         reply_author_id = await _resolve_existing_reply_author_id(
                             ticket,
@@ -1756,7 +1821,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                             await tickets_repo.create_reply(
                                 ticket_id=int(ticket_id),
                                 author_id=reply_author_id,
-                                body=sanitized.html,
+                                body=reply_body,
                                 is_internal=False,
                                 external_reference=message_id if message_id else None,
                                 created_at=reply_created_at,

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -21,10 +21,10 @@ from app.services import modules as modules_service
 from app.services import system_state
 from app.services import tickets as tickets_service
 from app.services.m365 import M365Error
-from app.services.sanitization import sanitize_rich_text
 
 # Reuse filter helpers from the IMAP module so we share the same filter DSL.
 from app.services.imap import (
+    _build_attachment_only_reply_body,
     _evaluate_filter,
     _extract_domains,
     _extract_email_addresses,
@@ -37,6 +37,7 @@ from app.services.imap import (
     _normalise_filter,
     _normalise_priority,
     _normalise_string,
+    _sanitize_inbound_reply_body,
     _resolve_ticket_entities,
     _save_email_attachment,
     _CID_REFERENCE_PATTERN,
@@ -1479,8 +1480,15 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                     # Add reply to existing ticket
                     if not is_new_ticket:
                         conversation_source = body or ""
-                        sanitized = sanitize_rich_text(conversation_source)
-                        if sanitized.has_rich_content:
+                        sanitized = _sanitize_inbound_reply_body(conversation_source)
+                        has_attachment_reply = bool(msg.get("hasAttachments"))
+                        reply_body = sanitized.html
+                        if not sanitized.has_rich_content and has_attachment_reply:
+                            reply_body = _build_attachment_only_reply_body(
+                                from_address=from_header or from_address,
+                                subject=subject,
+                            )
+                        if sanitized.has_rich_content or has_attachment_reply:
                             reply_created_at = received_at or datetime.now(timezone.utc)
                             reply_author_id = await _resolve_existing_reply_author_id(
                                 ticket,
@@ -1491,7 +1499,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                 await tickets_repo.create_reply(
                                     ticket_id=int(ticket_id),
                                     author_id=reply_author_id,
-                                    body=sanitized.html,
+                                    body=reply_body,
                                     is_internal=False,
                                     external_reference=(
                                         internet_msg_id if internet_msg_id else None

--- a/tests/test_email_ticket_replies.py
+++ b/tests/test_email_ticket_replies.py
@@ -162,6 +162,37 @@ class TestSubjectNormalization:
         result = _normalize_subject_for_matching(subject)
         assert result == ""
 
+def test_inbound_reply_body_falls_back_when_header_stripping_removes_content():
+    """Inbound replies with real text should still create a safe body if header stripping is too aggressive."""
+    from app.services.imap import _sanitize_inbound_reply_body
+
+    body = _sanitize_inbound_reply_body(
+        "From: Customer <customer@example.com>\n"
+        "Sent: Friday, 10 July 2026 10:31 AM\n"
+        "Subject: Re: Website management\n"
+        "Please see the attached update <script>alert(1)</script>"
+    )
+
+    assert body.has_rich_content is True
+    assert "Please see the attached update" in body.html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body.html
+    assert "<script>" not in body.html
+
+
+def test_attachment_only_reply_body_escapes_sender_and_subject():
+    """Attachment-only inbound replies should still produce safe conversation text."""
+    from app.services.imap import _build_attachment_only_reply_body
+
+    body = _build_attachment_only_reply_body(
+        from_address='Customer <bad@example.com><script>alert(1)</script>',
+        subject='Re: Website <management>',
+    )
+
+    assert "Email reply received with attachment(s)" in body
+    assert "Customer &lt;bad@example.com&gt;&lt;script&gt;alert(1)&lt;/script&gt;" in body
+    assert "Re: Website &lt;management&gt;" in body
+    assert "<script>" not in body
+
 
 @pytest.mark.anyio
 class TestFindExistingTicket:


### PR DESCRIPTION
### Motivation

- Prevent losing real reply text when `sanitize_rich_text` strips content that looks like quoted headers, and ensure replies with only attachments still create a visible conversation entry.
- Share the same reply-handling behavior across IMAP and Microsoft 365 mail sync logic so both connectors record safe reply bodies consistently.

### Description

- Added `_sanitize_inbound_reply_body` to `app/services/imap.py` to sanitize HTML but fall back to escaped plain-text wrapped as HTML when header-stripping would otherwise leave an empty result.
- Added `_build_attachment_only_reply_body` to `app/services/imap.py` to generate a safe, concise HTML note when an inbound message contains attachments but no usable body text, and added `html.escape` import to ensure sender/subject are escaped.
- Updated IMAP and M365 reply handling to use `_sanitize_inbound_reply_body` and to insert the attachment-only note when there are attachments but no rich content, replacing prior direct calls to `sanitize_rich_text` and ensuring reply creation uses the computed `reply_body`.
- Exposed the new helpers for reuse in `app/services/m365_mail.py` and updated imports accordingly.

### Testing

- Added `test_inbound_reply_body_falls_back_when_header_stripping_removes_content` which asserts fallback escaping preserves reply text and strips unsafe markup, and it succeeded.
- Added `test_attachment_only_reply_body_escapes_sender_and_subject` which asserts the attachment-only message is generated and properly escapes sender/subject, and it succeeded.
- Ran the test suite containing the modified email-reply tests (`tests/test_email_ticket_replies.py`) and existing related tests, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a503e897a54832d8e26dbb434885634)