### PR TITLE
Fix quote PDF layout and product detail rendering (sanitize HTML, enable iframes, remove image column)

### DIFF
--- a/app/features/quotes/routes.py
+++ b/app/features/quotes/routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import secrets
+import re
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from html import escape
@@ -21,7 +22,7 @@ from app.repositories import cart as cart_repo
 from app.repositories import shop as shop_repo
 from app.repositories import users as user_repo
 from app.security.session import session_manager
-
+from app.services.sanitization import sanitize_rich_text
 
 router = APIRouter(tags=["Quotes"])
 
@@ -77,24 +78,18 @@ def _build_quote_pdf_html(
     company_name = escape(str((company or {}).get("name") or ""))
     quote_name = escape(str(quote.get("name") or ""))
     po_number = escape(str(quote.get("po_number") or ""))
-    subtotal = sum(Decimal(str(item.get("price") or "0")) * int(item.get("quantity") or 0) for item in items)
+    subtotal = sum(
+        Decimal(str(item.get("price") or "0")) * int(item.get("quantity") or 0)
+        for item in items
+    )
 
-    image_header = '<th class="thumb-col">Image</th>' if include_line_images else ""
     rows = []
     for item in items:
         qty = int(item.get("quantity") or 0)
         unit_price = Decimal(str(item.get("price") or "0"))
         line_total = unit_price * qty
-        image_cell = ""
-        if include_line_images:
-            image_url = _absolute_asset_url(request, item.get("image_url"))
-            image_cell = (
-                f'<td class="thumb-col"><img class="line-thumb" src="{escape(image_url, quote=True)}" alt=""></td>'
-                if image_url else '<td class="thumb-col text-muted">—</td>'
-            )
         rows.append(
             "<tr>"
-            f"{image_cell}"
             f"<td><strong>{escape(str(item.get('product_name') or 'Product'))}</strong><br>"
             f"<span class='muted'>SKU: {escape(str(item.get('sku') or '—'))}</span></td>"
             f"<td class='num'>{qty}</td>"
@@ -103,20 +98,44 @@ def _build_quote_pdf_html(
             "</tr>"
         )
 
+    def _absolutise_rich_text_assets(html_value: str) -> str:
+        def replace_src(match: re.Match[str]) -> str:
+            src = _absolute_asset_url(request, match.group(2))
+            if not src:
+                return match.group(0)
+            return f"{match.group(1)}{escape(src, quote=True)}{match.group(3)}"
+
+        return re.sub(
+            r"(<(?:img|iframe)\b[^>]*?\bsrc=[\"\'])(.*?)([\"\'])",
+            replace_src,
+            html_value,
+            flags=re.IGNORECASE,
+        )
+
     detail_pages = []
     for item in items:
-        image_url = _absolute_asset_url(request, item.get("image_url"))
+        image_url = (
+            _absolute_asset_url(request, item.get("image_url"))
+            if include_line_images
+            else None
+        )
         image_html = (
             f'<img class="detail-image" src="{escape(image_url, quote=True)}" alt="">'
-            if image_url else '<div class="image-placeholder">No image available</div>'
+            if image_url
+            else '<div class="image-placeholder">No image available</div>'
         )
-        description = escape(str(item.get("description") or "No description available."))
+        sanitized_description = sanitize_rich_text(str(item.get("description") or ""))
+        description = (
+            _absolutise_rich_text_assets(sanitized_description.html)
+            if sanitized_description.html
+            else "<p>No description available.</p>"
+        )
         detail_pages.append(
             "<section class='product-page page-break'>"
             "<p class='eyebrow'>Product Details</p>"
             f"<h1>{escape(str(item.get('product_name') or 'Product'))}</h1>"
             f"{image_html}"
-            f"<div class='description'>{description.replace(chr(10), '<br>')}</div>"
+            f"<div class='description rich-text-viewer'>{description}</div>"
             "</section>"
         )
 
@@ -131,7 +150,7 @@ def _build_quote_pdf_html(
     h1, h2, p {{ margin: 0; }}
     .hero {{ border-bottom: 3px solid #2563eb; display: flex; justify-content: space-between; margin-bottom: 22px; padding-bottom: 18px; }}
     .eyebrow {{ color: #2563eb; font-size: 10px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }}
-    .hero h1 {{ font-size: 32px; margin-top: 4px; }}
+    .hero h1 {{ font-size: 22px; margin-top: 4px; overflow-wrap: anywhere; }}
     .meta {{ background: #f4f7fb; border-radius: 10px; padding: 14px; width: 220px; }}
     .meta div {{ display: flex; justify-content: space-between; margin: 5px 0; }}
     .section-title {{ font-size: 16px; margin: 20px 0 8px; }}
@@ -150,6 +169,10 @@ def _build_quote_pdf_html(
     .detail-image {{ border: 1px solid #e5e7eb; border-radius: 12px; display: block; max-height: 290px; max-width: 100%; object-fit: contain; padding: 12px; }}
     .image-placeholder {{ background: #f4f7fb; border-radius: 12px; color: #6b7280; padding: 50px; text-align: center; }}
     .description {{ font-size: 12px; margin-top: 18px; }}
+    .description p {{ margin: 0 0 8px; }}
+    .description ul, .description ol {{ margin: 0 0 8px 18px; padding: 0; }}
+    .description img {{ max-height: 240px; max-width: 100%; object-fit: contain; }}
+    .description iframe {{ border: 1px solid #e5e7eb; min-height: 260px; width: 100%; }}
   </style>
 </head>
 <body>
@@ -165,7 +188,7 @@ def _build_quote_pdf_html(
     </div>
     <h2 class="section-title">Quote Items</h2>
     <table>
-      <thead><tr>{image_header}<th>Product</th><th class="num">Qty</th><th class="num">Unit</th><th class="num">Total</th></tr></thead>
+      <thead><tr><th>Product</th><th class="num">Qty</th><th class="num">Unit</th><th class="num">Total</th></tr></thead>
       <tbody>{''.join(rows)}</tbody>
     </table>
     <div class="totals"><div class="grand"><span>Total</span><span>{_format_money(subtotal)}</span></div></div>
@@ -248,7 +271,10 @@ async def quotes_page(
         enriched_quotes.append(record)
 
     status_options = sorted(
-        {(record["status_value"], record["status_label"]) for record in enriched_quotes},
+        {
+            (record["status_value"], record["status_label"])
+            for record in enriched_quotes
+        },
         key=lambda item: item[1].lower(),
     )
 
@@ -282,7 +308,9 @@ async def quotes_page(
         "quotes_total_all": total_quotes,
         "filters_active": bool(status_key),
     }
-    return await main_module._render_template("shop/quotes.html", request, user, extra=extra)
+    return await main_module._render_template(
+        "shop/quotes.html", request, user, extra=extra
+    )
 
 
 @router.get(
@@ -313,7 +341,9 @@ async def export_quote_pdf(
     quote_summary = await shop_repo.get_quote_summary(quote_number, company_id)
     quote_items = await shop_repo.list_quote_items(quote_number, company_id)
     if not quote_summary or not quote_items:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found"
+        )
 
     html = _build_quote_pdf_html(
         request=request,
@@ -420,26 +450,36 @@ async def save_as_quote(request: Request) -> RedirectResponse:
     if not session:
         return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
     if company_id is None:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No active company selected")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="No active company selected"
+        )
 
     form = await request.form()
     po_number_raw = form.get("poNumber")
-    po_number = (str(po_number_raw).strip() or None) if po_number_raw is not None else None
+    po_number = (
+        (str(po_number_raw).strip() or None) if po_number_raw is not None else None
+    )
     if po_number and len(po_number) > 100:
         po_number = po_number[:100]
 
     quote_name_raw = form.get("quoteName")
-    quote_name = (str(quote_name_raw).strip() or None) if quote_name_raw is not None else None
+    quote_name = (
+        (str(quote_name_raw).strip() or None) if quote_name_raw is not None else None
+    )
     if quote_name and len(quote_name) > 255:
         quote_name = quote_name[:255]
 
     items = await cart_repo.list_items(session.id)
     if not items:
-        return RedirectResponse(url=request.url_for("cart_page"), status_code=status.HTTP_303_SEE_OTHER)
+        return RedirectResponse(
+            url=request.url_for("cart_page"), status_code=status.HTTP_303_SEE_OTHER
+        )
 
     quote_number = "QUO" + "".join(secrets.choice("0123456789") for _ in range(12))
 
-    expires_at = datetime.now(timezone.utc) + timedelta(days=get_settings().quote_expiry_days)
+    expires_at = datetime.now(timezone.utc) + timedelta(
+        days=get_settings().quote_expiry_days
+    )
 
     for item in items:
         await shop_repo.create_quote(

--- a/app/services/sanitization.py
+++ b/app/services/sanitization.py
@@ -8,49 +8,64 @@ from typing import Mapping
 
 import nh3
 
-_ALLOWED_TAGS: frozenset[str] = frozenset((
-    "a",
-    "b",
-    "blockquote",
-    "br",
-    "code",
-    "img",
-    "div",
-    "em",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "hr",
-    "i",
-    "li",
-    "ol",
-    "p",
-    "pre",
-    "span",
-    "strong",
-    "sub",
-    "sup",
-    "table",
-    "tbody",
-    "td",
-    "th",
-    "thead",
-    "tr",
-    "u",
-    "ul",
-))
+_ALLOWED_TAGS: frozenset[str] = frozenset(
+    (
+        "a",
+        "b",
+        "blockquote",
+        "br",
+        "code",
+        "img",
+        "div",
+        "em",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "hr",
+        "i",
+        "iframe",
+        "li",
+        "ol",
+        "p",
+        "pre",
+        "span",
+        "strong",
+        "sub",
+        "sup",
+        "table",
+        "tbody",
+        "td",
+        "th",
+        "thead",
+        "tr",
+        "u",
+        "ul",
+    )
+)
 
 _ALLOWED_ATTRIBUTES: dict[str, set[str]] = {
     "a": {"href", "title", "target"},
     "img": {"src", "alt", "title", "width", "height", "loading", "decoding"},
+    "iframe": {
+        "src",
+        "title",
+        "width",
+        "height",
+        "loading",
+        "allow",
+        "allowfullscreen",
+        "referrerpolicy",
+    },
     "span": {"data-mention"},
     "table": {"role"},
 }
 
-_ALLOWED_PROTOCOLS: frozenset[str] = frozenset(("http", "https", "mailto", "tel", "data"))
+_ALLOWED_PROTOCOLS: frozenset[str] = frozenset(
+    ("http", "https", "mailto", "tel", "data")
+)
 
 _STYLE_BLOCK_PATTERN = re.compile(r"(?is)<style.*?>.*?</style>")
 _INLINE_CSS_PATTERN = re.compile(r"(?is)^(?:\s*[a-z0-9._#-]+\s*\{[^}]*\}\s*)+")
@@ -93,7 +108,9 @@ def _strip_quoted_email_headers(value: str) -> str:
             # metadata such as Subject, Sent, or Date. This avoids trimming legitimate
             # content (e.g. voicemail summaries) that happen to include simple From/To
             # lines within the body.
-            if header_hits >= 2 and header_prefixes.intersection({"subject", "sent", "date"}):
+            if header_hits >= 2 and header_prefixes.intersection(
+                {"subject", "sent", "date"}
+            ):
                 return "\n".join(lines[:idx]).rstrip()
     return value
 
@@ -127,11 +144,15 @@ def sanitize_rich_text(value: str | None) -> SanitizedRichText:
     else:
         html_value = ""
     text_content = nh3.clean(html_value, tags=frozenset()).strip()
-    contains_media = bool(re.search(r"<img\b[^>]*\bsrc=", html_value, flags=re.IGNORECASE))
+    contains_media = bool(
+        re.search(r"<(?:img|iframe)\b[^>]*\bsrc=", html_value, flags=re.IGNORECASE)
+    )
     if not text_content and not contains_media:
         html_value = ""
     has_content = bool(text_content) or contains_media
-    return SanitizedRichText(html=html_value, text_content=text_content, has_rich_content=has_content)
+    return SanitizedRichText(
+        html=html_value, text_content=text_content, has_rich_content=has_content
+    )
 
 
 __all__ = ["SanitizedRichText", "sanitize_rich_text"]

--- a/app/services/shop_packages.py
+++ b/app/services/shop_packages.py
@@ -4,6 +4,7 @@ from decimal import Decimal, ROUND_HALF_UP
 from typing import Any, Sequence
 
 from app.repositories import shop as shop_repo
+from app.services.sanitization import sanitize_rich_text
 
 
 def _quantise_price(value: Decimal) -> Decimal:
@@ -35,6 +36,9 @@ def _build_product_candidate(
         "product_vendor_sku": source.get("product_vendor_sku"),
         "product_image_url": source.get("product_image_url"),
         "product_description": source.get("product_description"),
+        "product_description_html": sanitize_rich_text(
+            str(source.get("product_description") or "")
+        ).html,
         "product_archived": bool(source.get("product_archived")),
         "priority": priority,
         "substitution_type": substitution_type,
@@ -42,7 +46,9 @@ def _build_product_candidate(
     price = source.get("product_price")
     candidate["product_price"] = _to_decimal(price)
     vip_price = source.get("product_vip_price")
-    candidate["product_vip_price"] = None if vip_price is None else _to_decimal(vip_price)
+    candidate["product_vip_price"] = (
+        None if vip_price is None else _to_decimal(vip_price)
+    )
     stock_value = source.get("product_stock")
     try:
         candidate["product_stock"] = int(stock_value)
@@ -114,6 +120,9 @@ def _prepare_package_items(
             available_per_package = 0
 
         prepared_item = dict(item)
+        prepared_item["product_description_html"] = sanitize_rich_text(
+            str(item.get("product_description") or "")
+        ).html
         prepared_item["quantity"] = quantity
         prepared_item["primary_product"] = primary_candidate
         prepared_item["resolved_product"] = selected
@@ -155,7 +164,9 @@ def _compute_package_metrics(
         if (
             resolved_archived
             or resolved_restricted
-            or (restricted_product_ids and resolved_product_id in restricted_product_ids)
+            or (
+                restricted_product_ids and resolved_product_id in restricted_product_ids
+            )
         ):
             restricted = True
 
@@ -178,7 +189,9 @@ def _compute_package_metrics(
     return _quantise_price(running_total), stock_level, restricted
 
 
-async def load_admin_packages(*, include_archived: bool = False) -> list[dict[str, Any]]:
+async def load_admin_packages(
+    *, include_archived: bool = False
+) -> list[dict[str, Any]]:
     filters = shop_repo.PackageFilters(include_archived=include_archived)
     packages = await shop_repo.list_packages(filters)
     package_ids = [package["id"] for package in packages]

--- a/app/static/js/cart.js
+++ b/app/static/js/cart.js
@@ -181,6 +181,7 @@
     'hr',
     'i',
     'img',
+    'iframe',
     'li',
     'ol',
     'p',
@@ -202,6 +203,7 @@
   const RICH_TEXT_ALLOWED_ATTRIBUTES = {
     a: new Set(['href', 'title', 'target', 'rel']),
     img: new Set(['src', 'alt', 'title', 'width', 'height', 'loading', 'decoding']),
+    iframe: new Set(['src', 'title', 'width', 'height', 'loading', 'allow', 'allowfullscreen', 'referrerpolicy']),
     span: new Set(['data-mention']),
     table: new Set(['role']),
   };
@@ -242,6 +244,9 @@
       return;
     }
     if ((attributeName === 'width' || attributeName === 'height') && !/^\d{1,4}$/.test(value)) {
+      return;
+    }
+    if (attributeName === 'allowfullscreen' && value && !['allowfullscreen', 'true'].includes(value)) {
       return;
     }
     if (attributeName === 'target' && value !== '_blank') {

--- a/app/static/js/shop_packages.js
+++ b/app/static/js/shop_packages.js
@@ -215,21 +215,22 @@
       }
     }
 
-    if (item.product_description) {
+    const descriptionHtml = typeof item.product_description_html === 'string' ? item.product_description_html.trim() : '';
+    const descriptionText = typeof item.product_description === 'string' ? item.product_description.trim() : '';
+    if (descriptionHtml || descriptionText) {
       const descriptionTitle = document.createElement('h3');
       descriptionTitle.className = 'modal__subtitle';
       descriptionTitle.textContent = 'Description';
       container.appendChild(descriptionTitle);
 
-      item.product_description.split(/\r?\n/).forEach((line) => {
-        const trimmed = line.trim();
-        if (!trimmed) {
-          return;
-        }
-        const paragraph = document.createElement('p');
-        paragraph.textContent = trimmed;
-        container.appendChild(paragraph);
-      });
+      const descriptionDiv = document.createElement('div');
+      descriptionDiv.className = 'modal__description rich-text-viewer';
+      if (descriptionHtml) {
+        descriptionDiv.innerHTML = descriptionHtml;
+      } else {
+        descriptionDiv.textContent = descriptionText;
+      }
+      container.appendChild(descriptionDiv);
     }
   }
 
@@ -281,6 +282,8 @@
             resolved.product_image_url || item.product_image_url,
           product_description:
             resolved.product_description || item.product_description,
+          product_description_html:
+            resolved.product_description_html || item.product_description_html,
         };
         const key = `${packageId}:${itemId}`;
         itemsByKey.set(key, {


### PR DESCRIPTION
### Motivation
- Quote PDFs were displaying an oversized quote number and included an IMAGE column that shouldn't appear in the Quote Items table.  
- Product Details pages and PDF detail sections were showing raw HTML tags (not rendered), and embedded assets (images/iframes) were not being included or resolved for PDF export.  
- Package/product detail UI needed to display sanitized rich HTML consistently (instead of literal HTML text).  

### Description
- Reduced the visual size of the quote number heading and allowed wrapping so long `quote_number` values no longer dominate the PDF header (`app/features/quotes/routes.py`).  
- Removed the `IMAGE` column from the Quote Items table in the PDF export and only show product, qty, unit and total columns (`app/features/quotes/routes.py`).  
- Rendered product descriptions in the PDF Product Details pages as sanitized rich HTML and added logic to absolutise `img`/`iframe` `src` attributes for the PDF `base_url` so embedded media resolve in the generated PDF (`app/features/quotes/routes.py`).  
- Included product detail images in product detail pages when `withImages` is enabled and added CSS rules for rendering rich description elements (paragraphs, lists, images, iframes) in the PDF (`app/features/quotes/routes.py`).  
- Extended rich-text sanitiser to allow safe `iframe` tags and attributes and to treat iframe-only descriptions as valid media content (`app/services/sanitization.py`).  
- Added `product_description_html` (sanitised HTML) to package/product payloads and used it in the package product-details modal so HTML is rendered safely rather than shown as raw text (`app/services/shop_packages.py`, `app/static/js/shop_packages.js`).  
- Updated client-side rich-text handling to accept `iframe` elements and the necessary attributes and to render `product_description_html` into the product/package detail modals (`app/static/js/cart.js`, `app/static/js/shop_packages.js`).  

### Testing
- Formatted changed Python files with `python -m black app/features/quotes/routes.py app/services/sanitization.py app/services/shop_packages.py` and recompiled with `python -m compileall -q app/features/quotes app/services`, both completed successfully.  
- Performed a local smoke test of sanitisation to confirm `iframe` is preserved and `<script>` is stripped using `sanitize_rich_text(...)`, which succeeded.  
- Attempted to run `pytest tests/test_quotes_feature_pack.py tests/test_shop_optional_accessories.py -q`, but collection failed in the environment due to a missing system dependency (`libmagic`) required by `python-magic`; tests are therefore blocked in CI-like environment (not a code regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a547671952c833293128f6d7adbed11)