### PR TITLE
Keep hidden ticket statuses filterable

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8690,8 +8690,8 @@ async def _render_tickets_dashboard(
         for definition in dashboard.status_definitions
         if (bool(user.get("is_super_admin")) and not definition.hide_from_admins) or (not bool(user.get("is_super_admin")) and not definition.hide_from_technicians)
     ]
-    status_definitions_payload = [
-        {
+    def _status_definition_payload(definition: tickets_service.TicketStatusDefinition) -> dict[str, Any]:
+        return {
             "tech_status": definition.tech_status,
             "tech_label": definition.tech_label,
             "public_status": definition.public_status,
@@ -8699,7 +8699,14 @@ async def _render_tickets_dashboard(
             "hide_from_technicians": definition.hide_from_technicians,
             "hide_from_admins": definition.hide_from_admins,
         }
+
+    status_definitions_payload = [
+        _status_definition_payload(definition)
         for definition in selectable_status_definitions
+    ]
+    filter_status_definitions_payload = [
+        _status_definition_payload(definition)
+        for definition in dashboard.status_definitions
     ]
     status_label_map = {
         definition.tech_status: definition.tech_label for definition in dashboard.status_definitions
@@ -8725,6 +8732,7 @@ async def _render_tickets_dashboard(
         "ticket_status_counts": global_status_counts,
         "ticket_available_statuses": dashboard.available_statuses,
         "ticket_status_definitions": status_definitions_payload,
+        "ticket_filter_status_definitions": filter_status_definitions_payload,
         "ticket_status_label_map": status_label_map,
         "ticket_public_status_map": public_status_map,
         "ticket_reply_default_status": reply_default_status,

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -278,7 +278,7 @@
               <div class="ticket-filters__section">
                 <h3 class="ticket-filters__section-title">Filter by Status</h3>
                 <div class="ticket-filters__status-grid">
-                  {% for status_option in ticket_status_definitions %}
+                  {% for status_option in ticket_filter_status_definitions | default(ticket_status_definitions) %}
                     <label class="ticket-filters__status-item">
                       <input 
                         type="checkbox" 

--- a/tests/test_tickets_dashboard_logging.py
+++ b/tests/test_tickets_dashboard_logging.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import status
@@ -51,8 +52,11 @@ async def test_phone_search_error_does_not_log_raw_phone(monkeypatch):
         captured["meta"] = meta
 
     monkeypatch.setattr(main_module.tickets_repo, "list_tickets_by_requester_phone", fake_list_tickets_by_requester_phone)
+    monkeypatch.setattr(main_module.tickets_repo, "count_tickets_by_status", AsyncMock(return_value={}))
     monkeypatch.setattr(main_module.tickets_service, "load_dashboard_state", fake_load_dashboard_state)
     monkeypatch.setattr(main_module, "_get_ticket_dashboard_reference_data", fake_get_reference_data)
+    monkeypatch.setattr(main_module.labour_types_service, "list_labour_types", AsyncMock(return_value=[]))
+    monkeypatch.setattr(main_module.site_settings_repo, "get_next_ticket_number", AsyncMock(return_value=1))
     monkeypatch.setattr(main_module, "_render_template", fake_render_template)
     monkeypatch.setattr(main_module, "log_error", fake_log_error)
 
@@ -68,3 +72,72 @@ async def test_phone_search_error_does_not_log_raw_phone(monkeypatch):
     assert captured["message"] == "Error searching tickets by phone number"
     assert captured["meta"]["phone_number_provided"] is True
     assert "phone_number" not in captured["meta"]
+
+@pytest.mark.anyio
+async def test_hidden_statuses_remain_available_as_dashboard_filters(monkeypatch):
+    captured: dict[str, object] = {}
+    status_definitions = [
+        main_module.tickets_service.TicketStatusDefinition(
+            tech_status="open",
+            tech_label="Open",
+            public_status="Open",
+        ),
+        main_module.tickets_service.TicketStatusDefinition(
+            tech_status="vendor_wait",
+            tech_label="Vendor Wait",
+            public_status="Waiting",
+            hide_from_technicians=True,
+            hide_from_admins=True,
+        ),
+    ]
+
+    async def fake_load_dashboard_state(**kwargs):
+        return SimpleNamespace(
+            tickets=[],
+            total=0,
+            status_counts={},
+            available_statuses=[definition.tech_status for definition in status_definitions],
+            status_definitions=status_definitions,
+            modules=[],
+            companies=[],
+            technicians=[],
+            company_lookup={},
+            user_lookup={},
+        )
+
+    async def fake_get_reference_data():
+        return {
+            "modules": [],
+            "companies": [],
+            "technicians": [],
+            "company_lookup": {},
+            "user_lookup": {},
+        }
+
+    async def fake_render_template(name, request, user, extra=None):
+        captured["template_name"] = name
+        captured["extra"] = extra or {}
+        return HTMLResponse("ok", status_code=status.HTTP_200_OK)
+
+    monkeypatch.setattr(main_module.tickets_service, "load_dashboard_state", fake_load_dashboard_state)
+    monkeypatch.setattr(main_module.tickets_repo, "count_tickets_by_status", AsyncMock(return_value={}))
+    monkeypatch.setattr(main_module, "_get_ticket_dashboard_reference_data", fake_get_reference_data)
+    monkeypatch.setattr(main_module.labour_types_service, "list_labour_types", AsyncMock(return_value=[]))
+    monkeypatch.setattr(main_module.site_settings_repo, "get_next_ticket_number", AsyncMock(return_value=1))
+    monkeypatch.setattr(main_module, "_render_template", fake_render_template)
+
+    request = Request({"type": "http", "method": "GET", "path": "/admin/tickets", "headers": []})
+
+    response = await main_module._render_tickets_dashboard(
+        request,
+        {"id": 5, "is_super_admin": False},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert captured["template_name"] == "admin/tickets.html"
+    extra = captured["extra"]
+    assert [item["tech_status"] for item in extra["ticket_status_definitions"]] == ["open"]
+    assert [item["tech_status"] for item in extra["ticket_filter_status_definitions"]] == [
+        "open",
+        "vendor_wait",
+    ]


### PR DESCRIPTION
### Motivation
- Hidden ticket statuses should remain usable as filter options in the admin ticket dashboard while still being prevented from being set by admins/technicians.

### Description
- Add a helper `def _status_definition_payload(definition: tickets_service.TicketStatusDefinition) -> dict[str, Any]` and build two payloads: `ticket_status_definitions` (selectable statuses respecting `hide_from_admins`/`hide_from_technicians`) and `ticket_filter_status_definitions` (the full catalogue from `dashboard.status_definitions`).
- Pass `ticket_filter_status_definitions` into the admin dashboard template and update the Filter by Status UI to iterate `ticket_filter_status_definitions | default(ticket_status_definitions)` so filters show the full list while legacy contexts still work.
- Add a regression test `test_hidden_statuses_remain_available_as_dashboard_filters` to assert hidden statuses are excluded from settable options but present in the filter payload, and add a few test stubs (`count_tickets_by_status`, `labour_types_service.list_labour_types`, `site_settings_repo.get_next_ticket_number`) to keep the test isolated.

### Testing
- Ran `pytest -q tests/test_tickets_dashboard_logging.py` with the modified tests and both relevant cases passed (`2 passed`, many unrelated warnings only). 
- Ran `python -m compileall app/main.py tests/test_tickets_dashboard_logging.py` and `git diff --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a559ffb667c83329fe45c7a28439394)