### PR TITLE
Add Bulk Edit for ticket statuses in admin/tickets

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -14,6 +14,7 @@ Mirrors the routes that used to live in ``app/main.py``:
 * ``POST /admin/tickets/{ticket_id}/ai/reprocess``
 * ``POST /admin/tickets/{ticket_id}/delete``
 * ``POST /admin/tickets/bulk-delete``
+* ``POST /admin/tickets/bulk-edit``
 * ``POST /admin/tickets/{ticket_id}/replies``
 """
 
@@ -1351,6 +1352,79 @@ async def admin_delete_ticket(ticket_id: int, request: Request):
 
     message = f"Ticket {ticket_id} deleted."
     return flash_redirect("/admin/tickets", message, "success")
+
+
+@router.post("/admin/tickets/bulk-edit", response_class=HTMLResponse)
+async def admin_bulk_edit_tickets(request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        return redirect
+
+    form = await request.form()
+    raw_ids = form.getlist("ticketIds")
+    ticket_ids: list[int] = []
+    seen: set[int] = set()
+    for raw in raw_ids:
+        try:
+            identifier = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if identifier <= 0 or identifier in seen:
+            continue
+        seen.add(identifier)
+        ticket_ids.append(identifier)
+
+    if not ticket_ids:
+        return await main_module._render_tickets_dashboard(
+            request,
+            current_user,
+            error_message="Select at least one ticket to update.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    status_raw = str(form.get("status", "")).strip()
+    try:
+        status_value = await tickets_service.validate_status_choice(
+            status_raw,
+            allow_hidden=bool(current_user.get("is_super_admin")),
+        )
+    except ValueError as exc:
+        return await main_module._render_tickets_dashboard(
+            request,
+            current_user,
+            error_message=str(exc),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        updated_count = await tickets_repo.set_tickets_status(ticket_ids, status_value)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log_error("Failed to bulk edit tickets", ticket_ids=ticket_ids, status=status_value, error=str(exc))
+        return await main_module._render_tickets_dashboard(
+            request,
+            current_user,
+            error_message="Unable to update the selected tickets. Please try again.",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+    for ticket_id in ticket_ids:
+        await tickets_service.broadcast_ticket_event(action="updated", ticket_id=ticket_id)
+        await tickets_service.emit_ticket_updated_event(
+            ticket_id,
+            actor_type="technician",
+            actor=current_user,
+        )
+
+    message_suffix = "ticket" if updated_count == 1 else "tickets"
+    redirect_message = f"Updated {updated_count} {message_suffix}."
+    if updated_count < len(ticket_ids):
+        redirect_message += " Some selected tickets were not found."
+
+    return_url_raw = form.get("returnUrl")
+    return_url = str(return_url_raw) if isinstance(return_url_raw, str) else ""
+    destination = _safe_local_redirect_target(return_url, fallback="") or "/admin/tickets"
+    return flash_redirect(destination, redirect_message, "success")
 
 
 @router.post("/admin/tickets/bulk-delete", response_class=HTMLResponse)

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1185,6 +1185,53 @@ async def set_ticket_status(
     return await update_ticket(ticket_id, **fields)
 
 
+async def set_tickets_status(
+    ticket_ids: Iterable[int],
+    status: str,
+    *,
+    closed_at: datetime | None = None,
+) -> int:
+    """Set the status for multiple tickets and return the number of rows changed."""
+
+    normalised_ids: list[int] = []
+    seen: set[int] = set()
+    for raw_id in ticket_ids:
+        try:
+            identifier = int(raw_id)
+        except (TypeError, ValueError):
+            continue
+        if identifier <= 0 or identifier in seen:
+            continue
+        seen.add(identifier)
+        normalised_ids.append(identifier)
+
+    if not normalised_ids:
+        return 0
+
+    placeholders = ", ".join(["%s"] * len(normalised_ids))
+    params: list[Any] = [status, status]
+    closed_clause = "closed_at = NULL,"
+    if closed_at is not None:
+        closed_clause = "closed_at = %s,"
+        params.append(closed_at)
+    elif status in {"resolved", "closed"}:
+        closed_clause = "closed_at = COALESCE(closed_at, UTC_TIMESTAMP(6)),"
+
+    params.extend(normalised_ids)
+    return await db.execute_rowcount(
+        f"""
+        UPDATE tickets
+        SET status_changed_at = CASE WHEN status <> %s
+                THEN UTC_TIMESTAMP(6) ELSE COALESCE(status_changed_at, created_at) END,
+            status = %s,
+            {closed_clause}
+            updated_at = UTC_TIMESTAMP(6)
+        WHERE id IN ({placeholders})
+        """,
+        tuple(params),
+    )
+
+
 async def delete_ticket(ticket_id: int) -> None:
     log_info("Deleting ticket", ticket_id=ticket_id)
     await db.execute("DELETE FROM tickets WHERE id = %s", (ticket_id,))

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -699,6 +699,8 @@
     const countLabel = document.querySelector('[data-bulk-delete-count]');
     const mergeButton = document.querySelector('[data-ticket-merge-open]');
     const mergeCountLabel = document.querySelector('[data-ticket-merge-count]');
+    const bulkEditButton = document.querySelector('[data-ticket-bulk-edit-open]');
+    const bulkEditCountLabel = document.querySelector('[data-ticket-bulk-edit-count]');
     const selectAll = table.querySelector('[data-bulk-select-all]');
     const filterInputs = document.querySelectorAll('[data-table-filter="tickets-table"]');
 
@@ -761,6 +763,14 @@
         const count = selected.length;
         mergeCountLabel.textContent = `${count} selected`;
         mergeCountLabel.hidden = count === 0;
+      }
+      if (bulkEditButton) {
+        bulkEditButton.disabled = selected.length === 0;
+      }
+      if (bulkEditCountLabel) {
+        const count = selected.length;
+        bulkEditCountLabel.textContent = `${count} selected`;
+        bulkEditCountLabel.hidden = count === 0;
       }
       if (selectAll) {
         if (!visible.length) {
@@ -830,6 +840,54 @@
           event.preventDefault();
         }
       });
+    }
+
+    if (bulkEditButton) {
+      const modal = document.querySelector('[data-ticket-bulk-edit-modal]');
+      const form = modal ? modal.querySelector('[data-ticket-bulk-edit-form]') : null;
+      const selectedContainer = modal ? modal.querySelector('[data-ticket-bulk-edit-selected]') : null;
+      const summary = modal ? modal.querySelector('[data-ticket-bulk-edit-summary]') : null;
+      const error = modal ? modal.querySelector('[data-ticket-bulk-edit-error]') : null;
+      const closeButtons = modal ? modal.querySelectorAll('[data-ticket-bulk-edit-close]') : [];
+      const closeModal = () => {
+        if (modal) modal.hidden = true;
+      };
+      closeButtons.forEach((button) => button.addEventListener('click', closeModal));
+      const populateSelectedInputs = () => {
+        const selected = getVisibleCheckboxes().filter((checkbox) => checkbox.checked);
+        if (selectedContainer) {
+          selectedContainer.replaceChildren(...selected.map((checkbox) => {
+            const input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = 'ticketIds';
+            input.value = checkbox.value;
+            return input;
+          }));
+        }
+        if (summary) {
+          summary.textContent = `${selected.length} selected ${selected.length === 1 ? 'ticket' : 'tickets'}`;
+        }
+        return selected.length;
+      };
+      bulkEditButton.addEventListener('click', () => {
+        if (!modal) return;
+        const count = populateSelectedInputs();
+        if (!count) return;
+        if (error) error.hidden = true;
+        modal.hidden = false;
+      });
+      if (form) {
+        form.addEventListener('submit', (event) => {
+          const count = populateSelectedInputs();
+          if (!count) {
+            event.preventDefault();
+            if (error) {
+              error.textContent = 'Select at least one ticket to update.';
+              error.hidden = false;
+            }
+          }
+        });
+      }
     }
 
     if (mergeButton) {
@@ -1014,7 +1072,8 @@
 
     const canBulkDelete = table.getAttribute('data-can-bulk-delete') === 'true';
     const canMergeTickets = table.getAttribute('data-can-merge-tickets') === 'true';
-    const canSelectTickets = canBulkDelete || canMergeTickets;
+    const canBulkEditTickets = table.getAttribute('data-can-bulk-edit-tickets') === 'true';
+    const canSelectTickets = canBulkDelete || canMergeTickets || canBulkEditTickets;
     const bulkDeleteFormId = table.getAttribute('data-bulk-delete-form-id') || '';
     const emptyMessage = table.getAttribute('data-table-empty-label') || 'No records found.';
 

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -10,7 +10,8 @@
   {% set show_unbill_tickets = is_super_admin %}
   {% set show_email_blocklist = is_super_admin %}
   {% set can_merge_tickets = is_helpdesk_technician | default(false) %}
-  {% set show_ticket_tools = show_ticket_automations or show_syncro_import or show_ticket_status_editor or show_labour_type_editor or show_next_ticket_number or show_unbill_tickets or show_email_blocklist or show_tag_exclusions or can_bulk_delete_tickets or can_merge_tickets %}
+  {% set can_bulk_edit_tickets = is_helpdesk_technician | default(false) %}
+  {% set show_ticket_tools = show_ticket_automations or show_syncro_import or show_ticket_status_editor or show_labour_type_editor or show_next_ticket_number or show_unbill_tickets or show_email_blocklist or show_tag_exclusions or can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets %}
   <div class="header-title-menu">
     <span class="header-title-menu__label">Ticketing workspace</span>
     <button
@@ -105,6 +106,22 @@
               <a href="/admin/tag-exclusions" class="header-title-menu__link" role="menuitem">AI tag exclusions</a>
             </li>
           {% endif %}
+          {% if can_bulk_edit_tickets %}
+            <li class="header-title-menu__item" role="none">
+              <button
+                type="button"
+                class="header-title-menu__link"
+                role="menuitem"
+                data-ticket-bulk-edit-open
+                aria-haspopup="dialog"
+                aria-controls="bulk-edit-tickets-modal"
+                disabled
+              >
+                Bulk Edit
+                <span data-ticket-bulk-edit-count hidden>(0)</span>
+              </button>
+            </li>
+          {% endif %}
           {% if can_merge_tickets %}
             <li class="header-title-menu__item" role="none">
               <button
@@ -154,6 +171,41 @@
       {% include "partials/csrf.html" %}
       <input type="hidden" name="cutoffDate" value="" data-unbill-tickets-date-input />
     </form>
+  {% endif %}
+
+  {% if can_bulk_edit_tickets %}
+    <div class="modal" id="bulk-edit-tickets-modal" data-ticket-bulk-edit-modal hidden role="dialog" aria-modal="true" aria-labelledby="bulk-edit-tickets-title">
+      <div class="modal__backdrop" data-ticket-bulk-edit-close></div>
+      <div class="modal__dialog">
+        <div class="modal__header">
+          <h2 id="bulk-edit-tickets-title">Bulk edit selected tickets</h2>
+          <button type="button" class="modal__close" data-ticket-bulk-edit-close aria-label="Close bulk edit tickets modal">×</button>
+        </div>
+        <form action="/admin/tickets/bulk-edit" method="post" data-ticket-bulk-edit-form>
+          {% include "partials/csrf.html" %}
+          <input type="hidden" name="returnUrl" value="{{ request.url.path }}{% if request.url.query %}?{{ request.url.query }}{% endif %}" />
+          <div data-ticket-bulk-edit-selected></div>
+          <div class="modal__body">
+            <p>Update the status for <strong data-ticket-bulk-edit-summary>0 selected tickets</strong>. Use this to quickly close excess notification tickets during an influx.</p>
+            <div class="form-field">
+              <label class="form-label" for="bulk-edit-ticket-status">Status</label>
+              <select id="bulk-edit-ticket-status" name="status" class="form-input" required>
+                {% for status_option in ticket_status_definitions %}
+                  <option value="{{ status_option.tech_status }}">{{ status_option.tech_label }}</option>
+                {% else %}
+                  <option value="closed">Closed</option>
+                {% endfor %}
+              </select>
+            </div>
+            <p class="form-help" data-ticket-bulk-edit-error hidden></p>
+          </div>
+          <div class="modal__footer">
+            <button type="button" class="button button--ghost" data-ticket-bulk-edit-close>Cancel</button>
+            <button type="submit" class="button button--primary" data-ticket-bulk-edit-submit>Update tickets</button>
+          </div>
+        </form>
+      </div>
+    </div>
   {% endif %}
 
   {% if can_merge_tickets %}
@@ -479,13 +531,14 @@
             data-csrf-token="{{ csrf_token or '' }}"
             data-can-bulk-delete="{{ 'true' if can_bulk_delete_tickets else 'false' }}"
             data-can-merge-tickets="{{ 'true' if can_merge_tickets else 'false' }}"
+            data-can-bulk-edit-tickets="{{ 'true' if can_bulk_edit_tickets else 'false' }}"
             data-bulk-delete-form-id="tickets-bulk-delete-form"
             data-table-empty-label="No tickets found for the selected filters."
             {% if ticket_autoload %}data-table-autoload{% endif %}
           >
             <thead>
               <tr>
-                {% if can_bulk_delete_tickets or can_merge_tickets %}
+                {% if can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets %}
                   <th scope="col" class="table__select tickets-table__column tickets-table__column--select">
                     <input
                       type="checkbox"
@@ -553,7 +606,7 @@
                   {% set assigned_name = ([assigned.first_name, assigned.last_name] | select | join(' ')) | trim if assigned else '' %}
                   {% set assigned_label = assigned_name or (assigned.email if assigned else '—') %}
                   <tr>
-                    {% if can_bulk_delete_tickets or can_merge_tickets %}
+                    {% if can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets %}
                       <td data-label="Select" class="table__select tickets-table__cell tickets-table__cell--select">
                         <input
                           type="checkbox"
@@ -641,7 +694,7 @@
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="{{ 38 + (1 if can_bulk_delete_tickets or can_merge_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
+                  <td colspan="{{ 38 + (1 if can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
                 </tr>
               {% endif %}
             </tbody>


### PR DESCRIPTION
### Motivation
- Technicians need a fast way to update the status of multiple selected tickets (for example to quickly close excess notification tickets during an influx). 
- Provide the same selection/permission UX used by existing bulk actions so the new feature fits the current admin workflow.

### Description
- UI: Added a new Ticket tools menu button and modal for "Bulk Edit" in `app/templates/admin/tickets.html`, including a status selector and hidden container for selected ticket IDs, and a `data-can-bulk-edit-tickets` flag for dynamic tables. 
- Client: Wired selection state and modal behaviour in `app/static/js/admin.js` so the Bulk Edit button enables when tickets are selected, populates hidden `ticketIds` inputs, validates empty selection, and submits the form. 
- Server: Added a helpdesk-protected POST endpoint `POST /admin/tickets/bulk-edit` in `app/features/tickets/admin_routes.py` that validates status input, normalises submitted IDs, calls the repository helper, emits ticket update events, and redirects back with a flash. 
- Repo helper: Added `set_tickets_status` in `app/repositories/tickets.py` to perform a single SQL `UPDATE` for multiple ticket IDs while handling `status_changed_at`, `closed_at`, and `updated_at` consistently.

### Testing
- Compiled Python modules with `python -m compileall app/features/tickets/admin_routes.py app/repositories/tickets.py`, which succeeded. 
- Syntax-checked client code with `node --check app/static/js/admin.js`, which succeeded. 
- Ran repository/diff checks (`git diff --check`) to ensure no whitespace/errors, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a542f136e0c8332b87797e1d43dc709)