### PR TITLE
Add LOG_LEVEL support for server console and application logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -215,8 +215,11 @@ PUBLIC_BASE_URL=
 OPNFORM_BASE_URL=
 # Set true to emit DEBUG-level verbose logs, including high-frequency tray heartbeat events.
 VERBOSE_LOGGING=false
-# Main application log file. Receives INFO-and-above server events in addition
-# to journald/stdout, one entry per line, including the feature pack field for filtering.
+# Optional minimum server log level for console and the main application log.
+# Accepted values: DEBUG, INFO, WARNING, ERROR, CRITICAL. Defaults to DEBUG when VERBOSE_LOGGING=true, otherwise INFO.
+LOG_LEVEL=
+# Main application log file. Receives server events at LOG_LEVEL and above in
+# addition to journald/stdout, one entry per line, including the feature pack field for filtering.
 # Set empty to disable the file sink.
 APP_LOG_PATH=/var/log/myportal/myportal.log
 FAIL2BAN_LOG_PATH=

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -324,12 +324,21 @@ class Settings(BaseSettings):
             "high-frequency tray heartbeat events."
         ),
     )
+    log_level: str | None = Field(
+        default=None,
+        validation_alias="LOG_LEVEL",
+        description=(
+            "Minimum server log level for console and main application log output. "
+            "Accepted values: DEBUG, INFO, WARNING, ERROR, CRITICAL. "
+            "Defaults to DEBUG when VERBOSE_LOGGING is true, otherwise INFO."
+        ),
+    )
     app_log_path: Path | None = Field(
         default=Path("/var/log/myportal/myportal.log"),
         validation_alias="APP_LOG_PATH",
         description=(
-            "Main application log file. Receives the same INFO-and-above server "
-            "events sent to journald/stdout, with one entry per line and the "
+            "Main application log file. Receives server events at LOG_LEVEL and above "
+            "sent to journald/stdout, with one entry per line and the "
             "feature pack field included for filtering. Set empty to disable."
         ),
     )
@@ -650,6 +659,24 @@ class Settings(BaseSettings):
         if isinstance(value, str):
             # Split on '#' and take the first part, then strip whitespace
             value = value.split("#")[0].strip()
+        return value
+
+    @field_validator("log_level", mode="before")
+    @classmethod
+    def _normalize_log_level(cls, value: str | None) -> str | None:
+        """Normalize optional LOG_LEVEL values from environment files."""
+
+        if value is None:
+            return None
+        if isinstance(value, str):
+            normalized = value.split("#")[0].strip().upper()
+            if normalized == "":
+                return None
+            allowed = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+            if normalized not in allowed:
+                allowed_values = ", ".join(sorted(allowed))
+                raise ValueError(f"LOG_LEVEL must be one of: {allowed_values}")
+            return normalized
         return value
 
     @field_validator(

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -130,7 +130,7 @@ def configure_logging() -> None:
         return file_log_format + "\n"
 
     settings = get_settings()
-    log_level = "DEBUG" if settings.verbose_logging else "INFO"
+    log_level = settings.log_level or ("DEBUG" if settings.verbose_logging else "INFO")
 
     logger.add(sink=lambda msg: print(msg, end=""), format=_format_console_record, level=log_level)
     _configure_uvicorn_access_logging(verbose=settings.verbose_logging)

--- a/docs/wiki/compliance/Logging and Audit.md
+++ b/docs/wiki/compliance/Logging and Audit.md
@@ -23,6 +23,7 @@ list. The most useful ones:
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `FAIL2BAN_LOG_PATH` | _unset_ | Path to the main disk log file. When set, the application writes a structured Loguru sink that Fail2ban / SIEM tools can tail. |
+| `LOG_LEVEL` | `INFO` (`DEBUG` when `VERBOSE_LOGGING=true`) | Minimum level for server console and `APP_LOG_PATH` output. Set `WARNING` to exclude DEBUG and INFO entries. Accepted values: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |
 | `LOG_ROTATION` | `50 MB` | Loguru rotation policy. Accepts a size (`50 MB`), an interval (`1 day`), or a clock time (`00:00`). Set empty to disable. |
 | `LOG_RETENTION` | `30 days` | How long rotated log files are kept. |
 | `LOG_COMPRESSION` | `gz` | Compression format for rotated files. Set empty to keep them uncompressed. |

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -79,6 +79,54 @@ def test_configure_logging_writes_application_log_one_line_per_entry(tmp_path):
     logger.remove()
 
 
+def test_log_level_filters_application_log_entries(tmp_path):
+    """LOG_LEVEL controls the minimum level for the main application log sink."""
+    log_path = tmp_path / "myportal.log"
+
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
+    with patch.dict(
+        os.environ,
+        {
+            "SESSION_SECRET": "test-secret",
+            "TOTP_ENCRYPTION_KEY": "test-totp-key",
+            "APP_LOG_PATH": str(log_path),
+            "LOG_LEVEL": "WARNING",
+            "LOG_ROTATION": "",
+            "LOG_RETENTION": "",
+            "LOG_COMPRESSION": "",
+        },
+    ):
+        configure_logging()
+        logger.info("filtered info")
+        logger.warning("kept warning")
+        logger.complete()
+
+    contents = log_path.read_text(encoding="utf-8")
+    assert "filtered info" not in contents
+    assert "kept warning" in contents
+    get_settings.cache_clear()
+    logger.remove()
+
+
+def test_log_level_normalizes_env_value():
+    """LOG_LEVEL accepts lowercase values and inline comments from .env files."""
+    from app.core.config import Settings
+
+    with patch.dict(
+        os.environ,
+        {
+            "SESSION_SECRET": "test-secret",
+            "TOTP_ENCRYPTION_KEY": "test-totp-key",
+            "LOG_LEVEL": "warning  # quiet logs",
+        },
+        clear=True,
+    ):
+        settings = Settings()
+
+    assert settings.log_level == "WARNING"
+
 def test_default_application_log_rotation_and_retention():
     """Main file log defaults to daily rotation and seven-day retention."""
     from app.core.config import Settings


### PR DESCRIPTION
### Motivation

- Allow server operators to set a minimum log level from `.env` so noisy DEBUG/INFO output can be suppressed (e.g. set `LOG_LEVEL=WARNING`).
- Preserve the existing `VERBOSE_LOGGING` behaviour while giving admins an explicit override for console and main file sinks.

### Description

- Add an optional `log_level: str | None` `Settings` field with `validation_alias="LOG_LEVEL"` and a `.env`-style validator that normalizes casing, strips inline comments, treats blank values as unset, and validates allowed levels (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`).
- Use the resolved `settings.log_level` when configuring Loguru sinks (console and `APP_LOG_PATH`) falling back to `DEBUG` when `VERBOSE_LOGGING` is true or `INFO` otherwise.
- Update `.env.example` and the logging documentation to describe `LOG_LEVEL` and its behaviour.
- Add tests: `test_log_level_filters_application_log_entries` to assert filtering of application log entries by level, and `test_log_level_normalizes_env_value` to assert normalization of `.env` values.

### Testing

- `python -m py_compile app/core/config.py app/core/logging.py tests/test_logging.py` completed successfully to validate syntax.
- Running `pytest tests/test_logging.py` was attempted but test collection failed due to an environment-level missing system dependency (`libmagic`) required by `python-magic`, preventing the test run from completing.
- Static checks performed during development (syntax compile and diff checks) did not report problems beyond the external dependency blocking `pytest` collection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5059993f0c8332997c168ab84d7672)