### PR TITLE
Use ProductFilters.in_stock_only for stock filtering in shop repo

### DIFF
--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -342,7 +342,7 @@ async def list_products(filters: ProductFilters) -> list[dict[str, Any]]:
         conditions.append(f"p.category_id IN ({placeholders})")
         params.extend(filters.category_ids)
     _append_product_search_filter(conditions, params, filters.search_term)
-    if not include_out_of_stock:
+    if filters.in_stock_only:
         conditions.append("p.stock > 0")
 
     if conditions:
@@ -419,7 +419,7 @@ async def list_products_summary(filters: ProductFilters) -> list[dict[str, Any]]
         conditions.append(f"p.category_id IN ({placeholders})")
         params.extend(filters.category_ids)
     _append_product_search_filter(conditions, params, filters.search_term)
-    if not include_out_of_stock:
+    if filters.in_stock_only:
         conditions.append("p.stock > 0")
 
     if conditions:
@@ -476,7 +476,7 @@ async def count_products(filters: ProductFilters) -> int:
         conditions.append(f"p.category_id IN ({placeholders})")
         params.extend(filters.category_ids)
     _append_product_search_filter(conditions, params, filters.search_term)
-    if not include_out_of_stock:
+    if filters.in_stock_only:
         conditions.append("p.stock > 0")
 
     if conditions:

--- a/tests/test_shop_product_search.py
+++ b/tests/test_shop_product_search.py
@@ -67,3 +67,58 @@ def test_prepare_product_search_term_falls_back_to_prefix_like_without_fulltext_
 
     assert mode == "prefix"
     assert value == "a-%"
+
+
+def test_list_products_summary_defaults_do_not_reference_out_of_stock_flag(monkeypatch):
+    """Admin product summaries should not crash or filter stock by default."""
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_all(query, params=None):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(shop_repo.db, "fetch_all", fake_fetch_all)
+
+    filters = shop_repo.ProductFilters(include_archived=False)
+    products = asyncio.run(shop_repo.list_products_summary(filters))
+
+    assert products == []
+    assert "p.stock > 0" not in str(captured["query"])
+
+
+def test_list_products_summary_honors_in_stock_only(monkeypatch):
+    """Customer product summaries should filter stock when requested."""
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_all(query, params=None):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(shop_repo.db, "fetch_all", fake_fetch_all)
+
+    filters = shop_repo.ProductFilters(include_archived=False, in_stock_only=True)
+    products = asyncio.run(shop_repo.list_products_summary(filters))
+
+    assert products == []
+    assert "p.stock > 0" in str(captured["query"])
+
+
+def test_count_products_honors_in_stock_only(monkeypatch):
+    """Product counts should use the shared in-stock filter field."""
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_one(query, params=None):
+        captured["query"] = query
+        captured["params"] = params
+        return {"total_count": 0}
+
+    monkeypatch.setattr(shop_repo.db, "fetch_one", fake_fetch_one)
+
+    total = asyncio.run(
+        shop_repo.count_products(shop_repo.ProductFilters(in_stock_only=True))
+    )
+
+    assert total == 0
+    assert "p.stock > 0" in str(captured["query"])


### PR DESCRIPTION
### Motivation
- Fix a NameError/behavioral bug where repository queries referenced an undefined `include_out_of_stock` flag leading to failures in shop pages and inconsistent stock filtering.
- Standardise on the existing `ProductFilters.in_stock_only` field so customer/admin flows can explicitly request in-stock filtering.

### Description
- Replaced the incorrect `include_out_of_stock` usage with `filters.in_stock_only` in repository queries for `list_products`, `list_products_summary`, and `count_products` so the stock filter is driven by `ProductFilters`.
- Added regression tests in `tests/test_shop_product_search.py` to assert that `list_products_summary` does not apply a stock filter by default and that `in_stock_only=True` produces a `p.stock > 0` clause for summaries and counts.

### Testing
- Compiled and syntax-checked the modified module with `python -m py_compile app/repositories/shop.py` which succeeded.
- Performed an AST parse check with `ast.parse(...)` which succeeded.
- Attempted to run `pytest -q tests/test_shop_product_search.py tests/test_shop_category_visibility.py` to validate the new tests, but test collection was blocked by the environment missing the `libmagic` shared library required by `python-magic`, so the pytest run did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5069f809688332a4befdf9ac2aa397)