### PR TITLE
Fix inline email images in ticket imports

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -63,7 +63,9 @@ def _content_reference_keys(part: email.message.Message) -> set[str]:
         try:
             filename = str(make_header(decode_header(filename)))
         except Exception:
-            pass
+            # Malformed/unknown encoded filenames are tolerated; fall back to
+            # the raw filename value for reference key normalization.
+            filename = filename
         key = _normalise_content_reference(filename)
         if key:
             keys.add(key)

--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -9,6 +9,7 @@ import json
 import re
 import secrets
 from datetime import datetime, timezone
+from urllib.parse import unquote
 from email.header import decode_header, make_header
 from email.utils import getaddresses, parsedate_to_datetime
 from html import escape
@@ -33,6 +34,40 @@ from app.services.sanitization import sanitize_rich_text
 _MAX_FETCH_BYTES = 5 * 1024 * 1024
 _MAX_TICKET_EXTERNAL_REFERENCE_CHARS = 128
 _CID_REFERENCE_PATTERN = re.compile(r"(?i)cid:([^\"'>\s]+)")
+
+
+def _normalise_content_reference(value: str | None) -> str:
+    """Normalise Content-ID/Content-Location values for cid: lookups."""
+
+    reference = _normalise_string(value)
+    if not reference:
+        return ""
+    reference = reference.strip("<>")
+    try:
+        reference = unquote(reference)
+    except Exception:  # pragma: no cover - unquote is defensive here
+        pass
+    return reference.strip().lower()
+
+
+def _content_reference_keys(part: email.message.Message) -> set[str]:
+    """Return lookup keys that may identify an inline MIME resource."""
+
+    keys: set[str] = set()
+    for header_name in ("Content-ID", "Content-Location"):
+        key = _normalise_content_reference(part.get(header_name))
+        if key:
+            keys.add(key)
+    filename = part.get_filename()
+    if filename:
+        try:
+            filename = str(make_header(decode_header(filename)))
+        except Exception:
+            pass
+        key = _normalise_content_reference(filename)
+        if key:
+            keys.add(key)
+    return keys
 
 
 def _normalise_ticket_external_reference(value: str | None) -> str | None:
