### PR TITLE
Fix canned responses modal viewport sizing

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -4537,10 +4537,11 @@ dialog.modal:not([open]) {
   border-radius: 1rem;
   padding: calc(var(--space-gap-roomy) * 2.5);
   position: relative;
+  box-sizing: border-box;
   width: 90vw;
   max-width: 90vw;
-  height: 90vh;
-  max-height: 90vh;
+  height: auto;
+  max-height: min(90vh, calc(100vh - (var(--space-gap-roomy) * 5)));
   overflow-x: hidden;
   overflow-y: auto;
   border: 1px solid rgba(148, 163, 184, 0.25);


### PR DESCRIPTION
### Motivation
- The “Manage canned responses” modal could extend beyond the viewport so the Add section was pushed off-screen on short/tall content; the modal needs to respect viewport caps while including its padding in the calculation.

### Description
- Update `.modal__content` in `app/static/css/app.css` to add `box-sizing: border-box`, set `height: auto`, and constrain the visible size with `max-height: min(90vh, calc(100vh - (var(--space-gap-roomy) * 5)))` so the modal sizes naturally and scrolls internally when content is tall.

### Testing
- Ran a small automated check with `python` that asserts the CSS contains `box-sizing: border-box;` and the new `max-height` expression, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a583fdc50fc83329100d00cb5095392)