### PR TITLE
Add "Hide from admins" flag for ticket statuses

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -519,7 +519,13 @@ async def list_ticket_statuses_endpoint(
     current_user: dict = Depends(require_helpdesk_technician),
 ) -> TicketStatusListResponse:
     definitions = await tickets_service.list_status_definitions()
-    if not current_user.get("is_super_admin"):
+    if current_user.get("is_super_admin"):
+        definitions = [
+            definition
+            for definition in definitions
+            if not definition.hide_from_admins
+        ]
+    else:
         definitions = [
             definition
             for definition in definitions
@@ -532,6 +538,7 @@ async def list_ticket_statuses_endpoint(
             public_status=definition.public_status,
             is_default=definition.is_default,
             hide_from_technicians=definition.hide_from_technicians,
+            hide_from_admins=definition.hide_from_admins,
         )
         for definition in definitions
     ]
@@ -564,6 +571,7 @@ async def replace_ticket_statuses_endpoint(
             public_status=definition.public_status,
             is_default=definition.is_default,
             hide_from_technicians=definition.hide_from_technicians,
+            hide_from_admins=definition.hide_from_admins,
         )
         for definition in definitions
     ]

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -772,11 +772,18 @@ def _build_ticket_status_payloads(
     public_labels: Sequence[str],
     existing_slugs: Sequence[str],
     hidden_flags: Sequence[str],
+    admin_hidden_flags: Sequence[str],
     default_status_value: str,
 ) -> list[dict[str, Any]]:
     statuses: list[dict[str, Any]] = []
     max_length = (
-        max(len(tech_labels), len(public_labels), len(existing_slugs), len(hidden_flags))
+        max(
+            len(tech_labels),
+            len(public_labels),
+            len(existing_slugs),
+            len(hidden_flags),
+            len(admin_hidden_flags),
+        )
         if (tech_labels or public_labels or existing_slugs)
         else 0
     )
@@ -784,7 +791,18 @@ def _build_ticket_status_payloads(
         tech_label = tech_labels[index] if index < len(tech_labels) else ""
         public_status = public_labels[index] if index < len(public_labels) else ""
         existing_slug = existing_slugs[index] if index < len(existing_slugs) else None
-        hide_from_technicians = index < len(hidden_flags) and str(hidden_flags[index]).strip().lower() in {"1", "true", "on", "yes"}
+        hide_from_technicians = index < len(hidden_flags) and str(hidden_flags[index]).strip().lower() in {
+            "1",
+            "true",
+            "on",
+            "yes",
+        }
+        hide_from_admins = index < len(admin_hidden_flags) and str(admin_hidden_flags[index]).strip().lower() in {
+            "1",
+            "true",
+            "on",
+            "yes",
+        }
         if not tech_label and not public_status:
             continue
         candidate_slug = ticket_status_repo.slugify_status_label(tech_label)
@@ -802,6 +820,7 @@ def _build_ticket_status_payloads(
                 "existingSlug": existing_slug,
                 "isDefault": is_default,
                 "hideFromTechnicians": hide_from_technicians,
+                "hideFromAdmins": hide_from_admins,
             }
         )
     return statuses
@@ -819,6 +838,7 @@ async def admin_replace_ticket_statuses(request: Request):
     public_labels = form.getlist("publicLabel")
     existing_slugs = form.getlist("existingSlug")
     hidden_flags = form.getlist("hideFromTechnicians")
+    admin_hidden_flags = form.getlist("hideFromAdmins")
     default_status_value = ticket_status_repo.slugify_status_label(str(form.get("defaultStatus") or ""))
 
     statuses = _build_ticket_status_payloads(
@@ -826,6 +846,7 @@ async def admin_replace_ticket_statuses(request: Request):
         public_labels,
         existing_slugs,
         hidden_flags,
+        admin_hidden_flags,
         default_status_value,
     )
 
@@ -1519,7 +1540,13 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
     selectable_status_definitions = [
         definition
         for definition in status_definitions
-        if bool(current_user.get("is_super_admin")) or not definition.hide_from_technicians
+        if (
+            bool(current_user.get("is_super_admin"))
+            and not definition.hide_from_admins
+        ) or (
+            not bool(current_user.get("is_super_admin"))
+            and not definition.hide_from_technicians
+        )
     ]
     valid_reply_statuses = {definition.tech_status for definition in selectable_status_definitions}
     default_reply_status = next((definition.tech_status for definition in selectable_status_definitions if definition.is_default), None)

