### PR TITLE
Treat shipment-watch ticket replies as system for automations

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1634,7 +1634,11 @@ async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> 
             tr.created_at,
             tr.is_internal,
             CASE WHEN tr.is_internal = 1 THEN 'internal_note' ELSE 'message' END AS kind,
-            CASE WHEN tr.is_internal = 1 THEN 'technician' ELSE 'requester' END AS ticket_update_actor_type
+            CASE
+                WHEN tr.external_reference LIKE 'shipment-watch:%' THEN 'system'
+                WHEN tr.is_internal = 1 THEN 'technician'
+                ELSE 'requester'
+            END AS ticket_update_actor_type
         FROM ticket_replies AS tr
         INNER JOIN (
             SELECT ticket_id, MAX(id) AS latest_reply_id

--- a/tests/test_ticket_shipment_tracking.py
+++ b/tests/test_ticket_shipment_tracking.py
@@ -405,7 +405,10 @@ async def test_process_due_shipment_watches_skips_not_due(monkeypatch):
     async def fake_create_reply(**kwargs):
         return {"id": 100, **kwargs}
 
+    emit_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
     async def fake_emit(*args, **kwargs):
+        emit_calls.append((args, kwargs))
         return None
 
     monkeypatch.setattr(svc.tickets_repo, "create_reply", fake_create_reply)
@@ -416,6 +419,7 @@ async def test_process_due_shipment_watches_skips_not_due(monkeypatch):
 
     assert result["checked"] == 1
     assert result["posted"] == 1
+    assert [kwargs.get("actor_type") for _, kwargs in emit_calls] == ["system", "system"]
     assert any(entry["watch_id"] == 1 for entry in updates)
     assert all(entry["watch_id"] != 2 for entry in updates)
 

--- a/tests/test_tickets_repository.py
+++ b/tests/test_tickets_repository.py
@@ -100,6 +100,10 @@ class _AutomationContextDB:
     def __init__(self):
         self.fetch_calls = []
 
+    async def fetch_one(self, sql, params):
+        self.fetch_calls.append((sql.strip(), params))
+        return {"expense_total": 0, "expense_count": 0}
+
     async def fetch_all(self, sql, params):
         self.fetch_calls.append((sql.strip(), params))
         if "SUM(CASE WHEN is_billable" in sql:
@@ -116,6 +120,7 @@ class _AutomationContextDB:
                     "created_at": None,
                     "is_internal": 1,
                     "kind": "internal_note",
+                    "ticket_update_actor_type": "technician",
                 }
             ]
         return []
@@ -366,6 +371,18 @@ async def test_automation_filter_context_derives_latest_reply_kind(monkeypatch):
     )
     assert context[5]["latest_reply_id"] == 12
     assert context[5]["latest_reply_kind"] == "internal_note"
+    assert context[5]["ticket_update_actor_type"] == "technician"
+
+
+@pytest.mark.anyio
+async def test_automation_filter_context_treats_shipment_reply_as_system(monkeypatch):
+    dummy_db = _AutomationContextDB()
+    monkeypatch.setattr(tickets, "db", dummy_db)
+
+    await tickets.get_automation_filter_context_by_ticket_ids([5])
+
+    latest_query = dummy_db.fetch_calls[-1][0]
+    assert "WHEN tr.external_reference LIKE 'shipment-watch:%' THEN 'system'" in latest_query
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- Shipment tracking updates posted as ticket replies were not being classified as `system` actor updates, preventing automations that filter on `ticket_update.actor_type == system` from firing.

### Description
- Update the automation context query in `app/repositories/tickets.py` to map replies with `external_reference` like `shipment-watch:%` to the `system` actor via a `CASE` expression in `get_automation_filter_context_by_ticket_ids`.
- Add an assertion to `tests/test_ticket_shipment_tracking.py` to verify shipment watch processing emits `emit_ticket_replied_event` and `emit_ticket_updated_event` calls with `actor_type="system"`.
- Extend `tests/test_tickets_repository.py` to (a) include a `fetch_one` stub in the `_AutomationContextDB` test double and (b) add a regression test that the derived `ticket_update_actor_type` SQL contains the `shipment-watch`->`system` mapping and that the context returns `ticket_update_actor_type` as expected.

### Testing
- Ran the failing test run that revealed the issue with `pytest -q tests/test_ticket_shipment_tracking.py tests/test_tickets_repository.py` which showed `4 failed` before fixes. 
- After the change and test updates, ran `pytest -q tests/test_ticket_shipment_tracking.py tests/test_tickets_repository.py::test_automation_filter_context_derives_latest_reply_kind tests/test_tickets_repository.py::test_automation_filter_context_treats_shipment_reply_as_system` and the targeted tests passed (`19 passed`, with warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a58453138f48332afbebd58049a9d87)