### PR TITLE
Add PDF export for quotes (with/without images) and product detail pages

### DIFF
--- a/app/features/quotes/routes.py
+++ b/app/features/quotes/routes.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import secrets
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from html import escape
 from functools import lru_cache
 from typing import Any
 from urllib.parse import quote
 
+from weasyprint import HTML  # type: ignore
+
 from fastapi import APIRouter, HTTPException, Query, Request, status
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
 
 from app.core.config import get_settings
 from app.features.orders import routes as orders_routes
@@ -27,6 +31,149 @@ def _main():
     from app import main as main_module
 
     return main_module
+
+
+def _format_money(value: Any) -> str:
+    try:
+        amount = Decimal(str(value or "0"))
+    except Exception:
+        amount = Decimal("0")
+    return f"${amount:,.2f}"
+
+
+def _format_pdf_date(value: Any) -> str:
+    if not value:
+        return "—"
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value)
+        except ValueError:
+            return escape(value)
+    if isinstance(value, datetime):
+        return value.strftime("%d %b %Y")
+    return escape(str(value))
+
+
+def _absolute_asset_url(request: Request, url: str | None) -> str | None:
+    if not url:
+        return None
+    text = str(url).strip()
+    if not text:
+        return None
+    if text.startswith(("http://", "https://", "data:")):
+        return text
+    return f"{str(request.base_url).rstrip('/')}/{text.lstrip('/')}"
+
+
+def _build_quote_pdf_html(
+    *,
+    request: Request,
+    company: dict[str, Any] | None,
+    quote: dict[str, Any],
+    items: list[dict[str, Any]],
+    include_line_images: bool,
+) -> str:
+    quote_number = escape(str(quote.get("quote_number") or ""))
+    company_name = escape(str((company or {}).get("name") or ""))
+    quote_name = escape(str(quote.get("name") or ""))
+    po_number = escape(str(quote.get("po_number") or ""))
+    subtotal = sum(Decimal(str(item.get("price") or "0")) * int(item.get("quantity") or 0) for item in items)
+
+    image_header = '<th class="thumb-col">Image</th>' if include_line_images else ""
+    rows = []
+    for item in items:
+        qty = int(item.get("quantity") or 0)
+        unit_price = Decimal(str(item.get("price") or "0"))
+        line_total = unit_price * qty
+        image_cell = ""
+        if include_line_images:
+            image_url = _absolute_asset_url(request, item.get("image_url"))
+            image_cell = (
+                f'<td class="thumb-col"><img class="line-thumb" src="{escape(image_url, quote=True)}" alt=""></td>'
+                if image_url else '<td class="thumb-col text-muted">—</td>'
+            )
+        rows.append(
+            "<tr>"
+            f"{image_cell}"
+            f"<td><strong>{escape(str(item.get('product_name') or 'Product'))}</strong><br>"
+            f"<span class='muted'>SKU: {escape(str(item.get('sku') or '—'))}</span></td>"
+            f"<td class='num'>{qty}</td>"
+            f"<td class='num'>{_format_money(unit_price)}</td>"
+            f"<td class='num'>{_format_money(line_total)}</td>"
+            "</tr>"
+        )
+
+    detail_pages = []
+    for item in items:
+        image_url = _absolute_asset_url(request, item.get("image_url"))
+        image_html = (
+            f'<img class="detail-image" src="{escape(image_url, quote=True)}" alt="">'
+            if image_url else '<div class="image-placeholder">No image available</div>'
+        )
+        description = escape(str(item.get("description") or "No description available."))
+        detail_pages.append(
+            "<section class='product-page page-break'>"
+            "<p class='eyebrow'>Product Details</p>"
+            f"<h1>{escape(str(item.get('product_name') or 'Product'))}</h1>"
+            f"{image_html}"
+            f"<div class='description'>{description.replace(chr(10), '<br>')}</div>"
+            "</section>"
+        )
+
+    return f"""
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    @page {{ size: A4; margin: 18mm; }}
+    body {{ color: #172033; font-family: Arial, sans-serif; font-size: 11px; line-height: 1.4; }}
+    h1, h2, p {{ margin: 0; }}
+    .hero {{ border-bottom: 3px solid #2563eb; display: flex; justify-content: space-between; margin-bottom: 22px; padding-bottom: 18px; }}
+    .eyebrow {{ color: #2563eb; font-size: 10px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }}
+    .hero h1 {{ font-size: 32px; margin-top: 4px; }}
+    .meta {{ background: #f4f7fb; border-radius: 10px; padding: 14px; width: 220px; }}
+    .meta div {{ display: flex; justify-content: space-between; margin: 5px 0; }}
+    .section-title {{ font-size: 16px; margin: 20px 0 8px; }}
+    table {{ border-collapse: collapse; width: 100%; }}
+    th {{ background: #172033; color: white; font-size: 10px; letter-spacing: .04em; padding: 9px; text-align: left; text-transform: uppercase; }}
+    td {{ border-bottom: 1px solid #e4e8ef; padding: 9px; vertical-align: top; }}
+    .num {{ text-align: right; white-space: nowrap; }}
+    .muted, .text-muted {{ color: #6b7280; }}
+    .thumb-col {{ width: 58px; }}
+    .line-thumb {{ border: 1px solid #e5e7eb; border-radius: 6px; max-height: 42px; max-width: 52px; object-fit: contain; }}
+    .totals {{ margin-left: auto; margin-top: 18px; width: 260px; }}
+    .totals div {{ display: flex; justify-content: space-between; padding: 8px 0; }}
+    .grand {{ border-top: 2px solid #172033; font-size: 16px; font-weight: 700; }}
+    .page-break {{ page-break-before: always; }}
+    .product-page h1 {{ font-size: 26px; margin: 6px 0 16px; }}
+    .detail-image {{ border: 1px solid #e5e7eb; border-radius: 12px; display: block; max-height: 290px; max-width: 100%; object-fit: contain; padding: 12px; }}
+    .image-placeholder {{ background: #f4f7fb; border-radius: 12px; color: #6b7280; padding: 50px; text-align: center; }}
+    .description {{ font-size: 12px; margin-top: 18px; }}
+  </style>
+</head>
+<body>
+  <section>
+    <div class="hero">
+      <div><p class="eyebrow">Quote</p><h1>{quote_number}</h1><p>{quote_name}</p></div>
+      <div class="meta">
+        <div><span>Company</span><strong>{company_name or '—'}</strong></div>
+        <div><span>Created</span><strong>{_format_pdf_date(quote.get('created_at'))}</strong></div>
+        <div><span>Expires</span><strong>{_format_pdf_date(quote.get('expires_at'))}</strong></div>
+        <div><span>PO</span><strong>{po_number or '—'}</strong></div>
+      </div>
+    </div>
+    <h2 class="section-title">Quote Items</h2>
+    <table>
+      <thead><tr>{image_header}<th>Product</th><th class="num">Qty</th><th class="num">Unit</th><th class="num">Total</th></tr></thead>
+      <tbody>{''.join(rows)}</tbody>
+    </table>
+    <div class="totals"><div class="grand"><span>Total</span><span>{_format_money(subtotal)}</span></div></div>
+  </section>
+  {''.join(detail_pages)}
+</body>
+</html>
+"""
 
 
 @router.get("/quotes", response_class=HTMLResponse)
