### PR TITLE
Add ticket update actor column to admin tickets

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -494,6 +494,7 @@ async def get_ticket_dashboard(
                     else None
                 ),
                 latest_reply_kind=automation_data.get("latest_reply_kind"),
+                ticket_update_actor_type=automation_data.get("ticket_update_actor_type"),
             )
         )
     filters = TicketSearchFilters(

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1445,6 +1445,7 @@ async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> 
             "latest_reply_at": None,
             "latest_reply_is_internal": None,
             "latest_reply_kind": None,
+            "ticket_update_actor_type": None,
         }
         for ticket_id in unique_ids
     }
@@ -1509,7 +1510,8 @@ async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> 
             tr.id,
             tr.created_at,
             tr.is_internal,
-            CASE WHEN tr.is_internal = 1 THEN 'internal_note' ELSE 'message' END AS kind
+            CASE WHEN tr.is_internal = 1 THEN 'internal_note' ELSE 'message' END AS kind,
+            CASE WHEN tr.is_internal = 1 THEN 'technician' ELSE 'requester' END AS ticket_update_actor_type
         FROM ticket_replies AS tr
         INNER JOIN (
             SELECT ticket_id, MAX(id) AS latest_reply_id
@@ -1526,6 +1528,7 @@ async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> 
         result[ticket_id]["latest_reply_at"] = _make_aware(row.get("created_at"))
         result[ticket_id]["latest_reply_is_internal"] = bool(row.get("is_internal"))
         result[ticket_id]["latest_reply_kind"] = row.get("kind")
+        result[ticket_id]["ticket_update_actor_type"] = row.get("ticket_update_actor_type")
 
     return result
 

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -170,6 +170,7 @@ class TicketDashboardRow(BaseModel):
     last_reply_age_hours: Optional[int] = None
     latest_reply_is_internal: Optional[bool] = None
     latest_reply_kind: Optional[str] = None
+    ticket_update_actor_type: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1220,6 +1220,7 @@
       appendTextCell('last-reply-age-hours', 'ticket.last_reply_age_hours', ticket.last_reply_age_hours ?? '—', { value: ticket.last_reply_age_hours ?? '' });
       appendTextCell('latest-reply-internal', 'reply.is_internal', ticket.latest_reply_is_internal ?? '—');
       appendTextCell('latest-reply-kind', 'reply.kind', ticket.latest_reply_kind || '—');
+      appendTextCell('ticket-update-actor-type', 'ticket_update.actor_type', ticket.ticket_update_actor_type || '—');
 
       return row;
     }

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -446,7 +446,8 @@
                     ('in-status-hours', 'ticket.in_status_age_hours'),
                     ('last-reply-age-hours', 'ticket.last_reply_age_hours'),
                     ('latest-reply-internal', 'reply.is_internal'),
-                    ('latest-reply-kind', 'reply.kind')
+                    ('latest-reply-kind', 'reply.kind'),
+                    ('ticket-update-actor-type', 'ticket_update.actor_type')
                   ] %}
                   {% for column_key, column_label in automation_column_options %}
                     <label class="ticket-columns__option">
@@ -537,6 +538,7 @@
                 <th scope="col" data-sort="int" data-column="last-reply-age-hours" class="tickets-table__column tickets-table__column--last-reply-age-hours">ticket.last_reply_age_hours</th>
                 <th scope="col" data-sort="string" data-column="latest-reply-internal" class="tickets-table__column tickets-table__column--latest-reply-internal">reply.is_internal</th>
                 <th scope="col" data-sort="string" data-column="latest-reply-kind" class="tickets-table__column tickets-table__column--latest-reply-kind">reply.kind</th>
+                <th scope="col" data-sort="string" data-column="ticket-update-actor-type" class="tickets-table__column tickets-table__column--ticket-update-actor-type">ticket_update.actor_type</th>
                 <th scope="col" class="table__actions tickets-table__column tickets-table__column--actions">Actions</th>
               </tr>
             </thead>
@@ -631,6 +633,7 @@
                     <td data-label="ticket.last_reply_age_hours" data-column="last-reply-age-hours" class="tickets-table__cell tickets-table__cell--last-reply-age-hours">{{ last_reply_age_hours if last_reply_age_hours != '' else '—' }}</td>
                     <td data-label="reply.is_internal" data-column="latest-reply-internal" class="tickets-table__cell tickets-table__cell--latest-reply-internal">{{ 'true' if automation_data.get('latest_reply_is_internal') else ('false' if automation_data.get('latest_reply_id') else '—') }}</td>
                     <td data-label="reply.kind" data-column="latest-reply-kind" class="tickets-table__cell tickets-table__cell--latest-reply-kind">{{ automation_data.get('latest_reply_kind') or '—' }}</td>
+                    <td data-label="ticket_update.actor_type" data-column="ticket-update-actor-type" class="tickets-table__cell tickets-table__cell--ticket-update-actor-type">{{ automation_data.get('ticket_update_actor_type') or '—' }}</td>
                     <td class="table__actions tickets-table__cell tickets-table__cell--actions">
                       <a href="/admin/tickets/{{ ticket.id }}" class="button button--ghost">Open</a>
                     </td>
@@ -638,7 +641,7 @@
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="{{ 37 + (1 if can_bulk_delete_tickets or can_merge_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
+                  <td colspan="{{ 38 + (1 if can_bulk_delete_tickets or can_merge_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
                 </tr>
               {% endif %}
             </tbody>

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -89,6 +89,14 @@ def test_table_cell_data_column_attributes():
         )
 
 
+
+def test_ticket_update_actor_type_column_is_available():
+    """The automation variable ticket_update.actor_type should be available as a ticket column."""
+    html = _template_html()
+    assert "('ticket-update-actor-type', 'ticket_update.actor_type')" in html
+    assert 'data-column="ticket-update-actor-type"' in html
+    assert 'data-label="ticket_update.actor_type"' in html
+
 def test_ticket_columns_js_included():
     """The ticket_columns.js script should be included in the page."""
     html = _template_html()


### PR DESCRIPTION
### Motivation
- Expose the automation variable `ticket_update.actor_type` as a configurable column in the admin tickets grid so operators can see who (requester/technician) last updated a ticket from the list view.

### Description
- Added a new column option and table markup in `app/templates/admin/tickets.html` for `ticket-update-actor-type` and wired it into the column chooser and table cells. 
- Populated `ticket_update_actor_type` in the list context by extending `get_automation_filter_context_by_ticket_ids` in `app/repositories/tickets.py` to return `technician` for internal replies and `requester` for public messages. 
- Exposed the field in the dashboard response by adding `ticket_update_actor_type` to `TicketDashboardRow` in `app/schemas/tickets.py` and including it in the dashboard row construction in `app/api/routes/tickets.py`. 
- Rendered the new column in client-side dynamic table updates by adding `ticket-update-actor-type` handling in `app/static/js/admin.js`. 
- Updated `tests/test_ticket_column_customisation.py` to include a regression that the `ticket_update.actor_type` column is available and the template contains the expected data attributes, and adjusted the table empty `colspan` accordingly.

### Testing
- Ran `pytest tests/test_ticket_column_customisation.py` and the test suite for that file passed (`12 passed`).
- Ran `python -m compileall app/api/routes/tickets.py app/repositories/tickets.py app/schemas/tickets.py` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a506c5c770c8332a2af8afb353e1387)