### PR TITLE
Escape % in shipment-watch LIKE pattern to avoid aiomysql format error

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1635,7 +1635,7 @@ async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> 
             tr.is_internal,
             CASE WHEN tr.is_internal = 1 THEN 'internal_note' ELSE 'message' END AS kind,
             CASE
-                WHEN tr.external_reference LIKE 'shipment-watch:%' THEN 'system'
+                WHEN tr.external_reference LIKE 'shipment-watch:%%' THEN 'system'
                 WHEN tr.is_internal = 1 THEN 'technician'
                 ELSE 'requester'
             END AS ticket_update_actor_type

--- a/tests/test_tickets_repository.py
+++ b/tests/test_tickets_repository.py
@@ -382,7 +382,7 @@ async def test_automation_filter_context_treats_shipment_reply_as_system(monkeyp
     await tickets.get_automation_filter_context_by_ticket_ids([5])
 
     latest_query = dummy_db.fetch_calls[-1][0]
-    assert "WHEN tr.external_reference LIKE 'shipment-watch:%' THEN 'system'" in latest_query
+    assert "WHEN tr.external_reference LIKE 'shipment-watch:%%' THEN 'system'" in latest_query
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- Prevent a `ValueError: unsupported format character` raised when aiomysql/PyMySQL interpolates a literal `%` inside the `LIKE` pattern used by the ticket automation query. 
- Ensure the automation-filter logic still recognises `shipment-watch:` external references while avoiding Python-format-string interpretation.

### Description
- In `get_automation_filter_context_by_ticket_ids` updated the `LIKE` pattern from `shipment-watch:%` to an escaped literal `shipment-watch:%%` so the `%` survives aiomysql interpolation. 
- Updated the test expectation in `tests/test_tickets_repository.py` to assert the escaped pattern `shipment-watch:%%` appears in the generated query. 
- No other logic or behavior was changed.

### Testing
- Ran the focused test pair `pytest tests/test_tickets_repository.py::test_automation_filter_context_derives_latest_reply_kind tests/test_tickets_repository.py::test_automation_filter_context_treats_shipment_reply_as_system -q`, and both tests passed. 
- Ran `python -m py_compile app/repositories/tickets.py` which succeeded. 
- Ran `pytest tests/test_tickets_repository.py -q`; targeted changes passed but the full file run reported two pre-existing/environment-related failures in ticket-creation tests due to the database pool not being initialised, which are unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a584e134edc8332a2ed20fe6e262928)