### PR TITLE
Add Main shop card to filtered shop views

### DIFF
--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -10,6 +10,7 @@
 {% set is_shop_super_admin = is_super_admin | default(current_user and current_user.get('is_super_admin')) %}
 {% set show_packages = show_packages | default(false) %}
 {% set showing_product_category = (current_category is number) and not show_packages and not show_featured %}
+{% set show_main_shop_card = current_category is not none and not showing_category_cards %}
 
 {% block header_title_content %}
   <div class="header__title-content">
@@ -111,8 +112,8 @@
       </div>
     {% else %}
       <div class="shop-card-grid">
-        {% if showing_product_category %}
-          <a class="shop-product-card shop-product-card--navigation" href="{{ request.url_for('shop_page') }}{{ shop_query() }}">
+        {% if show_main_shop_card %}
+          <a class="shop-product-card shop-product-card--navigation" href="{{ request.url_for('shop_page') }}">
             <span class="shop-product-card__media shop-product-card__media--navigation" aria-hidden="true">
               <span class="shop-product-card__placeholder">🏪</span>
             </span>

--- a/tests/test_shop_category_back_card.py
+++ b/tests/test_shop_category_back_card.py
@@ -1,18 +1,29 @@
 from pathlib import Path
 
 
-def test_category_back_card_is_first_product_grid_item():
+def test_main_shop_card_is_first_filtered_shop_grid_item():
     template = Path("app/templates/shop/index.html").read_text()
 
-    flag_position = template.index("showing_product_category")
+    flag_position = template.index("show_main_shop_card")
     grid_position = template.index('<div class="shop-card-grid">')
     back_card_position = template.index("Main shop")
     product_loop_position = template.index("{% for product in products %}")
 
     assert flag_position < grid_position
     assert grid_position < back_card_position < product_loop_position
-    assert "href=\"{{ request.url_for('shop_page') }}{{ shop_query() }}\"" in template
+    assert "href=\"{{ request.url_for('shop_page') }}\"" in template
     assert "Return to the main shop page" in template
+    assert "{% if show_main_shop_card %}" in template
+
+
+def test_main_shop_card_shows_for_category_packages_and_featured_pages():
+    template = Path("app/templates/shop/index.html").read_text()
+
+    assert "current_category is not none" in template
+    assert "not showing_category_cards" in template
+    handlers = Path("app/features/shop/handlers.py").read_text()
+
+    assert '"current_category": "packages" if show_packages else "featured"' in handlers
 
 
 def test_shop_template_has_no_bottom_pagination():


### PR DESCRIPTION
### Motivation
- Ensure the shop UI always exposes a "Main shop" navigation card on filtered product grids (category, packages, featured) so users can easily return to the front shop page.
- Avoid preserving the current filter query when returning to the front shop page to provide a clear reset of shop filters.

### Description
- Add a template flag `show_main_shop_card` in `app/templates/shop/index.html` computed as `current_category is not none and not showing_category_cards` to surface the back-navigation card for filtered views.
- Replace the previous conditional that only showed the back card for category views with `show_main_shop_card` and update the card link to point directly to `request.url_for('shop_page')` (removing `shop_query()` for a full reset).
- Update the regression test `tests/test_shop_category_back_card.py` to check the new flag, verify the card is the first grid item, and assert that the handler builds the `current_category` flag used to show the card.

### Testing
- Ran `pytest -q tests/test_shop_category_back_card.py tests/test_shop_product_details_refresh.py` and all tests passed (`5 passed`).
- Verified the template change by inspecting `app/templates/shop/index.html` and ensuring the new `show_main_shop_card` flag and link are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50cc505eb8832db99a7a964239ddac)