### PR TITLE
Add per-instance calls webhook id

### DIFF
--- a/app/features/calls/routes.py
+++ b/app/features/calls/routes.py
@@ -44,6 +44,9 @@ async def admin_calls_page(request: Request):
     if redirect:
         return redirect
 
+    webhook_token = await calls_repo.get_or_create_webhook_token()
+    webhook_path = f"/phonewebhook/{webhook_token}/"
+    webhook_url = str(request.url_for("receive_phone_webhook", webhook_token=webhook_token))
     events = await calls_repo.list_call_events()
     return await main_module._render_template(
         "admin/calls.html",
@@ -52,6 +55,9 @@ async def admin_calls_page(request: Request):
         extra={
             "title": "Calls",
             "call_events": events,
+            "webhook_path": webhook_path,
+            "webhook_url": webhook_url,
+            "webhook_example_path": f"{webhook_path}?number=$remote&remote=$remote&call-id=$call-id",
             "supported_events": calls_repo.SUPPORTED_EVENTS,
             "supported_variables": calls_repo.SUPPORTED_VARIABLES,
         },

--- a/app/repositories/calls.py
+++ b/app/repositories/calls.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import json
+import secrets
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any
 
 from app.core.database import db
+from app.repositories import integration_modules as module_repo
 
 SUPPORTED_EVENTS: tuple[str, ...] = (
     "Incoming Call",
@@ -50,6 +52,56 @@ SUPPORTED_VARIABLES: tuple[str, ...] = (
 
 _SUPPORTED_VARIABLE_SET = frozenset(SUPPORTED_VARIABLES)
 _SUPPORTED_EVENT_BY_KEY = {event.lower(): event for event in SUPPORTED_EVENTS}
+
+_PLACEHOLDER_WEBHOOK_TOKEN = "obscure_static_id_for_security"
+_WEBHOOK_TOKEN_BYTES = 24
+
+
+def _generate_webhook_token() -> str:
+    return secrets.token_urlsafe(_WEBHOOK_TOKEN_BYTES)
+
+
+def _token_needs_replacement(value: Any) -> bool:
+    token = str(value or "").strip()
+    return (
+        not token
+        or token == _PLACEHOLDER_WEBHOOK_TOKEN
+        or "<" in token
+        or ">" in token
+        or "{" in token
+        or "}" in token
+    )
+
+
+def _normalise_settings(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+async def get_or_create_webhook_token() -> str:
+    """Return the per-instance calls webhook token, creating one if needed."""
+    await _ensure_connection()
+    module = await module_repo.get_module("calls")
+    settings = _normalise_settings((module or {}).get("settings"))
+    token = str(settings.get("webhook_token") or "").strip()
+    path = str(settings.get("webhook_path") or "").strip()
+    if _token_needs_replacement(token):
+        token = _generate_webhook_token()
+    desired_path = f"/phonewebhook/{token}/"
+    if path != desired_path or settings.get("webhook_token") != token:
+        settings["webhook_token"] = token
+        settings["webhook_path"] = desired_path
+        if module:
+            await module_repo.update_module("calls", settings=settings)
+        else:
+            await module_repo.upsert_module(
+                slug="calls",
+                name="Calls",
+                description="Receive ActionURL-compatible phone events over HTTP GET and log supported call metadata in a central list.",
+                icon="📞",
+                enabled=True,
+                settings=settings,
+            )
+    return token
 
 
 async def _ensure_connection() -> None:

--- a/app/templates/admin/calls.html
+++ b/app/templates/admin/calls.html
@@ -13,10 +13,17 @@
   <div>
     <h2>Phone webhook endpoint</h2>
     <p>
-      Configure phones to send an HTTP GET request to
-      <code>/phonewebhook/&lt;obscure_static_id_for_security&gt;/</code> with supported query parameters.
-      Example: <code>/phonewebhook/obscure_static_id_for_security/?number=$remote&amp;remote=$remote&amp;call-id=$call-id</code>.
+      Configure phones to send an HTTP GET request to this MyPortal instance's unique webhook endpoint
+      with supported query parameters.
     </p>
+    <dl class="definition-list">
+      <dt>Webhook URL</dt>
+      <dd><code>{{ webhook_url }}</code></dd>
+      <dt>Webhook path</dt>
+      <dd><code>{{ webhook_path }}</code></dd>
+      <dt>Example</dt>
+      <dd><code>{{ webhook_example_path }}</code></dd>
+    </dl>
   </div>
   <details>
     <summary>Supported events and dynamic variables</summary>

--- a/migrations/299_calls_feature_pack.sql
+++ b/migrations/299_calls_feature_pack.sql
@@ -19,6 +19,8 @@ CREATE TABLE IF NOT EXISTS phone_call_events (
     INDEX idx_phone_call_events_webhook_token (webhook_token)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+SET @calls_webhook_token = LOWER(REPLACE(UUID(), '-', ''));
+
 INSERT INTO integration_modules (slug, name, description, icon, enabled, settings)
 VALUES (
     'calls',
@@ -27,10 +29,22 @@ VALUES (
     '📞',
     1,
     JSON_OBJECT(
-        'webhook_path', '/phonewebhook/{obscure_static_id_for_security}/',
+        'webhook_token', @calls_webhook_token,
+        'webhook_path', CONCAT('/phonewebhook/', @calls_webhook_token, '/'),
         'supported_variables', JSON_ARRAY('phone_ip', 'mac', 'product', 'program_version', 'hardware_version', 'language', 'local', 'display_local', 'remote', 'display_remote', 'call-id', 'active_user', 'active_host', 'duration', 'calldirection')
     )
 ) ON DUPLICATE KEY UPDATE
     name = VALUES(name),
     description = VALUES(description),
-    icon = VALUES(icon);
+    icon = VALUES(icon),
+    settings = CASE
+        WHEN JSON_UNQUOTE(JSON_EXTRACT(settings, '$.webhook_token')) IS NULL
+          OR JSON_UNQUOTE(JSON_EXTRACT(settings, '$.webhook_token')) = ''
+          OR JSON_UNQUOTE(JSON_EXTRACT(settings, '$.webhook_token')) = 'obscure_static_id_for_security'
+        THEN VALUES(settings)
+        ELSE JSON_SET(
+            settings,
+            '$.webhook_path',
+            CONCAT('/phonewebhook/', JSON_UNQUOTE(JSON_EXTRACT(settings, '$.webhook_token')), '/')
+        )
+    END;

--- a/tests/test_calls_webhook_token.py
+++ b/tests/test_calls_webhook_token.py
@@ -1,0 +1,76 @@
+import asyncio
+
+from app.repositories import calls
+
+
+class ModuleRepoStub:
+    def __init__(self, module):
+        self.module = module
+        self.updated = None
+        self.upserted = None
+
+    async def get_module(self, slug):
+        assert slug == "calls"
+        return self.module
+
+    async def update_module(self, slug, *, settings):
+        assert slug == "calls"
+        self.updated = settings
+        if self.module is not None:
+            self.module = {**self.module, "settings": settings}
+        return self.module
+
+    async def upsert_module(self, **kwargs):
+        self.upserted = kwargs
+        self.module = {"settings": kwargs["settings"]}
+        return self.module
+
+
+def test_get_or_create_webhook_token_replaces_placeholder(monkeypatch):
+    async def run():
+        stub = ModuleRepoStub(
+            {
+                "settings": {
+                    "webhook_token": "obscure_static_id_for_security",
+                    "webhook_path": "/phonewebhook/{obscure_static_id_for_security}/",
+                    "supported_variables": ["remote"],
+                }
+            }
+        )
+        monkeypatch.setattr(calls, "module_repo", stub)
+        monkeypatch.setattr(calls, "_ensure_connection", _noop)
+        monkeypatch.setattr(calls, "_generate_webhook_token", lambda: "generated-token")
+
+        token = await calls.get_or_create_webhook_token()
+
+        assert token == "generated-token"
+        assert stub.updated["webhook_token"] == "generated-token"
+        assert stub.updated["webhook_path"] == "/phonewebhook/generated-token/"
+        assert stub.updated["supported_variables"] == ["remote"]
+
+    asyncio.run(run())
+
+
+def test_get_or_create_webhook_token_keeps_existing_token(monkeypatch):
+    async def run():
+        stub = ModuleRepoStub(
+            {
+                "settings": {
+                    "webhook_token": "existing-token",
+                    "webhook_path": "/phonewebhook/existing-token/",
+                }
+            }
+        )
+        monkeypatch.setattr(calls, "module_repo", stub)
+        monkeypatch.setattr(calls, "_ensure_connection", _noop)
+
+        token = await calls.get_or_create_webhook_token()
+
+        assert token == "existing-token"
+        assert stub.updated is None
+
+    asyncio.run(run())
+
+
+async def _noop():
+    return None


### PR DESCRIPTION
### Motivation
- Replace the static placeholder webhook id with a secure, unique per-instance token so each MyPortal install has its own calls webhook URL.  
- Surface the actual webhook URL/path/example in the Calls admin page so administrators know where to point phone ActionURL webhooks.

### Description
- Add `get_or_create_webhook_token()` to `app/repositories/calls.py` to generate a URL-safe token, persist it in the `integration_modules` settings, and repair placeholder values when necessary.  
- Update the admin route `admin_calls_page` in `app/features/calls/routes.py` to call `get_or_create_webhook_token()` and pass `webhook_url`, `webhook_path`, and `webhook_example_path` into the template.  
- Replace the static placeholder text in the template `app/templates/admin/calls.html` with a definition list that displays `{{ webhook_url }}`, `{{ webhook_path }}`, and an example request.  
- Modify `migrations/299_calls_feature_pack.sql` to seed a generated webhook token on install and to preserve or repair existing settings for upgrades.  
- Add unit tests in `tests/test_calls_webhook_token.py` covering replacement of the placeholder token and preservation of an existing token.

### Testing
- Ran `pytest tests/test_calls_webhook_token.py` which passed (2 tests).  
- Ran `python -m py_compile app/repositories/calls.py app/features/calls/routes.py` to verify syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5864c0053483328819fc91c3934159)