### PR TITLE
Fix shop card details and sizing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,8 @@ LICENSES_WEBHOOK_URL=
 LICENSES_WEBHOOK_API_KEY=
 SHOP_WEBHOOK_URL=
 SHOP_WEBHOOK_API_KEY=
+# Minimum visible product-name characters before shop cards truncate long names.
+SHOP_PRODUCT_NAME_MIN_VISIBLE_CHARS=24
 # Number of days before quotes expire (default: 7)
 QUOTE_EXPIRY_DAYS=7
 M365_ADMIN_CLIENT_ID=

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -130,6 +130,12 @@ class Settings(BaseSettings):
     shop_webhook_api_key: str | None = Field(
         default=None, validation_alias="SHOP_WEBHOOK_API_KEY"
     )
+    shop_product_name_min_visible_chars: int = Field(
+        default=24,
+        validation_alias="SHOP_PRODUCT_NAME_MIN_VISIBLE_CHARS",
+        ge=1,
+        le=120,
+    )
     quote_expiry_days: int = Field(
         default=7, validation_alias="QUOTE_EXPIRY_DAYS", ge=1
     )

--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -440,6 +440,9 @@ async def shop_page(
         "search_term": search_term,
         "cart_error": cart_error,
         "low_stock_threshold": _main().SHOP_LOW_STOCK_THRESHOLD,
+        "shop_product_name_min_visible_chars": (
+            _main().settings.shop_product_name_min_visible_chars
+        ),
         "active_subscription_product_ids": active_subscription_product_ids,
         "total_count": total_count,
         "page": page,

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10915,6 +10915,7 @@ a.stat-strip__stat:focus-visible {
   grid-template-columns: repeat(auto-fill, minmax(min(16rem, 100%), 1fr));
   gap: var(--space-gap-base);
   align-content: start;
+  grid-auto-rows: 1fr;
 }
 
 .shop-card-grid--categories {
@@ -10996,6 +10997,8 @@ a.stat-strip__stat:focus-visible {
   display: flex;
   flex-direction: column;
   min-width: 0;
+  min-height: 24rem;
+  height: 100%;
   overflow: hidden;
 }
 
@@ -11064,5 +11067,9 @@ a.stat-strip__stat:focus-visible {
 
   .shop-product-card__media {
     min-height: 8rem;
+  }
+
+  .shop-product-card {
+    min-height: 22rem;
   }
 }

--- a/app/static/js/shop.js
+++ b/app/static/js/shop.js
@@ -214,26 +214,27 @@
   }
 
 
-  function findSafeTitleTruncation(value, limit) {
+  function findSafeTitleTruncation(value, limit, minVisibleChars) {
     if (typeof value !== 'string' || value.length <= limit) {
       return value;
     }
+    const minimum = Number.isFinite(minVisibleChars) && minVisibleChars > 0 ? minVisibleChars : 1;
+    const effectiveLimit = Math.max(limit, minimum + 1);
     const commaIndex = value.indexOf(',');
     const dashIndex = value.indexOf('-');
-    const candidates = [commaIndex, dashIndex].filter((index) => index > 0);
+    const candidates = [commaIndex, dashIndex].filter((index) => index >= minimum);
     if (candidates.length > 0) {
       const safeIndex = Math.min(...candidates);
-      if (safeIndex >= 8) {
-        return `${value.slice(0, safeIndex).trim()}…`;
-      }
+      return `${value.slice(0, safeIndex).trim()}…`;
     }
-    return `${value.slice(0, Math.max(limit - 1, 1)).trim()}…`;
+    return `${value.slice(0, Math.max(effectiveLimit - 1, minimum)).trim()}…`;
   }
 
   function truncateSafeProductTitles(container) {
     container.querySelectorAll('[data-shop-safe-title]').forEach((title) => {
       const fullTitle = title.getAttribute('title') || title.textContent || '';
-      title.textContent = findSafeTitleTruncation(fullTitle.trim(), 58);
+      const minVisibleChars = Number(title.getAttribute('data-min-visible-chars'));
+      title.textContent = findSafeTitleTruncation(fullTitle.trim(), 58, minVisibleChars);
     });
   }
 
@@ -273,22 +274,9 @@
     truncateSafeProductTitles(container);
 
 
-    const imageModal = document.getElementById('product-image-modal');
     const detailsModal = document.getElementById('product-details-modal');
-    const imagePreview = document.getElementById('product-image-preview');
 
-    bindModalDismissal(imageModal);
     bindModalDismissal(detailsModal);
-
-    container.querySelectorAll('[data-image-preview]').forEach((button) => {
-      button.addEventListener('click', () => {
-        if (!imageModal || !imagePreview) {
-          return;
-        }
-        imagePreview.src = button.getAttribute('data-image-url') || '';
-        openModal(imageModal);
-      });
-    });
 
     container.querySelectorAll('[data-product-details]').forEach((button) => {
       button.addEventListener('click', async () => {

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -165,7 +165,7 @@
               {% if product.is_package %}
                 <span class="package-thumb" aria-hidden="true">🎁</span>
               {% elif product.image_url %}
-                <button type="button" class="link-button" data-image-preview data-image-url="{{ product.image_url }}">
+                <button type="button" class="link-button" data-product-details="{{ product.id }}" aria-label="View details for {{ product.name }}">
                   <img src="{{ product.image_url }}" alt="" class="product-thumb" loading="lazy" />
                 </button>
               {% else %}
@@ -173,7 +173,7 @@
               {% endif %}
             </div>
             <div class="shop-product-card__body">
-              <h3 class="shop-product-card__title" title="{{ product.name }}" data-shop-safe-title>{{ product.name }}</h3>
+              <h3 class="shop-product-card__title" title="{{ product.name }}" data-shop-safe-title data-min-visible-chars="{{ shop_product_name_min_visible_chars }}">{{ product.name }}</h3>
               <p class="shop-product-card__sku">{{ product.sku }}</p>
               {% if product.is_package %}
                 {% set item_count = product.get('items', []) | sum(attribute='quantity') %}
@@ -231,15 +231,6 @@
   </section>
 </div>
 
-<div class="modal" id="product-image-modal" role="dialog" aria-modal="true" hidden>
-  <div class="modal__content" role="document">
-    <button type="button" class="modal__close" data-modal-close>
-      <span class="visually-hidden">Close image preview</span>
-      &times;
-    </button>
-    <img src="" alt="Selected product image" id="product-image-preview" />
-  </div>
-</div>
 
 <div class="modal" id="product-details-modal" role="dialog" aria-modal="true" hidden>
   <div class="modal__content" role="document">


### PR DESCRIPTION
### Motivation
- Ensure clicking a product image on the shop listing opens the product details view instead of an image popup. 
- Keep all shop product cards visually consistent across pages by enforcing equal grid row sizing and card heights. 
- Provide a configurable minimum visible product-name length via environment so truncation preserves a sensible number of characters.

### Description
- Route product-image clicks to the existing details flow by changing the image button to use `data-product-details` and removing the standalone image preview modal in `app/templates/shop/index.html` and `app/static/js/shop.js`.
- Remove image-preview modal logic and bind image clicks to the product details modal in `app/static/js/shop.js`, and update the title truncation to respect a per-title `data-min-visible-chars` attribute.
- Add a new typed setting `shop_product_name_min_visible_chars` to `app/core/config.py` and expose it to the template via `app/features/shop/handlers.py` so templates can render `data-min-visible-chars` on titles.
- Update styles in `app/static/css/app.css` to use `grid-auto-rows: 1fr`, set card `min-height` and `height: 100%` so shop cards maintain the same height across pages, and update `.env.example` with `SHOP_PRODUCT_NAME_MIN_VISIBLE_CHARS`.

### Testing
- Ran `python -m compileall app/core/config.py app/features/shop/handlers.py` which succeeded. 
- Attempted `pytest -q tests/test_shop_product_public_payload.py tests/test_shop_product_summary.py` but collection failed due to a missing system dependency (`libmagic`) in the environment. 
- Ran `git diff --check` (pre-commit checks) which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50708c12f483329574a0d800612fe4)