### PR TITLE
Disable shipment tracking after delivery or ticket closure

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1129,6 +1129,14 @@ async def clear_ticket_billing_fields(ticket_ids: list[int]) -> int:
         (datetime.now(timezone.utc), *clean_ids),
     )
 
+
+async def _disable_shipment_watch(ticket_id: int) -> None:
+    await db.execute(
+        "UPDATE ticket_shipment_watches SET active = 0 WHERE ticket_id = %s",
+        (ticket_id,),
+    )
+
+
 async def update_ticket(ticket_id: int, **fields: Any) -> TicketRecord | None:
     if not fields:
         return await get_ticket(ticket_id)
@@ -1159,6 +1167,8 @@ async def update_ticket(ticket_id: int, **fields: Any) -> TicketRecord | None:
     query = f"UPDATE tickets SET {', '.join(assignments)} WHERE id = %s"
     params.append(ticket_id)
     await db.execute(query, tuple(params))
+    if str(fields.get("status") or "").casefold() == "closed" or fields.get("closed_at") is not None:
+        await _disable_shipment_watch(ticket_id)
     log_info("Ticket updated successfully", ticket_id=ticket_id)
     return await get_ticket(ticket_id)
 
@@ -1228,7 +1238,7 @@ async def set_tickets_status(
         closed_clause = "closed_at = COALESCE(closed_at, UTC_TIMESTAMP(6)),"
 
     params.extend(normalised_ids)
-    return await db.execute_rowcount(
+    affected = await db.execute_rowcount(
         f"""
         UPDATE tickets
         SET status_changed_at = CASE WHEN status <> %s
@@ -1240,6 +1250,12 @@ async def set_tickets_status(
         """,
         tuple(params),
     )
+    if status.casefold() == "closed" or closed_at is not None:
+        await db.execute(
+            f"UPDATE ticket_shipment_watches SET active = 0 WHERE ticket_id IN ({placeholders})",
+            tuple(normalised_ids),
+        )
+    return affected
 
 
 async def delete_ticket(ticket_id: int) -> None:

--- a/app/services/ticket_shipment_tracking.py
+++ b/app/services/ticket_shipment_tracking.py
@@ -23,6 +23,9 @@ from app.services import modules as modules_service
 from app.services import tickets as tickets_service
 
 
+DELIVERED_IN_FULL_STATUS = "delivered in full"
+
+
 _BLOCKED_NETWORKS = [
     ipaddress.ip_network("127.0.0.0/8"),
     ipaddress.ip_network("10.0.0.0/8"),
@@ -120,6 +123,12 @@ def _safe_iso(value: Any) -> str | None:
 
 def _is_missing_scalar(value: Any) -> bool:
     return value in (None, "")
+
+
+def _is_delivered_in_full(snapshot_payload: Mapping[str, Any] | None) -> bool:
+    if not snapshot_payload:
+        return False
+    return str(snapshot_payload.get("status") or "").strip().casefold() == DELIVERED_IN_FULL_STATUS
 
 
 def _snapshot_payload(snapshot: CanonicalShipmentSnapshot | Mapping[str, Any] | None) -> dict[str, Any] | None:
@@ -654,6 +663,10 @@ async def process_due_shipment_watches(*, limit: int = 200) -> dict[str, int]:
                     last_snapshot_json=snapshot_payload,
                 )
 
+                delivered_in_full = _is_delivered_in_full(snapshot_payload)
+                if delivered_in_full:
+                    await shipment_watch_repo.disable_watch(ticket_id)
+
                 first_success = previous_hash is None
                 has_update = changed_now or first_success
                 if not has_update:
@@ -735,6 +748,7 @@ __all__ = [
     "process_due_shipment_watches",
     "upsert_watch",
     "_has_meaningful_change",
+    "_is_delivered_in_full",
     "_is_watch_due",
     "_render_ticket_reply",
     "_validate_tracking_url",

--- a/tests/test_ticket_shipment_tracking.py
+++ b/tests/test_ticket_shipment_tracking.py
@@ -256,6 +256,82 @@ async def test_startrack_normalize_prefers_fallback_when_llm_is_incorrect(monkey
     assert payload["tracking_events"] == []
 
 
+def test_delivered_in_full_status_detection_is_exact_case_insensitive():
+    assert svc._is_delivered_in_full({"status": "Delivered in Full"}) is True
+    assert svc._is_delivered_in_full({"status": " delivered in full "}) is True
+    assert svc._is_delivered_in_full({"status": "Delivered"}) is False
+
+
+@pytest.mark.anyio
+async def test_process_due_shipment_watches_disables_delivered_in_full_watch(monkeypatch):
+    now = datetime.now(timezone.utc)
+    due_watch = {
+        "id": 1,
+        "ticket_id": 10,
+        "provider": "startrack",
+        "tracking_url": "https://www.startrack.com.au/track/ABC123",
+        "poll_interval_seconds": 60,
+        "last_checked_at": now - timedelta(minutes=5),
+        "last_snapshot": {"status": "In transit"},
+        "last_snapshot_hash": "old",
+        "active": True,
+        "public_comments_enabled": False,
+    }
+
+    async def fake_list(limit=200):
+        return [due_watch]
+
+    async def fake_get(watch_id):
+        return due_watch
+
+    async def fake_update(watch_id, **kwargs):
+        return None
+
+    disabled_ticket_ids: list[int] = []
+
+    async def fake_disable(ticket_id):
+        disabled_ticket_ids.append(ticket_id)
+
+    monkeypatch.setattr(svc.shipment_watch_repo, "list_active_watches", fake_list)
+    monkeypatch.setattr(svc.shipment_watch_repo, "get_watch_by_id", fake_get)
+    monkeypatch.setattr(svc.shipment_watch_repo, "update_watch_check_state", fake_update)
+    monkeypatch.setattr(svc.shipment_watch_repo, "disable_watch", fake_disable)
+
+    provider = svc.StarTrackProviderAdapter()
+
+    async def fake_fetch(url: str):
+        return {"url": url, "html": "", "text": "Delivered in Full"}
+
+    async def fake_normalize(raw):
+        return svc.CanonicalShipmentSnapshot(
+            status="Delivered in Full",
+            eta_date=None,
+            proof_of_delivery_date="2026-07-16",
+            signatory=None,
+            items_in_transit=0,
+            onboard_for_delivery=0,
+            items_delivered=1,
+            tracking_events=[],
+        )
+
+    monkeypatch.setattr(provider, "fetch", fake_fetch)
+    monkeypatch.setattr(provider, "normalize", fake_normalize)
+    monkeypatch.setattr(svc, "detect_provider", lambda url: provider)
+
+    @asynccontextmanager
+    async def fake_lock(name, timeout=1):
+        yield True
+
+    monkeypatch.setattr(svc.db, "acquire_lock", fake_lock)
+
+    result = await svc.process_due_shipment_watches(limit=10)
+
+    assert result["checked"] == 1
+    assert result["changed"] == 1
+    assert result["posted"] == 0
+    assert disabled_ticket_ids == [10]
+
+
 @pytest.mark.anyio
 async def test_process_due_shipment_watches_skips_not_due(monkeypatch):
     now = datetime.now(timezone.utc)


### PR DESCRIPTION
### Motivation

- Shipment watches should stop once a shipment is delivered in full to avoid unnecessary polling and comments.  
- Shipment tracking is also pointless after a ticket is closed, so watches must be disabled when tickets are closed (single or bulk).  

### Description

- Added a canonical delivered-status constant and detection helper `DELIVERED_IN_FULL_STATUS` and `_is_delivered_in_full` in `app/services/ticket_shipment_tracking.py`.  
- During `process_due_shipment_watches` the service now checks for the delivered-in-full snapshot and disables the corresponding watch via `shipment_watch_repo.disable_watch(ticket_id)` as soon as that snapshot is observed.  
- Added `_disable_shipment_watch` helper to `app/repositories/tickets.py` and wired automatic disabling when a ticket is closed in `update_ticket`, and for bulk updates in `set_tickets_status` (disables watches for affected ticket ids).  
- Added unit tests exercising the new delivered-in-full detection and the automatic disabling behavior in `tests/test_ticket_shipment_tracking.py`.

### Testing

- Ran static compile checks with `python -m py_compile app/repositories/tickets.py app/services/ticket_shipment_tracking.py` and they succeeded.  
- Ran the shipment-watch unit tests with `pytest tests/test_ticket_shipment_tracking.py -q` and all tests in that file passed (17 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5843f91c248332bfe9951c6a198442)