### PR TITLE
Respect LOG_LEVEL in uvicorn wrapper

### DIFF
--- a/scripts/start_with_auto_update.sh
+++ b/scripts/start_with_auto_update.sh
@@ -21,6 +21,59 @@ detect_bool() {
   esac
 }
 
+
+normalize_log_level() {
+  local value="${1:-}"
+  value="${value%%#*}"
+  # Trim leading/trailing whitespace.
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  if [[ -z "$value" ]]; then
+    return 1
+  fi
+  case "${value,,}" in
+    debug|info|warning|error|critical|trace)
+      printf '%s' "${value,,}"
+      return 0
+      ;;
+    warn)
+      printf 'warning'
+      return 0
+      ;;
+    fatal)
+      printf 'critical'
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+has_uvicorn_log_level_arg() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --log-level|--log-level=*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+build_uvicorn_command() {
+  UVICORN_COMMAND=("$@")
+  local resolved_log_level=""
+  if resolved_log_level=$(normalize_log_level "${UVICORN_LOG_LEVEL:-}"); then
+    :
+  elif resolved_log_level=$(normalize_log_level "${LOG_LEVEL:-}"); then
+    :
+  fi
+
+  if [[ -n "$resolved_log_level" ]] && ! has_uvicorn_log_level_arg "$@"; then
+    UVICORN_COMMAND+=(--log-level "$resolved_log_level")
+  fi
+}
+
 numeric_or_default() {
   local input="$1"
   local fallback="$2"
@@ -59,7 +112,8 @@ trap 'forward_signal INT' INT
 trap 'forward_signal QUIT' QUIT
 
 run_uvicorn() {
-  "$@" &
+  build_uvicorn_command "$@"
+  "${UVICORN_COMMAND[@]}" &
   uvicorn_pid=$!
   wait "$uvicorn_pid"
   local status=$?

--- a/tests/test_start_with_auto_update.py
+++ b/tests/test_start_with_auto_update.py
@@ -1,0 +1,63 @@
+"""Tests for the Uvicorn auto-update wrapper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "scripts" / "start_with_auto_update.sh"
+
+
+def _run_wrapper(tmp_path: Path, env_overrides: dict[str, str], *extra_args: str) -> list[str]:
+    argv_path = tmp_path / "argv.txt"
+    fake_uvicorn = tmp_path / "fake_uvicorn.py"
+    fake_uvicorn.write_text(
+        "import pathlib, sys\n"
+        f"pathlib.Path({str(argv_path)!r}).write_text('\\n'.join(sys.argv[1:]), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "UVICORN_AUTO_UPDATE_ENABLED": "false",
+            "UVICORN_AUTO_UPDATE_ATTEMPTS": "1",
+        }
+    )
+    env.update(env_overrides)
+
+    subprocess.run(
+        [str(WRAPPER), sys.executable, str(fake_uvicorn), "app.main:app", *extra_args],
+        cwd=ROOT,
+        env=env,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return argv_path.read_text(encoding="utf-8").splitlines()
+
+
+def test_wrapper_maps_log_level_to_uvicorn_log_level(tmp_path: Path) -> None:
+    """LOG_LEVEL from .env is passed through to Uvicorn's own logger."""
+
+    argv = _run_wrapper(tmp_path, {"LOG_LEVEL": "WARNING  # quiet server logs"})
+
+    assert argv[-2:] == ["--log-level", "warning"]
+
+
+def test_wrapper_preserves_explicit_uvicorn_log_level(tmp_path: Path) -> None:
+    """Explicit Uvicorn CLI log-level settings still take precedence."""
+
+    argv = _run_wrapper(
+        tmp_path,
+        {"LOG_LEVEL": "WARNING", "UVICORN_LOG_LEVEL": "ERROR"},
+        "--log-level",
+        "info",
+    )
+
+    assert argv.count("--log-level") == 1
+    assert argv[-2:] == ["--log-level", "info"]


### PR DESCRIPTION
### Motivation
- Uvicorn was emitting INFO-level access logs even when `.env` set `LOG_LEVEL=WARNING` because the wrapper did not pass normalized log level to the Uvicorn process. 
- The change ensures environment-configured log levels and common aliases/comments are honoured by the runtime wrapper so server-side noise (e.g. websocket/access INFO lines) can be silenced.

### Description
- Added `normalize_log_level`, `has_uvicorn_log_level_arg`, and `build_uvicorn_command` helpers to `scripts/start_with_auto_update.sh` to parse and normalize `UVICORN_LOG_LEVEL`/`LOG_LEVEL` (stripping inline `#` comments and mapping aliases) and to append `--log-level <level>` to the Uvicorn command when no explicit `--log-level` was provided. 
- Modified `run_uvicorn()` in the wrapper to call `build_uvicorn_command` and execute the resolved `UVICORN_COMMAND` array so Uvicorn receives the computed `--log-level` when appropriate. 
- Added `tests/test_start_with_auto_update.py` unit tests that exercise `.env`-style `LOG_LEVEL` with inline comments and ensure explicit CLI `--log-level` arguments still take precedence.

### Testing
- Ran `pytest -q tests/test_start_with_auto_update.py` and the two new tests passed. 
- Verified shell syntax with `bash -n scripts/start_with_auto_update.sh` which succeeded. 
- Attempted `pytest -q tests/test_logging.py tests/test_start_with_auto_update.py` but it failed during collection due to an environment dependency error (`ImportError: failed to find libmagic`), so some integration tests were not run to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a542865ff888332919186d09102b12e)