@@ -136,6 +283,52 @@ async def quotes_page(
         "filters_active": bool(status_key),
     }
     return await main_module._render_template("shop/quotes.html", request, user, extra=extra)
+
+
+@router.get(
+    "/quotes/export/{quote_number}",
+    response_class=Response,
+    name="export_quote_pdf",
+    include_in_schema=False,
+)
+async def export_quote_pdf(
+    request: Request,
+    quote_number: str,
+    with_images: bool = Query(False, alias="withImages"),
+) -> Response:
+    main_module = _main()
+    (
+        user,
+        membership,
+        company,
+        company_id,
+        redirect,
+    ) = await main_module._load_company_section_context(
+        request,
+        permission_field="can_access_quotes",
+    )
+    if redirect:
+        return redirect
+
+    quote_summary = await shop_repo.get_quote_summary(quote_number, company_id)
+    quote_items = await shop_repo.list_quote_items(quote_number, company_id)
+    if not quote_summary or not quote_items:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
+
+    html = _build_quote_pdf_html(
+        request=request,
+        company=company,
+        quote=quote_summary,
+        items=quote_items,
+        include_line_images=with_images,
+    )
+    pdf_bytes = HTML(string=html, base_url=str(request.base_url)).write_pdf()
+    filename = f"{quote_number}-{'with-images' if with_images else 'no-images'}.pdf"
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.post(

--- a/app/templates/shop/quotes.html
+++ b/app/templates/shop/quotes.html
@@ -95,7 +95,7 @@
         <tbody>
           {% for quote in quotes %}
             {% set is_admin = is_company_admin|default(false) %}
-            {% set has_actions = (not quote.is_expired) or is_admin %}
+            {% set has_actions = true %}
             <tr data-status="{{ quote.status_value }}">
               <td data-label="Quote">
                 <button type="button" class="button-link" data-quote-view data-quote-number="{{ quote.quote_number }}" data-company-id="{{ quote.company_id }}">
@@ -154,6 +154,12 @@
                           </li>
                         {% endif %}
                       {% endif %}
+                      <li class="header-title-menu__item" role="none">
+                        <a class="header-title-menu__link" role="menuitem" href="/quotes/export/{{ quote.quote_number }}?withImages=false">Export Quote (no images)</a>
+                      </li>
+                      <li class="header-title-menu__item" role="none">
+                        <a class="header-title-menu__link" role="menuitem" href="/quotes/export/{{ quote.quote_number }}?withImages=true">Export Quote (with images)</a>
+                      </li>
                       {% if is_admin %}
                         <li class="header-title-menu__item" role="none">
                           <button


### PR DESCRIPTION
### Motivation
- Provide an Export Quote action that generates a PDF from a saved quote using the requested visual template and include optional line-item thumbnails. 
- Include follow-on Product Details pages in the generated PDF containing product name, image and description.

### Description
- Added helper functions and an HTML generator in `app/features/quotes/routes.py` to build the quote PDF markup, format money/dates, resolve absolute asset URLs, and render product detail pages for each line item. 
- Added a new route `GET /quotes/export/{quote_number}` (query param `withImages`) which renders the HTML and returns a downloadable PDF using WeasyPrint; the route returns `application/pdf` with a descriptive filename. 
- Updated the quotes list template `app/templates/shop/quotes.html` to add two row actions: “Export Quote (no images)” and “Export Quote (with images)”, and made actions visible so the export options are available for all quotes (including expired). 
- Implemented thumbnail support for line items when `withImages=true`, and product detail pages always include product image (or a placeholder) and description.

### Testing
- Compiled the modified module with `python -m compileall app/features/quotes/routes.py`, which succeeded. 
- Ran `git diff --check` to ensure no whitespace/patch issues, which reported no problems. 
- Attempted to exercise the runtime helper via an inline Python import, but execution was blocked by missing required environment settings (`SESSION_SECRET` and `TOTP_ENCRYPTION_KEY`), preventing further runtime invocation in the local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a547164534c8332972001b9a9c3c19a)