--- a/app/main.py
+++ b/app/main.py
@@ -7999,7 +7999,7 @@ async def _render_portal_ticket_detail(
     selectable_status_definitions = [
         definition
         for definition in status_definitions
-        if is_super_admin or not definition.hide_from_technicians
+        if (is_super_admin and not definition.hide_from_admins) or (not is_super_admin and not definition.hide_from_technicians)
     ]
     status_label_map = {definition.tech_status: definition.public_status for definition in status_definitions}
     available_statuses = [definition.tech_status for definition in selectable_status_definitions]
@@ -8380,6 +8380,7 @@ async def _render_portal_ticket_detail(
                 "public_status": definition.public_status,
                 "is_default": definition.is_default,
                 "hide_from_technicians": definition.hide_from_technicians,
+                "hide_from_admins": definition.hide_from_admins,
             }
             for definition in status_definitions
         ],
@@ -8560,7 +8561,7 @@ async def _render_tickets_dashboard(
     selectable_status_definitions = [
         definition
         for definition in dashboard.status_definitions
-        if bool(user.get("is_super_admin")) or not definition.hide_from_technicians
+        if (bool(user.get("is_super_admin")) and not definition.hide_from_admins) or (not bool(user.get("is_super_admin")) and not definition.hide_from_technicians)
     ]
     status_definitions_payload = [
         {
@@ -8569,6 +8570,7 @@ async def _render_tickets_dashboard(
             "public_status": definition.public_status,
             "is_default": definition.is_default,
             "hide_from_technicians": definition.hide_from_technicians,
+            "hide_from_admins": definition.hide_from_admins,
         }
         for definition in selectable_status_definitions
     ]
@@ -9010,7 +9012,7 @@ async def _render_ticket_detail(
     selectable_status_definitions = [
         definition
         for definition in status_definitions
-        if bool(user.get("is_super_admin")) or not definition.hide_from_technicians
+        if (bool(user.get("is_super_admin")) and not definition.hide_from_admins) or (not bool(user.get("is_super_admin")) and not definition.hide_from_technicians)
     ]
     status_label_map = {definition.tech_status: definition.tech_label for definition in status_definitions}
     public_status_map = {definition.tech_status: definition.public_status for definition in status_definitions}
@@ -9233,6 +9235,7 @@ async def _render_ticket_detail(
                 "public_status": definition.public_status,
                 "is_default": definition.is_default,
                 "hide_from_technicians": definition.hide_from_technicians,
+                "hide_from_admins": definition.hide_from_admins,
             }
             for definition in selectable_status_definitions
         ],

--- a/app/repositories/ticket_statuses.py
+++ b/app/repositories/ticket_statuses.py
@@ -37,18 +37,20 @@ def _normalise_row(row: dict[str, Any]) -> dict[str, Any]:
     public = str(row.get("public_status") or "").strip()
     is_default = bool(row.get("is_default", False))
     hide_from_technicians = bool(row.get("hide_from_technicians", False))
+    hide_from_admins = bool(row.get("hide_from_admins", False))
     return {
         "tech_status": slug,
         "tech_label": label or slug.replace("_", " ").title(),
         "public_status": public or label or slug.replace("_", " ").title(),
         "is_default": is_default,
         "hide_from_technicians": hide_from_technicians,
+        "hide_from_admins": hide_from_admins,
     }
 
 
 async def list_statuses() -> list[dict[str, Any]]:
     rows = await db.fetch_all(
-        "SELECT tech_status, tech_label, public_status, is_default, hide_from_technicians FROM ticket_statuses ORDER BY tech_label ASC"
+        "SELECT tech_status, tech_label, public_status, is_default, hide_from_technicians, hide_from_admins FROM ticket_statuses ORDER BY tech_label ASC"
     )
     return [_normalise_row(row) for row in rows]
 
@@ -64,12 +66,13 @@ async def ensure_default_statuses() -> list[dict[str, str]]:
                 for definition in DEFAULT_STATUS_DEFINITIONS:
                     await cursor.execute(
                         """
-                        INSERT INTO ticket_statuses (tech_status, tech_label, public_status, hide_from_technicians, created_at, updated_at)
-                        VALUES (%s, %s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
+                        INSERT INTO ticket_statuses (tech_status, tech_label, public_status, hide_from_technicians, hide_from_admins, created_at, updated_at)
+                        VALUES (%s, %s, %s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
                         ON DUPLICATE KEY UPDATE
                             tech_label = VALUES(tech_label),
                             public_status = VALUES(public_status),
                             hide_from_technicians = VALUES(hide_from_technicians),
+                            hide_from_admins = VALUES(hide_from_admins),
                             updated_at = UTC_TIMESTAMP(6)
                         """,
                         (
@@ -77,6 +80,7 @@ async def ensure_default_statuses() -> list[dict[str, str]]:
                             definition["tech_label"],
                             definition["public_status"],
                             int(bool(definition.get("hide_from_technicians", False))),
+                            int(bool(definition.get("hide_from_admins", False))),
                         ),
                     )
                 await conn.commit()
@@ -144,10 +148,11 @@ async def replace_statuses(definitions: Sequence[dict[str, Any]]) -> list[dict[s
                                     public_status = %s,
                                     is_default = %s,
                                     hide_from_technicians = %s,
+                                    hide_from_admins = %s,
                                     updated_at = UTC_TIMESTAMP(6)
                                 WHERE tech_status = %s
                                 """,
-                                (label, public_status, is_default, int(bool(definition.get("hide_from_technicians", False))), original_slug),
+                                (label, public_status, is_default, int(bool(definition.get("hide_from_technicians", False))), int(bool(definition.get("hide_from_admins", False))), original_slug),
                             )
                         else:
                             if slug in current_slugs and slug != original_slug:
@@ -162,10 +167,11 @@ async def replace_statuses(definitions: Sequence[dict[str, Any]]) -> list[dict[s
                                     public_status = %s,
                                     is_default = %s,
                                     hide_from_technicians = %s,
+                                    hide_from_admins = %s,
                                     updated_at = UTC_TIMESTAMP(6)
                                 WHERE tech_status = %s
                                 """,
-                                (slug, label, public_status, is_default, int(bool(definition.get("hide_from_technicians", False))), original_slug),
+                                (slug, label, public_status, is_default, int(bool(definition.get("hide_from_technicians", False))), int(bool(definition.get("hide_from_admins", False))), original_slug),
                             )
                             await cursor.execute(
                                 "UPDATE tickets SET status = %s WHERE status = %s",
@@ -178,10 +184,10 @@ async def replace_statuses(definitions: Sequence[dict[str, Any]]) -> list[dict[s
                             raise ValueError("Tech status values must be unique.")
                         await cursor.execute(
                             """
-                            INSERT INTO ticket_statuses (tech_status, tech_label, public_status, is_default, hide_from_technicians, created_at, updated_at)
-                            VALUES (%s, %s, %s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
+                            INSERT INTO ticket_statuses (tech_status, tech_label, public_status, is_default, hide_from_technicians, hide_from_admins, created_at, updated_at)
+                            VALUES (%s, %s, %s, %s, %s, %s, UTC_TIMESTAMP(6), UTC_TIMESTAMP(6))
                             """,
-                            (slug, label, public_status, is_default, int(bool(definition.get("hide_from_technicians", False))),)
+                            (slug, label, public_status, is_default, int(bool(definition.get("hide_from_technicians", False))), int(bool(definition.get("hide_from_admins", False))),)
                         )
                         current_slugs.add(slug)
 
@@ -226,7 +232,7 @@ async def get_status_definition(slug: str) -> dict[str, Any] | None:
     if not slug:
         return None
     row = await db.fetch_one(
-        "SELECT tech_status, tech_label, public_status, is_default, hide_from_technicians FROM ticket_statuses WHERE tech_status = %s",
+        "SELECT tech_status, tech_label, public_status, is_default, hide_from_technicians, hide_from_admins FROM ticket_statuses WHERE tech_status = %s",
         (slug,),
     )
     return _normalise_row(row) if row else None
@@ -235,6 +241,6 @@ async def get_status_definition(slug: str) -> dict[str, Any] | None:
 async def get_default_status() -> dict[str, Any] | None:
     """Get the default status definition."""
     row = await db.fetch_one(
-        "SELECT tech_status, tech_label, public_status, is_default, hide_from_technicians FROM ticket_statuses WHERE is_default = 1",
+        "SELECT tech_status, tech_label, public_status, is_default, hide_from_technicians, hide_from_admins FROM ticket_statuses WHERE is_default = 1",
     )
     return _normalise_row(row) if row else None

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -237,6 +237,7 @@ class TicketStatusDefinitionModel(BaseModel):
     public_status: str = Field(alias="publicStatus")
     is_default: bool = Field(default=False, alias="isDefault")
     hide_from_technicians: bool = Field(default=False, alias="hideFromTechnicians")
+    hide_from_admins: bool = Field(default=False, alias="hideFromAdmins")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -248,6 +249,7 @@ class TicketStatusUpdateInput(BaseModel):
     tech_status: str | None = Field(default=None, alias="techStatus", max_length=64)
     is_default: bool = Field(default=False, alias="isDefault")
     hide_from_technicians: bool = Field(default=False, alias="hideFromTechnicians")
+    hide_from_admins: bool = Field(default=False, alias="hideFromAdmins")
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -116,6 +116,7 @@ class TicketStatusDefinition:
     public_status: str
     is_default: bool = False
     hide_from_technicians: bool = False
+    hide_from_admins: bool = False
 
 
 def _build_status_definitions(records: Sequence[Mapping[str, Any]]) -> list[TicketStatusDefinition]:
@@ -128,6 +129,7 @@ def _build_status_definitions(records: Sequence[Mapping[str, Any]]) -> list[Tick
         public_status = str(record.get("public_status") or "").strip() or label
         is_default = bool(record.get("is_default", False))
         hide_from_technicians = bool(record.get("hide_from_technicians", False))
+        hide_from_admins = bool(record.get("hide_from_admins", False))
         definitions.append(
             TicketStatusDefinition(
                 tech_status=slug,
@@ -135,6 +137,7 @@ def _build_status_definitions(records: Sequence[Mapping[str, Any]]) -> list[Tick
                 public_status=public_status,
                 is_default=is_default,
                 hide_from_technicians=hide_from_technicians,
+                hide_from_admins=hide_from_admins,
             )
         )
     return definitions
@@ -147,6 +150,7 @@ def _default_status_records() -> list[dict[str, str]]:
             "tech_label": item["tech_label"],
             "public_status": item["public_status"],
             "hide_from_technicians": item.get("hide_from_technicians", False),
+            "hide_from_admins": item.get("hide_from_admins", False),
         }
         for item in ticket_status_repo.DEFAULT_STATUS_DEFINITIONS
     ]
@@ -231,6 +235,11 @@ async def replace_ticket_statuses(status_inputs: Sequence[Mapping[str, Any]]) ->
             or definition.get("hideFromTechnicians")
             or False
         )
+        hide_from_admins = bool(
+            definition.get("hide_from_admins")
+            or definition.get("hideFromAdmins")
+            or False
+        )
 
         if is_default:
             if has_default:
@@ -263,6 +272,7 @@ async def replace_ticket_statuses(status_inputs: Sequence[Mapping[str, Any]]) ->
                 "original_slug": original_slug or slug,
                 "is_default": is_default,
                 "hide_from_technicians": hide_from_technicians,
+                "hide_from_admins": hide_from_admins,
             }
         )
 

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -2536,6 +2536,11 @@
         if (hiddenInput && checkbox) {
           hiddenInput.value = checkbox.checked ? '1' : '0';
         }
+        const adminHiddenInput = row.querySelector('[data-status-admin-hidden-input]');
+        const adminCheckbox = row.querySelector('[data-status-admin-hidden-checkbox]');
+        if (adminHiddenInput && adminCheckbox) {
+          adminHiddenInput.value = adminCheckbox.checked ? '1' : '0';
+        }
       });
     }
 
