### PR TITLE
Improve shop product detail modal

### DIFF
--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -490,6 +490,26 @@ async def shop_product_detail_api(request: Request, product_id: int):
 
 
 def _public_shop_product_payload(product: Mapping[str, Any], *, is_vip: bool) -> dict[str, Any]:
+    def public_related_items(items: Sequence[Mapping[str, Any]] | None) -> list[dict[str, Any]]:
+        public_items: list[dict[str, Any]] = []
+        for item in items or []:
+            price = item.get("price")
+            if is_vip and item.get("vip_price") is not None:
+                price = item.get("vip_price")
+            public_items.append(
+                {
+                    "id": item.get("id"),
+                    "name": item.get("name"),
+                    "sku": item.get("sku"),
+                    "image_url": item.get("image_url"),
+                    "price": price,
+                    "stock": item.get("stock"),
+                    "category_id": item.get("category_id"),
+                    "category_name": item.get("category_name"),
+                }
+            )
+        return public_items
+
     sanitized_description = sanitize_rich_text(str(product.get("description") or ""))
     payload = {
         "id": product.get("id"),
@@ -508,9 +528,9 @@ def _public_shop_product_payload(product: Mapping[str, Any], *, is_vip: bool) ->
         "category_id": product.get("category_id"),
         "category_name": product.get("category_name"),
         "features": product.get("features") or [],
-        "cross_sell_products": product.get("cross_sell_products") or [],
+        "cross_sell_products": public_related_items(product.get("cross_sell_products")),
         "cross_sell_product_ids": product.get("cross_sell_product_ids") or [],
-        "upsell_products": product.get("upsell_products") or [],
+        "upsell_products": public_related_items(product.get("upsell_products")),
         "upsell_product_ids": product.get("upsell_product_ids") or [],
     }
 

