### PR TITLE
Fix canned response newline insertion

### DIFF
--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -2874,21 +2874,31 @@
       return loadedResponses;
     }
 
+    function cannedResponseTextToHtml(text) {
+      return String(text)
+        .replace(/\r\n?/g, '\n')
+        .trim()
+        .split(/\n{2,}/)
+        .map((paragraph) => paragraph
+          .split('\n')
+          .map((line) => escapeHtml(line))
+          .join('<br>'))
+        .map((paragraph) => `<p>${paragraph || '<br>'}</p>`)
+        .join('');
+    }
+
     function appendResponse(text) {
-      const responseText = typeof text === 'string' ? text.trim() : '';
+      const responseText = typeof text === 'string' ? text.replace(/\r\n?/g, '\n').trim() : '';
       if (!responseText) {
         return;
       }
       if (editor instanceof HTMLElement) {
         const current = editor.innerHTML.trim();
-        const escaped = responseText
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/\n/g, '<br>');
-        editor.innerHTML = current ? `${current}<p>${escaped}</p>` : `<p>${escaped}</p>`;
+        const responseHtml = cannedResponseTextToHtml(responseText);
+        editor.innerHTML = current ? `${current}${responseHtml}` : responseHtml;
         editor.dispatchEvent(new Event('input', { bubbles: true }));
         editor.focus();
+        return;
       }
       if (fallback instanceof HTMLTextAreaElement) {
         fallback.value = fallback.value.trim() ? `${fallback.value}\n\n${responseText}` : responseText;


### PR DESCRIPTION
### Motivation

- Canned responses were being inserted into the rich-text editor with extra newlines and incorrect paragraph structure because plain text was naively converted to HTML using single `<br>` replacements. 
- The rich-text editor hidden/fallback value could be overwritten incorrectly after insertion, causing inconsistent content between the editor surface and the form fallback.

### Description

- Add `cannedResponseTextToHtml()` to normalise CRLF to LF, escape content, preserve single-line breaks as `<br>`, and turn blank-line breaks into separate `<p>` paragraphs. 
- Update `appendResponse()` to use `cannedResponseTextToHtml()` and insert the resulting HTML into the rich-text surface (`data-rich-text-content`) instead of inserting plain text with extra `<br>`s. 
- Short-circuit after updating the rich-text surface to avoid also updating the plain-text fallback hidden field and causing duplicate/extra newlines.

### Testing

- Ran `git diff --check` and it passed with no whitespace or diff errors. 
- Ran `node --check app/static/js/ticket_detail.js` to validate the modified JS syntax and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a583f67a8e4833280e1f5d1f17bff83)