### PR TITLE
Make package cards larger

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -11092,6 +11092,17 @@ a.stat-strip__stat:focus-visible {
   width: 4.5rem;
 }
 
+
+@media (min-width: 760px) {
+  .shop-product-card--package {
+    grid-column: span 2;
+  }
+
+  .shop-product-card--package .shop-product-card__media {
+    min-height: 20rem;
+  }
+}
+
 @media (max-width: 640px) {
   .shop-tile {
     grid-template-columns: 5rem 1fr;

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -160,7 +160,7 @@
     {% else %}
       <div class="shop-card-grid">
         {% for product in products %}
-          <article class="shop-product-card" {% if product.is_package %}data-package-id="{{ product.id }}"{% else %}data-product-id="{{ product.id }}"{% endif %} data-stock="{{ product.stock }}">
+          <article class="shop-product-card{% if product.is_package %} shop-product-card--package{% endif %}" {% if product.is_package %}data-package-id="{{ product.id }}"{% else %}data-product-id="{{ product.id }}"{% endif %} data-stock="{{ product.stock }}">
             <div class="shop-product-card__media">
               {% if product.is_package %}
                 <div class="package-thumb-grid" aria-label="Included products in {{ product.name }}">


### PR DESCRIPTION
### Motivation
- Implement the request to make package cards roughly twice the size of regular product cards so packages stand out in the shop grid.

### Description
- Add a package-specific modifier class to product cards in `app/templates/shop/index.html` and update `app/static/css/app.css` to make `.shop-product-card--package` span two grid columns and give its media area extra height on wider viewports while leaving the existing mobile layout unchanged.

### Testing
- Verified presence of the class and CSS by running a small Python check that asserted `shop-product-card--package` appears in `app/templates/shop/index.html` and the responsive CSS rules exist, which succeeded. 
- Ran `pytest` for shop-related tests but test collection failed due to a missing system dependency (`libmagic`) required by the `python-magic` package, so the full test suite could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50735752b8832d9289fda4e4d208af)