@@ -1067,6 +1102,7 @@ def _extract_body_and_attachments(message: email.message.Message) -> tuple[str, 
         plain_parts: list[str] = []
         html_parts: list[str] = []
         inline_images: dict[str, tuple[str, bytes]] = {}
+        referenced_inline_keys: set[str] = set()
         attachments: list[dict[str, Any]] = []
 
         for part in message.walk():
@@ -1083,21 +1119,30 @@ def _extract_body_and_attachments(message: email.message.Message) -> tuple[str, 
                     plain_parts.append(text)
                 else:
                     html_parts.append(text)
+                    referenced_inline_keys.update(
+                        _normalise_content_reference(match.group(1))
+                        for match in _CID_REFERENCE_PATTERN.finditer(text)
+                    )
+                    referenced_inline_keys.discard("")
                 continue
 
-            content_id = part.get("Content-ID")
-            
-            # Handle inline images (embed as base64)
-            if content_id and disposition != "attachment" and content_type.startswith("image/"):
+            content_reference_keys = _content_reference_keys(part)
+
+            # Handle inline images (embed as base64). Some clients mark images as
+            # attachments or omit Content-ID while still referencing Content-Location
+            # or the filename from the HTML body, so collect every image with a
+            # usable reference key before deciding whether it should also be saved
+            # as a regular ticket attachment.
+            if content_type.startswith("image/") and content_reference_keys:
                 payload = part.get_payload(decode=True) or b""
                 if payload and len(payload) <= _MAX_FETCH_BYTES:
-                    normalised_id = content_id.strip().strip("<>").lower()
-                    if normalised_id:
-                        inline_images[normalised_id] = (content_type, payload)
-                continue
-            
+                    for reference_key in content_reference_keys:
+                        inline_images[reference_key] = (content_type, payload)
+                if disposition != "attachment" or content_reference_keys.intersection(referenced_inline_keys):
+                    continue
+
             # Handle non-inline attachments (files to save)
-            if disposition == "attachment" or (part.get_filename() and not content_id):
+            if disposition == "attachment" or (part.get_filename() and not content_reference_keys):
                 payload = part.get_payload(decode=True) or b""
                 if not payload or len(payload) > _MAX_FETCH_BYTES:
                     continue
@@ -1129,7 +1174,7 @@ def _extract_body_and_attachments(message: email.message.Message) -> tuple[str, 
                     cid_value = match.group(1)
                     if not cid_value:
                         return match.group(0)
-                    lookup_key = cid_value.strip().strip("<>").lower()
+                    lookup_key = _normalise_content_reference(cid_value)
                     resource = inline_images.get(lookup_key)
                     if not resource:
                         return match.group(0)

--- a/tests/test_email_ticket_replies.py
+++ b/tests/test_email_ticket_replies.py
@@ -653,5 +653,62 @@ async def test_add_email_cc_watchers_adds_users_and_external_addresses(monkeypat
     ]
 
 
+
+def test_extract_body_embeds_url_encoded_content_id_image():
+    """Inline images referenced by URL-encoded cid values should render in ticket bodies."""
+    from email.message import EmailMessage
+
+    from app.services.imap import _extract_body_and_attachments
+
+    message = EmailMessage()
+    message.set_content("Please see photo of the back of her phone.")
+    message.add_alternative(
+        (
+            '<p>Please see photo of the back of her phone.</p>'
+            '<img src="cid:image001.png%40abc123" width="480" height="640">'
+        ),
+        subtype="html",
+    )
+    html_part = message.get_payload()[1]
+    html_part.add_related(
+        b"fake-png-data",
+        maintype="image",
+        subtype="png",
+        cid="<image001.png@abc123>",
+        filename="image001.png",
+    )
+
+    body, attachments = _extract_body_and_attachments(message)
+
+    assert 'src="data:image/png;base64,' in body
+    assert "cid:image001" not in body
+    assert attachments == []
+
+
+def test_extract_body_embeds_content_location_image():
+    """Some clients identify inline body images by Content-Location instead of Content-ID."""
+    from email.message import EmailMessage
+    from email.mime.image import MIMEImage
+
+    from app.services.imap import _extract_body_and_attachments
+
+    message = EmailMessage()
+    message.set_content("Please see photo.")
+    message.add_alternative(
+        '<p>Please see photo.</p><img src="cid:phone-back.png">', subtype="html"
+    )
+    image = MIMEImage(b"fake-png-data", _subtype="png")
+    image.add_header("Content-Disposition", "inline", filename="phone-back.png")
+    image.add_header("Content-Location", "phone-back.png")
+    message.get_payload()[1].make_related()
+    message.get_payload()[1].attach(image)
+
+    body, attachments = _extract_body_and_attachments(message)
+
+    assert 'src="data:image/png;base64,' in body
+    assert "cid:phone-back.png" not in body
+    assert attachments == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
### Motivation
- Embedded inline images referenced by `cid:` were not resolved when values were URL-encoded or referenced via `Content-Location`/filename, causing broken images in imported ticket replies and resulting in duplicate saved attachments.
- The importer needs to recognise the variety of MIME reference forms mail clients use so inline images render in the ticket body instead of being stored as separate attachments.

### Description
- Add `_normalise_content_reference` to canonicalise `Content-ID`, `Content-Location`, and filename references (including URL-decoding) and `_content_reference_keys` to collect possible lookup keys from a MIME part in `app/services/imap.py`.
- Update `_extract_body_and_attachments` to: track `cid:` references found in HTML parts, collect inline image parts keyed by the normalised reference values, embed matched inline images as base64 `data:` URLs when replacing `cid:` references, and avoid adding those referenced images to the attachments list.
- Use the same normalisation logic when replacing `cid:` occurrences in HTML so URL-encoded and Content-Location references are resolved consistently.
- Add regression tests in `tests/test_email_ticket_replies.py` covering URL-encoded `cid:` references and `Content-Location`-based inline images.

### Testing
- Compiled the modified modules with `python -m compileall app/services/imap.py tests/test_email_ticket_replies.py` which succeeded.
- Ran the focused test file with `SESSION_SECRET=x TOTP_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef python -m pytest tests/test_email_ticket_replies.py -q` and the suite passed (`40 passed`, several warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54502d9b64833287f8ad62856bc0c1)