### PR TITLE
Allow API-key ticket replies and add PowerShell sample in help docs

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -930,9 +930,12 @@ async def add_reply(
     ticket_id: int,
     payload: TicketReplyCreate,
     request: Request,
-    session: SessionData = Depends(get_current_session),
-    current_user: dict = Depends(get_current_user),
+    actor: dict = Depends(_resolve_ticket_actor),
 ) -> TicketReplyResponse:
+    current_user: dict | None = actor.get("user")
+    api_key_record: dict | None = actor.get("api_key")
+    session: SessionData | None = getattr(request.state, "session", None)
+
     # Check if this ticket has been merged into another
     merged_target_id = await tickets_repo.get_merged_target_ticket_id(ticket_id)
     if merged_target_id and merged_target_id != ticket_id:
@@ -952,8 +955,14 @@ async def add_reply(
             detail="Cannot add replies to a billed ticket. This ticket has been invoiced and closed.",
         )
 
-    has_helpdesk_access = await _has_helpdesk_permission(current_user)
-    if not has_helpdesk_access and ticket.get("requester_id") != session.user_id:
+    has_helpdesk_access = bool(api_key_record)
+    if current_user:
+        has_helpdesk_access = has_helpdesk_access or await _has_helpdesk_permission(
+            current_user
+        )
+
+    author_id = session.user_id if session else None
+    if not has_helpdesk_access and ticket.get("requester_id") != author_id:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found"
         )
