### PR TITLE
Enable customer chat, technician-initiated chat, and tray desktop push notifications by default

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -273,7 +273,7 @@ async def get_device_config(
     if device.get("company_id"):
         company = await companies_repo.get_company_by_id(int(device["company_id"]))
         chat_enabled = bool(
-            company and company.get("tray_chat_enabled") and _settings.matrix_enabled
+            company and company.get("tray_chat_enabled", True) and _settings.matrix_enabled
         )
     return TrayConfigResponse(
         version=int(config.get("version") or 1),
@@ -2103,7 +2103,7 @@ async def issue_chat_token(
     if company_id:
         company = await companies_repo.get_company_by_id(int(company_id))
         if not (
-            company and company.get("tray_chat_enabled") and _settings.matrix_enabled
+            company and company.get("tray_chat_enabled", True) and _settings.matrix_enabled
         ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/app/services/tray.py
+++ b/app/services/tray.py
@@ -664,7 +664,7 @@ async def push_notification_to_company_devices(
     if company_id is None:
         return {"targeted": 0, "delivered": 0, "queued": 0}
     company = await companies_repo.get_company_by_id(int(company_id))
-    if not company or not company.get("tray_notifications_enabled"):
+    if not company or not company.get("tray_notifications_enabled", True):
         return {"targeted": 0, "delivered": 0, "queued": 0}
 
     active_devices = await tray_repo.list_devices(
@@ -737,6 +737,6 @@ def technician_can_initiate(
         return True
     if not company:
         return False
-    if not company.get("tray_chat_enabled"):
+    if not company.get("tray_chat_enabled", True):
         return False
     return bool(user.get("is_helpdesk_technician"))

--- a/migrations/298_enable_company_chat_notification_defaults.sql
+++ b/migrations/298_enable_company_chat_notification_defaults.sql
@@ -1,0 +1,22 @@
+-- Migration 298: Enable company chat and desktop notification defaults
+-- Ensure new and existing companies have chat and desktop push notifications
+-- enabled unless an admin disables them after this migration.
+
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS customer_chat_enabled TINYINT(1) NOT NULL DEFAULT 1;
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS tray_chat_enabled TINYINT(1) NOT NULL DEFAULT 1;
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS tray_notifications_enabled TINYINT(1) NOT NULL DEFAULT 1;
+
+UPDATE companies
+SET customer_chat_enabled = 1,
+    tray_chat_enabled = 1,
+    tray_notifications_enabled = 1
+WHERE customer_chat_enabled IS NULL
+   OR customer_chat_enabled <> 1
+   OR tray_chat_enabled IS NULL
+   OR tray_chat_enabled <> 1
+   OR tray_notifications_enabled IS NULL
+   OR tray_notifications_enabled <> 1;
+
+ALTER TABLE companies MODIFY COLUMN customer_chat_enabled TINYINT(1) NOT NULL DEFAULT 1;
+ALTER TABLE companies MODIFY COLUMN tray_chat_enabled TINYINT(1) NOT NULL DEFAULT 1;
+ALTER TABLE companies MODIFY COLUMN tray_notifications_enabled TINYINT(1) NOT NULL DEFAULT 1;


### PR DESCRIPTION
### Motivation
- Ensure chat and tray desktop push notification features are enabled by default for both new and existing companies so admins opt-out rather than opt-in. 
- Treat missing or unset company flags as enabled at runtime to avoid surprising behaviour for companies created before these columns existed.

### Description
- Add migration `migrations/298_enable_company_chat_notification_defaults.sql` which creates the three columns `customer_chat_enabled`, `tray_chat_enabled`, and `tray_notifications_enabled` with `DEFAULT 1`, backfills existing rows to `1`, and re-applies `NOT NULL DEFAULT 1` for each column. 
- Update `app/api/routes/tray.py` to treat `company.get("tray_chat_enabled")` as `company.get("tray_chat_enabled", True)` when resolving device config and issuing chat tokens. 
- Update `app/services/tray.py` to treat `tray_notifications_enabled` and `tray_chat_enabled` as enabled by default via `company.get(..., True)` and to use the default when deciding whether to push notifications or allow technician-initiated chats. 

### Testing
- Ran `python -m py_compile app/api/routes/tray.py app/services/tray.py` which succeeded. 
- Executed `python -m pytest tests/test_tray_app.py` which ran the tray test suite and produced test results (2 failed, 14 passed, 28 errors) due to import/runtime issues in the environment. 
- Attempted `python -m pytest tests/test_tray_app.py tests/test_tray_devices_page.py` which failed during collection with an `ImportError` for the system `libmagic` dependency in the test environment, preventing completion of those tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a55a352ce54833283eed0215597912a)