### PR TITLE
Bypass LLM for StarTrack ticket updates

### DIFF
--- a/app/services/ticket_shipment_tracking.py
+++ b/app/services/ticket_shipment_tracking.py
@@ -196,6 +196,32 @@ def _extract_startrack_essential_fields(html_text: str) -> str:
     return "\n".join(lines)
 
 
+def _extract_labeled_filter_value(text: str, element_id: str) -> str | None:
+    pattern = rf"(?:^|\n)\s*{re.escape(element_id)}\s*:\s*([^\n\r]+)"
+    match = re.search(pattern, text, flags=re.IGNORECASE)
+    return _safe_iso(match.group(1) if match else None)
+
+
+def _startrack_snapshot_from_selected_fields(text: str) -> CanonicalShipmentSnapshot | None:
+    status = _extract_labeled_filter_value(text, "__c1_lblStatus")
+    eta_date = _extract_labeled_filter_value(text, "__c1_lblETADate")
+    if not status and not eta_date:
+        return None
+
+    status_text = (status or "").lower()
+    return CanonicalShipmentSnapshot(
+        status=status,
+        eta_date=eta_date,
+        proof_of_delivery_date=None,
+        signatory=None,
+        items_in_transit=1 if "in transit" in status_text else 0,
+        onboard_for_delivery=(
+            1 if re.search(r"on\s*board|onboard", status_text) and "deliver" in status_text else 0
+        ),
+        items_delivered=1 if "delivered" in status_text and "delivery" not in status_text else 0,
+        tracking_events=[],
+    )
+
 def _extract_json_object(raw_text: str) -> dict[str, Any] | None:
     text = str(raw_text or "").strip()
     if not text:
@@ -294,6 +320,10 @@ class StarTrackProviderAdapter(ProviderAdapter):
     async def normalize(self, raw: Mapping[str, Any]) -> CanonicalShipmentSnapshot:
         raw_text = str(raw.get("text") or "")
         html_text = str(raw.get("html") or "")
