### PR TITLE
Fix WhisperX ticket attachment selection and path resolution

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -102,6 +102,7 @@ def _default_whisperx_settings() -> dict[str, Any]:
         "stereo_split": _ensure_bool(os.getenv("WHISPERX_STEREO_SPLIT"), False),
     }
 
+
 def _get_tacticalrmm_calls_per_second() -> float:
     """Return the configured TacticalRMM request rate limit.
 
@@ -532,7 +533,9 @@ def _extract_ticket_id_from_email_payload(payload: Mapping[str, Any]) -> int | N
     return None
 
 
-async def _load_ticket_email_attachments(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+async def _load_ticket_email_attachments(
+    payload: Mapping[str, Any],
+) -> list[dict[str, Any]]:
     """Load ticket attachments for automation email modules when possible.
 
     Explicit payload attachments are respected by callers; this helper only supplies
@@ -550,7 +553,9 @@ async def _load_ticket_email_attachments(payload: Mapping[str, Any]) -> list[dic
     if isinstance(context, Mapping):
         reply = context.get("reply")
         if isinstance(reply, Mapping) and isinstance(reply.get("attachments"), list):
-            attachments = [item for item in reply["attachments"] if isinstance(item, Mapping)]
+            attachments = [
+                item for item in reply["attachments"] if isinstance(item, Mapping)
+            ]
 
     if not attachments:
         if ticket_id is None:
@@ -613,6 +618,7 @@ def _attachments_for_smtp2go(attachments: list[dict[str, Any]]) -> list[dict[str
             }
         )
     return formatted
+
 
 def _coerce_int(
     value: Any, *, minimum: int | None = None, maximum: int | None = None
@@ -3043,7 +3049,9 @@ async def _invoke_smtp(
     # Payload sender takes precedence over settings from_address
     sender = str(payload.get("sender") or settings.get("from_address") or "") or None
     attachments = (
-        payload.get("attachments") if isinstance(payload.get("attachments"), list) else None
+        payload.get("attachments")
+        if isinstance(payload.get("attachments"), list)
+        else None
     )
     if attachments is None:
         attachments = await _load_ticket_email_attachments(payload)
@@ -3266,7 +3274,9 @@ async def _invoke_smtp2go(
         else None
     )
     if attachments is None:
-        attachments = _attachments_for_smtp2go(await _load_ticket_email_attachments(payload))
+        attachments = _attachments_for_smtp2go(
+            await _load_ticket_email_attachments(payload)
+        )
     template_id = str(payload.get("template_id") or "").strip() or None
     template_data = (
         payload.get("template_data")
@@ -6138,6 +6148,46 @@ def _is_audio_attachment(attachment: Mapping[str, Any]) -> bool:
     return f".{ext}" in _WHISPERX_AUDIO_EXTENSIONS
 
 
+def _is_wav_attachment(attachment: Mapping[str, Any]) -> bool:
+    """Return True when an attachment is a WAV file."""
+    mime = (attachment.get("mime_type") or "").lower().strip()
+    if mime in {"audio/wav", "audio/x-wav", "audio/wave"}:
+        return True
+    original = attachment.get("original_filename") or attachment.get("filename") or ""
+    return Path(str(original)).suffix.lower() == ".wav"
+
+
+def _attachment_sort_key(attachment: Mapping[str, Any]) -> tuple[str, int]:
+    """Sort attachments chronologically, using id as a stable tie breaker."""
+    uploaded_at = attachment.get("uploaded_at")
+    uploaded_key = (
+        uploaded_at.isoformat()
+        if hasattr(uploaded_at, "isoformat")
+        else str(uploaded_at or "")
+    )
+    try:
+        attachment_id = int(attachment.get("id") or 0)
+    except (TypeError, ValueError):
+        attachment_id = 0
+    return uploaded_key, attachment_id
+
+
+def _resolve_ticket_attachment_path(
+    attachments_service: Any, attachment: Mapping[str, Any]
+) -> Path | None:
+    """Return the existing storage path for an attachment, including legacy storage."""
+    filename = attachment.get("filename")
+    if not filename:
+        return None
+    file_path = attachments_service.get_attachment_file_path(filename)
+    if file_path.exists():
+        return file_path
+    legacy_file_path = attachments_service.get_legacy_attachment_file_path(filename)
+    if legacy_file_path.exists():
+        return legacy_file_path
+    return None
+
+
 def _split_stereo_wav(file_path: Path) -> tuple[Path, Path] | None:
     """Split a stereo WAV file into two temporary mono channel files.
 
@@ -6293,6 +6343,7 @@ async def _invoke_whisperx(
     """
     from app.repositories import tickets as tickets_repo
     from app.repositories import ticket_attachments as attachments_repo
+    from app.services import ticket_attachments as attachments_service
 
     raw_context = payload.get("context")
     context = raw_context if isinstance(raw_context, Mapping) else {}
@@ -6351,20 +6402,27 @@ async def _invoke_whisperx(
         if not existing:
             raise ValueError(f"Ticket {ticket_id_int} not found")
 
-        upload_dir = Path(__file__).parent.parent / "static" / "uploads" / "tickets"
-
         # -- list attachments and filter audio files (with short polling) --
         audio_attachments: list[Mapping[str, Any]] = []
-        ready_attachments: list[Mapping[str, Any]] = []
+        ready_attachment_paths: list[tuple[Mapping[str, Any], Path]] = []
         for poll_attempt in range(_WHISPERX_ATTACHMENT_POLL_ATTEMPTS):
             all_attachments = await attachments_repo.list_attachments(ticket_id_int)
             audio_attachments = [a for a in all_attachments if _is_audio_attachment(a)]
 
-            ready_attachments = [
-                a for a in audio_attachments if (upload_dir / a["filename"]).exists()
+            wav_attachments = [a for a in audio_attachments if _is_wav_attachment(a)]
+            if wav_attachments:
+                # Voicemail tickets can collect multiple WAV attachments; process only
+                # the newest WAV to avoid transcribing stale voicemail copies.
+                audio_attachments = [max(wav_attachments, key=_attachment_sort_key)]
+
+            ready_attachment_paths = [
+                (a, path)
+                for a in audio_attachments
+                if (path := _resolve_ticket_attachment_path(attachments_service, a))
+                is not None
             ]
 
-            if ready_attachments:
+            if ready_attachment_paths:
                 break
 
             if poll_attempt < _WHISPERX_ATTACHMENT_POLL_ATTEMPTS - 1:
@@ -6380,7 +6438,7 @@ async def _invoke_whisperx(
         if not audio_attachments:
             raise ValueError(f"No audio attachments found on ticket {ticket_id_int}")
 
-        if not ready_attachments:
+        if not ready_attachment_paths:
             raise ValueError(
                 f"Audio attachments not yet available on disk for ticket {ticket_id_int}"
             )
@@ -6394,8 +6452,7 @@ async def _invoke_whisperx(
         stereo_split = settings.get("stereo_split", False)
 
         async with httpx.AsyncClient(timeout=300.0) as client:
-            for attachment in ready_attachments:
-                file_path = upload_dir / attachment["filename"]
+            for attachment, file_path in ready_attachment_paths:
                 original_name = (
                     attachment.get("original_filename") or attachment["filename"]
                 )
@@ -6876,7 +6933,9 @@ async def _resolve_trello_company_for_action(
     return None
 
 
-async def _resolve_company_from_ticket_id(ticket_id_value: Any) -> dict[str, Any] | None:
+async def _resolve_company_from_ticket_id(
+    ticket_id_value: Any,
+) -> dict[str, Any] | None:
     try:
         ticket_id = int(ticket_id_value)
     except (TypeError, ValueError):

--- a/tests/test_modules_whisperx.py
+++ b/tests/test_modules_whisperx.py
@@ -1,4 +1,5 @@
 """Tests for the WhisperX automation module handler."""
+
 import array
 import asyncio
 import json
@@ -18,6 +19,7 @@ async def _noop(*args, **kwargs):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 class _FakeResponse:
     """Minimal httpx.Response stand-in."""
@@ -41,7 +43,9 @@ class _FakeResponse:
     def raise_for_status(self):
         if self.status_code >= 400:
             raise httpx.HTTPStatusError(
-                "error", request=self.request, response=self,
+                "error",
+                request=self.request,
+                response=self,
             )
 
 
@@ -59,7 +63,15 @@ class _AsyncClientFactory:
         return False
 
     async def post(self, url, *, files=None, data=None, params=None, headers=None):
-        self.calls.append({"url": url, "files": files, "data": data, "params": params, "headers": headers})
+        self.calls.append(
+            {
+                "url": url,
+                "files": files,
+                "data": data,
+                "params": params,
+                "headers": headers,
+            }
+        )
         return self._response
 
 
@@ -73,7 +85,9 @@ def _webhook_helpers(monkeypatch):
     async def fake_record_attempt(**kwargs):
         fake_event_state["attempt_count"] = kwargs.get("attempt_number", 1)
 
-    async def fake_mark_completed(event_id, *, attempt_number, response_status, response_body):
+    async def fake_mark_completed(
+        event_id, *, attempt_number, response_status, response_body
+    ):
         fake_event_state.update(
             status="succeeded",
             attempt_count=attempt_number,
@@ -81,7 +95,9 @@ def _webhook_helpers(monkeypatch):
             response_body=response_body,
         )
 
-    async def fake_mark_failed(event_id, *, attempt_number, error_message, response_status, response_body):
+    async def fake_mark_failed(
+        event_id, *, attempt_number, error_message, response_status, response_body
+    ):
         fake_event_state.update(
             status="failed",
             attempt_count=attempt_number,
@@ -91,9 +107,13 @@ def _webhook_helpers(monkeypatch):
     async def fake_get_event(event_id):
         return dict(fake_event_state)
 
-    monkeypatch.setattr(modules.webhook_monitor, "create_manual_event", fake_create_event)
+    monkeypatch.setattr(
+        modules.webhook_monitor, "create_manual_event", fake_create_event
+    )
     monkeypatch.setattr(modules.webhook_repo, "record_attempt", fake_record_attempt)
-    monkeypatch.setattr(modules.webhook_repo, "mark_event_completed", fake_mark_completed)
+    monkeypatch.setattr(
+        modules.webhook_repo, "mark_event_completed", fake_mark_completed
+    )
     monkeypatch.setattr(modules.webhook_repo, "mark_event_failed", fake_mark_failed)
     monkeypatch.setattr(modules.webhook_repo, "get_event", fake_get_event)
 
@@ -128,6 +148,7 @@ def test_whisperx_module_settings_load_from_env(monkeypatch):
         "language": "cy",
         "stereo_split": True,
     }
+
 
 def test_invoke_whisperx_transcribes_and_adds_note(monkeypatch, tmp_path):
     """Happy path: one WAV attachment → transcription → internal note."""
@@ -170,7 +191,9 @@ def test_invoke_whisperx_transcribes_and_adds_note(monkeypatch, tmp_path):
     monkeypatch.setattr(tickets_repo_mod, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(attach_repo_mod, "list_attachments", fake_list_attachments)
     monkeypatch.setattr(tickets_repo_mod, "create_reply", fake_create_reply)
-    monkeypatch.setattr(modules.tickets_service, "emit_ticket_updated_event", fake_emit_event)
+    monkeypatch.setattr(
+        modules.tickets_service, "emit_ticket_updated_event", fake_emit_event
+    )
 
     # Fake HTTP client
     whisperx_response = _FakeResponse({"text": "Hello this is a voicemail message."})
@@ -187,7 +210,11 @@ def test_invoke_whisperx_transcribes_and_adds_note(monkeypatch, tmp_path):
         created_target = True
 
     try:
-        settings = {"base_url": "http://whisperx.local", "api_key": "test-key", "language": "en"}
+        settings = {
+            "base_url": "http://whisperx.local",
+            "api_key": "test-key",
+            "language": "en",
+        }
         payload = {"ticket_id": 10}
 
         result = asyncio.run(modules._invoke_whisperx(settings, payload))
@@ -237,6 +264,7 @@ def test_invoke_whisperx_no_audio_attachments(monkeypatch):
 
     import app.repositories.tickets as tickets_repo_mod
     import app.repositories.ticket_attachments as attach_repo_mod
+
     monkeypatch.setattr(tickets_repo_mod, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(attach_repo_mod, "list_attachments", fake_list_attachments)
 
@@ -303,10 +331,13 @@ def test_invoke_whisperx_add_note_false(monkeypatch, tmp_path):
 
     import app.repositories.tickets as tickets_repo_mod
     import app.repositories.ticket_attachments as attach_repo_mod
+
     monkeypatch.setattr(tickets_repo_mod, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(attach_repo_mod, "list_attachments", fake_list_attachments)
     monkeypatch.setattr(tickets_repo_mod, "create_reply", fake_create_reply)
-    monkeypatch.setattr(modules.tickets_service, "emit_ticket_updated_event", fake_emit_event)
+    monkeypatch.setattr(
+        modules.tickets_service, "emit_ticket_updated_event", fake_emit_event
+    )
 
     whisperx_response = _FakeResponse({"text": "Transcribed text"})
     client_factory = _AsyncClientFactory(whisperx_response)
@@ -327,7 +358,9 @@ def test_invoke_whisperx_add_note_false(monkeypatch, tmp_path):
 
         result = asyncio.run(modules._invoke_whisperx(settings, payload))
 
-        assert result["status"] == "succeeded", f"result={result}, last_error={fake_event_state.get('last_error')}"
+        assert (
+            result["status"] == "succeeded"
+        ), f"result={result}, last_error={fake_event_state.get('last_error')}"
         assert result["transcription_count"] == 1
         assert result["reply_id"] is None
         assert reply_created["called"] is False
@@ -348,6 +381,7 @@ def test_invoke_whisperx_ticket_id_from_context(monkeypatch):
 
     import app.repositories.tickets as tickets_repo_mod
     import app.repositories.ticket_attachments as attach_repo_mod
+
     monkeypatch.setattr(tickets_repo_mod, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(attach_repo_mod, "list_attachments", fake_list_attachments)
 
@@ -363,19 +397,37 @@ def test_invoke_whisperx_ticket_id_from_context(monkeypatch):
 
 def test_is_audio_attachment_by_mime():
     """_is_audio_attachment matches common audio MIME types."""
-    assert modules._is_audio_attachment({"mime_type": "audio/wav", "original_filename": "f.wav"})
-    assert modules._is_audio_attachment({"mime_type": "audio/mpeg", "original_filename": "f.mp3"})
-    assert modules._is_audio_attachment({"mime_type": "audio/ogg", "original_filename": "f.ogg"})
-    assert not modules._is_audio_attachment({"mime_type": "application/pdf", "original_filename": "f.pdf"})
-    assert not modules._is_audio_attachment({"mime_type": "image/png", "original_filename": "f.png"})
+    assert modules._is_audio_attachment(
+        {"mime_type": "audio/wav", "original_filename": "f.wav"}
+    )
+    assert modules._is_audio_attachment(
+        {"mime_type": "audio/mpeg", "original_filename": "f.mp3"}
+    )
+    assert modules._is_audio_attachment(
+        {"mime_type": "audio/ogg", "original_filename": "f.ogg"}
+    )
+    assert not modules._is_audio_attachment(
+        {"mime_type": "application/pdf", "original_filename": "f.pdf"}
+    )
+    assert not modules._is_audio_attachment(
+        {"mime_type": "image/png", "original_filename": "f.png"}
+    )
 
 
 def test_is_audio_attachment_by_extension():
     """_is_audio_attachment falls back to file extension."""
-    assert modules._is_audio_attachment({"mime_type": "", "original_filename": "voicemail.wav"})
-    assert modules._is_audio_attachment({"mime_type": None, "original_filename": "recording.mp3"})
-    assert modules._is_audio_attachment({"mime_type": "application/octet-stream", "original_filename": "call.flac"})
-    assert not modules._is_audio_attachment({"mime_type": "", "original_filename": "document.txt"})
+    assert modules._is_audio_attachment(
+        {"mime_type": "", "original_filename": "voicemail.wav"}
+    )
+    assert modules._is_audio_attachment(
+        {"mime_type": None, "original_filename": "recording.mp3"}
+    )
+    assert modules._is_audio_attachment(
+        {"mime_type": "application/octet-stream", "original_filename": "call.flac"}
+    )
+    assert not modules._is_audio_attachment(
+        {"mime_type": "", "original_filename": "document.txt"}
+    )
 
 
 def test_invoke_whisperx_waits_for_attachment_file(monkeypatch, tmp_path):
@@ -401,10 +453,14 @@ def test_invoke_whisperx_waits_for_attachment_file(monkeypatch, tmp_path):
         # First poll: no attachments yet, second poll: attachment appears
         return [] if call_count["calls"] == 1 else [attachment]
 
+    from app.services import ticket_attachments as attachments_service
+
     # Prepare upload directory but do not create the file yet
-    upload_dir = Path(modules.__file__).parent.parent / "static" / "uploads" / "tickets"
+    upload_dir = attachments_service.get_attachment_file_path(
+        attachment["filename"]
+    ).parent
     upload_dir.mkdir(parents=True, exist_ok=True)
-    delayed_file = upload_dir / attachment["filename"]
+    delayed_file = attachments_service.get_attachment_file_path(attachment["filename"])
     if delayed_file.exists():
         delayed_file.unlink()
 
@@ -424,8 +480,10 @@ def test_invoke_whisperx_waits_for_attachment_file(monkeypatch, tmp_path):
     monkeypatch.setattr(tickets_repo_mod, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(attach_repo_mod, "list_attachments", fake_list_attachments)
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
     async def fake_create_reply(**kw):
         return {"id": 123}
+
     monkeypatch.setattr(tickets_repo_mod, "create_reply", fake_create_reply)
     monkeypatch.setattr(modules.tickets_service, "emit_ticket_updated_event", _noop)
 
@@ -435,7 +493,9 @@ def test_invoke_whisperx_waits_for_attachment_file(monkeypatch, tmp_path):
     try:
         result = asyncio.run(modules._invoke_whisperx(settings, payload))
 
-        assert result["status"] == "succeeded", f"result={result}, last_error={fake_event_state.get('last_error')}"
+        assert (
+            result["status"] == "succeeded"
+        ), f"result={result}, last_error={fake_event_state.get('last_error')}"
         assert result["transcription_count"] == 1
         assert call_count["calls"] >= 2  # ensured we polled at least twice
     finally:
@@ -443,9 +503,80 @@ def test_invoke_whisperx_waits_for_attachment_file(monkeypatch, tmp_path):
             delayed_file.unlink()
 
 
+def test_invoke_whisperx_uses_newest_wav_attachment(monkeypatch):
+    """When multiple WAV files are attached, only the newest WAV is transcribed."""
+    _webhook_helpers(monkeypatch)
+
+    async def fake_get_ticket(tid):
+        return {"id": tid}
+
+    attachments = [
+        {
+            "id": 11,
+            "ticket_id": 25147,
+            "filename": "older.wav",
+            "original_filename": "Older voicemail.wav",
+            "mime_type": "audio/wav",
+            "file_size": 10,
+            "uploaded_at": "2026-07-16T10:00:00",
+        },
+        {
+            "id": 9994,
+            "ticket_id": 25147,
+            "filename": "newer.wav",
+            "original_filename": "Voicemail sound attachment.wav",
+            "mime_type": "audio/wav",
+            "file_size": 10,
+            "uploaded_at": "2026-07-16T11:00:00",
+        },
+    ]
+
+    async def fake_list_attachments(tid, *, access_levels=None):
+        return attachments
+
+    from app.services import ticket_attachments as attachments_service
+    import app.repositories.tickets as tickets_repo_mod
+    import app.repositories.ticket_attachments as attach_repo_mod
+
+    older_file = attachments_service.get_attachment_file_path("older.wav")
+    newer_file = attachments_service.get_attachment_file_path("newer.wav")
+    older_file.parent.mkdir(parents=True, exist_ok=True)
+    older_file.write_bytes(b"RIFF older")
+    newer_file.write_bytes(b"RIFF newer")
+
+    client_factory = _AsyncClientFactory(_FakeResponse({"text": "new message"}))
+    monkeypatch.setattr(modules.httpx, "AsyncClient", lambda *a, **kw: client_factory)
+    monkeypatch.setattr(tickets_repo_mod, "get_ticket", fake_get_ticket)
+    monkeypatch.setattr(attach_repo_mod, "list_attachments", fake_list_attachments)
+
+    async def fake_create_reply(**kw):
+        return {"id": 123}
+
+    monkeypatch.setattr(tickets_repo_mod, "create_reply", fake_create_reply)
+    monkeypatch.setattr(modules.tickets_service, "emit_ticket_updated_event", _noop)
+
+    try:
+        result = asyncio.run(
+            modules._invoke_whisperx(
+                {"base_url": "http://whisperx.local"}, {"ticket_id": 25147}
+            )
+        )
+
+        assert result["status"] == "succeeded"
+        assert result["transcription_count"] == 1
+        assert (
+            client_factory.calls[0]["files"]["audio_file"][0]
+            == "Voicemail sound attachment.wav"
+        )
+    finally:
+        older_file.unlink(missing_ok=True)
+        newer_file.unlink(missing_ok=True)
+
+
 # ---------------------------------------------------------------------------
 # Stereo split integration tests
 # ---------------------------------------------------------------------------
+
 
 def _make_stereo_wav(path, n_frames=50, sample_rate=8000):
     """Write a minimal 2-channel 16-bit PCM WAV file to *path*."""
@@ -455,8 +586,8 @@ def _make_stereo_wav(path, n_frames=50, sample_rate=8000):
         w.setframerate(sample_rate)
         samples = array.array("h")
         for _ in range(n_frames):
-            samples.append(100)   # left  / callee
-            samples.append(200)   # right / caller
+            samples.append(100)  # left  / callee
+            samples.append(200)  # right / caller
         w.writeframes(samples.tobytes())
 
 
@@ -499,7 +630,9 @@ def test_invoke_whisperx_stereo_split(monkeypatch, tmp_path):
     monkeypatch.setattr(tickets_repo_mod, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(attach_repo_mod, "list_attachments", fake_list_attachments)
     monkeypatch.setattr(tickets_repo_mod, "create_reply", fake_create_reply)
-    monkeypatch.setattr(modules.tickets_service, "emit_ticket_updated_event", fake_emit_event)
+    monkeypatch.setattr(
+        modules.tickets_service, "emit_ticket_updated_event", fake_emit_event
+    )
 
     caller_resp = _FakeResponse({"text": "Caller says hello."})
     callee_resp = _FakeResponse({"text": "Callee says hi."})
@@ -590,7 +723,9 @@ def test_invoke_whisperx_stereo_split_mono_falls_back(monkeypatch, tmp_path):
     monkeypatch.setattr(tickets_repo_mod, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(attach_repo_mod, "list_attachments", fake_list_attachments)
     monkeypatch.setattr(tickets_repo_mod, "create_reply", fake_create_reply)
-    monkeypatch.setattr(modules.tickets_service, "emit_ticket_updated_event", fake_emit_event)
+    monkeypatch.setattr(
+        modules.tickets_service, "emit_ticket_updated_event", fake_emit_event
+    )
 
     class _CountingClient:
         def __init__(self):


### PR DESCRIPTION
### Motivation
- WhisperX transcription was failing with errors like `Audio attachments not yet available on disk for ticket NNNNN` due to resolving files from the old static path instead of private storage and legacy fallback.  
- Voicemail tickets can have multiple WAV files and the system should transcribe the most recent WAV (avoid stale copies).  
- Ensure the transcription path uses the same reliable resolution as the download endpoint and is resilient to delayed file availability.

### Description
- Added WAV-aware helpers: `_is_wav_attachment`, `_attachment_sort_key`, and `_resolve_ticket_attachment_path` to detect WAVs, sort by `uploaded_at`/`id`, and resolve file paths including legacy fallback.  
- Switched WhisperX handler `_invoke_whisperx` to use `attachments_service.get_attachment_file_path()` (with legacy fallback) and to carry resolved `Path` objects into the transcription loop.  
- When multiple WAV attachments exist, prefer only the newest WAV (via `max(..., key=_attachment_sort_key)`) so a single, most-recent voicemail is transcribed.  
- Updated tests in `tests/test_modules_whisperx.py` to use the ticket attachment service paths and added `test_invoke_whisperx_uses_newest_wav_attachment` plus adjusted the delayed-file test to simulate private storage availability.  
- Minor formatting/whitespace cleanups applied with `black` for the changed files.

### Testing
- Formatted changed files with `python -m black app/services/modules.py tests/test_modules_whisperx.py` which completed successfully.  
- Ran unit tests for the WhisperX module with `python -m pytest tests/test_modules_whisperx.py -q` and observed `13 passed` (all tests in that file passed).  
- The introduced tests exercise delayed file availability and newest-WAV selection and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a585ac68be8833282fcf957b0774260)