### PR TITLE
Autosave admin ticket details and assets on blur/change

### DIFF
--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -445,6 +445,124 @@
     return parts.join(' · ');
   }
 
+
+  function initialiseTicketDetailsAutosave() {
+    const form = document.querySelector('[data-ticket-details-autosave]');
+    if (!(form instanceof HTMLFormElement)) {
+      return;
+    }
+
+    const statusElements = Array.from(document.querySelectorAll('[data-ticket-details-autosave-status]'));
+    const externalSubmitButtons = form.id
+      ? Array.from(document.querySelectorAll(`button[type="submit"][form="${form.id}"], input[type="submit"][form="${form.id}"]`))
+      : [];
+    const submitButtons = externalSubmitButtons.concat(
+      Array.from(form.querySelectorAll('button[type="submit"], input[type="submit"]')),
+    );
+    let lastSavedSnapshot = new URLSearchParams(new FormData(form)).toString();
+    let pendingTimer = null;
+    let inFlight = null;
+    let queued = false;
+
+    function setStatus(message, state) {
+      statusElements.forEach((element) => {
+        element.textContent = message;
+        element.classList.toggle('form-help--error', state === 'error');
+      });
+    }
+
+    function currentSnapshot() {
+      return new URLSearchParams(new FormData(form)).toString();
+    }
+
+    async function saveNow() {
+      if (!form.reportValidity()) {
+        setStatus('Fix the highlighted fields before changes can be saved.', 'error');
+        return;
+      }
+
+      const snapshot = currentSnapshot();
+      if (snapshot === lastSavedSnapshot) {
+        return;
+      }
+
+      if (inFlight) {
+        queued = true;
+        return inFlight;
+      }
+
+      setStatus('Saving changes…', 'saving');
+      submitButtons.forEach((button) => {
+        button.disabled = true;
+        button.setAttribute('aria-disabled', 'true');
+      });
+
+      inFlight = fetch(form.action, {
+        method: form.method || 'POST',
+        body: new FormData(form),
+        credentials: 'same-origin',
+        headers: {
+          Accept: 'text/html',
+          'X-Requested-With': 'fetch',
+        },
+      })
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error((await response.text()) || `Save failed with status ${response.status}`);
+          }
+          lastSavedSnapshot = snapshot;
+          setStatus('Saved.', 'saved');
+        })
+        .catch((error) => {
+          console.error('Failed to autosave ticket details', error);
+          setStatus('Autosave failed. Use Save changes to retry.', 'error');
+        })
+        .finally(() => {
+          inFlight = null;
+          submitButtons.forEach((button) => {
+            button.disabled = false;
+            button.removeAttribute('aria-disabled');
+          });
+          if (queued) {
+            queued = false;
+            scheduleSave(0);
+          }
+        });
+
+      return inFlight;
+    }
+
+    function scheduleSave(delayMs = 250) {
+      window.clearTimeout(pendingTimer);
+      pendingTimer = window.setTimeout(() => {
+        saveNow();
+      }, delayMs);
+    }
+
+    function isAutosavedControl(target) {
+      if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement || target instanceof HTMLTextAreaElement)) {
+        return false;
+      }
+      return target.form === form;
+    }
+
+    document.addEventListener('focusout', (event) => {
+      if (isAutosavedControl(event.target)) {
+        scheduleSave();
+      }
+    });
+
+    document.addEventListener('change', (event) => {
+      if (isAutosavedControl(event.target)) {
+        scheduleSave();
+      }
+    });
+
+    document.addEventListener('ticket:details-autosave', () => {
+      scheduleSave();
+    });
+  }
+
   function initialiseAssetSelector() {
     const select = document.querySelector('[data-ticket-asset-selector]');
     if (!(select instanceof HTMLSelectElement)) {
@@ -784,6 +902,7 @@
       });
       renderLinkedAssets();
       renderOptions();
