### PR TITLE
Compact long email Message-IDs for ticket external references, add CC watcher import, and improve M365 recipient handling

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import email
+import hashlib
 import imaplib
 import io
 import json
@@ -30,7 +31,45 @@ from app.services import tickets as tickets_service
 from app.services.sanitization import sanitize_rich_text
 
 _MAX_FETCH_BYTES = 5 * 1024 * 1024
+_MAX_TICKET_EXTERNAL_REFERENCE_CHARS = 128
 _CID_REFERENCE_PATTERN = re.compile(r"(?i)cid:([^\"'>\s]+)")
+
+
+def _normalise_ticket_external_reference(value: str | None) -> str | None:
+    """Return a database-safe external reference for tickets/replies.
+
+    The ticket_replies.external_reference column is limited to 128 characters.
+    RFC 5322 Message-ID values and Graph internetMessageId values can exceed
+    that limit, especially for Exchange Online replies.  Store short values as
+    they are; for long values, keep a recognizable prefix and append a stable
+    hash so imports remain idempotent and future References/In-Reply-To lookups
+    can match the compacted value.
+    """
+
+    reference = _normalise_string(value)
+    if not reference:
+        return None
+    if len(reference) <= _MAX_TICKET_EXTERNAL_REFERENCE_CHARS:
+        return reference
+
+    digest = hashlib.sha256(reference.encode("utf-8")).hexdigest()[:32]
+    suffix = f":sha256:{digest}"
+    prefix_length = _MAX_TICKET_EXTERNAL_REFERENCE_CHARS - len(suffix)
+    return f"{reference[:prefix_length]}{suffix}"
+
+
+def _expand_ticket_external_references(values: list[str] | None) -> list[str]:
+    """Return raw and compacted reference variants without duplicates."""
+
+    references: list[str] = []
+    seen: set[str] = set()
+    for value in values or []:
+        for candidate in (value, _normalise_ticket_external_reference(value)):
+            reference = _normalise_string(candidate)
+            if reference and reference not in seen:
+                references.append(reference)
+                seen.add(reference)
+    return references
 
 
 def _redact_account(account: Mapping[str, Any]) -> dict[str, Any]:
@@ -392,6 +431,54 @@ def _build_attachment_only_reply_body(
         "<p>Email reply received with attachment(s), but no message body was "
         f"available after sanitisation.{detail_html}</p>"
     )
+
+async def _add_email_cc_watchers(
+    ticket_id: int,
+    cc_addresses: list[str],
+    *,
+    exclude_addresses: list[str] | None = None,
+) -> None:
+    """Add original email CC recipients as ticket watchers.
+
+    Inbound mail often includes interested customer contacts in Cc.  Persisting
+    them as watchers allows those contacts to reply later and ensures future
+    ticket notifications include the same audience.  Addresses are normalized,
+    de-duplicated, and added idempotently by local user id when possible, or by
+    email address otherwise.
+    """
+
+    excluded = {
+        _normalise_email_address(address)
+        for address in (exclude_addresses or [])
+        if _normalise_email_address(address)
+    }
+    seen: set[str] = set()
+    for raw_address in cc_addresses:
+        address = _normalise_email_address(raw_address)
+        if not address or address in seen or address in excluded:
+            continue
+        seen.add(address)
+
+        user_id: int | None = None
+        try:
+            user = await users_repo.get_user_by_email(address)
+        except Exception:
+            user = None
+        if user:
+            user_id = _extract_record_id(user)
+
+        try:
+            if user_id is not None:
+                await tickets_repo.add_watcher(ticket_id, user_id=user_id)
+            else:
+                await tickets_repo.add_watcher(ticket_id, email=address)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            log_error(
+                "Failed to add email CC recipient as ticket watcher",
+                ticket_id=ticket_id,
+                email=address,
+                error=str(exc),
+            )
 
 
 def _extract_domains(addresses: list[str]) -> list[str]:
