### PR TITLE
Make tray chat room names descriptive

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -1320,7 +1320,7 @@ async def start_device_chat(
         try:
             matrix_resp = await matrix_service.create_room(
                 name=subject,
-                topic=f"Tray-initiated support chat: {subject}",
+                topic=f"Technician-initiated tray support chat for {subject}",
             )
             matrix_room_id = matrix_resp.get("room_id", "")
         except Exception as exc:

--- a/app/static/js/assets.js
+++ b/app/static/js/assets.js
@@ -242,6 +242,9 @@
         if (!deviceUid) {
           return;
         }
+        const row = button.closest('[data-asset-id]');
+        const assetName = (button.getAttribute('data-asset-name') || (row ? row.getAttribute('data-asset-name') : '') || 'Asset').trim();
+        const chatSubject = `${assetName} - Helpdesk chat`;
         button.disabled = true;
         try {
           const response = await fetch(`/api/tray/${encodeURIComponent(deviceUid)}/chat/start`, {
@@ -251,7 +254,7 @@
               'Content-Type': 'application/json',
               'X-CSRF-Token': getCsrfToken(),
             },
-            body: JSON.stringify({ subject: 'Helpdesk chat' }),
+            body: JSON.stringify({ subject: chatSubject }),
           });
           if (!response.ok) {
             throw new Error(await response.text());

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -641,6 +641,8 @@
     const detailsFormId = linkedContainer.dataset.detailsFormId || '';
     const tacticalBaseUrlRaw = linkedContainer.dataset.tacticalBaseUrl || '';
     const initialCompanyId = select.dataset.initialCompanyId || '';
+    const ticketNumber = (linkedContainer.dataset.ticketNumber || '').trim();
+    const ticketSubject = (linkedContainer.dataset.ticketSubject || '').trim();
 
     const tacticalBaseUrl = tacticalBaseUrlRaw.replace(/\/+$/, '');
     const optionLookup = new Map();
@@ -874,6 +876,7 @@
         chatButton.type = 'button';
         chatButton.className = 'button button--ghost button--icon ticket-assets-linked__action';
         chatButton.setAttribute('data-linked-asset-chat', '');
+        chatButton.setAttribute('data-asset-name', displayName);
         chatButton.title = 'Open chat';
         chatButton.setAttribute('aria-label', `Open chat with ${displayName}`);
         if (record.tray_device_uid) {
@@ -1100,6 +1103,11 @@
         if (!uid) {
           return;
         }
+        const assetElement = chatButton.closest('[data-linked-asset]');
+        const nameEl = assetElement ? assetElement.querySelector('[data-linked-asset-name]') : null;
+        const assetName = (chatButton.getAttribute('data-asset-name') || (nameEl ? nameEl.textContent : '') || 'Asset').trim();
+        const ticketLabel = ticketNumber ? `#${ticketNumber}` : 'ticket';
+        const chatSubject = [assetName, ticketLabel, ticketSubject].filter(Boolean).join(' - ');
         chatButton.disabled = true;
         fetch(`/api/tray/${encodeURIComponent(uid)}/chat/start`, {
           method: 'POST',
@@ -1108,7 +1116,7 @@
             'X-CSRF-Token': getCsrfToken(),
             Accept: 'application/json',
           },
-          body: JSON.stringify({ subject: 'Helpdesk chat' }),
+          body: JSON.stringify({ subject: chatSubject || 'Helpdesk chat' }),
         })
           .then(async (response) => {
             if (!response.ok) {

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -821,6 +821,8 @@
                   data-tactical-base-url="{{ tacticalrmm_base_url or '' }}"
                   data-empty-message="No assets are linked to this ticket yet."
                   data-details-form-id="ticket-details-form"
+                  data-ticket-number="{{ ticket.ticket_number or ticket.id }}"
+                  data-ticket-subject="{{ ticket.subject | e }}"
                 >
                   <ul class="ticket-assets-linked__list" data-linked-assets-list>
                     {% for asset in ticket_assets %}
@@ -899,6 +901,7 @@
                             class="button button--ghost button--icon ticket-assets-linked__action"
                             data-linked-asset-chat
                             data-device-uid="{{ asset.tray_device_uid or '' }}"
+                            data-asset-name="{{ display_name | e }}"
                             {% if not asset.tray_device_uid %}disabled aria-disabled="true"{% endif %}
                             title="Open chat"
                             aria-label="Open chat with {{ display_name }}"

--- a/app/templates/assets/index.html
+++ b/app/templates/assets/index.html
@@ -106,7 +106,7 @@
         </thead>
         <tbody>
           {% for asset in assets %}
-            <tr id="asset-{{ asset.id }}" data-asset-id="{{ asset.id }}">
+            <tr id="asset-{{ asset.id }}" data-asset-id="{{ asset.id }}" data-asset-name="{{ (asset.name or asset.hostname or ('Asset ' ~ asset.id)) | e }}">
               {% for column in columns %}
                 {% set key = column.key %}
                 {% set value = asset.get(key) %}
@@ -221,6 +221,7 @@
                             role="menuitem"
                             data-tray-chat
                             data-device-uid="{{ asset.tray_device_uid }}"
+                            data-asset-name="{{ (asset.name or asset.hostname or ('Asset ' ~ asset.id)) | e }}"
                           >Open Chat</button>
                         </li>
                       {% endif %}


### PR DESCRIPTION
### Motivation
- Technician-initiated tray chats were hard to find because room names defaulted to a generic "Helpdesk chat", so include asset and ticket context to make rooms easier to identify. 
- Improve the Matrix room topic wording for technician-created tray chats to more clearly indicate the action origin.

### Description
- Build descriptive chat subjects for tray-initiated chats from the asset name, ticket number, and ticket subject in `app/static/js/ticket_detail.js`, with a fallback to `Helpdesk chat` when values are absent. 
- Include the asset name in chat subjects started from the assets list by updating `app/static/js/assets.js` to compute `chatSubject` and post it to the tray chat API. 
- Expose metadata used by the JS (ticket number and ticket subject) on the ticket-detail linked-assets container and add `data-asset-name` attributes for assets and chat buttons in `app/templates/admin/ticket_detail.html` and `app/templates/assets/index.html` so client code can assemble descriptive names. 
- Update the Matrix room `topic` string for technician-created tray chats in `app/api/routes/tray.py` to read `Technician-initiated tray support chat for {subject}`.

### Testing
- Ran `python -m compileall app/api/routes/tray.py app/schemas/tray.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a56f2f390d88332be9b171bc316007a)