### PR TITLE
Fix automation history modal sizing

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -4442,16 +4442,25 @@ dialog.modal:not([open]) {
     padding: var(--space-gap-base);
   }
 
-  .modal__dialog {
+  .modal__dialog,
+  .modal__panel {
     width: 100%;
     max-height: calc(100vh - (var(--space-gap-base) * 2));
   }
 
   .modal__dialog .modal__header,
   .modal__dialog .modal__body,
+  .modal__panel > .modal__header,
+  .modal__panel > .modal__body,
   .modal__footer {
     padding-left: var(--space-gap-base);
     padding-right: var(--space-gap-base);
+  }
+
+  .modal__panel > .modal__footer,
+  .modal__panel > .modal__body > .modal__footer {
+    margin-right: calc(var(--space-gap-base) * -1);
+    margin-left: calc(var(--space-gap-base) * -1);
   }
 }
 
@@ -4470,7 +4479,48 @@ dialog.modal:not([open]) {
   box-shadow: 0 24px 50px -20px rgba(15, 23, 42, 0.85);
 }
 
-.modal__panel,
+.modal__panel {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  width: min(92vw, 44rem);
+  max-height: min(86vh, 48rem);
+  overflow: hidden;
+  color: #f8fafc;
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.98), rgba(15, 23, 42, 0.98));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 1rem;
+  box-shadow: 0 30px 80px -24px rgba(2, 6, 23, 0.95), 0 0 0 1px rgba(15, 23, 42, 0.7);
+}
+
+.modal__panel--wide {
+  width: min(96vw, 76rem);
+  max-height: min(90vh, 56rem);
+}
+
+.modal__panel > .modal__header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-gap-base);
+  padding: calc(var(--space-gap-roomy) * 1.25) calc(var(--space-gap-roomy) * 1.5) var(--space-gap-base);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.22);
+}
+
+.modal__panel > .modal__body {
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-gap-roomy) calc(var(--space-gap-roomy) * 1.5);
+}
+
+.modal__panel > .modal__footer,
+.modal__panel > .modal__body > .modal__footer {
+  margin-right: calc(var(--space-gap-roomy) * -1.5);
+  margin-left: calc(var(--space-gap-roomy) * -1.5);
+}
+
 .modal__inner,
 .modal-content {
   position: relative;


### PR DESCRIPTION
### Motivation

- The automation history panel was rendering as unstyled full-page content instead of a bounded, centered modal because the panel lacked the modal chrome rules present for other dialogs.
- The audit/history tables require a wider modal option to comfortably display table columns without overflowing the viewport.
- Ensure mobile/responsive constraints so modals remain within the viewport on small screens.

### Description

- Add full panel chrome for the modal by implementing `.modal__panel` rules (background, border, radius, shadow, sizing, scroll containment) in `app/static/css/app.css`.
- Add a `.modal__panel--wide` modifier to provide a larger width/max-height suited for history/audit tables and keep content constrained within the viewport.
- Extend responsive rules so `.modal__panel` participates in mobile width/max-height logic and footer/body padding is corrected for narrow screens.

### Testing

- Ran a simple brace-balance verification using `python - <<'PY' ...` on `app/static/css/app.css`, which passed and reported balanced braces.
- Ran `python -m pytest tests/test_automations_repository.py`, but test collection failed due to a missing native `libmagic` dependency required by `python-magic` in the environment so tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a504b779188832db61cd08f53ea1e21)