+      document.dispatchEvent(new CustomEvent('ticket:details-autosave'));
     }
 
     function removeLinkedAssetById(assetId) {
@@ -797,6 +916,7 @@
       linkedMap.delete(id);
       renderLinkedAssets();
       renderOptions();
+      document.dispatchEvent(new CustomEvent('ticket:details-autosave'));
     }
 
     function clearLinkedAssets() {
@@ -2596,6 +2716,7 @@
     initialiseTicketSplit();
     initialiseReplyTimeEditing();
     initialiseCallRecordingTimeEditing();
+    initialiseTicketDetailsAutosave();
     initialiseAssetSelector();
     initialiseRequesterSelector();
     initialiseTaskManagement();

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -96,7 +96,7 @@
               </div>
             </summary>
             <div class="card-collapsible__content">
-            <form id="ticket-details-form" action="/admin/tickets/{{ ticket.id }}/details" method="post" class="form card__form">
+            <form id="ticket-details-form" action="/admin/tickets/{{ ticket.id }}/details" method="post" class="form card__form" data-ticket-details-autosave>
               {% if csrf_token %}
                 <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
               {% endif %}
@@ -194,6 +194,7 @@
                   {% endfor %}
                 </select>
               </div>
+              <p class="form-help" data-ticket-details-autosave-status role="status" aria-live="polite">Changes save automatically when you leave a field.</p>
               <div class="form-actions">
                 <button type="submit" class="button button--primary">Save changes</button>
               </div>
@@ -916,6 +917,7 @@
                 </label>
                 <p class="form-help">Optionally notify linked tray devices that this ticket was updated.</p>
               </div>
+              <p class="form-help" data-ticket-details-autosave-status role="status" aria-live="polite">Asset changes save automatically.</p>
               <div class="form-actions">
                 <button type="submit" class="button button--primary" form="ticket-details-form">Save asset changes</button>
               </div>

--- a/tests/test_ticket_rename.py
+++ b/tests/test_ticket_rename.py
@@ -18,3 +18,17 @@ def test_admin_ticket_details_route_persists_subject_update():
     assert '"subject": subject_value' in route_source
     assert 'error_message="Enter a ticket subject."' in route_source
     assert 'error_message="Subject must be 255 characters or fewer."' in route_source
+
+
+def test_admin_ticket_detail_form_enables_autosave_for_details_and_assets():
+    template = Path("app/templates/admin/ticket_detail.html").read_text()
+    script = Path("app/static/js/ticket_detail.js").read_text()
+
+    assert "data-ticket-details-autosave" in template
+    assert "data-ticket-details-autosave-status" in template
+    assert "Changes save automatically when you leave a field." in template
+    assert "Asset changes save automatically." in template
+    assert "function initialiseTicketDetailsAutosave()" in script
+    assert "document.addEventListener('focusout'" in script
+    assert "document.addEventListener('change'" in script
+    assert "ticket:details-autosave" in script


### PR DESCRIPTION
### Motivation
- Reduce friction by automatically persisting edits to Ticket Details, Additional Details and linked Assets when a technician leaves or changes a field instead of requiring explicit Save clicks. 
- Provide visible autosave status feedback and keep existing submit buttons as a fallback.

### Description
- Added `data-ticket-details-autosave` to the admin ticket details form and `data-ticket-details-autosave-status` status elements in `app/templates/admin/ticket_detail.html` to surface autosave state and messages. 
- Implemented `initialiseTicketDetailsAutosave()` in `app/static/js/ticket_detail.js` which listens for `focusout`/`change` on form controls, diffs snapshots, batches saves, serialises concurrent requests, and disables submit buttons during a save. 
- Wired linked asset add/remove flows to dispatch `ticket:details-autosave` so asset changes trigger the same autosave flow, and registered the autosave initializer during page setup. 
- Kept existing save buttons intact and added short user-facing helper text; added a small regression test to verify template and script hooks. 

### Testing
- Ran `pytest tests/test_ticket_rename.py` (including new autosave assertions) and all tests passed. 
- Ran `node --check app/static/js/ticket_detail.js` and the JS syntax check passed. 
- Ran `git diff --check` and no whitespace/merge issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a542216c8488332b514ef6865ec2880)