+
+        selected_fields_snapshot = _startrack_snapshot_from_selected_fields(raw_text)
+        if selected_fields_snapshot is not None:
+            return selected_fields_snapshot
 
         fallback_payload: dict[str, Any] = {
             "status": _extract_status_fallback(raw_text),
@@ -508,46 +538,18 @@ def _has_meaningful_change(
 
 
 def _render_ticket_reply(snapshot: Mapping[str, Any], watch: Mapping[str, Any]) -> str:
-    events = snapshot.get("tracking_events") or []
-    event_lines: list[str] = []
-    for event in events[:8]:
-        if not isinstance(event, Mapping):
-            continue
-        occurred_at = str(event.get("occurred_at") or "").strip() or "Unknown time"
-        description = str(event.get("description") or event.get("status") or "Update").strip()
-        location = str(event.get("location") or "").strip()
-        detail = f"- {occurred_at}: {description}"
-        if location:
-            detail = f"{detail} ({location})"
-        event_lines.append(detail)
-
-    provider = str(watch.get("provider") or "Unknown provider").strip()
-    consignment = str(watch.get("consignment_id") or "").strip() or "Not available"
+    status = str(snapshot.get("status") or "Unknown").strip() or "Unknown"
+    eta_date = str(snapshot.get("eta_date") or "Not available").strip() or "Not available"
+    tracking_url = str(watch.get("tracking_url") or "").strip()
 
     lines = [
-        "Shipment tracking update",
-        "",
-        f"- Provider: {provider}",
-        f"- Consignment: {consignment}",
-        f"- Status: {snapshot.get('status') or 'Unknown'}",
-        f"- ETA: {snapshot.get('eta_date') or 'Not available'}",
-        f"- POD date: {snapshot.get('proof_of_delivery_date') or 'Not available'}",
-        f"- Signatory: {snapshot.get('signatory') or 'Not available'}",
-        f"- Items in transit: {snapshot.get('items_in_transit') or 0}",
-        f"- Onboard for delivery: {snapshot.get('onboard_for_delivery') or 0}",
-        f"- Items delivered: {snapshot.get('items_delivered') or 0}",
+        "Hi {{requester}}",
+        f"Your order for this ticket is currently {status}, the estimated delivery date is {eta_date}.",
     ]
-
-    if event_lines:
-        lines.append("")
-        lines.append("Recent tracking events:")
-        lines.extend(event_lines)
-
-    tracking_url = str(watch.get("tracking_url") or "").strip()
     if tracking_url:
-        lines.append("")
-        lines.append(f"Tracking URL: {tracking_url}")
-
+        lines.append(f"For full tracking details please see the couriers website at {tracking_url}")
+    else:
+        lines.append("For full tracking details please see the couriers website.")
     return "\n".join(lines)
 
 

--- a/tests/test_ticket_shipment_tracking.py
+++ b/tests/test_ticket_shipment_tracking.py
@@ -100,27 +100,54 @@ def test_meaningful_change_logic():
     assert svc._has_meaningful_change(None, current_changed) is True
 
 
-def test_reply_template_contains_required_fields():
+def test_reply_template_contains_customer_friendly_tracking_summary():
     snapshot = {
-        "status": "In transit",
-        "eta_date": "2026-07-20",
+        "status": "On Board for Delivery",
+        "eta_date": "16/07/2026",
         "proof_of_delivery_date": None,
-        "signatory": "J Smith",
-        "items_in_transit": 2,
+        "signatory": None,
+        "items_in_transit": 0,
         "onboard_for_delivery": 1,
         "items_delivered": 0,
-        "tracking_events": [{"occurred_at": "2026-07-15 10:00", "description": "Processed", "location": "Sydney"}],
+        "tracking_events": [],
     }
-    watch = {"provider": "startrack", "consignment_id": "ABC123", "tracking_url": "https://www.startrack.com.au/track/ABC123"}
+    watch = {
+        "provider": "startrack",
+        "consignment_id": "UDWZ50125918",
+        "tracking_url": "https://msto.startrack.com.au/track-trace/?id=UDWZ50125918",
+    }
     body = svc._render_ticket_reply(snapshot, watch)
 
-    assert "ETA" in body
-    assert "POD date" in body
-    assert "Status" in body
-    assert "Items in transit" in body
-    assert "Onboard for delivery" in body
-    assert "Items delivered" in body
-    assert "Signatory" in body
+    assert body == (
+        "Hi {{requester}}\n"
+        "Your order for this ticket is currently On Board for Delivery, the estimated delivery date is 16/07/2026.\n"
+        "For full tracking details please see the couriers website at "
+        "https://msto.startrack.com.au/track-trace/?id=UDWZ50125918"
+    )
+
+
+@pytest.mark.anyio
+async def test_startrack_normalize_bypasses_llm_when_selected_fields_are_available(monkeypatch):
+    provider = svc.StarTrackProviderAdapter()
+
+    async def fail_llm(**kwargs):
+        raise AssertionError("LLM should not be called for selected StarTrack status and ETA fields")
+
+    monkeypatch.setattr(svc, "_extract_snapshot_with_llm", fail_llm)
+
+    raw = {
+        "url": "https://msto.startrack.com.au/track-trace/?id=UDWZ50125918",
+        "html": "__c1_lblConsignmentNumber: UDWZ50125918\n__c1_lblStatus: On Board for Delivery\n__c1_lblETADate: 16/07/2026",
+        "text": "__c1_lblConsignmentNumber: UDWZ50125918\n__c1_lblStatus: On Board for Delivery\n__c1_lblETADate: 16/07/2026",
+    }
+
+    snapshot = await provider.normalize(raw)
+    payload = snapshot.model_dump()
+
+    assert payload["status"] == "On Board for Delivery"
+    assert payload["eta_date"] == "16/07/2026"
+    assert payload["onboard_for_delivery"] == 1
+    assert payload["tracking_events"] == []
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- Avoid calling the LLM for simple StarTrack pages when the selected filter output already contains status and ETA. 
- Provide a concise, customer-facing ticket reply message instead of the verbose internal tracking dump.

### Description
- Add `_extract_labeled_filter_value` and `_startrack_snapshot_from_selected_fields` to parse `#__c1_lblStatus` and `#__c1_lblETADate` and build a `CanonicalShipmentSnapshot` directly. 
- Short-circuit `StarTrackProviderAdapter.normalize` to return the selected-fields snapshot when available, bypassing `_extract_snapshot_with_llm`. 
- Replace the verbose `_render_ticket_reply` output with a customer-friendly reply that contains `Hi {{requester}}`, the shipment `status`, `eta_date`, and the courier `tracking_url`. 
- Update and add tests in `tests/test_ticket_shipment_tracking.py` to assert the new reply wording and that normalization bypasses the LLM when selected StarTrack fields exist.

### Testing
- Ran `pytest -q tests/test_ticket_shipment_tracking.py` and the test suite passed (`15 passed`) with framework deprecation warnings. 
- Verified the modified unit tests exercise the new functions and the LLM bypass logic and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a58235987308332994e7bde4922b6db)