### PR TITLE
Add 'Main shop' back-navigation card to shop category pages

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -11002,6 +11002,27 @@ a.stat-strip__stat:focus-visible {
   overflow: hidden;
 }
 
+a.shop-product-card {
+  color: inherit;
+  text-decoration: none;
+}
+
+.shop-product-card--navigation {
+  border-color: rgba(56, 189, 248, 0.32);
+  transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+
+.shop-product-card--navigation:hover,
+.shop-product-card--navigation:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(15, 23, 42, 0.62);
+}
+
+.shop-product-card__media--navigation {
+  background: rgba(56, 189, 248, 0.12);
+}
+
 .shop-product-card__media {
   min-height: 10rem;
   padding: var(--space-gap-base);

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -9,6 +9,7 @@
 
 {% set is_shop_super_admin = is_super_admin | default(current_user and current_user.get('is_super_admin')) %}
 {% set show_packages = show_packages | default(false) %}
+{% set showing_product_category = (current_category is number) and not show_packages and not show_featured %}
 
 {% block header_title_content %}
   <div class="header__title-content">
@@ -159,6 +160,21 @@
       </div>
     {% else %}
       <div class="shop-card-grid">
+        {% if showing_product_category %}
+          <a class="shop-product-card shop-product-card--navigation" href="{{ request.url_for('shop_page') }}{{ shop_query() }}">
+            <span class="shop-product-card__media shop-product-card__media--navigation" aria-hidden="true">
+              <span class="shop-product-card__placeholder">🏪</span>
+            </span>
+            <span class="shop-product-card__body">
+              <strong class="shop-product-card__title">Main shop</strong>
+              <span class="shop-product-card__sku">All categories</span>
+              <span class="shop-product-card__meta">Return to the main shop page</span>
+            </span>
+            <span class="shop-product-card__actions">
+              <span class="button button--ghost" aria-hidden="true">Back</span>
+            </span>
+          </a>
+        {% endif %}
         {% for product in products %}
           <article class="shop-product-card" {% if product.is_package %}data-package-id="{{ product.id }}"{% else %}data-product-id="{{ product.id }}"{% endif %} data-stock="{{ product.stock }}">
             <div class="shop-product-card__media">

--- a/tests/test_shop_category_back_card.py
+++ b/tests/test_shop_category_back_card.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_category_back_card_is_first_product_grid_item():
+    template = Path("app/templates/shop/index.html").read_text()
+
+    flag_position = template.index("showing_product_category")
+    grid_position = template.index('<div class="shop-card-grid">')
+    back_card_position = template.index("Main shop")
+    product_loop_position = template.index("{% for product in products %}")
+
+    assert flag_position < grid_position
+    assert grid_position < back_card_position < product_loop_position
+    assert "href=\"{{ request.url_for('shop_page') }}{{ shop_query() }}\"" in template
+    assert "Return to the main shop page" in template


### PR DESCRIPTION
### Motivation
- Provide an explicit, first-position card on product category pages that returns the user to the main shop selection, satisfying the requirement to always surface a back-to-shop card as the first item.

### Description
- Add a template flag `showing_product_category` and render a `Main shop` navigation card at the start of the product card grid when viewing a numeric category (file: `app/templates/shop/index.html`).
- Insert an accessible anchor-styled product card linking to the unfiltered shop page (`request.url_for('shop_page')`) that includes title, meta text and a visual affordance for navigation (file: `app/templates/shop/index.html`).
- Extend CSS for linkable product cards and a `.shop-product-card--navigation` variant to preserve hover/focus affordances and consistent visual style (file: `app/static/css/app.css`).
- Add a regression test `tests/test_shop_category_back_card.py` that asserts the back-card appears before the product loop and contains the correct link and descriptive text.

### Testing
- ✅ Ran the new unit test `pytest tests/test_shop_category_back_card.py`, which passed.
- ✅ Verified the Jinja2 template can be parsed programmatically with `Environment(...).get_template('shop/index.html')`.
- ⚠️ Attempted to run the broader combined pytest invocation including `tests/test_shop_pagination_counts_filtered_products.py`, but collection failed due to a missing system library (`libmagic`) required by the application imports; this is an external environment dependency and not related to the template changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5072ca22b0832dbd13d1bcb46f887e)