### PR TITLE
Disable default ticket creation notifications

### DIFF
--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -22,10 +22,6 @@ from app.repositories.tickets import TicketRecord
 from app.services import automations as automations_service
 from app.repositories import users as user_repo
 from app.services import modules as modules_service
-from app.services import email as email_service
-from app.services import notification_event_settings
-from app.services import notifications as notifications_service
-from app.services import value_templates
 from app.services.tagging import filter_helpful_slugs, get_all_excluded_tags, is_helpful_slug, slugify_tag
 from app.services.sanitization import sanitize_rich_text
 from app.services.realtime import RefreshNotifier, refresh_notifier
@@ -1128,156 +1124,16 @@ async def _send_ticket_creation_email(
     *,
     requester_email_fallback: str | None = None,
 ) -> None:
-    """Send a confirmation email to the ticket requester.
+    """Do not send default ticket creation notifications.
 
-    Uses the notification service when the requester has a user account so that
-    their in-app and email preferences are respected.  Falls back to a direct
-    email send when only an email address is available (e.g. IMAP tickets whose
-    sender is not a registered user).
+    New ticket notifications are intentionally handled exclusively by ticket
+    automations (the ``tickets.created`` automation event emitted by
+    :func:`create_ticket`).  This no-op helper is retained for compatibility
+    with callers that still pass ``send_creation_notification=True`` while
+    preventing the platform notification service or fallback email sender from
+    producing default messages such as ``MyPortal notification: Your ticket``.
     """
-    requester_id: int | None = enriched_ticket.get("requester_id")  # type: ignore[assignment]
-    requester_email: str | None = enriched_ticket.get("requester_email") or requester_email_fallback  # type: ignore[assignment]
-    if requester_email is not None:
-        requester_email = requester_email.strip() or None
-
-    if not requester_email and not requester_id:
-        return
-
-    ticket_number = str(enriched_ticket.get("ticket_number") or enriched_ticket.get("id") or "")
-    subject_text = str(enriched_ticket.get("subject") or "")
-    notification_ticket = {
-        "id": enriched_ticket.get("id"),
-        "ticket_number": enriched_ticket.get("ticket_number"),
-        "subject": enriched_ticket.get("subject"),
-    }
-
-    if requester_id is not None:
-        # Use the notification service so user preferences are respected and an
-        # in-app notification is also recorded.
-        try:
-            await notifications_service.emit_notification(
-                event_type="tickets.created",
-                user_id=requester_id,
-                metadata={"ticket": notification_ticket},
-            )
-        except Exception as exc:  # pragma: no cover - defensive logging
-            log_error(
-                "Failed to emit ticket creation notification",
-                ticket_id=enriched_ticket.get("id"),
-                requester_id=requester_id,
-                error=str(exc),
-            )
-        return
-
-    # No user account – send a direct email to the known email address.
-    if not requester_email:
-        return
-
-    settings = get_settings()
-    app_name = settings.app_name or "Support"
-
-    # Render the email body using the configured notification template so that
-    # admin-configured JSON templates are honoured for external requesters too.
-    ticket_context = dict(enriched_ticket)
-    if requester_email and not ticket_context.get("requester_email"):
-        ticket_context["requester_email"] = requester_email
-    context: dict[str, Any] = {"ticket": ticket_context}
-    rendered_message: str | None = None
-    event_setting: dict[str, Any] = {}
-    try:
-        event_setting = await notification_event_settings.get_event_setting("tickets.created")
-        template = str(event_setting.get("message_template") or "")
-        if template:
-            rendered_message = str(await value_templates.render_string_async(template, context))
-    except Exception as exc:
-        log_error(
-            "Failed to render ticket creation notification template; using fallback",
-            ticket_id=enriched_ticket.get("id"),
-            error=str(exc),
-        )
-        rendered_message = None
-
-    # Fire any configured module_actions for the defined ticket creation notification.
-    # This honours admin-configured integrations (e.g. smtp2go, ntfy) for external
-    # requesters.  The fallback direct email is only sent when no email-delivery
-    # module action is configured, or when the email-delivery module action fails.
-    _module_actions = event_setting.get("module_actions") or [] if event_setting else []
-    _has_email_action = any(
-        str(action.get("module") or "").strip() in notifications_service._EMAIL_DELIVERY_MODULES
-        for action in _module_actions
-        if isinstance(action, Mapping)
-    )
-    _email_action_failed = False
-    if _module_actions:
-        _notification_context: dict[str, Any] = {
-            "event_type": "tickets.created",
-            "metadata": {"ticket": dict(enriched_ticket)},
-            "message": rendered_message,
-            "ticket": dict(ticket_context),
-        }
-        for _action in _module_actions:
-            _slug = str(_action.get("module") or "").strip()
-            if not _slug:
-                continue
-            _payload_source = _action.get("payload")
-            if isinstance(_payload_source, Mapping):
-                _payload_source = dict(_payload_source)
-            else:
-                _payload_source = _payload_source or {}
-            try:
-                _rendered_payload = await value_templates.render_value_async(
-                    _payload_source, _notification_context
-                )
-                if isinstance(_rendered_payload, Mapping):
-                    _payload_data: dict[str, Any] = dict(_rendered_payload)
-                else:
-                    _payload_data = {"value": _rendered_payload}
-                _payload_data.setdefault("context", _notification_context)
-                await modules_service.trigger_module(_slug, _payload_data, background=False)
-            except Exception as exc:
-                log_error(
-                    "Ticket creation notification module action failed",
-                    ticket_id=enriched_ticket.get("id"),
-                    module=_slug,
-                    error=str(exc),
-                )
-                if _slug in notifications_service._EMAIL_DELIVERY_MODULES:
-                    _email_action_failed = True
-
-    if _has_email_action and not _email_action_failed:
-        # The defined notification handled email delivery; skip the fallback.
-        return
-
-    if not rendered_message:
-        # Fallback when the defined notification did not deliver an email.
-        rendered_message = (
-            f"Your ticket #{ticket_number} has been created: {subject_text}"
-            if ticket_number
-            else f"Your ticket has been created: {subject_text}"
-        )
-
-    message_preview = rendered_message[:50].strip()
-    if len(rendered_message) > 50:
-        message_preview += "..."
-    email_subject = f"{app_name} notification: {message_preview}"
-
-    text_body = rendered_message
-    html_body = f"<p>{html.escape(rendered_message)}</p>"
-
-    try:
-        await email_service.send_email(
-            subject=email_subject,
-            recipients=[requester_email],
-            html_body=html_body,
-            text_body=text_body,
-        )
-    except email_service.EmailDispatchError as exc:  # pragma: no cover - defensive logging
-        log_error(
-            "Failed to send ticket creation email",
-            ticket_id=enriched_ticket.get("id"),
-            requester_email=requester_email,
-            error=str(exc),
-        )
+    return None
 
 
 async def create_ticket(
@@ -1361,18 +1217,9 @@ async def create_ticket(
 
     enriched_ticket = await _enrich_ticket_context(ticket)
 
-    if send_creation_notification:
-        try:
-            await _send_ticket_creation_email(
-                enriched_ticket,
-                requester_email_fallback=requester_email,
-            )
-        except Exception as exc:  # pragma: no cover - defensive logging
-            log_error(
-                "Failed to send ticket creation email",
-                ticket_id=ticket.get("id"),
-                error=str(exc),
-            )
+    # New ticket notifications must be handled by Ticket Automations only.
+    # ``send_creation_notification`` is retained for API compatibility but no
+    # longer triggers default platform notification/email delivery.
 
     if trigger_automations:
         try:

--- a/tests/test_ticket_creation_email.py
+++ b/tests/test_ticket_creation_email.py
@@ -1,4 +1,4 @@
-"""Tests for ticket creation email notifications."""
+"""Tests for ticket creation notification routing."""
 from __future__ import annotations
 
 import pytest
@@ -6,8 +6,7 @@ import pytest
 from app.services import tickets as tickets_service
 from app.services import notifications as notifications_service
 from app.services import email as email_service
-from app.services import modules as modules_service
-from app.services import notification_event_settings
+from app.services import automations as automations_service
 
 
 @pytest.fixture
@@ -15,717 +14,120 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
-def _default_tickets_created_setting(event_type: str) -> dict:
-    """Return a representative tickets.created event setting for tests."""
-    return {
-        "event_type": event_type,
-        "display_name": "Ticket created",
-        "message_template": "Your ticket #{{ ticket.ticket_number }} has been created: {{ ticket.subject }}",
-        "module_actions": [],
-        "allow_channel_in_app": True,
-        "allow_channel_email": True,
-        "allow_channel_sms": False,
-        "default_channel_in_app": True,
-        "default_channel_email": True,
-        "default_channel_sms": False,
-    }
-
-# ---------------------------------------------------------------------------
-# _send_ticket_creation_email – requester with user account
-# ---------------------------------------------------------------------------
-
 @pytest.mark.anyio
-async def test_send_creation_email_calls_notify_for_user_requester(monkeypatch):
-    """When the requester has a user account, emit_notification is used."""
-    captured: dict[str, object] = {}
-
-    async def fake_emit_notification(*, event_type, user_id, metadata):
-        captured["event_type"] = event_type
-        captured["user_id"] = user_id
-        captured["metadata"] = metadata
-
-    monkeypatch.setattr(notifications_service, "emit_notification", fake_emit_notification)
-
-    enriched = {
-        "id": 10,
-        "ticket_number": "100",
-        "subject": "Printer offline",
-        "requester_id": 5,
-        "requester_email": "user@example.com",
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
-
-    assert captured["event_type"] == "tickets.created"
-    assert captured["user_id"] == 5
-    assert captured["metadata"]["ticket"] == {
-        "id": 10,
-        "ticket_number": "100",
-        "subject": "Printer offline",
-    }
-
-
-@pytest.mark.anyio
-async def test_send_creation_email_notification_metadata_excludes_sensitive_ticket_fields(monkeypatch):
-    """Notification metadata includes only safe ticket summary fields."""
-    captured: dict[str, object] = {}
-
-    async def fake_emit_notification(*, event_type, user_id, metadata):
-        captured["event_type"] = event_type
-        captured["user_id"] = user_id
-        captured["metadata"] = metadata
-
-    monkeypatch.setattr(notifications_service, "emit_notification", fake_emit_notification)
-
-    enriched = {
-        "id": 10,
-        "ticket_number": "100",
-        "subject": "Printer offline",
-        "requester_id": 5,
-        "requester_email": "user@example.com",
-        "requester": {
-            "id": 5,
-            "email": "user@example.com",
-            "mobile_phone": "+15551234",
-            "is_super_admin": False,
-        },
-        "latest_reply": {
-            "id": 40,
-            "body_text": "Internal escalation details",
-            "is_internal": True,
-        },
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
-
-    assert captured["event_type"] == "tickets.created"
-    assert captured["user_id"] == 5
-    assert captured["metadata"]["ticket"] == {
-        "id": 10,
-        "ticket_number": "100",
-        "subject": "Printer offline",
-    }
-
-
-@pytest.mark.anyio
-async def test_send_creation_email_skips_direct_send_when_user_requester(monkeypatch):
-    """Direct email sending is skipped when the requester has a user account."""
-    direct_send_called = False
-
-    async def fake_emit_notification(**kwargs):
-        pass
-
-    async def fake_send_email(**kwargs):
-        nonlocal direct_send_called
-        direct_send_called = True
-        return True, None
-
-    monkeypatch.setattr(notifications_service, "emit_notification", fake_emit_notification)
-    monkeypatch.setattr(email_service, "send_email", fake_send_email)
-
-    enriched = {
-        "id": 11,
-        "ticket_number": "101",
-        "subject": "VPN issue",
-        "requester_id": 7,
-        "requester_email": "vpn@example.com",
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
-
-    assert not direct_send_called
-
-
-# ---------------------------------------------------------------------------
-# _send_ticket_creation_email – requester without user account (email only)
-# ---------------------------------------------------------------------------
-
-@pytest.mark.anyio
-async def test_send_creation_email_sends_direct_when_no_requester_id(monkeypatch):
-    """A direct email is sent when only an email address is available."""
-    captured: dict[str, object] = {}
-
-    monkeypatch.setattr(
-        notification_event_settings,
-        "get_event_setting",
-        lambda event_type: _default_tickets_created_setting(event_type),
-    )
-
-    async def fake_send_email(*, subject, recipients, html_body, text_body=None, **kwargs):
-        captured["subject"] = subject
-        captured["recipients"] = recipients
-        captured["html_body"] = html_body
-        captured["text_body"] = text_body
-        return True, None
-
-    monkeypatch.setattr(email_service, "send_email", fake_send_email)
-
-    enriched = {
-        "id": 20,
-        "ticket_number": "200",
-        "subject": "Network down",
-        "requester_id": None,
-        "requester_email": None,
-    }
-
-    await tickets_service._send_ticket_creation_email(
-        enriched,
-        requester_email_fallback="external@example.com",
-    )
-
-    assert captured["recipients"] == ["external@example.com"]
-    assert "#200" in captured["subject"]
-    assert "Network down" in captured["subject"]
-
-
-@pytest.mark.anyio
-async def test_send_creation_email_uses_enriched_email_when_no_user_id(monkeypatch):
-    """Uses requester_email from enriched ticket when there is no requester_id."""
-    captured_recipients: list[str] = []
-
-    monkeypatch.setattr(
-        notification_event_settings,
-        "get_event_setting",
-        lambda event_type: _default_tickets_created_setting(event_type),
-    )
-
-    async def fake_send_email(*, recipients, **kwargs):
-        captured_recipients.extend(recipients)
-        return True, None
-
-    monkeypatch.setattr(email_service, "send_email", fake_send_email)
-
-    enriched = {
-        "id": 21,
-        "ticket_number": "201",
-        "subject": "Hardware fault",
-        "requester_id": None,
-        "requester_email": "hw@example.com",
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
-
-    assert "hw@example.com" in captured_recipients
-
-
-@pytest.mark.anyio
-async def test_send_creation_email_noop_when_no_email_or_id(monkeypatch):
-    """No email or notification is sent when neither id nor email is available."""
+async def test_send_ticket_creation_email_is_noop_for_registered_requester(monkeypatch):
+    """Default ticket creation notifications are not sent for registered users."""
     emit_called = False
     send_called = False
 
-    async def fake_emit(**kwargs):
+    async def fake_emit_notification(**kwargs):
         nonlocal emit_called
         emit_called = True
 
-    async def fake_send(**kwargs):
+    async def fake_send_email(**kwargs):
         nonlocal send_called
         send_called = True
         return True, None
 
-    monkeypatch.setattr(notifications_service, "emit_notification", fake_emit)
-    monkeypatch.setattr(email_service, "send_email", fake_send)
+    monkeypatch.setattr(notifications_service, "emit_notification", fake_emit_notification)
+    monkeypatch.setattr(email_service, "send_email", fake_send_email)
 
-    enriched = {
-        "id": 30,
-        "ticket_number": "300",
-        "subject": "No requester",
-        "requester_id": None,
-        "requester_email": None,
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
+    await tickets_service._send_ticket_creation_email(
+        {
+            "id": 10,
+            "ticket_number": "100",
+            "subject": "Printer offline",
+            "requester_id": 5,
+            "requester_email": "user@example.com",
+        }
+    )
 
     assert not emit_called
     assert not send_called
 
 
-# ---------------------------------------------------------------------------
-# create_ticket integration – email is triggered
-# ---------------------------------------------------------------------------
+@pytest.mark.anyio
+async def test_send_ticket_creation_email_is_noop_for_external_requester(monkeypatch):
+    """Default ticket creation emails are not sent for external email-only requesters."""
+    send_called = False
+
+    async def fake_send_email(**kwargs):
+        nonlocal send_called
+        send_called = True
+        return True, None
+
+    monkeypatch.setattr(email_service, "send_email", fake_send_email)
+
+    await tickets_service._send_ticket_creation_email(
+        {
+            "id": 20,
+            "ticket_number": "200",
+            "subject": "Network down",
+            "requester_id": None,
+            "requester_email": None,
+        },
+        requester_email_fallback="external@example.com",
+    )
+
+    assert not send_called
+
 
 @pytest.mark.anyio
-async def test_create_ticket_triggers_creation_email(monkeypatch):
-    """create_ticket calls _send_ticket_creation_email after enriching the ticket."""
+async def test_create_ticket_uses_ticket_automations_instead_of_default_notification(monkeypatch):
+    """New-ticket notifications are delegated to the tickets.created automation event only."""
     from app.repositories import tickets as tickets_repo
-    from app.services import automations as automations_service
+
+    automation_events: list[str] = []
+    default_notification_called = False
 
     async def fake_create_ticket_repo(**kwargs):
         ticket_id = kwargs.get("id") if kwargs.get("id") is not None else 55
         return {"id": ticket_id, **{k: v for k, v in kwargs.items() if k != "id"}}
 
-    async def fake_handle_event(event_name, context):
-        return []
+    async def fake_create_reply(**kwargs):
+        return {"id": 999, **kwargs}
 
-    async def fake_get_company(company_id):
-        return None
-
-    async def fake_get_user(user_id):
-        return {"id": user_id, "email": "requester@example.com", "first_name": "Alice", "last_name": "Smith"}
-
-    async def fake_resolve_status(value):
-        return value or "open"
-
-    captured_email_call: dict[str, object] = {}
-
-    async def fake_send_creation_email(enriched_ticket, *, requester_email_fallback=None):
-        captured_email_call["ticket_id"] = enriched_ticket.get("id")
-        captured_email_call["requester_email_fallback"] = requester_email_fallback
-
-    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket_repo)
-    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
-    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
-    monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
-    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
-    monkeypatch.setattr(tickets_service, "_send_ticket_creation_email", fake_send_creation_email)
-
-    ticket = await tickets_service.create_ticket(
-        subject="Server unreachable",
-        description="Can't ping the server",
-        requester_id=9,
-        company_id=None,
-        assigned_user_id=None,
-        priority="high",
-        status="open",
-        category=None,
-        module_slug=None,
-        external_reference=None,
-    )
-
-    assert ticket["id"] == 55
-    assert captured_email_call["ticket_id"] == 55
-    assert captured_email_call["requester_email_fallback"] is None
-
-
-@pytest.mark.anyio
-async def test_create_ticket_passes_requester_email_fallback(monkeypatch):
-    """create_ticket forwards requester_email to _send_ticket_creation_email."""
-    from app.repositories import tickets as tickets_repo
-    from app.services import automations as automations_service
-
-    async def fake_create_ticket_repo(**kwargs):
-        return {"id": 60, **{k: v for k, v in kwargs.items() if k != "id"}}
-
-    async def fake_handle_event(event_name, context):
-        return []
-
-    async def fake_get_company(company_id):
-        return None
-
-    async def fake_get_user(user_id):
-        return None
-
-    async def fake_resolve_status(value):
-        return value or "open"
-
-    captured: dict[str, object] = {}
-
-    async def fake_send_creation_email(enriched_ticket, *, requester_email_fallback=None):
-        captured["requester_email_fallback"] = requester_email_fallback
-
-    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket_repo)
-    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
-    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
-    monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
-    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
-    monkeypatch.setattr(tickets_service, "_send_ticket_creation_email", fake_send_creation_email)
-
-    await tickets_service.create_ticket(
-        subject="IMAP ticket",
-        description="Sent via email",
-        requester_id=None,
-        company_id=None,
-        assigned_user_id=None,
-        priority="normal",
-        status="open",
-        category="email",
-        module_slug="imap",
-        external_reference=None,
-        requester_email="sender@example.com",
-    )
-
-    assert captured["requester_email_fallback"] == "sender@example.com"
-
-
-@pytest.mark.anyio
-async def test_create_ticket_can_skip_creation_notification(monkeypatch):
-    """create_ticket can suppress direct creation notifications while keeping automations."""
-    from app.repositories import tickets as tickets_repo
-    from app.services import automations as automations_service
-
-    async def fake_create_ticket_repo(**kwargs):
-        return {"id": 61, **{k: v for k, v in kwargs.items() if k != "id"}}
-
-    automation_events: list[str] = []
+    async def fake_enrich(ticket):
+        return dict(ticket, ticket_number="T-55", requester_email="requester@example.com")
 
     async def fake_handle_event(event_name, context):
         automation_events.append(event_name)
         return []
 
-    async def fake_get_company(company_id):
+    async def fake_default_notification(*args, **kwargs):
+        nonlocal default_notification_called
+        default_notification_called = True
+
+    async def fake_broadcast(**kwargs):
         return None
 
-    async def fake_get_user(user_id):
-        return {"id": user_id, "email": "requester@example.com"}
+    async def fake_resolve_status(status):
+        return str(status)
 
-    async def fake_resolve_status(value):
-        return value or "open"
-
-    notification_called = False
-
-    async def fake_send_creation_email(enriched_ticket, *, requester_email_fallback=None):
-        nonlocal notification_called
-        notification_called = True
-
-    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket_repo)
-    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
-    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
-    monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
     monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
-    monkeypatch.setattr(tickets_service, "_send_ticket_creation_email", fake_send_creation_email)
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket_repo)
+    monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
+    monkeypatch.setattr(tickets_service, "_enrich_ticket_context", fake_enrich)
+    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
+    monkeypatch.setattr(tickets_service, "_send_ticket_creation_email", fake_default_notification)
+    monkeypatch.setattr(tickets_service, "broadcast_ticket_event", fake_broadcast)
 
-    await tickets_service.create_ticket(
-        subject="Imported ticket",
-        description="Imported from Syncro",
-        requester_id=9,
-        company_id=None,
+    ticket = await tickets_service.create_ticket(
+        subject="Automation only",
+        description="Notify through automations",
+        requester_id=5,
+        requester_staff_id=None,
+        company_id=1,
         assigned_user_id=None,
-        priority="normal",
+        priority="Medium",
         status="open",
         category=None,
         module_slug=None,
-        external_reference="12345",
-        send_creation_notification=False,
+        external_reference=None,
+        requester_email="requester@example.com",
+        send_creation_notification=True,
     )
 
-    assert not notification_called
+    assert ticket["id"] == 55
     assert automation_events == ["tickets.created"]
-
-
-# ---------------------------------------------------------------------------
-# _send_ticket_creation_email – template rendering for external requester
-# ---------------------------------------------------------------------------
-
-@pytest.mark.anyio
-async def test_send_creation_email_uses_event_template_for_external_requester(monkeypatch):
-    """When the requester has no account, the email body uses the notification event template."""
-    captured: dict[str, object] = {}
-
-    async def fake_get_event_setting(event_type: str):
-        return {
-            "event_type": event_type,
-            "display_name": "Ticket created",
-            "message_template": "Custom template: ticket #{{ ticket.ticket_number }} - {{ ticket.subject }}",
-            "module_actions": [],
-            "allow_channel_in_app": True,
-            "allow_channel_email": True,
-            "allow_channel_sms": False,
-            "default_channel_in_app": True,
-            "default_channel_email": True,
-            "default_channel_sms": False,
-        }
-
-    async def fake_send_email(*, subject, recipients, html_body, text_body=None, **kwargs):
-        captured["subject"] = subject
-        captured["recipients"] = recipients
-        captured["html_body"] = html_body
-        captured["text_body"] = text_body
-        return True, None
-
-    monkeypatch.setattr(notification_event_settings, "get_event_setting", fake_get_event_setting)
-    monkeypatch.setattr(email_service, "send_email", fake_send_email)
-
-    enriched = {
-        "id": 40,
-        "ticket_number": "400",
-        "subject": "Custom template test",
-        "requester_id": None,
-        "requester_email": "external@example.com",
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
-
-    # The rendered template should appear in the email body and subject
-    expected_message = "Custom template: ticket #400 - Custom template test"
-    assert captured["text_body"] == expected_message
-    assert f"<p>{expected_message}</p>" == captured["html_body"]
-    assert "Custom template: ticket #400" in captured["subject"]
-
-
-@pytest.mark.anyio
-async def test_send_creation_email_uses_requester_fallback_in_template(monkeypatch):
-    """Fallback email address is available to templates when requester is unknown."""
-    captured: dict[str, object] = {}
-
-    async def fake_get_event_setting(event_type: str):
-        return {
-            "event_type": event_type,
-            "display_name": "Ticket created",
-            "message_template": "{{ ticket.requester_email }}",
-            "module_actions": [],
-            "allow_channel_in_app": True,
-            "allow_channel_email": True,
-            "allow_channel_sms": False,
-            "default_channel_in_app": True,
-            "default_channel_email": True,
-            "default_channel_sms": False,
-        }
-
-    async def fake_send_email(*, subject, recipients, html_body, text_body=None, **kwargs):
-        captured["subject"] = subject
-        captured["recipients"] = recipients
-        captured["html_body"] = html_body
-        captured["text_body"] = text_body
-        return True, None
-
-    monkeypatch.setattr(notification_event_settings, "get_event_setting", fake_get_event_setting)
-    monkeypatch.setattr(email_service, "send_email", fake_send_email)
-
-    enriched = {
-        "id": 401,
-        "ticket_number": "401",
-        "subject": "Fallback template test",
-        "requester_id": None,
-        "requester_email": None,
-    }
-
-    await tickets_service._send_ticket_creation_email(
-        enriched,
-        requester_email_fallback="unknown@example.com",
-    )
-
-    assert captured["recipients"] == ["unknown@example.com"]
-    assert captured["text_body"] == "unknown@example.com"
-    assert captured["html_body"] == "<p>unknown@example.com</p>"
-    assert "unknown@example.com" in captured["subject"]
-
-
-@pytest.mark.anyio
-async def test_send_creation_email_falls_back_when_template_unavailable(monkeypatch):
-    """When event setting lookup fails, a sensible fallback message is used."""
-    captured: dict[str, object] = {}
-
-    async def failing_get_event_setting(event_type: str):
-        raise RuntimeError("Database unavailable")
-
-    async def fake_send_email(*, subject, recipients, html_body, text_body=None, **kwargs):
-        captured["subject"] = subject
-        captured["recipients"] = recipients
-        captured["text_body"] = text_body
-        return True, None
-
-    monkeypatch.setattr(notification_event_settings, "get_event_setting", failing_get_event_setting)
-    monkeypatch.setattr(email_service, "send_email", fake_send_email)
-
-    enriched = {
-        "id": 41,
-        "ticket_number": "401",
-        "subject": "Fallback test",
-        "requester_id": None,
-        "requester_email": "fallback@example.com",
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
-
-    assert captured["recipients"] == ["fallback@example.com"]
-    assert "#401" in captured["subject"]
-    assert "Fallback test" in captured["subject"]
-    assert "#401" in captured["text_body"]
-    assert "Fallback test" in captured["text_body"]
-
-
-# ---------------------------------------------------------------------------
-# _send_ticket_creation_email – module_actions for external requester
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.anyio
-async def test_send_creation_email_skips_direct_send_when_email_module_action_succeeds(monkeypatch):
-    """When an email-delivery module action succeeds, no fallback direct email is sent."""
-    direct_send_called = False
-    module_triggered: list[str] = []
-
-    async def fake_get_event_setting(event_type: str):
-        return {
-            "event_type": event_type,
-            "display_name": "Ticket created",
-            "message_template": "Ticket #{{ ticket.ticket_number }} created",
-            "module_actions": [{"module": "smtp2go", "payload": {"to": ["{{ ticket.requester_email }}"]}}],
-            "allow_channel_in_app": True,
-            "allow_channel_email": True,
-            "allow_channel_sms": False,
-            "default_channel_in_app": True,
-            "default_channel_email": True,
-            "default_channel_sms": False,
-        }
-
-    async def fake_trigger_module(slug, payload, *, background=True, **kwargs):
-        module_triggered.append(slug)
-        return {"status": "success"}
-
-    async def fake_send_email(**kwargs):
-        nonlocal direct_send_called
-        direct_send_called = True
-        return True, None
-
-    monkeypatch.setattr(notification_event_settings, "get_event_setting", fake_get_event_setting)
-    monkeypatch.setattr(modules_service, "trigger_module", fake_trigger_module)
-    monkeypatch.setattr(email_service, "send_email", fake_send_email)
-
-    enriched = {
-        "id": 50,
-        "ticket_number": "500",
-        "subject": "Module action test",
-        "requester_id": None,
-        "requester_email": "ext@example.com",
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
-
-    # smtp2go module should have been triggered
-    assert "smtp2go" in module_triggered
-    # Direct fallback email should NOT have been sent
-    assert not direct_send_called
-
-
-@pytest.mark.anyio
-async def test_send_creation_email_skips_when_requester_email_blank(monkeypatch):
-    """No notification is attempted when requester email is blank/whitespace."""
-    module_triggered: list[str] = []
-    direct_send_called = False
-
-    async def fake_get_event_setting(event_type: str):
-        return {
-            "event_type": event_type,
-            "display_name": "Ticket created",
-            "message_template": "Ticket created",
-            "module_actions": [{"module": "smtp2go", "payload": {"to": ["{{ ticket.requester_email }}"]}}],
-            "allow_channel_in_app": True,
-            "allow_channel_email": True,
-            "allow_channel_sms": False,
-            "default_channel_in_app": True,
-            "default_channel_email": True,
-            "default_channel_sms": False,
-        }
-
-    async def fake_trigger_module(slug, payload, *, background=True, **kwargs):
-        module_triggered.append(slug)
-        return {"status": "success"}
-
-    async def fake_send_email(**kwargs):
-        nonlocal direct_send_called
-        direct_send_called = True
-        return True, None
-
-    monkeypatch.setattr(notification_event_settings, "get_event_setting", fake_get_event_setting)
-    monkeypatch.setattr(modules_service, "trigger_module", fake_trigger_module)
-    monkeypatch.setattr(email_service, "send_email", fake_send_email)
-
-    enriched = {
-        "id": 51,
-        "ticket_number": "501",
-        "subject": "Blank requester test",
-        "requester_id": None,
-        "requester_email": "   ",
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
-
-    assert not module_triggered
-    assert not direct_send_called
-
-
-@pytest.mark.anyio
-async def test_send_creation_email_uses_fallback_when_email_module_action_fails(monkeypatch):
-    """When the email-delivery module action fails, the fallback direct email is sent."""
-    captured: dict[str, object] = {}
-
-    async def fake_get_event_setting(event_type: str):
-        return {
-            "event_type": event_type,
-            "display_name": "Ticket created",
-            "message_template": "Ticket #{{ ticket.ticket_number }} created: {{ ticket.subject }}",
-            "module_actions": [{"module": "smtp2go", "payload": {}}],
-            "allow_channel_in_app": True,
-            "allow_channel_email": True,
-            "allow_channel_sms": False,
-            "default_channel_in_app": True,
-            "default_channel_email": True,
-            "default_channel_sms": False,
-        }
-
-    async def failing_trigger_module(slug, payload, *, background=True, **kwargs):
-        raise RuntimeError("smtp2go API unreachable")
-
-    async def fake_send_email(*, subject, recipients, html_body, text_body=None, **kwargs):
-        captured["recipients"] = recipients
-        captured["text_body"] = text_body
-        return True, None
-
-    monkeypatch.setattr(notification_event_settings, "get_event_setting", fake_get_event_setting)
-    monkeypatch.setattr(modules_service, "trigger_module", failing_trigger_module)
-    monkeypatch.setattr(email_service, "send_email", fake_send_email)
-
-    enriched = {
-        "id": 51,
-        "ticket_number": "501",
-        "subject": "Fallback on failure",
-        "requester_id": None,
-        "requester_email": "ext2@example.com",
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
-
-    # Fallback direct email should have been sent
-    assert captured.get("recipients") == ["ext2@example.com"]
-    assert "501" in str(captured.get("text_body"))
-    assert "Fallback on failure" in str(captured.get("text_body"))
-
-
-@pytest.mark.anyio
-async def test_send_creation_email_fires_module_and_fallback_for_non_email_action(monkeypatch):
-    """Non-email module actions fire AND the fallback direct email is also sent."""
-    module_triggered: list[str] = []
-    direct_send_called = False
-
-    async def fake_get_event_setting(event_type: str):
-        return {
-            "event_type": event_type,
-            "display_name": "Ticket created",
-            "message_template": "Ticket #{{ ticket.ticket_number }} created",
-            "module_actions": [{"module": "ntfy", "payload": {"topic": "tickets"}}],
-            "allow_channel_in_app": True,
-            "allow_channel_email": True,
-            "allow_channel_sms": False,
-            "default_channel_in_app": True,
-            "default_channel_email": True,
-            "default_channel_sms": False,
-        }
-
-    async def fake_trigger_module(slug, payload, *, background=True, **kwargs):
-        module_triggered.append(slug)
-        return {"status": "success"}
-
-    async def fake_send_email(**kwargs):
-        nonlocal direct_send_called
-        direct_send_called = True
-        return True, None
-
-    monkeypatch.setattr(notification_event_settings, "get_event_setting", fake_get_event_setting)
-    monkeypatch.setattr(modules_service, "trigger_module", fake_trigger_module)
-    monkeypatch.setattr(email_service, "send_email", fake_send_email)
-
-    enriched = {
-        "id": 52,
-        "ticket_number": "502",
-        "subject": "Non-email module test",
-        "requester_id": None,
-        "requester_email": "ext3@example.com",
-    }
-
-    await tickets_service._send_ticket_creation_email(enriched)
-
-    # ntfy module should have been triggered
-    assert "ntfy" in module_triggered
-    # Direct email should also be sent (ntfy is not an email-delivery module)
-    assert direct_send_called
+    assert not default_notification_called


### PR DESCRIPTION
### Motivation
- Prevent the platform from sending default ticket creation emails/notifications (e.g. subjects like "MyPortal notification: Your ticket ...") because new-ticket notifications must be delivered via Ticket Automations only.
- Preserve API compatibility for callers that set `send_creation_notification` while ensuring automated workflows control outbound delivery.

### Description
- Replaced the legacy `_send_ticket_creation_email` implementation with a no-op that returns immediately and documents that automations handle new-ticket notifications.
- Removed unused notification/email/template imports from `app/services/tickets.py` and stopped calling the legacy helper from `create_ticket` while leaving `send_creation_notification` as a compatibility flag.
- Updated/trimmed `tests/test_ticket_creation_email.py` to verify that registered and external requesters do not receive default notifications and that the `tickets.created` automation event is still emitted.
- Adjusted test mocks to avoid touching the real DB and focused assertions on automation routing and that the legacy notification path is not invoked.

### Testing
- Ran `pytest -q tests/test_ticket_creation_email.py` and the test file passed (`3 passed`) with warnings unrelated to the change.
- Verified the modified module compiles successfully using `python -m compileall` (no syntax errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a504c04a510832dbcd9e4c697e306d1)