### PR TITLE
Move ticket quick search above status filters

### DIFF
--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -342,14 +342,29 @@
                 </div>
               </div>
 
+              <!-- Search Section -->
+              <div class="ticket-filters__section ticket-filters__section--horizontal">
+                <div class="ticket-filters__search-control">
+                  <label class="form-label" for="ticket-quick-filter">Quick search</label>
+                  <input
+                    id="ticket-quick-filter"
+                    type="search"
+                    class="form-input"
+                    placeholder="Filter tickets"
+                    aria-label="Filter tickets"
+                    data-table-filter="tickets-table" data-ticket-dashboard-search
+                  />
+                </div>
+              </div>
+
               <!-- Filters Section -->
               <div class="ticket-filters__section">
                 <h3 class="ticket-filters__section-title">Filter by Status</h3>
                 <div class="ticket-filters__status-grid">
                   {% for status_option in ticket_filter_status_definitions | default(ticket_status_definitions) %}
                     <label class="ticket-filters__status-item">
-                      <input 
-                        type="checkbox" 
+                      <input
+                        type="checkbox"
                         value="{{ status_option.tech_status }}"
                         data-status-filter
                         checked
@@ -357,21 +372,6 @@
                       <span class="ticket-filters__status-label">{{ status_option.tech_label }}</span>
                     </label>
                   {% endfor %}
-                </div>
-              </div>
-
-              <!-- Search Section -->
-              <div class="ticket-filters__section ticket-filters__section--horizontal">
-                <div class="ticket-filters__search-control">
-                  <label class="form-label" for="ticket-quick-filter">Quick search</label>
-                  <input 
-                    id="ticket-quick-filter"
-                    type="search" 
-                    class="form-input" 
-                    placeholder="Filter tickets" 
-                    aria-label="Filter tickets" 
-                    data-table-filter="tickets-table" data-ticket-dashboard-search 
-                  />
                 </div>
               </div>
 


### PR DESCRIPTION
### Motivation
- Improve the ticket dashboard UX by placing the Quick search control above the Filter by Status so users can search immediately without scrolling.

### Description
- Moved the Quick search markup above the Filter by Status in `app/templates/admin/tickets.html` and cleaned trailing whitespace / normalized the input element formatting.

### Testing
- Ran `git diff --check` and `git status --short` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a585b9c58bc8332b3b230aabda56d47)