### PR TITLE
Refine product recommendations in item details modal

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -11214,6 +11214,10 @@ a.shop-product-card {
   align-items: stretch;
 }
 
+.product-details-modal__related-grid--single {
+  grid-template-columns: 1fr;
+}
+
 .product-details-modal__media {
   display: flex;
   align-items: center;

--- a/app/static/js/shop.js
+++ b/app/static/js/shop.js
@@ -263,6 +263,10 @@
   }
 
   function buildRecommendationSection(title, items) {
+    if (!items || items.length === 0) {
+      return null;
+    }
+
     const section = document.createElement('section');
     section.className = 'product-details-modal__section product-details-modal__recommendations';
 
@@ -273,13 +277,7 @@
 
     const list = document.createElement('div');
     list.className = 'product-details-modal__recommendation-list';
-    (items || []).forEach((item) => list.appendChild(buildRecommendationCard(item)));
-    if (!items || items.length === 0) {
-      const empty = document.createElement('p');
-      empty.className = 'text-muted';
-      empty.textContent = 'No items configured yet.';
-      list.appendChild(empty);
-    }
+    items.forEach((item) => list.appendChild(buildRecommendationCard(item)));
     section.appendChild(list);
     return section;
   }
@@ -353,11 +351,19 @@
     details.appendChild(descriptionDiv);
     layout.appendChild(details);
 
-    const related = document.createElement('div');
-    related.className = 'product-details-modal__related-grid';
-    related.appendChild(buildRecommendationSection('Cross-sell items', product.cross_sell_products || []));
-    related.appendChild(buildRecommendationSection('Up-sell items', product.upsell_products || []));
-    layout.appendChild(related);
+    const recommendationSections = [
+      buildRecommendationSection('Goes well with this', product.cross_sell_products || []),
+      buildRecommendationSection('Need a little more?', product.upsell_products || []),
+    ].filter(Boolean);
+    if (recommendationSections.length > 0) {
+      const related = document.createElement('div');
+      related.className = 'product-details-modal__related-grid';
+      if (recommendationSections.length === 1) {
+        related.classList.add('product-details-modal__related-grid--single');
+      }
+      recommendationSections.forEach((section) => related.appendChild(section));
+      layout.appendChild(related);
+    }
 
     container.appendChild(layout);
   }


### PR DESCRIPTION
### Motivation
- Replace the technical labels `Cross-sell items` and `Up-sell items` with friendlier, customer-facing headings to improve clarity.
- Avoid rendering empty recommendation sections so the modal uses space more effectively and remains concise.

### Description
- Update `app/static/js/shop.js` to rename headings to `Goes well with this` and `Need a little more?` when building recommendation sections.
- Change `buildRecommendationSection` to return `null` for empty item lists and remove the placeholder text so empty sections are omitted.
- Render the related recommendations as a filtered list and only append the recommendations grid when at least one section exists.
- Add `.product-details-modal__related-grid--single` in `app/static/css/app.css` to allow a single populated section to span the modal width.

### Testing
- Ran `node --check app/static/js/shop.js` and it completed without errors.
- Ran `python -m pytest tests/test_shop_product_public_payload.py tests/test_cart_update.py -q` and the targeted tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a50cd7cc54c832d9afd71d196032fea)