### PR TITLE
Add per-company "Default ticket replies to Billable" setting (enabled by default)

### DIFF
--- a/app/features/companies/handlers.py
+++ b/app/features/companies/handlers.py
@@ -517,6 +517,19 @@ async def _render_company_edit_page(
         ),
         "email_domains": _string_value("email_domains", default_email_domains),
         "is_vip": _bool_value("is_vip", bool(company_record.get("is_vip"))),
+        "default_ticket_replies_billable": _bool_value(
+            "default_ticket_replies_billable",
+            bool(
+                int(
+                    company_record.get(
+                        "default_ticket_replies_billable",
+                        1,
+                    )
+                    if company_record.get("default_ticket_replies_billable") is not None
+                    else 1
+                )
+            ),
+        ),
         "payment_method": _string_value(
             "payment_method",
             (company_record.get("payment_method") or "invoice_prepay").strip(),
@@ -1369,6 +1382,7 @@ async def admin_update_company(company_id: int, request: Request):
     offboarding_email_forwarding_enabled = bool(
         form.get("offboardingEmailForwardingEnabled")
     )
+    default_ticket_replies_billable = bool(form.get("defaultTicketRepliesBillable"))
     onedrive_export_selection_raw = str(form.get("onedriveExportSite") or "").strip()
     onedrive_export_site_id_raw = ""
     onedrive_export_drive_id_raw = ""
@@ -1432,6 +1446,7 @@ async def admin_update_company(company_id: int, request: Request):
         "payment_method": payment_method,
         "require_po": require_po,
         "offboarding_email_forwarding_enabled": offboarding_email_forwarding_enabled,
+        "default_ticket_replies_billable": default_ticket_replies_billable,
         "onedrive_export_site_id": onedrive_export_site_id_raw,
         "onedrive_export_drive_id": onedrive_export_drive_id_raw,
         "onedrive_export_site_name": onedrive_export_site_name_raw,
@@ -1497,6 +1512,9 @@ async def admin_update_company(company_id: int, request: Request):
         "require_po": 1 if require_po else 0,
         "offboarding_email_forwarding_enabled": (
             1 if offboarding_email_forwarding_enabled else 0
+        ),
+        "default_ticket_replies_billable": (
+            1 if default_ticket_replies_billable else 0
         ),
         "onedrive_export_site_id": onedrive_export_site_id_raw or None,
         "onedrive_export_site_name": onedrive_export_site_name_raw or None,

--- a/app/repositories/companies.py
+++ b/app/repositories/companies.py
@@ -16,6 +16,13 @@ def _normalise_company(row: dict[str, Any]) -> dict[str, Any]:
         normalised["id"] = int(normalised["id"])
     if "archived" in normalised and normalised["archived"] is not None:
         normalised["archived"] = int(normalised["archived"])
+    if (
+        "default_ticket_replies_billable" in normalised
+        and normalised["default_ticket_replies_billable"] is not None
+    ):
+        normalised["default_ticket_replies_billable"] = int(
+            normalised["default_ticket_replies_billable"]
+        )
     return normalised
 
 

--- a/app/schemas/companies.py
+++ b/app/schemas/companies.py
@@ -16,6 +16,7 @@ class CompanyBase(BaseModel):
     xero_id: Optional[str] = None
     huntress_organization_id: Optional[str] = None
     archived: Optional[int] = None
+    default_ticket_replies_billable: Optional[int] = 1
     email_domains: list[str] = Field(default_factory=list)
     trello_board_id: Optional[str] = None
     trello_api_key: Optional[str] = None
@@ -43,6 +44,7 @@ class CompanyUpdate(BaseModel):
     xero_id: Optional[str] = None
     huntress_organization_id: Optional[str] = None
     archived: Optional[int] = None
+    default_ticket_replies_billable: Optional[int] = None
     email_domains: Optional[list[str]] = None
     trello_board_id: Optional[str] = None
     trello_api_key: Optional[str] = None

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -257,6 +257,19 @@
             </label>
           </div>
           <div class="form-field form-field--checkbox">
+            <label class="checkbox" for="edit-company-default-ticket-replies-billable">
+              <input
+                id="edit-company-default-ticket-replies-billable"
+                type="checkbox"
+                name="defaultTicketRepliesBillable"
+                value="1"
+                {% if form_data.default_ticket_replies_billable %}checked{% endif %}
+              />
+              <span>Default ticket replies to Billable</span>
+            </label>
+            <p class="form-help">When enabled, the Billable checkbox is ticked automatically for new technician ticket replies. Technicians can untick it on individual replies when needed.</p>
+          </div>
+          <div class="form-field form-field--checkbox">
             <label class="checkbox" for="edit-company-offboarding-email-forwarding">
               <input
                 id="edit-company-offboarding-email-forwarding"

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -1295,7 +1295,12 @@
                 </div>
                 <div class="form-field form-field--checkbox">
                   <label class="checkbox">
-                    <input type="checkbox" name="isBillable" value="true" />
+                    <input
+                      type="checkbox"
+                      name="isBillable"
+                      value="true"
+                      {% if ticket_company is none or ticket_company.default_ticket_replies_billable is not defined or ticket_company.default_ticket_replies_billable %}checked{% endif %}
+                    />
                     <span>Billable</span>
                   </label>
                 </div>

--- a/migrations/301_company_default_ticket_reply_billable.sql
+++ b/migrations/301_company_default_ticket_reply_billable.sql
@@ -1,0 +1,8 @@
+-- Per-company default for technician ticket replies. Enabled by default so
+-- existing and newly-created companies pre-tick the Billable checkbox.
+ALTER TABLE companies
+  ADD COLUMN IF NOT EXISTS default_ticket_replies_billable TINYINT(1) NOT NULL DEFAULT 1;
+
+UPDATE companies
+SET default_ticket_replies_billable = 1
+WHERE default_ticket_replies_billable IS NULL;


### PR DESCRIPTION
### Motivation
- Provide an easy per-company toggle so technician-created ticket replies are pre-marked as Billable while still allowing technicians to untick per-reply. 
- The setting must be enabled for all existing and new companies by default to avoid changing current behaviour unless explicitly opted out.

### Description
- Add a DB migration `migrations/301_company_default_ticket_reply_billable.sql` to add `default_ticket_replies_billable TINYINT(1) NOT NULL DEFAULT 1` and set it for existing rows. 
- Expose the field in the companies API/schema by adding `default_ticket_replies_billable` to `app/schemas/companies.py` and ensure it is normalised in `app/repositories/companies.py`.
- Surface the control in the admin company edit UI by adding the `Default ticket replies to Billable` checkbox to `app/templates/admin/company_edit.html` and wire loading/parsing/saving in `app/features/companies/handlers.py`.
- Use the company setting to pre-check the Billable checkbox on the admin ticket reply form by updating `app/templates/admin/ticket_detail.html` so replies default to checked when the company setting is enabled.

### Testing
- Compiled modified Python modules with `python -m compileall app/repositories/companies.py app/schemas/companies.py app/features/companies/handlers.py` and the compilation succeeded. 
- Parsed updated Jinja templates with a small script using `jinja2.Environment().parse()` for `app/templates/admin/company_edit.html` and `app/templates/admin/ticket_detail.html`, and parsing succeeded. 
- Ran a quick repository lint check with `git diff --check` to ensure no trailing whitespace or parse issues, and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5825353684833288cc5ec2c45a7cd6)