### PR TITLE
Allow quote carts with out-of-stock items

### DIFF
--- a/app/features/cart/routes.py
+++ b/app/features/cart/routes.py
@@ -165,15 +165,6 @@ async def add_to_cart(request: Request) -> RedirectResponse:
                 selected_upgrade_source = candidate
                 break
 
-    available_stock = int(product.get("stock") or 0)
-    if available_stock <= 0 or existing_quantity + requested_quantity > available_stock:
-        remaining = max(available_stock - existing_quantity, 0)
-        message = quote(f"Cannot add item. Only {remaining} left in stock.")
-        return RedirectResponse(
-            url=f"{request.url_for('cart_page')}?cartError={message}",
-            status_code=status.HTTP_303_SEE_OTHER,
-        )
-
     unit_price = main_module.shop_service.get_product_price(product, is_vip=is_vip)
     new_quantity = existing_quantity + requested_quantity
 
@@ -245,7 +236,7 @@ async def add_package_to_cart(request: Request) -> RedirectResponse:
         is_vip=is_vip,
     )
     selected_package = next((pkg for pkg in packages if int(pkg.get("id") or 0) == package_id), None)
-    if not selected_package or not selected_package.get("is_available"):
+    if not selected_package or selected_package.get("archived") or selected_package.get("is_restricted"):
         message = quote("Selected package is not currently available.")
         return RedirectResponse(
             url=f"{request.url_for('shop_packages_page')}?cart_error={message}",
@@ -298,19 +289,8 @@ async def add_package_to_cart(request: Request) -> RedirectResponse:
                 status_code=status.HTTP_303_SEE_OTHER,
             )
 
-        stock_available = int(product.get("stock") or 0)
         existing_item = await main_module.cart_repo.get_item(session.id, product_id)
         existing_quantity = existing_item.get("quantity") if existing_item else 0
-        if stock_available <= 0 or existing_quantity + required_quantity > stock_available:
-            remaining = max(stock_available - existing_quantity, 0)
-            product_name = str(product.get("name") or "the product")
-            message = quote(
-                f"Cannot add package. {product_name} has only {remaining} left in stock."
-            )
-            return RedirectResponse(
-                url=f"{request.url_for('shop_packages_page')}?cart_error={message}",
-                status_code=status.HTTP_303_SEE_OTHER,
-            )
 
         unit_price = main_module.shop_service.get_product_price(product, is_vip=is_vip)
         new_quantity = existing_quantity + required_quantity
@@ -764,23 +744,6 @@ async def update_cart_items(request: Request) -> RedirectResponse:
             removals.add(product_id)
             continue
 
