### PR TITLE
Highlight M365 license allocation statuses

### DIFF
--- a/app/repositories/licenses.py
+++ b/app/repositories/licenses.py
@@ -184,7 +184,9 @@ async def list_staff_by_license_for_company(company_id: int) -> dict[int, list[d
     """Return a mapping of license_id -> list of assigned staff for a company."""
     rows = await db.fetch_all(
         """
-        SELECT DISTINCT l.id AS license_id, s.id AS staff_id, s.first_name, s.last_name, s.email
+        SELECT DISTINCT l.id AS license_id, s.id AS staff_id, s.first_name, s.last_name, s.email,
+               s.enabled,
+               CASE WHEN mb.user_principal_name IS NULL THEN 0 ELSE 1 END AS is_shared_mailbox
         FROM licenses AS l
         INNER JOIN (
             SELECT sl.license_id, sl.staff_id
@@ -195,6 +197,10 @@ async def list_staff_by_license_for_company(company_id: int) -> dict[int, list[d
             INNER JOIN office_group_members AS ogm ON ogm.group_id = gl.group_id
         ) AS la ON la.license_id = l.id
         INNER JOIN staff AS s ON s.id = la.staff_id
+        LEFT JOIN m365_mailboxes AS mb
+          ON mb.company_id = l.company_id
+         AND LOWER(mb.user_principal_name) = LOWER(s.email)
+         AND mb.mailbox_type = 'SharedMailbox'
         WHERE l.company_id = %s
         ORDER BY l.id, s.last_name, s.first_name
         """,
@@ -209,6 +215,8 @@ async def list_staff_by_license_for_company(company_id: int) -> dict[int, list[d
                 "first_name": row["first_name"],
                 "last_name": row["last_name"],
                 "email": row["email"],
+                "enabled": bool(row.get("enabled", True)),
+                "is_shared_mailbox": bool(row.get("is_shared_mailbox", False)),
             }
         )
     return result
@@ -217,8 +225,14 @@ async def list_staff_by_license_for_company(company_id: int) -> dict[int, list[d
 async def list_staff_for_license(license_id: int) -> list[dict[str, Any]]:
     rows = await db.fetch_all(
         """
-        SELECT DISTINCT s.id, s.first_name, s.last_name, s.email
+        SELECT DISTINCT s.id, s.first_name, s.last_name, s.email, s.enabled,
+               CASE WHEN mb.user_principal_name IS NULL THEN 0 ELSE 1 END AS is_shared_mailbox
         FROM staff AS s
+        INNER JOIN licenses AS l ON l.id = %s
+        LEFT JOIN m365_mailboxes AS mb
+          ON mb.company_id = l.company_id
+         AND LOWER(mb.user_principal_name) = LOWER(s.email)
+         AND mb.mailbox_type = 'SharedMailbox'
         WHERE s.id IN (
             SELECT sl.staff_id FROM staff_licenses AS sl WHERE sl.license_id = %s
             UNION
@@ -229,7 +243,7 @@ async def list_staff_for_license(license_id: int) -> list[dict[str, Any]]:
         )
         ORDER BY s.last_name, s.first_name
         """,
-        (license_id, license_id),
+        (license_id, license_id, license_id),
     )
     return [dict(row) for row in rows]
 

--- a/app/schemas/licenses.py
+++ b/app/schemas/licenses.py
@@ -41,4 +41,6 @@ class LicenseStaffResponse(BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     email: Optional[str] = None
+    enabled: bool = True
+    is_shared_mailbox: bool = False
 

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -11383,3 +11383,18 @@ a.shop-product-card {
   color: var(--color-success, #16a34a);
   font-weight: 600;
 }
+
+.license-allocation-item {
+  border-radius: var(--radius-sm, 0.375rem);
+  padding: 0.4rem 0.6rem;
+}
+
+.license-allocation-item--shared {
+  background: rgba(251, 146, 60, 0.18);
+  color: #fed7aa;
+}
+
+.license-allocation-item--disabled {
+  background: rgba(248, 113, 113, 0.2);
+  color: #fecaca;
+}

--- a/app/templates/licenses/index.html
+++ b/app/templates/licenses/index.html
@@ -335,8 +335,20 @@
         } else {
           data.forEach((member) => {
             const li = document.createElement('li');
+            li.classList.add('license-allocation-item');
+            if (member.enabled === false) {
+              li.classList.add('license-allocation-item--disabled');
+            } else if (member.is_shared_mailbox) {
+              li.classList.add('license-allocation-item--shared');
+            }
+
+            const name = `${member.first_name || ''} ${member.last_name || ''}`.trim();
             const email = member.email ? ` (${member.email})` : '';
-            li.textContent = `${member.first_name || ''} ${member.last_name || ''}${email}`.trim();
+            const labels = [];
+            if (member.enabled === false) labels.push('Disabled');
+            if (member.is_shared_mailbox) labels.push('Shared mailbox');
+            const suffix = labels.length ? ` — ${labels.join(', ')}` : '';
+            li.textContent = `${name}${email}${suffix}`.trim();
             allocatedList.appendChild(li);
           });
         }


### PR DESCRIPTION
### Motivation

- Improve clarity when viewing allocated Microsoft 365 licenses by surfacing account state in the allocated-users modal and visually distinguishing shared mailboxes and disabled accounts.

### Description

- Include `enabled` and `is_shared_mailbox` metadata in allocation queries by joining allocated staff to the `m365_mailboxes` table in `app/repositories/licenses.py` and returning those fields with each allocated user.
- Expose the new fields in the API schema by adding `enabled` and `is_shared_mailbox` to `LicenseStaffResponse` in `app/schemas/licenses.py`.
- Update the allocated-users modal in `app/templates/licenses/index.html` to append status labels and add `license-allocation-item--shared` or `license-allocation-item--disabled` CSS classes based on the new fields.
- Add corresponding CSS rules in `app/static/css/app.css` to show orange highlighting for shared mailboxes and red highlighting for disabled accounts.

### Testing

- Compiled updated modules with `python -m compileall app/repositories/licenses.py app/schemas/licenses.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5863ddc7f08332b4fd3f42c6a7a9e9)