@@ -986,7 +995,7 @@ async def add_reply(
 
     reply = await tickets_repo.create_reply(
         ticket_id=ticket_id,
-        author_id=session.user_id,
+        author_id=author_id,
         body=sanitised_body.html,
         is_internal=payload.is_internal if has_helpdesk_access else False,
         minutes_spent=payload.minutes_spent if has_helpdesk_access else None,
@@ -1001,12 +1010,12 @@ async def add_reply(
     await tickets_service.emit_ticket_updated_event(
         ticket_id,
         actor_type="technician" if has_helpdesk_access else "requester",
-        actor=current_user,
+        actor=current_user or api_key_record,
     )
     await tickets_service.emit_ticket_replied_event(
         ticket_id,
         actor_type="technician" if has_helpdesk_access else "requester",
-        actor=current_user,
+        actor=current_user or api_key_record,
     )
     updated_ticket = await tickets_repo.get_ticket(ticket_id)
     ticket_payload = updated_ticket or ticket
@@ -1051,32 +1060,38 @@ async def add_reply(
             card_id = trello_service.card_id_from_external_reference(
                 ticket_payload.get("external_reference")
             )
-            if not card_id:
-                return reply
-
-            trello_company: dict[str, Any] | None = None
-            trello_company_id = ticket_payload.get("company_id")
-            if trello_company_id is not None:
-                try:
-                    trello_company = await company_repo.get_company_by_id(
-                        int(trello_company_id)
+            if card_id:
+                trello_company: dict[str, Any] | None = None
+                trello_company_id = ticket_payload.get("company_id")
+                if trello_company_id is not None:
+                    try:
+                        trello_company = await company_repo.get_company_by_id(
+                            int(trello_company_id)
+                        )
+                    except (TypeError, ValueError):
+                        pass
+                actor_record = current_user or {}
+                first_name = str(actor_record.get("first_name") or "").strip()
+                last_name = str(actor_record.get("last_name") or "").strip()
+                author_parts = [p for p in (first_name, last_name) if p]
+                author_display = (
+                    " ".join(author_parts)
+                    if author_parts
+                    else str(
+                        actor_record.get("email")
+                        or (
+                            api_key_record.get("description")
+                            if api_key_record
+                            else "API"
+                        )
                     )
-                except (TypeError, ValueError):
-                    pass
-            first_name = str(current_user.get("first_name") or "").strip()
-            last_name = str(current_user.get("last_name") or "").strip()
-            author_parts = [p for p in (first_name, last_name) if p]
-            author_display = (
-                " ".join(author_parts)
-                if author_parts
-                else str(current_user.get("email") or "Staff")
-            )
-            await trello_service.post_reply_comment(
-                card_id,
-                author_display,
-                sanitised_reply_payload.html,
-                company=trello_company,
-            )
+                )
+                await trello_service.post_reply_comment(
+                    card_id,
+                    author_display,
+                    sanitised_reply_payload.html,
+                    company=trello_company,
+                )
         except Exception as exc:
             logger.debug(
                 "Trello reply sync failed for ticket {}: {}", ticket_id, exc
@@ -1090,22 +1105,26 @@ async def add_reply(
     # change accidentally adds it to the snapshot.
     reply_metadata: dict[str, object] = {
         "reply_id": reply.get("id"),
-        "author_id": session.user_id,
+        "author_id": author_id,
         "is_internal": bool(reply.get("is_internal")),
         "channel": "internal" if reply.get("is_internal") else "public",
         "minutes_spent": reply.get("minutes_spent"),
         "is_billable": bool(reply.get("is_billable")),
     }
+    if api_key_record:
+        reply_metadata["api_key_id"] = api_key_record.get("id")
+        reply_metadata["api_key_prefix"] = api_key_record.get("key_prefix")
     reply_metadata.update(summarise_reply_body(sanitised_body.html))
     await audit_service.record(
         action="ticket.replied",
         request=request,
-        user_id=int(session.user_id),
+        user_id=int(author_id) if author_id is not None else None,
         entity_type="ticket",
         entity_id=ticket_id,
         before=None,
         after=None,
         metadata=reply_metadata,
+        api_key=str(api_key_record.get("key_prefix")) if api_key_record else None,
         sensitive_extra_keys=("body", "html", "text", "content"),
     )
     return TicketReplyResponse(

--- a/docs/wiki/tickets/Tickets API.md
+++ b/docs/wiki/tickets/Tickets API.md
@@ -191,3 +191,75 @@ The admin UI uses `GET /api/companies/{company_id}/assets` to populate the multi
 * `tactical_asset_id` / `syncro_asset_id` – Identifiers from upstream RMM systems.
 
 Assets are only returned for companies that the authenticated user is authorised to manage. Requests from non-super admin accounts receive `403 Forbidden`.
+
+## Search and reply from PowerShell
+
+Automation scripts can search tickets and post replies with an API key. This is useful when a PowerShell script gathers diagnostic output and needs to add the result back to the matching helpdesk ticket.
+
+### API key permissions
+
+Create an API key in **Admin → API Keys** and scope it to only the endpoints the script needs:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/tickets/` | Search for tickets by subject, description, or external reference. |
+| `POST` | `/api/tickets/{ticket_id}/replies` | Add a public or internal reply to a ticket. |
+
+Use IP restrictions where possible so the key only works from the automation host. Store the key outside the script, for example in an environment variable or a protected secret vault.
+
+### Search by subject and post script output
+
+The example below searches for the newest ticket matching a subject phrase, runs a local command, and posts the command output as a ticket reply. HTML is sent intentionally because ticket replies are rich text; command output is HTML-encoded before being wrapped in a `<pre>` block.
+
+```powershell
+$BaseUrl = "https://portal.example.com"
+$ApiKey = $env:MYPORTAL_API_KEY
+$Subject = "Device health check"
+
+if ([string]::IsNullOrWhiteSpace($ApiKey)) {
+    throw "MYPORTAL_API_KEY is not set."
+}
+
+$Headers = @{
+    "x-api-key" = $ApiKey
+    "Accept" = "application/json"
+}
+
+$SearchUri = "{0}/api/tickets/?search={1}&limit=1" -f $BaseUrl, [uri]::EscapeDataString($Subject)
+$SearchResult = Invoke-RestMethod -Method Get -Uri $SearchUri -Headers $Headers
+
+if (-not $SearchResult.items -or $SearchResult.items.Count -eq 0) {
+    throw "No ticket found for subject search: $Subject"
+}
+
+$Ticket = $SearchResult.items[0]
+
+$ScriptOutput = & {
+    hostname
+    Get-Date -AsUTC
+    Get-Service -Name Spooler | Format-List Name, Status, StartType | Out-String
+} | Out-String
+
+$EncodedOutput = [System.Net.WebUtility]::HtmlEncode($ScriptOutput)
+
+$ReplyBody = @{
+    body = "<p>Automated diagnostic results from $($env:COMPUTERNAME):</p><pre>$EncodedOutput</pre>"
+    is_internal = $false
+    minutes_spent = 0
+    is_billable = $false
+} | ConvertTo-Json -Depth 5
+
+$ReplyHeaders = $Headers.Clone()
+$ReplyHeaders["Content-Type"] = "application/json"
+
+$ReplyUri = "{0}/api/tickets/{1}/replies" -f $BaseUrl, $Ticket.id
+$Reply = Invoke-RestMethod -Method Post -Uri $ReplyUri -Headers $ReplyHeaders -Body $ReplyBody
+
+"Posted reply {0} to ticket {1}: {2}" -f $Reply.reply.id, $Reply.ticket.id, $Reply.ticket.subject
+```
+
+### Notes
+
+* API-key replies are treated as helpdesk replies and can set `is_internal`, `minutes_spent`, `is_billable`, and `labourTypeId`.
+* Public replies may trigger configured downstream integrations for the ticket, such as chat or Trello synchronisation.
+* The response includes the updated `ticket` object and created `reply` object, so scripts can log the reply ID for auditing.


### PR DESCRIPTION
### Motivation

- Enable automation scenarios where an external script (for example a PowerShell diagnostic) can find a ticket and post the results back as a reply using a scoped API key.
- Preserve existing security model and auditing while allowing API-key driven replies to behave like helpdesk replies when the key is permitted.

### Description

- Updated the ticket reply endpoint to accept either a browser session user or a scoped API key by using the existing `_resolve_ticket_actor` flow and branching logic in `app/api/routes/tickets.py`.
- API-key calls are treated as helpdesk-capable when a valid API key is present so `is_internal`, `minutes_spent`, `is_billable`, and `labour_type_id` may be supplied, while normal requester protections remain for non-helpdesk callers. (`app/api/routes/tickets.py`)
- Events, broadcasts, Solidtime scheduling and Trello comment sync are preserved for API-key-created replies and actor information is supplied from either the user record or the API key record when available. (`app/api/routes/tickets.py`)
- Audit metadata now includes API key identifiers (`api_key_id` and `api_key_prefix`) for replies created by keys while still redacting reply bodies from audit logs. (`app/api/routes/tickets.py`)
- Added documentation with guidance about required API key permissions, recommendation to restrict keys by IP, and a PowerShell example showing how to search tickets by subject and post encoded command output as a reply. (`docs/wiki/tickets/Tickets API.md`)

### Testing

- Ran `python -m compileall app/api/routes/tickets.py` and confirmed the module compiles successfully. (passed)
- Ran `git diff --check` to verify no whitespace/format errors. (passed)
- Ran `pytest tests/test_help_pages.py -q` but collection failed in this environment due to a missing system dependency (`ImportError: failed to find libmagic`), unrelated to the change; the test run was blocked by the environment and did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a504288e294832d985bddadd57d4585)