### PR TITLE
Enable ticket asset chat for matched tray devices

### DIFF
--- a/app/api/routes/companies.py
+++ b/app/api/routes/companies.py
@@ -11,6 +11,7 @@ from app.repositories import companies as company_repo
 from app.repositories import company_memberships as membership_repo
 from app.repositories import company_recurring_invoice_items as recurring_items_repo
 from app.repositories import staff as staff_repo
+from app.repositories import tray as tray_repo
 from app.schemas.assets import AssetResponse
 from app.schemas.companies import CompanyCreate, CompanyResponse, CompanyUpdate
 from app.schemas.company_recurring_invoice_items import (
@@ -281,9 +282,38 @@ async def list_company_assets(
     if not company:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
     rows = await assets_repo.list_company_assets(company_id)
+    asset_ids = []
+    for row in rows:
+        try:
+            asset_ids.append(int(row.get("id")))
+        except (AttributeError, TypeError, ValueError):
+            continue
+    tray_devices_by_asset = await tray_repo.list_active_devices_by_asset_ids(asset_ids)
+    active_tray_devices = await tray_repo.list_devices(company_id=company_id, status="active")
+
+    def _matching_tray_device(record: dict[str, Any]) -> dict[str, Any] | None:
+        try:
+            asset_id = int(record.get("id"))
+        except (TypeError, ValueError):
+            asset_id = None
+        if asset_id and asset_id in tray_devices_by_asset:
+            return tray_devices_by_asset[asset_id]
+        serial_number = str(record.get("serial_number") or "").strip().lower()
+        asset_name = str(record.get("name") or "").strip().lower()
+        for device in active_tray_devices:
+            if device.get("asset_id"):
+                continue
+            device_serial = str(device.get("serial_number") or "").strip().lower()
+            device_hostname = str(device.get("hostname") or "").strip().lower()
+            if (serial_number and device_serial == serial_number) or (asset_name and device_hostname == asset_name):
+                return device
+        return None
+
     assets: list[dict[str, Any]] = []
     for row in rows:
         record = dict(row)
+        tray_device = _matching_tray_device(record)
+        record["tray_device_uid"] = (str(tray_device.get("device_uid") or "").strip() or None) if tray_device else None
         for numeric_key in ("ram_gb", "approx_age", "performance_score"):
             value = record.get(numeric_key)
             if value is None or value == "":

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -993,8 +993,21 @@ async def list_ticket_assets(ticket_id: int) -> list[dict[str, Any]]:
             (
                 SELECT td.device_uid
                 FROM tray_devices AS td
-                WHERE td.asset_id = ta.asset_id AND td.status = 'active'
-                ORDER BY td.last_seen_utc DESC, td.updated_at DESC, td.id DESC
+                WHERE td.status = 'active'
+                  AND td.company_id = a.company_id
+                  AND (
+                    td.asset_id = ta.asset_id
+                    OR (
+                      (td.asset_id IS NULL OR td.asset_id = 0)
+                      AND (
+                        (a.serial_number IS NOT NULL AND a.serial_number <> '' AND LOWER(td.serial_number) = LOWER(a.serial_number))
+                        OR (a.name IS NOT NULL AND a.name <> '' AND LOWER(td.hostname) = LOWER(a.name))
+                      )
+                    )
+                  )
+                ORDER BY
+                    CASE WHEN td.asset_id = ta.asset_id THEN 0 ELSE 1 END,
+                    td.last_seen_utc DESC, td.updated_at DESC, td.id DESC
                 LIMIT 1
             ) AS tray_device_uid
         FROM ticket_assets AS ta

--- a/app/schemas/assets.py
+++ b/app/schemas/assets.py
@@ -28,3 +28,4 @@ class AssetResponse(BaseModel):
     warranty_end_date: Optional[date] = None
     syncro_asset_id: Optional[str] = None
     tactical_asset_id: Optional[str] = None
+    tray_device_uid: Optional[str] = None

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -955,6 +955,7 @@
             serial_number: record.serial_number,
             status: record.status,
             tactical_asset_id: record.tactical_asset_id,
+            tray_device_uid: record.tray_device_uid,
           };
         })
         .filter((option) => option !== null);


### PR DESCRIPTION
### Motivation
- Ensure the asset chat button on `/admin/tickets/{id}` is enabled when a matching tray device exists even if the device was enrolled before the asset link was populated. 

### Description
- Update `list_ticket_assets` SQL in `app/repositories/tickets.py` to resolve an active `tray_device_uid` by either the linked `asset_id` or by falling back to matching `serial_number` or `hostname` for unlinked devices while scoping to the company. 
- Extend the company assets API in `app/api/routes/companies.py` to include `tray_device_uid` by calling `tray_repo.list_active_devices_by_asset_ids` and `tray_repo.list_devices` and matching devices by asset id, serial, or hostname. 
- Add `tray_device_uid` to the `AssetResponse` schema in `app/schemas/assets.py` so the API surface exposes device UIDs. 
- Preserve `tray_device_uid` in the ticket detail client-side mapping by adding it to the assets returned by `app/static/js/ticket_detail.js` so dynamically-added assets can immediately enable the chat action. 

### Testing
- Ran `python3 -m compileall app/repositories/tickets.py app/api/routes/companies.py app/schemas/assets.py` and compilation succeeded. 
- Ran `git diff --check` to validate whitespace/patch issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5423d52a208332a5503a9e45616823)