### PR TITLE
Add TrayAgentID sync column to assets

### DIFF
--- a/app/features/assets/routes.py
+++ b/app/features/assets/routes.py
@@ -30,6 +30,7 @@ _ASSET_TABLE_COLUMNS: list[dict[str, str]] = [
     {"key": "ram_gb", "label": "RAM (GB)", "sort": "number"},
     {"key": "hdd_size", "label": "Storage", "sort": "string"},
     {"key": "last_sync", "label": "Last sync", "sort": "date", "priority": "essential"},
+    {"key": "tray_agent_synced", "label": "TrayAgentID synced", "sort": "number", "field_type": "checkbox"},
     {"key": "motherboard_manufacturer", "label": "Motherboard", "sort": "string"},
     {"key": "form_factor", "label": "Form factor", "sort": "string"},
     {"key": "last_user", "label": "Last user", "sort": "string", "priority": "essential"},
@@ -222,6 +223,7 @@ async def assets_page(request: Request):
         tray_device = tray_devices_by_asset.get(int(record["id"])) if record.get("id") else None
         record["tray_device_uid"] = tray_device.get("device_uid") if tray_device else None
         record["tray_device_hostname"] = tray_device.get("hostname") if tray_device else None
+        record["tray_agent_synced"] = bool(record["tray_device_uid"])
         record["can_open_chat"] = bool(record["tray_device_uid"] and main_module.settings.matrix_enabled)
         asset_id = record.get("id")
         asset_cf = cf_values_by_asset.get(asset_id, {})

--- a/tests/test_assets_permissions.py
+++ b/tests/test_assets_permissions.py
@@ -83,3 +83,77 @@ async def test_assets_page_redirects_when_menu_permission_is_none(monkeypatch):
 
     assert response.status_code == 303
     assert response.headers["location"] == "/"
+
+
+@pytest.mark.anyio
+async def test_assets_page_adds_tray_agent_sync_column(monkeypatch):
+    user = {"id": 7, "company_id": 42, "is_super_admin": False}
+    membership = {
+        "company_id": 42,
+        "can_manage_assets": False,
+        "menu_permissions": {"menu.assets": "read"},
+    }
+
+    async def fake_require_authenticated_user(request):
+        return user, None
+
+    async def fake_get_user_company(user_id, company_id):
+        return membership
+
+    async def fake_get_company_by_id(company_id):
+        return {"id": company_id, "name": "Acme"}
+
+    async def fake_list_company_assets(company_id):
+        return [
+            {
+                "id": 100,
+                "company_id": company_id,
+                "name": "Workstation-100",
+                "type": "workstation",
+                "status": "active",
+            },
+            {
+                "id": 200,
+                "company_id": company_id,
+                "name": "Workstation-200",
+                "type": "workstation",
+                "status": "active",
+            },
+        ]
+
+    async def fake_list_field_definitions():
+        return []
+
+    async def fake_get_all_asset_field_values(asset_ids):
+        return {}
+
+    async def fake_list_active_devices_by_asset_ids(asset_ids):
+        assert asset_ids == [100, 200]
+        return {100: {"id": 1, "asset_id": 100, "device_uid": "tray-100", "hostname": "pc-100"}}
+
+    async def fake_render_template(template, request, current_user, *, extra=None):
+        assert template == "assets/index.html"
+        column = next(column for column in extra["columns"] if column["key"] == "tray_agent_synced")
+        assert column == {
+            "key": "tray_agent_synced",
+            "label": "TrayAgentID synced",
+            "sort": "number",
+            "field_type": "checkbox",
+        }
+        assets_by_id = {asset["id"]: asset for asset in extra["assets"]}
+        assert assets_by_id[100]["tray_agent_synced"] is True
+        assert assets_by_id[200]["tray_agent_synced"] is False
+        return HTMLResponse("assets page")
+
+    monkeypatch.setattr(main_module, "_require_authenticated_user", fake_require_authenticated_user)
+    monkeypatch.setattr(assets_routes.user_company_repo, "get_user_company", fake_get_user_company)
+    monkeypatch.setattr(assets_routes.company_repo, "get_company_by_id", fake_get_company_by_id)
+    monkeypatch.setattr(assets_routes.asset_repo, "list_company_assets", fake_list_company_assets)
+    monkeypatch.setattr(assets_routes.asset_custom_fields_repo, "list_field_definitions", fake_list_field_definitions)
+    monkeypatch.setattr(assets_routes.asset_custom_fields_repo, "get_all_asset_field_values", fake_get_all_asset_field_values)
+    monkeypatch.setattr(assets_routes.tray_repo, "list_active_devices_by_asset_ids", fake_list_active_devices_by_asset_ids)
+    monkeypatch.setattr(main_module, "_render_template", fake_render_template)
+
+    response = await assets_routes.assets_page(_request())
+
+    assert response.status_code == 200


### PR DESCRIPTION
### Motivation
- Provide a selectable column in the Assets table so administrators can see which assets have a Tactical RMM `TrayAgentID` linked (i.e. a tray device was attached when TRMM data was synchronised). 

### Description
- Add a new table column definition `{"key": "tray_agent_synced", "label": "TrayAgentID synced", "sort": "number", "field_type": "checkbox"}` to `app/features/assets/routes.py` so it appears in the column picker. 
- Populate the column per-row by setting `record["tray_agent_synced"] = bool(record["tray_device_uid"])` after loading active tray devices via `tray_repo.list_active_devices_by_asset_ids`. 
- Include the new column in the existing `all_columns` flow so it is passed to the template. 
- Add route-level test coverage in `tests/test_assets_permissions.py` that asserts the column metadata is present and that linked/unlinked assets yield `True`/`False` values. 

### Testing
- Ran `python -m py_compile app/features/assets/routes.py tests/test_assets_permissions.py` which succeeded. 
- Added `tests/test_assets_permissions.py::test_assets_page_adds_tray_agent_sync_column` to verify column metadata and boolean values are passed to the template. 
- Attempted `pytest -q tests/test_assets_permissions.py` but test collection was blocked by a missing system dependency (`libmagic`) required by the environment, so full test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a55a95202248332983d35140beaa688)