### PR TITLE
Send ticket reply attachments in automation emails

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -1697,18 +1697,21 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
         mentioned_user_ids = await _valid_mentioned_user_ids(ticket, _parse_mentioned_user_ids(form))
         if mentioned_user_ids:
             await tickets_repo.bulk_add_watchers(ticket_id, mentioned_user_ids)
+        reply_attachments: list[dict[str, Any]] = []
         attachments = form.getlist("attachments")
         if attachments:
             for attachment in attachments:
                 filename = (attachment.filename or "") if attachment else ""
                 if filename:
                     try:
-                        await attachments_service.save_uploaded_file(
+                        saved_attachment = await attachments_service.save_uploaded_file(
                             ticket_id=ticket_id,
                             file=attachment,
                             access_level="closed",
                             uploaded_by_user_id=author_id,
                         )
+                        if saved_attachment:
+                            reply_attachments.append(saved_attachment)
                     except Exception as exc:  # pragma: no cover - defensive logging
                         log_error(
                             "Failed to save attachment",
@@ -1728,17 +1731,20 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
         await tickets_service.refresh_ticket_ai_summary(ticket_id)
         await tickets_service.refresh_ticket_ai_tags(ticket_id)
         await tickets_service.broadcast_ticket_event(action="reply", ticket_id=ticket_id)
+        reply_event_payload = dict(created_reply)
+        if reply_attachments:
+            reply_event_payload["attachments"] = reply_attachments
         await tickets_service.emit_ticket_updated_event(
             ticket_id,
             actor_type="technician",
             actor=current_user,
-            reply=created_reply,
+            reply=reply_event_payload,
         )
         await tickets_service.emit_ticket_replied_event(
             ticket_id,
             actor_type="technician",
             actor=current_user,
-            reply=created_reply,
+            reply=reply_event_payload,
         )
     except Exception as exc:  # pragma: no cover - defensive logging
         log_error("Failed to create ticket reply", error=str(exc))

--- a/app/features/tickets/portal_routes.py
+++ b/app/features/tickets/portal_routes.py
@@ -393,17 +393,20 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
             await tickets_repo.set_ticket_status(ticket_id, reply_status)
 
         # Handle file attachments
+        reply_attachments: list[dict[str, Any]] = []
         attachments = form.getlist("attachments")
         if attachments:
             for attachment in attachments:
                 if hasattr(attachment, "filename") and attachment.filename:
                     try:
-                        await attachments_service.save_uploaded_file(
+                        saved_attachment = await attachments_service.save_uploaded_file(
                             ticket_id=ticket_id,
                             file=attachment,
                             access_level="closed",
                             uploaded_by_user_id=user_id,
                         )
+                        if saved_attachment:
+                            reply_attachments.append(saved_attachment)
                     except Exception as exc:
                         log_error(
                             "Failed to save attachment",
@@ -432,17 +435,20 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
         pass
     await tickets_service.refresh_ticket_ai_tags(ticket_id)
     actor_type = "technician" if has_helpdesk_access or is_super_admin else "requester"
+    reply_event_payload = dict(created_reply)
+    if reply_attachments:
+        reply_event_payload["attachments"] = reply_attachments
     await tickets_service.emit_ticket_updated_event(
         ticket_id,
         actor_type=actor_type,
         actor=user,
-        reply=created_reply,
+        reply=reply_event_payload,
     )
     await tickets_service.emit_ticket_replied_event(
         ticket_id,
         actor_type=actor_type,
         actor=user,
-        reply=created_reply,
+        reply=reply_event_payload,
     )
     await tickets_service.broadcast_ticket_event(action="reply", ticket_id=ticket_id)
 

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -511,28 +511,38 @@ async def _load_ticket_email_attachments(payload: Mapping[str, Any]) -> list[dic
     """Load ticket attachments for automation email modules when possible.
 
     Explicit payload attachments are respected by callers; this helper only supplies
-    attachments automatically when the automation context identifies a ticket.
+    attachments automatically when the automation context identifies a ticket. Reply
+    events can provide the attachments uploaded with that reply so the outgoing
+    email does not have to fall back to every attachment on the ticket.
     """
     ticket_id = _extract_ticket_id_from_email_payload(payload)
-    if ticket_id is None:
-        return []
+    context = payload.get("context")
 
     from app.repositories import ticket_attachments as attachments_repo
     from app.services import ticket_attachments as attachments_service
 
-    email_attachments: list[dict[str, Any]] = []
-    try:
-        attachments = await attachments_repo.list_attachments(
-            ticket_id, access_levels=("open", "closed")
-        )
-    except Exception as exc:  # pragma: no cover - defensive logging
-        logger.warning(
-            "Unable to load ticket attachments for automation email",
-            ticket_id=ticket_id,
-            error=str(exc),
-        )
-        return []
+    attachments: list[Mapping[str, Any]] = []
+    if isinstance(context, Mapping):
+        reply = context.get("reply")
+        if isinstance(reply, Mapping) and isinstance(reply.get("attachments"), list):
+            attachments = [item for item in reply["attachments"] if isinstance(item, Mapping)]
 
+    if not attachments:
+        if ticket_id is None:
+            return []
+        try:
+            attachments = await attachments_repo.list_attachments(
+                ticket_id, access_levels=("open", "closed")
+            )
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning(
+                "Unable to load ticket attachments for automation email",
+                ticket_id=ticket_id,
+                error=str(exc),
+            )
+            return []
+
+    email_attachments: list[dict[str, Any]] = []
     for attachment in attachments:
         filename = str(attachment.get("filename") or "").strip()
         if not filename:


### PR DESCRIPTION
### Motivation
- Ticket reply emails and automation modules were not including attachments uploaded as part of the reply, causing attachments to be omitted from outgoing messages and automation context.

### Description
- Capture saved attachment records when creating replies in `app/features/tickets/admin_routes.py` by appending `saved_attachment` to a `reply_attachments` list after `save_uploaded_file` returns. 
- Apply the same capture logic for portal replies in `app/features/tickets/portal_routes.py` so user-submitted reply attachments are recorded.
- When emitting `tickets.updated`/`tickets.replied` events, attach the reply-specific attachments to the reply payload (populate `reply_event_payload["attachments"]`) so automations receive the attachments in `context.reply.attachments`.
- Update `app/services/modules.py::_load_ticket_email_attachments` to prefer `context.reply.attachments` when present and fall back to loading ticket-level attachments via the repository when no reply-specific list is available.

### Testing
- Compiled modified modules with `python -m py_compile app/features/tickets/admin_routes.py app/features/tickets/portal_routes.py app/services/modules.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a55aa5e2a7c83328aea319dbdcc5512)