### PR TITLE
Fix email ticket attachment downloads

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -1884,12 +1884,20 @@ async def download_ticket_attachment(
                     status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
                 )
 
-    # Get file path
-    file_path = attachments_service.get_attachment_file_path(attachment.get("filename"))
+    # Get file path. Email ingestion previously wrote files to the legacy
+    # static uploads directory while records pointed at ticket attachments.
+    # Prefer private storage, but fall back so existing requester-reply
+    # attachments remain downloadable after the storage move.
+    filename = attachment.get("filename")
+    file_path = attachments_service.get_attachment_file_path(filename)
     if not file_path.exists():
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
-        )
+        legacy_file_path = attachments_service.get_legacy_attachment_file_path(filename)
+        if legacy_file_path.exists():
+            file_path = legacy_file_path
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
+            )
 
     return FileResponse(
         path=file_path,
@@ -1923,12 +1931,20 @@ async def download_open_attachment(token: str):
             status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
         )
 
-    # Get file path
-    file_path = attachments_service.get_attachment_file_path(attachment.get("filename"))
+    # Get file path. Email ingestion previously wrote files to the legacy
+    # static uploads directory while records pointed at ticket attachments.
+    # Prefer private storage, but fall back so existing requester-reply
+    # attachments remain downloadable after the storage move.
+    filename = attachment.get("filename")
+    file_path = attachments_service.get_attachment_file_path(filename)
     if not file_path.exists():
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
-        )
+        legacy_file_path = attachments_service.get_legacy_attachment_file_path(filename)
+        if legacy_file_path.exists():
+            file_path = legacy_file_path
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
+            )
 
     return FileResponse(
         path=file_path,

--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -28,6 +28,7 @@ from app.repositories import ticket_attachments as attachments_repo
 from app.security.encryption import decrypt_secret, encrypt_secret
 from app.services import modules as modules_service
 from app.services import system_state
+from app.services import ticket_attachments as attachments_service
 from app.services import tickets as tickets_service
 from app.services.sanitization import sanitize_rich_text
 
@@ -1606,49 +1607,16 @@ async def _save_email_attachment(
     content_type: str,
     payload: bytes,
 ) -> dict[str, Any] | None:
-    """
-    Save an email attachment to disk and create a database record.
-    
-    Args:
-        ticket_id: The ticket ID to attach the file to
-        filename: Original filename from the email
-        content_type: MIME type of the attachment
-        payload: File content as bytes
-    
-    Returns:
-        The created attachment record or None if save failed
-    """
+    """Save an email attachment using the shared private attachment store."""
     try:
-        # Generate secure filename
-        secure_filename = _generate_secure_filename(filename)
-        
-        # Get upload directory
-        upload_dir = _get_upload_directory()
-        file_path = upload_dir / secure_filename
-        
-        # Save file to disk
-        file_size = len(payload)
-        with open(file_path, "wb") as f:
-            f.write(payload)
-        
-        log_info(
-            f"Saved email attachment {secure_filename} ({file_size} bytes) for ticket {ticket_id}",
+        return await attachments_service.save_file_bytes(
             ticket_id=ticket_id,
-            original_filename=filename,
-            secure_filename=secure_filename,
-        )
-        
-        # Create database record with "restricted" access level
-        attachment = await attachments_repo.create_attachment(
-            ticket_id=ticket_id,
-            filename=secure_filename,
-            original_filename=filename,
-            file_size=file_size,
+            contents=payload,
+            original_filename=filename or "attachment",
             mime_type=content_type,
-            access_level="restricted",
+            access_level="closed",
             uploaded_by_user_id=None,
         )
-        return attachment
     except Exception as e:
         log_error(
             f"Failed to save email attachment: {e}",
@@ -1656,12 +1624,6 @@ async def _save_email_attachment(
             filename=filename,
             error=str(e),
         )
-        # Clean up file if it was created
-        if file_path.exists():
-            try:
-                file_path.unlink()
-            except Exception:
-                pass
         return None
 
 

--- a/app/services/ticket_attachments.py
+++ b/app/services/ticket_attachments.py
@@ -9,7 +9,7 @@ import secrets
 from pathlib import Path
 from typing import Any
 
-import magic
+import importlib
 from fastapi import UploadFile
 from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 
@@ -101,7 +101,8 @@ def _sniff_mime_type(header_bytes: bytes) -> str | None:
     spoofable.
     """
     try:
-        return magic.from_buffer(header_bytes, mime=True)
+        magic_module = importlib.import_module("magic")
+        return magic_module.from_buffer(header_bytes, mime=True)
     except Exception as exc:
         log_error(f"MIME sniffing failed: {exc}")
         return None
@@ -361,10 +362,28 @@ async def delete_attachment_file(attachment: dict[str, Any]) -> None:
             # Don't raise - file might already be gone, record is deleted
 
 
+def _safe_attachment_path(base_dir: Path, filename: str) -> Path:
+    """Resolve an attachment path under *base_dir* without allowing traversal."""
+    if not filename:
+        return base_dir / "__invalid_attachment_filename__"
+    candidate = (base_dir / filename).resolve()
+    try:
+        candidate.relative_to(base_dir.resolve())
+    except ValueError:
+        return base_dir / "__invalid_attachment_filename__"
+    return candidate
+
+
 def get_attachment_file_path(filename: str) -> Path:
-    """Get the full path to an attachment file."""
+    """Get the full path to an attachment file in private storage."""
     upload_dir = _get_upload_directory()
-    return upload_dir / filename
+    return _safe_attachment_path(upload_dir, filename)
+
+
+def get_legacy_attachment_file_path(filename: str) -> Path:
+    """Get the pre-private-storage path used by older email attachment saves."""
+    legacy_dir = Path(__file__).resolve().parents[1] / "static" / "uploads" / "tickets"
+    return _safe_attachment_path(legacy_dir, filename)
 
 
 def generate_open_access_token(attachment_id: int, expires_in_seconds: int = 86400) -> str:

--- a/tests/test_path_traversal_prevention.py
+++ b/tests/test_path_traversal_prevention.py
@@ -179,3 +179,76 @@ def test_resolve_private_upload_complex_traversal_attempts(temp_upload_dir):
     for malicious_path in malicious_paths:
         with pytest.raises((HTTPException, FileNotFoundError)):
             _resolve_private_upload(malicious_path)
+
+@pytest.mark.anyio("asyncio")
+async def test_download_ticket_attachment_falls_back_to_legacy_email_storage(monkeypatch, tmp_path):
+    from app.api.routes import tickets as tickets_route
+    from app.services import ticket_attachments as attachment_service
+
+    private_dir = tmp_path / "private"
+    legacy_dir = tmp_path / "legacy"
+    private_dir.mkdir()
+    legacy_dir.mkdir()
+    legacy_file = legacy_dir / "legacy-token.pdf"
+    legacy_file.write_bytes(b"legacy attachment")
+
+    async def fake_get_attachment(attachment_id):
+        return {
+            "id": attachment_id,
+            "ticket_id": 25020,
+            "filename": "legacy-token.pdf",
+            "original_filename": "reply.pdf",
+            "mime_type": "application/pdf",
+            "access_level": "open",
+        }
+
+    async def fake_get_ticket(ticket_id):
+        return {"id": ticket_id, "requester_id": 123}
+
+    async def fake_has_helpdesk_permission(user):
+        return True
+
+    monkeypatch.setattr(tickets_route.attachments_repo, "get_attachment", fake_get_attachment)
+    monkeypatch.setattr(tickets_route.tickets_repo, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(tickets_route, "_has_helpdesk_permission", fake_has_helpdesk_permission)
+    monkeypatch.setattr(
+        attachment_service,
+        "get_attachment_file_path",
+        lambda filename: private_dir / filename,
+    )
+    monkeypatch.setattr(
+        attachment_service,
+        "get_legacy_attachment_file_path",
+        lambda filename: legacy_dir / filename,
+    )
+
+    response = await tickets_route.download_ticket_attachment(25020, 9991, {"id": 1})
+
+    assert Path(response.path) == legacy_file
+
+
+@pytest.mark.anyio("asyncio")
+async def test_save_email_attachment_uses_shared_private_store(monkeypatch):
+    from app.services import imap
+
+    calls = []
+
+    async def fake_save_file_bytes(**kwargs):
+        calls.append(kwargs)
+        return {"id": 9991, "filename": "private-token.pdf", "access_level": kwargs["access_level"]}
+
+    monkeypatch.setattr(imap.attachments_service, "save_file_bytes", fake_save_file_bytes)
+
+    result = await imap._save_email_attachment(25020, "reply.pdf", "application/pdf", b"pdf")
+
+    assert result == {"id": 9991, "filename": "private-token.pdf", "access_level": "closed"}
+    assert calls == [
+        {
+            "ticket_id": 25020,
+            "contents": b"pdf",
+            "original_filename": "reply.pdf",
+            "mime_type": "application/pdf",
+            "access_level": "closed",
+            "uploaded_by_user_id": None,
+        }
+    ]


### PR DESCRIPTION
### Motivation
- Downloads for older ticket reply attachments were returning `File not found` after moving to private storage and email-ingestion continued to write to the legacy static uploads directory.
- Email ingestion saved attachments differently from the ticket attachment service, causing inconsistent storage locations and access-level handling for inbound email attachments.
- Path traversal risks and import-time failures when `libmagic` is unavailable needed mitigation to make attachment handling robust in test and production environments.

### Description
- Made the ticket download endpoints prefer private storage via `attachments_service.get_attachment_file_path()` and fall back to a legacy static uploads path via `attachments_service.get_legacy_attachment_file_path()` when the private file is missing in `app/api/routes/tickets.py`.
- Updated IMAP email attachment saving to reuse the shared API `save_file_bytes(...)` in `app/services/imap.py`, storing inbound email attachments in the private store with `access_level="closed"`.
- Added a safe resolver `_safe_attachment_path()` and `get_legacy_attachment_file_path()` in `app/services/ticket_attachments.py` to prevent path traversal while supporting legacy files, and updated `get_attachment_file_path()` to use the safe resolver.
- Changed MIME sniffing to lazy-import `python-magic` via `importlib.import_module("magic")` inside `_sniff_mime_type()` to avoid import-time errors when `libmagic` is not installed.
- Added regression coverage by appending two async tests to `tests/test_path_traversal_prevention.py` that verify the legacy fallback download and that IMAP email attachment saving uses the shared private store.

### Testing
- Ran `pytest -q tests/test_path_traversal_prevention.py` and the added/modified tests passed (tests for path traversal and the two new async attachment tests succeeded).
- Ran targeted M365 Graph attachment tests `pytest -q tests/test_m365_mail_service.py::test_save_graph_attachments_fetches_value_when_content_bytes_missing tests/test_m365_mail_service.py::test_save_graph_attachments_still_uses_content_bytes_when_present tests/test_m365_mail_service.py::test_save_graph_attachments_encodes_message_id` and all three tests passed.
- No automated tests failed as part of these changes; existing related tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a581e27341083329208aaff5ab63941)