### PR TITLE
Fix inbound ticket reply authors

### DIFF
--- a/app/features/receive_sms/routes.py
+++ b/app/features/receive_sms/routes.py
@@ -174,9 +174,14 @@ async def receive_sms(payload: ReceiveSMSPayload, request: Request, api_key_reco
                 action = "reopened"
             else:
                 action = "appended"
+            author_id = ticket.get("requester_id")
+            if author_id is None:
+                contact = await _find_contact(payload.from_number)
+                author_id = contact.get("requester_id")
             await tickets_repo.create_reply(
-                ticket_id=int(ticket["id"]), author_id=ticket.get("requester_id"), body=body,
+                ticket_id=int(ticket["id"]), author_id=author_id, body=body,
                 is_internal=False, external_reference=f"sms:{normalised_phone}:{sms_at.isoformat()}", created_at=sms_at,
+                author_display_name=(payload.name or payload.from_number) if author_id is None else None,
             )
         else:
             contact = await _find_contact(payload.from_number)

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1230,6 +1230,8 @@ async def create_reply(
     external_reference: str | None = None,
     created_at: datetime | None = None,
     labour_type_id: int | None = None,
+    author_email: str | None = None,
+    author_display_name: str | None = None,
 ) -> TicketRecord:
     labour_type_id = await _default_labour_type_for_time_entry(minutes_spent, labour_type_id)
 
@@ -1249,6 +1251,14 @@ async def create_reply(
         1 if is_internal else 0,
         1 if is_billable else 0,
     ]
+    clean_author_email = str(author_email or "").strip() or None
+    clean_author_display_name = str(author_display_name or "").strip() or None
+    if clean_author_email is not None:
+        columns.append("author_email")
+        params.append(clean_author_email[:255])
+    if clean_author_display_name is not None:
+        columns.append("author_display_name")
+        params.append(clean_author_display_name[:255])
     if minutes_spent is not None:
         columns.append("minutes_spent")
         params.append(minutes_spent)
@@ -1310,6 +1320,8 @@ async def create_reply(
         "external_reference": external_reference,
         "created_at": created_at,
         "labour_type_id": labour_type_id,
+        "author_email": clean_author_email,
+        "author_display_name": clean_author_display_name,
     }
     return _normalise_reply(fallback_row)
 

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -69,6 +69,8 @@ class TicketReply(BaseModel):
     id: int
     ticket_id: int
     author_id: Optional[int]
+    author_email: Optional[str] = None
+    author_display_name: Optional[str] = None
     body: str
     is_internal: bool
     minutes_spent: Optional[int] = Field(default=None, ge=0)

--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -1940,6 +1940,8 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                 is_internal=False,
                                 external_reference=_normalise_ticket_external_reference(message_id),
                                 created_at=reply_created_at,
+                                author_email=from_email_addr if reply_author_id is None else None,
+                                author_display_name=from_address if reply_author_id is None else None,
                             )
                             reply_added = True
                             log_info(

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -1523,6 +1523,8 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                                         _normalise_ticket_external_reference(internet_msg_id)
                                     ),
                                     created_at=reply_created_at,
