### PR TITLE
Expand package card image grids

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -11122,6 +11122,11 @@ a.shop-product-card {
   .shop-product-card--package .shop-product-card__media {
     min-height: 20rem;
   }
+
+  .shop-product-card--package .package-thumb-grid {
+    height: 18rem;
+    max-width: none;
+  }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
### Motivation
- Allow bundled product images on package cards to fill the larger media area on desktop layouts so package thumbnails no longer appear constrained to the smaller grid.

### Description
- Adjusted `app/static/css/app.css` to add rules inside `@media (min-width: 760px)` that expand the package image grid by setting `.shop-product-card--package .package-thumb-grid { height: 18rem; max-width: none; }`.

### Testing
- Ran `python -m compileall app` which completed successfully and ran `git diff --check` which reported no issues; attempted browser automation for screenshots but the `playwright` module is not installed so no automated screenshots were captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50750da35c832db1f67dce9f77d2fa)