### PR TITLE
Include reply context in tickets.updated events and add tests

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -1011,11 +1011,13 @@ async def add_reply(
         ticket_id,
         actor_type="technician" if has_helpdesk_access else "requester",
         actor=current_user or api_key_record,
+        reply=reply,
     )
     await tickets_service.emit_ticket_replied_event(
         ticket_id,
         actor_type="technician" if has_helpdesk_access else "requester",
         actor=current_user or api_key_record,
+        reply=reply,
     )
     updated_ticket = await tickets_repo.get_ticket(ticket_id)
     ticket_payload = updated_ticket or ticket

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -1631,6 +1631,7 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
             ticket_id,
             actor_type="technician",
             actor=current_user,
+            reply=created_reply,
         )
         await tickets_service.emit_ticket_replied_event(
             ticket_id,

--- a/app/features/tickets/portal_routes.py
+++ b/app/features/tickets/portal_routes.py
@@ -436,6 +436,7 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
         ticket_id,
         actor_type=actor_type,
         actor=user,
+        reply=created_reply,
     )
     await tickets_service.emit_ticket_replied_event(
         ticket_id,

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -745,15 +745,17 @@ async def emit_ticket_updated_event(
     *,
     actor_type: str | None = None,
     actor: Mapping[str, Any] | None = None,
+    reply: Mapping[str, Any] | None = None,
     trigger_automations: bool = True,
 ) -> None:
-    """Emit a ``tickets.updated`` automation event with actor metadata."""
+    """Emit a ``tickets.updated`` automation event with actor/reply metadata."""
 
     await _emit_ticket_event(
         "tickets.updated",
         ticket,
         actor_type=actor_type,
         actor=actor,
+        reply=reply,
         trigger_automations=trigger_automations,
     )
 

--- a/tests/test_ticket_reply_automation_context.py
+++ b/tests/test_ticket_reply_automation_context.py
@@ -36,3 +36,55 @@ async def test_emit_ticket_replied_event_includes_internal_reply_context(monkeyp
     assert captured["context"]["reply"]["id"] == 55
     assert captured["context"]["reply"]["is_internal"] is True
     assert captured["context"]["reply"]["kind"] == "internal_note"
+
+
+@pytest.mark.anyio
+async def test_emit_ticket_updated_event_includes_public_reply_context(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    async def fake_get_ticket(ticket_id: int):
+        assert ticket_id == 456
+        return {"id": 456, "status": "open", "subject": "Example"}
+
+    async def fake_enrich(ticket):
+        return dict(ticket)
+
+    async def fake_handle_event(event_name, context):
+        captured["event_name"] = event_name
+        captured["context"] = context
+        return []
+
+    monkeypatch.setattr(tickets_service.tickets_repo, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(tickets_service, "_enrich_ticket_context", fake_enrich)
+    monkeypatch.setattr(tickets_service.automations_service, "handle_event", fake_handle_event)
+
+    await tickets_service.emit_ticket_updated_event(
+        456,
+        actor_type="technician",
+        actor={"id": 7, "email": "tech@example.test"},
+        reply={"id": 77, "is_internal": False, "body": "public"},
+    )
+
+    assert captured["event_name"] == "tickets.updated"
+    assert captured["context"]["ticket_update"]["actor_type"] == "technician"
+    assert captured["context"]["reply"]["id"] == 77
+    assert captured["context"]["reply"]["is_internal"] is False
+    assert captured["context"]["reply"]["kind"] == "message"
+
+
+def test_reply_message_filter_matches_updated_event_context():
+    from app.services import automations as automations_service
+
+    context = {
+        "ticket_update": {"actor_type": "technician"},
+        "reply": {"kind": "message", "is_internal": False},
+    }
+    filters = {
+        "all": [
+            {"match": {"ticket_update.actor_type": "technician"}},
+            {"match": {"reply.kind": "message"}},
+            {"match": {"reply.is_internal": False}},
+        ]
+    }
+
+    assert automations_service._filters_match(filters, context)


### PR DESCRIPTION
### Motivation

- Ensure reply metadata is included when emitting `tickets.updated` events so automations and listeners can react to reply content and privacy (internal vs public).

### Description

- Extended `emit_ticket_updated_event` to accept a `reply` argument and forward it to `_emit_ticket_event` so reply context is included in the emitted event payload.
- Passed the created reply into `emit_ticket_updated_event` and `emit_ticket_replied_event` across API (`app/api/routes/tickets.py`), admin (`app/features/tickets/admin_routes.py`), and portal (`app/features/tickets/portal_routes.py`) reply flows.
- Updated the `tickets.updated` docstring to indicate it now carries reply metadata.
- Added unit tests (`tests/test_ticket_reply_automation_context.py`) verifying that `tickets.updated` includes public reply context and that automations filters match reply message contexts.

### Testing

- Ran the new tests `tests/test_ticket_reply_automation_context.py` using `pytest` and they passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a504ddf8a1c832daa918f3f9fd90870)