### PR TITLE
Split comma-separated recipient entries for SMTP2Go and improve list parsing

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -480,11 +480,21 @@ def _ensure_bool(value: Any, default: bool) -> bool:
 def _ensure_list(value: Any) -> list[str]:
     if value is None:
         return []
+
     if isinstance(value, list):
-        return [str(item).strip() for item in value if str(item).strip()]
-    if isinstance(value, str):
-        return [part.strip() for part in value.split(",") if part.strip()]
-    return []
+        values = value
+    elif isinstance(value, str):
+        values = [value]
+    else:
+        return []
+
+    result: list[str] = []
+    for item in values:
+        for part in str(item).split(","):
+            part = part.strip()
+            if part:
+                result.append(part)
+    return result
 
 
 def _extract_ticket_id_from_email_payload(payload: Mapping[str, Any]) -> int | None:

--- a/app/services/smtp2go.py
+++ b/app/services/smtp2go.py
@@ -10,6 +10,7 @@ Provides functionality for:
 from __future__ import annotations
 
 import base64
+from email.utils import formataddr, getaddresses
 from html import escape as html_escape
 import json
 import secrets
@@ -207,6 +208,38 @@ def _normalise_attachment_payloads(
     return normalised or None
 
 
+def _normalise_email_address_list(addresses: list[str] | str | None) -> list[str]:
+    """Return a flat list of SMTP2Go-compatible RFC 5322 addresses.
+
+    Some callers and form payloads provide multiple recipients as a single
+    comma-separated string (for example, ``["a@example.com, b@example.com"]``).
+    SMTP2Go validates each list item as one RFC 5322 mailbox, so split those
+    combined entries before the API request while preserving display-name
+    address formatting where possible.
+    """
+    if not addresses:
+        return []
+
+    raw_addresses: list[str]
+    if isinstance(addresses, str):
+        raw_addresses = [addresses]
+    else:
+        raw_addresses = [str(address) for address in addresses if address is not None]
+
+    parsed_addresses = getaddresses(raw_addresses)
+    normalised: list[str] = []
+    for display_name, email_address in parsed_addresses:
+        email_address = email_address.strip()
+        if not email_address:
+            continue
+
+        if display_name:
+            normalised.append(formataddr((display_name.strip(), email_address)))
+        else:
+            normalised.append(email_address)
+
+    return normalised
+
 def get_email_template(template_type: EmailTemplateType) -> dict[str, Any]:
     """Get an email template by type.
     
@@ -382,11 +415,17 @@ async def send_email_via_api(
         if not api_key:
             raise SMTP2GoError("SMTP2Go API key not configured")
         
+        # Normalise recipient fields before validation and blocklist checks so
+        # SMTP2Go receives one RFC 5322 address per list item.
+        to = _normalise_email_address_list(to)
+        cc = _normalise_email_address_list(cc)
+        bcc = _normalise_email_address_list(bcc)
+
         # Suppress blocklisted recipients before any SMTP2Go API attempt.
         try:
             from app.repositories import email_blocklist as email_blocklist_repo
 
-            to, blocked_to = await email_blocklist_repo.filter_allowed(to or [])
+            to, blocked_to = await email_blocklist_repo.filter_allowed(to)
             if cc:
                 cc, blocked_cc = await email_blocklist_repo.filter_allowed(cc)
             else:

--- a/tests/test_smtp2go.py
+++ b/tests/test_smtp2go.py
@@ -156,6 +156,64 @@ async def test_send_email_via_api_success(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_send_email_via_api_splits_comma_separated_cc(monkeypatch):
+    """Ensure SMTP2Go CC payloads contain one address per list item."""
+
+    captured_payload = {}
+
+    class MockResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "data": {
+                    "error_code": "SUCCESS",
+                    "email_id": "test-message-id-123",
+                }
+            }
+
+    class MockAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def post(self, url, json=None):
+            captured_payload.update(json)
+            return MockResponse()
+
+    async def mock_get_module_settings(slug):
+        return {"api_key": "test-api-key-123"}
+
+    from app.services import modules as modules_service
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", MockAsyncClient)
+    monkeypatch.setattr(modules_service, "get_module_settings", mock_get_module_settings)
+
+    await smtp2go.send_email_via_api(
+        to=["customer@example.com"],
+        cc=["nathan@biomecentric.com.au, shaun@biomecentric.com.au"],
+        subject="Test Subject",
+        html_body="<p>Test body</p>",
+        sender="sender@example.com",
+    )
+
+    assert captured_payload["cc"] == [
+        "nathan@biomecentric.com.au",
+        "shaun@biomecentric.com.au",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_send_email_via_api_flattens_response_envelope(monkeypatch):
     """Ensure nested response envelopes expose tracking identifiers."""
 

--- a/tests/test_smtp2go_html_body_key.py
+++ b/tests/test_smtp2go_html_body_key.py
@@ -68,6 +68,40 @@ async def test_invoke_smtp2go_with_html_key(monkeypatch, mock_smtp2go_dependenci
 
 
 @pytest.mark.asyncio
+async def test_invoke_smtp2go_splits_rendered_watcher_cc_list_item(
+    monkeypatch, mock_smtp2go_dependencies
+):
+    """Rendered watcher emails in one CC list item are split before sending."""
+
+    settings = {
+        "api_key": "test-api-key",
+        "enable_tracking": True,
+    }
+    payload = {
+        "cc": [
+            "nathan@biomecentric.com.au, shaun@biomecentric.com.au",
+        ],
+        "html_body": "<p>Reply body</p>",
+        "sender": "Hawkins IT Solutions <support@hawkinsit.au>",
+        "subject": "RE: Ticket #123 - Example",
+        "to": [
+            "requester@example.com",
+        ],
+    }
+
+    await modules._invoke_smtp2go(settings, payload)
+
+    assert mock_smtp2go_dependencies["to"] == ["requester@example.com"]
+    assert mock_smtp2go_dependencies["cc"] == [
+        "nathan@biomecentric.com.au",
+        "shaun@biomecentric.com.au",
+    ]
+    assert mock_smtp2go_dependencies["sender"] == (
+        "Hawkins IT Solutions <support@hawkinsit.au>"
+    )
+
+
+@pytest.mark.asyncio
 async def test_invoke_smtp2go_with_html_body_key(monkeypatch, mock_smtp2go_dependencies):
     """Test _invoke_smtp2go with 'html_body' key (new format)."""
     


### PR DESCRIPTION
### Motivation
- Address incoming payloads that include multiple email addresses in a single list item (e.g. `"a@example.com, b@example.com"`) so the SMTP2Go API receives one RFC 5322 mailbox per list element. 
- Make `_ensure_list` more robust by splitting comma-delimited parts inside list items and preserving all non-empty parts.

### Description
- Add helper `_normalise_email_address_list` using `getaddresses` and `formataddr` to parse display-name plus address formats and flatten comma-separated entries into a list of single addresses. 
- Call `_normalise_email_address_list` for `to`, `cc`, and `bcc` inside `send_email_via_api` before blocklist checks and validation. 
- Update blocklist usage to operate on the normalized lists and remove the previous `or []` fallback on `to`. 
- Rewrite `_ensure_list` to accept `list` or `str`, split comma-separated parts inside list elements, trim and filter empties, and return a flattened `list[str]`.

### Testing
- Added `test_send_email_via_api_splits_comma_separated_cc` to verify `send_email_via_api` splits comma-separated `cc` list items and the test passed. 
- Added `test_invoke_smtp2go_splits_rendered_watcher_cc_list_item` to ensure `_invoke_smtp2go` splits rendered CC list items and the test passed. 
- Ran existing SMTP2Go unit tests (including `test_send_email_via_api_success` and envelope flattening tests) and they passed under the mocked `httpx.AsyncClient` implementations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a571fecc39c8332b95179617f0ae1eb)