### PR TITLE
Match tray ticket requesters by phone fallback

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -436,9 +436,9 @@ async def tray_submit_ticket(
     The bearer auth token is the preferred device identity and is used to link
     the ticket to the corresponding asset and company.  ``device_uid`` remains
     accepted as a backwards-compatible fallback for older tray clients that do
-    not send bearer auth.  Name, email, and phone are provided by the user in
-    the tray dialog; email is used to match an existing portal user account
-    when one exists.
+    not send bearer auth. Name, email, and phone are provided by the user in
+    the tray dialog. The requester is matched by email first, then by phone
+    number when no email match exists.
 
     Dynamic question answers are validated server-side against the current
     question definitions.  Required visible questions must have a non-empty
@@ -474,10 +474,13 @@ async def tray_submit_ticket(
     # Normalise email once; reused for both lookup and ticket creation.
     normalised_email = payload.email.strip().lower()
 
-    # Attempt to resolve an existing portal user by email so the ticket
-    # appears under their account and they receive notifications normally.
+    # Resolve an existing portal user so the ticket appears under their account
+    # and they receive notifications normally. Email takes precedence over a
+    # phone match, including when the phone belongs to another user.
     requester_id: int | None = None
     existing_user = await users_repo.get_user_by_email(normalised_email)
+    if existing_user is None and payload.phone:
+        existing_user = await users_repo.get_user_by_phone(payload.phone)
     if existing_user:
         requester_id = int(existing_user["id"])
 

--- a/app/repositories/users.py
+++ b/app/repositories/users.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Any, List, Optional
 
@@ -36,6 +37,26 @@ def _build_safe_update_clause(updates: dict[str, Any]) -> tuple[str, list[Any]]:
 async def get_user_by_email(email: str) -> Optional[dict[str, Any]]:
     row = await db.fetch_one("SELECT * FROM users WHERE email = %s", (email,))
     return row
+
+
+async def get_user_by_phone(phone: str) -> Optional[dict[str, Any]]:
+    """Return the first user whose mobile number matches ``phone``.
+
+    Phone numbers are compared after removing common formatting characters so
+    tray submissions can match stored numbers despite formatting differences.
+    """
+    normalised_phone = re.sub(r"[\s\-\(\)\+]", "", phone.strip())
+    if not normalised_phone:
+        return None
+    return await db.fetch_one(
+        """
+        SELECT * FROM users
+        WHERE REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(COALESCE(mobile_phone, ''), ' ', ''), '-', ''), '(', ''), ')', ''), '+', '') = %s
+        ORDER BY id ASC
+        LIMIT 1
+        """,
+        (normalised_phone,),
+    )
 
 
 async def get_user_by_id(user_id: int) -> Optional[dict[str, Any]]:

--- a/tests/test_tray_submit_ticket_auth.py
+++ b/tests/test_tray_submit_ticket_auth.py
@@ -77,6 +77,147 @@ async def test_tray_submit_ticket_uses_bearer_token_without_device_uid(monkeypat
 
 
 @pytest.mark.anyio
+async def test_tray_submit_ticket_matches_requester_by_phone_when_email_is_unknown(
+    monkeypatch,
+):
+    from app.api.routes import tray as tray_routes
+    from app.schemas.tray import TrayTicketSubmitRequest
+
+    created: dict[str, object] = {}
+    phone_lookups: list[str] = []
+
+    async def fake_get_device_by_uid(device_uid: str):
+        return {
+            "id": 123,
+            "uid": device_uid,
+            "status": "active",
+            "company_id": 456,
+            "asset_id": None,
+        }
+
+    async def fake_get_user_by_email(email: str):
+        assert email == "unknown@example.com"
+        return None
+
+    async def fake_get_user_by_phone(phone: str):
+        phone_lookups.append(phone)
+        return {"id": 42}
+
+    async def fake_get_questions_for_company(company_id: int | None):
+        return []
+
+    async def fake_resolve_status_or_default(status: str | None):
+        return "open"
+
+    async def fake_create_ticket(**kwargs):
+        created.update(kwargs)
+        return {"id": 789, "ticket_number": "T-789"}
+
+    monkeypatch.setattr(
+        tray_routes.tray_repo, "get_device_by_uid", fake_get_device_by_uid
+    )
+    monkeypatch.setattr(
+        tray_routes.users_repo, "get_user_by_email", fake_get_user_by_email
+    )
+    monkeypatch.setattr(
+        tray_routes.users_repo, "get_user_by_phone", fake_get_user_by_phone
+    )
+    monkeypatch.setattr(
+        tray_routes.tq_service,
+        "get_questions_for_company",
+        fake_get_questions_for_company,
+    )
+    monkeypatch.setattr(
+        tray_routes.tickets_service,
+        "resolve_status_or_default",
+        fake_resolve_status_or_default,
+    )
+    monkeypatch.setattr(
+        tray_routes.tickets_service, "create_ticket", fake_create_ticket
+    )
+
+    payload = TrayTicketSubmitRequest(
+        device_uid="device-abc",
+        name="Jane",
+        email="unknown@example.com",
+        phone="+1 (555) 010-1234",
+        subject="Help",
+    )
+    await tray_routes.tray_submit_ticket(payload, SimpleNamespace(headers={}))  # type: ignore[arg-type]
+
+    assert phone_lookups == ["+1 (555) 010-1234"]
+    assert created["requester_id"] == 42
+    assert created["requester_email"] is None
+
+
+@pytest.mark.anyio
+async def test_tray_submit_ticket_prefers_email_match_over_phone(monkeypatch):
+    from app.api.routes import tray as tray_routes
+    from app.schemas.tray import TrayTicketSubmitRequest
+
+    created: dict[str, object] = {}
+
+    async def fake_get_device_by_uid(device_uid: str):
+        return {
+            "id": 123,
+            "uid": device_uid,
+            "status": "active",
+            "company_id": None,
+            "asset_id": None,
+        }
+
+    async def fake_get_user_by_email(email: str):
+        return {"id": 10}
+
+    async def fail_get_user_by_phone(phone: str):
+        raise AssertionError("phone lookup must not run after an email match")
+
+    async def fake_get_questions_for_company(company_id: int | None):
+        return []
+
+    async def fake_resolve_status_or_default(status: str | None):
+        return "open"
+
+    async def fake_create_ticket(**kwargs):
+        created.update(kwargs)
+        return {"id": 789, "ticket_number": "T-789"}
+
+    monkeypatch.setattr(
+        tray_routes.tray_repo, "get_device_by_uid", fake_get_device_by_uid
+    )
+    monkeypatch.setattr(
+        tray_routes.users_repo, "get_user_by_email", fake_get_user_by_email
+    )
+    monkeypatch.setattr(
+        tray_routes.users_repo, "get_user_by_phone", fail_get_user_by_phone
+    )
+    monkeypatch.setattr(
+        tray_routes.tq_service,
+        "get_questions_for_company",
+        fake_get_questions_for_company,
+    )
+    monkeypatch.setattr(
+        tray_routes.tickets_service,
+        "resolve_status_or_default",
+        fake_resolve_status_or_default,
+    )
+    monkeypatch.setattr(
+        tray_routes.tickets_service, "create_ticket", fake_create_ticket
+    )
+
+    payload = TrayTicketSubmitRequest(
+        device_uid="device-abc",
+        name="Jane",
+        email="jane@example.com",
+        phone="555-0100",
+        subject="Help",
+    )
+    await tray_routes.tray_submit_ticket(payload, SimpleNamespace(headers={}))  # type: ignore[arg-type]
+
+    assert created["requester_id"] == 10
+
+
+@pytest.mark.anyio
 async def test_tray_submit_syncro_ticket_keeps_contact_details_when_contact_matches(
     monkeypatch,
 ):

--- a/tests/test_users_repository_sql_safety.py
+++ b/tests/test_users_repository_sql_safety.py
@@ -18,7 +18,7 @@ def test_build_safe_update_clause_allows_known_columns():
     assert params == ["Alice", 1]
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_update_user_rejects_unknown_columns_before_query(monkeypatch):
     executed = False
 
@@ -31,3 +31,35 @@ async def test_update_user_rejects_unknown_columns_before_query(monkeypatch):
     with pytest.raises(ValueError, match="Unsupported update fields"):
         await users.update_user(1, **{"email = 'x' --": "bad"})
     assert not executed
+
+
+@pytest.mark.anyio
+async def test_get_user_by_phone_normalises_common_phone_formatting(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_one(query, params):
+        captured["query"] = query
+        captured["params"] = params
+        return {"id": 42}
+
+    monkeypatch.setattr(users.db, "fetch_one", fake_fetch_one)
+
+    result = await users.get_user_by_phone(" +1 (555) 010-1234 ")
+
+    assert result == {"id": 42}
+    assert captured["params"] == ("15550101234",)
+    assert "COALESCE(mobile_phone, '')" in captured["query"]
+
+
+@pytest.mark.anyio
+async def test_get_user_by_phone_ignores_empty_normalised_values(monkeypatch):
+    queried = False
+
+    async def fake_fetch_one(*args, **kwargs):
+        nonlocal queried
+        queried = True
+
+    monkeypatch.setattr(users.db, "fetch_one", fake_fetch_one)
+
+    assert await users.get_user_by_phone("+ - ()") is None
+    assert not queried


### PR DESCRIPTION
### Motivation
- When a user creates a ticket via the tray icon we should automatically set the ticket `requester` by matching the provided contact to an existing portal user, preferring email but falling back to phone when no email match exists.

### Description
- Update `POST /api/tray/submit-ticket` logic in `app/api/routes/tray.py` to attempt email lookup first and only call a phone lookup when no email user is found.
- Add `get_user_by_phone` to `app/repositories/users.py` which normalizes common phone formatting (removes spaces, dashes, parentheses and leading `+`) before querying `users.mobile_phone`.
- Clarify code comments to document that email takes precedence and phone is used as a fallback.
- Add tests to cover the new behaviour: phone fallback when email is unknown, email-precedence (phone lookup not run when email matches), normalized phone lookup, and ignoring empty-normalised phone values in `tests/test_tray_submit_ticket_auth.py` and `tests/test_users_repository_sql_safety.py`.

### Testing
- Ran `pytest -q tests/test_users_repository_sql_safety.py tests/test_tray_submit_ticket_auth.py` and the targeted tests passed (`9 passed`, warnings only).
- Ran `python -m compileall -q app/api/routes/tray.py app/repositories/users.py` with no syntax errors.
- Ran `ruff check` on the modified files and `git diff --check` to ensure style/format and no trailing whitespace; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a597bd3d6dc833284e1957e49743c1c)