### PR TITLE
Fix modal sizing on mobile and reset modal scroll on open

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -4513,7 +4513,7 @@ dialog.modal:not([open]) {
   .modal__dialog,
   .modal__panel {
     width: 100%;
-    max-height: calc(100vh - (var(--space-gap-base) * 2));
+    max-height: calc(100dvh - (var(--space-gap-base) * 2));
   }
 
   .modal__dialog .modal__header,
@@ -4537,10 +4537,12 @@ dialog.modal:not([open]) {
   border-radius: 1rem;
   padding: calc(var(--space-gap-roomy) * 2.5);
   position: relative;
+  box-sizing: border-box;
   width: 90vw;
   max-width: 90vw;
-  height: 90vh;
-  max-height: 90vh;
+  height: auto;
+  max-height: calc(100dvh - (var(--space-gap-roomy) * 5));
+  margin: auto;
   overflow-x: hidden;
   overflow-y: auto;
   border: 1px solid rgba(148, 163, 184, 0.25);

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -2504,6 +2504,10 @@
       modal.hidden = false;
       modal.classList.add('is-visible');
       modal.setAttribute('aria-hidden', 'false');
+      const modalContent = modal.querySelector('.modal__content, .modal__panel, .modal__dialog, .modal-content');
+      if (modalContent) {
+        modalContent.scrollTop = 0;
+      }
       if (activeTrigger) {
         activeTrigger.setAttribute('aria-expanded', 'true');
       }


### PR DESCRIPTION
### Motivation
- Ensure modals size correctly on mobile devices when browser UI changes the viewport height.
- Prevent previously scrolled modal content from showing a scrolled position when reopening a modal.

### Description
- Use `dvh` for mobile-aware max-height calculations and adjust `.modal__content` to `height: auto`, set `max-height: calc(100dvh - (var(--space-gap-roomy) * 5))`, and add `margin: auto` to improve vertical centering.
- Add `box-sizing: border-box` to `.modal__content` to ensure padding is included in size calculations.
- Reset modal internal scroll when opening by setting `scrollTop = 0` on the first matching element found with selector `.modal__content, .modal__panel, .modal__dialog, .modal-content` in `openModal`.

### Testing
- Ran frontend linting with `npm run lint` and the linter passed.
- Built the frontend with `npm run build` and the build succeeded.
- Ran automated JavaScript tests with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a583fdc50fc83329100d00cb5095392)