### PR TITLE
Remove admin shop pagination

### DIFF
--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import math
 from collections.abc import Mapping, Sequence
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from pathlib import Path
@@ -1192,8 +1191,6 @@ async def admin_shop_page(
     request: Request,
     show_archived: bool = Query(False, alias="showArchived"),
     search: str = Query("", alias="search"),
-    page: int = Query(1, ge=1),
-    page_size: int = Query(50, alias="pageSize", ge=1, le=200),
 ):
     from app.repositories import companies as company_repo
     from app.repositories import shop as shop_repo
@@ -1207,30 +1204,26 @@ async def admin_shop_page(
     categories_task = asyncio.create_task(shop_repo.list_all_categories_flat())
     filter_categories_task = asyncio.create_task(shop_repo.list_categories_with_products())
     search_term = search.strip()
-    offset = (page - 1) * page_size
     filters = shop_repo.ProductFilters(
         include_archived=show_archived,
         search_term=search_term or None,
         include_out_of_stock=True,
-        limit=page_size,
-        offset=offset,
         sort="name_asc",
     )
     products_task = asyncio.create_task(
         shop_repo.list_products_summary(filters)
     )
-    total_count_task = asyncio.create_task(shop_repo.count_products(filters))
     companies_task = asyncio.create_task(company_repo.list_companies())
     subscription_categories_task = asyncio.create_task(subscription_categories_repo.list_categories())
 
-    categories, filter_categories, products, total_count, companies, subscription_categories = await asyncio.gather(
+    categories, filter_categories, products, companies, subscription_categories = await asyncio.gather(
         categories_task,
         filter_categories_task,
         products_task,
-        total_count_task,
         companies_task,
         subscription_categories_task,
     )
+    total_count = len(products)
 
     for product in products:
         product["price_below_threshold"] = shop_service.is_price_below_dbp_threshold(
@@ -1267,9 +1260,6 @@ async def admin_shop_page(
         "search_term": search_term,
         "subscription_categories": subscription_categories,
         "total_count": total_count,
-        "page": page,
-        "page_size": page_size,
-        "total_pages": max(1, math.ceil(total_count / page_size)) if page_size else 1,
     }
     return await _main()._render_template("admin/shop.html", request, current_user, extra=extra)
 

--- a/app/static/js/shop_admin.js
+++ b/app/static/js/shop_admin.js
@@ -1234,7 +1234,7 @@
         try {
           const actionUrl = new URL(editForm.action, window.location.href);
           const current = new URL(window.location.href);
-          ['showArchived', 'page', 'pageSize', 'search'].forEach((param) => {
+          ['showArchived', 'search'].forEach((param) => {
             const value = current.searchParams.get(param);
             if (value !== null) {
               actionUrl.searchParams.set(param, value);

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -66,23 +66,6 @@
 {% endblock %}
 
 {% block content %}
-{% macro admin_shop_query(target_page=None) -%}
-  {%- set ns = namespace(params=[]) -%}
-  {%- if show_archived -%}
-    {%- set ns.params = ns.params + ['showArchived=1'] -%}
-  {%- endif -%}
-  {%- if page_size -%}
-    {%- set ns.params = ns.params + ['pageSize=' ~ page_size] -%}
-  {%- endif -%}
-  {%- if search_term -%}
-    {%- set ns.params = ns.params + ['search=' ~ (search_term | urlencode)] -%}
-  {%- endif -%}
-  {%- if target_page is not none and target_page > 1 -%}
-    {%- set ns.params = ns.params + ['page=' ~ target_page] -%}
-  {%- endif -%}
-  {%- if ns.params -%}?{{ ns.params | join('&') }}{%- endif -%}
-{%- endmacro %}
-
 <div class="admin-grid">
   <section class="card card--panel">
     <header class="card__header card__header--stacked">
@@ -302,21 +285,7 @@
       </table>
     </div>
     {% if total_count > 0 %}
-      <div class="table-pagination table-pagination--active">
-        <div class="table-pagination__group">
-          {% if page > 1 %}
-            <a class="button button--ghost table-pagination__button" href="{{ request.url_for('admin_shop_page') }}{{ admin_shop_query(page - 1) }}">Previous</a>
-          {% else %}
-            <button type="button" class="button button--ghost table-pagination__button" disabled>Previous</button>
-          {% endif %}
-          {% if page < total_pages %}
-            <a class="button button--ghost table-pagination__button" href="{{ request.url_for('admin_shop_page') }}{{ admin_shop_query(page + 1) }}">Next</a>
-          {% else %}
-            <button type="button" class="button button--ghost table-pagination__button" disabled>Next</button>
-          {% endif %}
-        </div>
-        <p class="table-pagination__status" aria-live="polite">Page {{ page }} of {{ total_pages }} · {{ total_count }} total</p>
-      </div>
+      <p class="table-pagination__status" aria-live="polite">Showing all {{ total_count }} products.</p>
     {% endif %}
   </section>
 </div>


### PR DESCRIPTION
### Motivation
- The admin `/admin/shop` view should display all products in one continuous list instead of paginated pages. 
- Avoid preserving now-removed pagination query parameters during product edits and simplify the UI status to reflect the full list.

### Description
- Stopped accepting `page` and `pageSize` in `admin_shop_page` and removed limit/offset from the `ProductFilters` so the handler loads the full product set; total count is now `len(products)` instead of a separate DB count (`app/features/shop/handlers.py`).
- Removed the pagination macro and pagination controls from the admin shop template and replaced them with a single status line `Showing all {{ total_count }} products.` (`app/templates/admin/shop.html`).
- Updated client-side behaviour to stop carrying `page` and `pageSize` through edit form actions and to preserve only relevant params (`showArchived` and `search`) (`app/static/js/shop_admin.js`).
- Cleaned up unused imports related to the removed pagination logic in the handler (`app/features/shop/handlers.py`).

### Testing
- Ran `python -m compileall app/features/shop/handlers.py` successfully to ensure the modified module compiles. 
- Ran `git diff --check` to validate no whitespace/merge issues were left behind and it passed. 
- Attempted `pytest tests/test_shop_admin_profit_serialization.py::test_admin_shop_page_profit_is_float` but collection failed due to a missing system dependency (`libmagic`) required by `python-magic`, so the full test run was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50cb201188832d9ef813f72002ae07)