### PR TITLE
Allow WAV and other safe audio/video MIME types for ticket attachments

### DIFF
--- a/app/services/ticket_attachments.py
+++ b/app/services/ticket_attachments.py
@@ -45,6 +45,25 @@ ALLOWED_MIME_TYPES = {
     "application/x-7z-compressed",
     "application/x-tar",
     "application/gzip",
+    # Audio (safe binary media used by voicemail/transcription workflows)
+    "audio/wav",
+    "audio/x-wav",
+    "audio/wave",
+    "audio/vnd.wave",
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/ogg",
+    "audio/flac",
+    "audio/x-flac",
+    "audio/webm",
+    "audio/mp4",
+    "audio/x-m4a",
+    # Video (safe binary media)
+    "video/mp4",
+    "video/mpeg",
+    "video/ogg",
+    "video/webm",
+    "video/quicktime",
     # Other
     "application/json",
 }

--- a/tests/test_ticket_attachments.py
+++ b/tests/test_ticket_attachments.py
@@ -249,6 +249,38 @@ def test_validate_file_upload_too_large():
     assert "exceeds maximum" in error
 
 
+def test_validate_file_upload_allows_voicemail_wav():
+    """Office 365 voicemail WAV attachments should pass upload validation."""
+    mock_file = MagicMock()
+    mock_file.filename = "voicemail.wav"
+    mock_file.content_type = "audio/wav"
+    mock_file.size = 1000
+
+    is_valid, error = attachments_service.validate_file_upload(mock_file)
+
+    assert is_valid is True
+    assert error is None
+
+
+def test_allowed_mime_types_include_whisperx_audio_formats():
+    """All audio formats that WhisperX can process should be safe attachments."""
+    whisperx_audio_types = {
+        "audio/wav",
+        "audio/x-wav",
+        "audio/wave",
+        "audio/mpeg",
+        "audio/mp3",
+        "audio/ogg",
+        "audio/flac",
+        "audio/x-flac",
+        "audio/webm",
+        "audio/mp4",
+        "audio/x-m4a",
+    }
+
+    assert whisperx_audio_types <= attachments_service.ALLOWED_MIME_TYPES
+
+
 def test_validate_file_upload_invalid_mime_type():
     """Test validation fails with invalid MIME type."""
     mock_file = MagicMock()


### PR DESCRIPTION
### Motivation
- Voicemail messages from Office 365 arrive as WAV files and need to be preserved as ticket attachments so downstream transcription (e.g. WhisperX) can process them. 
- The existing attachment allowlist excluded audio/video binary formats which caused safe media attachments to be dropped. 

### Description
- Added common audio MIME types (including `audio/wav`, `audio/x-wav`, `audio/wave`, `audio/vnd.wave`, and other WhisperX-supported types) to the shared allowlist in `app/services/ticket_attachments.py` under `ALLOWED_MIME_TYPES`.
- Added common safe video MIME types to `ALLOWED_MIME_TYPES` to avoid rejecting binary media attachments while preserving existing exclusions for SVG/HTML/XML.
- Added unit tests in `tests/test_ticket_attachments.py` to assert that Office 365 voicemail WAV attachments are accepted and that the WhisperX audio MIME set is included in the allowlist.

### Testing
- Ran targeted unit tests covering the new validation and Graph attachment handling: `pytest tests/test_ticket_attachments.py::test_validate_file_upload_allows_voicemail_wav tests/test_ticket_attachments.py::test_allowed_mime_types_include_whisperx_audio_formats tests/test_ticket_attachments.py::test_validate_file_upload_invalid_mime_type tests/test_m365_mail_service.py::test_save_graph_attachments_fetches_value_when_content_bytes_missing tests/test_m365_mail_service.py::test_save_graph_attachments_still_uses_content_bytes_when_present -q`, and the targeted tests passed.
- Running the full `tests/test_ticket_attachments.py` in this environment produced failures unrelated to the change because the test runner lacked an async plugin (async tests require `pytest-asyncio` or similar); this is an environment/test harness issue rather than a regression in attachment validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5850b81aec83328cb3150dd557fb8b)