### PR TITLE
Fix admin shop search filtering

### DIFF
--- a/app/static/js/shop_admin.js
+++ b/app/static/js/shop_admin.js
@@ -619,7 +619,7 @@
           categoryFilter.value = state.category;
           categoryFilter.dispatchEvent(new Event('change', { bubbles: true }));
         }
-        const searchInput = document.querySelector('[data-table-filter="admin-products-table"]');
+        const searchInput = document.querySelector('[data-admin-product-search]');
         if (searchInput && state.search != null) {
           searchInput.value = state.search;
           searchInput.dispatchEvent(new Event('input', { bubbles: true }));
@@ -1234,7 +1234,7 @@
         try {
           const actionUrl = new URL(editForm.action, window.location.href);
           const current = new URL(window.location.href);
-          ['showArchived', 'page', 'pageSize'].forEach((param) => {
+          ['showArchived', 'page', 'pageSize', 'search'].forEach((param) => {
             const value = current.searchParams.get(param);
             if (value !== null) {
               actionUrl.searchParams.set(param, value);
@@ -1253,7 +1253,7 @@
           if (categoryFilter) {
             state.category = categoryFilter.value;
           }
-          const searchInput = document.querySelector('[data-table-filter="admin-products-table"]');
+          const searchInput = document.querySelector('[data-admin-product-search]');
           if (searchInput) {
             state.search = searchInput.value;
           }

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -99,7 +99,6 @@
           name="search"
           value="{{ search_term }}"
           data-admin-product-search
-          data-table-filter="admin-products-table"
         />
         <select class="form-input card__control" id="stock-filter">
           <option value="">All stock</option>


### PR DESCRIPTION
### Motivation
- The admin product search input was also wired into the generic client-side table filter which caused server-side search results to be hidden after the page loaded.

### Description
- Removed the `data-table-filter="admin-products-table"` attribute from the admin shop search input so client-side table filtering no longer hides server-rendered results.
- Updated `app/static/js/shop_admin.js` to use the dedicated `data-admin-product-search` selector when restoring filter state and saving the search value to `sessionStorage`.
- Preserved the `search` query parameter when appending URL params to the product edit form action so redirects return to the same searched result set.

### Testing
- Ran `python -m compileall app/features/shop/handlers.py`, which completed successfully.
- Executed a small assertion script that checks the template and JavaScript wiring (selector usage and presence of `'showArchived', 'page', 'pageSize', 'search'`), which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50732cc604832dadb3393a6952d306)