### PR TITLE
Add bulk scheduled task creation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5775,6 +5775,12 @@ async def admin_scheduled_tasks(
     for cid in sorted(missing_company_ids):
         company_options.append({"value": str(cid), "label": f"Company #{cid}"})
 
+    bulk_company_options = [
+        {"value": option["value"], "label": option["label"]}
+        for option in company_options
+        if option.get("value")
+    ]
+
     extra = {
         "title": "Scheduled Tasks",
         "tasks": prepared_tasks,
@@ -5782,8 +5788,129 @@ async def admin_scheduled_tasks(
         "upgrade_status": system_state_service.get_upgrade_status(),
         "command_options": command_options,
         "company_options": company_options,
+        "bulk_company_options": bulk_company_options,
     }
     return await _render_template("admin/scheduled_tasks.html", request, current_user, extra=extra)
+
+
+
+@app.post("/admin/scheduled-tasks/bulk-create", response_class=HTMLResponse)
+async def admin_bulk_create_scheduled_tasks(request: Request):
+    current_user, redirect = await _require_super_admin_page(request)
+    if redirect:
+        return redirect
+
+    form = await request.form()
+    command = str(form.get("command") or "").strip()
+    cron = str(form.get("cron") or "").strip()
+    raw_company_ids = form.getlist("companyIds")
+    description = str(form.get("description") or "").strip() or None
+
+    if command == "create_scheduled_ticket":
+        json_payload = str(form.get("jsonPayload") or "").strip()
+        if not json_payload:
+            return flash_redirect("/admin/scheduled-tasks", "JSON payload is required for scheduled ticket tasks.", "error")
+        try:
+            json.loads(json_payload)
+        except json.JSONDecodeError:
+            return flash_redirect("/admin/scheduled-tasks", "JSON payload is not valid JSON.", "error")
+        description = json_payload
+
+    if not command:
+        return flash_redirect("/admin/scheduled-tasks", "Select a task option to bulk create.", "error")
+
+    cron_fields = cron.split()
+    if len(cron_fields) not in {5, 6}:
+        return flash_redirect("/admin/scheduled-tasks", "Enter a valid five- or six-field cron expression.", "error")
+    try:
+        start_minute = int(cron_fields[0])
+        start_hour = int(cron_fields[1])
+    except (TypeError, ValueError):
+        return flash_redirect("/admin/scheduled-tasks", "Bulk create requires numeric minute and hour cron fields.", "error")
+    if start_minute < 0 or start_minute > 59 or start_hour < 0 or start_hour > 23:
+        return flash_redirect("/admin/scheduled-tasks", "Cron start time must be between 00:00 and 23:59 UTC.", "error")
+
+    company_ids: list[int] = []
+    seen: set[int] = set()
+    for raw in raw_company_ids:
+        try:
+            company_id = int(str(raw).strip())
+        except (TypeError, ValueError):
+            continue
+        if company_id <= 0 or company_id in seen:
+            continue
+        seen.add(company_id)
+        company_ids.append(company_id)
+
+    if not company_ids:
+        return flash_redirect("/admin/scheduled-tasks", "Select at least one active company.", "error")
+
+    companies = await company_repo.list_companies()
+    active_company_lookup: dict[int, str] = {}
+    for company in companies:
+        try:
+            cid = int(company.get("id")) if company.get("id") is not None else None
+        except (TypeError, ValueError):
+            cid = None
+        if cid is not None:
+            active_company_lookup[cid] = str(company.get("name") or f"Company #{cid}")
+
+    invalid_company_ids = [cid for cid in company_ids if cid not in active_company_lookup]
+    if invalid_company_ids:
+        return flash_redirect("/admin/scheduled-tasks", "One or more selected companies are no longer active.", "error")
+
+    try:
+        max_retries = int(str(form.get("maxRetries") or "12").strip())
+        retry_backoff_seconds = int(str(form.get("retryBackoffSeconds") or "300").strip())
+    except (TypeError, ValueError):
+        return flash_redirect("/admin/scheduled-tasks", "Retry settings must be numeric.", "error")
+    if max_retries < 0:
+        return flash_redirect("/admin/scheduled-tasks", "Max retries must be zero or a positive number.", "error")
+    if retry_backoff_seconds < 30:
+        return flash_redirect("/admin/scheduled-tasks", "Retry backoff must be at least 30 seconds.", "error")
+
+    command_label = TASK_COMMAND_LABELS.get(command, command)
+    active = form.get("active") is not None
+    exclude_from_calendar = form.get("excludeFromCalendar") is not None
+    created_count = 0
+    for offset, company_id in enumerate(company_ids):
+        fields = list(cron_fields)
+        total_minutes = start_hour * 60 + start_minute + offset
+        fields[0] = str(total_minutes % 60)
+        fields[1] = str((total_minutes // 60) % 24)
+        company_name = active_company_lookup[company_id]
+        await scheduled_tasks_repo.create_task(
+            name=f"{company_name} — {command_label}",
+            command=command,
+            cron=" ".join(fields),
+            company_id=company_id,
+            description=description,
+            active=active,
+            max_retries=max_retries,
+            retry_backoff_seconds=retry_backoff_seconds,
+            exclude_from_calendar=exclude_from_calendar,
+        )
+        created_count += 1
+
+    if created_count:
+        await scheduler_service.refresh()
+
+    log_info(
+        "Scheduled tasks bulk created",
+        created_count=created_count,
+        command=command,
+        start_cron=cron,
+        created_by=current_user.get("id") if current_user else None,
+        company_ids=company_ids,
+    )
+
+    noun = "task" if created_count == 1 else "tasks"
+    show_inactive_param = "1" if form.get("show_inactive") else ""
+    base_url = "/admin/scheduled-tasks"
+    redirect_url = f"{base_url}?show_inactive={show_inactive_param}" if show_inactive_param else base_url
+    response = RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
+    set_flash(response, f"Created {created_count} scheduled {noun} from {start_hour:02d}:{start_minute:02d} UTC.", "success")
+    return response
 
 
 @app.post("/admin/scheduled-tasks/bulk-delete", response_class=HTMLResponse)

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -3,6 +3,7 @@
   let taskModal = null;
   let logsModal = null;
   let previewModal = null;
+  let bulkTaskModal = null;
   let activeTaskContext = { id: '', name: '' };
 
   function toJsonTemplate(data) {
@@ -1456,6 +1457,63 @@
     }
   }
 
+
+  function bindBulkTaskCreateForm() {
+    const openButtons = document.querySelectorAll('[data-bulk-task-create]');
+    openButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        if (bulkTaskModal) {
+          openModal(bulkTaskModal);
+        }
+      });
+    });
+
+    const form = query('bulk-scheduled-task-form');
+    if (!form) {
+      return;
+    }
+
+    const commandField = query('bulk-task-command');
+    const descriptionField = query('bulk-task-description-field');
+    const jsonPayloadField = query('bulk-task-json-payload-field');
+    const jsonPayloadInput = query('bulk-task-json-payload');
+
+    const togglePayload = () => {
+      const requiresPayload = commandField && commandField.value === 'create_scheduled_ticket';
+      if (descriptionField) {
+        descriptionField.hidden = Boolean(requiresPayload);
+      }
+      if (jsonPayloadField) {
+        jsonPayloadField.hidden = !requiresPayload;
+      }
+      if (jsonPayloadInput) {
+        jsonPayloadInput.required = Boolean(requiresPayload);
+      }
+    };
+
+    if (commandField) {
+      commandField.addEventListener('change', togglePayload);
+      togglePayload();
+    }
+
+    form.addEventListener('submit', (event) => {
+      const selectedCompanies = form.querySelectorAll('input[name="companyIds"]:checked');
+      if (selectedCompanies.length < 1) {
+        event.preventDefault();
+        window.alert('Select at least one active company.');
+        return;
+      }
+      if (commandField && commandField.value === 'create_scheduled_ticket' && jsonPayloadInput) {
+        try {
+          JSON.parse(jsonPayloadInput.value || '');
+        } catch (error) {
+          event.preventDefault();
+          window.alert('Invalid JSON payload. Please check your JSON syntax.');
+        }
+      }
+    });
+  }
+
   function bindTaskActions() {
     document.querySelectorAll('[data-task-edit]').forEach((button) => {
       button.addEventListener('click', () => {
@@ -2686,11 +2744,14 @@
     taskModal = query('task-editor-modal');
     logsModal = query('task-logs-modal');
     previewModal = query('task-preview-modal');
+    bulkTaskModal = query('bulk-task-create-modal');
     bindModalDismissal(taskModal);
     bindModalDismissal(logsModal);
     bindModalDismissal(previewModal);
+    bindModalDismissal(bulkTaskModal);
     clearTaskForm();
     bindTaskForm();
+    bindBulkTaskCreateForm();
     bindTaskActions();
     bindScheduledTaskRowDropdowns();
     bindAutomationDeleteActions();

--- a/app/templates/admin/scheduled_tasks.html
+++ b/app/templates/admin/scheduled_tasks.html
@@ -5,6 +5,15 @@
   <a class="button button--ghost" href="/admin/cron-calendar">Schedule calendar</a>
   <button
     type="button"
+    class="button button--ghost"
+    data-bulk-task-create
+    aria-haspopup="dialog"
+    aria-controls="bulk-task-create-modal"
+  >
+    Bulk create
+  </button>
+  <button
+    type="button"
     class="button button--primary"
     data-task-create
     aria-haspopup="dialog"
@@ -336,6 +345,81 @@
       </div>
     </div>
   </section>
+</div>
+
+<div class="modal" id="bulk-task-create-modal" role="dialog" aria-modal="true" hidden>
+  <div class="modal__content" role="document">
+    <button type="button" class="modal__close" data-modal-close>
+      <span class="visually-hidden">Close bulk task creator</span>
+    </button>
+    <h2 class="modal__title">Bulk create scheduled tasks</h2>
+    <div class="modal__body">
+      <form id="bulk-scheduled-task-form" class="form" method="post" action="/admin/scheduled-tasks/bulk-create" autocomplete="off">
+        {% include "partials/csrf.html" %}
+        {% if show_inactive %}<input type="hidden" name="show_inactive" value="1" />{% endif %}
+        <div class="form-field">
+          <label class="form-label" for="bulk-task-command">Task option</label>
+          <select class="form-input" id="bulk-task-command" name="command" required>
+            {% for option in command_options %}
+              <option value="{{ option.value }}">{{ option.label }}</option>
+            {% endfor %}
+          </select>
+          <p class="form-help">One scheduled task will be created for each selected company.</p>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="bulk-task-cron">Desired start cron expression</label>
+          <input class="form-input" id="bulk-task-cron" name="cron" required placeholder="0 2 * * *" pattern="^[^\s]+(\s+[^\s]+){4,5}$" />
+          <p class="form-help">The minute and hour are auto-incremented by one minute per company, starting from this UTC time.</p>
+        </div>
+        <div class="form-field" id="bulk-task-description-field">
+          <label class="form-label" for="bulk-task-description">Description</label>
+          <textarea class="form-input form-input--textarea" id="bulk-task-description" name="description" rows="3"></textarea>
+          <p class="form-help">Optional description or notes copied to each created task.</p>
+        </div>
+        <div class="form-field" id="bulk-task-json-payload-field" hidden>
+          <label class="form-label" for="bulk-task-json-payload">JSON Payload</label>
+          <textarea class="form-input form-input--textarea" id="bulk-task-json-payload" name="jsonPayload" rows="8" placeholder='{"subject": "Example ticket", "description": "Ticket details", "priority": "normal", "status": "open"}'></textarea>
+          <p class="form-help">Required when bulk creating scheduled ticket tasks. The same payload is copied to each company task.</p>
+        </div>
+        <div class="form-field form-field--inline">
+          <label class="form-label" for="bulk-task-max-retries">Max retries</label>
+          <input class="form-input" id="bulk-task-max-retries" name="maxRetries" type="number" min="0" value="12" />
+        </div>
+        <div class="form-field form-field--inline">
+          <label class="form-label" for="bulk-task-backoff">Retry backoff (seconds)</label>
+          <input class="form-input" id="bulk-task-backoff" name="retryBackoffSeconds" type="number" min="30" value="300" />
+        </div>
+        <div class="form-field form-field--checkbox">
+          <label class="form-checkbox">
+            <input type="checkbox" id="bulk-task-active" name="active" checked />
+            <span>Tasks active</span>
+          </label>
+        </div>
+        <div class="form-field form-field--checkbox">
+          <label class="form-checkbox">
+            <input type="checkbox" id="bulk-task-exclude-calendar" name="excludeFromCalendar" />
+            <span>Hide from cron calendar</span>
+          </label>
+        </div>
+        <fieldset class="form-field">
+          <legend class="form-label">Active companies</legend>
+          <div class="checkbox-list">
+            {% for option in bulk_company_options %}
+              <label class="form-checkbox-label">
+                <input type="checkbox" class="form-checkbox" name="companyIds" value="{{ option.value }}" />
+                <span class="form-checkbox-text">{{ option.label }}</span>
+              </label>
+            {% endfor %}
+          </div>
+          <p class="form-help">Tick every company that should receive this scheduled task.</p>
+        </fieldset>
+        <div class="form-actions">
+          <button type="submit" class="button button--primary">Create tasks</button>
+          <button type="button" class="button button--ghost" data-modal-close>Cancel</button>
+        </div>
+      </form>
+    </div>
+  </div>
 </div>
 
 <div class="modal" id="task-editor-modal" role="dialog" aria-modal="true" hidden>


### PR DESCRIPTION
### Motivation
- Enable super-admins to create the same scheduled task across many companies in one operation and to spread start times to avoid simultaneous execution spikes.

### Description
- Added a Bulk create action and modal to the Scheduled Tasks admin page allowing selection of a task option, desired start cron, retry/calendar settings, optional JSON payload for ticket creation, and a selectable list of active companies.
- Implemented server-side handler `POST /admin/scheduled-tasks/bulk-create` that validates inputs (cron minute/hour numeric bounds, JSON payload for `create_scheduled_ticket`, active-company membership, numeric retry/backoff) and creates one scheduled task per selected company.
- Implemented auto-increment minute spreading logic that increments the minute/hour by one minute per company from the requested UTC start time while preserving the rest of the cron expression.
- Added client-side wiring and validation: toggling/validation of the JSON payload field for ticket tasks, company selection checks before submit, modal lifecycle integration, and minor UI additions to the template and JS initialisation.

### Testing
- `python -m py_compile app/main.py` — succeeded.
- `node --check app/static/js/automation.js` and `node --check app/static/js/scheduled_task_columns.js` — succeeded.
- `python -m compileall app/schemas app/repositories` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54825c6dfc83328b72f14772a62b31)