### PR TITLE
Remove shop pagination and show all categories/products on a single page

### DIFF
--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -339,8 +339,6 @@ async def shop_page(
 
         products.sort(key=lambda entry: str(entry.get("name") or "").lower())
         total_count = len(products)
-        offset = (page - 1) * page_size
-        products = products[offset: offset + page_size]
     else:
         if show_featured:
             products = _prepare_customer_products(
@@ -377,8 +375,6 @@ async def shop_page(
             products = _prepare_customer_products(await shop_repo.list_products_summary(filters))
 
         total_count = len(products)
-        offset = (page - 1) * page_size
-        products = products[offset: offset + page_size]
 
     products = _strip_internal_shop_product_fields(products)
     products = cast(list[dict[str, Any]], _main()._serialise_for_json(products))
@@ -460,9 +456,9 @@ async def shop_page(
         ),
         "active_subscription_product_ids": active_subscription_product_ids,
         "total_count": total_count,
-        "page": page,
-        "page_size": page_size,
-        "total_pages": max(1, math.ceil(total_count / page_size)) if page_size else 1,
+        "page": 1,
+        "page_size": total_count,
+        "total_pages": 1,
     }
     return await _main()._render_template("shop/index.html", request, user, extra=extra)
 

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -35,7 +35,7 @@
 {% endblock %}
 
 {% block content %}
-{% macro shop_query(category_id=None, target_page=None) -%}
+{% macro shop_query(category_id=None) -%}
   {%- set ns = namespace(params=[]) -%}
   {%- if category_id is not none -%}
     {%- set ns.params = ns.params + ['category=' ~ category_id] -%}
@@ -45,12 +45,6 @@
   {%- endif -%}
   {%- if show_out_of_stock -%}
     {%- set ns.params = ns.params + ['showOutOfStock=1'] -%}
-  {%- endif -%}
-  {%- if page_size -%}
-    {%- set ns.params = ns.params + ['pageSize=' ~ page_size] -%}
-  {%- endif -%}
-  {%- if target_page is not none and target_page > 1 -%}
-    {%- set ns.params = ns.params + ['page=' ~ target_page] -%}
   {%- endif -%}
   {%- if ns.params -%}?{{ ns.params | join('&') }}{%- endif -%}
 {%- endmacro %}
@@ -68,9 +62,6 @@
           {% endif %}
           {% if show_out_of_stock %}
             <input type="hidden" name="showOutOfStock" value="1" />
-          {% endif %}
-          {% if page_size and page_size != 24 %}
-            <input type="hidden" name="pageSize" value="{{ page_size }}" />
           {% endif %}
           <input
             type="search"
@@ -197,23 +188,6 @@
         {% else %}
           <p class="text-muted">{{ 'No packages are currently available.' if show_packages else 'No featured products are currently available.' if show_featured else 'No products are currently available.' }}</p>
         {% endfor %}
-      </div>
-    {% endif %}
-    {% if total_count > 0 %}
-      <div class="table-pagination table-pagination--active">
-        <div class="table-pagination__group">
-          {% if page > 1 %}
-            <a class="button button--ghost table-pagination__button" href="{{ request.url_for('shop_page') }}{{ shop_query(current_category, page - 1) }}">Previous</a>
-          {% else %}
-            <button type="button" class="button button--ghost table-pagination__button" disabled>Previous</button>
-          {% endif %}
-          {% if page < total_pages %}
-            <a class="button button--ghost table-pagination__button" href="{{ request.url_for('shop_page') }}{{ shop_query(current_category, page + 1) }}">Next</a>
-          {% else %}
-            <button type="button" class="button button--ghost table-pagination__button" disabled>Next</button>
-          {% endif %}
-        </div>
-        <p class="table-pagination__status" aria-live="polite">Page {{ page }} of {{ total_pages }} · {{ total_count }} total</p>
       </div>
     {% endif %}
   </section>

--- a/tests/test_shop_category_back_card.py
+++ b/tests/test_shop_category_back_card.py
@@ -13,3 +13,12 @@ def test_category_back_card_is_first_product_grid_item():
     assert grid_position < back_card_position < product_loop_position
     assert "href=\"{{ request.url_for('shop_page') }}{{ shop_query() }}\"" in template
     assert "Return to the main shop page" in template
+
+
+def test_shop_template_has_no_bottom_pagination():
+    template = Path("app/templates/shop/index.html").read_text()
+
+    assert "table-pagination" not in template
+    assert "Page {{ page }}" not in template
+    assert "shop_query(current_category, page" not in template
+    assert 'name="pageSize"' not in template

--- a/tests/test_shop_pagination_counts_filtered_products.py
+++ b/tests/test_shop_pagination_counts_filtered_products.py
@@ -16,7 +16,7 @@ def _make_request(path: str = "/shop") -> Request:
 
 
 @pytest.mark.anyio("asyncio")
-async def test_shop_page_pagination_counts_only_visible_products(monkeypatch):
+async def test_shop_page_shows_all_visible_products_without_pagination(monkeypatch):
     request = _make_request("/shop")
     user = {"id": 9, "company_id": 5}
     membership = {"can_access_shop": 1}
@@ -41,6 +41,8 @@ async def test_shop_page_pagination_counts_only_visible_products(monkeypatch):
                 {"id": 1, "name": "Visible", "price": "10.00", "vip_price": None},
                 {"id": 2, "name": "Below DBP", "price": "12.00", "vip_price": None},
                 {"id": 3, "name": "No Price", "price": "0", "vip_price": None},
+                {"id": 4, "name": "Visible Two", "price": "15.00", "vip_price": None},
+                {"id": 5, "name": "Visible Three", "price": "20.00", "vip_price": None},
             ]
         ),
     )
