### PR TITLE
Disable tray chat message popups

### DIFF
--- a/tray/ui/chat_notification.go
+++ b/tray/ui/chat_notification.go
@@ -63,40 +63,14 @@ func handleChatOpen(payload chatOpenPayload) {
 }
 
 func handleChatMessage(payload chatMessagePayload) {
-	actionURL := registerChatOpenAction(payload.RoomID)
-	if actionURL == "" {
-		logger.Warn("handleChatMessage: could not register chat notification action for room_id=%d", payload.RoomID)
-	}
-
-	// Replies should bring an active chat back to the user's attention. Closed
-	// rooms are rejected by the popup/token endpoints so stale notifications do
-	// not create a fresh "Chat from <device>" room.
+	// Incoming chat replies should open or focus the tray chat window without
+	// also displaying a desktop popup. The chat window itself is the active
+	// conversation surface and continues polling the room while open. Closed
+	// rooms are rejected by the popup/token endpoints so stale messages do not
+	// create a fresh "Chat from <device>" room.
 	if chatURL := chatOpenURL(payload.RoomID); chatURL != "" {
 		go openChatWindowFunc(chatURL, gConfig)
 	}
-
-	title, body := chatMessageNotificationText(payload)
-	showChatSessionNotificationFunc(title, body, actionURL)
-}
-
-func chatMessageNotificationText(payload chatMessagePayload) (string, string) {
-	sender := strings.TrimSpace(payload.Sender)
-	if sender == "" {
-		sender = "A technician"
-	}
-
-	subject := strings.TrimSpace(payload.Subject)
-	message := summarizeChatMessage(payload.Message)
-
-	title := "New MyPortal chat message"
-	body := sender + " replied to your support chat"
-	if subject != "" {
-		body += ": " + subject
-	}
-	if message != "" {
-		body += "\n" + message
-	}
-	return title, body
 }
 
 func chatNotificationText(payload chatOpenPayload) (string, string) {

--- a/tray/ui/chat_notification_test.go
+++ b/tray/ui/chat_notification_test.go
@@ -35,27 +35,3 @@ func TestChatNotificationTextFallsBackToTechnician(t *testing.T) {
 		t.Fatalf("body = %q, want fallback initiator", body)
 	}
 }
-
-func TestChatMessageNotificationTextIncludesSenderSubjectAndMessage(t *testing.T) {
-	title, body := chatMessageNotificationText(chatMessagePayload{
-		Subject: "Printer issue",
-		Sender:  "Alex Tech",
-		Message: "Please try printing again.",
-	})
-
-	if title != "New MyPortal chat message" {
-		t.Fatalf("title = %q", title)
-	}
-	for _, want := range []string{"Alex Tech", "Printer issue", "Please try printing again."} {
-		if !strings.Contains(body, want) {
-			t.Fatalf("body = %q, want it to contain %q", body, want)
-		}
-	}
-}
-
-func TestChatMessageNotificationTextFallsBackToTechnician(t *testing.T) {
-	_, body := chatMessageNotificationText(chatMessagePayload{})
-	if !strings.Contains(body, "A technician replied to your support chat") {
-		t.Fatalf("body = %q, want fallback sender", body)
-	}
-}

--- a/tray/ui/main_nowebview_test.go
+++ b/tray/ui/main_nowebview_test.go
@@ -12,19 +12,15 @@ import (
 	"github.com/bradhawkins85/myportal-tray/internal/ipc"
 )
 
-func TestHandleIPCMessageDispatchesChatMessageNotification(t *testing.T) {
+func TestHandleIPCMessageOpensChatMessageWithoutNotification(t *testing.T) {
 	previousNotify := showChatSessionNotificationFunc
 	previousOpen := openChatWindowFunc
 	previousRequest := requestChatTokenFunc
 	previousPortalURL := gPortalURL
 	gPortalURL = "https://portal.example.test"
-	var gotTitle string
-	var gotBody string
-	var gotURL string
+	notified := false
 	showChatSessionNotificationFunc = func(title, body, chatURL string) {
-		gotTitle = title
-		gotBody = body
-		gotURL = chatURL
+		notified = true
 	}
 	requestChatTokenFunc = func(roomID int) string {
 		return gPortalURL + "/tray/chat?token=test-token&room=" + itoa(roomID)
@@ -52,16 +48,8 @@ func TestHandleIPCMessageDispatchesChatMessageNotification(t *testing.T) {
 
 	handleIPCMessage(ipc.Message{Type: "chat_message", Payload: payload})
 
-	if gotTitle != "New MyPortal chat message" {
-		t.Fatalf("title = %q", gotTitle)
-	}
-	for _, want := range []string{"Alex Tech", "Printer offline", "Please try printing again."} {
-		if !strings.Contains(gotBody, want) {
-			t.Fatalf("body = %q, want it to contain %q", gotBody, want)
-		}
-	}
-	if gotURL == "" {
-		t.Fatalf("chat notification action URL should not be empty")
+	if notified {
+		t.Fatal("chat_message should not display a popup notification")
 	}
 	select {
 	case chatURL := <-opened:


### PR DESCRIPTION
### Motivation
- Incoming tray chat replies were producing desktop popup notifications even when the tray chat window is (or will be) opened and actively polling the room, which leads to redundant popups and a noisy UX.

### Description
- Stop dispatching desktop popup notifications for `chat_message` IPC events by changing `handleChatMessage` in `tray/ui/chat_notification.go` to only open/focus the tray chat window and not call the notification path.
- Remove the now-unused `chatMessageNotificationText` helper and related notification logic used only for reply popups in `tray/ui/chat_notification.go`.
- Update the IPC unit test in `tray/ui/main_nowebview_test.go` to assert that `chat_message` opens the chat window without triggering `showChatSessionNotificationFunc`.
- Remove obsolete chat-message notification text tests from `tray/ui/chat_notification_test.go` which asserted the old reply-popup behaviour.

### Testing
- Ran `cd tray && go test -tags nowebview ./ui` which passed (`ok github.com/bradhawkins85/myportal-tray/ui`).
- Attempted `cd tray && go test ./ui` but the full test run failed in this environment due to a missing system pkg-config dependency (`ayatana-appindicator3-0.1`) unrelated to the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a571c0c11c08332b94e26c1c00cc77b)