### PR TITLE
Show shop categories and featured as cards; responsive product cards with safe title truncation

### DIFF
--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -215,10 +215,14 @@ async def shop_page(
 
     category_param = category.strip() if isinstance(category, str) and category.strip() else None
     show_packages = False
+    show_featured = False
     category_id: int | None = None
     if category_param:
-        if category_param.lower() == "packages":
+        category_key = category_param.lower()
+        if category_key == "packages":
             show_packages = True
+        elif category_key == "featured":
+            show_featured = True
         else:
             try:
                 parsed_category = int(category_param)
@@ -238,7 +242,32 @@ async def shop_page(
     )
 
     products: list[dict[str, Any]]
+    category_cards: list[dict[str, Any]] = []
     total_count = 0
+    showing_category_cards = not show_packages and not show_featured and category_id is None and not effective_search
+
+    def _product_has_price(product: Mapping[str, Any]) -> bool:
+        raw_price = product.get("price")
+        if raw_price is None:
+            return False
+        try:
+            return Decimal(str(raw_price)) > 0
+        except (InvalidOperation, TypeError, ValueError):
+            return False
+
+    def _prepare_customer_products(raw_products: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+        prepared = [
+            dict(product)
+            for product in raw_products
+            if not shop_service.is_price_below_dbp_threshold(product, is_vip=is_vip)
+        ]
+        if is_vip:
+            for product in prepared:
+                vip_price = product.get("vip_price")
+                if vip_price is not None:
+                    product["price"] = vip_price
+        return [product for product in prepared if _product_has_price(product)]
+
     if show_packages:
         packages = await shop_packages_service.load_company_packages(
             company_id=company_id,
@@ -298,44 +327,40 @@ async def shop_page(
         offset = (page - 1) * page_size
         products = products[offset: offset + page_size]
     else:
-        # Get category IDs to filter by (including descendants)
-        category_ids = None
-        if category_id is not None:
-            category_ids = await shop_repo.get_category_descendants(category_id)
+        if show_featured:
+            products = _prepare_customer_products(
+                await shop_repo.list_featured_products_for_company(
+                    company_id=company_id,
+                    include_out_of_stock=show_out_of_stock,
+                )
+            )
+            if effective_search:
+                products = [
+                    product
+                    for product in products
+                    if search_term_lower
+                    and (
+                        search_term_lower in str(product.get("name") or "").lower()
+                        or search_term_lower in str(product.get("sku") or "").lower()
+                    )
+                ]
+        else:
+            # Get category IDs to filter by (including descendants)
+            category_ids = None
+            if category_id is not None:
+                category_ids = await shop_repo.get_category_descendants(category_id)
 
-        filters = shop_repo.ProductFilters(
-            include_archived=False,
-            company_id=company_id,
-            category_ids=category_ids,
-            search_term=effective_search,
-            in_stock_only=not show_out_of_stock,
-            sort="name_asc",
-        )
+            filters = shop_repo.ProductFilters(
+                include_archived=False,
+                company_id=company_id,
+                category_ids=category_ids,
+                search_term=effective_search,
+                in_stock_only=not show_out_of_stock,
+                sort="name_asc",
+            )
 
-        products = await shop_repo.list_products_summary(filters)
+            products = _prepare_customer_products(await shop_repo.list_products_summary(filters))
 
-        products = [
-            product
-            for product in products
-            if not shop_service.is_price_below_dbp_threshold(product, is_vip=is_vip)
-        ]
-
-        if is_vip:
-            for product in products:
-                vip_price = product.get("vip_price")
-                if vip_price is not None:
-                    product["price"] = vip_price
-
-        def _product_has_price(product: Mapping[str, Any]) -> bool:
-            raw_price = product.get("price")
-            if raw_price is None:
-                return False
-            try:
-                return Decimal(str(raw_price)) > 0
-            except (InvalidOperation, TypeError, ValueError):
-                return False
-
-        products = [product for product in products if _product_has_price(product)]
         total_count = len(products)
         offset = (page - 1) * page_size
         products = products[offset: offset + page_size]
@@ -358,6 +383,47 @@ async def shop_page(
 
     categories = _filter_categories(categories, available_category_ids)
 
+    if showing_category_cards:
+        category_preview_products = _prepare_customer_products(
+            await shop_repo.list_products_summary(
+                shop_repo.ProductFilters(
+                    include_archived=False,
+                    company_id=company_id,
+                    in_stock_only=not show_out_of_stock,
+                    sort="name_asc",
+                )
+            )
+        )
+        preview_by_category: dict[int, dict[str, Any]] = {}
+        for product in category_preview_products:
+            product_category_id = product.get("category_id")
+            if product_category_id is None:
+                continue
+            product_category_id = int(product_category_id)
+            existing = preview_by_category.get(product_category_id)
+            if existing is None or (not existing.get("image_url") and product.get("image_url")):
+                preview_by_category[product_category_id] = product
+
+        def _category_card_entries(cats: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+            cards: list[dict[str, Any]] = []
+            for cat in cats:
+                children = cat.get("children") or []
+                child_cards = _category_card_entries(children)
+                preview = preview_by_category.get(int(cat["id"]))
+                if preview is None and child_cards:
+                    preview = next((child.get("preview_product") for child in child_cards if child.get("image_url")), None)
+                count = (1 if int(cat["id"]) in available_category_ids else 0) + sum(int(child.get("count") or 0) for child in child_cards)
+                cards.append({
+                    "id": int(cat["id"]),
+                    "name": cat.get("name") or "Category",
+                    "count": count,
+                    "image_url": preview.get("image_url") if preview else None,
+                    "preview_product": preview,
+                })
+            return cards
+
+        category_cards = _category_card_entries(categories)
+
     # Get active subscription product IDs for the customer
     active_subscription_product_ids = await subscriptions_repo.get_active_subscription_product_ids(company_id)
 
@@ -365,8 +431,11 @@ async def shop_page(
         "title": "Shop",
         "categories": categories,
         "products": products,
-        "current_category": "packages" if show_packages else category_id,
+        "current_category": "packages" if show_packages else "featured" if show_featured else category_id,
         "show_packages": show_packages,
+        "show_featured": show_featured,
+        "showing_category_cards": showing_category_cards,
+        "category_cards": category_cards,
         "show_out_of_stock": show_out_of_stock,
         "search_term": search_term,
         "cart_error": cart_error,

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10909,3 +10909,160 @@ a.stat-strip__stat:focus-visible {
   color: var(--color-text-muted, #64748b);
   font-size: 0.85rem;
 }
+
+.shop-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(16rem, 100%), 1fr));
+  gap: var(--space-gap-base);
+  align-content: start;
+}
+
+.shop-card-grid--categories {
+  grid-template-columns: repeat(auto-fill, minmax(min(18rem, 100%), 1fr));
+}
+
+.shop-tile,
+.shop-product-card {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.16);
+}
+
+.shop-tile {
+  display: grid;
+  grid-template-columns: 6rem 1fr;
+  min-height: 7rem;
+  overflow: hidden;
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.shop-tile:hover,
+.shop-tile:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(15, 23, 42, 0.62);
+}
+
+.shop-tile--special {
+  border-color: rgba(56, 189, 248, 0.32);
+}
+
+.shop-tile__media,
+.shop-product-card__media {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.shop-tile__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.shop-tile__media--icon,
+.shop-tile__placeholder,
+.shop-product-card__placeholder {
+  font-size: 2rem;
+}
+
+.shop-tile__body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: var(--space-gap-base);
+  min-width: 0;
+}
+
+.shop-tile__title,
+.shop-product-card__title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shop-tile__meta,
+.shop-product-card__sku {
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}
+
+.shop-product-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.shop-product-card__media {
+  min-height: 10rem;
+  padding: var(--space-gap-base);
+}
+
+.shop-product-card__media .product-thumb,
+.shop-product-card__media .package-thumb {
+  width: 100%;
+  height: 9rem;
+  max-width: 12rem;
+}
+
+.shop-product-card__media .link-button {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.shop-product-card__body,
+.shop-product-card__actions {
+  padding: var(--space-gap-base);
+}
+
+.shop-product-card__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.shop-product-card__title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.shop-product-card__sku,
+.shop-product-card .package-meta {
+  margin: 0;
+}
+
+.shop-product-card__meta,
+.shop-product-card__actions,
+.shop-product-card__cart {
+  display: flex;
+  align-items: center;
+  gap: var(--space-gap-tight);
+  flex-wrap: wrap;
+}
+
+.shop-product-card__actions {
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+  justify-content: space-between;
+}
+
+.shop-product-card__cart .form-input--sm {
+  width: 4.5rem;
+}
+
+@media (max-width: 640px) {
+  .shop-tile {
+    grid-template-columns: 5rem 1fr;
+  }
+
+  .shop-product-card__media {
+    min-height: 8rem;
+  }
+}

--- a/app/static/js/shop.js
+++ b/app/static/js/shop.js
@@ -213,6 +213,30 @@
     });
   }
 
+
+  function findSafeTitleTruncation(value, limit) {
+    if (typeof value !== 'string' || value.length <= limit) {
+      return value;
+    }
+    const commaIndex = value.indexOf(',');
+    const dashIndex = value.indexOf('-');
+    const candidates = [commaIndex, dashIndex].filter((index) => index > 0);
+    if (candidates.length > 0) {
+      const safeIndex = Math.min(...candidates);
+      if (safeIndex >= 8) {
+        return `${value.slice(0, safeIndex).trim()}…`;
+      }
+    }
+    return `${value.slice(0, Math.max(limit - 1, 1)).trim()}…`;
+  }
+
+  function truncateSafeProductTitles(container) {
+    container.querySelectorAll('[data-shop-safe-title]').forEach((title) => {
+      const fullTitle = title.getAttribute('title') || title.textContent || '';
+      title.textContent = findSafeTitleTruncation(fullTitle.trim(), 58);
+    });
+  }
+
   function restoreShopSearchFocus(container) {
     const searchInput = container.querySelector('[data-shop-search]');
     if (!searchInput) {
@@ -246,6 +270,7 @@
     bindStockLimitInputs(container);
     bindShopSearch(container);
     restoreShopSearchFocus(container);
+    truncateSafeProductTitles(container);
 
 
     const imageModal = document.getElementById('product-image-modal');

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -64,13 +64,23 @@
       <span class="shop-categories__icon shop-categories__icon--packages" aria-hidden="true"></span>
       <span>Packages</span>
     </a>
+    <a
+      class="shop-categories__link {% if current_category == 'featured' %}is-active{% endif %}"
+      href="{{ request.url_for('shop_page') }}{{ shop_query('featured') }}"
+      {% if current_category == 'featured' %}aria-current="page"{% endif %}
+    >
+      <span class="shop-categories__icon shop-categories__icon--featured" aria-hidden="true"></span>
+      <span>Featured</span>
+    </a>
     <div class="shop-category-select-wrapper">
       <select
         class="form-input shop-category-select"
         aria-label="Select product category"
         onchange="(function(selectEl){var raw=selectEl.options[selectEl.selectedIndex].getAttribute('data-url');if(!raw){return;}try{var parsed=new URL(raw, window.location.origin);if((parsed.protocol==='http:'||parsed.protocol==='https:')&&parsed.origin===window.location.origin){window.location.assign(parsed.pathname+parsed.search+parsed.hash);}}catch(e){}})(this);"
       >
-        <option data-url="{{ request.url_for('shop_page') }}{{ shop_query() }}" {% if not current_category or current_category == 'packages' %}selected{% endif %}>All products</option>
+        <option data-url="{{ request.url_for('shop_page') }}{{ shop_query() }}" {% if not current_category %}selected{% endif %}>Product categories</option>
+        <option data-url="{{ request.url_for('shop_page') }}{{ shop_query('packages') }}" {% if current_category == 'packages' %}selected{% endif %}>Packages</option>
+        <option data-url="{{ request.url_for('shop_page') }}{{ shop_query('featured') }}" {% if current_category == 'featured' %}selected{% endif %}>Featured</option>
         {% for category in categories %}
           {% if category.children %}
             <option data-url="{{ request.url_for('shop_page') }}{{ shop_query(category.id) }}" {% if current_category == category.id %}selected{% endif %}>{{ category.name }}</option>
@@ -88,7 +98,7 @@
   <section class="card card--panel shop-layout__content">
     <header class="card__header">
       <div>
-        <h2 class="card__title">{{ 'Available packages' if show_packages else 'Available products' }}</h2>
+        <h2 class="card__title">{{ 'Product categories' if showing_category_cards else 'Available packages' if show_packages else 'Featured products' if show_featured else 'Available products' }}</h2>
       </div>
       <div class="card__controls shop-toolbar">
         <form method="get" action="{{ request.url_for('shop_page') }}" class="shop-search-form" role="search">
@@ -105,147 +115,102 @@
             type="search"
             name="q"
             class="form-input card__control"
-            placeholder="{{ 'Search packages' if show_packages else 'Search products' }}"
-            aria-label="{{ 'Search packages' if show_packages else 'Search products' }}"
+            placeholder="{{ 'Search packages' if show_packages else 'Search featured products' if show_featured else 'Search products' }}"
+            aria-label="{{ 'Search packages' if show_packages else 'Search featured products' if show_featured else 'Search products' }}"
             value="{{ search_term or '' }}"
             data-shop-search
           />
         </form>
       </div>
     </header>
-    <div class="table-wrapper">
-      <table class="table" id="shop-table" data-table data-table-id="shop">
-        <thead>
-          <tr>
-            <th scope="col" data-mobile-priority="supporting">Image</th>
-            <th scope="col" data-sort="string" data-mobile-priority="essential">Name</th>
-            <th scope="col" data-sort="string" data-mobile-priority="supporting">SKU</th>
-            <th scope="col" data-sort="number" data-mobile-priority="essential">Price</th>
-            <th scope="col" data-sort="number" data-mobile-priority="essential">Stock</th>
-            <th scope="col" class="table__actions" data-mobile-priority="essential">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for product in products %}
-            {% if product.is_package %}
-              <tr data-package-id="{{ product.id }}" data-stock="{{ product.stock }}">
-                <td data-label="Image">
-                  <span class="package-thumb" aria-hidden="true">🎁</span>
-                  <span class="visually-hidden">Package</span>
-                </td>
-                <td data-label="Name">
-                  <div class="package-name">
-                    {% set item_count = product.get('items', []) | sum(attribute='quantity') %}
-                    {% if item_count == 0 %}
-                      {% set item_count = product.product_count %}
-                    {% endif %}
-                    <strong>{{ product.name }}</strong>
-                    <p class="package-meta">
-                      Includes {{ product.product_count }} {{ 'product' if product.product_count == 1 else 'products' }}
-                      ({{ item_count }} {{ 'item' if item_count == 1 else 'items' }})
-                    </p>
-                    <details class="package-details">
-                      <summary>Included products</summary>
-                      <ul class="list list--bullet">
-                        {% for item in product.get('items', []) %}
-                          <li>{{ item.product_name }} ({{ item.product_sku }}) × {{ item.quantity }}</li>
-                        {% endfor %}
-                      </ul>
-                    </details>
-                  </div>
-                </td>
-                <td data-label="SKU">{{ product.sku }}</td>
-                <td data-label="Price" data-value="{{ product.price }}">${{ '%.2f'|format(product.price) }}</td>
-                <td data-label="Stock" data-value="{{ product.stock }}">
-                  {{ stock_helpers.stock_status_badge(product.stock, low_stock_threshold) }}
-                </td>
-                <td class="table__actions">
-                  <div class="table__action-buttons">
-                    {% if product.stock > 0 %}
-                      {% if cart_allowed %}
-                        <form action="/cart/add-package" method="post" class="inline-form">
-                          {% include "partials/csrf.html" %}
-                          <input type="hidden" name="packageId" value="{{ product.id }}" />
-                          <label class="visually-hidden" for="package-qty-{{ product.id }}">Quantity for {{ product.name }}</label>
-                          <input
-                            class="form-input form-input--sm"
-                            id="package-qty-{{ product.id }}"
-                            type="number"
-                            name="quantity"
-                            min="1"
-                            max="{{ product.stock }}"
-                            value="1"
-                            data-stock-limit="{{ product.stock }}"
-                          />
-                          <button type="submit" class="button">Add to cart</button>
-                        </form>
-                      {% endif %}
-                    {% else %}
-                      <span class="badge badge--muted">Out of stock</span>
-                    {% endif %}
-                  </div>
-                </td>
-              </tr>
-            {% else %}
-              <tr data-product-id="{{ product.id }}" data-stock="{{ product.stock }}">
-                <td data-label="Image">
-                  {% if product.image_url %}
-                    <button type="button" class="link-button" data-image-preview data-image-url="{{ product.image_url }}">
-                      <img src="{{ product.image_url }}" alt="" class="product-thumb" loading="lazy" />
-                    </button>
-                  {% else %}
-                    <span class="text-muted">—</span>
-                  {% endif %}
-                </td>
-                <td data-label="Name">{{ product.name }}</td>
-                <td data-label="SKU">{{ product.sku }}</td>
-                <td data-label="Price" data-value="{{ product.price }}">${{ '%.2f'|format(product.price) }}</td>
-                <td data-label="Stock" data-value="{{ product.stock }}">
-                  {{ stock_helpers.stock_status_badge(product.stock, low_stock_threshold) }}
-                </td>
-                <td class="table__actions">
-                  <div class="table__action-buttons">
-                    <button type="button" class="button button--ghost" data-product-details="{{ product.id }}">Details</button>
-                    {% set is_subscription = product.subscription_category_id is not none %}
-                    {% set has_active_subscription = is_subscription and product.id in active_subscription_product_ids %}
-                    {% if has_active_subscription %}
-                      <a href="/subscriptions" class="button button--primary">Manage</a>
-                    {% elif product.stock > 0 %}
-                      {% if cart_allowed %}
-                        <form action="/cart/add" method="post" class="inline-form">
-                          {% include "partials/csrf.html" %}
-                          <input type="hidden" name="productId" value="{{ product.id }}" />
-                          <label class="visually-hidden" for="quantity-{{ product.id }}">Quantity for {{ product.name }}</label>
-                          <input
-                            class="form-input form-input--sm"
-                            id="quantity-{{ product.id }}"
-                            type="number"
-                            name="quantity"
-                            min="1"
-                            max="{{ product.stock }}"
-                            value="1"
-                            data-stock-limit="{{ product.stock }}"
-                          />
-                          <button type="submit" class="button">Add to cart</button>
-                        </form>
-                      {% endif %}
-                    {% else %}
-                      <span class="badge badge--muted">Out of stock</span>
-                    {% endif %}
-                  </div>
-                </td>
-              </tr>
-            {% endif %}
-          {% else %}
-            <tr>
-              <td colspan="6" class="table__empty">
-                {{ 'No packages are currently available.' if show_packages else 'No products are currently available.' }}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
+    {% if showing_category_cards %}
+      <div class="shop-card-grid shop-card-grid--categories">
+        <a class="shop-tile shop-tile--special" href="{{ request.url_for('shop_page') }}{{ shop_query('packages') }}">
+          <span class="shop-tile__media shop-tile__media--icon" aria-hidden="true">🎁</span>
+          <span class="shop-tile__body">
+            <strong class="shop-tile__title">Packages</strong>
+            <span class="shop-tile__meta">Bundled products ready to order</span>
+          </span>
+        </a>
+        <a class="shop-tile shop-tile--special" href="{{ request.url_for('shop_page') }}{{ shop_query('featured') }}">
+          <span class="shop-tile__media shop-tile__media--icon" aria-hidden="true">⭐</span>
+          <span class="shop-tile__body">
+            <strong class="shop-tile__title">Featured</strong>
+            <span class="shop-tile__meta">Products highlighted for your company</span>
+          </span>
+        </a>
+        {% for category in category_cards %}
+          <a class="shop-tile" href="{{ request.url_for('shop_page') }}{{ shop_query(category.id) }}">
+            <span class="shop-tile__media">
+              {% if category.image_url %}
+                <img src="{{ category.image_url }}" alt="" loading="lazy" />
+              {% else %}
+                <span class="shop-tile__placeholder" aria-hidden="true">🗂</span>
+              {% endif %}
+            </span>
+            <span class="shop-tile__body">
+              <strong class="shop-tile__title">{{ category.name }}</strong>
+              <span class="shop-tile__meta">View products</span>
+            </span>
+          </a>
+        {% else %}
+          <p class="text-muted">No product categories are currently available.</p>
+        {% endfor %}
+      </div>
+    {% else %}
+      <div class="shop-card-grid">
+        {% for product in products %}
+          <article class="shop-product-card" {% if product.is_package %}data-package-id="{{ product.id }}"{% else %}data-product-id="{{ product.id }}"{% endif %} data-stock="{{ product.stock }}">
+            <div class="shop-product-card__media">
+              {% if product.is_package %}
+                <span class="package-thumb" aria-hidden="true">🎁</span>
+              {% elif product.image_url %}
+                <button type="button" class="link-button" data-image-preview data-image-url="{{ product.image_url }}">
+                  <img src="{{ product.image_url }}" alt="" class="product-thumb" loading="lazy" />
+                </button>
+              {% else %}
+                <span class="shop-product-card__placeholder" aria-hidden="true">🛍</span>
+              {% endif %}
+            </div>
+            <div class="shop-product-card__body">
+              <h3 class="shop-product-card__title" title="{{ product.name }}" data-shop-safe-title>{{ product.name }}</h3>
+              <p class="shop-product-card__sku">{{ product.sku }}</p>
+              {% if product.is_package %}
+                {% set item_count = product.get('items', []) | sum(attribute='quantity') %}
+                {% if item_count == 0 %}{% set item_count = product.product_count %}{% endif %}
+                <p class="package-meta">Includes {{ product.product_count }} {{ 'product' if product.product_count == 1 else 'products' }} ({{ item_count }} {{ 'item' if item_count == 1 else 'items' }})</p>
+              {% endif %}
+              <div class="shop-product-card__meta">
+                <strong>${{ '%.2f'|format(product.price) }}</strong>
+                {{ stock_helpers.stock_status_badge(product.stock, low_stock_threshold) }}
+              </div>
+            </div>
+            <div class="shop-product-card__actions">
+              {% if not product.is_package %}
+                <button type="button" class="button button--ghost" data-product-details="{{ product.id }}">Details</button>
+              {% endif %}
+              {% set is_subscription = product.subscription_category_id is defined and product.subscription_category_id is not none %}
+              {% set has_active_subscription = is_subscription and product.id in active_subscription_product_ids %}
+              {% if has_active_subscription %}
+                <a href="/subscriptions" class="button button--primary">Manage</a>
+              {% elif product.stock > 0 and cart_allowed %}
+                <form action="{{ '/cart/add-package' if product.is_package else '/cart/add' }}" method="post" class="inline-form shop-product-card__cart">
+                  {% include "partials/csrf.html" %}
+                  <input type="hidden" name="{{ 'packageId' if product.is_package else 'productId' }}" value="{{ product.id }}" />
+                  <label class="visually-hidden" for="quantity-{{ 'package' if product.is_package else 'product' }}-{{ product.id }}">Quantity for {{ product.name }}</label>
+                  <input class="form-input form-input--sm" id="quantity-{{ 'package' if product.is_package else 'product' }}-{{ product.id }}" type="number" name="quantity" min="1" max="{{ product.stock }}" value="1" data-stock-limit="{{ product.stock }}" />
+                  <button type="submit" class="button">Add</button>
+                </form>
+              {% elif product.stock <= 0 %}
+                <span class="badge badge--muted">Out of stock</span>
+              {% endif %}
+            </div>
+          </article>
+        {% else %}
+          <p class="text-muted">{{ 'No packages are currently available.' if show_packages else 'No featured products are currently available.' if show_featured else 'No products are currently available.' }}</p>
+        {% endfor %}
+      </div>
+    {% endif %}
     {% if total_count > 0 %}
       <div class="table-pagination table-pagination--active">
         <div class="table-pagination__group">


### PR DESCRIPTION
### Motivation
- Improve Shop browsing by presenting high-level Categories as clickable cards instead of a long product list, and surface Packages and a company-specific Featured section up-front.
- Provide more visual, responsive product tiles that adapt to screen size and better highlight images and pricing.
- Ensure product titles truncate at a safe delimiter (first `,` or `-`) where possible to avoid awkward mid-name truncation.

### Description
- Added support for a `category=featured` view and a `show_featured` flag in `shop_page` to load company featured products using `list_featured_products_for_company` and to apply search filtering for featured items (`app/features/shop/handlers.py`).
- Default shop index now shows category cards (with two special cards for `Packages` and `Featured`) when no category or search is active, and automatically selects a preview image for each category from one of its products (`app/features/shop/handlers.py`).
- Replaced the product table on the Shop page with responsive card grids for categories and products/packages and preserved actions (details, add-to-cart, subscription management) in the new card layout (`app/templates/shop/index.html`).
- Added CSS for category tiles and product cards to `app/static/css/app.css` implementing a responsive grid and tile styles.
- Added client-side truncation utilities to `app/static/js/shop.js`: `findSafeTitleTruncation` that prefers truncation at the first `,` or `-` (if reasonably positioned) and a `truncateSafeProductTitles` call on DOM ready to apply truncation to elements with `data-shop-safe-title`.

### Testing
- `python3 -m compileall app/features/shop/handlers.py` — succeeded.
- Parsed the updated template with Jinja2 via `Environment().parse(Path('app/templates/shop/index.html').read_text())` — succeeded.
- Ran `git diff --check` to validate whitespace/overlap issues — no problems reported.
- Ran `pytest tests/test_products_service.py tests/test_subscription_shop_integration.py tests/test_cart_template_decimal.py` — test collection failed due to missing system dependency (`libmagic`) required by the test environment, so full test execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50680299cc833295709d75370389f1)