@@ -2590,6 +2595,14 @@
       }
       if (checkbox) {
         checkbox.checked = false;
+      }
+      const adminHiddenInput = row.querySelector('[data-status-admin-hidden-input]');
+      const adminCheckbox = row.querySelector('[data-status-admin-hidden-checkbox]');
+      if (adminHiddenInput) {
+        adminHiddenInput.value = '0';
+      }
+      if (adminCheckbox) {
+        adminCheckbox.checked = false;
       }
       list.appendChild(row);
       updateRowIdentifiers();

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -800,6 +800,7 @@
                 <th scope="col">Tech status (technician label)</th>
                 <th scope="col">Public status (customer label)</th>
                 <th scope="col">Hide from technicians</th>
+                <th scope="col">Hide from admins</th>
                 <th scope="col" class="table__actions">Actions</th>
               </tr>
             </thead>
@@ -848,6 +849,13 @@
                         <span>Hide</span>
                       </label>
                     </td>
+                    <td data-label="Hide from admins">
+                      <input type="hidden" name="hideFromAdmins" value="{% if status_option.hide_from_admins %}1{% else %}0{% endif %}" data-status-admin-hidden-input />
+                      <label class="checkbox">
+                        <input type="checkbox" data-status-admin-hidden-checkbox {% if status_option.hide_from_admins %}checked{% endif %} />
+                        <span>Hide</span>
+                      </label>
+                    </td>
                     <td class="table__actions">
                       <button
                         type="button"
