### PR TITLE
Support ticket.body in automation filters (enriched context, UI, docs, tests)

### DIFF
--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -561,7 +561,16 @@ async def _enrich_ticket_context(ticket: Mapping[str, Any]) -> TicketRecord:
             replies = [record for record in fetched_replies if isinstance(record, Mapping)]
 
     latest_reply: dict[str, Any] | None = None
+    initial_body: str | None = None
     if replies:
+        for reply_record in replies:
+            if bool(reply_record.get("is_internal")):
+                continue
+            reply_body = reply_record.get("body")
+            if reply_body is None:
+                continue
+            initial_body = str(reply_body)
+            break
         reply = dict(replies[-1])
         author_value = reply.get("author") if isinstance(reply.get("author"), Mapping) else None
         author_id = reply.get("author_id")
@@ -574,6 +583,9 @@ async def _enrich_ticket_context(ticket: Mapping[str, Any]) -> TicketRecord:
         reply["author_display_name"] = snapshot_display or reply.get("author_display_name")
         latest_reply = reply
     enriched["latest_reply"] = latest_reply
+    if initial_body is None and enriched.get("description") is not None:
+        initial_body = str(enriched.get("description"))
+    enriched["body"] = initial_body or ""
 
     if isinstance(ticket_id, int):
         filter_context = await _safely_call(tickets_repo.get_automation_filter_context, ticket_id)

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -1887,6 +1887,7 @@
           datalist.id = 'automation-filter-field-suggestions';
           [
             'ticket.subject',
+            'ticket.body',
             'ticket.status',
             'ticket.priority',
             'ticket.requester_email',

--- a/app/templates/admin/automations_create_event.html
+++ b/app/templates/admin/automations_create_event.html
@@ -117,7 +117,7 @@
                   >{{ values.get('triggerFiltersRaw', '') }}</textarea>
                 </div>
                 <p class="form-help" data-filter-builder-error hidden></p>
-                <p class="form-help">Build common trigger filters with structured conditions. Use in/not in with comma-separated values such as Resolved, Closed for multi-value ticket status filters. Use Advanced JSON for complex nested logic.</p>
+                <p class="form-help">Build common trigger filters with structured conditions. Use <code>ticket.body</code> to match the initial request body, and use in/not in with comma-separated values such as Resolved, Closed for multi-value ticket status filters. Use Advanced JSON for complex nested logic.</p>
               </div>
               <div class="form-field" data-automation-actions>
                 <label class="form-label">Trigger actions</label>

--- a/app/templates/admin/automations_create_scheduled.html
+++ b/app/templates/admin/automations_create_scheduled.html
@@ -126,7 +126,7 @@
                   >{{ values.get('triggerFiltersRaw', '') }}</textarea>
                 </div>
                 <p class="form-help" data-filter-builder-error hidden></p>
-                <p class="form-help">Use ticket fields such as <code>ticket.status</code>, <code>ticket.age_days</code>, <code>ticket.updated_age_hours</code>, <code>ticket.in_status_age_hours</code>, and <code>ticket.last_reply_age_hours</code>. Use Advanced JSON for complex nested logic.</p>
+                <p class="form-help">Use ticket fields such as <code>ticket.status</code>, <code>ticket.body</code>, <code>ticket.age_days</code>, <code>ticket.updated_age_hours</code>, <code>ticket.in_status_age_hours</code>, and <code>ticket.last_reply_age_hours</code>. Use Advanced JSON for complex nested logic.</p>
               </div>
               <div class="form-field" data-automation-actions>
                 <label class="form-label">Scheduled actions</label>

--- a/tests/test_automation_trigger_filters.py
+++ b/tests/test_automation_trigger_filters.py
@@ -22,6 +22,18 @@ def test_filters_match_subject_like_infix():
     assert automations_service._filters_match(filters, context)
 
 
+def test_filters_match_ticket_body_contains_spam_phrase():
+    context = {
+        "ticket": {
+            "subject": "Hello",
+            "body": "Limited offer: buy followers and boost your rankings today.",
+        }
+    }
+    filters = {"contains": {"ticket.body": "buy followers"}}
+
+    assert automations_service._filters_match(filters, context)
+
+
 def test_filters_like_handles_escape_sequences():
     context = {"ticket": {"subject": "CPU at 100%"}}
     filters = {"match": {"ticket.subject": r"CPU at 100\%"}}

--- a/tests/test_tickets_service_create.py
+++ b/tests/test_tickets_service_create.py
@@ -444,6 +444,7 @@ async def test_enrich_ticket_context_includes_relationship_details(monkeypatch):
     ]
     assert enriched["watchers"][0]["email"] == "watcher.one@example.com"
     assert enriched["watchers"][1]["display_name"] == "Quinn Patil"
+    assert enriched["body"] == "Printer restored"
     assert enriched["latest_reply"]
     assert enriched["latest_reply"]["body"] == "Printer restored"
     assert enriched["latest_reply"]["author_email"] == "tech@example.com"

--- a/wiki/Automation-Variables.md
+++ b/wiki/Automation-Variables.md
@@ -19,6 +19,8 @@ Use dotted paths in automation filters to reference specific ticket fields. Key
 paths now available include:
 
 - `ticket.number` / `ticket.ticket_number` - Ticket number (e.g., "TKT-123")
+- `ticket.body` - Initial request body, using the first public conversation
+  entry when available and falling back to the ticket description
 - `ticket.requester.email` / `ticket.requester.display_name`
 - `ticket.assigned_user.email` / `ticket.assigned_user.display_name`
 - `ticket.company.name`


### PR DESCRIPTION
### Motivation
- Administrators need to build automations that inspect the initial ticket content to detect spam or take actions based on the request body.
- The automation filter builder and scheduled/event automations should expose a stable `ticket.body` field that represents the first public conversation entry (or falls back to the description).
- Provide UI hints and documentation so filter authors know `ticket.body` exists and how it is populated.

### Description
- Populate `ticket.body` in the enriched ticket context from the first non-internal reply, falling back to the ticket `description` when no public reply exists by updating `app/services/tickets.py` (`_enrich_ticket_context`).
- Add `ticket.body` to the automation filter builder suggestions in `app/static/js/automation.js` so it can be selected in the UI.
- Update help text in the automation editor templates (`app/templates/admin/automations_create_event.html` and `app/templates/admin/automations_create_scheduled.html`) to mention `ticket.body`.
- Document the new field in `wiki/Automation-Variables.md` and add a unit test verifying `ticket.body` filtering behavior in `tests/test_automation_trigger_filters.py` plus a test assertion that `body` is present in the enriched ticket in `tests/test_tickets_service_create.py`.

### Testing
- Ran `python -m py_compile app/services/tickets.py` which succeeded.
- Ran `git diff --check` which produced no issues.
- Attempted `pytest tests/test_automation_trigger_filters.py tests/test_tickets_service_create.py -q` but test collection failed in this environment due to missing system dependency `libmagic` required by `python-magic` (ImportError), so tests could not be executed end-to-end here.
- Attempted running tests inside the virtualenv (`./venv/bin/python -m pytest ...`) but collection failed due to missing `aiosqlite` in the venv; full test execution is blocked until these dependencies are available in CI or the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a549900a2b483329503ea0782f42357)