@@ -1204,7 +1291,7 @@ async def _find_existing_ticket_for_reply(
     Returns:
         Ticket record if found, None otherwise
     """
-    related_ids = [message_id for message_id in related_message_ids or [] if message_id]
+    related_ids = _expand_ticket_external_references(related_message_ids)
 
     if related_ids:
         from app.repositories.tickets import _normalise_ticket
@@ -1785,13 +1872,19 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                         status=None,
                         category="email",
                         module_slug="imap",
-                        external_reference=message_id,
+                        external_reference=_normalise_ticket_external_reference(message_id),
                         initial_reply_author_id=requester_id,
                         requester_email=from_email_addr if requester_id is None else None,
                     )
                     is_new_ticket = True
                     ticket_id = ticket.get("id") if isinstance(ticket, Mapping) else None
                     if ticket_id is not None:
+                        cc_addresses = _extract_email_addresses(message.get("Cc"))
+                        await _add_email_cc_watchers(
+                            int(ticket_id),
+                            cc_addresses,
+                            exclude_addresses=[from_email_addr] if from_email_addr else None,
+                        )
                         try:
                             await tickets_service.refresh_ticket_ai_summary(int(ticket_id))
                         except RuntimeError:
@@ -1845,7 +1938,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                 author_id=reply_author_id,
                                 body=reply_body,
                                 is_internal=False,
-                                external_reference=message_id if message_id else None,
+                                external_reference=_normalise_ticket_external_reference(message_id),
                                 created_at=reply_created_at,
                             )
                             reply_added = True

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -25,6 +25,7 @@ from app.services.m365 import M365Error
 # Reuse filter helpers from the IMAP module so we share the same filter DSL.
 from app.services.imap import (
     _build_attachment_only_reply_body,
+    _add_email_cc_watchers,
     _evaluate_filter,
     _extract_domains,
     _extract_email_addresses,
@@ -35,6 +36,7 @@ from app.services.imap import (
     _is_any_email_address_known,
     _normalise_bool,
     _normalise_filter,
+    _normalise_ticket_external_reference,
     _normalise_priority,
     _normalise_string,
     _sanitize_inbound_reply_body,
@@ -753,6 +755,21 @@ async def _resolve_mail_folder_identifier(
 
     return await _resolve_top_level(folder_path)
 
+def _extract_graph_recipient_addresses(recipients: list[dict[str, Any]]) -> list[str]:
+    """Return normalized email addresses from Graph recipient objects."""
+
+    addresses: list[str] = []
+    for recipient in recipients:
+        email_addr = (
+            recipient.get("emailAddress", {}) if isinstance(recipient, Mapping) else {}
+        )
+        addr = _normalise_string(
+            email_addr.get("address") if isinstance(email_addr, Mapping) else None
+        )
+        if addr:
+            addresses.append(addr.lower())
+    return addresses
+
 
 def _build_filter_context(
     *,
@@ -778,19 +795,10 @@ def _build_filter_context(
     bcc_recipients = graph_message.get("bccRecipients") or []
     reply_to_list = graph_message.get("replyTo") or []
 
-    def _extract_recipient_addresses(recipients: list[dict[str, Any]]) -> list[str]:
-        addresses: list[str] = []
-        for r in recipients:
-            email_addr = r.get("emailAddress", {})
-            addr = (email_addr.get("address") or "").strip()
-            if addr:
-                addresses.append(addr)
-        return addresses
-
-    to_addresses = _extract_recipient_addresses(to_recipients)
-    cc_addresses = _extract_recipient_addresses(cc_recipients)
-    bcc_addresses = _extract_recipient_addresses(bcc_recipients)
-    reply_to_addresses = _extract_recipient_addresses(reply_to_list)
+    to_addresses = _extract_graph_recipient_addresses(to_recipients)
+    cc_addresses = _extract_graph_recipient_addresses(cc_recipients)
+    bcc_addresses = _extract_graph_recipient_addresses(bcc_recipients)
+    reply_to_addresses = _extract_graph_recipient_addresses(reply_to_list)
 
     # Build headers dict from internetMessageHeaders if available
     headers: dict[str, str] = {}
@@ -1047,7 +1055,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
         query_params = {
             "$top": "50",
             "$select": (
-                "id,subject,body,from,toRecipients,ccRecipients,bccRecipients,"
+                "id,subject,body,bodyPreview,from,toRecipients,ccRecipients,bccRecipients,"
                 "replyTo,internetMessageHeaders,internetMessageId,isRead,receivedDateTime,"
                 "hasAttachments,conversationId"
             ),
@@ -1280,6 +1288,8 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                 subject = msg.get("subject") or f"Email from {upn}"
                 body_content = msg.get("body", {})
                 body = body_content.get("content") or ""
+                if not body:
+                    body = msg.get("bodyPreview") or ""
                 if msg.get("hasAttachments") and body:
                     body = await _embed_graph_inline_images(
                         access_token=access_token,
@@ -1421,7 +1431,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                             status=None,
                             category="email",
                             module_slug=_MODULE_SLUG,
-                            external_reference=internet_msg_id,
+                            external_reference=_normalise_ticket_external_reference(internet_msg_id),
                             initial_reply_author_id=requester_id,
                             requester_email=(
                                 from_email_addr if requester_id is None else None
@@ -1432,6 +1442,14 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                             ticket.get("id") if isinstance(ticket, Mapping) else None
                         )
                         if ticket_id is not None:
+                            cc_addresses = _extract_graph_recipient_addresses(
+                                msg.get("ccRecipients") or []
+                            )
+                            await _add_email_cc_watchers(
+                                int(ticket_id),
+                                cc_addresses,
+                                exclude_addresses=[from_email_addr] if from_email_addr else None,
+                            )
                             try:
                                 await tickets_service.refresh_ticket_ai_summary(
                                     int(ticket_id)
@@ -1502,7 +1520,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                     body=reply_body,
                                     is_internal=False,
                                     external_reference=(
-                                        internet_msg_id if internet_msg_id else None
+                                        _normalise_ticket_external_reference(internet_msg_id)
                                     ),
                                     created_at=reply_created_at,
                                 )

--- a/migrations/295_expand_ticket_reply_body.sql
+++ b/migrations/295_expand_ticket_reply_body.sql
@@ -1,0 +1,5 @@
+-- Allow inbound email replies with long quoted histories or inline content to be stored.
+-- MySQL TEXT is limited to 64 KiB and caused M365 reply appends to fail with
+-- "Data too long for column 'body'". SQLite treats LONGTEXT as TEXT affinity.
+ALTER TABLE ticket_replies
+  MODIFY COLUMN body LONGTEXT NOT NULL;

--- a/tests/test_email_ticket_replies.py
+++ b/tests/test_email_ticket_replies.py
@@ -598,5 +598,60 @@ class TestFindExistingTicket:
         assert "%alice@example.com%" in captured["params"]
 
 
+
+def test_long_email_external_references_are_compacted_for_ticket_columns():
+    from app.services.imap import (
+        _expand_ticket_external_references,
+        _normalise_ticket_external_reference,
+    )
+
+    long_reference = "<" + "a" * 180 + "@example.com>"
+
+    stored = _normalise_ticket_external_reference(long_reference)
+
+    assert stored is not None
+    assert len(stored) == 128
+    assert ":sha256:" in stored
+    assert len(stored.rsplit(":sha256:", 1)[1]) == 32
+    assert long_reference in _expand_ticket_external_references([long_reference])
+    assert stored in _expand_ticket_external_references([long_reference])
+
+
+def test_short_email_external_references_are_stored_unchanged():
+    from app.services.imap import _normalise_ticket_external_reference
+
+    assert _normalise_ticket_external_reference("<short@example.com>") == "<short@example.com>"
+
+
+@pytest.mark.anyio
+async def test_add_email_cc_watchers_adds_users_and_external_addresses(monkeypatch):
+    """Original CC recipients should become ticket watchers for future replies."""
+    from app.services import imap
+
+    added: list[tuple[int, int | None, str | None]] = []
+
+    async def fake_get_user_by_email(email: str):
+        if email == "known@example.com":
+            return {"id": 42, "email": email}
+        return None
+
+    async def fake_add_watcher(ticket_id: int, user_id=None, email=None):
+        added.append((ticket_id, user_id, email))
+
+    monkeypatch.setattr(imap.users_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(imap.tickets_repo, "add_watcher", fake_add_watcher)
+
+    await imap._add_email_cc_watchers(
+        123,
+        ["Known@Example.com", "external@example.com", "known@example.com", "requester@example.com"],
+        exclude_addresses=["requester@example.com"],
+    )
+
+    assert added == [
+        (123, 42, None),
+        (123, None, "external@example.com"),
+    ]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_imap_service.py
+++ b/tests/test_imap_service.py
@@ -1060,3 +1060,15 @@ async def test_resolve_existing_reply_author_id_preserves_resolved_requester_id(
     )
 
     assert author_id == 99
+
+
+def test_m365_graph_recipient_extraction_normalizes_addresses():
+    from app.services import m365_mail
+
+    assert m365_mail._extract_graph_recipient_addresses(
+        [
+            {"emailAddress": {"address": "CC.One@Example.com"}},
+            {"emailAddress": {"address": " cc.two@example.com "}},
+            {"emailAddress": {"address": ""}},
+        ]
+    ) == ["cc.one@example.com", "cc.two@example.com"]


### PR DESCRIPTION
### Motivation
- Prevent failures and data truncation when storing long email `Message-ID` or Graph `internetMessageId` values in the `ticket_replies.external_reference` column which is limited to 128 characters. 
- Preserve idempotent matching for replies by making long external references stable and searchable while keeping a recognizable prefix. 
- Improve ticket behavior by automatically adding original message Cc recipients as watchers and normalizing Graph recipient addresses so M365 imports mirror IMAP behavior.

### Description
- Added `_normalise_ticket_external_reference` to compact long external references by keeping a prefix and appending a stable `:sha256:` digest, and `_expand_ticket_external_references` to produce raw and compact variants for matching. 
- Updated reply and ticket creation flows in `app/services/imap.py` and `app/services/m365_mail.py` to use `_normalise_ticket_external_reference` for `external_reference` storage and to query using expanded variants. 
- Added `_add_email_cc_watchers` to import Cc recipients as ticket watchers (resolving local users when possible), and `_extract_graph_recipient_addresses` in `m365_mail.py` to normalize Graph recipient objects; wired these into ticket creation for both IMAP and M365 imports. 
- Added fallback to use `bodyPreview` when Graph `body.content` is empty, and adjusted imports to include `hashlib` and a new `_MAX_TICKET_EXTERNAL_REFERENCE_CHARS` constant. 
- Added migration `295_expand_ticket_reply_body.sql` to change `ticket_replies.body` to `LONGTEXT` to allow larger inbound reply bodies.

### Testing
- Added unit tests in `tests/test_email_ticket_replies.py` that validate long reference compaction via `_normalise_ticket_external_reference` and expansion via `_expand_ticket_external_references`, and that `_add_email_cc_watchers` adds known users and external addresses; these tests passed when run. 
- Added a unit test in `tests/test_imap_service.py` verifying `_extract_graph_recipient_addresses` normalizes Graph recipient objects; this test passed when run. 
- Ran the modified test files with `pytest` and observed successful completion for the new and updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5052f64e38832d8517060e340f66c6)