### PR TITLE
Add ticket canned responses

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -42,6 +42,7 @@ from app.repositories import company_memberships as membership_repo
 from app.repositories import staff as staff_repo
 from app.repositories import ticket_statuses as ticket_status_repo
 from app.repositories import ticket_attachments as attachments_repo
+from app.repositories import ticket_canned_responses as canned_responses_repo
 from app.repositories import ticket_expenses as expenses_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import email_blocklist as email_blocklist_repo
@@ -53,6 +54,7 @@ from app.services import ticket_attachments as attachments_service
 from app.services import rag_retrieval
 from app.services import tickets as tickets_service
 from app.services import ticket_shipment_tracking as shipment_watch_service
+from app.services import message_templates as message_template_service
 from app.services import unbill_tickets as unbill_tickets_service
 from app.services import tray as tray_service
 from app.services.sanitization import sanitize_rich_text
@@ -1627,6 +1629,66 @@ async def admin_bulk_delete_tickets(request: Request):
 
     return flash_redirect(destination, redirect_message, "success")
 
+
+
+def _ticket_template_context(ticket: Mapping[str, Any]) -> dict[str, Any]:
+    requester_name = str(ticket.get("requester_name") or ticket.get("requester_display_name") or "").strip()
+    requester_email = str(ticket.get("requester_email") or "").strip()
+    return {
+        "ticket": dict(ticket),
+        "requester": {"name": requester_name, "email": requester_email},
+        "company": {"name": str(ticket.get("company_name") or "").strip()},
+    }
+
+
+@router.post("/admin/tickets/{ticket_id:int}/canned-responses", response_class=HTMLResponse)
+async def admin_create_ticket_canned_response(ticket_id: int, request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        return redirect
+    form = await request.form()
+    title = str(form.get("title") or "").strip()
+    body = str(form.get("body") or "").strip()
+    if not title or not body:
+        return await main_module._render_ticket_detail(
+            request,
+            current_user,
+            ticket_id=ticket_id,
+            error_message="Enter both a title and reply text for the canned response.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    if len(title) > 255:
+        return await main_module._render_ticket_detail(
+            request,
+            current_user,
+            ticket_id=ticket_id,
+            error_message="Canned response title cannot exceed 255 characters.",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    user_id = main_module._get_current_user_id(current_user)
+    await canned_responses_repo.create_response(title=title, body=body, created_by_user_id=user_id)
+    return RedirectResponse(f"/admin/tickets/{ticket_id}", status_code=status.HTTP_303_SEE_OTHER)
+
+
+@router.get("/admin/tickets/{ticket_id:int}/canned-responses", response_class=JSONResponse)
+async def admin_list_ticket_canned_responses(ticket_id: int, request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        return JSONResponse({"detail": "Authentication required"}, status_code=status.HTTP_401_UNAUTHORIZED)
+    ticket = await tickets_repo.get_ticket(ticket_id)
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
+    context = _ticket_template_context(ticket)
+    responses = []
+    for response in await canned_responses_repo.list_responses():
+        responses.append({
+            "id": response["id"],
+            "title": response["title"],
+            "body": message_template_service.render_content(str(response.get("body") or ""), context),
+        })
+    return JSONResponse({"responses": responses})
 
 @router.post("/admin/tickets/{ticket_id:int}/replies", response_class=HTMLResponse)
 async def admin_create_ticket_reply(ticket_id: int, request: Request):

--- a/app/main.py
+++ b/app/main.py
@@ -8999,6 +8999,7 @@ async def _render_ticket_detail(
 
     # Fetch call recordings linked to this ticket
     from app.repositories import call_recordings as call_recordings_repo
+    from app.repositories import ticket_canned_responses as canned_responses_repo
     call_recordings = await call_recordings_repo.list_ticket_call_recordings(ticket_id)
 
     attachment_records: list[Mapping[str, Any]] = []
@@ -9326,6 +9327,7 @@ async def _render_ticket_detail(
 
     ticket_related_items = await _load_ticket_stored_related_items(ticket_id)
     ticket_expenses = await expenses_repo.list_expenses(ticket_id)
+    ticket_canned_responses = await canned_responses_repo.list_responses()
     ticket_expense_total = sum(Decimal(str(expense.get("amount") or 0)) for expense in ticket_expenses)
 
     # Find relevant knowledge base articles based on AI tag matching
@@ -9378,6 +9380,7 @@ async def _render_ticket_detail(
         "ticket_shipment_watch": shipment_watch,
         "ticket_attachments": formatted_attachments,
         "ticket_expenses": ticket_expenses,
+        "ticket_canned_responses": ticket_canned_responses,
         "ticket_expense_total": ticket_expense_total,
         "ticket_related_auto_scan": False,
         "ticket_related_items": ticket_related_items,

--- a/app/repositories/ticket_canned_responses.py
+++ b/app/repositories/ticket_canned_responses.py
@@ -1,0 +1,66 @@
+"""Repository helpers for ticket canned responses."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from app.core.database import db
+
+CannedResponseRecord = dict[str, Any]
+
+
+def _make_aware(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    return None
+
+
+def _normalise_record(row: Mapping[str, Any] | None) -> CannedResponseRecord | None:
+    if not row:
+        return None
+    record = dict(row)
+    for key in ("id", "created_by_user_id"):
+        if record.get(key) is not None:
+            record[key] = int(record[key])
+    for key in ("created_at", "updated_at"):
+        record[key] = _make_aware(record.get(key))
+    return record
+
+
+async def list_responses() -> list[CannedResponseRecord]:
+    rows = await db.fetch_all(
+        """
+        SELECT id, title, body, created_by_user_id, created_at, updated_at
+        FROM ticket_canned_responses
+        ORDER BY title ASC, id ASC
+        """
+    )
+    return [record for row in rows if (record := _normalise_record(row))]
+
+
+async def create_response(*, title: str, body: str, created_by_user_id: int | None) -> CannedResponseRecord:
+    response_id = await db.execute_returning_lastrowid(
+        """
+        INSERT INTO ticket_canned_responses (title, body, created_by_user_id)
+        VALUES (%s, %s, %s)
+        """,
+        (title, body, created_by_user_id),
+    )
+    row = await db.fetch_one(
+        """
+        SELECT id, title, body, created_by_user_id, created_at, updated_at
+        FROM ticket_canned_responses
+        WHERE id = %s
+        """,
+        (response_id,),
+    )
+    record = _normalise_record(row)
+    if record is None:
+        raise RuntimeError("Unable to load created canned response")
+    return record

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -2838,6 +2838,108 @@
     });
   }
 
+
+  function initialiseCannedResponses() {
+    const pickerModal = document.querySelector('[data-canned-responses-modal]');
+    const createModal = document.querySelector('[data-canned-response-create-modal]');
+    const editor = document.querySelector('[data-rich-text-content]');
+    const fallback = document.querySelector('[data-rich-text-value]');
+    const ticketId = pickerModal ? pickerModal.getAttribute('data-ticket-id') : '';
+    let loadedResponses = null;
+
+    function show(modal) {
+      if (modal instanceof HTMLElement) {
+        modal.hidden = false;
+      }
+    }
+
+    function hide(modal) {
+      if (modal instanceof HTMLElement) {
+        modal.hidden = true;
+      }
+    }
+
+    async function loadResponses() {
+      if (loadedResponses || !ticketId) {
+        return loadedResponses || [];
+      }
+      const response = await fetch(`/admin/tickets/${ticketId}/canned-responses`, {
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(await getApiErrorMessage(response, 'Unable to load canned responses.'));
+      }
+      const data = await response.json();
+      loadedResponses = Array.isArray(data.responses) ? data.responses : [];
+      return loadedResponses;
+    }
+
+    function appendResponse(text) {
+      const responseText = typeof text === 'string' ? text.trim() : '';
+      if (!responseText) {
+        return;
+      }
+      if (editor instanceof HTMLElement) {
+        const current = editor.innerHTML.trim();
+        const escaped = responseText
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/\n/g, '<br>');
+        editor.innerHTML = current ? `${current}<p>${escaped}</p>` : `<p>${escaped}</p>`;
+        editor.dispatchEvent(new Event('input', { bubbles: true }));
+        editor.focus();
+      }
+      if (fallback instanceof HTMLTextAreaElement) {
+        fallback.value = fallback.value.trim() ? `${fallback.value}\n\n${responseText}` : responseText;
+        fallback.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    }
+
+    document.querySelectorAll('[data-canned-responses-open]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        show(pickerModal);
+        const error = pickerModal ? pickerModal.querySelector('[data-canned-responses-error]') : null;
+        if (error instanceof HTMLElement) {
+          error.hidden = true;
+          error.textContent = '';
+        }
+        try {
+          await loadResponses();
+        } catch (loadError) {
+          if (error instanceof HTMLElement) {
+            error.textContent = loadError instanceof Error ? loadError.message : 'Unable to load canned responses.';
+            error.hidden = false;
+          }
+        }
+      });
+    });
+
+    document.querySelectorAll('[data-canned-response-insert]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const id = button.getAttribute('data-response-id');
+        try {
+          const responses = await loadResponses();
+          const selected = responses.find((response) => String(response.id) === String(id));
+          appendResponse(selected ? selected.body : '');
+          hide(pickerModal);
+        } catch (error) {
+          console.error('Unable to insert canned response:', error);
+        }
+      });
+    });
+
+    document.querySelectorAll('[data-canned-responses-close]').forEach((button) => {
+      button.addEventListener('click', () => hide(pickerModal));
+    });
+    document.querySelectorAll('[data-canned-response-create-open]').forEach((button) => {
+      button.addEventListener('click', () => show(createModal));
+    });
+    document.querySelectorAll('[data-canned-response-create-close]').forEach((button) => {
+      button.addEventListener('click', () => hide(createModal));
+    });
+  }
+
   function ready() {
     const messageWrappers = document.querySelectorAll('[data-timeline-message]');
 
@@ -2861,6 +2963,7 @@
     initialiseTaskManagement();
     initialiseWatcherManagement();
     initialiseTicketMentions();
+    initialiseCannedResponses();
     initialiseAttachmentActions();
     initTicketRelated();
     convertUtcElements();

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -70,6 +70,7 @@
               Solidtime
             </a>
           {% endif %}
+          <button type="button" class="button button--ghost" data-canned-response-create-open>Create canned response</button>
           {% if can_delete_ticket %}
             <form
               action="/admin/tickets/{{ ticket.id }}/delete"
@@ -1122,6 +1123,7 @@
             <summary class="card__header card__header--collapsible">
               <div class="card__title-group">
                 <h2 class="card__title">Add a reply</h2>
+                <button type="button" class="button button--secondary button--small" data-canned-responses-open>Use canned response</button>
                 <button type="button" class="button button--secondary button--small" data-ticket-reply-cache-load data-ticket-reply-cache-target="ticket-reply-form" hidden>Load Previous Reply</button>
               </div>
               <div class="card__collapsible-meta">
@@ -1563,6 +1565,48 @@
         </div>
       </div>
     </section>
+  </div>
+
+
+
+  <div class="modal" id="canned-responses-modal" role="dialog" aria-modal="true" aria-labelledby="canned-responses-title" hidden data-canned-responses-modal data-ticket-id="{{ ticket.id }}">
+    <div class="modal__content" role="document">
+      <button type="button" class="modal__close" data-canned-responses-close aria-label="Close">×</button>
+      <h2 class="modal__title" id="canned-responses-title">Canned responses</h2>
+      <p class="form-help">Selecting a response appends it after any existing reply text.</p>
+      <div class="list" data-canned-responses-list>
+        {% for response in ticket_canned_responses %}
+          <button type="button" class="button button--ghost" data-canned-response-insert data-response-id="{{ response.id }}">{{ response.title }}</button>
+        {% else %}
+          <p class="card__empty">No canned responses have been created yet.</p>
+        {% endfor %}
+      </div>
+      <p class="form-help" data-canned-responses-error hidden></p>
+    </div>
+  </div>
+
+  <div class="modal" id="canned-response-create-modal" role="dialog" aria-modal="true" aria-labelledby="canned-response-create-title" hidden data-canned-response-create-modal>
+    <div class="modal__content" role="document">
+      <button type="button" class="modal__close" data-canned-response-create-close aria-label="Close">×</button>
+      <h2 class="modal__title" id="canned-response-create-title">Create canned response</h2>
+      <form action="/admin/tickets/{{ ticket.id }}/canned-responses" method="post" class="form">
+        {% if csrf_token %}
+          <input type="hidden" name="_csrf" value="{{ csrf_token }}" />
+        {% endif %}
+        <div class="form-field">
+          <label class="form-label required" for="canned-response-title">Title</label>
+          <input id="canned-response-title" name="title" class="form-input" maxlength="255" required />
+        </div>
+        <div class="form-field">
+          <label class="form-label required" for="canned-response-body">Reply text</label>
+          <textarea id="canned-response-body" name="body" class="form-input" rows="8" required placeholder="Use variables like {{ '{{ ticket.ticket_number }}' }}, {{ '{{ ticket.subject }}' }}, {{ '{{ requester.name }}' }}, or {{ '{{ company.name }}' }}."></textarea>
+          <p class="form-help">Variables are enriched when the canned response is inserted into a ticket reply.</p>
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="button button--primary">Save response</button>
+        </div>
+      </form>
+    </div>
   </div>
 
   <div class="modal" id="reply-time-modal" role="dialog" aria-modal="true" hidden>

--- a/migrations/301_ticket_canned_responses.sql
+++ b/migrations/301_ticket_canned_responses.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS ticket_canned_responses (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  body TEXT NOT NULL,
+  created_by_user_id INT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_ticket_canned_responses_title (title),
+  CONSTRAINT fk_ticket_canned_responses_created_by FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE SET NULL
+);


### PR DESCRIPTION
### Motivation
- Provide technicians with reusable, variable-enriched reply text accessible from the ticket UI to speed responses and ensure consistency.
- Allow admins/techs to create and persist canned responses from the ticket tools UI and insert them into reply drafts without overwriting existing reply text.

### Description
- Added a new repository and migration to persist canned responses in `ticket_canned_responses` (`app/repositories/ticket_canned_responses.py`, `migrations/301_ticket_canned_responses.sql`).
- Implemented admin routes `POST /admin/tickets/{ticket_id}/canned-responses` to create responses and `GET /admin/tickets/{ticket_id}/canned-responses` to return ticket-enriched response bodies, using `message_templates.render_content` to resolve variables (changes in `app/features/tickets/admin_routes.py`).
- Loaded canned responses into the ticket detail template context so the picker can render available responses (`app/main.py`).
- Added UI affordances in the admin ticket detail: a top-right “Use canned response” button, a header action to open a create modal, plus two modals for selecting and creating responses (`app/templates/admin/ticket_detail.html`).
- Added client-side logic to fetch enriched canned responses, append a selected response after any existing reply text (does not overwrite), and manage modal open/close behavior (`app/static/js/ticket_detail.js`).

### Testing
- Ran `git diff --check` and found no whitespace or index issues (success).
- Ran `python -m py_compile app/features/tickets/admin_routes.py app/main.py app/repositories/ticket_canned_responses.py` to validate Python syntax (success).
- Ran `node --check app/static/js/ticket_detail.js` to validate JS syntax (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5821070b388332a8bc5041cac3a297)