### PR TITLE
Add ticket review date field

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -464,6 +464,7 @@ async def get_ticket_dashboard(
                 or requester_label,
                 category=ticket.get("category"),
                 external_reference=ticket.get("external_reference"),
+                review_date=ticket.get("review_date"),
                 created_at=created_at,
                 updated_at=updated_at,
                 closed_at=ticket.get("closed_at"),

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import asyncio
 import re
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any, Mapping
 from urllib.parse import urlsplit
 
@@ -1040,6 +1040,19 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
     company_raw = form.get("companyId")
     category_value = _clean_text(form.get("category")) or None
     external_reference = _clean_text(form.get("externalReference")) or None
+    review_date_raw = _clean_text(form.get("reviewDate"))
+    review_date_value: date | None = None
+    if review_date_raw:
+        try:
+            review_date_value = date.fromisoformat(review_date_raw)
+        except ValueError:
+            return await main_module._render_ticket_detail(
+                request,
+                current_user,
+                ticket_id=ticket_id,
+                error_message="Select a valid review date.",
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
     return_url_raw = form.get("returnUrl")
     return_url = _clean_text(return_url_raw)
 
@@ -1230,6 +1243,7 @@ async def admin_update_ticket_details(ticket_id: int, request: Request):
         "company_id": company_id,
         "category": category_value,
         "external_reference": external_reference,
+        "review_date": review_date_value,
     }
 
     raw_asset_values = form.getlist("assetIds") if hasattr(form, "getlist") else []

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any, Iterable, Sequence
 
 from app.core.database import db
@@ -207,6 +207,15 @@ def _normalise_ticket(row: dict[str, Any]) -> TicketRecord:
     for key in ("id", "company_id", "requester_id", "requester_staff_id", "assigned_user_id", "merged_into_ticket_id", "split_from_ticket_id"):
         if key in record and record[key] is not None:
             record[key] = int(record[key])
+    if "review_date" in record:
+        review_date = record.get("review_date")
+        if isinstance(review_date, datetime):
+            record["review_date"] = review_date.date()
+        elif isinstance(review_date, str) and review_date.strip():
+            try:
+                record["review_date"] = date.fromisoformat(review_date.strip()[:10])
+            except ValueError:
+                record["review_date"] = None
     for key in (
         "created_at",
         "updated_at",
@@ -379,6 +388,7 @@ async def create_ticket(
         "module_slug": module_slug,
         "external_reference": external_reference,
         "ticket_number": ticket_number,
+        "review_date": None,
         "ai_summary": None,
         "ai_summary_status": None,
         "ai_summary_model": None,

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from enum import Enum
 from typing import Optional
 
@@ -17,6 +17,7 @@ class TicketBase(BaseModel):
     company_id: Optional[int] = None
     assigned_user_id: Optional[int] = None
     external_reference: Optional[str] = Field(default=None, max_length=128)
+    review_date: Optional[date] = None
 
 
 class TicketCreate(TicketBase):
@@ -33,6 +34,7 @@ class TicketUpdate(BaseModel):
     company_id: Optional[int] = None
     assigned_user_id: Optional[int] = None
     external_reference: Optional[str] = Field(default=None, max_length=128)
+    review_date: Optional[date] = None
 
 
 class TicketReplyCreate(BaseModel):
@@ -151,6 +153,7 @@ class TicketDashboardRow(BaseModel):
     requester_display_name: Optional[str] = None
     category: Optional[str] = None
     external_reference: Optional[str] = None
+    review_date: Optional[date] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     closed_at: Optional[datetime] = None

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -11371,3 +11371,13 @@ a.shop-product-card {
     min-height: 14rem;
   }
 }
+
+.ticket-review-date--past {
+  color: var(--color-danger, #dc2626);
+  font-weight: 600;
+}
+
+.ticket-review-date--future {
+  color: var(--color-success, #16a34a);
+  font-weight: 600;
+}

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1138,6 +1138,29 @@
       }
     }
 
+    function formatReviewDate(value) {
+      if (!value) {
+        return '—';
+      }
+      const dateText = String(value).slice(0, 10);
+      return /^\d{4}-\d{2}-\d{2}$/.test(dateText) ? dateText : '—';
+    }
+
+    function reviewDateClass(value) {
+      const dateText = formatReviewDate(value);
+      if (dateText === '—') {
+        return '';
+      }
+      const today = new Date().toISOString().slice(0, 10);
+      if (dateText < today) {
+        return ' ticket-review-date--past';
+      }
+      if (dateText > today) {
+        return ' ticket-review-date--future';
+      }
+      return '';
+    }
+
     function formatUpdatedAt(value) {
       if (!value) {
         return '—';
@@ -1216,7 +1239,7 @@
         const cell = document.createElement('td');
         cell.dataset.label = label;
         cell.dataset.column = column;
-        cell.className = `tickets-table__cell tickets-table__cell--${column}`;
+        cell.className = `tickets-table__cell tickets-table__cell--${column}${options && options.className ? options.className : ''}`;
         if (options && options.value !== undefined) {
           cell.dataset.value = String(options.value || '');
         }
@@ -1251,6 +1274,7 @@
       appendTextCell('company', 'Company', companyDisplay);
       appendTextCell('assigned', 'Assigned', ticket.assigned_user_email || '—');
       appendTextCell('updated', 'Updated', formatUpdatedAt(ticket.updated_at), { value: ticket.updated_at || '' });
+      appendTextCell('review-date', 'Review Date', formatReviewDate(ticket.review_date), { value: ticket.review_date || '', className: reviewDateClass(ticket.review_date) });
       appendTextCell('category', 'Category', ticket.category || '—');
       appendTextCell('requester', 'Requester', ticket.requester_label || ticket.requester_email || ticket.requester_id || '—');
       appendTextCell('module', 'Module', ticket.module_slug || '—');

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -184,6 +184,17 @@
                 <p class="form-help">{{ ticket_requester_phone_display or '—' }}</p>
               </div>
               <div class="form-field">
+                <label class="form-label" for="ticket-review-date-detail">Review Date</label>
+                <input
+                  id="ticket-review-date-detail"
+                  name="reviewDate"
+                  type="date"
+                  class="form-input"
+                  value="{{ ticket.review_date.isoformat() if ticket.review_date else '' }}"
+                />
+                <p class="form-help">Flag when this ticket should be reviewed again.</p>
+              </div>
+              <div class="form-field">
                 <label class="form-label" for="ticket-assigned-detail">Assigned to</label>
                 <select id="ticket-assigned-detail" name="assignedUserId" class="form-input">
                   <option value="">Unassigned</option>

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -441,6 +441,10 @@
                     <span>Updated</span>
                   </label>
                   <label class="ticket-columns__option">
+                    <input type="checkbox" class="ticket-column-toggle" data-column="review-date" />
+                    <span>Review Date</span>
+                  </label>
+                  <label class="ticket-columns__option">
                     <input type="checkbox" class="ticket-column-toggle" data-column="category" />
                     <span>Category</span>
                   </label>
@@ -563,6 +567,7 @@
                 <th scope="col" data-sort="string" data-column="company" class="tickets-table__column tickets-table__column--company">Company</th>
                 <th scope="col" data-sort="string" data-column="assigned" class="tickets-table__column tickets-table__column--assigned">Assigned</th>
                 <th scope="col" data-sort="string" data-column="updated" class="tickets-table__column tickets-table__column--updated">Updated</th>
+                <th scope="col" data-sort="string" data-column="review-date" class="tickets-table__column tickets-table__column--review-date">Review Date</th>
                 <th scope="col" data-sort="string" data-column="category" class="tickets-table__column tickets-table__column--category">Category</th>
                 <th scope="col" data-sort="string" data-column="requester" class="tickets-table__column tickets-table__column--requester">Requester</th>
                 <th scope="col" data-sort="string" data-column="module" class="tickets-table__column tickets-table__column--module">Module</th>
@@ -644,6 +649,9 @@
                     <td data-label="Company" data-column="company" class="tickets-table__cell tickets-table__cell--company">{{ company.name if company else (ticket.company_id or '—') }}</td>
                     <td data-label="Assigned" data-column="assigned" class="tickets-table__cell tickets-table__cell--assigned">{{ assigned_label }}</td>
                     <td data-label="Updated" data-column="updated" class="tickets-table__cell tickets-table__cell--updated">{{ ticket.updated_at.astimezone().strftime('%Y-%m-%d %H:%M') if ticket.updated_at else '—' }}</td>
+                    {% set review_date = ticket.review_date %}
+                    {% set review_date_class = 'ticket-review-date--past' if review_date and review_date < ticket_dashboard_now.date() else ('ticket-review-date--future' if review_date and review_date > ticket_dashboard_now.date() else '') %}
+                    <td data-label="Review Date" data-column="review-date" class="tickets-table__cell tickets-table__cell--review-date {{ review_date_class }}">{{ review_date.isoformat() if review_date else '—' }}</td>
                     <td data-label="Category" data-column="category" class="tickets-table__cell tickets-table__cell--category">{{ ticket.category or '—' }}</td>
                     {% set requester = user_lookup.get(ticket.requester_id) %}
                     {% set requester_name = ([requester.first_name, requester.last_name] | select | join(' ')) | trim if requester else '' %}
@@ -694,7 +702,7 @@
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="{{ 38 + (1 if can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
+                  <td colspan="{{ 39 + (1 if can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
                 </tr>
               {% endif %}
             </tbody>

--- a/migrations/291_ticket_review_date.sql
+++ b/migrations/291_ticket_review_date.sql
@@ -1,0 +1,3 @@
+-- Add an optional technician review date to tickets.
+ALTER TABLE tickets ADD COLUMN review_date DATE NULL;
+CREATE INDEX idx_tickets_review_date ON tickets(review_date);


### PR DESCRIPTION
### Motivation
- Provide technicians a simple `Review Date` they can set per-ticket to flag when a ticket should be revisited now or in the future.
- Surface that date in the admin tickets table so queues can be scanned and filtered visually and programmatically.

### Description
- Add a nullable `review_date` column and index via `migrations/291_ticket_review_date.sql` to persist the new field.
- Extend schemas by adding `review_date: Optional[date]` to `app/schemas/tickets.py` so API and Pydantic models include the field.
- Parse and normalise `review_date` in `app/repositories/tickets.py` and include it in ticket fallback records so repository reads return a `date` value.
- Accept, validate (ISO date), and persist `reviewDate` from the ticket details autosave form in `app/features/tickets/admin_routes.py` and include it in the `update_fields` payload.
- Add a date picker to the ticket detail form in `app/templates/admin/ticket_detail.html` that participates in the existing autosave flow (`data-ticket-details-autosave`).
- Render `Review Date` as a toggleable column in the admin tickets table (`app/templates/admin/tickets.html`) and include it in dashboard API rows via `app/api/routes/tickets.py` so live table refreshes populate the column.
- Update client-side table rendering in `app/static/js/admin.js` to format the date and apply `ticket-review-date--past`/`ticket-review-date--future` classes, and adjust `appendTextCell` to accept an optional `className` option for styling.
- Add CSS rules in `app/static/css/app.css` to show past dates in red and future dates in green.

### Testing
- Ran `python -m compileall` on modified modules and compilation succeeded.
- Ran `git diff --check` to verify whitespace/patch problems and it reported no issues.
- Attempted to run `pytest -q tests` but the test run did not complete in this environment (stalled after no output); other automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a55d3d40e588332a00aee49c104b35c)