### PR TITLE
Validate watcher user IDs and support email-only staff in watcher UI

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -36,6 +36,7 @@ from app.repositories import ticket_attachments as attachments_repo
 from app.repositories import ticket_tasks as ticket_tasks_repo
 from app.repositories import ticket_views as ticket_views_repo
 from app.repositories import tickets as tickets_repo
+from app.repositories import users as user_repo
 from app.schemas.tickets import (
     LabourTypeCreateRequest,
     LabourTypeListResponse,
@@ -1272,6 +1273,12 @@ async def add_watcher(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found"
         )
+    watcher_user = await user_repo.get_user_by_id(user_id)
+    if not watcher_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Watcher user not found"
+        )
+
     await tickets_repo.add_watcher(ticket_id, user_id=user_id)
     await audit_service.record(
         action="ticket.watcher.add",

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -2073,20 +2073,24 @@
 
     // Handle add watcher by user ID
     addButton.addEventListener('click', async () => {
-      const userId = selectElement.value;
-      if (!userId) {
+      const watcherValue = selectElement.value;
+      if (!watcherValue) {
         return;
       }
 
       const selectedOption = selectElement.options[selectElement.selectedIndex];
+      const watcherKind = selectedOption.dataset.watcherKind || 'user';
       const userEmail = selectedOption.textContent || '';
+      const watcherUrl = watcherKind === 'email'
+        ? `/api/tickets/${ticketId}/watchers/email?email=${encodeURIComponent(watcherValue)}`
+        : `/api/tickets/${ticketId}/watchers/${watcherValue}`;
 
       addButton.disabled = true;
       addButton.setAttribute('aria-busy', 'true');
 
       try {
         const csrfToken = getCsrfToken();
-        const response = await fetch(`/api/tickets/${ticketId}/watchers/${userId}`, {
+        const response = await fetch(watcherUrl, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -2104,7 +2108,11 @@
         selectElement.value = '';
 
         // Add to watchers list
-        addWatcherToList(userId, userEmail, null);
+        addWatcherToList(
+          watcherKind === 'user' ? watcherValue : null,
+          userEmail,
+          watcherKind === 'email' ? watcherValue : null,
+        );
       } catch (error) {
         console.error('Failed to add watcher:', error);
         alert(error instanceof Error ? error.message : 'Failed to add watcher');

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -389,7 +389,11 @@
                                   {% endif %}
                                 {% endfor %}
                                 {% if not is_watching.value %}
-                                  <option value="{{ staff_user.id }}">{{ staff_user.email }}</option>
+                                  {% if staff_user.user_id %}
+                                    <option value="{{ staff_user.user_id }}" data-watcher-kind="user">{{ staff_user.email }}</option>
+                                  {% else %}
+                                    <option value="{{ staff_user.email }}" data-watcher-kind="email">{{ staff_user.email }}</option>
+                                  {% endif %}
                                 {% endif %}
                               {% endfor %}
                             {% endif %}

--- a/tests/test_ticket_watchers_api.py
+++ b/tests/test_ticket_watchers_api.py
@@ -166,6 +166,11 @@ def test_add_watcher_success(monkeypatch, active_session):
 
     monkeypatch.setattr(tickets_repo, "get_ticket", mock_get_ticket)
     monkeypatch.setattr(tickets_repo, "add_watcher", mock_add_watcher)
+    monkeypatch.setattr(
+        ticket_routes.user_repo,
+        "get_user_by_id",
+        AsyncMock(return_value={"id": user_id, "email": "watcher@example.com"}),
+    )
     monkeypatch.setattr(tickets_repo, "list_watchers", mock_list_watchers)
     monkeypatch.setattr(tickets_repo, "list_replies", mock_list_replies)
     monkeypatch.setattr(
@@ -218,6 +223,39 @@ def test_add_watcher_ticket_not_found(monkeypatch, active_session):
                 headers={"X-CSRF-Token": active_session.csrf_token},
             )
         assert response.status_code == status.HTTP_404_NOT_FOUND
+    finally:
+        _reset_overrides()
+
+
+def test_add_watcher_user_not_found(monkeypatch, active_session):
+    """Adding a watcher by user ID returns 404 before hitting the database FK."""
+    ticket_id = 123
+    user_id = 9876
+
+    async def mock_get_ticket(tid):
+        return {"id": tid, "subject": "Test ticket"}
+
+    mock_add_watcher = AsyncMock()
+
+    monkeypatch.setattr(tickets_repo, "get_ticket", mock_get_ticket)
+    monkeypatch.setattr(tickets_repo, "add_watcher", mock_add_watcher)
+    monkeypatch.setattr(
+        ticket_routes.user_repo,
+        "get_user_by_id",
+        AsyncMock(return_value=None),
+    )
+
+    _override_dependencies(active_session)
+
+    try:
+        with TestClient(app) as client:
+            response = client.post(
+                f"/api/tickets/{ticket_id}/watchers/{user_id}",
+                headers={"X-CSRF-Token": active_session.csrf_token},
+            )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json()["detail"] == "Watcher user not found"
+        mock_add_watcher.assert_not_awaited()
     finally:
         _reset_overrides()
 


### PR DESCRIPTION
### Motivation
- Prevent MySQL foreign key IntegrityError when adding a watcher with an invalid `user_id` by validating the user first.
- Allow staff records without a linked portal user to be added as email-only watchers from the admin UI rather than sending an invalid staff id to the user-watcher endpoint.

### Description
- Add a user existence check in the watcher endpoint so `POST /api/tickets/{ticket_id}/watchers/{user_id}` returns `404 Watcher user not found` when the user is missing (`app/api/routes/tickets.py`).
- Update the admin watcher picker to distinguish registered users from email-only staff by emitting `data-watcher-kind` and using the user id or email as the option value (`app/templates/admin/ticket_detail.html`).
- Update the ticket detail JavaScript to select the correct API endpoint depending on the option kind (user vs email) and to render the added watcher entry correctly (`app/static/js/ticket_detail.js`).
- Add regression coverage and adjust an existing test to mock the user lookup, including a new test that asserts a `404` is returned and no DB insert is attempted for missing users (`tests/test_ticket_watchers_api.py`).

### Testing
- Ran `python -m py_compile app/api/routes/tickets.py` which succeeded.
- Ran `pytest -q tests/test_ticket_watchers_api.py` but test collection failed due to a missing system dependency (`libmagic`) required by the test environment, so the new tests could not be executed end-to-end.
- The change set includes the new regression test that should pass once the test environment provides `libmagic`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a55abac592883328c0edbf1dcb338f2)