### PR TITLE
Canonicalize SVG attachments for duplicate detection and wait for files before hashing

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -7,7 +7,8 @@ import json
 import os
 import string
 import wave
-import xml.etree.ElementTree as ET
+from defusedxml import ElementTree as DefusedET
+from defusedxml.common import DefusedXmlException
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 import asyncio
@@ -5752,15 +5753,18 @@ def _normalised_svg_bytes(contents: bytes) -> bytes | None:
 
     try:
         text = contents.decode("utf-8-sig")
-        root = ET.fromstring(text)
+        root = DefusedET.fromstring(text)
         for element in root.iter():
+            if element.attrib:
+                sorted_attributes = sorted(element.attrib.items())
+                element.attrib.clear()
+                element.attrib.update(sorted_attributes)
             if element.text and not element.text.strip():
                 element.text = None
             if element.tail and not element.tail.strip():
                 element.tail = None
-        normalised_text = ET.tostring(root, encoding="unicode", short_empty_elements=False)
-        return ET.canonicalize(normalised_text).encode("utf-8")
-    except (ET.ParseError, UnicodeDecodeError, ValueError):
+        return DefusedET.tostring(root, encoding="utf-8", short_empty_elements=False)
+    except (DefusedET.ParseError, DefusedXmlException, UnicodeDecodeError, ValueError):
         return None
 
 

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -7,6 +7,7 @@ import json
 import os
 import string
 import wave
+import xml.etree.ElementTree as ET
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 import asyncio
@@ -38,6 +39,9 @@ from app.services.realtime import RefreshNotifier, refresh_notifier
 from app.services import tickets as tickets_service
 
 REQUEST_TIMEOUT = httpx.Timeout(15.0, connect=5.0)
+
+_SMART_ATTACHMENT_POLL_ATTEMPTS = 5
+_SMART_ATTACHMENT_POLL_DELAY_SECONDS = 0.5
 
 _BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
 
@@ -5743,6 +5747,53 @@ def _resolve_ticket_id_from_payload(payload: Mapping[str, Any]) -> int:
     return ticket_id_int
 
 