+                                    author_email=from_email_addr if reply_author_id is None else None,
+                                    author_display_name=(from_header or from_address) if reply_author_id is None else None,
                                 )
                                 reply_added = True
                                 log_info(

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -558,10 +558,10 @@ async def _enrich_ticket_context(ticket: Mapping[str, Any]) -> TicketRecord:
         author_user = await _resolve_user_snapshot(author_value, author_id)
         author_snapshot = _build_user_snapshot(author_user)
         reply["author"] = author_snapshot
-        reply["author_email"] = author_snapshot.get("email") if author_snapshot else None
-        reply["author_display_name"] = (
-            author_snapshot.get("display_name") if author_snapshot else None
-        )
+        snapshot_email = author_snapshot.get("email") if author_snapshot else None
+        snapshot_display = author_snapshot.get("display_name") if author_snapshot else None
+        reply["author_email"] = snapshot_email or reply.get("author_email")
+        reply["author_display_name"] = snapshot_display or reply.get("author_display_name")
         latest_reply = reply
     enriched["latest_reply"] = latest_reply
 

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -1224,7 +1224,7 @@
                             {{ reply.created_at.astimezone().strftime('%Y-%m-%d %H:%M') if reply.created_at else '—' }}
                           </span>
                           <span class="timeline__action">
-                            {{ reply.author.email if reply.author else 'System' }}
+                            {{ reply.author.email if reply.author else (reply.author_display_name or reply.author_email or 'System') }}
                             {% if reply.is_internal %}
                               <span class="badge badge--muted">Internal</span>
                             {% endif %}

--- a/migrations/296_ticket_reply_author_snapshot.sql
+++ b/migrations/296_ticket_reply_author_snapshot.sql
@@ -1,0 +1,9 @@
+-- Store an inbound reply author snapshot for email-only watchers and SMS senders
+ALTER TABLE ticket_replies
+ADD COLUMN IF NOT EXISTS author_email VARCHAR(255) NULL AFTER author_id;
+
+ALTER TABLE ticket_replies
+ADD COLUMN IF NOT EXISTS author_display_name VARCHAR(255) NULL AFTER author_email;
+
+CREATE INDEX IF NOT EXISTS idx_ticket_replies_author_email
+    ON ticket_replies (author_email);

--- a/tests/test_receive_sms_feature_pack.py
+++ b/tests/test_receive_sms_feature_pack.py
@@ -104,6 +104,8 @@ def test_receive_sms_existing_ticket_reply_refreshes_ai(monkeypatch):
             return {"id": 456, "requester_id": 11, "status": "open"}
 
         async def fake_create_reply(**kwargs):
+            assert kwargs["author_id"] == 11
+            assert kwargs["author_display_name"] is None
             calls.append(("reply", int(kwargs["ticket_id"])))
             return {"id": 99}
 
@@ -135,6 +137,51 @@ def test_receive_sms_existing_ticket_reply_refreshes_ai(monkeypatch):
         assert result["status"] == "appended"
         assert result["ticket_id"] == 456
         assert calls == [("reply", 456), ("summary", 456), ("tags", 456)]
+
+    asyncio.run(run_test())
+
+
+def test_receive_sms_existing_ticket_without_requester_stores_sender_snapshot(monkeypatch):
+    async def run_test():
+        created_kwargs = {}
+
+        async def fake_find_sms_ticket(*_args, **_kwargs):
+            return {"id": 456, "requester_id": None, "status": "open"}
+
+        async def fake_find_contact(*_args, **_kwargs):
+            return {"requester_id": None, "requester_staff_id": None, "company_id": None}
+
+        async def fake_create_reply(**kwargs):
+            created_kwargs.update(kwargs)
+            return {"id": 99}
+
+        async def fake_refresh(*_args, **_kwargs):
+            return None
+
+        async def fake_emit(*_args, **_kwargs):
+            return None
+
+        monkeypatch.setattr(receive_sms_routes, "_find_sms_ticket", fake_find_sms_ticket)
+        monkeypatch.setattr(receive_sms_routes, "_find_contact", fake_find_contact)
+        monkeypatch.setattr(receive_sms_routes.tickets_repo, "create_reply", fake_create_reply)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_summary", fake_refresh)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_tags", fake_refresh)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "emit_ticket_updated_event", fake_emit)
+
+        payload = receive_sms_routes.ReceiveSMSPayload(
+            type="SMSIn",
+            **{"from": "+61 400 123 456"},
+            name="Customer",
+            message="SGVsbG8=",
+            date="2026-06-16",
+            time="15:00",
+        )
+
+        result = await receive_sms_routes.receive_sms(payload, request=None, api_key_record={"id": 7})
+
+        assert result["status"] == "appended"
+        assert created_kwargs["author_id"] is None
+        assert created_kwargs["author_display_name"] == "Customer"
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
### Motivation
- Replies originating from email (IMAP/M365) or SMS were showing as coming from “System” when the sender could not be resolved to a local user; the change aims to preserve and display the actual sender (email or SMS name/number) in those cases.

### Description
- Add persistent reply author snapshot columns by introducing `migrations/296_ticket_reply_author_snapshot.sql` with `author_email` and `author_display_name` and an index on `author_email`.
- Extend `create_reply` to accept `author_email` and `author_display_name` and persist trimmed snapshots as part of reply creation (updates in `app/repositories/tickets.py`).
- Populate snapshot values for inbound email replies when no local `author_id` is resolved in IMAP and M365 sync flows (changes in `app/services/imap.py` and `app/services/m365_mail.py`).
- Improve SMS inbound handling to prefer the ticket `requester_id` or a matched contact and to persist the SMS sender name/number when no requester exists (changes in `app/features/receive_sms/routes.py`).
- Ensure ticket enrichment prefers stored snapshot fields when building `latest_reply` and update the reply schema and admin timeline template to display `author_display_name`/`author_email` before falling back to `System` (changes in `app/services/tickets.py`, `app/schemas/tickets.py`, and `app/templates/admin/ticket_detail.html`).
- Add/adjust tests to cover SMS sender snapshot and requester-preservation behaviour (updates in `tests/test_receive_sms_feature_pack.py`).

### Testing
- Ran Python compile checks with `python -m py_compile app/repositories/tickets.py app/services/imap.py app/services/m365_mail.py app/features/receive_sms/routes.py app/services/tickets.py app/schemas/tickets.py` which succeeded.
- Attempted targeted test run with `pytest -q tests/test_receive_sms_feature_pack.py tests/test_imap_service.py::test_resolve_existing_reply_author_id_matches_ticket_watcher tests/test_tickets_service_create.py::test_enrich_ticket_context_includes_related_metadata` but execution was blocked by the test environment missing the system library `libmagic` (ImportError from the `python-magic` package), preventing full pytest verification.
- Performed static checks with `git diff --check` (no whitespace/errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a506bf241b0832daa8cbb658d063347)