### PR TITLE
Include ticket attachments in automation emails

### DIFF
--- a/app/services/email.py
+++ b/app/services/email.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
+import mimetypes
 import smtplib
 import ssl
 from email.message import EmailMessage
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 from loguru import logger
 
@@ -15,6 +17,31 @@ from app.services import webhook_monitor
 
 class EmailDispatchError(Exception):
     """Raised when an email fails to send via SMTP."""
+
+
+def _normalise_attachment(attachment: Mapping[str, Any]) -> tuple[str, bytes, str | None]:
+    filename = (
+        str(attachment.get("filename") or attachment.get("name") or "attachment").strip()
+        or "attachment"
+    )
+    content = attachment.get("content")
+    if isinstance(content, str):
+        content_bytes = base64.b64decode(content)
+    elif isinstance(content, bytes):
+        content_bytes = content
+    elif isinstance(content, bytearray):
+        content_bytes = bytes(content)
+    else:
+        raise ValueError(f"Attachment {filename!r} does not include bytes or base64 content")
+    mime_type = str(
+        attachment.get("mime_type")
+        or attachment.get("mimetype")
+        or attachment.get("content_type")
+        or ""
+    ).strip()
+    if not mime_type:
+        mime_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    return filename, content_bytes, mime_type
 
 
 def _normalise_recipients(recipients: Iterable[str]) -> list[str]:
