### PR TITLE
Add super-admin refresh icon to product details modal

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -11142,3 +11142,49 @@ a.shop-product-card {
     min-height: 22rem;
   }
 }
+
+.modal__icon-action-form {
+  position: absolute;
+  top: var(--space-gap-tight);
+  right: calc(var(--space-gap-roomy) + 3rem);
+  z-index: 2;
+  margin: 0;
+}
+
+.modal__icon-action-form[hidden] {
+  display: none;
+}
+
+.modal__icon-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.96);
+  color: #f8fafc;
+  cursor: pointer;
+  box-shadow: 0 12px 24px -16px rgba(15, 23, 42, 0.95);
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.modal__icon-action:hover,
+.modal__icon-action:focus-visible {
+  background: rgba(30, 41, 59, 1);
+  border-color: rgba(148, 163, 184, 0.55);
+  transform: scale(1.03);
+}
+
+.modal__icon-action:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.9);
+  outline-offset: 2px;
+}
+
+.modal__icon-action svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  pointer-events: none;
+}

--- a/app/static/js/shop.js
+++ b/app/static/js/shop.js
@@ -275,12 +275,24 @@
 
 
     const detailsModal = document.getElementById('product-details-modal');
+    const refreshForm = detailsModal
+      ? detailsModal.querySelector('[data-product-refresh-form]')
+      : null;
 
     bindModalDismissal(detailsModal);
 
     container.querySelectorAll('[data-product-details]').forEach((button) => {
       button.addEventListener('click', async () => {
         const id = Number(button.getAttribute('data-product-details'));
+        if (refreshForm) {
+          if (Number.isFinite(id) && id > 0) {
+            refreshForm.action = `/shop/admin/product/${id}/refresh-description`;
+            refreshForm.hidden = false;
+          } else {
+            refreshForm.removeAttribute('action');
+            refreshForm.hidden = true;
+          }
+        }
         renderProductDetails(null);
         openModal(detailsModal);
         if (!Number.isFinite(id) || id <= 0) {

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -222,6 +222,28 @@
 
 <div class="modal" id="product-details-modal" role="dialog" aria-modal="true" hidden>
   <div class="modal__content" role="document">
+    {% if is_shop_super_admin %}
+      <form
+        method="post"
+        class="modal__icon-action-form product-details-refresh-form"
+        data-product-refresh-form
+        hidden
+      >
+        {% include "partials/csrf.html" %}
+        <button
+          type="submit"
+          class="modal__icon-action product-details-refresh-form__button"
+          data-product-refresh-button
+          aria-label="Refresh product details"
+          title="Refresh product details"
+        >
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path fill="currentColor" d="M17.65 6.35A7.95 7.95 0 0 0 12 4a8 8 0 1 0 7.45 5.08 1 1 0 1 0-1.86.74A6 6 0 1 1 12 6c1.66 0 3.14.69 4.22 1.78L14 10h6V4z" />
+          </svg>
+          <span class="visually-hidden">Refresh product details</span>
+        </button>
+      </form>
+    {% endif %}
     <button type="button" class="modal__close" data-modal-close>
       <span class="visually-hidden">Close product details</span>
       &times;

--- a/tests/test_shop_product_details_refresh.py
+++ b/tests/test_shop_product_details_refresh.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+def test_shop_product_details_modal_has_super_admin_refresh_form() -> None:
+    template = Path("app/templates/shop/index.html").read_text()
+
+    assert "{% if is_shop_super_admin %}" in template
+    assert "data-product-refresh-form" in template
+    assert "data-product-refresh-button" in template
+    assert "Refresh product details" in template
+    assert "{% include \"partials/csrf.html\" %}" in template
+
+
+def test_shop_product_details_refresh_form_uses_admin_refresh_endpoint() -> None:
+    script = Path("app/static/js/shop.js").read_text()
+
+    assert "detailsModal.querySelector('[data-product-refresh-form]')" in script
+    assert "refreshForm.action = `/shop/admin/product/${id}/refresh-description`;" in script
+    assert "refreshForm.hidden = false;" in script
+    assert "refreshForm.hidden = true;" in script


### PR DESCRIPTION
### Motivation
- Super-admins need an in-place way to trigger the same "Refresh Details" process available in the shop admin page from the public product details popup modal.
- The intent is to reuse the existing admin refresh endpoint so refresh behaviour is consistent and audit/logging remains centralized.

### Description
- Added a super-admin-only refresh action form inside the product details modal in `app/templates/shop/index.html` that includes CSRF protection and an accessible icon button. (`data-product-refresh-form`, `data-product-refresh-button`).
- Wired the modal to set the form `action` dynamically to the existing admin endpoint `/shop/admin/product/{product_id}/refresh-description` and show/hide the form in `app/static/js/shop.js` when opening the modal for a product.
- Added modal icon styling to `app/static/css/app.css` so the refresh icon sits beside the modal close control and follows the app's button patterns.
- Added regression tests in `tests/test_shop_product_details_refresh.py` to assert the presence of the super-admin-only form and the JS wiring to the admin refresh endpoint.

### Testing
- Ran the new tests with `pytest -q tests/test_shop_product_details_refresh.py` and they passed (`2 passed`).
- Attempted to run a broader test set including `tests/test_shop_product_public_payload.py`, but collection failed due to the environment missing the system `libmagic` library required by `python-magic` during app import, preventing full test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50c9aa1d24832daf1f73f838e42f3b)