### PR TITLE
Add product links to shop products and quote PDFs

### DIFF
--- a/app/features/quotes/routes.py
+++ b/app/features/quotes/routes.py
@@ -130,12 +130,20 @@ def _build_quote_pdf_html(
             if sanitized_description.html
             else "<p>No description available.</p>"
         )
+        product_link = str(item.get("product_link") or "").strip()
+        product_link_html = (
+            "<p class='product-link'><strong>Product Link:</strong> "
+            f"<a href='{escape(product_link, quote=True)}'>{escape(product_link)}</a></p>"
+            if product_link
+            else ""
+        )
         detail_pages.append(
             "<section class='product-page page-break'>"
             "<p class='eyebrow'>Product Details</p>"
             f"<h1>{escape(str(item.get('product_name') or 'Product'))}</h1>"
             f"{image_html}"
             f"<div class='description rich-text-viewer'>{description}</div>"
+            f"{product_link_html}"
             "</section>"
         )
 
@@ -173,6 +181,8 @@ def _build_quote_pdf_html(
     .description ul, .description ol {{ margin: 0 0 8px 18px; padding: 0; }}
     .description img {{ max-height: 240px; max-width: 100%; object-fit: contain; }}
     .description iframe {{ border: 1px solid #e5e7eb; min-height: 260px; width: 100%; }}
+    .product-link {{ border-top: 1px solid #e5e7eb; font-size: 12px; margin-top: 18px; padding-top: 10px; overflow-wrap: anywhere; }}
+    .product-link a {{ color: #2563eb; }}
   </style>
 </head>
 <body>

--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -2017,6 +2017,7 @@ async def admin_create_shop_product(
     sku: str = Form(...),
     vendor_sku: str = Form(...),
     description: str | None = Form(default=None),
+    product_link: str | None = Form(default=None),
     price: str = Form(...),
     stock: str = Form(...),
     vip_price: str | None = Form(default=None),
@@ -2052,6 +2053,7 @@ async def admin_create_shop_product(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Vendor SKU cannot be empty")
 
     description_value = description.strip() if description and description.strip() else None
+    product_link_value = product_link.strip() if product_link and product_link.strip() else None
 
     try:
         price_decimal = Decimal(price).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
@@ -2158,6 +2160,7 @@ async def admin_create_shop_product(
             sku=cleaned_sku,
             vendor_sku=cleaned_vendor_sku,
             description=description_value,
+            product_link=product_link_value,
             price=price_decimal,
             stock=stock_int,
             vip_price=vip_decimal,
@@ -2210,6 +2213,7 @@ async def admin_update_shop_product(
     sku: str = Form(...),
     vendor_sku: str = Form(...),
     description: str | None = Form(default=None),
+    product_link: str | None = Form(default=None),
     price: str = Form(...),
     stock: str = Form(...),
     vip_price: str | None = Form(default=None),
@@ -2256,6 +2260,7 @@ async def admin_update_shop_product(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Vendor SKU cannot be empty")
 
     description_value = description.strip() if description and description.strip() else None
+    product_link_value = product_link.strip() if product_link and product_link.strip() else None
 
     feature_payload: list[dict[str, Any]] | None = None
     if features not in (None, ""):
@@ -2446,6 +2451,7 @@ async def admin_update_shop_product(
             sku=cleaned_sku,
             vendor_sku=cleaned_vendor_sku,
             description=description_value,
+            product_link=product_link_value,
             price=price_decimal,
             stock=stock_int,
             vip_price=vip_decimal,

--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -1385,6 +1385,7 @@ async def create_product(
     price_monthly_commitment: Decimal | None = None,
     price_annual_monthly_payment: Decimal | None = None,
     price_annual_annual_payment: Decimal | None = None,
+    product_link: str | None = None,
 ) -> dict[str, Any]:
     async with db.acquire() as conn:
         async with conn.cursor(aiomysql.DictCursor) as cursor:
@@ -1393,8 +1394,9 @@ async def create_product(
                 INSERT INTO shop_products
                     (name, sku, vendor_sku, description, image_url, price, vip_price, stock,
                      category_id, subscription_category_id, commitment_type, payment_frequency,
-                     price_monthly_commitment, price_annual_monthly_payment, price_annual_annual_payment)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                     price_monthly_commitment, price_annual_monthly_payment, price_annual_annual_payment,
+                     product_link)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 """,
                 (
                     name,
@@ -1412,6 +1414,7 @@ async def create_product(
                     price_monthly_commitment,
                     price_annual_monthly_payment,
                     price_annual_annual_payment,
+                    product_link,
                 ),
             )
             product_id = int(cursor.lastrowid)
@@ -1678,6 +1681,7 @@ async def list_order_items(order_number: str, company_id: int) -> list[dict[str,
             p.sku,
             p.description,
             p.image_url,
+            p.product_link,
             p.stock,
             p.stock_nsw,
             p.stock_qld,
@@ -1783,6 +1787,7 @@ async def update_product(
     scheduled_vip_price: Decimal | None = None,
     scheduled_buy_price: Decimal | None = None,
     price_change_date: Any | None = None,
+    product_link: str | None = None,
 ) -> dict[str, Any] | None:
     async with db.acquire() as conn:
         async with conn.cursor(aiomysql.DictCursor) as cursor:
@@ -1795,6 +1800,7 @@ async def update_product(
                     vendor_sku = %s,
                     description = %s,
                     image_url = %s,
+                    product_link = %s,
                     price = %s,
                     vip_price = %s,
                     stock = %s,
@@ -1822,6 +1828,7 @@ async def update_product(
                     vendor_sku,
                     description,
                     image_url,
+                    product_link,
                     price,
                     vip_price,
                     stock,
@@ -2278,15 +2285,16 @@ async def upsert_product_from_feed(
     stock_at: date | None,
     warranty_length: str | None,
     manufacturer: str | None,
+    product_link: str | None = None,
 ) -> None:
     await db.execute(
         """
         INSERT INTO shop_products
             (name, sku, vendor_sku, description, image_url, price, vip_price, stock,
              category_id, stock_nsw, stock_qld, stock_vic, stock_sa, stock_wa, buy_price,
-             weight, length, width, height, stock_at, warranty_length, manufacturer)
+             weight, length, width, height, stock_at, warranty_length, manufacturer, product_link)
         VALUES
-            (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON DUPLICATE KEY UPDATE
             name = VALUES(name),
             sku = VALUES(sku),
@@ -2308,7 +2316,11 @@ async def upsert_product_from_feed(
             height = VALUES(height),
             stock_at = VALUES(stock_at),
             warranty_length = VALUES(warranty_length),
-            manufacturer = VALUES(manufacturer)
+            manufacturer = VALUES(manufacturer),
+            product_link = CASE
+                WHEN COALESCE(NULLIF(product_link, ''), '') = '' THEN VALUES(product_link)
+                ELSE product_link
+            END
         """,
         (
             name,
@@ -2333,6 +2345,7 @@ async def upsert_product_from_feed(
             stock_at,
             warranty_length,
             manufacturer,
+            product_link,
         ),
     )
 
@@ -2834,6 +2847,7 @@ async def list_quote_items(quote_number: str, company_id: int) -> list[dict[str,
             p.sku,
             p.description,
             p.image_url,
+            p.product_link,
             p.stock,
             p.stock_nsw,
             p.stock_qld,

--- a/app/repositories/stock_feed.py
+++ b/app/repositories/stock_feed.py
@@ -189,6 +189,7 @@ def _normalise_row(row: dict[str, Any]) -> dict[str, Any]:
         "warranty_length": row.get("warranty_length") or None,
         "manufacturer": row.get("manufacturer") or None,
         "image_url": row.get("image_url") or None,
+        "website_url": row.get("website_url") or None,
         "opt_accessori": row.get("opt_accessori") or None,
         "duplicate_sku_import": bool(_coerce_int(row.get("duplicate_sku_import"))),
         "duplicate_sku_count": _coerce_int(row.get("duplicate_sku_count")),
@@ -226,12 +227,12 @@ async def replace_feed(items: Sequence[Mapping[str, Any]]) -> None:
                             " sku, product_name, product_name2, rrp, category_name,"
                             " on_hand_nsw, on_hand_qld, on_hand_vic, on_hand_sa,"
                             " dbp, weight, length, width, height, pub_date,"
-                            " warranty_length, manufacturer, image_url, opt_accessori,"
+                            " warranty_length, manufacturer, image_url, website_url, opt_accessori,"
                             " duplicate_sku_import, duplicate_sku_count"
                             ") VALUES ("
                             " %s, %s, %s, %s, %s,"
                             " %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,"
-                            " %s, %s, %s, %s, %s, %s"
+                            " %s, %s, %s, %s, %s, %s, %s"
                             ")"
                         ),
                         [
@@ -254,6 +255,7 @@ async def replace_feed(items: Sequence[Mapping[str, Any]]) -> None:
                                 item.get("warranty_length"),
                                 item.get("manufacturer"),
                                 item.get("image_url"),
+                                item.get("website_url"),
                                 item.get("opt_accessori"),
                                 1 if item.get("duplicate_sku_import") else 0,
                                 item.get("duplicate_sku_count", 0),

--- a/app/services/products.py
+++ b/app/services/products.py
@@ -306,6 +306,7 @@ def _parse_feed_item(element: Element) -> dict[str, Any] | None:
         _get_feed_value(element, "Manufacturer", "manufacturer")
     )
     image_url = _optional_text(_get_feed_value(element, "ImageUrl", "image_url"))
+    website_url = _optional_text(_get_feed_value(element, "WebsiteUrl", "website_url"))
 
     pub_date_raw = _get_feed_value(element, "pubDate", "pub_date")
     pub_date = _parse_stock_date(pub_date_raw)
@@ -341,6 +342,7 @@ def _parse_feed_item(element: Element) -> dict[str, Any] | None:
         "warranty_length": warranty_length,
         "manufacturer": manufacturer,
         "image_url": image_url,
+        "website_url": website_url,
         "opt_accessori": opt_accessori,
     }
 
@@ -690,6 +692,11 @@ async def _process_feed_item(
         str(current_product.get("image_url") or "").strip() if current_product else ""
     )
     feed_image_url = str(item.get("image_url") or "").strip()
+    feed_website_url = str(item.get("website_url") or "").strip()
+    existing_product_link = (
+        str(current_product.get("product_link") or "").strip() if current_product else ""
+    )
+    product_link = feed_website_url if feed_website_url and not existing_product_link else None
     image_url: str | None = None
     if existing_image_url:
         image_url = None
@@ -719,6 +726,7 @@ async def _process_feed_item(
         stock_at=stock_at,
         warranty_length=warranty_length,
         manufacturer=manufacturer,
+        product_link=product_link,
     )
 
     if update_recommendations:

--- a/app/static/js/shop_admin.js
+++ b/app/static/js/shop_admin.js
@@ -1034,6 +1034,10 @@
         editForm.querySelector('#edit-product-sku').value = product.sku || '';
         editForm.querySelector('#edit-product-vendor').value = product.vendor_sku || '';
         editForm.querySelector('#edit-product-description').value = product.description || '';
+        const productLinkField = editForm.querySelector('#edit-product-link');
+        if (productLinkField) {
+          productLinkField.value = product.product_link || '';
+        }
         editForm.querySelector('#edit-product-price').value = product.price != null ? product.price : '';
         editForm.querySelector('#edit-product-vip').value = product.vip_price != null ? product.vip_price : '';
         editForm.querySelector('#edit-product-stock').value = product.stock != null ? product.stock : '';

--- a/app/templates/admin/shop.html
+++ b/app/templates/admin/shop.html
@@ -334,7 +334,7 @@
       <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
       {% endif %}
       <input type="hidden" id="edit-product-id" />
-      
+
       <!-- Row 1: Name, SKU, Vendor SKU, Category -->
       <div class="form-field">
         <label class="form-label" for="edit-product-name">Name</label>
@@ -357,7 +357,7 @@
           {% endfor %}
         </select>
       </div>
-      
+
       <!-- Row 2: Price, VIP Price, Stock, Image -->
       <div class="form-field" data-field-type="standard-price">
         <label class="form-label" for="edit-product-price">Price</label>
@@ -376,7 +376,7 @@
         <input class="form-input" id="edit-product-image" name="image" type="file" accept="image/*" />
         <p class="form-helper" id="edit-product-image-filename" hidden></p>
       </div>
-      
+
       <!-- Row 3: Description -->
       <div class="form-field form-field--wide">
         <div class="form-label-row">
@@ -385,7 +385,7 @@
         </div>
         <textarea class="form-input form-input--textarea" id="edit-product-description" name="description"></textarea>
       </div>
-      
+
       <!-- Row 4: Cross-sell and Up-sell products -->
       <div class="form-field form-field--wide">
         <label class="form-label">Cross-sell products</label>
@@ -421,7 +421,7 @@
         <ul class="tag-list" id="edit-product-upsell-list" aria-label="Up-sell products"></ul>
         <p class="form-helper">Add SKUs for upgrade options to suggest at checkout.</p>
       </div>
-      
+
       <!-- Row 5: Subscription-related fields -->
       <div class="form-field">
         <label class="form-label" for="edit-product-subscription-category">Subscription category</label>
@@ -496,7 +496,7 @@
           </div>
         </div>
       </details>
-      
+
       <!-- Features section (keeping at the end) -->
       <div class="form-field form-field--wide">
         <label class="form-label" for="edit-product-features-filter">Features</label>
@@ -525,7 +525,13 @@
         </div>
         <input type="hidden" name="features" id="edit-product-features-data" value="[]" />
       </div>
-      
+
+      <div class="form-field form-field--wide">
+        <label class="form-label" for="edit-product-link">Product Link</label>
+        <input class="form-input" id="edit-product-link" name="product_link" type="url" placeholder="https://example.com/product" />
+        <p class="form-helper">Optional vendor or product page URL shown on PDF quotes.</p>
+      </div>
+
       <div class="form-actions">
         <button type="submit" class="button">Save product</button>
         <button type="button" class="button button--ghost" data-modal-close>Cancel</button>

--- a/app/templates/admin/shop_product_create.html
+++ b/app/templates/admin/shop_product_create.html
@@ -32,7 +32,7 @@
           {% if csrf_token %}
           <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
           {% endif %}
-          
+
           <!-- Row 1: Name, SKU, Vendor SKU, Category -->
           <div class="form-field">
             <label class="form-label" for="product-name">Name</label>
@@ -55,7 +55,7 @@
               {% endfor %}
             </select>
           </div>
-          
+
           <!-- Row 2: Price, VIP Price, Stock, Image -->
           <div class="form-field" data-field-type="standard-price">
             <label class="form-label" for="product-price">Price</label>
@@ -73,13 +73,19 @@
             <label class="form-label" for="product-image">Image</label>
             <input class="form-input" id="product-image" name="image" type="file" accept="image/*" />
           </div>
-          
+
+          <div class="form-field form-field--wide">
+            <label class="form-label" for="product-link">Product Link</label>
+            <input class="form-input" id="product-link" name="product_link" type="url" placeholder="https://example.com/product" />
+            <p class="form-helper">Optional vendor or product page URL shown on PDF quotes.</p>
+          </div>
+
           <!-- Row 3: Description -->
           <div class="form-field form-field--wide">
             <label class="form-label" for="product-description">Description</label>
             <textarea class="form-input" id="product-description" name="description" rows="4"></textarea>
           </div>
-          
+
           <!-- Row 4: Cross-sell and Up-sell products -->
           <div class="form-field form-field--wide">
             <label class="form-label">Cross-sell products</label>
@@ -113,7 +119,7 @@
             <ul class="tag-list" id="product-upsell-list" aria-label="Up-sell products"></ul>
             <p class="form-helper">Add SKUs for upgrade options to suggest at checkout.</p>
           </div>
-          
+
           <!-- Row 5: Subscription-related fields -->
           <div class="form-field">
             <label class="form-label" for="product-subscription-category">Subscription category</label>
@@ -158,7 +164,7 @@
             <input class="form-input" id="product-price-annual-annual" name="price_annual_annual_payment" type="number" step="0.01" />
             <p class="form-helper">Price for annual commitment with annual payment (full year).</p>
           </div>
-          
+
           <div class="form-actions">
             <button type="submit" class="button">Add product</button>
             <a class="button button--ghost" href="/admin/shop">Cancel</a>

--- a/migrations/297_shop_product_link.sql
+++ b/migrations/297_shop_product_link.sql
@@ -1,0 +1,5 @@
+ALTER TABLE shop_products
+  ADD COLUMN IF NOT EXISTS product_link VARCHAR(2048) NULL AFTER image_url;
+
+ALTER TABLE stock_feed
+  ADD COLUMN IF NOT EXISTS website_url VARCHAR(2048) NULL AFTER image_url;


### PR DESCRIPTION
### Motivation
- Store and surface a vendor/product URL for shop items so admins can capture a canonical external product page and surface it in PDF quotes.
- Populate that link from incoming XML stock feeds (`WebsiteUrl`) when a product has no existing Product Link to preserve manual overrides.

### Description
- Add `product_link` to `shop_products` and `website_url` to `stock_feed` via `migrations/297_shop_product_link.sql` and carry the field through the stack (`app/repositories/stock_feed.py`, `app/services/products.py`).
- Parse `WebsiteUrl` from the stock-feed XML and set `product_link` on feed upsert only when the existing `product_link` is empty, and ensure the upsert does not overwrite non-empty values (`CASE WHEN COALESCE(NULLIF(product_link, ''), '') = '' THEN VALUES(product_link) ELSE product_link END`) in `app/repositories/shop.py` and `app/services/products.py`.
- Expose `product_link` on the admin product create/edit forms and hydrate it in the edit modal via `app/templates/admin/shop.html`, `app/templates/admin/shop_product_create.html`, and `app/static/js/shop_admin.js`, and persist it through `app/features/shop/handlers.py` and repository APIs in `app/repositories/shop.py`.
- Include `product_link` in quote item queries and render a clickable "Product Link" in the product detail pages of PDF quotes via `app/repositories/shop.py` and `app/features/quotes/routes.py`.

### Testing
- Ran compilation checks with `python -m compileall` against the modified modules which succeeded. 
- Ran `git diff --check` to validate whitespace/format issues which passed. 
- Attempted `pytest tests/test_products_service.py tests/test_shop_admin_update_product_features.py tests/test_shop_admin_subscription_fields.py` but test collection failed due to a missing system dependency (`libmagic`) required by the test environment, so full test verification is blocked until that dependency is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54794583108332bbd00074c979154a)