### PR TITLE
Add canned response management (create / edit / delete)

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -1642,16 +1642,23 @@ def _ticket_template_context(ticket: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
-async def _create_ticket_canned_response_from_form(request: Request, current_user: Mapping[str, Any]) -> str | None:
+async def _ticket_canned_response_form_values(request: Request) -> tuple[str | None, str | None, str | None]:
     form = await request.form()
     title = str(form.get("title") or "").strip()
     body = str(form.get("body") or "").strip()
     if not title or not body:
-        return "Enter both a title and reply text for the canned response."
+        return None, None, "Enter both a title and reply text for the canned response."
     if len(title) > 255:
-        return "Canned response title cannot exceed 255 characters."
+        return None, None, "Canned response title cannot exceed 255 characters."
+    return title, body, None
+
+
+async def _create_ticket_canned_response_from_form(request: Request, current_user: Mapping[str, Any]) -> str | None:
+    title, body, error_message = await _ticket_canned_response_form_values(request)
+    if error_message:
+        return error_message
     user_id = _main()._get_current_user_id(current_user)
-    await canned_responses_repo.create_response(title=title, body=body, created_by_user_id=user_id)
+    await canned_responses_repo.create_response(title=str(title), body=str(body), created_by_user_id=user_id)
     return None
 
 
@@ -1665,6 +1672,37 @@ async def admin_create_global_ticket_canned_response(request: Request):
     if error_message:
         return flash_redirect("/admin/tickets", error_message, "error")
     return flash_redirect("/admin/tickets", "Canned response created.", "success")
+
+
+@router.post("/admin/tickets/canned-responses/{response_id:int}", response_class=HTMLResponse)
+async def admin_update_global_ticket_canned_response(response_id: int, request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        return redirect
+    title, body, error_message = await _ticket_canned_response_form_values(request)
+    if error_message:
+        return flash_redirect("/admin/tickets", error_message, "error")
+    updated = await canned_responses_repo.update_response(
+        response_id=response_id,
+        title=str(title),
+        body=str(body),
+    )
+    if updated is None:
+        return flash_redirect("/admin/tickets", "Canned response not found.", "error")
+    return flash_redirect("/admin/tickets", "Canned response updated.", "success")
+
+
+@router.post("/admin/tickets/canned-responses/{response_id:int}/delete", response_class=HTMLResponse)
+async def admin_delete_global_ticket_canned_response(response_id: int, request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        return redirect
+    deleted = await canned_responses_repo.delete_response(response_id)
+    if not deleted:
+        return flash_redirect("/admin/tickets", "Canned response not found.", "error")
+    return flash_redirect("/admin/tickets", "Canned response deleted.", "success")
 
 
 @router.post("/admin/tickets/{ticket_id:int}/canned-responses", response_class=HTMLResponse)

--- a/app/main.py
+++ b/app/main.py
@@ -8726,6 +8726,12 @@ async def _render_tickets_dashboard(
             else (dashboard.available_statuses[0] if dashboard.available_statuses else "open")
         )
     labour_types = await labour_types_service.list_labour_types()
+    from app.repositories import ticket_canned_responses as canned_responses_repo
+
+    if await _is_helpdesk_technician(user, request):
+        ticket_canned_responses = await canned_responses_repo.list_responses()
+    else:
+        ticket_canned_responses = []
     extra = {
         "title": "Ticketing workspace",
         "tickets": tickets,
@@ -8743,6 +8749,7 @@ async def _render_tickets_dashboard(
         "ticket_company_lookup": reference_data["company_lookup"],
         "ticket_user_lookup": reference_data["user_lookup"],
         "ticket_labour_types": labour_types,
+        "ticket_canned_responses": ticket_canned_responses,
         "ticket_time_lookup": ticket_time_lookup,
         "ticket_automation_filter_lookup": ticket_automation_filter_lookup,
         "ticket_dashboard_now": datetime.now(timezone.utc),

--- a/app/repositories/ticket_canned_responses.py
+++ b/app/repositories/ticket_canned_responses.py
@@ -44,6 +44,18 @@ async def list_responses() -> list[CannedResponseRecord]:
     return [record for row in rows if (record := _normalise_record(row))]
 
 
+async def get_response(response_id: int) -> CannedResponseRecord | None:
+    row = await db.fetch_one(
+        """
+        SELECT id, title, body, created_by_user_id, created_at, updated_at
+        FROM ticket_canned_responses
+        WHERE id = %s
+        """,
+        (response_id,),
+    )
+    return _normalise_record(row)
+
+
 async def create_response(*, title: str, body: str, created_by_user_id: int | None) -> CannedResponseRecord:
     response_id = await db.execute_returning_lastrowid(
         """
@@ -64,3 +76,29 @@ async def create_response(*, title: str, body: str, created_by_user_id: int | No
     if record is None:
         raise RuntimeError("Unable to load created canned response")
     return record
+
+
+async def update_response(*, response_id: int, title: str, body: str) -> CannedResponseRecord | None:
+    await db.execute(
+        """
+        UPDATE ticket_canned_responses
+        SET title = %s, body = %s, updated_at = CURRENT_TIMESTAMP
+        WHERE id = %s
+        """,
+        (title, body, response_id),
+    )
+    return await get_response(response_id)
+
+
+async def delete_response(response_id: int) -> bool:
+    existing = await get_response(response_id)
+    if existing is None:
+        return False
+    await db.execute(
+        """
+        DELETE FROM ticket_canned_responses
+        WHERE id = %s
+        """,
+        (response_id,),
+    )
+    return True

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -44,7 +44,7 @@
                 aria-haspopup="dialog"
                 aria-controls="canned-response-create-modal"
               >
-                Create canned response
+                Manage canned responses
               </button>
             </li>
           {% endif %}
@@ -177,23 +177,51 @@
     <div class="modal" id="canned-response-create-modal" role="dialog" aria-modal="true" aria-labelledby="canned-response-create-title" hidden>
       <div class="modal__content" role="document">
         <button type="button" class="modal__close" data-modal-close aria-label="Close">×</button>
-        <h2 class="modal__title" id="canned-response-create-title">Create canned response</h2>
-        <form action="/admin/tickets/canned-responses" method="post" class="form">
-          {% include "partials/csrf.html" %}
-          <div class="form-field">
-            <label class="form-label required" for="canned-response-title">Title</label>
-            <input id="canned-response-title" name="title" class="form-input" maxlength="255" required />
-          </div>
-          <div class="form-field">
-            <label class="form-label required" for="canned-response-body">Reply text</label>
-            <textarea id="canned-response-body" name="body" class="form-input" rows="8" required placeholder="Use variables like {{ '{{ ticket.ticket_number }}' }}, {{ '{{ ticket.subject }}' }}, {{ '{{ requester.name }}' }}, or {{ '{{ company.name }}' }}."></textarea>
-            <p class="form-help">Variables are enriched when the canned response is inserted into a ticket reply.</p>
-          </div>
-          <div class="form-actions">
-            <button type="button" class="button button--ghost" data-modal-close>Cancel</button>
-            <button type="submit" class="button button--primary">Save response</button>
-          </div>
-        </form>
+        <h2 class="modal__title" id="canned-response-create-title">Manage canned responses</h2>
+        <details class="card" open>
+          <summary class="card__title">Add canned response</summary>
+          <form action="/admin/tickets/canned-responses" method="post" class="form">
+            {% include "partials/csrf.html" %}
+            <div class="form-field">
+              <label class="form-label required" for="canned-response-title">Title</label>
+              <input id="canned-response-title" name="title" class="form-input" maxlength="255" required />
+            </div>
+            <div class="form-field">
+              <label class="form-label required" for="canned-response-body">Reply text</label>
+              <textarea id="canned-response-body" name="body" class="form-input" rows="8" required placeholder="Use variables like {{ '{{ ticket.ticket_number }}' }}, {{ '{{ ticket.subject }}' }}, {{ '{{ requester.name }}' }}, or {{ '{{ company.name }}' }}."></textarea>
+              <p class="form-help">Variables are enriched when the canned response is inserted into a ticket reply.</p>
+            </div>
+            <div class="form-actions">
+              <button type="button" class="button button--ghost" data-modal-close>Cancel</button>
+              <button type="submit" class="button button--primary">Save response</button>
+            </div>
+          </form>
+        </details>
+        <div class="form-section">
+          <h3 class="form-section__title">Existing responses</h3>
+          {% for response in ticket_canned_responses %}
+            <details class="card">
+              <summary class="card__title">{{ response.title }}</summary>
+              <form action="/admin/tickets/canned-responses/{{ response.id }}" method="post" class="form">
+                {% include "partials/csrf.html" %}
+                <div class="form-field">
+                  <label class="form-label required" for="canned-response-title-{{ response.id }}">Title</label>
+                  <input id="canned-response-title-{{ response.id }}" name="title" class="form-input" maxlength="255" required value="{{ response.title }}" />
+                </div>
+                <div class="form-field">
+                  <label class="form-label required" for="canned-response-body-{{ response.id }}">Reply text</label>
+                  <textarea id="canned-response-body-{{ response.id }}" name="body" class="form-input" rows="8" required>{{ response.body }}</textarea>
+                </div>
+                <div class="form-actions">
+                  <button type="submit" class="button button--primary">Update response</button>
+                  <button type="submit" class="button button--danger" formaction="/admin/tickets/canned-responses/{{ response.id }}/delete" formnovalidate onclick="return window.confirm('Delete this canned response?')">Delete response</button>
+                </div>
+              </form>
+            </details>
+          {% else %}
+            <p class="card__empty">No canned responses have been created yet.</p>
+          {% endfor %}
+        </div>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
### Motivation
- Provide helpdesk users the ability to manage canned responses (create, edit, delete) from the ticket tools modal so responses can be maintained without leaving the ticket UI.

### Description
- Added repository helpers `get_response`, `update_response`, and `delete_response` in `app/repositories/ticket_canned_responses.py` to support CRUD operations.
- Introduced admin routes in `app/features/tickets/admin_routes.py` for updating and deleting responses at `POST /admin/tickets/canned-responses/{response_id}` and `POST /admin/tickets/canned-responses/{response_id}/delete`, and factored form validation into `_ticket_canned_response_form_values`.
- Updated the ticket admin UI in `app/templates/admin/tickets.html` to rename the action to "Manage canned responses" and expanded the modal to include an add form and an editable list of existing responses with update and delete buttons (delete uses a confirmation dialog).
- Loaded `ticket_canned_responses` into the tickets dashboard and ticket detail rendering context in `app/main.py` for helpdesk technicians so the template can render existing responses.

### Testing
- Ran `python -m compileall app/repositories/ticket_canned_responses.py app/features/tickets/admin_routes.py app/main.py` which completed successfully.
- Ran `git diff --check` to validate no spacing/whitespace issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a583a835d448332ace66ca2703f1b3b)