### PR TITLE
Trigger ticket automations for inbound SMS replies

### DIFF
--- a/app/features/receive_sms/routes.py
+++ b/app/features/receive_sms/routes.py
@@ -166,6 +166,7 @@ async def receive_sms(payload: ReceiveSMSPayload, request: Request, api_key_reco
     body = sanitize_rich_text(message_text).html
     ticket = await _find_sms_ticket(normalised_phone, sms_day)
     action = "created"
+    reply: dict[str, Any] | None = None
     try:
         if ticket:
             if str(ticket.get("status") or "").lower() in {"closed", "resolved"}:
@@ -178,7 +179,7 @@ async def receive_sms(payload: ReceiveSMSPayload, request: Request, api_key_reco
             if author_id is None:
                 contact = await _find_contact(payload.from_number)
                 author_id = contact.get("requester_id")
-            await tickets_repo.create_reply(
+            reply = await tickets_repo.create_reply(
                 ticket_id=int(ticket["id"]), author_id=author_id, body=body,
                 is_internal=False, external_reference=f"sms:{normalised_phone}:{sms_at.isoformat()}", created_at=sms_at,
                 author_display_name=(payload.name or payload.from_number) if author_id is None else None,
@@ -203,7 +204,17 @@ async def receive_sms(payload: ReceiveSMSPayload, request: Request, api_key_reco
             )
         ticket_id = int(ticket["id"])
         await _refresh_sms_ticket_ai(ticket_id)
-        await tickets_service.emit_ticket_updated_event(ticket, actor_type="api_key", actor={"id": api_key_record.get("id")})
+        if reply is not None:
+            await tickets_service.emit_ticket_replied_event(
+                ticket,
+                actor_type="requester",
+                reply=reply,
+            )
+            await tickets_service.emit_ticket_updated_event(
+                ticket,
+                actor_type="requester",
+                reply=reply,
+            )
     except Exception as exc:
         log_error("Failed to process inbound SMS", error=str(exc), from_number=payload.from_number)
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to process inbound SMS") from exc

--- a/tests/test_receive_sms_feature_pack.py
+++ b/tests/test_receive_sms_feature_pack.py
@@ -76,6 +76,7 @@ def test_receive_sms_created_ticket_refreshes_ai(monkeypatch):
         monkeypatch.setattr(receive_sms_routes.db, "execute", fake_execute)
         monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_summary", fake_summary)
         monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_tags", fake_tags)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "emit_ticket_replied_event", fake_emit)
         monkeypatch.setattr(receive_sms_routes.tickets_service, "emit_ticket_updated_event", fake_emit)
 
         payload = receive_sms_routes.ReceiveSMSPayload(
@@ -115,14 +116,20 @@ def test_receive_sms_existing_ticket_reply_refreshes_ai(monkeypatch):
         async def fake_tags(ticket_id):
             calls.append(("tags", ticket_id))
 
-        async def fake_emit(*_args, **_kwargs):
-            return None
+        emit_calls: list[tuple[str, tuple, dict]] = []
+
+        async def fake_emit_replied(*args, **kwargs):
+            emit_calls.append(("replied", args, kwargs))
+
+        async def fake_emit_updated(*args, **kwargs):
+            emit_calls.append(("updated", args, kwargs))
 
         monkeypatch.setattr(receive_sms_routes, "_find_sms_ticket", fake_find_sms_ticket)
         monkeypatch.setattr(receive_sms_routes.tickets_repo, "create_reply", fake_create_reply)
         monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_summary", fake_summary)
         monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_tags", fake_tags)
-        monkeypatch.setattr(receive_sms_routes.tickets_service, "emit_ticket_updated_event", fake_emit)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "emit_ticket_replied_event", fake_emit_replied)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "emit_ticket_updated_event", fake_emit_updated)
 
         payload = receive_sms_routes.ReceiveSMSPayload(
             type="SMSIn",
@@ -137,6 +144,11 @@ def test_receive_sms_existing_ticket_reply_refreshes_ai(monkeypatch):
         assert result["status"] == "appended"
         assert result["ticket_id"] == 456
         assert calls == [("reply", 456), ("summary", 456), ("tags", 456)]
+        assert [call[0] for call in emit_calls] == ["replied", "updated"]
+        for _event_name, args, kwargs in emit_calls:
+            assert args == ({"id": 456, "requester_id": 11, "status": "open"},)
+            assert kwargs["actor_type"] == "requester"
+            assert kwargs["reply"] == {"id": 99}
 
     asyncio.run(run_test())
 
@@ -166,6 +178,7 @@ def test_receive_sms_existing_ticket_without_requester_stores_sender_snapshot(mo
         monkeypatch.setattr(receive_sms_routes.tickets_repo, "create_reply", fake_create_reply)
         monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_summary", fake_refresh)
         monkeypatch.setattr(receive_sms_routes.tickets_service, "refresh_ticket_ai_tags", fake_refresh)
+        monkeypatch.setattr(receive_sms_routes.tickets_service, "emit_ticket_replied_event", fake_emit)
         monkeypatch.setattr(receive_sms_routes.tickets_service, "emit_ticket_updated_event", fake_emit)
 
         payload = receive_sms_routes.ReceiveSMSPayload(


### PR DESCRIPTION
### Motivation
- Inbound SMS replies were not generating automation events, preventing automations that rely on `ticket_update.actor_type` and `ticket.latest_reply` from firing.

### Description
- Capture the reply returned from `tickets_repo.create_reply` into a `reply` variable so it can be included in automation context in `app/features/receive_sms/routes.py`.
- Emit both `tickets.replied` and `tickets.updated` events with `actor_type="requester"` and the `reply` payload for existing SMS tickets so automations can match requester-scoped filters.
- Update tests in `tests/test_receive_sms_feature_pack.py` to monkeypatch and assert calls to `emit_ticket_replied_event` and `emit_ticket_updated_event`, and to verify the reply payload and `actor_type` are present.

### Testing
- Ran `python -m py_compile app/features/receive_sms/routes.py tests/test_receive_sms_feature_pack.py`, which succeeded.
- Attempted `python -m pytest tests/test_receive_sms_feature_pack.py tests/test_sms_automation_context.py`, which failed during test collection due to a missing native dependency (`ImportError: failed to find libmagic`), blocking full pytest verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a55d03c881483328a21c416572f3953)