--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -2012,6 +2012,10 @@ async def _fetch_recommendation_map(
             p.name,
             p.sku,
             p.archived,
+            p.image_url,
+            p.price,
+            p.vip_price,
+            p.stock,
             p.category_id,
             c.name AS category_name
         FROM {table_name} AS rel
@@ -2033,6 +2037,10 @@ async def _fetch_recommendation_map(
             "id": related_id,
             "name": row.get("name"),
             "sku": row.get("sku"),
+            "image_url": row.get("image_url"),
+            "price": _coerce_decimal(row.get("price")),
+            "vip_price": _coerce_decimal(row.get("vip_price")),
+            "stock": _coerce_int(row.get("stock"), default=0),
             "category_id": _coerce_optional_int(row.get("category_id")),
             "category_name": row.get("category_name"),
             "archived": bool(_coerce_int(row.get("archived"), default=0)),

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -11188,3 +11188,133 @@ a.shop-product-card {
   height: 1.25rem;
   pointer-events: none;
 }
+
+.modal__content--product-details {
+  max-width: min(72rem, calc(100vw - 2rem));
+}
+
+.product-details-modal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-gap-roomy);
+}
+
+.product-details-modal__section {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 1rem;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.035), rgba(15, 23, 42, 0.01));
+  padding: var(--space-gap-roomy);
+}
+
+.product-details-modal__hero,
+.product-details-modal__related-grid {
+  display: grid;
+  grid-template-columns: minmax(16rem, 0.9fr) minmax(18rem, 1.1fr);
+  gap: var(--space-gap-roomy);
+  align-items: stretch;
+}
+
+.product-details-modal__media {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 20rem;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.product-details-modal__image {
+  max-height: 26rem;
+  background: #fff;
+}
+
+.product-details-modal__placeholder {
+  font-size: 4rem;
+}
+
+.product-details-modal__summary,
+.product-details-modal__actions,
+.product-details-modal__recommendation-list,
+.product-details-recommendation-card__body {
+  display: flex;
+  flex-direction: column;
+}
+
+.product-details-modal__summary {
+  justify-content: center;
+  gap: var(--space-gap-base);
+}
+
+.product-details-modal__title {
+  margin-bottom: var(--space-gap-tight);
+}
+
+.product-details-modal__actions {
+  gap: var(--space-gap-base);
+  align-items: flex-start;
+  margin-top: var(--space-gap-base);
+}
+
+.product-details-modal__cart {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-gap-tight);
+}
+
+.product-details-modal__cart .form-input--sm {
+  width: 5rem;
+}
+
+.product-details-modal__details .modal__subtitle,
+.product-details-modal__recommendations .modal__subtitle {
+  margin-top: 0;
+}
+
+.product-details-modal__recommendation-list {
+  gap: var(--space-gap-base);
+}
+
+.product-details-recommendation-card {
+  display: grid;
+  grid-template-columns: 5rem 1fr;
+  gap: var(--space-gap-base);
+  align-items: center;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.85rem;
+  padding: var(--space-gap-base);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.product-details-recommendation-card__image {
+  width: 5rem;
+  height: 5rem;
+  object-fit: contain;
+  border-radius: 0.65rem;
+  background: #fff;
+}
+
+.product-details-recommendation-card__body {
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.product-details-recommendation-card__price {
+  font-weight: 700;
+}
+
+.product-details-refresh-form {
+  position: absolute;
+  top: var(--space-gap-tight);
+  right: calc(var(--space-gap-roomy) + 3rem);
+}
+
+@media (max-width: 760px) {
+  .product-details-modal__hero,
+  .product-details-modal__related-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .product-details-modal__media {
+    min-height: 14rem;
+  }
+}

--- a/app/static/js/shop.js
+++ b/app/static/js/shop.js
@@ -134,6 +134,19 @@
     return row;
   }
 
+  function getCsrfToken() {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    if (meta && meta.getAttribute('content')) {
+      return meta.getAttribute('content');
+    }
+    const input = document.querySelector('input[name="_csrf"]');
+    return input ? input.value : '';
+  }
+
+  function formatPrice(value) {
+    return `$${Number(value || 0).toFixed(2)}`;
+  }
+
   async function fetchProductDetails(productId) {
     const response = await fetch(`/api/shop/products/${productId}`, {
       headers: {
@@ -145,6 +158,130 @@
       throw new Error(`Unable to load product details (${response.status})`);
     }
     return response.json();
+  }
+
+  function buildModalAddToCart(product) {
+    const stock = Number(product && product.stock);
+    const modal = document.getElementById('product-details-modal');
+    const cartAllowed = modal && modal.getAttribute('data-cart-allowed') === 'true';
+    if (!cartAllowed || !Number.isFinite(stock) || stock <= 0) {
+      const status = document.createElement('span');
+      status.className = 'badge badge--muted';
+      status.textContent = stock <= 0 ? 'Out of stock' : 'Cart unavailable';
+      return status;
+    }
+
+    const form = document.createElement('form');
+    form.action = '/cart/add';
+    form.method = 'post';
+    form.className = 'inline-form product-details-modal__cart';
+
+    const csrfToken = getCsrfToken();
+    if (csrfToken) {
+      const csrf = document.createElement('input');
+      csrf.type = 'hidden';
+      csrf.name = '_csrf';
+      csrf.value = csrfToken;
+      form.appendChild(csrf);
+    }
+
+    const productId = document.createElement('input');
+    productId.type = 'hidden';
+    productId.name = 'productId';
+    productId.value = String(product.id);
+    form.appendChild(productId);
+
+    const label = document.createElement('label');
+    label.className = 'visually-hidden';
+    label.setAttribute('for', `modal-product-quantity-${product.id}`);
+    label.textContent = `Quantity for ${product.name}`;
+    form.appendChild(label);
+
+    const quantity = document.createElement('input');
+    quantity.className = 'form-input form-input--sm';
+    quantity.id = `modal-product-quantity-${product.id}`;
+    quantity.type = 'number';
+    quantity.name = 'quantity';
+    quantity.min = '1';
+    quantity.max = String(stock);
+    quantity.value = '1';
+    quantity.setAttribute('data-stock-limit', String(stock));
+    form.appendChild(quantity);
+
+    const button = document.createElement('button');
+    button.type = 'submit';
+    button.className = 'button button--primary';
+    button.textContent = 'Add to cart';
+    form.appendChild(button);
+    bindStockLimitInputs(form);
+    return form;
+  }
+
+  function buildRecommendationCard(item) {
+    const card = document.createElement('article');
+    card.className = 'product-details-recommendation-card';
+
+    if (item.image_url) {
+      const image = document.createElement('img');
+      image.src = item.image_url;
+      image.alt = '';
+      image.loading = 'lazy';
+      image.className = 'product-details-recommendation-card__image';
+      card.appendChild(image);
+    }
+
+    const body = document.createElement('div');
+    body.className = 'product-details-recommendation-card__body';
+
+    const name = document.createElement('strong');
+    name.textContent = item.name || 'Recommended product';
+    body.appendChild(name);
+
+    if (item.sku) {
+      const sku = document.createElement('span');
+      sku.className = 'text-muted';
+      sku.textContent = item.sku;
+      body.appendChild(sku);
+    }
+
+    if (item.price !== undefined && item.price !== null) {
+      const price = document.createElement('span');
+      price.className = 'product-details-recommendation-card__price';
+      price.textContent = formatPrice(item.price);
+      body.appendChild(price);
+    }
+
+    const detailsButton = document.createElement('button');
+    detailsButton.type = 'button';
+    detailsButton.className = 'button button--ghost button--sm';
+    detailsButton.setAttribute('data-product-details', String(item.id));
+    detailsButton.textContent = 'View';
+    body.appendChild(detailsButton);
+
+    card.appendChild(body);
+    return card;
+  }
+
+  function buildRecommendationSection(title, items) {
+    const section = document.createElement('section');
+    section.className = 'product-details-modal__section product-details-modal__recommendations';
+
+    const heading = document.createElement('h3');
+    heading.className = 'modal__subtitle';
+    heading.textContent = title;
+    section.appendChild(heading);
+
+    const list = document.createElement('div');
+    list.className = 'product-details-modal__recommendation-list';
+    (items || []).forEach((item) => list.appendChild(buildRecommendationCard(item)));
+    if (!items || items.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'text-muted';
+      empty.textContent = 'No items configured yet.';
+      list.appendChild(empty);
+    }
+    section.appendChild(list);
+    return section;
   }
 
   function renderProductDetails(product) {
@@ -161,34 +298,68 @@
       return;
     }
 
+    const layout = document.createElement('div');
+    layout.className = 'product-details-modal';
+
+    const hero = document.createElement('section');
+    hero.className = 'product-details-modal__hero product-details-modal__section';
+
+    const media = document.createElement('div');
+    media.className = 'product-details-modal__media';
     if (product.image_url) {
       const image = document.createElement('img');
       image.src = product.image_url;
       image.alt = `${product.name} image`;
-      image.className = 'modal__image';
-      container.appendChild(image);
+      image.className = 'modal__image product-details-modal__image';
+      media.appendChild(image);
+    } else {
+      const placeholder = document.createElement('span');
+      placeholder.className = 'shop-product-card__placeholder product-details-modal__placeholder';
+      placeholder.textContent = '🛍';
+      media.appendChild(placeholder);
     }
+    hero.appendChild(media);
 
-    container.appendChild(createDetailRow('Price', `$${Number(product.price || 0).toFixed(2)}`));
-    container.appendChild(createDetailRow('Availability', describeStockStatus(product.stock)));
+    const summary = document.createElement('div');
+    summary.className = 'product-details-modal__summary';
+    const title = document.createElement('h2');
+    title.className = 'modal__title product-details-modal__title';
+    title.textContent = product.name || 'Product details';
+    summary.appendChild(title);
+    summary.appendChild(createDetailRow('Price', formatPrice(product.price)));
+    summary.appendChild(createDetailRow('Availability', describeStockStatus(product.stock)));
+    const actions = document.createElement('div');
+    actions.className = 'product-details-modal__actions';
+    actions.appendChild(buildModalAddToCart(product));
+    summary.appendChild(actions);
+    hero.appendChild(summary);
+    layout.appendChild(hero);
 
+    const details = document.createElement('section');
+    details.className = 'product-details-modal__section product-details-modal__details';
+    const detailsTitle = document.createElement('h3');
+    detailsTitle.className = 'modal__subtitle';
+    detailsTitle.textContent = 'Product details';
+    details.appendChild(detailsTitle);
+    const descriptionDiv = document.createElement('div');
+    descriptionDiv.className = 'modal__description rich-text-viewer';
     const descriptionHtml = typeof product.description_html === 'string' ? product.description_html.trim() : '';
     const descriptionText = typeof product.description === 'string' ? product.description.trim() : '';
-    if (descriptionHtml || descriptionText) {
-      const descriptionTitle = document.createElement('h3');
-      descriptionTitle.className = 'modal__subtitle';
-      descriptionTitle.textContent = 'Description';
-      container.appendChild(descriptionTitle);
-
-      const descriptionDiv = document.createElement('div');
-      descriptionDiv.className = 'modal__description rich-text-viewer';
-      if (descriptionHtml) {
-        descriptionDiv.innerHTML = descriptionHtml;
-      } else {
-        descriptionDiv.textContent = descriptionText;
-      }
-      container.appendChild(descriptionDiv);
+    if (descriptionHtml) {
+      descriptionDiv.innerHTML = descriptionHtml;
+    } else {
+      descriptionDiv.textContent = descriptionText || 'No product details are available yet.';
     }
+    details.appendChild(descriptionDiv);
+    layout.appendChild(details);
+
+    const related = document.createElement('div');
+    related.className = 'product-details-modal__related-grid';
+    related.appendChild(buildRecommendationSection('Cross-sell items', product.cross_sell_products || []));
+    related.appendChild(buildRecommendationSection('Up-sell items', product.upsell_products || []));
+    layout.appendChild(related);
+
+    container.appendChild(layout);
   }
 
   function bindShopSearch(container) {
@@ -281,31 +452,37 @@
 
     bindModalDismissal(detailsModal);
 
-    container.querySelectorAll('[data-product-details]').forEach((button) => {
-      button.addEventListener('click', async () => {
-        const id = Number(button.getAttribute('data-product-details'));
-        if (refreshForm) {
-          if (Number.isFinite(id) && id > 0) {
-            refreshForm.action = `/shop/admin/product/${id}/refresh-description`;
-            refreshForm.hidden = false;
-          } else {
-            refreshForm.removeAttribute('action');
-            refreshForm.hidden = true;
-          }
+    async function openProductDetails(id) {
+      if (refreshForm) {
+        if (Number.isFinite(id) && id > 0) {
+          refreshForm.action = `/shop/admin/product/${id}/refresh-description`;
+          refreshForm.hidden = false;
+        } else {
+          refreshForm.removeAttribute('action');
+          refreshForm.hidden = true;
         }
+      }
+      renderProductDetails(null);
+      openModal(detailsModal);
+      if (!Number.isFinite(id) || id <= 0) {
+        return;
+      }
+      try {
+        const product = await fetchProductDetails(id);
+        renderProductDetails(product);
+      } catch (error) {
+        console.error('Unable to load product details', error);
         renderProductDetails(null);
-        openModal(detailsModal);
-        if (!Number.isFinite(id) || id <= 0) {
-          return;
-        }
-        try {
-          const product = await fetchProductDetails(id);
-          renderProductDetails(product);
-        } catch (error) {
-          console.error('Unable to load product details', error);
-          renderProductDetails(null);
-        }
-      });
+      }
+    }
+
+    container.addEventListener('click', (event) => {
+      const button = event.target.closest('[data-product-details]');
+      if (!button) {
+        return;
+      }
+      event.preventDefault();
+      openProductDetails(Number(button.getAttribute('data-product-details')));
     });
   });
 })();

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -194,8 +194,8 @@
 </div>
 
 
-<div class="modal" id="product-details-modal" role="dialog" aria-modal="true" hidden>
-  <div class="modal__content" role="document">
+<div class="modal" id="product-details-modal" role="dialog" aria-modal="true" data-cart-allowed="{{ 'true' if cart_allowed else 'false' }}" hidden>
+  <div class="modal__content modal__content--product-details" role="document">
     {% if is_shop_super_admin %}
       <form
         method="post"


### PR DESCRIPTION
### Motivation
- Make the product popup more appealing and informative for customers by splitting it into a clear, five-section layout (hero image, purchase summary, product details, cross-sell, up-sell). 
- Surface actionable controls (add-to-cart, quantity) and provide richer related-item cards so customers can buy or explore related products without leaving the popup. 
- Preserve admin controls (refresh description) while keeping the modal responsive and accessible.

### Description
- Reworked modal template to expose cart availability to the client and apply a dedicated product-details content class by adding `data-cart-allowed` and `modal__content--product-details` to `app/templates/shop/index.html`.
- Rebuilt client-side rendering in `app/static/js/shop.js` to render a five-section modal: hero image, purchase summary with `Add to cart` (CSRF input and stock-limit validation), product details, cross-sell cards, and up-sell cards, and converted the product-details opener to delegated `click` handling for dynamic recommendations.
- Added recommendation card builders and UI helpers (`getCsrfToken`, `formatPrice`, `buildModalAddToCart`, `buildRecommendationCard`, `buildRecommendationSection`) and reused existing stock-limit validation logic.
- Extended data returned for recommendations in `app/repositories/shop.py` and adjusted the public payload in `app/features/shop/handlers.py` to include `image_url`, `price`/`vip_price`, and `stock` for related items and to present VIP pricing where applicable.
- Added responsive styles to `app/static/css/app.css` for the wider modal, two-column desktop layout and stacked mobile layout, plus styling for recommendation cards.

### Testing
- Ran lint/checks: `git diff --check` and `node --check app/static/js/shop.js` (no JS syntax errors).
- Verified Python modules compile with `python3 -m compileall app/features/shop/handlers.py app/repositories/shop.py` (successful).
- Executed targeted unit tests `pytest -q tests/test_shop_product_public_payload.py tests/test_shop_repository_recommendations.py` after ensuring the test environment had `libmagic` available; tests passed (9 passed, multiple warnings unrelated to changes).
- Smoke-checked modal behaviour in the DOM by exercising the new delegated click handler and ensuring refresh form visibility logic and add-to-cart CSRF injection run without errors (via automated event-driven JS checks performed during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50caf67b14832db7abb4a970c85368)