### PR TITLE
Fix admin shop search across pagination

### DIFF
--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -1108,6 +1108,7 @@ async def admin_remove_package_item(
 async def admin_shop_page(
     request: Request,
     show_archived: bool = Query(False, alias="showArchived"),
+    search: str = Query("", alias="search"),
     page: int = Query(1, ge=1),
     page_size: int = Query(50, alias="pageSize", ge=1, le=200),
 ):
@@ -1122,9 +1123,12 @@ async def admin_shop_page(
         return redirect
     categories_task = asyncio.create_task(shop_repo.list_all_categories_flat())
     filter_categories_task = asyncio.create_task(shop_repo.list_categories_with_products())
+    search_term = search.strip()
     offset = (page - 1) * page_size
     filters = shop_repo.ProductFilters(
         include_archived=show_archived,
+        search_term=search_term or None,
+        include_out_of_stock=True,
         limit=page_size,
         offset=offset,
         sort="name_asc",
@@ -1177,6 +1181,7 @@ async def admin_shop_page(
         "products": products,
         "all_companies": companies,
         "show_archived": show_archived,
+        "search_term": search_term,
         "subscription_categories": subscription_categories,
         "total_count": total_count,
         "page": page,

--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -61,6 +61,7 @@ class ProductFilters:
     category_ids: list[int] | None = None
     search_term: str | None = None
     in_stock_only: bool = False
+    include_out_of_stock: bool = False
     limit: int | None = None
     offset: int | None = None
     sort: str = "name_asc"
@@ -342,7 +343,7 @@ async def list_products(filters: ProductFilters) -> list[dict[str, Any]]:
         conditions.append(f"p.category_id IN ({placeholders})")
         params.extend(filters.category_ids)
     _append_product_search_filter(conditions, params, filters.search_term)
-    if not include_out_of_stock:
+    if not filters.include_out_of_stock:
         conditions.append("p.stock > 0")
 
     if conditions:
@@ -419,7 +420,7 @@ async def list_products_summary(filters: ProductFilters) -> list[dict[str, Any]]
         conditions.append(f"p.category_id IN ({placeholders})")
         params.extend(filters.category_ids)
     _append_product_search_filter(conditions, params, filters.search_term)
-    if not include_out_of_stock:
+    if not filters.include_out_of_stock:
         conditions.append("p.stock > 0")
 
     if conditions:
@@ -476,7 +477,7 @@ async def count_products(filters: ProductFilters) -> int:
         conditions.append(f"p.category_id IN ({placeholders})")
         params.extend(filters.category_ids)
     _append_product_search_filter(conditions, params, filters.search_term)
-    if not include_out_of_stock:
+    if not filters.include_out_of_stock:
         conditions.append("p.stock > 0")
 
     if conditions:

--- a/app/static/js/shop_admin.js
+++ b/app/static/js/shop_admin.js
@@ -549,6 +549,42 @@
       });
     }
 
+    const adminProductSearch = document.querySelector('[data-admin-product-search]');
+    let adminProductSearchTimer = null;
+
+    function updateAdminProductSearch() {
+      if (!adminProductSearch) {
+        return;
+      }
+      const url = new URL(window.location.href);
+      const searchTerm = adminProductSearch.value.trim();
+      if (searchTerm) {
+        url.searchParams.set('search', searchTerm);
+      } else {
+        url.searchParams.delete('search');
+      }
+      url.searchParams.delete('page');
+      window.location.href = url.toString();
+    }
+
+    if (adminProductSearch) {
+      adminProductSearch.addEventListener('input', () => {
+        if (adminProductSearchTimer) {
+          window.clearTimeout(adminProductSearchTimer);
+        }
+        adminProductSearchTimer = window.setTimeout(updateAdminProductSearch, 450);
+      });
+      adminProductSearch.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          if (adminProductSearchTimer) {
+            window.clearTimeout(adminProductSearchTimer);
+          }
+          updateAdminProductSearch();
+        }
+      });
+    }
+
     if (stockFilter) {
       stockFilter.addEventListener('change', applyFilters);
     }

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -74,6 +74,9 @@
   {%- if page_size -%}
     {%- set ns.params = ns.params + ['pageSize=' ~ page_size] -%}
   {%- endif -%}
