### PR TITLE
Add Calls feature pack and admin webhook log

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -179,15 +179,15 @@ class Settings(BaseSettings):
     default_timezone: str = Field(default="UTC", validation_alias="CRON_TIMEZONE")
     enable_csrf: bool = Field(default=True, validation_alias="ENABLE_CSRF")
     feature_packs: str = Field(
-        default="tickets,service_status,notifications,knowledge_base,chat,assets,automations,reports,reporting,backups,issue_tracker,webhooks,shop,quotes,invoices,compliance,continuity,help,subscriptions,companies,api_keys,call_recordings,cart,orders,staff,message_templates,plausible,smtp,sms_gateway,receive_sms,imap,password_pusher,solidtime,trello,huntress,hudu,m365_mail,m365_admin,reprocess_ai,xero,tacticalrmm,syncro,uptimekuma,chatgpt_mcp,ollama,ntfy,matrix_chat_assign,marketing",
+        default="tickets,service_status,notifications,knowledge_base,chat,assets,automations,reports,reporting,backups,issue_tracker,webhooks,shop,quotes,invoices,compliance,continuity,help,subscriptions,companies,api_keys,call_recordings,calls,cart,orders,staff,message_templates,plausible,smtp,sms_gateway,receive_sms,imap,password_pusher,solidtime,trello,huntress,hudu,m365_mail,m365_admin,reprocess_ai,xero,tacticalrmm,syncro,uptimekuma,chatgpt_mcp,ollama,ntfy,matrix_chat_assign,marketing",
         validation_alias="FEATURE_PACKS",
         description=(
             "Comma-separated list of feature pack slugs (subpackages of "
             "``app.features``) to load on startup.  Each pack can be "
             "hot-reloaded via ``POST /api/features/{slug}/reload``.  "
-            "Defaults to 'tickets,service_status,notifications,knowledge_base,chat,assets,automations,reports,reporting,backups,issue_tracker,webhooks,shop,quotes,invoices,compliance,continuity,help,subscriptions,companies,api_keys,call_recordings,cart,orders,staff,message_templates,plausible,smtp,sms_gateway,receive_sms,imap,password_pusher,solidtime,trello,huntress,hudu,m365_mail,m365_admin,reprocess_ai,xero,tacticalrmm,syncro,uptimekuma,chatgpt_mcp,ollama,ntfy,matrix_chat_assign,marketing' "
+            "Defaults to 'tickets,service_status,notifications,knowledge_base,chat,assets,automations,reports,reporting,backups,issue_tracker,webhooks,shop,quotes,invoices,compliance,continuity,help,subscriptions,companies,api_keys,call_recordings,calls,cart,orders,staff,message_templates,plausible,smtp,sms_gateway,receive_sms,imap,password_pusher,solidtime,trello,huntress,hudu,m365_mail,m365_admin,reprocess_ai,xero,tacticalrmm,syncro,uptimekuma,chatgpt_mcp,ollama,ntfy,matrix_chat_assign,marketing' "
             "because the ticket, service-status, notifications, knowledge-base, "
-            "chat, assets, automations, reports, reporting, backups, issue-tracker, webhooks, shop, quotes, invoices, compliance, continuity, help, subscriptions, companies, API keys, call recordings, cart, orders, staff, message templates, Plausible, SMTP, SMS Gateway, Receive SMS, IMAP, Password Pusher, Solidtime, Trello, Huntress, Hudu, M365 Mail, M365 Admin, Reprocess AI, Xero, TacticalRMM, Syncro, Uptime Kuma, ChatGPT MCP, Ollama, ntfy, Matrix Chat Auto-Assign, and Marketing integrations all live in those packs; set to an empty string "
+            "chat, assets, automations, reports, reporting, backups, issue-tracker, webhooks, shop, quotes, invoices, compliance, continuity, help, subscriptions, companies, API keys, call recordings, calls, cart, orders, staff, message templates, Plausible, SMTP, SMS Gateway, Receive SMS, IMAP, Password Pusher, Solidtime, Trello, Huntress, Hudu, M365 Mail, M365 Admin, Reprocess AI, Xero, TacticalRMM, Syncro, Uptime Kuma, ChatGPT MCP, Ollama, ntfy, Matrix Chat Auto-Assign, and Marketing integrations all live in those packs; set to an empty string "
             "to disable all packs (those routes will then 404)."
         ),
     )

