### PR TITLE
Open product links in new tabs

### DIFF
--- a/app/features/quotes/routes.py
+++ b/app/features/quotes/routes.py
@@ -122,7 +122,8 @@ def _build_quote_pdf_html(
         product_link = str(item.get("product_link") or "").strip()
         product_link_html = (
             "<p class='product-link'><strong>Product Link:</strong> "
-            f"<a href='{escape(product_link, quote=True)}'>{escape(product_link)}</a></p>"
+            f"<a href='{escape(product_link, quote=True)}' target='_blank' "
+            f"rel='noopener noreferrer'>{escape(product_link)}</a></p>"
             if product_link
             else ""
         )

--- a/app/features/shop/handlers.py
+++ b/app/features/shop/handlers.py
@@ -517,6 +517,7 @@ def _public_shop_product_payload(product: Mapping[str, Any], *, is_vip: bool) ->
         "description": product.get("description"),
         "description_html": sanitized_description.html,
         "image_url": product.get("image_url"),
+        "product_link": product.get("product_link"),
         "price": product.get("price"),
         "vip_price": product.get("vip_price"),
         "stock": product.get("stock"),

--- a/app/static/js/shop.js
+++ b/app/static/js/shop.js
@@ -327,6 +327,15 @@
     summary.appendChild(createDetailRow('Availability', describeStockStatus(product.stock)));
     const actions = document.createElement('div');
     actions.className = 'product-details-modal__actions';
+    if (product.product_link) {
+      const productLink = document.createElement('a');
+      productLink.className = 'button button--ghost';
+      productLink.href = product.product_link;
+      productLink.target = '_blank';
+      productLink.rel = 'noopener noreferrer';
+      productLink.textContent = 'Open product link';
+      actions.appendChild(productLink);
+    }
     actions.appendChild(buildModalAddToCart(product));
     summary.appendChild(actions);
     hero.appendChild(summary);


### PR DESCRIPTION
### Motivation
- Product links surfaced in product details and PDFs should open in a new browser tab to avoid navigating users away from the portal and to follow safe external link practices.

### Description
- Expose `product_link` in the public shop product detail API payload so the frontend can render external product links (`app/features/shop/handlers.py`).
- Render an "Open product link" anchor in the product details modal that uses `target="_blank"` and `rel="noopener noreferrer"` (`app/static/js/shop.js`).
- Ensure product links in generated quote PDFs include `target="_blank"` and `rel="noopener noreferrer"` for safe new-tab behaviour (`app/features/quotes/routes.py`).

### Testing
- Compiled modified Python modules with `python -m compileall app/features/shop/handlers.py app/features/quotes/routes.py` and the compilation succeeded.
- Ran `git diff --check` to validate whitespace and merge issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a548014935083329e98a32cfc97307b)