@@ -889,6 +897,13 @@
                       <span>Hide</span>
                     </label>
                   </td>
+                  <td data-label="Hide from admins">
+                    <input type="hidden" name="hideFromAdmins" value="0" data-status-admin-hidden-input />
+                    <label class="checkbox">
+                      <input type="checkbox" data-status-admin-hidden-checkbox />
+                      <span>Hide</span>
+                    </label>
+                  </td>
                   <td class="table__actions">
                     <button type="button" class="button button--ghost" data-status-remove disabled>Remove</button>
                   </td>
@@ -924,6 +939,13 @@
         <input type="hidden" name="hideFromTechnicians" value="0" data-status-hidden-input />
         <label class="checkbox">
           <input type="checkbox" data-status-hidden-checkbox />
+          <span>Hide</span>
+        </label>
+      </td>
+      <td data-label="Hide from admins">
+        <input type="hidden" name="hideFromAdmins" value="0" data-status-admin-hidden-input />
+        <label class="checkbox">
+          <input type="checkbox" data-status-admin-hidden-checkbox />
           <span>Hide</span>
         </label>
       </td>

--- a/migrations/283_ticket_status_hide_from_admins.sql
+++ b/migrations/283_ticket_status_hide_from_admins.sql
@@ -1,0 +1,4 @@
+ALTER TABLE ticket_statuses
+ADD COLUMN IF NOT EXISTS hide_from_admins TINYINT(1) NOT NULL DEFAULT 0 AFTER hide_from_technicians;
+
+CREATE INDEX IF NOT EXISTS idx_ticket_statuses_hide_from_admins ON ticket_statuses (hide_from_admins);

