### PR TITLE
Load WhisperX settings from environment

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -87,6 +87,21 @@ DEFAULT_CHATGPT_TOOLS = [
 ]
 
 
+def _default_whisperx_settings() -> dict[str, Any]:
+    """Return WhisperX module defaults sourced from the environment.
+
+    These values are evaluated after the project ``.env`` file is loaded at
+    module import time, allowing operators to configure both ticket attachment
+    and call recording transcription from the same environment keys.
+    """
+
+    return {
+        "base_url": str(os.getenv("WHISPERX_BASE_URL", "")).strip().rstrip("/"),
+        "api_key": str(os.getenv("WHISPERX_API_KEY", "")).strip(),
+        "language": str(os.getenv("WHISPERX_LANGUAGE", "")).strip() or "en",
+        "stereo_split": _ensure_bool(os.getenv("WHISPERX_STEREO_SPLIT"), False),
+    }
+
 def _get_tacticalrmm_calls_per_second() -> float:
     """Return the configured TacticalRMM request rate limit.
 
@@ -968,6 +983,13 @@ DEFAULT_MODULES: list[dict[str, Any]] = [
         },
     },
     {
+        "slug": "whisperx",
+        "name": "WhisperX",
+        "description": "Transcribe ticket audio attachments and call recordings with a WhisperX-compatible ASR service.",
+        "icon": "🎙️",
+        "settings": _default_whisperx_settings(),
+    },
+    {
         "slug": "unifi-talk",
         "name": "Unifi Talk",
         "description": "Import call recordings from Unifi Talk server via SFTP. Downloads MP3 recordings to local storage for transcription processing.",
@@ -1225,6 +1247,7 @@ _ENV_BACKED_MODULE_FIELDS: dict[str, tuple[str, ...]] = {
         "port",
     ),
     "uptimekuma": ("shared_secret_hash", "sync_service_status"),
+    "whisperx": ("base_url", "api_key", "language", "stereo_split"),
     "xero": (
         "client_id",
         "client_secret",
@@ -1878,6 +1901,21 @@ def _coerce_settings(
         _env = os.getenv("CALL_RECORDINGS_PHONE_SYSTEM", "").strip().lower()
         if _env and _env in CALL_RECORDINGS_PHONE_SYSTEM_TYPES:
             merged["phone_system_type"] = _env
+    elif slug == "whisperx":
+        env_settings = _default_whisperx_settings()
+        merged.update(
+            {
+                "base_url": str(merged.get("base_url") or "").strip().rstrip("/"),
+                "api_key": str(merged.get("api_key") or "").strip(),
+                "language": str(merged.get("language") or "").strip() or "en",
+                "stereo_split": _ensure_bool(merged.get("stereo_split"), False),
+            }
+        )
+        for key in ("base_url", "api_key", "language"):
+            if env_settings[key]:
+                merged[key] = env_settings[key]
+        if os.getenv("WHISPERX_STEREO_SPLIT") is not None:
+            merged["stereo_split"] = env_settings["stereo_split"]
     elif slug == "unifi-talk":
         overrides = payload or {}
         password_override = overrides.get("password")

--- a/tests/test_modules_whisperx.py
+++ b/tests/test_modules_whisperx.py
@@ -104,6 +104,31 @@ def _webhook_helpers(monkeypatch):
 # Tests
 # ---------------------------------------------------------------------------
 
+
+def test_whisperx_module_settings_load_from_env(monkeypatch):
+    """WhisperX runtime settings should use .env/environment values."""
+    monkeypatch.setenv("WHISPERX_BASE_URL", "http://env-whisperx.local/")
+    monkeypatch.setenv("WHISPERX_API_KEY", "env-key")
+    monkeypatch.setenv("WHISPERX_LANGUAGE", "cy")
+    monkeypatch.setenv("WHISPERX_STEREO_SPLIT", "true")
+
+    settings = modules._coerce_settings(
+        "whisperx",
+        {
+            "base_url": "http://stored-whisperx.local",
+            "api_key": "stored-key",
+            "language": "en",
+            "stereo_split": False,
+        },
+    )
+
+    assert settings == {
+        "base_url": "http://env-whisperx.local",
+        "api_key": "env-key",
+        "language": "cy",
+        "stereo_split": True,
+    }
+
 def test_invoke_whisperx_transcribes_and_adds_note(monkeypatch, tmp_path):
     """Happy path: one WAV attachment → transcription → internal note."""
     fake_event_state = _webhook_helpers(monkeypatch)


### PR DESCRIPTION
### Motivation

- Ensure WhisperX transcription settings are sourced from the project `.env` / process environment so runtime transcription uses the configured endpoint and credentials instead of stale DB values.
- Make the module's runtime configuration consistent with call-recordings behavior which already uses environment-backed WhisperX settings.

### Description

- Add a new helper `_default_whisperx_settings()` that reads `WHISPERX_BASE_URL`, `WHISPERX_API_KEY`, `WHISPERX_LANGUAGE`, and `WHISPERX_STEREO_SPLIT` from the environment and normalises values. (`app/services/modules.py`)
- Register a `whisperx` entry in `DEFAULT_MODULES` using `_default_whisperx_settings()` so the module has environment-backed defaults. (`app/services/modules.py`)
- Mark WhisperX fields as env-backed in `_ENV_BACKED_MODULE_FIELDS` and update `_coerce_settings()` to prefer `.env` values for `base_url`, `api_key`, `language`, and `stereo_split` when present, with special handling so `stereo_split` is only overridden when the env var is set. (`app/services/modules.py`)
- Add a regression test `test_whisperx_module_settings_load_from_env` to assert that environment values override stored settings. (`tests/test_modules_whisperx.py`)

### Testing

- Ran `python -m compileall app/services/modules.py` and the module compiled successfully. (success)
- Ran `pytest tests/test_modules_whisperx.py -q` and the test suite completed successfully (12 passed, with expected warnings). (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5857927ffc8332baf5f0385aed47ed)