### PR TITLE
Show package product image grids

### DIFF
--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -309,6 +309,20 @@ async def shop_page(
                 continue
             if price_value <= 0:
                 continue
+            package_images = []
+            for item in items:
+                resolved_product = item.get("resolved_product") or {}
+                package_images.append(
+                    {
+                        "name": resolved_product.get("product_name")
+                        or item.get("product_name")
+                        or "Included product",
+                        "image_url": resolved_product.get("product_image_url")
+                        or item.get("product_image_url"),
+                        "quantity": int(item.get("quantity") or 0),
+                    }
+                )
+
             products.append(
                 {
                     "id": package.get("id"),
@@ -318,6 +332,7 @@ async def shop_page(
                     "stock": stock_level,
                     "is_package": True,
                     "items": items,
+                    "package_images": package_images,
                     "product_count": int(package.get("product_count") or 0),
                 }
             )

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -4045,6 +4045,38 @@ button.header-title-menu__link,
   font-size: 1.5rem;
 }
 
+
+.package-thumb-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 12rem;
+  height: 9rem;
+}
+
+.package-thumb-grid__item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.32);
+}
+
+.package-thumb-grid__item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.package-thumb-grid__placeholder {
+  font-size: 1.25rem;
+}
+
 .package-name {
   display: flex;
   flex-direction: column;

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -163,7 +163,19 @@
           <article class="shop-product-card" {% if product.is_package %}data-package-id="{{ product.id }}"{% else %}data-product-id="{{ product.id }}"{% endif %} data-stock="{{ product.stock }}">
             <div class="shop-product-card__media">
               {% if product.is_package %}
-                <span class="package-thumb" aria-hidden="true">🎁</span>
+                <div class="package-thumb-grid" aria-label="Included products in {{ product.name }}">
+                  {% for package_image in product.get('package_images', [])[:4] %}
+                    <span class="package-thumb-grid__item" title="{{ package_image.name }}{% if package_image.quantity and package_image.quantity > 1 %} × {{ package_image.quantity }}{% endif %}">
+                      {% if package_image.image_url %}
+                        <img src="{{ package_image.image_url }}" alt="" loading="lazy" />
+                      {% else %}
+                        <span class="package-thumb-grid__placeholder" aria-hidden="true">🛍</span>
+                      {% endif %}
+                    </span>
+                  {% else %}
+                    <span class="package-thumb" aria-hidden="true">🎁</span>
+                  {% endfor %}
+                </div>
               {% elif product.image_url %}
                 <button type="button" class="link-button" data-product-details="{{ product.id }}" aria-label="View details for {{ product.name }}">
                   <img src="{{ product.image_url }}" alt="" class="product-thumb" loading="lazy" />


### PR DESCRIPTION
### Motivation
- Improve the storefront package cards to display actual included product imagery instead of a generic present placeholder so shoppers can preview bundle contents at a glance.

### Description
- Build a `package_images` list for each package in `app/features/shop/handlers.py` by collecting resolved product name, `product_image_url`, and `quantity` from package items and attach it to the product payload as `package_images`.
- Replace the single gift icon in `app/templates/shop/index.html` with a compact image grid that renders up to four included product thumbnails and falls back to a per-item placeholder or the original package emoji when no images exist.
- Add CSS rules in `app/static/css/app.css` (`.package-thumb-grid`, `.package-thumb-grid__item`, and related) to size and crop the image grid to match existing shop card media sizing and aesthetics.
- Preserve existing package metadata (`price`, `stock`, `product_count`, `items`) and fallback behavior for items without images.

### Testing
- Attempted to run unit tests with `python -m pytest tests/test_shop_packages_service.py tests/test_shop_cart_permission_visibility.py -q`, but collection failed due to a missing system dependency: `libmagic` required by the `python-magic` package (test run blocked).
- Verified the updated template can be loaded with Jinja2 using `Environment(loader=FileSystemLoader('app/templates')).get_template('shop/index.html')`, which succeeded.
- Verified `app/features/shop/handlers.py` compiles successfully with `python -m py_compile app/features/shop/handlers.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50725f99908332be2e4f954f402b49)