### PR TITLE
Fix tray chat enablement for ticket assets

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9273,6 +9273,15 @@ async def _render_ticket_detail(
     asset_options: list[dict[str, Any]] = []
     if ticket_company_id is not None:
         company_assets = await assets_repo.list_company_assets(ticket_company_id)
+        company_asset_ids: list[int] = []
+        for asset_row in company_assets:
+            try:
+                company_asset_ids.append(int(asset_row.get("id")))
+            except (AttributeError, TypeError, ValueError):
+                continue
+        from app.repositories import tray as tray_repo
+
+        tray_devices_by_asset = await tray_repo.list_active_devices_by_asset_ids(company_asset_ids)
 
         def _format_asset_label(asset_row: Mapping[str, Any]) -> str:
             asset_name = str(asset_row.get("name") or "").strip() or "Asset"
@@ -9293,6 +9302,7 @@ async def _render_ticket_detail(
                 asset_id_int = int(asset_id)
             except (TypeError, ValueError):
                 continue
+            tray_device = tray_devices_by_asset.get(asset_id_int)
             asset_options.append(
                 {
                     "id": asset_id_int,
@@ -9301,6 +9311,10 @@ async def _render_ticket_detail(
                     "serial_number": str(asset_row.get("serial_number") or "").strip() or None,
                     "status": str(asset_row.get("status") or "").strip() or None,
                     "tactical_asset_id": str(asset_row.get("tactical_asset_id") or "").strip() or None,
+                    "tray_device_uid": (
+                        str((tray_device or {}).get("device_uid") or asset_row.get("tray_device_uid") or "").strip()
+                        or None
+                    ),
                 }
             )
 

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -646,6 +646,11 @@
         typeof tacticalIdRaw === 'string' || typeof tacticalIdRaw === 'number'
           ? String(tacticalIdRaw).trim()
           : '';
+      const trayDeviceUidRaw = option.tray_device_uid ?? option.device_uid ?? option.trayDeviceUid;
+      const trayDeviceUid =
+        typeof trayDeviceUidRaw === 'string' || typeof trayDeviceUidRaw === 'number'
+          ? String(trayDeviceUidRaw).trim()
+          : '';
       let name = '';
       if (typeof option.name === 'string' && option.name.trim() !== '') {
         name = option.name.trim();
@@ -672,6 +677,7 @@
         serial_number: serialNumber || null,
         status: statusValue || null,
         tactical_asset_id: tacticalId || null,
+        tray_device_uid: trayDeviceUid || null,
       };
     }
 

--- a/tests/test_ticket_rename.py
+++ b/tests/test_ticket_rename.py
@@ -32,3 +32,14 @@ def test_admin_ticket_detail_form_enables_autosave_for_details_and_assets():
     assert "document.addEventListener('focusout'" in script
     assert "document.addEventListener('change'" in script
     assert "ticket:details-autosave" in script
+
+
+def test_admin_ticket_asset_picker_preserves_tray_device_uid_for_chat():
+    main_source = Path("app/main.py").read_text()
+    script = Path("app/static/js/ticket_detail.js").read_text()
+
+    assert "tray_repo.list_active_devices_by_asset_ids(company_asset_ids)" in main_source
+    assert '"tray_device_uid": (' in main_source
+    assert "option.tray_device_uid ?? option.device_uid ?? option.trayDeviceUid" in script
+    assert "tray_device_uid: trayDeviceUid || null" in script
+    assert "if (record.tray_device_uid)" in script


### PR DESCRIPTION
### Motivation
- Technicians cannot initiate a tray chat from an admin ticket when the selected asset's enrolled tray device UID (`tray_device_uid`) is not propagated into the ticket asset picker, so synced TacticalRMM TrayAgentID links were not enabling the chat button.

### Description
- Look up active tray devices per-company assets and attach the resolved `tray_device_uid` to each `asset_options` entry in `_render_ticket_detail` so options include the enrolled device UID when available (`app/main.py`).
- Preserve `tray_device_uid` through the client-side asset normalisation by extracting `tray_device_uid` from multiple possible fields and returning it in `normaliseOption` so newly selected assets render an enabled chat button (`app/static/js/ticket_detail.js`).
- Add a regression assertion that verifies the server injects `tray_repo.list_active_devices_by_asset_ids(...)` and the client preserves `tray_device_uid` to prevent regressions (`tests/test_ticket_rename.py`).

### Testing
- Ran `pytest tests/test_ticket_rename.py` and the suite passed (4 tests, all OK). 
- Attempted `pytest tests/test_admin_ticket_detail.py tests/test_ticket_asset_link.py` but collection failed due to missing system dependency `libmagic` required by `python-magic` in the test environment, so those tests are blocked by the environment rather than the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a55ad14a8e0833296682021cdd88fd5)