### PR TITLE
Fix quote PDF product image embedding

### DIFF
--- a/app/features/quotes/routes.py
+++ b/app/features/quotes/routes.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-import secrets
+import base64
+import mimetypes
 import re
+import secrets
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from html import escape
 from functools import lru_cache
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from weasyprint import HTML  # type: ignore
 
@@ -66,6 +68,40 @@ def _absolute_asset_url(request: Request, url: str | None) -> str | None:
     return f"{str(request.base_url).rstrip('/')}/{text.lstrip('/')}"
 
 
+def _private_upload_data_uri(url: str | None) -> str | None:
+    if not url:
+        return None
+    parsed = urlparse(str(url).strip())
+    if parsed.scheme or parsed.netloc or not parsed.path.startswith("/uploads/"):
+        return None
+
+    upload_path = parsed.path.removeprefix("/uploads/")
+    if not upload_path:
+        return None
+
+    try:
+        image_path = _main()._resolve_private_upload(upload_path)
+        image_bytes = image_path.read_bytes()
+    except Exception:
+        return None
+
+    mime_type = mimetypes.guess_type(image_path.name)[0] or "application/octet-stream"
+    encoded = base64.b64encode(image_bytes).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def _pdf_image_src(request: Request, url: str | None) -> str | None:
+    data_uri = _private_upload_data_uri(url)
+    if data_uri:
+        return data_uri
+
+    text = str(url or "").strip()
+    if text.startswith("/uploads/"):
+        return None
+
+    return _absolute_asset_url(request, url)
+
+
 def _build_quote_pdf_html(
     *,
     request: Request,
@@ -104,7 +140,7 @@ def _build_quote_pdf_html(
     detail_pages = []
     for item in items:
         image_url = (
-            _absolute_asset_url(request, item.get("image_url"))
+            _pdf_image_src(request, item.get("image_url"))
             if include_line_images
             else None
         )

--- a/tests/test_quote_pdf_export.py
+++ b/tests/test_quote_pdf_export.py
@@ -30,7 +30,18 @@ def _request() -> Request:
     )
 
 
-def test_quote_pdf_includes_product_image_but_removes_description_images():
+def test_quote_pdf_includes_product_image_but_removes_description_images(tmp_path, monkeypatch):
+    image_path = tmp_path / "shop" / "laptop.png"
+    image_path.parent.mkdir()
+    image_path.write_bytes(b"png-bytes")
+
+    class FakeMain:
+        @staticmethod
+        def _resolve_private_upload(file_path):
+            return tmp_path / str(file_path)
+
+    monkeypatch.setattr("app.features.quotes.routes._main", lambda: FakeMain)
+
     html = _build_quote_pdf_html(
         request=_request(),
         company={"name": "Example Co"},
@@ -56,7 +67,7 @@ def test_quote_pdf_includes_product_image_but_removes_description_images():
     details_index = html.index('class=\'description rich-text-viewer\'')
 
     assert name_index < image_index < details_index
-    assert "https://portal.example/uploads/shop/laptop.png" in html
+    assert "data:image/png;base64,cG5nLWJ5dGVz" in html
     assert 'alt="Laptop"' in html
     assert "#e8f5e9" not in html
     assert "#22c55e" not in html
@@ -87,3 +98,33 @@ def test_quote_pdf_omits_image_card_when_store_image_is_unavailable():
     assert "No image available" not in html
     assert "#e8f5e9" not in html
     assert "#22c55e" not in html
+
+
+def test_quote_pdf_omits_unreadable_private_upload_instead_of_showing_alt_text(monkeypatch):
+    class FakeMain:
+        @staticmethod
+        def _resolve_private_upload(file_path):
+            raise FileNotFoundError(str(file_path))
+
+    monkeypatch.setattr("app.features.quotes.routes._main", lambda: FakeMain)
+
+    html = _build_quote_pdf_html(
+        request=_request(),
+        company={"name": "Example Co"},
+        quote={"quote_number": "Q-3", "name": "Refresh"},
+        items=[
+            {
+                "product_name": "MeetingBar",
+                "sku": "MEET-1",
+                "quantity": 1,
+                "price": Decimal("999.00"),
+                "image_url": "/uploads/shop/missing.png",
+                "description": "<p>Video bar</p>",
+            }
+        ],
+        include_line_images=True,
+    )
+
+    assert 'class="product-image-card"' not in html
+    assert 'alt="MeetingBar"' not in html
+    assert "https://portal.example/uploads/shop/missing.png" not in html


### PR DESCRIPTION
### Motivation
- WeasyPrint-rendered quote PDFs were showing product name/alt text instead of images because private `/uploads/...` product images require authenticated HTTP access and could not be fetched during PDF rendering.
- The change aims to embed private product images into the generated HTML as data URIs or omit unreadable private uploads so the PDF output does not contain broken image tags or alt text in place of images.

### Description
- Add `_private_upload_data_uri` which resolves a `/uploads/...` private file via the app main module and returns a base64 `data:` URI for inlining images, using `mimetypes` and `base64`.
- Add `_pdf_image_src` which prefers the embedded data URI for private uploads, returns `None` for unreadable `/uploads/` paths, and falls back to `_absolute_asset_url` for public URLs.
- Update `_build_quote_pdf_html` to use `_pdf_image_src` when `include_line_images` is enabled so PDFs embed private images or omit unreadable ones instead of rendering a broken `<img>` tag.
- Update imports (`base64`, `mimetypes`, `urlparse`) and extend `tests/test_quote_pdf_export.py` to cover embedded private images and the behavior when a private upload cannot be read (using `tmp_path` and `monkeypatch`).

### Testing
- Ran `pytest tests/test_quote_pdf_export.py -q` and the test file passed (`3 passed`) which verifies embedded private image data URIs and missing-upload behavior.
- Ran `python -m py_compile app/features/quotes/routes.py tests/test_quote_pdf_export.py` which succeeded to ensure syntax validity.
- Ran `git diff --check` (and basic repository checks) with no issues before committing the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a548578e368833287629d0e9ad2e358)