--- a/tests/test_tickets_dashboard_api.py
+++ b/tests/test_tickets_dashboard_api.py
@@ -229,6 +229,8 @@ def test_build_ticket_status_payloads_marks_new_default():
         ["Awaiting reply"],
         ["Awaiting reply"],
         [""],
+        [""],
+        [""],
         "awaiting_reply",
     )
 


### PR DESCRIPTION
### Motivation
- Provide a way to mark some ticket statuses as only selectable by automations and hide them from super-admins in the edit ticket views, similar to the existing `Hide from technicians` behavior.

### Description
- Add a new `hide_from_admins` column to `ticket_statuses` with migration `migrations/283_ticket_status_hide_from_admins.sql` and index, and persist it in repository SQL `SELECT/INSERT/UPDATE` statements and lookups in `app/repositories/ticket_statuses.py`.
- Extend the service and models to carry the flag by updating `TicketStatusDefinition` and status-building logic in `app/services/tickets.py`, and expose it in API schemas `app/schemas/tickets.py` (`hideFromAdmins` aliases).
- Update the admin ticket status editor UI and client-side handling by adding a "Hide from admins" column, hidden input, checkbox and JS sync/reset logic in `app/templates/admin/tickets.html` and `app/static/js/admin.js`, and accept/process the new form field in `app/features/tickets/admin_routes.py`.
- Filter status selections so super-admins do not see statuses with `hide_from_admins` while non-admin technicians continue to be filtered by `hide_from_technicians` by changing response filtering and payloads in `app/api/routes/tickets.py`, `app/main.py`, and relevant admin routes.

### Testing
- Compiled modified modules with `python -m compileall app/repositories/ticket_statuses.py app/services/tickets.py app/schemas/tickets.py app/api/routes/tickets.py app/features/tickets/admin_routes.py app/main.py` which completed successfully.
- Ran `git diff --check` which reported no whitespace/merge issues.
- Attempted to run targeted tests `pytest tests/test_ticket_statuses_service.py tests/test_tickets_dashboard_api.py`, but test collection failed due to a missing system dependency (`libmagic`) required by the test environment (error from `python-magic`), so full test verification could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a542e8bd824833291f02845af8d59d7)