+  {%- if search_term -%}
+    {%- set ns.params = ns.params + ['search=' ~ (search_term | urlencode)] -%}
+  {%- endif -%}
   {%- if target_page is not none and target_page > 1 -%}
     {%- set ns.params = ns.params + ['page=' ~ target_page] -%}
   {%- endif -%}
@@ -93,6 +96,9 @@
           class="form-input card__control"
           placeholder="Search products"
           aria-label="Search products"
+          name="search"
+          value="{{ search_term }}"
+          data-admin-product-search
           data-table-filter="admin-products-table"
         />
         <select class="form-input card__control" id="stock-filter">

--- a/tests/test_shop_product_search.py
+++ b/tests/test_shop_product_search.py
@@ -67,3 +67,47 @@ def test_prepare_product_search_term_falls_back_to_prefix_like_without_fulltext_
 
     assert mode == "prefix"
     assert value == "a-%"
+
+
+def test_list_products_summary_applies_search_before_pagination(monkeypatch):
+    """Admin summaries should push search into SQL before LIMIT/OFFSET."""
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_all(query, params=None):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(shop_repo.db, "fetch_all", fake_fetch_all)
+
+    filters = shop_repo.ProductFilters(
+        search_term="page two product",
+        include_out_of_stock=True,
+        limit=50,
+        offset=0,
+    )
+    asyncio.run(shop_repo.list_products_summary(filters))
+
+    query = str(captured["query"])
+    assert "MATCH (p.name, p.sku, p.vendor_sku) AGAINST (%s IN BOOLEAN MODE)" in query
+    assert query.index("MATCH") < query.index("LIMIT")
+    assert "+page* +two* +product*" in str(captured["params"])
+
+
+def test_count_products_uses_same_search_filter_as_summary(monkeypatch):
+    """Pagination totals should count only products matching the search term."""
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_one(query, params=None):
+        captured["query"] = query
+        captured["params"] = params
+        return {"total_count": 1}
+
+    monkeypatch.setattr(shop_repo.db, "fetch_one", fake_fetch_one)
+
+    filters = shop_repo.ProductFilters(search_term="needle", include_out_of_stock=True)
+    total = asyncio.run(shop_repo.count_products(filters))
+
+    assert total == 1
+    assert "MATCH (p.name, p.sku, p.vendor_sku) AGAINST (%s IN BOOLEAN MODE)" in str(captured["query"])
+    assert "+needle*" in str(captured["params"])


### PR DESCRIPTION
### Motivation
- Admin product search was only applied client-side and/or after pagination, so searching from page 1 would miss products located on later pages. 
- The admin UI needs server-side search filtering that is preserved across pages so pagination and totals reflect the same filtered result set.

### Description
- Add a `search` query parameter to the `/admin/shop` handler and trim/pass it into `ProductFilters.search_term` so the server receives the admin search term. 
- Add `include_out_of_stock` to `ProductFilters` and enable it for the admin listing so searches operate over the full catalog rather than only visible rows. 
- Change repository queries (`list_products`, `list_products_summary`, `count_products`) to apply `_append_product_search_filter` before `LIMIT`/`OFFSET` and to use `filters.include_out_of_stock` when applying the stock condition. 
- Update the admin template to preserve `search` in pagination links and the search input, add debounced JS that updates the URL (and resets `page`) when the admin search changes, and add tests verifying search is applied before pagination and that counts use the same search filter.

### Testing
- Ran `python -m py_compile app/repositories/shop.py app/features/shop/handlers.py` which succeeded. 
- Added tests in `tests/test_shop_product_search.py` and attempted `python -m pytest tests/test_shop_product_search.py -q`, but test collection failed due to an environment ImportError for the system `libmagic` dependency required by `python-magic` (so the new repository tests could not be fully executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a506908cae08332984bc8d45bdbaf28)