### PR TITLE
Fix ticket reply message when no attachments selected

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -1721,11 +1721,11 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
                         )
                         has_failed_attachments = True
                 else:
-                    log_error(
-                        "Skipped attachment without filename; treating as failed upload",
-                        ticket_id=ticket_id,
-                    )
-                    has_failed_attachments = True
+                    # Browsers include an empty multipart field for the file input
+                    # when no files are selected. That is not an upload failure;
+                    # only named files that fail during save should affect the
+                    # success message.
+                    continue
         # Technicians should not be automatically added as ticket watchers when replying.
         await tickets_repo.set_ticket_status(ticket_id, reply_status)
         await tickets_service.refresh_ticket_ai_summary(ticket_id)

--- a/tests/test_admin_ticket_detail.py
+++ b/tests/test_admin_ticket_detail.py
@@ -370,6 +370,66 @@ async def test_admin_reply_uses_last_duplicate_reply_status(monkeypatch):
 
 
 @pytest.mark.anyio("asyncio")
+async def test_admin_reply_without_selected_attachments_uses_plain_success_message(monkeypatch):
+    """An empty file input should not be reported as a failed attachment upload."""
+
+    class DummySanitized:
+        def __init__(self, html: str):
+            self.html = html
+            self.text_content = html
+            self.has_rich_content = True
+
+    empty_upload = UploadFile(filename="", file=io.BytesIO(b""))
+    form_data = FormData(
+        [
+            ("body", "<p>reply</p>"),
+            ("attachments", empty_upload),
+        ]
+    )
+
+    class DummyRequest:
+        def __init__(self) -> None:
+            self.url = type("url", (), {"path": "/admin/tickets/9"})()
+
+        async def form(self):
+            return form_data
+
+    monkeypatch.setattr(
+        main,
+        "_require_helpdesk_page",
+        AsyncMock(return_value=({"id": 9, "is_super_admin": True}, None)),
+    )
+    monkeypatch.setattr(main, "sanitize_rich_text", lambda value: DummySanitized(str(value or "")))
+    monkeypatch.setattr(
+        main.tickets_repo,
+        "get_ticket",
+        AsyncMock(return_value={"id": 9, "xero_invoice_number": None}),
+    )
+    monkeypatch.setattr(main.tickets_repo, "create_reply", AsyncMock(return_value={"id": 91}))
+    monkeypatch.setattr(main.tickets_repo, "set_ticket_status", AsyncMock(return_value={"id": 9, "status": "pending"}))
+    monkeypatch.setattr(main.tickets_repo, "add_watcher", AsyncMock(return_value=None))
+    monkeypatch.setattr(main.tickets_service, "refresh_ticket_ai_summary", AsyncMock(return_value=None))
+    monkeypatch.setattr(main.tickets_service, "refresh_ticket_ai_tags", AsyncMock(return_value=None))
+    monkeypatch.setattr(main.tickets_service, "broadcast_ticket_event", AsyncMock(return_value=None))
+    monkeypatch.setattr(main.tickets_service, "emit_ticket_updated_event", AsyncMock(return_value=None))
+    monkeypatch.setattr(main.tickets_service, "emit_ticket_replied_event", AsyncMock(return_value=None))
+
+    save_mock = AsyncMock(return_value={"id": 1})
+    monkeypatch.setattr(main.attachments_service, "save_uploaded_file", save_mock)
+
+    response = await admin_routes.admin_create_ticket_reply(9, DummyRequest())
+
+    assert response.status_code == status.HTTP_303_SEE_OTHER
+    parsed = urlparse(response.headers.get("location", ""))
+    message_values = [value for values in parse_qs(parsed.query).values() for value in values]
+    message_values.extend(response.headers.getlist("set-cookie"))
+    decoded_messages = [unquote(value) for value in message_values]
+    assert any("Reply posted." in value for value in decoded_messages)
+    assert not any("failed" in value.lower() for value in decoded_messages)
+    save_mock.assert_not_awaited()
+
+
+@pytest.mark.anyio("asyncio")
 async def test_admin_reply_reports_failed_attachments(monkeypatch):
     """Failed attachment uploads should surface in the success message."""
 


### PR DESCRIPTION
### Motivation
- Empty multipart file fields from an unselected file input were being treated as failed uploads, causing the reply success popup to incorrectly say "some attachments failed to upload" when no files were chosen.

### Description
- Ignore empty multipart attachment fields (no filename) when processing reply uploads instead of setting `has_failed_attachments`, and add a regression test `test_admin_reply_without_selected_attachments_uses_plain_success_message` to confirm the plain success message is shown and the upload service is not called.

### Testing
- `pytest tests/test_admin_ticket_detail.py::test_admin_reply_without_selected_attachments_uses_plain_success_message` — passed.
- `pytest tests/test_admin_ticket_detail.py -q` — ran but surfaced unrelated pre-existing failures due to unmocked database interactions; the new test itself passed and the observed failures are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a55c65fba008332a203d63eb403ef66)