@@ -66,6 +68,8 @@ async def test_shop_page_pagination_counts_only_visible_products(monkeypatch):
     response = await main.shop_page(request, page=1, page_size=2)
 
     assert response == "ok"
-    assert captured_extra["total_count"] == 1
+    assert captured_extra["total_count"] == 3
     assert captured_extra["total_pages"] == 1
-    assert [product["id"] for product in captured_extra["products"]] == [1]
+    assert captured_extra["page"] == 1
+    assert captured_extra["page_size"] == 3
+    assert [product["id"] for product in captured_extra["products"]] == [1, 4, 5]


### PR DESCRIPTION
### Motivation
- The storefront should display all categories on the main `/shop` landing and all products within a category on a single page without customer-facing pagination controls.
- Simplify navigation by removing bottom pagination and avoid propagating `page`/`pageSize` through category/search links so users always see the full visible result set.

### Description
- Stop slicing product lists in the customer-facing handler by removing offset/limit logic in `app/features/shop/handlers.py` so all visible packages/products are returned to the template. 
- Normalise the shop context to a single-page result by setting `page` to `1`, `page_size` to `total_count`, and `total_pages` to `1` in the handler payload. 
- Remove pagination UI and `pageSize` propagation from `app/templates/shop/index.html` and simplify the `shop_query` macro to no longer accept a `target_page` parameter. 
- Update regression tests: add `test_shop_template_has_no_bottom_pagination` to `tests/test_shop_category_back_card.py` and adjust `tests/test_shop_pagination_counts_filtered_products.py` to assert that all visible products are returned and pagination metadata reflects the single-page behavior.

### Testing
- Ran `pytest tests/test_shop_category_back_card.py` and it passed (2 tests). 
- Compiled the modified handler with `python -m py_compile app/features/shop/handlers.py` and it succeeded. 
- Attempted `pytest tests/test_shop_pagination_counts_filtered_products.py tests/test_shop_category_back_card.py` but collection failed due to a missing system dependency (`libmagic`) required by the test import; the failure is environmental and not related to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50c8e0c80c832dbc92ebfecf358917)