### PR TITLE
Sync TRMM TrayAgentID to MyPortal tray devices

### DIFF
--- a/app/services/asset_importer.py
+++ b/app/services/asset_importer.py
@@ -7,7 +7,11 @@ from app.core.logging import log_error, log_info
 from app.repositories import asset_custom_fields as acf_repo
 from app.repositories import assets as assets_repo
 from app.repositories import companies as company_repo
+from app.repositories import tray as tray_repo
 from app.services import company_id_lookup, syncro, tacticalrmm
+
+
+TRMM_TRAY_AGENT_ID_FIELD = "TrayAgentID"
 
 
 def _clean_string(value: Any, *, max_length: int | None = None) -> str | None:
@@ -179,6 +183,66 @@ async def _sync_tactical_asset_custom_fields(
             )
 
 
+async def _sync_tactical_tray_device_link(
+    *,
+    company_id: int,
+    asset_id: int,
+    agent: Mapping[str, Any],
+) -> None:
+    """Link a MyPortal tray device to an imported TRMM asset.
+
+    The tray installer can write its MyPortal ``device_uid`` into the Tactical
+    RMM agent custom field named ``TrayAgentID``.  When Tactical assets are
+    imported, use that value to attach the already-enrolled tray device to the
+    matching MyPortal asset so ticket detail chat buttons can resolve the tray
+    device directly.
+    """
+
+    trmm_fields = tacticalrmm.extract_trmm_custom_fields(agent)
+    trmm_fields_lower = {name.lower(): field for name, field in trmm_fields.items()}
+    tray_field = trmm_fields.get(TRMM_TRAY_AGENT_ID_FIELD) or trmm_fields_lower.get(
+        TRMM_TRAY_AGENT_ID_FIELD.lower()
+    )
+    if not tray_field:
+        return
+
+    tray_device_uid = _clean_string(tray_field.get("value"))
+    if not tray_device_uid:
+        return
+
+    device = await tray_repo.get_device_by_uid(tray_device_uid)
+    if not device:
+        log_info(
+            "Tactical RMM TrayAgentID did not match an enrolled tray device",
+            company_id=company_id,
+            asset_id=asset_id,
+            tray_device_uid=tray_device_uid,
+        )
+        return
+
+    device_company_id = device.get("company_id")
+    if device_company_id not in (None, "", company_id):
+        try:
+            if int(device_company_id) != int(company_id):
+                log_error(
+                    "Tactical RMM TrayAgentID matched a tray device from another company",
+                    company_id=company_id,
+                    device_company_id=device_company_id,
+                    asset_id=asset_id,
+                    tray_device_uid=tray_device_uid,
+                )
+                return
+        except (TypeError, ValueError):
+            return
+
+    device_id = device.get("id")
+    try:
+        device_id_int = int(device_id)
+    except (TypeError, ValueError):
+        return
+    await tray_repo.link_device_to_asset(device_id_int, asset_id)
+
+
 async def import_tactical_assets_for_company(
     company_id: int,
     *,
@@ -247,6 +311,20 @@ async def import_tactical_assets_for_company(
             except Exception as exc:  # noqa: BLE001 – database/unexpected errors must not abort import
                 log_error(
                     "Unexpected error syncing custom fields for Tactical RMM asset",
+                    asset_id=asset_id,
+                    tactical_asset_id=tactical_id,
+                    error=str(exc),
+                )
+        if asset_id:
+            try:
+                await _sync_tactical_tray_device_link(
+                    company_id=company_id,
+                    asset_id=asset_id,
+                    agent=agent,
+                )
+            except Exception as exc:  # noqa: BLE001 – tray linking must not abort import
+                log_error(
+                    "Failed to sync Tactical RMM tray device link",
                     asset_id=asset_id,
                     tactical_asset_id=tactical_id,
                     error=str(exc),

--- a/tests/test_asset_importer.py
+++ b/tests/test_asset_importer.py
@@ -134,6 +134,61 @@ async def test_import_tactical_assets_truncates_long_hdd_size(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_import_tactical_assets_links_tray_device_from_trmm_custom_field(monkeypatch):
+    company_record = {"id": 11, "tacticalrmm_client_id": "client-11"}
+    agents = [
+        {
+            "id": 301,
+            "custom_fields": [
+                {"name": "TrayAgentID", "type": "text", "value": "tray-device-uid"}
+            ],
+        }
+    ]
+    linked: list[tuple[int, int]] = []
+
+    async def fake_get_company(company_id):
+        assert company_id == 11
+        return company_record
+
+    async def fake_fetch_agents(client_id):
+        assert client_id == "client-11"
+        return agents
+
+    def fake_extract(agent):
+        return {
+            "name": "BJP-PW0F631C",
+            "serial_number": "SERIAL-301",
+            "tactical_asset_id": "agent-301",
+        }
+
+    async def fake_upsert_asset(**kwargs):
+        return 42
+
+    async def fake_get_device_by_uid(device_uid):
+        assert device_uid == "tray-device-uid"
+        return {"id": 77, "company_id": 11, "device_uid": device_uid}
+
+    async def fake_link_device_to_asset(device_id, asset_id):
+        linked.append((device_id, asset_id))
+
+    async def fake_sync_fields(asset_id, trmm_agent_id, agent_data):
+        return None
+
+    monkeypatch.setattr(asset_importer.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(asset_importer.tacticalrmm, "fetch_agents", fake_fetch_agents)
+    monkeypatch.setattr(asset_importer.tacticalrmm, "extract_agent_details", fake_extract)
+    monkeypatch.setattr(asset_importer.assets_repo, "upsert_asset", fake_upsert_asset)
+    monkeypatch.setattr(asset_importer.tray_repo, "get_device_by_uid", fake_get_device_by_uid)
+    monkeypatch.setattr(asset_importer.tray_repo, "link_device_to_asset", fake_link_device_to_asset)
+    monkeypatch.setattr(asset_importer, "_sync_tactical_asset_custom_fields", fake_sync_fields)
+
+    processed = await asset_importer.import_tactical_assets_for_company(11)
+
+    assert processed == 1
+    assert linked == [(77, 42)]
+
+
+@pytest.mark.anyio
 async def test_import_all_tactical_assets_summarises(monkeypatch):
     companies = [
         {"id": 1, "tacticalrmm_client_id": "c1"},


### PR DESCRIPTION
### Motivation
- Ensure the ticket detail "chat" button can resolve a Tray device for imported Tactical RMM agents by reading a TRMM custom field containing the MyPortal tray `device_uid` and attaching the enrolled device to the imported asset.

### Description
- Added `TRMM_TRAY_AGENT_ID_FIELD = "TrayAgentID"` and a new helper `async def _sync_tactical_tray_device_link(...)` in `app/services/asset_importer.py` to read `TrayAgentID` from TRMM agent custom fields, validate the enrolled tray device, and call `tray_repo.link_device_to_asset`.
- Hooked the tray-link step into `import_tactical_assets_for_company` so linking runs after the asset upsert and custom-field sync, and ensured failures are logged but do not abort the import.
- Imported the tray repository (`from app.repositories import tray as tray_repo`) and added logging for unmatched or cross-company matches.
- Added a unit test `test_import_tactical_assets_links_tray_device_from_trmm_custom_field` in `tests/test_asset_importer.py` to cover the happy-path of linking an enrolled tray device when `TrayAgentID` is present on the TRMM agent.

### Testing
- Ran `python -m py_compile app/services/asset_importer.py tests/test_asset_importer.py` which succeeded.
- Ran `pytest tests/test_asset_importer.py tests/test_tray_trmm_token_sync.py` and both test files passed in this environment (tests exercising the new tray-link behavior passed).
- Attempted a broader test run including `tests/test_trmm_custom_field_import.py`, which initially failed in this environment due to test harness/plugin differences (`pytest.mark.asyncio` vs the available AnyIO pytest plugin); this is unrelated to the code changes and stems from the test environment configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5427aed6f4833288af2f682b5239e0)