### PR TITLE
Normalize SMTP2Go attachment payloads (use fileblob/url)

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -584,7 +584,7 @@ def _attachments_for_smtp2go(attachments: list[dict[str, Any]]) -> list[dict[str
         formatted.append(
             {
                 "filename": str(attachment.get("filename") or "attachment"),
-                "content": encoded,
+                "fileblob": encoded,
             }
         )
     return formatted

--- a/app/services/smtp2go.py
+++ b/app/services/smtp2go.py
@@ -9,6 +9,7 @@ Provides functionality for:
 
 from __future__ import annotations
 
+import base64
 from html import escape as html_escape
 import json
 import secrets
@@ -141,6 +142,59 @@ def _extract_tracking_identifier(event_data: dict[str, Any] | None) -> str | Non
             return value.strip()[:64]
 
     return None
+
+
+def _normalise_attachment_payloads(
+    attachments: list[dict[str, Any]] | None,
+) -> list[dict[str, str]] | None:
+    """Return SMTP2Go-compatible attachment payloads.
+
+    SMTP2Go's email/send endpoint requires each attachment to include either
+    ``fileblob`` (base64 file content) or ``url``.  Other parts of MyPortal and
+    legacy automation payloads use ``content`` for base64/bytes content, so
+    normalise that field before sending to avoid API model-validation errors.
+    """
+    if not attachments:
+        return None
+
+    normalised: list[dict[str, str]] = []
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+
+        filename = str(
+            attachment.get("filename")
+            or attachment.get("name")
+            or "attachment"
+        ).strip() or "attachment"
+
+        url = str(attachment.get("url") or "").strip()
+        if url:
+            normalised.append({"filename": filename, "url": url})
+            continue
+
+        fileblob = attachment.get("fileblob")
+        if isinstance(fileblob, str) and fileblob.strip():
+            normalised.append({"filename": filename, "fileblob": fileblob.strip()})
+            continue
+
+        content = attachment.get("content")
+        if isinstance(content, str) and content.strip():
+            encoded = content.strip()
+        elif isinstance(content, bytes):
+            encoded = base64.b64encode(content).decode("ascii")
+        elif isinstance(content, bytearray):
+            encoded = base64.b64encode(bytes(content)).decode("ascii")
+        else:
+            logger.warning(
+                "Skipping SMTP2Go attachment without url, fileblob, or content",
+                filename=filename,
+            )
+            continue
+
+        normalised.append({"filename": filename, "fileblob": encoded})
+
+    return normalised or None
 
 
 def get_email_template(template_type: EmailTemplateType) -> dict[str, Any]:
@@ -276,7 +330,7 @@ async def send_email_via_api(
     cc: list[str] | None = None,
     bcc: list[str] | None = None,
     custom_headers: dict[str, str] | None = None,
-    attachments: list[dict[str, str]] | None = None,
+    attachments: list[dict[str, Any]] | None = None,
     template_id: str | None = None,
     template_data: dict[str, Any] | None = None,
     tracking_id: str | None = None,
@@ -293,7 +347,7 @@ async def send_email_via_api(
         cc: List of CC recipient email addresses (optional)
         bcc: List of BCC recipient email addresses (optional)
         custom_headers: Additional email headers (optional)
-        attachments: List of attachment dicts with 'filename' and 'content' (base64) (optional)
+        attachments: List of attachment dicts with 'filename' plus 'fileblob', 'url', or legacy 'content' (optional)
         template_id: SMTP2Go template ID to use (optional)
         template_data: Template variables for SMTP2Go template (optional)
         tracking_id: Internal tracking ID to associate with this email (optional)
@@ -377,8 +431,9 @@ async def send_email_via_api(
             payload["bcc"] = bcc
         
         # Add attachments
-        if attachments and len(attachments) > 0:
-            payload["attachments"] = attachments
+        normalised_attachments = _normalise_attachment_payloads(attachments)
+        if normalised_attachments:
+            payload["attachments"] = normalised_attachments
         
         # Add SMTP2Go template fields
         if template_id:

--- a/tests/test_smtp2go.py
+++ b/tests/test_smtp2go.py
@@ -804,3 +804,71 @@ def test_send_email_records_response_tracking(monkeypatch):
         "tracking_id": "resp-track-456",
         "smtp2go_message_id": "smtp2go-123",
     }
+
+
+def test_normalise_attachment_payloads_uses_fileblob_for_legacy_content():
+    """SMTP2Go attachments must use fileblob rather than MyPortal's content key."""
+    payload = smtp2go._normalise_attachment_payloads(
+        [
+            {"filename": "note.txt", "content": b"hello"},
+            {"filename": "already.pdf", "fileblob": "cGRm"},
+            {"filename": "remote.png", "url": "https://example.com/remote.png"},
+        ]
+    )
+
+    assert payload == [
+        {"filename": "note.txt", "fileblob": "aGVsbG8="},
+        {"filename": "already.pdf", "fileblob": "cGRm"},
+        {"filename": "remote.png", "url": "https://example.com/remote.png"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_email_via_api_posts_fileblob_attachments(monkeypatch):
+    """Legacy content attachments are normalised before the SMTP2Go API call."""
+    captured = {}
+
+    class MockResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": {"error_code": "SUCCESS", "email_id": "msg-1"}}
+
+    class MockAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def post(self, url, json=None):
+            captured["json"] = json
+            return MockResponse()
+
+    async def mock_get_module_settings(slug):
+        return {"api_key": "test-api-key-123"}
+
+    from app.services import modules as modules_service
+    import httpx
+
+    monkeypatch.setattr(modules_service, "get_module_settings", mock_get_module_settings)
+    monkeypatch.setattr(httpx, "AsyncClient", MockAsyncClient)
+
+    await smtp2go.send_email_via_api(
+        to=["user@example.com"],
+        subject="Attachment Test",
+        html_body="<p>Body</p>",
+        sender="sender@example.com",
+        attachments=[{"filename": "note.txt", "content": b"hello"}],
+    )
+
+    assert captured["json"]["attachments"] == [
+        {"filename": "note.txt", "fileblob": "aGVsbG8="}
+    ]
+    assert "content" not in captured["json"]["attachments"][0]


### PR DESCRIPTION
### Motivation
- SMTP2Go's API rejects attachment objects that do not include either `url` or `fileblob`, causing 400 errors when MyPortal sent legacy `content`-style attachments.
- Various callers (automation modules, legacy payloads) historically used `content`/bytes for attachments, so a compatibility layer is required to convert those into SMTP2Go-compatible fields.

### Description
- Add `_normalise_attachment_payloads` to `app/services/smtp2go.py` to convert attachments that use legacy `content` (bytes/str/bytearray) into base64 `fileblob`, and preserve existing `fileblob` and `url` attachments. 
- Update `send_email_via_api` in `app/services/smtp2go.py` to run attachments through the normaliser before building the API `payload`. 
- Change automation formatting in `app/services/modules.py` so outbound SMTP2Go attachments use `fileblob` instead of the invalid `content` key. 
- Add regression tests in `tests/test_smtp2go.py` to cover normalization behaviour and to assert the outgoing SMTP2Go JSON payload contains `fileblob` (and not `content`).

### Testing
- Performed syntax/compile checks with `python3 -m py_compile app/services/smtp2go.py app/services/modules.py tests/test_smtp2go.py`, which completed successfully. 
- Attempted to run the new unit tests with `pytest -q tests/test_smtp2go.py`, but test collection failed in this environment due to a missing system dependency (`ImportError: failed to find libmagic`), so the full test execution could not be completed here. 
- The change is covered by new regression tests that will validate the fix when run in CI or an environment with the required native dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a55aeae189c833296ab8effd344fc0b)