@@ -41,6 +68,7 @@ async def send_email(
     timeout: float = 30.0,
     enable_tracking: bool = False,
     ticket_reply_id: int | None = None,
+    attachments: Sequence[Mapping[str, Any]] | None = None,
 ) -> tuple[bool, dict[str, Any] | None]:
     """Send an email using the configured SMTP server.
 
@@ -54,6 +82,7 @@ async def send_email(
         timeout: SMTP connection timeout in seconds
         enable_tracking: Enable email tracking (opens and clicks)
         ticket_reply_id: ID of the ticket reply being sent (required for tracking)
+        attachments: Optional file attachments. Content may be bytes or base64 text.
 
     Returns a tuple where the first element indicates if delivery was attempted and
     succeeded, and the second element contains the webhook monitor event metadata
@@ -112,6 +141,10 @@ async def send_email(
                 sender=sender,
                 reply_to=reply_to,
                 tracking_id=tracking_id,
+                attachments=[
+                    {"filename": name, "content": base64.b64encode(content).decode("ascii")}
+                    for name, content, _mime in (_normalise_attachment(item) for item in (attachments or []))
+                ] or None,
             )
 
             # Record tracking metadata if ticket reply ID provided
@@ -270,6 +303,18 @@ async def send_email(
             message.add_alternative(modified_html_body, subtype="html")
     else:
         message.set_content(modified_html_body, subtype="html")
+
+    for attachment in attachments or []:
+        filename, content_bytes, mime_type = _normalise_attachment(attachment)
+        maintype, _, subtype = mime_type.partition("/")
+        if not maintype or not subtype:
+            maintype, subtype = "application", "octet-stream"
+        message.add_attachment(
+            content_bytes,
+            maintype=maintype,
+            subtype=subtype,
+            filename=filename,
+        )
 
     port_segment = f":{settings.smtp_port}" if settings.smtp_port else ""
     endpoint = f"smtp://{settings.smtp_host}{port_segment}"

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import array
+import base64
 import hashlib
 import re
 import json
@@ -485,6 +486,98 @@ def _ensure_list(value: Any) -> list[str]:
         return [part.strip() for part in value.split(",") if part.strip()]
     return []
 
+
+def _extract_ticket_id_from_email_payload(payload: Mapping[str, Any]) -> int | None:
+    context = payload.get("context")
+    candidates: list[Any] = [payload.get("ticket_id")]
+    if isinstance(context, Mapping):
+        metadata = context.get("metadata")
+        ticket = context.get("ticket")
+        if isinstance(metadata, Mapping):
+            candidates.append(metadata.get("ticket_id"))
+        if isinstance(ticket, Mapping):
+            candidates.extend([ticket.get("id"), ticket.get("ticket_id")])
+    for candidate in candidates:
+        try:
+            ticket_id = int(candidate)
+        except (TypeError, ValueError):
+            continue
+        if ticket_id > 0:
+            return ticket_id
+    return None
+
+
+async def _load_ticket_email_attachments(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Load ticket attachments for automation email modules when possible.
+
+    Explicit payload attachments are respected by callers; this helper only supplies
+    attachments automatically when the automation context identifies a ticket.
+    """
+    ticket_id = _extract_ticket_id_from_email_payload(payload)
+    if ticket_id is None:
+        return []
+
+    from app.repositories import ticket_attachments as attachments_repo
+    from app.services import ticket_attachments as attachments_service
+
+    email_attachments: list[dict[str, Any]] = []
+    try:
+        attachments = await attachments_repo.list_attachments(
+            ticket_id, access_levels=("open", "closed")
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning(
+            "Unable to load ticket attachments for automation email",
+            ticket_id=ticket_id,
+            error=str(exc),
+        )
+        return []
+
+    for attachment in attachments:
+        filename = str(attachment.get("filename") or "").strip()
+        if not filename:
+            continue
+        file_path = attachments_service.get_attachment_file_path(filename)
+        try:
+            content = file_path.read_bytes()
+        except OSError as exc:
+            logger.warning(
+                "Ticket attachment unavailable for automation email",
+                ticket_id=ticket_id,
+                attachment_id=attachment.get("id"),
+                filename=filename,
+                error=str(exc),
+            )
+            continue
+        email_attachments.append(
+            {
+                "filename": str(attachment.get("original_filename") or filename),
+                "content": content,
+                "mime_type": attachment.get("mime_type") or "application/octet-stream",
+            }
+        )
+    return email_attachments
+
+
+def _attachments_for_smtp2go(attachments: list[dict[str, Any]]) -> list[dict[str, str]]:
+    formatted: list[dict[str, str]] = []
+    for attachment in attachments:
+        content = attachment.get("content")
+        if isinstance(content, str):
+            encoded = content
+        elif isinstance(content, bytes):
+            encoded = base64.b64encode(content).decode("ascii")
+        elif isinstance(content, bytearray):
+            encoded = base64.b64encode(bytes(content)).decode("ascii")
+        else:
+            continue
+        formatted.append(
+            {
+                "filename": str(attachment.get("filename") or "attachment"),
+                "content": encoded,
+            }
+        )
+    return formatted
 
 def _coerce_int(
     value: Any, *, minimum: int | None = None, maximum: int | None = None
@@ -2891,6 +2984,11 @@ async def _invoke_smtp(
     text_body = payload.get("text") or payload.get("text_body")
     # Payload sender takes precedence over settings from_address
     sender = str(payload.get("sender") or settings.get("from_address") or "") or None
+    attachments = (
+        payload.get("attachments") if isinstance(payload.get("attachments"), list) else None
+    )
+    if attachments is None:
+        attachments = await _load_ticket_email_attachments(payload)
 
     # Extract ticket reply ID from context if present, to enable email tracking
     enable_tracking = False
@@ -2955,6 +3053,7 @@ async def _invoke_smtp(
             sender=sender,
             enable_tracking=enable_tracking,
             ticket_reply_id=ticket_reply_id,
+            attachments=attachments,
         )
     except Exception as exc:  # pragma: no cover - defensive logging
         updated_event = await _record_failure(
@@ -3108,6 +3207,8 @@ async def _invoke_smtp2go(
         if isinstance(payload.get("attachments"), list)
         else None
     )
+    if attachments is None:
+        attachments = _attachments_for_smtp2go(await _load_ticket_email_attachments(payload))
     template_id = str(payload.get("template_id") or "").strip() or None
     template_data = (
         payload.get("template_data")


### PR DESCRIPTION
### Motivation
- Automation emails for ticket replies were not including ticket attachments, causing recipients to miss files sent via automations.
- The change aims to automatically attach ticket files to outgoing automation emails when the automation payload or context identifies a ticket, while preserving explicit `attachments` provided by automations.

### Description
- Added attachment normalization and SMTP-attachment support to `send_email` (`app/services/email.py`) via a new `_normalise_attachment` helper and an `attachments` parameter.
- Added ticket discovery and file-loading helpers (`_extract_ticket_id_from_email_payload`, `_load_ticket_email_attachments`, `_attachments_for_smtp2go`) in `app/services/modules.py` to auto-load `open`/`closed` ticket attachments when no explicit attachments are provided in the payload. 
- Wired automatic attachments into automation flows so `_invoke_smtp` passes `attachments` into `email_service.send_email` and `_invoke_smtp2go` converts bytes into the base64 `attachments` format expected by the SMTP2Go API. 
- When files are unavailable the implementation logs a warning and skips those files, and explicit `attachments` in the payload are preserved and take precedence.

### Testing
- Compiled modified modules with `python -m py_compile app/services/email.py app/services/modules.py`, which succeeded. 
- Ran `pytest tests/test_smtp2go_tracking_fixes.py -q`, which could not complete because async tests require an async pytest plugin (e.g. `pytest-asyncio`) in this environment and therefore failed to execute the async test functions. 
- Basic repository lint/compile checks were performed and the modified files were verified to parse; full async test suite should be run in CI with `pytest-asyncio` installed to validate end-to-end behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54c6e730d8833294e114386116bcdb)