### PR TITLE
Add hover highlights to data tables

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2455,6 +2455,19 @@ button.header-title-menu__link,
   min-width: 680px;
 }
 
+.table tbody tr {
+  transition: background-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.table tbody tr:hover {
+  background: rgba(56, 189, 248, 0.1);
+  box-shadow: inset 3px 0 0 rgba(56, 189, 248, 0.45);
+}
+
+.table tbody tr:has(a:hover, button:hover, input:hover, select:hover, textarea:hover) {
+  background: rgba(56, 189, 248, 0.12);
+}
+
 .tickets-table {
   min-width: 680px;
 }
@@ -6436,6 +6449,10 @@ dialog.modal:not([open]) {
   background: rgba(59, 130, 246, 0.18);
 }
 
+.table__row--active:hover {
+  background: rgba(59, 130, 246, 0.28);
+}
+
 .attempt-details {
   margin-top: 1.5rem;
   display: flex;
@@ -9314,6 +9331,10 @@ input.form-checkbox {
   font-size: 0.9375rem;
 }
 
+.data-table tbody tr {
+  transition: background-color 0.16s ease, box-shadow 0.16s ease;
+}
+
 .data-table--sticky thead {
   position: sticky;
   top: 0;
@@ -9381,7 +9402,12 @@ input.form-checkbox {
 }
 
 .data-table tbody tr:hover {
-  background: rgba(148, 163, 184, 0.05);
+  background: rgba(56, 189, 248, 0.1);
+  box-shadow: inset 3px 0 0 rgba(56, 189, 248, 0.45);
+}
+
+.data-table tbody tr:has(a:hover, button:hover, input:hover, select:hover, textarea:hover) {
+  background: rgba(56, 189, 248, 0.12);
 }
 
 /* Action Buttons */


### PR DESCRIPTION
### Motivation
- Improve row discoverability and make selecting rows easier across the platform's table components by adding a visible hover affordance. 
- Consolidate hover behavior between generic `.table` and macro-driven `.data-table` components so the UI feels consistent. 
- Preserve the existing distinct styling for already-active rows while making their hover state clearer.

### Description
- Added transition and hover styles for `.table tbody tr` that apply a subtle cyan background and a left inset accent via `box-shadow` for easier row targeting in `app/static/css/app.css`.
- Added a `:has(...)` rule to reduce the hover intensity when an interactive element inside a row (like links, inputs, buttons) itself receives hover, to avoid conflicting highlights. 
- Updated `.data-table` to use the same transition and hover treatment and added a slightly stronger hover for `.table__row--active` so active rows remain visually distinct.

### Testing
- Verified CSS brace balance with a small Python script using `Path.read_text()` which completed successfully. 
- Ran `git diff --check` to ensure no whitespace/format issues and it returned clean results. 
- Confirmed the changed stylesheet `app/static/css/app.css` was modified and contains the new hover rules without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a547e68130083329574e107fa995849)