### PR TITLE
Fix Trello action company credential resolution

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -6640,16 +6640,7 @@ async def _invoke_trello_add_comment(
     if not text:
         raise ValueError("text is required for the Trello add-comment action")
 
-    # Resolve the company from the automation context so that per-company
-    # Trello credentials are used when posting the comment.
-    context = payload.get("context")
-    company: dict[str, Any] | None = None
-    if isinstance(context, Mapping):
-        ticket_ctx = context.get("ticket")
-        if isinstance(ticket_ctx, Mapping):
-            company_value = ticket_ctx.get("company")
-            if isinstance(company_value, Mapping):
-                company = dict(company_value)
+    company = await _resolve_trello_company_for_action(payload, card_id)
 
     if event_future and not event_future.done():
         event_future.set_result(None)
@@ -6668,6 +6659,95 @@ async def _invoke_trello_add_comment(
         "card_id": card_id,
         "comment_id": result.get("id"),
     }
+
+
+async def _resolve_trello_company_for_action(
+    payload: Mapping[str, Any],
+    card_id: str,
+) -> dict[str, Any] | None:
+    """Resolve company credentials for a Trello automation action.
+
+    Automation contexts are not guaranteed to include an embedded
+    ``ticket.company`` record. Some flows only provide ``company_id`` on the
+    ticket, while manually-triggered actions may provide only a Trello card
+    reference. Resolve those common shapes before posting so company-scoped
+    Trello credentials are still used.
+    """
+    context = payload.get("context")
+    ticket_ctx: Mapping[str, Any] | None = None
+    if isinstance(context, Mapping):
+        raw_ticket_ctx = context.get("ticket")
+        if isinstance(raw_ticket_ctx, Mapping):
+            ticket_ctx = raw_ticket_ctx
+
+    if ticket_ctx is not None:
+        company_value = ticket_ctx.get("company")
+        if isinstance(company_value, Mapping):
+            return dict(company_value)
+
+        company = await _resolve_company_by_id(ticket_ctx.get("company_id"))
+        if company is not None:
+            return company
+
+    if isinstance(context, Mapping):
+        company = await _resolve_company_by_id(context.get("company_id"))
+        if company is not None:
+            return company
+
+        ticket_id = context.get("ticket_id")
+        if ticket_id is None and ticket_ctx is not None:
+            ticket_id = ticket_ctx.get("id")
+        company = await _resolve_company_from_ticket_id(ticket_id)
+        if company is not None:
+            return company
+
+    # Last resort: use the linked Trello ticket to discover the company. This
+    # covers payloads that render only ``{{ticket.external_reference}}`` into
+    # ``card_id`` without carrying the full ticket context.
+    try:
+        from app.services import trello as trello_service
+
+        ticket = await trello_service.find_ticket_for_card(card_id)
+    except Exception as exc:  # pragma: no cover - defensive lookup fallback
+        logger.debug("Trello company lookup by card failed for {}: {}", card_id, exc)
+        ticket = None
+    if isinstance(ticket, Mapping):
+        return await _resolve_company_by_id(ticket.get("company_id"))
+
+    return None
+
+
+async def _resolve_company_from_ticket_id(ticket_id_value: Any) -> dict[str, Any] | None:
+    try:
+        ticket_id = int(ticket_id_value)
+    except (TypeError, ValueError):
+        return None
+    if ticket_id <= 0:
+        return None
+    try:
+        from app.repositories import tickets as tickets_repo
+
+        ticket = await tickets_repo.get_ticket(ticket_id)
+    except Exception as exc:  # pragma: no cover - defensive lookup fallback
+        logger.debug("Trello company lookup by ticket {} failed: {}", ticket_id, exc)
+        return None
+    if not isinstance(ticket, Mapping):
+        return None
+    return await _resolve_company_by_id(ticket.get("company_id"))
+
+
+async def _resolve_company_by_id(company_id_value: Any) -> dict[str, Any] | None:
+    try:
+        company_id = int(company_id_value)
+    except (TypeError, ValueError):
+        return None
+    if company_id <= 0:
+        return None
+    try:
+        return await company_repo.get_company_by_id(company_id)
+    except Exception as exc:  # pragma: no cover - defensive lookup fallback
+        logger.debug("Trello company lookup by company {} failed: {}", company_id, exc)
+        return None
 
 
 async def _invoke_solidtime_reconcile(

--- a/tests/test_trello_automation_action.py
+++ b/tests/test_trello_automation_action.py
@@ -146,6 +146,82 @@ async def test_invoke_trello_add_comment_resolves_company_from_context(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_invoke_trello_add_comment_resolves_company_from_ticket_company_id(
+    monkeypatch,
+):
+    """Test company credentials are loaded when context only has ticket.company_id."""
+    captured_kwargs = {}
+
+    async def fake_add_comment(card_id, text, *, company=None):
+        captured_kwargs["company"] = company
+        return {"id": "xyz"}
+
+    async def fake_get_company_by_id(company_id):
+        assert company_id == 5
+        return {"id": 5, "name": "Acme", "trello_api_key": "key", "trello_token": "tok"}
+
+    monkeypatch.setattr("app.services.trello.add_comment_to_card", fake_add_comment)
+    monkeypatch.setattr(
+        "app.repositories.companies.get_company_by_id", fake_get_company_by_id
+    )
+
+    result = await modules._invoke_trello_add_comment(
+        {},
+        {
+            "card_id": "cardABC",
+            "text": "Comment text",
+            "context": {"ticket": {"id": 1, "company_id": 5}},
+        },
+        event_future=None,
+    )
+
+    assert result["status"] == "succeeded"
+    assert captured_kwargs["company"] == {
+        "id": 5,
+        "name": "Acme",
+        "trello_api_key": "key",
+        "trello_token": "tok",
+    }
+
+
+@pytest.mark.asyncio
+async def test_invoke_trello_add_comment_resolves_company_from_linked_card(
+    monkeypatch,
+):
+    """Test company credentials are loaded from the ticket linked to the card."""
+    captured_kwargs = {}
+
+    async def fake_add_comment(card_id, text, *, company=None):
+        captured_kwargs["company"] = company
+        return {"id": "xyz"}
+
+    async def fake_find_ticket_for_card(card_id):
+        assert card_id == "cardABC"
+        return {"id": 99, "company_id": 7}
+
+    async def fake_get_company_by_id(company_id):
+        assert company_id == 7
+        return {"id": 7, "name": "Globex", "trello_api_key": "key", "trello_token": "tok"}
+
+    monkeypatch.setattr("app.services.trello.add_comment_to_card", fake_add_comment)
+    monkeypatch.setattr(
+        "app.services.trello.find_ticket_for_card", fake_find_ticket_for_card
+    )
+    monkeypatch.setattr(
+        "app.repositories.companies.get_company_by_id", fake_get_company_by_id
+    )
+
+    result = await modules._invoke_trello_add_comment(
+        {},
+        {"card_id": "cardABC", "text": "Comment text"},
+        event_future=None,
+    )
+
+    assert result["status"] == "succeeded"
+    assert captured_kwargs["company"]["id"] == 7
+
+
+@pytest.mark.asyncio
 async def test_trello_is_included_in_trigger_action_modules(monkeypatch):
     """Test that trello appears in list_trigger_action_modules when enabled."""
     from app.repositories import integration_modules as module_repo


### PR DESCRIPTION
### Motivation

- Trello comment pushes were being skipped with the generic reason "Trello comment was not posted (module disabled, credentials missing, or API error)" when automation payloads did not include an embedded `ticket.company` object even though the company had Trello credentials and the webhook registration succeeded. 
- The change ensures the Trello add-comment action can resolve per-company credentials from the variety of automation context shapes produced by different flows.

### Description

- Replaced the inline `context.ticket.company` extraction in `_invoke_trello_add_comment` with a dedicated resolver function `async def _resolve_trello_company_for_action(payload, card_id)` that attempts multiple lookup paths. 
- The resolver checks `ticket.company` (preserved as highest priority), `ticket.company_id`, a top-level `company_id`, `ticket_id` (and `ticket.id`), and finally falls back to `trello.find_ticket_for_card(card_id)` to discover the linked ticket and its company. 
- Added helper functions `async def _resolve_company_from_ticket_id(...)` and `async def _resolve_company_by_id(...)` to safely load company records with defensive logging on failure. 
- Added regression tests in `tests/test_trello_automation_action.py` covering resolution from `ticket.company_id` and from a ticket discovered via the Trello card ID, while preserving existing tests for embedded `ticket.company` behaviour.

### Testing

- Ran `python -m py_compile app/services/modules.py tests/test_trello_automation_action.py` to verify syntax and it succeeded. 
- Installed required test prerequisites (system `libmagic` and `pytest-asyncio`) to enable test collection and execution. 
- Ran `pytest -q tests/test_trello_automation_action.py` and the Trello automation action tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a506e1599c88332b6a305a4251d32e2)