+def _normalised_svg_bytes(contents: bytes) -> bytes | None:
+    """Return a stable SVG representation for hashing, if parsing succeeds."""
+
+    try:
+        text = contents.decode("utf-8-sig")
+        root = ET.fromstring(text)
+        for element in root.iter():
+            if element.text and not element.text.strip():
+                element.text = None
+            if element.tail and not element.tail.strip():
+                element.tail = None
+        normalised_text = ET.tostring(root, encoding="unicode", short_empty_elements=False)
+        return ET.canonicalize(normalised_text).encode("utf-8")
+    except (ET.ParseError, UnicodeDecodeError, ValueError):
+        return None
+
+
+def _attachment_hash_key(
+    contents: bytes,
+    *,
+    algorithm: str,
+    filename: str,
+    original_filename: Any,
+    mime_type: Any,
+) -> tuple[str, str]:
+    """Build a content hash key for duplicate attachment detection.
+
+    Most attachments use an exact byte hash. SVG files are XML documents, so the
+    same content can be serialized with different insignificant whitespace. For
+    SVGs we hash a canonical XML representation so equal SVG content is treated
+    as a duplicate even if serialization differs.
+    """
+
+    extension_source = str(original_filename or filename).lower()
+    mime = str(mime_type or "").split(";", 1)[0].strip().lower()
+    if extension_source.endswith(".svg") or mime in {"image/svg+xml", "image/svg"}:
+        normalised = _normalised_svg_bytes(contents)
+        if normalised is not None:
+            digest = hashlib.new(algorithm)
+            digest.update(normalised)
+            return f"svg-c14n:{digest.hexdigest()}", "svg-c14n"
+
+    digest = hashlib.new(algorithm)
+    digest.update(contents)
+    return f"bytes:{digest.hexdigest()}", "bytes"
+
+
 async def _invoke_smart_attachment_removal(
     settings: Mapping[str, Any],
     payload: Mapping[str, Any],
@@ -5766,6 +5817,28 @@ async def _invoke_smart_attachment_removal(
     dry_run = bool(payload.get("dry_run", False))
 
     attachments = await attachments_repo.list_attachments(ticket_id)
+    for poll_attempt in range(_SMART_ATTACHMENT_POLL_ATTEMPTS):
+        missing_ready_files = []
+        for attachment in attachments:
+            filename = str(attachment.get("filename") or "").strip()
+            if not filename:
+                continue
+            file_path = attachments_service.get_attachment_file_path(filename)
+            if not file_path.exists() or not file_path.is_file():
+                missing_ready_files.append(filename)
+
+        if not missing_ready_files:
+            break
+
+        if poll_attempt < _SMART_ATTACHMENT_POLL_ATTEMPTS - 1:
+            logger.info(
+                "Ticket attachments found but files are not yet present; retrying",
+                ticket_id=ticket_id,
+                missing_files=len(missing_ready_files),
+                poll_attempt=poll_attempt + 1,
+            )
+            await asyncio.sleep(_SMART_ATTACHMENT_POLL_DELAY_SECONDS)
+
     seen: dict[str, dict[str, Any]] = {}
     duplicates: list[dict[str, Any]] = []
     missing_files: list[dict[str, Any]] = []
@@ -5792,11 +5865,9 @@ async def _invoke_smart_attachment_removal(
                 }
             )
             continue
-        digest = hashlib.new(algorithm)
         try:
             with open(file_path, "rb") as handle:
-                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                    digest.update(chunk)
+                contents = handle.read()
         except OSError as exc:
             errors.append(
                 {
@@ -5806,7 +5877,13 @@ async def _invoke_smart_attachment_removal(
                 }
             )
             continue
-        file_hash = digest.hexdigest()
+        file_hash, hash_type = _attachment_hash_key(
+            contents,
+            algorithm=algorithm,
+            filename=filename,
+            original_filename=attachment.get("original_filename"),
+            mime_type=attachment.get("mime_type"),
+        )
         original = seen.get(file_hash)
         if original is None:
             seen[file_hash] = attachment
@@ -5817,6 +5894,7 @@ async def _invoke_smart_attachment_removal(
             "filename": filename,
             "original_filename": attachment.get("original_filename"),
             "hash": file_hash,
+            "hash_type": hash_type,
         }
         duplicates.append(duplicate_entry)
         if dry_run:

--- a/tests/test_ticket_automation_actions.py
+++ b/tests/test_ticket_automation_actions.py
@@ -260,6 +260,67 @@ async def test_smart_attachment_removal_dry_run_preserves_duplicates(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_smart_attachment_removal_hashes_canonical_svg_content(
+    monkeypatch, tmp_path
+):
+    """SVG attachments with the same XML content are matched despite formatting."""
+    from app.repositories import tickets as tickets_repo
+    from app.repositories import ticket_attachments as attachments_repo
+    from app.services import ticket_attachments as attachments_service
+
+    attachments = [
+        {
+            "id": 9965,
+            "ticket_id": 25063,
+            "filename": "first.svg",
+            "original_filename": "qr-code (1).svg",
+            "mime_type": "image/svg+xml",
+        },
+        {
+            "id": 9967,
+            "ticket_id": 25063,
+            "filename": "duplicate.svg",
+            "original_filename": "qr-code (1).svg",
+            "mime_type": "image/svg+xml",
+        },
+    ]
+    (tmp_path / "first.svg").write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect height="10" width="10"></rect></svg>',
+        encoding="utf-8",
+    )
+    (tmp_path / "duplicate.svg").write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg">\n'
+        '  <rect height="10" width="10"></rect>\n'
+        "</svg>\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(tickets_repo, "get_ticket", AsyncMock(return_value={"id": 25063}))
+    monkeypatch.setattr(
+        attachments_repo, "list_attachments", AsyncMock(return_value=attachments)
+    )
+    monkeypatch.setattr(
+        attachments_service,
+        "get_attachment_file_path",
+        lambda filename: tmp_path / filename,
+    )
+    delete_mock = AsyncMock()
+    monkeypatch.setattr(attachments_service, "delete_attachment_file", delete_mock)
+
+    result = await modules._invoke_smart_attachment_removal(
+        {},
+        {"ticket_id": 25063},
+        event_future=None,
+    )
+
+    assert result["status"] == "succeeded"
+    assert result["unique"] == 1
+    assert result["duplicates_found"] == 1
+    assert result["duplicates"][0]["hash_type"] == "svg-c14n"
+    delete_mock.assert_awaited_once_with(attachments[1])
+
+
+@pytest.mark.asyncio
 async def test_invoke_update_ticket_description(monkeypatch, mock_webhook_monitor, mock_record_success):
     """Test that update-ticket-description module changes description."""
     from app.services import tickets as tickets_service


### PR DESCRIPTION
### Motivation
- Ensure duplicate detection for ticket attachments treats semantically identical SVGs as duplicates even when XML serialization/whitespace differs.
- Avoid false negatives when attachment DB records exist but files are not yet written to disk by polling briefly before processing.

### Description
- Add XML canonicalisation helper ` _normalised_svg_bytes` and a hashing helper `_attachment_hash_key` to produce a stable `svg-c14n` hash for SVG attachments or fall back to byte hashes for other files.
- Update `_invoke_smart_attachment_removal` to poll for attachment files to appear using `_SMART_ATTACHMENT_POLL_ATTEMPTS` and `_SMART_ATTACHMENT_POLL_DELAY_SECONDS` before processing and to read full file contents for hashing via the new helper.
- Record `hash_type` (`svg-c14n` or `bytes`) on found duplicates and keep existing `dry_run` behavior; introduce small constants and import `xml.etree.ElementTree as ET` to support XML processing.

### Testing
- Added unit test `test_smart_attachment_removal_hashes_canonical_svg_content` in `tests/test_ticket_automation_actions.py` to verify SVGs with different formatting are detected as duplicates and marked with `hash_type` `svg-c14n`.
- Ran the `tests/test_ticket_automation_actions.py` test file including the new test and the smart-attachment removal dry-run test, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a505e9cae988332a7739bc27b3648f9)