### PR TITLE
Add ticket Test action for scheduled and event automations

### DIFF
--- a/app/features/automations/handlers.py
+++ b/app/features/automations/handlers.py
@@ -38,8 +38,12 @@ async def _render_automations_dashboard(
         kind=kind_filter,
         limit=200,
     )
-    status_counts = Counter((automation.get("status") or "inactive").lower() for automation in automations)
-    kind_counts = Counter((automation.get("kind") or "scheduled").lower() for automation in automations)
+    status_counts = Counter(
+        (automation.get("status") or "inactive").lower() for automation in automations
+    )
+    kind_counts = Counter(
+        (automation.get("kind") or "scheduled").lower() for automation in automations
+    )
     extra = {
         "title": "Automation orchestration",
         "automations": automations,
@@ -49,7 +53,9 @@ async def _render_automations_dashboard(
         "success_message": success_message,
         "error_message": error_message,
     }
-    response = await _main()._render_template("admin/automations.html", request, user, extra=extra)
+    response = await _main()._render_template(
+        "admin/automations.html", request, user, extra=extra
+    )
     response.status_code = status_code
     return response
 
@@ -109,10 +115,10 @@ async def _render_automation_form(
         else "admin/automations_create_scheduled.html"
     )
     if kind_normalised == "event":
-        page_title = "Edit event automation" if is_edit_mode else "Create event automation"
-        page_subtitle = (
-            "Link webhook payloads and application events to integration modules for immediate processing."
+        page_title = (
+            "Edit event automation" if is_edit_mode else "Create event automation"
         )
+        page_subtitle = "Link webhook payloads and application events to integration modules for immediate processing."
         alternate_link = None
         if not is_edit_mode:
             alternate_link = {
@@ -120,10 +126,12 @@ async def _render_automation_form(
                 "label": "Switch to scheduled automation",
             }
     else:
-        page_title = "Edit scheduled automation" if is_edit_mode else "Create scheduled automation"
-        page_subtitle = (
-            "Configure cadence, triggers, and action payloads to run on a predictable rhythm."
+        page_title = (
+            "Edit scheduled automation"
+            if is_edit_mode
+            else "Create scheduled automation"
         )
+        page_subtitle = "Configure cadence, triggers, and action payloads to run on a predictable rhythm."
         alternate_link = None
         if not is_edit_mode:
             alternate_link = {
@@ -222,7 +230,9 @@ def _parse_automation_form_submission(
     trigger_event_raw = _get_str_value("triggerEvent").strip()
     trigger_filters_raw = _get_str_value("triggerFilters").strip()
     trigger_filters_mode_raw = _get_str_value("triggerFiltersMode").strip().lower()
-    trigger_filters_mode = "advanced" if trigger_filters_mode_raw == "advanced" else "builder"
+    trigger_filters_mode = (
+        "advanced" if trigger_filters_mode_raw == "advanced" else "builder"
+    )
     action_module_raw = _get_str_value("actionModule").strip()
     action_payload_raw = _get_str_value("actionPayload").strip()
 
@@ -243,7 +253,12 @@ def _parse_automation_form_submission(
     }
 
     if not name:
-        return None, form_state, "Enter an automation name.", status.HTTP_400_BAD_REQUEST
+        return (
+            None,
+            form_state,
+            "Enter an automation name.",
+            status.HTTP_400_BAD_REQUEST,
+        )
 
     cadence = cadence_raw or None
     cron_expression = cron_raw or None
@@ -263,7 +278,9 @@ def _parse_automation_form_submission(
             scheduled_time = datetime.fromisoformat(scheduled_time_raw)
             if scheduled_time.tzinfo is None:
                 local_tz = datetime.now().astimezone().tzinfo
-                scheduled_time = scheduled_time.replace(tzinfo=local_tz).astimezone(timezone.utc)
+                scheduled_time = scheduled_time.replace(tzinfo=local_tz).astimezone(
+                    timezone.utc
+                )
         except (ValueError, TypeError):
             return (
                 None,
@@ -273,9 +290,15 @@ def _parse_automation_form_submission(
             )
 
     try:
-        trigger_filters = json.loads(trigger_filters_raw) if trigger_filters_raw else None
+        trigger_filters = (
+            json.loads(trigger_filters_raw) if trigger_filters_raw else None
+        )
     except json.JSONDecodeError:
-        invalid_section = "Advanced JSON trigger filters" if trigger_filters_mode == "advanced" else "Trigger filter builder payload"
+        invalid_section = (
+            "Advanced JSON trigger filters"
+            if trigger_filters_mode == "advanced"
+            else "Trigger filter builder payload"
+        )
         return (
             None,
             form_state,
@@ -284,7 +307,11 @@ def _parse_automation_form_submission(
         )
     if trigger_filters is not None:
         if not isinstance(trigger_filters, dict):
-            invalid_section = "Advanced JSON trigger filters" if trigger_filters_mode == "advanced" else "Trigger filter builder payload"
+            invalid_section = (
+                "Advanced JSON trigger filters"
+                if trigger_filters_mode == "advanced"
+                else "Trigger filter builder payload"
+            )
             return (
                 None,
                 form_state,
@@ -348,7 +375,10 @@ def _parse_automation_form_submission(
                     f"Trigger action {index}: {exc}",
                     status.HTTP_400_BAD_REQUEST,
                 )
-            action_entry: dict[str, Any] = {"module": module_value, "payload": payload_value}
+            action_entry: dict[str, Any] = {
+                "module": module_value,
+                "payload": payload_value,
+            }
             raw_order = entry.get("order")
             if raw_order is not None:
                 try:
@@ -416,22 +446,35 @@ async def admin_reorder_automations(request: Request):
 
     current_user, redirect = await _main()._require_super_admin_page(request)
     if redirect:
-        return JSONResponse({"detail": "Authentication required"}, status_code=status.HTTP_401_UNAUTHORIZED)
+        return JSONResponse(
+            {"detail": "Authentication required"},
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
     try:
         payload = await request.json()
     except json.JSONDecodeError:
-        return JSONResponse({"detail": "Invalid JSON payload."}, status_code=status.HTTP_400_BAD_REQUEST)
+        return JSONResponse(
+            {"detail": "Invalid JSON payload."}, status_code=status.HTTP_400_BAD_REQUEST
+        )
     ordered_ids = payload.get("ordered_ids") if isinstance(payload, Mapping) else None
     if not isinstance(ordered_ids, list):
-        return JSONResponse({"detail": "ordered_ids must be a list."}, status_code=status.HTTP_400_BAD_REQUEST)
+        return JSONResponse(
+            {"detail": "ordered_ids must be a list."},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
     updated = await automation_repo.update_automation_order(ordered_ids)
-    return JSONResponse({
-        "success": True,
-        "automations": [
-            {"id": int(record["id"]), "execution_order": int(record.get("execution_order") or 0)}
-            for record in updated
-        ],
-    })
+    return JSONResponse(
+        {
+            "success": True,
+            "automations": [
+                {
+                    "id": int(record["id"]),
+                    "execution_order": int(record.get("execution_order") or 0),
+                }
+                for record in updated
+            ],
+        }
+    )
 
 
 async def admin_create_scheduled_automation_page(
@@ -471,7 +514,9 @@ async def admin_create_automation(request: Request):
     form = await request.form()
     kind_raw = str(form.get("kind", "")).strip()
     kind = "event" if kind_raw.lower() == "event" else "scheduled"
-    data, form_state, error_message, error_status = _parse_automation_form_submission(form, kind=kind)
+    data, form_state, error_message, error_status = _parse_automation_form_submission(
+        form, kind=kind
+    )
     if error_message:
         return await _render_automation_form(
             request,
@@ -535,7 +580,9 @@ async def admin_update_automation(automation_id: int, request: Request):
         return flash_redirect("/admin/automations", "Automation not found.", "error")
     form = await request.form()
     kind = str(automation.get("kind") or "scheduled")
-    data, form_state, error_message, error_status = _parse_automation_form_submission(form, kind=kind)
+    data, form_state, error_message, error_status = _parse_automation_form_submission(
+        form, kind=kind
+    )
     if error_message:
         return await _render_automation_form(
             request,
@@ -553,7 +600,9 @@ async def admin_update_automation(automation_id: int, request: Request):
     try:
         await automation_repo.update_automation(automation_id, **update_fields)
     except Exception as exc:  # pragma: no cover - defensive logging
-        log_error("Failed to update automation", automation_id=automation_id, error=str(exc))
+        log_error(
+            "Failed to update automation", automation_id=automation_id, error=str(exc)
+        )
         return await _render_automation_form(
             request,
             current_user,
@@ -589,13 +638,21 @@ async def admin_update_automation_status(automation_id: int, request: Request):
         )
     automation = await automation_repo.get_automation(automation_id)
     if not automation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found"
+        )
     await automation_repo.update_automation(automation_id, status=status_value)
     await automations_service.refresh_schedule(automation_id)
-    return flash_redirect("/admin/automations", f"Automation {automation_id} updated.", "success")
+    return flash_redirect(
+        "/admin/automations", f"Automation {automation_id} updated.", "success"
+    )
 
 
-async def admin_preview_automation(automation_id: int, request: Request, limit: int = Query(default=1000, ge=1, le=5000)):
+async def admin_preview_automation(
+    automation_id: int,
+    request: Request,
+    limit: int = Query(default=1000, ge=1, le=5000),
+):
     from app.repositories import automations as automation_repo
     from app.services import automations as automations_service
 
@@ -604,9 +661,13 @@ async def admin_preview_automation(automation_id: int, request: Request, limit: 
         return redirect
     automation = await automation_repo.get_automation(automation_id)
     if not automation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found"
+        )
     try:
-        preview = await automations_service.preview_scheduled_ticket_automation(automation, limit=limit)
+        preview = await automations_service.preview_scheduled_ticket_automation(
+            automation, limit=limit
+        )
     except ValueError as exc:
         return flash_redirect("/admin/automations", str(exc), "error")
     extra = {
@@ -615,12 +676,16 @@ async def admin_preview_automation(automation_id: int, request: Request, limit: 
         "preview": preview,
         "limit": limit,
     }
-    return await _main()._render_template("admin/automations_preview.html", request, current_user, extra=extra)
+    return await _main()._render_template(
+        "admin/automations_preview.html", request, current_user, extra=extra
+    )
 
 
-
-
-async def admin_simulate_automation(automation_id: int, request: Request, limit: int = Query(default=1000, ge=1, le=5000)):
+async def admin_simulate_automation(
+    automation_id: int,
+    request: Request,
+    limit: int = Query(default=1000, ge=1, le=5000),
+):
     from app.repositories import automations as automation_repo
     from app.services import automations as automations_service
 
@@ -629,9 +694,13 @@ async def admin_simulate_automation(automation_id: int, request: Request, limit:
         return redirect
     automation = await automation_repo.get_automation(automation_id)
     if not automation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found"
+        )
     try:
-        preview = await automations_service.simulate_event_ticket_automation(automation, limit=limit)
+        preview = await automations_service.simulate_event_ticket_automation(
+            automation, limit=limit
+        )
     except ValueError as exc:
         return flash_redirect("/admin/automations", str(exc), "error")
     extra = {
@@ -641,7 +710,9 @@ async def admin_simulate_automation(automation_id: int, request: Request, limit:
         "limit": limit,
         "is_simulation": True,
     }
-    return await _main()._render_template("admin/automations_preview.html", request, current_user, extra=extra)
+    return await _main()._render_template(
+        "admin/automations_preview.html", request, current_user, extra=extra
+    )
 
 
 async def admin_process_simulated_automation(automation_id: int, request: Request):
@@ -651,7 +722,9 @@ async def admin_process_simulated_automation(automation_id: int, request: Reques
     if redirect:
         return redirect
     form = await request.form()
-    ticket_ids = [int(value) for value in form.getlist("ticket_ids") if str(value).isdigit()]
+    ticket_ids = [
+        int(value) for value in form.getlist("ticket_ids") if str(value).isdigit()
+    ]
     try:
         limit = int(form.get("limit") or 1000)
     except (TypeError, ValueError):
@@ -668,7 +741,10 @@ async def admin_process_simulated_automation(automation_id: int, request: Reques
         f"Simulated automation {automation_id} processed {result.get('matched', 0)} ticket(s): "
         f"{result.get('succeeded', 0)} succeeded, {result.get('failed', 0)} failed."
     )
-    return flash_redirect(f"/admin/automations/{automation_id}/simulate", message, "success")
+    return flash_redirect(
+        f"/admin/automations/{automation_id}/simulate", message, "success"
+    )
+
 
 async def admin_execute_automation(automation_id: int, request: Request):
     from app.services import automations as automations_service
@@ -679,7 +755,9 @@ async def admin_execute_automation(automation_id: int, request: Request):
     try:
         result = await automations_service.execute_now(automation_id)
     except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)
+        ) from exc
     message = f"Automation {automation_id} executed with status {result.get('status')}."
     return flash_redirect("/admin/automations", message, "success")
 
@@ -695,16 +773,22 @@ async def admin_clone_automation(automation_id: int, request: Request):
 
     automation = await automation_repo.get_automation(automation_id)
     if not automation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found"
+        )
 
     next_run = None
     if automation.get("status") == "active":
         next_run = automations_service.calculate_next_run(automation)
 
     try:
-        cloned = await automation_repo.clone_automation(automation_id, next_run_at=next_run)
+        cloned = await automation_repo.clone_automation(
+            automation_id, next_run_at=next_run
+        )
     except Exception as exc:  # pragma: no cover - defensive logging
-        log_error("Failed to clone automation", automation_id=automation_id, error=str(exc))
+        log_error(
+            "Failed to clone automation", automation_id=automation_id, error=str(exc)
+        )
         return await _render_automations_dashboard(
             request,
             current_user,
@@ -713,7 +797,9 @@ async def admin_clone_automation(automation_id: int, request: Request):
         )
 
     if not cloned:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found"
+        )
 
     if cloned.get("status") == "active":
         await automations_service.refresh_schedule(int(cloned["id"]))
@@ -738,7 +824,9 @@ async def admin_delete_automation(automation_id: int, request: Request):
 
     automation = await automation_repo.get_automation(automation_id)
     if not automation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found"
+        )
 
     try:
         await automation_repo.delete_automation(automation_id)
@@ -758,22 +846,75 @@ async def admin_delete_automation(automation_id: int, request: Request):
     log_info(
         "Automation deleted",
         automation_id=automation_id,
-        deleted_by=current_user.get("id") if isinstance(current_user, Mapping) else None,
+        deleted_by=(
+            current_user.get("id") if isinstance(current_user, Mapping) else None
+        ),
     )
 
     message = f"Automation {automation_id} deleted."
     return flash_redirect("/admin/automations", message, "success")
 
 
-async def admin_automation_history(automation_id: int, request: Request, limit: int = Query(default=200, ge=1, le=1000)):
+async def admin_test_automation(automation_id: int, request: Request):
+    from app.services import automations as automations_service
+
+    current_user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return JSONResponse(
+            {"detail": "Authentication required"},
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
+    try:
+        payload = await request.json()
+    except json.JSONDecodeError:
+        return JSONResponse(
+            {"detail": "Invalid JSON payload."}, status_code=status.HTTP_400_BAD_REQUEST
+        )
+    if not isinstance(payload, Mapping):
+        return JSONResponse(
+            {"detail": "Payload must be an object."},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    ticket_number = str(payload.get("ticket_number") or "").strip()
+    if not ticket_number:
+        return JSONResponse(
+            {"detail": "Ticket number is required."},
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    apply_action = bool(payload.get("apply"))
+    try:
+        result = await automations_service.test_ticket_automation_by_id(
+            automation_id,
+            ticket_number=ticket_number,
+            apply=apply_action,
+        )
+    except ValueError as exc:
+        message = str(exc)
+        status_code = (
+            status.HTTP_404_NOT_FOUND
+            if "not found" in message.lower()
+            else status.HTTP_400_BAD_REQUEST
+        )
+        return JSONResponse({"detail": message}, status_code=status_code)
+    return JSONResponse(_main()._serialise_for_json(result))
+
+
+async def admin_automation_history(
+    automation_id: int, request: Request, limit: int = Query(default=200, ge=1, le=1000)
+):
     from app.repositories import automations as automation_repo
 
     current_user, redirect = await _main()._require_super_admin_page(request)
     if redirect:
-        return JSONResponse({"detail": "Authentication required"}, status_code=status.HTTP_401_UNAUTHORIZED)
+        return JSONResponse(
+            {"detail": "Authentication required"},
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
     automation = await automation_repo.get_automation(automation_id)
     if not automation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Automation not found"
+        )
     rows = await automation_repo.list_history(automation_id, limit=limit)
 
     def encode(value: Any) -> Any:
@@ -785,7 +926,9 @@ async def admin_automation_history(automation_id: int, request: Request, limit: 
             return [encode(item) for item in value]
         return value
 
-    return JSONResponse({
-        "automation": {"id": automation_id, "name": automation.get("name")},
-        "history": [encode(row) for row in rows],
-    })
+    return JSONResponse(
+        {
+            "automation": {"id": automation_id, "name": automation.get("name")},
+            "history": [encode(row) for row in rows],
+        }
+    )

--- a/app/features/automations/routes.py
+++ b/app/features/automations/routes.py
@@ -80,6 +80,11 @@ router.add_api_route(
     methods=["GET"],
 )
 router.add_api_route(
+    "/admin/automations/{automation_id}/test",
+    handlers.admin_test_automation,
+    methods=["POST"],
+)
+router.add_api_route(
     "/admin/automations/{automation_id}/execute",
     handlers.admin_execute_automation,
     methods=["POST"],

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -101,7 +101,9 @@ def _append_ticket_search_filter(
     ]
     like_params: list[Any] = [value, value]
     if include_external_reference:
-        like_clause.append(f"LOWER(COALESCE({prefixed_external_reference}, '')) LIKE LOWER(%s)")
+        like_clause.append(
+            f"LOWER(COALESCE({prefixed_external_reference}, '')) LIKE LOWER(%s)"
+        )
         like_params.append(value)
     where.append(f"({' OR '.join(like_clause)})")
     params.extend(like_params)
@@ -119,7 +121,9 @@ def _append_ticket_cursor_filter(
         return
     updated_column = f"{column_prefix}updated_at"
     id_column = f"{column_prefix}id"
-    where.append(f"({updated_column} < %s OR ({updated_column} = %s AND {id_column} < %s))")
+    where.append(
+        f"({updated_column} < %s OR ({updated_column} = %s AND {id_column} < %s))"
+    )
     params.extend([cursor_updated_at, cursor_updated_at, int(cursor_id)])
 
 
@@ -155,7 +159,11 @@ def _deserialise_tags(value: Any) -> list[str]:
         try:
             parsed = json.loads(text)
         except json.JSONDecodeError:
-            parts = [segment.strip() for segment in re.split(r"[,\n;]+", text) if segment.strip()]
+            parts = [
+                segment.strip()
+                for segment in re.split(r"[,\n;]+", text)
+                if segment.strip()
+            ]
             return parts
         if isinstance(parsed, list):
             return [str(item).strip() for item in parsed if str(item).strip()]
@@ -204,7 +212,15 @@ def _make_aware(value: Any) -> datetime | None:
 
 def _normalise_ticket(row: dict[str, Any]) -> TicketRecord:
     record = dict(row)
-    for key in ("id", "company_id", "requester_id", "requester_staff_id", "assigned_user_id", "merged_into_ticket_id", "split_from_ticket_id"):
+    for key in (
+        "id",
+        "company_id",
+        "requester_id",
+        "requester_staff_id",
+        "assigned_user_id",
+        "merged_into_ticket_id",
+        "split_from_ticket_id",
+    ):
         if key in record and record[key] is not None:
             record[key] = int(record[key])
     if "review_date" in record:
@@ -238,12 +254,19 @@ def _normalise_reply(row: dict[str, Any]) -> TicketRecord:
             record[key] = int(record[key])
     record["created_at"] = _make_aware(record.get("created_at"))
     # Normalise email tracking datetime fields
-    for key in ("email_sent_at", "email_opened_at", "email_delivered_at", "email_bounced_at"):
+    for key in (
+        "email_sent_at",
+        "email_opened_at",
+        "email_delivered_at",
+        "email_bounced_at",
+    ):
         record[key] = _make_aware(record.get(key))
     if "is_billable" in record:
         record["is_billable"] = bool(record.get("is_billable"))
     if not record.get("kind"):
-        record["kind"] = "internal_note" if bool(record.get("is_internal")) else "message"
+        record["kind"] = (
+            "internal_note" if bool(record.get("is_internal")) else "message"
+        )
     labour_name = record.get("labour_type_name")
     if labour_name is not None:
         record["labour_type_name"] = str(labour_name)
@@ -294,7 +317,9 @@ async def create_ticket(
 
     configured_next_ticket_number: int | None = None
     if id is None:
-        configured_next_ticket_number = await site_settings_repo.get_next_ticket_number()
+        configured_next_ticket_number = (
+            await site_settings_repo.get_next_ticket_number()
+        )
         if configured_next_ticket_number is not None:
             max_id_row = await db.fetch_one("SELECT MAX(id) as max_id FROM tickets")
             max_id_value = max_id_row.get("max_id") if max_id_row else None
@@ -341,8 +366,14 @@ async def create_ticket(
                     f"ALTER TABLE tickets AUTO_INCREMENT = {int(max_id) + 1}"
                 )
         except Exception as exc:  # pragma: no cover - defensive
-            log_debug("Failed to update AUTO_INCREMENT after explicit ID insert", error=str(exc))
-        if configured_next_ticket_number is not None and ticket_id >= configured_next_ticket_number:
+            log_debug(
+                "Failed to update AUTO_INCREMENT after explicit ID insert",
+                error=str(exc),
+            )
+        if (
+            configured_next_ticket_number is not None
+            and ticket_id >= configured_next_ticket_number
+        ):
             await site_settings_repo.set_next_ticket_number(ticket_id + 1)
     else:
         # Use normal auto-increment behavior
@@ -367,7 +398,10 @@ async def create_ticket(
                 ticket_number,
             ),
         )
-        if configured_next_ticket_number is not None and ticket_id >= configured_next_ticket_number:
+        if (
+            configured_next_ticket_number is not None
+            and ticket_id >= configured_next_ticket_number
+        ):
             await site_settings_repo.set_next_ticket_number(ticket_id + 1)
     if ticket_id:
         log_info("Ticket created successfully", ticket_id=ticket_id)
@@ -915,7 +949,30 @@ async def is_ticket_watcher(ticket_id: int, user_id: int) -> bool:
     return bool(row)
 
 
-async def get_ticket_by_external_reference(external_reference: str) -> TicketRecord | None:
+async def get_ticket_by_number_or_id(ticket_number: str) -> TicketRecord | None:
+    """Return a ticket by display ticket number, falling back to numeric ID."""
+
+    value = str(ticket_number or "").strip().lstrip("#")
+    if not value:
+        return None
+    row = await db.fetch_one(
+        "SELECT * FROM tickets WHERE ticket_number = %s LIMIT 1",
+        (value,),
+    )
+    if row:
+        return _normalise_ticket(row)
+    try:
+        ticket_id = int(value)
+    except (TypeError, ValueError):
+        return None
+    if ticket_id <= 0:
+        return None
+    return await get_ticket(ticket_id)
+
+
+async def get_ticket_by_external_reference(
+    external_reference: str,
+) -> TicketRecord | None:
     row = await db.fetch_one(
         "SELECT * FROM tickets WHERE external_reference = %s",
         (external_reference,),
@@ -923,7 +980,9 @@ async def get_ticket_by_external_reference(external_reference: str) -> TicketRec
     return _normalise_ticket(row) if row else None
 
 
-async def find_open_ticket_by_external_reference(external_reference: str) -> TicketRecord | None:
+async def find_open_ticket_by_external_reference(
+    external_reference: str,
+) -> TicketRecord | None:
     """Return the first non-closed ticket with the given external_reference, or None."""
     row = await db.fetch_one(
         "SELECT * FROM tickets WHERE external_reference = %s AND closed_at IS NULL LIMIT 1",
@@ -948,7 +1007,7 @@ async def list_tickets_by_requester_phone(
         return []
 
     # Normalize phone number by removing common formatting characters
-    normalized_phone = re.sub(r'[\s\-\(\)\+]', '', phone_number.strip())
+    normalized_phone = re.sub(r"[\s\-\(\)\+]", "", phone_number.strip())
 
     where_clauses = [
         "("
@@ -1041,7 +1100,8 @@ async def list_ticket_assets(ticket_id: int) -> list[dict[str, Any]]:
             "status": str(row.get("status") or "").strip() or None,
             "type": str(row.get("type") or "").strip() or None,
             "os_name": str(row.get("os_name") or "").strip() or None,
-            "tactical_asset_id": str(row.get("tactical_asset_id") or "").strip() or None,
+            "tactical_asset_id": str(row.get("tactical_asset_id") or "").strip()
+            or None,
             "tray_device_uid": str(row.get("tray_device_uid") or "").strip() or None,
             "linked_at": _make_aware(row.get("created_at")),
         }
@@ -1049,7 +1109,9 @@ async def list_ticket_assets(ticket_id: int) -> list[dict[str, Any]]:
     return assets
 
 
-async def replace_ticket_assets(ticket_id: int, asset_ids: Iterable[int]) -> list[dict[str, Any]]:
+async def replace_ticket_assets(
+    ticket_id: int, asset_ids: Iterable[int]
+) -> list[dict[str, Any]]:
     normalised_ids: list[int] = []
     seen: set[int] = set()
     for raw_id in asset_ids:
@@ -1095,7 +1157,9 @@ async def replace_ticket_assets(ticket_id: int, asset_ids: Iterable[int]) -> lis
     return await list_ticket_assets(ticket_id)
 
 
-async def list_billed_tickets_older_than(cutoff: datetime, *, limit: int = 10000) -> list[TicketRecord]:
+async def list_billed_tickets_older_than(
+    cutoff: datetime, *, limit: int = 10000
+) -> list[TicketRecord]:
     """Return billed, unmerged tickets created before the supplied UTC cutoff."""
     rows = await db.fetch_all(
         """
@@ -1167,7 +1231,10 @@ async def update_ticket(ticket_id: int, **fields: Any) -> TicketRecord | None:
     query = f"UPDATE tickets SET {', '.join(assignments)} WHERE id = %s"
     params.append(ticket_id)
     await db.execute(query, tuple(params))
-    if str(fields.get("status") or "").casefold() == "closed" or fields.get("closed_at") is not None:
+    if (
+        str(fields.get("status") or "").casefold() == "closed"
+        or fields.get("closed_at") is not None
+    ):
         await _disable_shipment_watch(ticket_id)
     log_info("Ticket updated successfully", ticket_id=ticket_id)
     return await get_ticket(ticket_id)
@@ -1319,7 +1386,9 @@ async def create_reply(
     author_email: str | None = None,
     author_display_name: str | None = None,
 ) -> TicketRecord:
-    labour_type_id = await _default_labour_type_for_time_entry(minutes_spent, labour_type_id)
+    labour_type_id = await _default_labour_type_for_time_entry(
+        minutes_spent, labour_type_id
+    )
 
     log_info(
         "Creating ticket reply",
@@ -1366,7 +1435,9 @@ async def create_reply(
         tuple(params),
     )
     if reply_id:
-        log_info("Ticket reply created successfully", reply_id=reply_id, ticket_id=ticket_id)
+        log_info(
+            "Ticket reply created successfully", reply_id=reply_id, ticket_id=ticket_id
+        )
         row = await db.fetch_one(
             """
             SELECT tr.*, lt.name AS labour_type_name, lt.code AS labour_type_code
@@ -1379,7 +1450,9 @@ async def create_reply(
         if row:
             normalised = _normalise_reply(row)
             reply_external = str(normalised.get("external_reference") or "")
-            if not normalised.get("is_internal") and not reply_external.startswith("chat:"):
+            if not normalised.get("is_internal") and not reply_external.startswith(
+                "chat:"
+            ):
                 try:
                     from app.services import chat_ticket_sync
 
@@ -1412,7 +1485,9 @@ async def create_reply(
     return _normalise_reply(fallback_row)
 
 
-async def list_replies(ticket_id: int, *, include_internal: bool = True) -> list[TicketRecord]:
+async def list_replies(
+    ticket_id: int, *, include_internal: bool = True
+) -> list[TicketRecord]:
     where = "ticket_id = %s"
     params: list[Any] = [ticket_id]
     if not include_internal:
@@ -1443,7 +1518,9 @@ async def count_time_entries(ticket_id: int) -> int:
     return int(row["count"]) if row else 0
 
 
-async def get_time_totals_by_ticket_ids(ticket_ids: list[int]) -> dict[int, dict[str, int]]:
+async def get_time_totals_by_ticket_ids(
+    ticket_ids: list[int],
+) -> dict[int, dict[str, int]]:
     """Return billable and non-billable minute totals keyed by ticket ID."""
     if not ticket_ids:
         return {}
@@ -1520,7 +1597,9 @@ async def get_automation_filter_context(ticket_id: int) -> dict[str, int | bool]
     }
 
 
-async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> dict[int, dict[str, Any]]:
+async def get_automation_filter_context_by_ticket_ids(
+    ticket_ids: list[int],
+) -> dict[int, dict[str, Any]]:
     """Return automation filter helper values keyed by ticket ID for ticket lists."""
 
     parsed_ids: set[int] = set()
@@ -1573,7 +1652,9 @@ async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> 
     for row in time_rows:
         ticket_id = int(row["ticket_id"])
         result[ticket_id]["billable_minutes"] = int(row.get("billable_minutes") or 0)
-        result[ticket_id]["non_billable_minutes"] = int(row.get("non_billable_minutes") or 0)
+        result[ticket_id]["non_billable_minutes"] = int(
+            row.get("non_billable_minutes") or 0
+        )
 
     attachment_rows = await db.fetch_all(
         f"""
@@ -1590,7 +1671,6 @@ async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> 
         result[ticket_id]["attachment_count"] = attachment_count
         result[ticket_id]["has_attachments"] = attachment_count > 0
 
-
     for ticket_id in unique_ids:
         expense_row = await db.fetch_one(
             """
@@ -1601,7 +1681,9 @@ async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> 
             (ticket_id,),
         )
         expense_count = int((expense_row or {}).get("expense_count") or 0)
-        result[ticket_id]["expense_total"] = float((expense_row or {}).get("expense_total") or 0)
+        result[ticket_id]["expense_total"] = float(
+            (expense_row or {}).get("expense_total") or 0
+        )
         result[ticket_id]["expense_count"] = expense_count
         result[ticket_id]["has_expenses"] = expense_count > 0
 
@@ -1651,16 +1733,22 @@ async def get_automation_filter_context_by_ticket_ids(ticket_ids: list[int]) -> 
     )
     for row in latest_reply_rows:
         ticket_id = int(row["ticket_id"])
-        result[ticket_id]["latest_reply_id"] = int(row.get("id")) if row.get("id") is not None else None
+        result[ticket_id]["latest_reply_id"] = (
+            int(row.get("id")) if row.get("id") is not None else None
+        )
         result[ticket_id]["latest_reply_at"] = _make_aware(row.get("created_at"))
         result[ticket_id]["latest_reply_is_internal"] = bool(row.get("is_internal"))
         result[ticket_id]["latest_reply_kind"] = row.get("kind")
-        result[ticket_id]["ticket_update_actor_type"] = row.get("ticket_update_actor_type")
+        result[ticket_id]["ticket_update_actor_type"] = row.get(
+            "ticket_update_actor_type"
+        )
 
     return result
 
 
-async def validate_replies_belong_to_ticket(reply_ids: list[int], ticket_id: int) -> tuple[bool, str | None]:
+async def validate_replies_belong_to_ticket(
+    reply_ids: list[int], ticket_id: int
+) -> tuple[bool, str | None]:
     """
     Validate that all reply IDs belong to the specified ticket.
     Returns (is_valid, error_message).
@@ -1733,15 +1821,25 @@ async def update_reply(
             current = await get_reply_by_id(reply_id)
             if effective_minutes is _UNSET:
                 current_minutes = current.get("minutes_spent") if current else None
-                effective_minutes = current_minutes if isinstance(current_minutes, int) else None
+                effective_minutes = (
+                    current_minutes if isinstance(current_minutes, int) else None
+                )
             if effective_labour_type_id is _UNSET:
-                current_labour_type_id = current.get("labour_type_id") if current else None
+                current_labour_type_id = (
+                    current.get("labour_type_id") if current else None
+                )
                 effective_labour_type_id = (
-                    current_labour_type_id if isinstance(current_labour_type_id, int) else None
+                    current_labour_type_id
+                    if isinstance(current_labour_type_id, int)
+                    else None
                 )
         default_labour_type_id = await _default_labour_type_for_time_entry(
             effective_minutes if isinstance(effective_minutes, int) else None,
-            effective_labour_type_id if isinstance(effective_labour_type_id, int) else None,
+            (
+                effective_labour_type_id
+                if isinstance(effective_labour_type_id, int)
+                else None
+            ),
         )
         if effective_labour_type_id is None:
             if default_labour_type_id is not None:
@@ -1761,7 +1859,9 @@ async def update_reply(
     return await get_reply_by_id(reply_id)
 
 
-async def add_watcher(ticket_id: int, user_id: int | None = None, email: str | None = None) -> None:
+async def add_watcher(
+    ticket_id: int, user_id: int | None = None, email: str | None = None
+) -> None:
     """Add a watcher to a ticket by user_id or email.
 
     At least one of user_id or email must be provided.
@@ -1795,7 +1895,9 @@ async def add_watcher(ticket_id: int, user_id: int | None = None, email: str | N
         )
 
 
-async def remove_watcher(ticket_id: int, user_id: int | None = None, email: str | None = None) -> None:
+async def remove_watcher(
+    ticket_id: int, user_id: int | None = None, email: str | None = None
+) -> None:
     """Remove a watcher from a ticket by user_id or email.
 
     At least one of user_id or email must be provided.
@@ -1849,7 +1951,9 @@ async def bulk_add_watchers(ticket_id: int, user_ids: Iterable[int]) -> None:
     )
 
 
-async def replace_watchers(ticket_id: int, user_ids: Iterable[int], emails: Iterable[str] | None = None) -> None:
+async def replace_watchers(
+    ticket_id: int, user_ids: Iterable[int], emails: Iterable[str] | None = None
+) -> None:
     """Replace all watchers for a ticket with new user_ids and emails."""
     await db.execute("DELETE FROM ticket_watchers WHERE ticket_id = %s", (ticket_id,))
     await bulk_add_watchers(ticket_id, user_ids)
@@ -1861,7 +1965,9 @@ async def replace_watchers(ticket_id: int, user_ids: Iterable[int], emails: Iter
                 await add_watcher(ticket_id, email=email_normalized)
 
 
-async def move_replies_to_ticket(reply_ids: Iterable[int], target_ticket_id: int) -> int:
+async def move_replies_to_ticket(
+    reply_ids: Iterable[int], target_ticket_id: int
+) -> int:
     """Move specified replies to a different ticket. Returns count of moved replies."""
     reply_list = list(reply_ids)
     if not reply_list:
@@ -1945,7 +2051,9 @@ async def split_ticket(
     return original_ticket, new_ticket, moved_count
 
 
-async def list_split_replies_for_original(original_ticket_id: int) -> list[TicketRecord]:
+async def list_split_replies_for_original(
+    original_ticket_id: int,
+) -> list[TicketRecord]:
     """Return replies moved to child tickets split from the original ticket."""
     rows = await db.fetch_all(
         """
@@ -2008,7 +2116,9 @@ async def merge_tickets(
                 user_id=watcher.get("user_id"),
                 email=watcher.get("email"),
             )
-        await db.execute("DELETE FROM ticket_watchers WHERE ticket_id = %s", (source_id,))
+        await db.execute(
+            "DELETE FROM ticket_watchers WHERE ticket_id = %s", (source_id,)
+        )
 
     # Move all replies from source tickets to target ticket
     for source_id in source_ticket_ids:
@@ -2050,6 +2160,7 @@ async def list_merged_child_tickets(parent_ticket_id: int) -> list[TicketRecord]
         (parent_ticket_id,),
     )
     return [_normalise_ticket(row) for row in rows]
+
 
 async def get_merged_target_ticket_id(ticket_id: int) -> int | None:
     """

--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -940,6 +940,91 @@ async def _scan_tickets_for_automation(
     }
 
 
+async def _build_ticket_test_context(
+    automation: Mapping[str, Any],
+    ticket: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    checked_at = now or datetime.now(timezone.utc)
+    ticket_context = _attach_ticket_age_context(ticket, now=checked_at)
+    try:
+        from app.services import tickets as tickets_service
+
+        enriched_ticket = await tickets_service._enrich_ticket_context(ticket_context)
+    except Exception:  # pragma: no cover - defensive fallback for test action
+        enriched_ticket = ticket_context
+    return {
+        "ticket": _attach_ticket_age_context(enriched_ticket, now=checked_at),
+        "ticket_update": {
+            "actor_type": "automation_test",
+            "actor_label": "Automation test",
+            "actor_user": None,
+            "simulated_event": automation.get("trigger_event"),
+        },
+        "schedule": {
+            "automation_id": automation.get("id"),
+            "automation_name": automation.get("name"),
+            "checked_at": checked_at.isoformat(),
+            "test": True,
+        },
+    }
+
+
+async def test_ticket_automation_by_id(
+    automation_id: int,
+    *,
+    ticket_number: str,
+    apply: bool = False,
+) -> dict[str, Any]:
+    """Evaluate one ticket against an automation and optionally run matching actions."""
+
+    automation = await automation_repo.get_automation(automation_id)
+    if not automation:
+        raise ValueError(f"Automation {automation_id} not found")
+    kind = str(automation.get("kind") or "").strip().lower()
+    if kind not in {"scheduled", "event"}:
+        raise ValueError("Only scheduled and event automations can be tested")
+    ticket = await tickets_repo.get_ticket_by_number_or_id(ticket_number)
+    if not ticket:
+        raise ValueError(f"Ticket {ticket_number} not found")
+    context = await _build_ticket_test_context(automation, ticket)
+    filters = automation.get("trigger_filters")
+    filters_mapping = filters if isinstance(filters, Mapping) else None
+    applies = _filters_match(filters_mapping, context)
+    result: dict[str, Any] = {
+        "automation_id": automation_id,
+        "automation_name": automation.get("name"),
+        "kind": kind,
+        "ticket": {
+            "id": ticket.get("id"),
+            "ticket_number": ticket.get("ticket_number"),
+            "subject": ticket.get("subject"),
+            "status": ticket.get("status"),
+        },
+        "applies": applies,
+        "applied": False,
+    }
+    if not applies:
+        result["reason"] = "Automation filters did not match the ticket."
+        return result
+    if apply:
+        action_result, action_error = await _invoke_automation_actions_for_context(
+            automation,
+            context=context,
+        )
+        result.update(
+            {
+                "applied": True,
+                "status": "failed" if action_error else "succeeded",
+                "result": action_result,
+            }
+        )
+        if action_error:
+            result["error"] = action_error
+    return result
+
+
 async def preview_scheduled_ticket_automation(
     automation: Mapping[str, Any],
     *,

--- a/app/static/js/automation.js
+++ b/app/static/js/automation.js
@@ -2878,4 +2878,45 @@
       });
     });
   });
+
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('[data-automation-test]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const automationId = button.getAttribute('data-automation-id');
+        const automationName = button.getAttribute('data-automation-name') || `#${automationId}`;
+        const ticketNumber = window.prompt(`Enter a ticket number to test "${automationName}" against:`);
+        if (!ticketNumber || !ticketNumber.trim()) return;
+
+        async function runTest(apply) {
+          const response = await fetch(`/admin/automations/${encodeURIComponent(automationId)}/test`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify({ ticket_number: ticketNumber.trim(), apply }),
+          });
+          const payload = await response.json().catch(() => ({}));
+          if (!response.ok) {
+            throw new Error(payload.detail || `Request failed with ${response.status}`);
+          }
+          return payload;
+        }
+
+        try {
+          const evaluation = await runTest(false);
+          const ticketLabel = evaluation.ticket?.ticket_number || evaluation.ticket?.id || ticketNumber.trim();
+          if (!evaluation.applies) {
+            window.alert(`Automation does not apply to ticket #${ticketLabel}.\n\n${evaluation.reason || 'The filters did not match.'}`);
+            return;
+          }
+          const shouldApply = window.confirm(`Automation applies to ticket #${ticketLabel}. Run/apply this automation immediately?`);
+          if (!shouldApply) return;
+          const applied = await runTest(true);
+          window.alert(`Automation test ${applied.status || 'completed'} for ticket #${ticketLabel}.`);
+        } catch (error) {
+          window.alert(`Unable to test automation: ${error.message}`);
+        }
+      });
+    });
+  });
+
 }());

--- a/app/templates/admin/automations.html
+++ b/app/templates/admin/automations.html
@@ -139,6 +139,11 @@
                             <a class="header-title-menu__link" role="menuitem" href="/admin/automations/{{ automation.id }}/simulate">Simulate</a>
                           </li>
                           {% endif %}
+                          {% if automation.kind in ['scheduled', 'event'] %}
+                          <li class="header-title-menu__item" role="none">
+                            <button type="button" class="header-title-menu__link" role="menuitem" data-automation-test data-automation-id="{{ automation.id }}" data-automation-name="{{ automation.name }}">Test</button>
+                          </li>
+                          {% endif %}
                           <li class="header-title-menu__item" role="none">
                             <form action="/admin/automations/{{ automation.id }}/execute" method="post" class="inline-form">
                               {% include "partials/csrf.html" %}


### PR DESCRIPTION
### Motivation
- Provide admins a safe way to verify whether a scheduled or event automation would apply to a specific ticket before running it. 
- Allow admins to optionally run the automation immediately against that ticket when the filters match.

### Description
- Added a `Test` action in the automation row actions menu and client-side flow that prompts for a ticket number, evaluates the automation filters, and asks to apply the automation (`app/templates/admin/automations.html`, `app/static/js/automation.js`).
- Implemented a JSON admin endpoint at `POST /admin/automations/{automation_id}/test` and handler `admin_test_automation` to validate input and dispatch evaluation/apply requests (`app/features/automations/routes.py`, `app/features/automations/handlers.py`).
- Added service helpers `_build_ticket_test_context` and `test_ticket_automation_by_id` to construct a ticket-scoped context, evaluate filters via existing `_filters_match`, and invoke automation actions when requested (`app/services/automations.py`).
- Added ticket lookup helper `get_ticket_by_number_or_id` to accept display ticket numbers or raw numeric IDs and wired it into the test flow (`app/repositories/tickets.py`).

### Testing
- Ran `python -m py_compile app/repositories/tickets.py app/services/automations.py app/features/automations/handlers.py app/features/automations/routes.py` which completed successfully. 
- Ran `git diff --check` which produced no trailing/merge errors. 
- Executed `pytest tests/test_webhooks_feature_pack.py -q` which passed. 
- Executed `pytest tests/test_trigger_action_modules.py tests/test_tickets_feature_pack.py -q` which produced failures caused by missing async test plugin (`pytest-asyncio`) for marked async tests and existing feature-pack route expectation mismatches unrelated to this change, so those failures are external to the new test action implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5854160d6083328f4957c8b8be0df7)