### PR TITLE
Avoid default ticket status changes when posting replies

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -1637,11 +1637,9 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
         )
     ]
     valid_reply_statuses = {definition.tech_status for definition in selectable_status_definitions}
-    default_reply_status = next((definition.tech_status for definition in selectable_status_definitions if definition.is_default), None)
-    if not default_reply_status:
-        default_reply_status = "pending" if "pending" in valid_reply_statuses else (next(iter(valid_reply_statuses), "open"))
-    reply_status = str(get_last_form_value(form, "replyStatus", default_reply_status) or default_reply_status).strip().lower()
-    if reply_status not in valid_reply_statuses:
+    selected_reply_status = get_last_form_value(form, "replyStatus")
+    reply_status = str(selected_reply_status or "").strip().lower() or None
+    if reply_status is not None and reply_status not in valid_reply_statuses:
         return await main_module._render_ticket_detail(
             request,
             current_user,
@@ -1741,7 +1739,8 @@ async def admin_create_ticket_reply(ticket_id: int, request: Request):
                     # success message.
                     continue
         # Technicians should not be automatically added as ticket watchers when replying.
-        await tickets_repo.set_ticket_status(ticket_id, reply_status)
+        if reply_status:
+            await tickets_repo.set_ticket_status(ticket_id, reply_status)
         await tickets_service.refresh_ticket_ai_summary(ticket_id)
         await tickets_service.refresh_ticket_ai_tags(ticket_id)
         await tickets_service.broadcast_ticket_event(action="reply", ticket_id=ticket_id)

--- a/app/features/tickets/portal_routes.py
+++ b/app/features/tickets/portal_routes.py
@@ -362,11 +362,9 @@ async def portal_ticket_reply(request: Request, ticket_id: int):
     if has_helpdesk_access or is_super_admin:
         status_definitions = await tickets_service.list_status_definitions()
         valid_reply_statuses = {definition.tech_status for definition in status_definitions}
-        default_reply_status = next((definition.tech_status for definition in status_definitions if definition.is_default), None)
-        if not default_reply_status:
-            default_reply_status = "pending" if "pending" in valid_reply_statuses else (next(iter(valid_reply_statuses), "open"))
-        reply_status = str(get_last_form_value(form, "replyStatus", default_reply_status) or default_reply_status).strip().lower()
-        if reply_status not in valid_reply_statuses:
+        selected_reply_status = get_last_form_value(form, "replyStatus")
+        reply_status = str(selected_reply_status or "").strip().lower() or None
+        if reply_status is not None and reply_status not in valid_reply_statuses:
             return await main_module._render_portal_ticket_detail(
                 request,
                 user,

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -1180,7 +1180,7 @@
               </div>
               <div class="form-actions">
                 <div class="ticket-reply-submit" data-ticket-reply-submit>
-                  <input type="hidden" name="replyStatus" value="{{ ticket_reply_default_status }}" data-ticket-reply-status-input />
+                  <input type="hidden" name="replyStatus" value="" data-ticket-reply-status-input />
                   <button type="submit" class="button button--primary ticket-reply-submit__primary">Post reply</button>
                   <details class="ticket-reply-submit__status-menu">
                     <summary class="button button--primary ticket-reply-submit__toggle" aria-label="Post reply with a selected ticket status">

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -451,7 +451,7 @@
                   <div class="form-actions">
                     {% if has_helpdesk_access or is_super_admin %}
                       <div class="ticket-reply-submit" data-ticket-reply-submit>
-                        <input type="hidden" name="replyStatus" value="{{ ticket_reply_default_status }}" data-ticket-reply-status-input />
+                        <input type="hidden" name="replyStatus" value="" data-ticket-reply-status-input />
                         <button type="submit" class="button button--primary ticket-reply-submit__primary">Post reply</button>
                         <details class="ticket-reply-submit__status-menu">
                           <summary class="button button--primary ticket-reply-submit__toggle" aria-label="Post reply with a selected ticket status">

--- a/tests/test_admin_ticket_detail.py
+++ b/tests/test_admin_ticket_detail.py
@@ -294,7 +294,7 @@ async def test_admin_reply_saves_attachments(monkeypatch):
 
     assert response.status_code == status.HTTP_303_SEE_OTHER
     assert "/admin/tickets/3" in response.headers.get("location", "")
-    assert set_status_mock.await_args.args == (3, "pending")
+    set_status_mock.assert_not_awaited()
     add_watcher_mock.assert_not_awaited()
     assert save_mock.await_count == 1
     called_args = save_mock.await_args.kwargs


### PR DESCRIPTION
### Motivation

- Prevent the primary "Post reply" action from implicitly changing a ticket's status to the default; only an explicit selection from the split-button menu should change status.

### Description

- Update reply forms in `app/templates/tickets/detail.html` and `app/templates/admin/ticket_detail.html` to leave the hidden `replyStatus` field empty for the primary Post reply action instead of pre-filling the default status.
- Change portal reply handling in `app/features/tickets/portal_routes.py` to read `replyStatus` without a fallback and treat it as optional, validating and applying it only when a non-empty value was explicitly provided.
- Apply the same optional-status logic in `app/features/tickets/admin_routes.py` and guard the call to `tickets_repo.set_ticket_status` so it runs only when a status was explicitly submitted.
- Adjust test expectation in `tests/test_admin_ticket_detail.py` so posting a reply without an explicitly selected status does not assert that `set_ticket_status` was called.

### Testing

- `python3 -m py_compile app/features/tickets/admin_routes.py app/features/tickets/portal_routes.py` succeeded.
- Running `pytest tests/test_admin_ticket_detail.py -q` was attempted but collection failed due to a missing system dependency (`ImportError: failed to find libmagic`), so the test run is blocked by the environment rather than the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a56c8a26ef08332997fe6cf9befd742)