### PR TITLE
Remove ticket detail save buttons

### DIFF
--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -195,9 +195,6 @@
                 </select>
               </div>
               <p class="form-help" data-ticket-details-autosave-status role="status" aria-live="polite">Changes save automatically when you leave a field.</p>
-              <div class="form-actions">
-                <button type="submit" class="button button--primary">Save changes</button>
-              </div>
             </form>
             </div>
           </details>
@@ -918,9 +915,6 @@
                 <p class="form-help">Optionally notify linked tray devices that this ticket was updated.</p>
               </div>
               <p class="form-help" data-ticket-details-autosave-status role="status" aria-live="polite">Asset changes save automatically.</p>
-              <div class="form-actions">
-                <button type="submit" class="button button--primary" form="ticket-details-form">Save asset changes</button>
-              </div>
               </div>
             </div>
           </details>


### PR DESCRIPTION
### Motivation
- Remove the manual "Save changes" and "Save asset changes" buttons from the admin ticket detail page to avoid redundant controls and rely on the existing autosave behaviour.

### Description
- Removed the `Save changes` button from the Ticket details form and the `Save asset changes` button from the Assets section in `app/templates/admin/ticket_detail.html`, while preserving the autosave status messages and the surrounding form markup.

### Testing
- Ran `git diff --check` which reported no issues.
- Ran `pytest -q tests/test_ticket_asset_link.py`, but test collection failed due to a missing system dependency (`ImportError: failed to find libmagic`), so the test run could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54390a47448332812ca244c2c261df)