### PR TITLE
Add automation drag-and-drop reordering

### DIFF
--- a/app/features/automations/handlers.py
+++ b/app/features/automations/handlers.py
@@ -411,6 +411,29 @@ async def admin_automations_page(
     )
 
 
+async def admin_reorder_automations(request: Request):
+    from app.repositories import automations as automation_repo
+
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return JSONResponse({"detail": "Authentication required"}, status_code=status.HTTP_401_UNAUTHORIZED)
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError:
+        return JSONResponse({"detail": "Invalid JSON payload."}, status_code=status.HTTP_400_BAD_REQUEST)
+    ordered_ids = payload.get("ordered_ids") if isinstance(payload, Mapping) else None
+    if not isinstance(ordered_ids, list):
+        return JSONResponse({"detail": "ordered_ids must be a list."}, status_code=status.HTTP_400_BAD_REQUEST)
+    updated = await automation_repo.update_automation_order(ordered_ids)
+    return JSONResponse({
+        "success": True,
+        "automations": [
+            {"id": int(record["id"]), "execution_order": int(record.get("execution_order") or 0)}
+            for record in updated
+        ],
+    })
+
+
 async def admin_create_scheduled_automation_page(
     request: Request,
 ):

--- a/app/features/automations/routes.py
+++ b/app/features/automations/routes.py
@@ -16,6 +16,11 @@ router.add_api_route(
     response_class=HTMLResponse,
 )
 router.add_api_route(
+    "/admin/automations/reorder",
+    handlers.admin_reorder_automations,
+    methods=["POST"],
+)
+router.add_api_route(
     "/admin/automations/create/scheduled",
     handlers.admin_create_scheduled_automation_page,
     methods=["GET"],

--- a/app/repositories/automations.py
+++ b/app/repositories/automations.py
@@ -253,12 +253,62 @@ async def list_automations(
         SELECT *
         FROM automations
         {where_clause}
-        ORDER BY updated_at DESC
+        ORDER BY
+            CASE WHEN execution_order = 0 THEN 1 ELSE 0 END ASC,
+            CASE WHEN execution_order = 0 THEN NULL ELSE execution_order END ASC,
+            CASE WHEN execution_order = 0 THEN updated_at ELSE NULL END DESC,
+            id ASC
         LIMIT %s OFFSET %s
         """,
         tuple(params),
     )
     return [_normalise_automation(row) for row in rows]
+
+
+async def update_automation_order(ordered_ids: list[int]) -> list[AutomationRecord]:
+    """Update display order for ordered automations without changing legacy order-0 rows."""
+
+    await _ensure_connection()
+    unique_ids: list[int] = []
+    seen: set[int] = set()
+    for automation_id in ordered_ids:
+        try:
+            normalised_id = int(automation_id)
+        except (TypeError, ValueError):
+            continue
+        if normalised_id > 0 and normalised_id not in seen:
+            unique_ids.append(normalised_id)
+            seen.add(normalised_id)
+
+    if not unique_ids:
+        return []
+
+    placeholders = ", ".join(["%s"] * len(unique_ids))
+    rows = await db.fetch_all(
+        f"SELECT id, execution_order FROM automations WHERE id IN ({placeholders})",
+        tuple(unique_ids),
+    )
+    existing_orders = {
+        int(row_dict["id"]): int(row_dict.get("execution_order") or 0)
+        for row_dict in (dict(row) for row in rows)
+    }
+    ordered_existing_ids = [automation_id for automation_id in unique_ids if automation_id in existing_orders]
+    reorderable_ids = [automation_id for automation_id in ordered_existing_ids if existing_orders[automation_id] > 0]
+
+    for order, automation_id in enumerate(reorderable_ids, start=1):
+        if existing_orders.get(automation_id) == order:
+            continue
+        await db.execute(
+            "UPDATE automations SET execution_order = %s, updated_at = UTC_TIMESTAMP(6) WHERE id = %s AND execution_order <> 0",
+            (order, automation_id),
+        )
+
+    refreshed_rows = await db.fetch_all(
+        f"SELECT * FROM automations WHERE id IN ({placeholders})",
+        tuple(unique_ids),
+    )
+    by_id = {int(row["id"]): _normalise_automation(row) for row in refreshed_rows}
+    return [by_id[automation_id] for automation_id in unique_ids if automation_id in by_id]
 
 
 async def update_automation(automation_id: int, **fields: Any) -> AutomationRecord | None:

--- a/app/templates/admin/automations.html
+++ b/app/templates/admin/automations.html
@@ -58,9 +58,10 @@
         </div>
 
         <div class="table-wrapper">
-          <table class="table" id="automations-table" data-table data-table-id="automations">
+          <table class="table" id="automations-table" data-table data-table-id="automations" data-automation-reorder-table>
             <thead>
               <tr>
+                <th scope="col" data-column-key="reorder">Reorder</th>
                 <th scope="col" data-sort="int" data-column-key="id">ID</th>
                 <th scope="col" data-sort="int" data-column-key="order">Order</th>
                 <th scope="col" data-sort="string" data-column-key="name">Name</th>
@@ -76,7 +77,15 @@
             <tbody>
               {% if automations %}
                 {% for automation in automations %}
-                  <tr>
+                  {% set can_reorder = (automation.execution_order if automation.execution_order is not none else 0) > 0 %}
+                  <tr data-automation-row data-automation-id="{{ automation.id }}" data-automation-order="{{ automation.execution_order if automation.execution_order is not none else 0 }}" draggable="{{ 'true' if can_reorder else 'false' }}">
+                    <td data-label="Reorder" data-column-key="reorder">
+                      {% if can_reorder %}
+                        <button type="button" class="button button--ghost button--small" data-automation-drag-handle aria-label="Drag {{ automation.name }} to reorder">☰</button>
+                      {% else %}
+                        <span title="Order 0 automations keep their current order and are not changed by drag reordering.">Locked</span>
+                      {% endif %}
+                    </td>
                     <td data-label="ID" data-column-key="id">{{ automation.id }}</td>
                     <td data-label="Order" data-column-key="order">{{ automation.execution_order if automation.execution_order is not none else 0 }}</td>
                     <td data-label="Name" data-column-key="name">{{ automation.name }}</td>
@@ -162,7 +171,7 @@
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="10" class="table__empty">No automations configured.</td>
+                  <td colspan="11" class="table__empty">No automations configured.</td>
                 </tr>
               {% endif %}
             </tbody>
@@ -225,6 +234,78 @@
         menu.addEventListener('toggle', function () {
           wrapper.style.overflow = menu.open ? 'visible' : '';
         });
+      });
+
+      const table = document.querySelector('[data-automation-reorder-table]');
+      if (!table) return;
+      const tbody = table.querySelector('tbody');
+      let draggedRow = null;
+
+      function reorderableRows() {
+        return Array.from(tbody.querySelectorAll('[data-automation-row][draggable="true"]'));
+      }
+
+      function orderedIds() {
+        return Array.from(tbody.querySelectorAll('[data-automation-row]')).map(function (row) {
+          return Number(row.dataset.automationId);
+        }).filter(Boolean);
+      }
+
+      async function saveOrder() {
+        const response = await fetch('/admin/automations/reorder', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify({ ordered_ids: orderedIds() }),
+        });
+        if (!response.ok) {
+          throw new Error('Failed to save automation order.');
+        }
+        const data = await response.json();
+        (data.automations || []).forEach(function (automation) {
+          const row = tbody.querySelector('[data-automation-id="' + automation.id + '"]');
+          if (!row) return;
+          row.dataset.automationOrder = String(automation.execution_order || 0);
+          const orderCell = row.querySelector('[data-column-key="order"]');
+          if (orderCell) orderCell.textContent = String(automation.execution_order || 0);
+        });
+      }
+
+      table.addEventListener('dragstart', function (event) {
+        const row = event.target.closest('[data-automation-row][draggable="true"]');
+        if (!row) return;
+        draggedRow = row;
+        event.dataTransfer.effectAllowed = 'move';
+        event.dataTransfer.setData('text/plain', row.dataset.automationId || '');
+        row.classList.add('is-dragging');
+      });
+
+      table.addEventListener('dragend', function () {
+        if (draggedRow) draggedRow.classList.remove('is-dragging');
+        draggedRow = null;
+      });
+
+      table.addEventListener('dragover', function (event) {
+        if (!draggedRow) return;
+        const target = event.target.closest('[data-automation-row][draggable="true"]');
+        if (!target || target === draggedRow) return;
+        event.preventDefault();
+        const rect = target.getBoundingClientRect();
+        const insertAfter = event.clientY > rect.top + rect.height / 2;
+        tbody.insertBefore(draggedRow, insertAfter ? target.nextSibling : target);
+      });
+
+      table.addEventListener('drop', async function (event) {
+        if (!draggedRow) return;
+        event.preventDefault();
+        try {
+          await saveOrder();
+        } catch (error) {
+          window.location.reload();
+        }
+      });
+
+      reorderableRows().forEach(function (row) {
+        row.title = 'Drag to reorder automation execution order.';
       });
     });
   </script>

--- a/tests/test_automations_feature_pack.py
+++ b/tests/test_automations_feature_pack.py
@@ -16,6 +16,7 @@ EXPECTED = {
     ("GET", "/admin/automations/create/scheduled"),
     ("GET", "/admin/automations/create/event"),
     ("POST", "/admin/automations"),
+    ("POST", "/admin/automations/reorder"),
     ("GET", "/admin/automations/{automation_id}/preview"),
     ("GET", "/admin/automations/{automation_id}/simulate"),
     ("POST", "/admin/automations/{automation_id}/simulate/process"),


### PR DESCRIPTION
### Motivation
- Provide a simple UI for re-ordering automations in the admin UI while preserving legacy automations that use `execution_order = 0` (these should remain locked and keep their existing order). 
- Ensure saved ordering only affects automations that were explicitly ordered (non-zero `execution_order`).

### Description
- Added a POST admin endpoint `POST /admin/automations/reorder` implemented in `app/features/automations/handlers.py` and wired in `app/features/automations/routes.py` to accept an `ordered_ids` list and persist ordering. 
- Implemented `update_automation_order` in `app/repositories/automations.py` which updates only automations with `execution_order > 0` and returns the refreshed records; input ids are de-duplicated and validated. 
- Changed `list_automations` ordering to surface explicitly-ordered automations first (by `execution_order`) while keeping `execution_order = 0` automations in their legacy `updated_at` order so existing behaviour for legacy rows is preserved. 
- Added client-side drag-and-drop controls and save logic to `app/templates/admin/automations.html` which marks rows with `execution_order == 0` as locked and posts the displayed order to the new endpoint; updated the automations pack smoke test expectation in `tests/test_automations_feature_pack.py` to include the new route.

### Testing
- Compiled modified modules with `python3 -m py_compile app/repositories/automations.py app/features/automations/handlers.py app/features/automations/routes.py` and the compilation succeeded. 
- Ran `git diff --check` to validate whitespace/patch hygiene with no issues. 
- Attempted to run `pytest tests/test_automations_feature_pack.py tests/test_automations_repository_datetimes.py`, but test collection was blocked by the environment missing the system `libmagic` dependency required by `python-magic`; automated tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54cc7089508332b74b6c038c07d6c6)