### PR TITLE
Fix scheduled ticket status-age automation scans

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -567,7 +567,7 @@ async def list_tickets_for_automation_scan(*, limit: int = 1000) -> list[TicketR
             ) AS latest_reply_at
         FROM tickets t
         WHERE t.merged_into_ticket_id IS NULL
-        ORDER BY t.updated_at ASC, t.id ASC
+        ORDER BY COALESCE(t.status_changed_at, t.created_at, t.updated_at) ASC, t.updated_at ASC, t.id ASC
         LIMIT %s
         """,
         (safe_limit,),

--- a/tests/test_tickets_repository.py
+++ b/tests/test_tickets_repository.py
@@ -695,3 +695,18 @@ async def test_update_reply_defaults_labour_type_when_time_entry_has_none(monkey
 
     assert "labour_type_id = %s" in dummy_db.execute_sql
     assert dummy_db.execute_params == (15, 1, 12, 7)
+
+
+@pytest.mark.anyio
+async def test_automation_scan_orders_by_status_age_candidates(monkeypatch):
+    dummy_db = _ListTicketsDB()
+    monkeypatch.setattr(tickets, "db", dummy_db)
+
+    records = await tickets.list_tickets_for_automation_scan(limit=250)
+
+    assert records == []
+    assert dummy_db.fetch_params == (250,)
+    assert (
+        "ORDER BY COALESCE(t.status_changed_at, t.created_at, t.updated_at) ASC, "
+        "t.updated_at ASC, t.id ASC"
+    ) in dummy_db.fetch_sql


### PR DESCRIPTION
### Motivation
- Scheduled ticket automations that filter on `ticket.in_status_age_hours` were not prioritising tickets by when their status last changed, causing scans to miss the most relevant candidates.

### Description
- Order scheduled automation candidates in `list_tickets_for_automation_scan` by `COALESCE(t.status_changed_at, t.created_at, t.updated_at)` then `t.updated_at` and `t.id` to prioritise status-age first.
- Add `test_automation_scan_orders_by_status_age_candidates` to `tests/test_tickets_repository.py` to assert the query ordering and that the `limit` parameter is passed through.
- Keep the existing reply timestamp selection (`latest_reply_at`) and scan limit safeguards unchanged.

### Testing
- Ran `pytest tests/test_tickets_repository.py::test_automation_scan_orders_by_status_age_candidates tests/test_automations_service.py::test_filters_match_supports_ticket_age_comparisons -q` and both tests passed.
- Verified the new repository test observes the updated `ORDER BY` SQL and that the scanned `limit` is respected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a583744d55883328fbc43ce82c58375)