-        raw_stock = product.get("stock")
-        try:
-            available_stock = int(raw_stock)
-        except (TypeError, ValueError):
-            available_stock = 0
-
-        if available_stock <= 0:
-            stock_conflicts.add(product_id)
-            removals.add(product_id)
-            invalid_entries = True
-            continue
-
-        if desired_quantity > available_stock:
-            stock_conflicts.add(product_id)
-            invalid_entries = True
-            continue
-
         await main_module.cart_repo.update_item_quantity(
             session_id=session.id,
             product_id=product_id,
@@ -943,6 +906,39 @@ async def place_order(request: Request) -> RedirectResponse:
     items = await main_module.cart_repo.list_items(session.id)
     if not items:
         return RedirectResponse(url=request.url_for("cart_page"), status_code=status.HTTP_303_SEE_OTHER)
+
+    out_of_stock_names: list[str] = []
+    for item in items:
+        try:
+            product_id = int(item.get("product_id") or 0)
+            quantity = int(item.get("quantity") or 0)
+        except (TypeError, ValueError):
+            continue
+        product = await main_module.shop_repo.get_product_by_id(
+            product_id,
+            company_id=company_id,
+        )
+        if not product:
+            out_of_stock_names.append(str(item.get("product_name") or "an unavailable item"))
+            continue
+        try:
+            available_stock = int(product.get("stock") or 0)
+        except (TypeError, ValueError):
+            available_stock = 0
+        if available_stock <= 0 or quantity > available_stock:
+            out_of_stock_names.append(str(product.get("name") or item.get("product_name") or "an item"))
+
+    if out_of_stock_names:
+        unique_names = sorted({name for name in out_of_stock_names if name})
+        if len(unique_names) == 1:
+            stock_message = f"Cannot place order because {unique_names[0]} is out of stock or exceeds available stock. You can still save the cart as a quote."
+        else:
+            stock_message = "Cannot place order because some cart items are out of stock or exceed available stock: " + ", ".join(unique_names) + ". You can still save the cart as a quote."
+        message = quote(stock_message)
+        return RedirectResponse(
+            url=f"{request.url_for('cart_page')}?orderMessage={message}",
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
 
     order_number = "ORD" + "".join(secrets.choice("0123456789") for _ in range(12))
 

--- a/app/static/js/shop.js
+++ b/app/static/js/shop.js
@@ -203,9 +203,8 @@
     quantity.type = 'number';
     quantity.name = 'quantity';
     quantity.min = '1';
-    quantity.max = String(stock);
+    quantity.max = '9999';
     quantity.value = '1';
-    quantity.setAttribute('data-stock-limit', String(stock));
     form.appendChild(quantity);
 
     const button = document.createElement('button');

--- a/app/templates/shop/cart.html
+++ b/app/templates/shop/cart.html
@@ -76,7 +76,7 @@
                 <td data-label="Unit price" data-value="{{ item.unit_price }}">${{ '%.2f'|format(item.unit_price) }}</td>
                 <td data-label="Quantity" data-value="{{ item.quantity }}">
                   {% set available = item.available_stock | default(0) | int %}
-                  {% set max_allowed = available if available > item.quantity else item.quantity %}
+                  {% set max_allowed = 9999 %}
                   <div class="cart-quantity">
                     {{ stock_helpers.stock_status_badge(available, low_stock_threshold) }}
                     <input
@@ -88,7 +88,6 @@
                       name="quantity_{{ item.product_id }}"
                       value="{{ item.quantity }}"
                       aria-label="Quantity for {{ item.product_name }}"
-                      data-stock-limit="{{ available }}"
                       required
                     />
                   </div>

--- a/app/templates/shop/index.html
+++ b/app/templates/shop/index.html
@@ -180,16 +180,14 @@
               {% set has_active_subscription = is_subscription and product.id in active_subscription_product_ids %}
               {% if has_active_subscription %}
                 <a href="/subscriptions" class="button button--primary">Manage</a>
-              {% elif product.stock > 0 and cart_allowed %}
+              {% elif cart_allowed %}
                 <form action="{{ '/cart/add-package' if product.is_package else '/cart/add' }}" method="post" class="inline-form shop-product-card__cart">
                   {% include "partials/csrf.html" %}
                   <input type="hidden" name="{{ 'packageId' if product.is_package else 'productId' }}" value="{{ product.id }}" />
                   <label class="visually-hidden" for="quantity-{{ 'package' if product.is_package else 'product' }}-{{ product.id }}">Quantity for {{ product.name }}</label>
-                  <input class="form-input form-input--sm" id="quantity-{{ 'package' if product.is_package else 'product' }}-{{ product.id }}" type="number" name="quantity" min="1" max="{{ product.stock }}" value="1" data-stock-limit="{{ product.stock }}" />
+                  <input class="form-input form-input--sm" id="quantity-{{ 'package' if product.is_package else 'product' }}-{{ product.id }}" type="number" name="quantity" min="1" max="9999" value="1" />
                   <button type="submit" class="button">Add</button>
                 </form>
-              {% elif product.stock <= 0 %}
-                <span class="badge badge--danger">Out Of Stock</span>
               {% endif %}
             </div>
           </article>

--- a/app/templates/shop/packages.html
+++ b/app/templates/shop/packages.html
@@ -103,8 +103,7 @@
               </td>
               <td class="table__actions">
                 <div class="table__action-buttons">
-                  {% if package.stock_level > 0 %}
-                    {% if cart_allowed %}
+                  {% if cart_allowed %}
                       <form action="/cart/add-package" method="post" class="inline-form">
                         {% include "partials/csrf.html" %}
                         <input type="hidden" name="packageId" value="{{ package.id }}" />
@@ -115,15 +114,11 @@
                           type="number"
                           name="quantity"
                           min="1"
-                          max="{{ package.stock_level }}"
+                          max="9999"
                           value="1"
-                          data-stock-limit="{{ package.stock_level }}"
                         />
                         <button type="submit" class="button">Add to cart</button>
                       </form>
-                    {% endif %}
-                  {% else %}
-                    <span class="badge badge--muted">Out of stock</span>
                   {% endif %}
                 </div>
               </td>

--- a/tests/test_cart_update.py
+++ b/tests/test_cart_update.py
@@ -187,7 +187,7 @@ def test_update_cart_zero_quantity_removes_item(monkeypatch, active_session, car
     assert recorded_removals == [(active_session.id, {7})]
 
 
-def test_update_cart_exceeds_stock(monkeypatch, active_session, cart_context):
+def test_update_cart_exceeds_stock_allows_quote_quantity(monkeypatch, active_session, cart_context):
     recorded_updates: list[tuple[int, int, int]] = []
     recorded_removals: list[tuple[int, set[int]]] = []
 
@@ -225,12 +225,53 @@ def test_update_cart_exceeds_stock(monkeypatch, active_session, cart_context):
     assert response.status_code == 303
     location = response.headers.get("location")
     params = parse_qs(urlparse(location).query)
-    assert params.get("cartError") == [
-        "Unable to increase some quantities due to limited stock."
-    ]
-    assert "cartMessage" not in params
-    assert recorded_updates == []
+    assert params.get("cartMessage") == ["Quantities updated."]
+    assert "cartError" not in params
+    assert recorded_updates == [(active_session.id, 9, 5)]
     assert recorded_removals == []
+
+
+def test_place_order_blocks_out_of_stock_cart_item(monkeypatch, active_session, cart_context):
+    create_order_calls: list[int] = []
+
+    async def fake_list_items(session_id):
+        return [
+            {
+                "product_id": 5,
+                "quantity": 3,
+                "unit_price": "25.00",
+                "product_name": "Widget",
+                "product_sku": "WID-001",
+            }
+        ]
+
+    async def fake_get_product_by_id(product_id, company_id=None):
+        return {"id": product_id, "stock": 0, "name": "Widget"}
+
+    async def fake_create_order(**kwargs):
+        create_order_calls.append(int(kwargs["product_id"]))
+        return 0, 0
+
+    monkeypatch.setattr(main_module.cart_repo, "list_items", fake_list_items)
+    monkeypatch.setattr(main_module.shop_repo, "get_product_by_id", fake_get_product_by_id)
+    monkeypatch.setattr(main_module.shop_repo, "create_order", fake_create_order)
+
+    with TestClient(app, follow_redirects=False) as client:
+        response = client.post(
+            "/cart/place-order",
+            data={"_csrf": active_session.csrf_token},
+        )
+
+    assert response.status_code == 303
+    location = response.headers.get("location")
+    assert location is not None
+    parsed = urlparse(location)
+    assert parsed.path == "/cart"
+    params = parse_qs(parsed.query)
+    assert params.get("orderMessage") == [
+        "Cannot place order because Widget is out of stock or exceeds available stock. You can still save the cart as a quote."
+    ]
+    assert create_order_calls == []
 
 
 def test_add_to_cart_redirects_to_cart(monkeypatch, active_session, cart_context):


### PR DESCRIPTION
### Motivation
- Enable users to add products to their cart and adjust quantities even when catalog stock is zero so carts can be used to generate quotes. 
- Ensure orders cannot be placed from `/cart` when any cart item is out of stock or exceeds available stock to prevent accidental purchases of unavailable items.

### Description
- Removed immediate stock checks from `add_to_cart` and `add_package_to_cart` so adding items and package components no longer rejects out-of-stock quantities and preserves subscription/product availability checks. 
- Relaxed `update_cart_items` stock validation to allow increasing quantities above current stock so quote flows can store desired quantities. 
- Added server-side validation in `place_order` to block order placement when any cart line is unavailable or exceeds available stock, returning an `orderMessage` that the cart can still be saved as a quote. 
- Adjusted UI and client code to stop enforcing live stock limits before add/update: product and package add forms and cart quantity inputs no longer cap `max` to product stock and related `data-stock-limit` attributes were removed or set to a high cap (`9999`), and `app/static/js/shop.js` modal quantity max updated accordingly. 
- Added/updated focused tests in `tests/test_cart_update.py` to cover quote-friendly updates and blocking order placement for out-of-stock cart items.

### Testing
- Compiled modified module with `python -m py_compile app/features/cart/routes.py`, which succeeded. 
- Ran targeted tests with `pytest tests/test_cart_update.py::test_update_cart_exceeds_stock_allows_quote_quantity tests/test_cart_update.py::test_place_order_blocks_out_of_stock_cart_item -q`, and both tests passed. 
- Ran the full `tests/test_cart_update.py` after installing `libmagic1`; the run produced 9 passing tests and 1 failure due to an existing unrelated `RecursionError` in `test_remove_cart_items_none` during `TestClient` startup (this appears to be an upstream test environment/startup issue and not caused by the changes here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5475ab7e048332b11aa08de026f91c)