--- a/app/features/calls/__init__.py
+++ b/app/features/calls/__init__.py
@@ -1,0 +1,17 @@
+"""Calls feature pack."""
+
+from __future__ import annotations
+
+from app.core.features import FeaturePack
+
+from .routes import router as calls_router
+
+
+PACK = FeaturePack(
+    slug="calls",
+    version="1.0.0",
+    routers=(calls_router,),
+)
+
+
+__all__ = ["PACK"]

--- a/app/features/calls/routes.py
+++ b/app/features/calls/routes.py
@@ -1,0 +1,61 @@
+"""Phone call webhook and admin routes for the calls feature pack."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+
+from app.repositories import calls as calls_repo
+
+
+router = APIRouter(tags=["Calls"])
+
+
+def _main():
+    from app import main as main_module
+
+    return main_module
+
+
+@router.get("/phonewebhook/{webhook_token}/")
+async def receive_phone_webhook(webhook_token: str, request: Request) -> JSONResponse:
+    """Receive ActionURL-compatible HTTP GET call events from phones."""
+    raw_params = {key: value for key, value in request.query_params.multi_items()}
+    supported_params = calls_repo.filter_supported_params(raw_params)
+    event_name = calls_repo.normalise_event(raw_params.get("event") or raw_params.get("event_name"))
+    source_ip = request.client.host if request.client else None
+    user_agent = request.headers.get("user-agent")
+    event = await calls_repo.create_call_event(
+        webhook_token=webhook_token,
+        event_name=event_name,
+        supported_params=supported_params,
+        raw_params=raw_params,
+        source_ip=source_ip,
+        user_agent=user_agent,
+    )
+    return JSONResponse({"ok": True, "id": event.get("id")})
+
+
+@router.get("/admin/calls", response_class=HTMLResponse)
+async def admin_calls_page(request: Request):
+    """Admin page for viewing phone call webhook events."""
+    main_module = _main()
+    current_user, _membership, redirect = await main_module._require_administration_access(request)
+    if redirect:
+        return redirect
+
+    events = await calls_repo.list_call_events()
+    return await main_module._render_template(
+        "admin/calls.html",
+        request,
+        current_user,
+        extra={
+            "title": "Calls",
+            "call_events": events,
+            "supported_events": calls_repo.SUPPORTED_EVENTS,
+            "supported_variables": calls_repo.SUPPORTED_VARIABLES,
+        },
+    )
+
+
+__all__ = ["router"]

--- a/app/repositories/calls.py
+++ b/app/repositories/calls.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from app.core.database import db
+
+SUPPORTED_EVENTS: tuple[str, ...] = (
+    "Incoming Call",
+    "Outgoing Call",
+    "Establish Call",
+    "Terminate Call",
+    "Off Hook",
+    "On Hook",
+    "Missed Call",
+    "DND On",
+    "DND Off",
+    "Call Forwarding On",
+    "Call Forwarding Off",
+    "Hold Call",
+    "Resume Call",
+    "Syslog On",
+    "Syslog Off",
+    "Booting Completed",
+    "Blind Transferring",
+    "Attended Transferring",
+    "Registration",
+    "Sign Off",
+)
+
+SUPPORTED_VARIABLES: tuple[str, ...] = (
+    "phone_ip",
+    "mac",
+    "product",
+    "program_version",
+    "hardware_version",
+    "language",
+    "local",
+    "display_local",
+    "remote",
+    "display_remote",
+    "call-id",
+    "active_user",
+    "active_host",
+    "duration",
+    "calldirection",
+)
+
+_SUPPORTED_VARIABLE_SET = frozenset(SUPPORTED_VARIABLES)
+_SUPPORTED_EVENT_BY_KEY = {event.lower(): event for event in SUPPORTED_EVENTS}
+
+
+async def _ensure_connection() -> None:
+    is_connected = getattr(db, "is_connected", None)
+    if callable(is_connected):
+        try:
+            if is_connected():
+                return
+        except Exception:  # pragma: no cover - defensive guard
+            pass
+    connect = getattr(db, "connect", None)
+    if not connect:
+        return
+    result = connect()
+    if hasattr(result, "__await__"):
+        await result
+
+
+def _make_aware(value: Any) -> datetime | None:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    return None
+
+
+def normalise_event(value: str | None) -> str | None:
+    if not value:
+        return None
+    return _SUPPORTED_EVENT_BY_KEY.get(value.strip().replace("_", " ").replace("-", " ").lower())
+
+
+def filter_supported_params(params: Mapping[str, Any]) -> dict[str, str]:
+    supported: dict[str, str] = {}
+    for key, value in params.items():
+        if key in _SUPPORTED_VARIABLE_SET:
+            supported[key] = str(value)
+    return supported
+
+
+def _loads_json(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return value
+
+
+def _normalise_record(row: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if not row:
+        return None
+    record = dict(row)
+    for key in ("id",):
+        if record.get(key) is not None:
+            record[key] = int(record[key])
+    for key in ("supported_params", "raw_params"):
+        record[key] = _loads_json(record.get(key)) or {}
+    record["received_at"] = _make_aware(record.get("received_at"))
+    return record
+
+
+async def create_call_event(
+    *,
+    webhook_token: str,
+    event_name: str | None,
+    supported_params: Mapping[str, Any],
+    raw_params: Mapping[str, Any],
+    source_ip: str | None,
+    user_agent: str | None,
+) -> dict[str, Any]:
+    await _ensure_connection()
+    remote_number = str(raw_params.get("number") or supported_params.get("remote") or "") or None
+    local_number = str(supported_params.get("local") or "") or None
+    call_id = str(supported_params.get("call-id") or "") or None
+    duration_seconds = None
+    try:
+        if supported_params.get("duration") not in (None, ""):
+            duration_seconds = int(str(supported_params.get("duration")))
+    except (TypeError, ValueError):
+        duration_seconds = None
+
+    call_event_id = await db.execute_returning_lastrowid(
+        """
+        INSERT INTO phone_call_events (
+            webhook_token, event_name, remote_number, local_number, call_id,
+            direction, duration_seconds, supported_params, raw_params,
+            source_ip, user_agent
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            webhook_token,
+            event_name,
+            remote_number,
+            local_number,
+            call_id,
+            supported_params.get("calldirection"),
+            duration_seconds,
+            json.dumps(dict(supported_params), sort_keys=True),
+            json.dumps(dict(raw_params), sort_keys=True),
+            source_ip,
+            user_agent,
+        ),
+    )
+    row = await db.fetch_one("SELECT * FROM phone_call_events WHERE id = %s", (call_event_id,))
+    return _normalise_record(row) or {}
+
+
+async def list_call_events(*, limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
+    await _ensure_connection()
+    rows = await db.fetch_all(
+        """
+        SELECT *
+        FROM phone_call_events
+        ORDER BY received_at DESC, id DESC
+        LIMIT %s OFFSET %s
+        """,
+        (limit, offset),
+    )
+    return [record for row in rows if (record := _normalise_record(row))]

--- a/app/security/menu_permissions.py
+++ b/app/security/menu_permissions.py
@@ -54,6 +54,7 @@ MENU_PERMISSIONS: tuple[MenuPermission, ...] = (
     MenuPermission("menu.admin.profile", "My Profile", "Administration", "View and update the user's administration profile."),
     MenuPermission("menu.admin.impersonation", "Impersonation", "Administration", "Access impersonation administration.", admin_only=True),
     MenuPermission("menu.admin.call_recordings", "Call Recordings", "Administration", "Access call recordings administration.", admin_only=True),
+    MenuPermission("menu.admin.calls", "Calls", "Administration", "Access phone call webhook logs.", admin_only=True),
     MenuPermission("menu.admin.scheduled_tasks", "Scheduled Tasks", "Administration", "Access scheduled task administration.", admin_only=True),
     MenuPermission("menu.admin.backup_history", "Backup History", "Administration", "Access backup history.", admin_only=True),
     MenuPermission("menu.admin.backup_summary", "Backup Summary", "Administration", "Access backup summary.", admin_only=True),

--- a/app/templates/admin/calls.html
+++ b/app/templates/admin/calls.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="page-header">
+  <div>
+    <p class="eyebrow">Administration</p>
+    <h1>Calls</h1>
+    <p class="page-header__subtitle">Central log of phone ActionURL webhook events received by MyPortal.</p>
+  </div>
+</section>
+
+<section class="card stack gap-md">
+  <div>
+    <h2>Phone webhook endpoint</h2>
+    <p>
+      Configure phones to send an HTTP GET request to
+      <code>/phonewebhook/&lt;obscure_static_id_for_security&gt;/</code> with supported query parameters.
+      Example: <code>/phonewebhook/obscure_static_id_for_security/?number=$remote&amp;remote=$remote&amp;call-id=$call-id</code>.
+    </p>
+  </div>
+  <details>
+    <summary>Supported events and dynamic variables</summary>
+    <div class="grid grid--two gap-md mt-md">
+      <div>
+        <h3>Events</h3>
+        <ul class="tag-list">
+          {% for event in supported_events %}
+            <li><code>{{ event }}</code></li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div>
+        <h3>Dynamic variables recorded</h3>
+        <ul class="tag-list">
+          {% for variable in supported_variables %}
+            <li><code>{{ variable }}</code></li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </details>
+</section>
+
+<section class="card mt-lg">
+  <div class="table-wrapper">
+    <table class="table" data-table data-table-id="admin_calls">
+      <thead>
+        <tr>
+          <th>Received</th>
+          <th>Event</th>
+          <th>Remote</th>
+          <th>Local</th>
+          <th>Direction</th>
+          <th>Duration</th>
+          <th>Call ID</th>
+          <th>Supported data</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for event in call_events %}
+          <tr>
+            <td>{{ event.received_at|datetime if event.received_at else '—' }}</td>
+            <td>{{ event.event_name or 'Unspecified' }}</td>
+            <td>{{ event.remote_number or '—' }}</td>
+            <td>{{ event.local_number or '—' }}</td>
+            <td>{{ event.direction or '—' }}</td>
+            <td>{% if event.duration_seconds is not none %}{{ event.duration_seconds }}s{% else %}—{% endif %}</td>
+            <td><code>{{ event.call_id or '—' }}</code></td>
+            <td><code>{{ event.supported_params|tojson }}</code></td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="8" class="muted">No call webhook events have been logged yet.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -492,6 +492,14 @@
                 <span class="menu__label">My Profile</span>
               </a>
             </li>
+            <li class="menu__item">
+              <a href="/admin/calls" {% if current_path.startswith('/admin/calls') %}aria-current="page"{% endif %}>
+                <span class="menu__icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" focusable="false"><path d="M6.62 10.79a15.05 15.05 0 0 0 6.59 6.59l2.2-2.2a1 1 0 0 1 1.01-.24 11.36 11.36 0 0 0 3.58.57 1 1 0 0 1 1 1V20a1 1 0 0 1-1 1A17 17 0 0 1 3 4a1 1 0 0 1 1-1h3.5a1 1 0 0 1 1 1 11.36 11.36 0 0 0 .57 3.58 1 1 0 0 1-.24 1.01l-2.21 2.2z"/></svg>
+                </span>
+                <span class="menu__label">Calls</span>
+              </a>
+            </li>
             {% if can_access_admin_backup_summary %}
               <li class="menu__item">
                 <a href="/admin/backup-summary" {% if current_path.startswith('/admin/backup-summary') %}aria-current="page"{% endif %}>

--- a/migrations/299_calls_feature_pack.sql
+++ b/migrations/299_calls_feature_pack.sql
@@ -1,0 +1,36 @@
+-- Calls feature pack: central ActionURL-compatible phone call event log.
+CREATE TABLE IF NOT EXISTS phone_call_events (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    webhook_token VARCHAR(255) NOT NULL,
+    event_name VARCHAR(64) NULL,
+    remote_number VARCHAR(128) NULL,
+    local_number VARCHAR(128) NULL,
+    call_id VARCHAR(255) NULL,
+    direction VARCHAR(64) NULL,
+    duration_seconds INT NULL,
+    supported_params JSON NOT NULL,
+    raw_params JSON NOT NULL,
+    source_ip VARCHAR(64) NULL,
+    user_agent VARCHAR(512) NULL,
+    received_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    INDEX idx_phone_call_events_received_at (received_at),
+    INDEX idx_phone_call_events_call_id (call_id),
+    INDEX idx_phone_call_events_remote_number (remote_number),
+    INDEX idx_phone_call_events_webhook_token (webhook_token)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO integration_modules (slug, name, description, icon, enabled, settings)
+VALUES (
+    'calls',
+    'Calls',
+    'Receive ActionURL-compatible phone events over HTTP GET and log supported call metadata in a central list.',
+    '📞',
+    1,
+    JSON_OBJECT(
+        'webhook_path', '/phonewebhook/{obscure_static_id_for_security}/',
+        'supported_variables', JSON_ARRAY('phone_ip', 'mac', 'product', 'program_version', 'hardware_version', 'language', 'local', 'display_local', 'remote', 'display_remote', 'call-id', 'active_user', 'active_host', 'duration', 'calldirection')
+    )
+) ON DUPLICATE KEY UPDATE
+    name = VALUES(name),
+    description = VALUES(description),
+    icon = VALUES(icon);


### PR DESCRIPTION
### Motivation
- Provide a central, admin-visible log of phone ActionURL-compatible events so phone activity can be tracked and later linked to tickets/recordings.
- Accept HTTP GET webhooks from phones and persist supported dynamic variables and raw payloads for auditing and downstream automation.
- Expose a feature-pack style admin UI and register the integration module so the pack can be hot-reloaded and enabled/disabled.

### Description
- Add a new `calls` feature pack with `app/features/calls/__init__.py` and routes in `app/features/calls/routes.py` that implement `GET /phonewebhook/{webhook_token}/` and an admin page at `GET /admin/calls`.
- Implement repository logic in `app/repositories/calls.py` to validate/normalize supported events and variables, persist `phone_call_events` rows, and list events; this stores both `supported_params` and `raw_params` plus metadata such as `source_ip` and `user_agent`.
- Add an admin template `app/templates/admin/calls.html` that shows endpoint guidance, supported events/variables, and a table of logged call events.
- Add a migration `migrations/299_calls_feature_pack.sql` to create the `phone_call_events` table and insert a `calls` entry into `integration_modules` with `supported_variables` metadata.
- Register the `calls` feature pack in the default `FEATURE_PACKS` list in `app/core/config.py` and add an admin menu permission/entry `menu.admin.calls` in `app/security/menu_permissions.py` and the left-nav in `app/templates/base.html`.

### Testing
- Compiled the modified modules successfully with `python -m compileall app/repositories/calls.py app/features/calls app/core/config.py app/security/menu_permissions.py`, and the compilation completed without errors.
- Static sanity checks: templates and new files were created and added; no runtime unit tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a586215ac848332afa1716c01601705)