### PR TITLE
Key general rate limiter by session (IP fallback) and make limits configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -422,6 +422,9 @@ MCP_ALLOWED_MODELS=users,tickets,change_log
 # Enforce read-only operations (default: true)
 MCP_READONLY=true
 # Maximum requests per minute per connection (default: 60)
+# General HTTP request rate limit per browser session (IP fallback for anonymous traffic)
+GENERAL_RATE_LIMIT=1200
+GENERAL_RATE_LIMIT_WINDOW_SECONDS=60
 MCP_RATE_LIMIT=60
 # Enable the audit-log and application-log MCP tools (search_audit_logs,
 # get_audit_log, get_application_logs). Set to false to hide these tools from

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -438,6 +438,19 @@ class Settings(BaseSettings):
         default=True,
         validation_alias="MCP_READONLY",
     )
+    general_rate_limit: int = Field(
+        default=1200,
+        validation_alias="GENERAL_RATE_LIMIT",
+        ge=1,
+        description="Maximum general HTTP requests per rate-limit window per session or IP.",
+    )
+    general_rate_limit_window_seconds: int = Field(
+        default=60,
+        validation_alias="GENERAL_RATE_LIMIT_WINDOW_SECONDS",
+        ge=1,
+        description="Window in seconds for the general HTTP request rate limit.",
+    )
+
     mcp_rate_limit: int = Field(
         default=60,
         validation_alias="MCP_RATE_LIMIT",

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import json
 import math
 import random
@@ -696,8 +697,20 @@ def _password_reset_key(request: Request) -> str:
     except Exception:
         return get_client_ip(request, default="anonymous") or "anonymous"
 
-endpoint_limiter.add_limit("/api/auth/password/forgot", "POST", limit=3, window_seconds=3600, key_func=_password_reset_key)
-endpoint_limiter.add_limit("/auth/password/forgot", "POST", limit=3, window_seconds=3600, key_func=_password_reset_key)
+endpoint_limiter.add_limit(
+    "/api/auth/password/forgot",
+    "POST",
+    limit=3,
+    window_seconds=3600,
+    key_func=_password_reset_key,
+)
+endpoint_limiter.add_limit(
+    "/auth/password/forgot",
+    "POST",
+    limit=3,
+    window_seconds=3600,
+    key_func=_password_reset_key,
+)
 
 # File upload: 10 files per hour per user
 def _user_upload_key(request: Request) -> str:
@@ -712,9 +725,21 @@ upload_paths = [
     "/api/business-continuity/attachments",
 ]
 for path in upload_paths:
-    endpoint_limiter.add_limit(path, "POST", limit=10, window_seconds=3600, key_func=_user_upload_key)
+    endpoint_limiter.add_limit(
+        path, "POST", limit=10, window_seconds=3600, key_func=_user_upload_key
+    )
 
-# API calls: 300 requests per minute per user (applied via general rate limiter)
+# General HTTP traffic: per authenticated browser session, with IP fallback for
+# unauthenticated requests. Keying authenticated traffic by IP caused busy NATs,
+# office networks, and reverse proxies to share a single bucket across many users.
+def _general_rate_limit_key(request: Request) -> str:
+    session_token = request.cookies.get(settings.session_cookie_name)
+    if session_token:
+        digest = hashlib.sha256(session_token.encode("utf-8")).hexdigest()
+        return f"session:{digest}"
+    ip = get_client_ip(request, default="anonymous") or "anonymous"
+    return f"ip:{ip}"
+
 
 app.add_middleware(
     EndpointRateLimiterMiddleware,
@@ -723,15 +748,24 @@ app.add_middleware(
 )
 
 general_rate_limiter = SimpleRateLimiter(
-    limit=300,
-    window_seconds=60,
+    limit=settings.general_rate_limit,
+    window_seconds=settings.general_rate_limit_window_seconds,
     redis_client=_rate_limit_redis,
     namespace="rate-limit:general",
 )
 app.add_middleware(
     RateLimiterMiddleware,
     rate_limiter=general_rate_limiter,
-    exempt_paths=(SWAGGER_UI_PATH, PROTECTED_OPENAPI_PATH, "/static", "/uploads", "/health", "/healthz", "/readyz"),
+    exempt_paths=(
+        SWAGGER_UI_PATH,
+        PROTECTED_OPENAPI_PATH,
+        "/static",
+        "/uploads",
+        "/health",
+        "/healthz",
+        "/readyz",
+    ),
+    key_func=_general_rate_limit_key,
 )
 
 app.add_middleware(

--- a/app/security/rate_limiter.py
+++ b/app/security/rate_limiter.py
@@ -134,10 +134,17 @@ class RateLimiterMiddleware(BaseHTTPMiddleware):
         *,
         rate_limiter: SimpleRateLimiter,
         exempt_paths: Iterable[str] | None = None,
+        key_func: Callable[[Request], str] | None = None,
     ) -> None:
         super().__init__(app)
         self.rate_limiter = rate_limiter
         self.exempt_paths = tuple(exempt_paths or ())
+        self.key_func = key_func or self._default_key_func
+
+    @staticmethod
+    def _default_key_func(request: Request) -> str:
+        client_ip = get_client_ip(request, default="anonymous")
+        return f"ip:{client_ip or 'anonymous'}"
 
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
@@ -145,8 +152,9 @@ class RateLimiterMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         client_ip = get_client_ip(request, default="anonymous")
+        key = self.key_func(request)
 
-        allowed, retry_after = await self.rate_limiter.check(client_ip or "anonymous")
+        allowed, retry_after = await self.rate_limiter.check(key)
         if not allowed:
             log_warning(
                 "Rate limit exceeded",

--- a/tests/test_endpoint_rate_limiting.py
+++ b/tests/test_endpoint_rate_limiting.py
@@ -194,3 +194,41 @@ def test_general_rate_limiter_exempts_upload_paths():
     assert client.get("/api/data").status_code == 200
     assert client.get("/api/data").status_code == 200
     assert client.get("/api/data").status_code == 429
+
+
+def test_general_rate_limiter_uses_custom_key_func():
+    """General rate limits can be keyed by session instead of shared IP."""
+    app = FastAPI()
+
+    @app.get("/api/data")
+    async def get_data():
+        return JSONResponse({"status": "ok"})
+
+    def key_func(request: Request) -> str:
+        session = request.cookies.get("myportal_session")
+        return f"session:{session}" if session else "ip:anonymous"
+
+    app.add_middleware(
+        RateLimiterMiddleware,
+        rate_limiter=SimpleRateLimiter(limit=2, window_seconds=60),
+        key_func=key_func,
+    )
+
+    client = TestClient(app)
+
+    assert (
+        client.get("/api/data", cookies={"myportal_session": "one"}).status_code == 200
+    )
+    assert (
+        client.get("/api/data", cookies={"myportal_session": "one"}).status_code == 200
+    )
+    assert (
+        client.get("/api/data", cookies={"myportal_session": "one"}).status_code == 429
+    )
+
+    assert (
+        client.get("/api/data", cookies={"myportal_session": "two"}).status_code == 200
+    )
+    assert (
+        client.get("/api/data", cookies={"myportal_session": "two"}).status_code == 200
+    )


### PR DESCRIPTION
### Motivation
- Reduce accidental bucket contention where multiple users behind NAT/reverse-proxy share a single IP bucket and hit shared general rate limits.  
- Allow the general HTTP rate limit to be tuned at runtime via environment variables.  
- Preserve existing endpoint-specific limits while enabling more precise keying for general traffic.

### Description
- Change `RateLimiterMiddleware` to accept an optional `key_func` and add a default IP-based key function; middleware now uses the provided key when checking the limiter (`app/security/rate_limiter.py`).  
- Introduce a session-keyed general rate-limit: compute a SHA-256 digest of the browser session cookie when present and fall back to IP for anonymous requests; wire that function into the app-level limiter (`app/main.py`).  
- Make the general limit and window configurable via new `Settings` fields `general_rate_limit` and `general_rate_limit_window_seconds` and add defaults and example env vars in `.env.example` (`app/core/config.py`, `.env.example`).  
- Add a unit test `test_general_rate_limiter_uses_custom_key_func` to verify custom keying (session vs IP) and adjust existing test formatting (`tests/test_endpoint_rate_limiting.py`).

### Testing
- Ran `python -m py_compile app/main.py tests/test_endpoint_rate_limiting.py` to validate syntax, which succeeded.  
- Ran `pytest tests/test_endpoint_rate_limiting.py -q` and all tests passed (`10 passed`, warnings only).  
- Verified code compiles and the new configuration variables are present in `.env.example`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a506fe0a8a083329b0a952882d4f2b6)