### PR TITLE
Prevent assigned technicians from watching tickets

### DIFF
--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -1009,6 +1009,9 @@ async def test_ticket_automation_by_id(
         result["reason"] = "Automation filters did not match the ticket."
         return result
     if apply:
+        from app.services import tickets as tickets_service
+
+        await tickets_service._remove_assigned_user_from_watchers(ticket)
         action_result, action_error = await _invoke_automation_actions_for_context(
             automation,
             context=context,
@@ -1161,6 +1164,7 @@ async def _execute_scheduled_ticket_automation(
     from app.services import tickets as tickets_service
 
     for ticket in scanned:
+        await tickets_service._remove_assigned_user_from_watchers(ticket)
         ticket_context = _attach_ticket_age_context(ticket, now=now)
         try:
             enriched_ticket = await tickets_service._enrich_ticket_context(

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -621,6 +621,20 @@ def _normalise_email_for_compare(value: Any) -> str | None:
     return candidate or None
 
 
+async def _remove_assigned_user_from_watchers(ticket: Mapping[str, Any]) -> None:
+    """Keep the assigned technician out of the ticket's watcher list."""
+
+    try:
+        assigned_user_id = int(ticket.get("assigned_user_id"))
+        ticket_id = int(ticket.get("id"))
+    except (TypeError, ValueError):
+        return
+    if assigned_user_id <= 0 or ticket_id <= 0:
+        return
+
+    await tickets_repo.remove_watcher(ticket_id, user_id=assigned_user_id)
+
+
 def _auto_detect_ticket_update_actor(
     ticket: Mapping[str, Any],
     actor: Mapping[str, Any] | None,
@@ -692,6 +706,9 @@ async def _emit_ticket_event(
 
     if ticket_record.get("merged_into_ticket_id"):
         return
+
+    if trigger_automations:
+        await _remove_assigned_user_from_watchers(ticket_record)
 
     enriched = await _enrich_ticket_context(ticket_record)
 
@@ -1238,6 +1255,9 @@ async def create_ticket(
                 ticket_id=ticket_id,
                 error=str(exc),
             )
+
+    if trigger_automations:
+        await _remove_assigned_user_from_watchers(ticket)
 
     enriched_ticket = await _enrich_ticket_context(ticket)
 

--- a/tests/test_tickets_service_create.py
+++ b/tests/test_tickets_service_create.py
@@ -114,6 +114,63 @@ async def test_create_ticket_can_skip_automations(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_create_ticket_removes_assigned_technician_watcher_before_automations(
+    monkeypatch,
+):
+    events: list[str] = []
+
+    async def fake_create_ticket(**kwargs):
+        return {
+            "id": 78,
+            **{key: value for key, value in kwargs.items() if key != "id"},
+        }
+
+    async def fake_get_company(company_id):
+        return None
+
+    async def fake_get_user(user_id):
+        return {"id": user_id, "email": "tech@example.com"}
+
+    async def fake_resolve_status(value):
+        return value or "open"
+
+    async def fake_remove_watcher(ticket_id, *, user_id=None, email=None):
+        assert (ticket_id, user_id, email) == (78, 10, None)
+        events.append("watcher_removed")
+
+    async def fake_handle_event(event_name, context):
+        assert events == ["watcher_removed"]
+        events.append(event_name)
+        return []
+
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_repo, "remove_watcher", fake_remove_watcher)
+    monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
+    monkeypatch.setattr(
+        tickets_service.company_repo, "get_company_by_id", fake_get_company
+    )
+    monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(
+        tickets_service, "resolve_status_or_default", fake_resolve_status
+    )
+
+    await tickets_service.create_ticket(
+        subject="Assigned ticket",
+        description=None,
+        requester_id=None,
+        company_id=None,
+        assigned_user_id=10,
+        priority="normal",
+        status="open",
+        category=None,
+        module_slug=None,
+        external_reference=None,
+    )
+
+    assert events == ["watcher_removed", "tickets.created"]
+
+
+@pytest.mark.anyio
 async def test_create_ticket_truncates_long_description(monkeypatch):
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
### Motivation

- Ensure the assigned technician is never automatically treated as a ticket watcher and is removed before any automations or notification filters run.

### Description

- Add `async def _remove_assigned_user_from_watchers(ticket)` to `app/services/tickets.py` to remove the assigned user's watcher entry when both `ticket.id` and `assigned_user_id` are valid.
- Call the new cleanup before building automation/event contexts in `emit`/creation flows by invoking it from `app/services/tickets.py` when `trigger_automations` is true (used for `tickets.created` and other ticket events).
- Invoke the same cleanup in automation execution paths in `app/services/automations.py` for manually-applied event tests (`test_ticket_automation_by_id` when `apply=True`) and for scheduled automation scans (`_execute_scheduled_ticket_automation`).
- Add a regression test `test_create_ticket_removes_assigned_technician_watcher_before_automations` in `tests/test_tickets_service_create.py` to verify the assigned technician is removed before the `tickets.created` automation is handled.

### Testing

- Ran lint/format checks with `ruff check`/`ruff format` on the modified files and resolved formatting issues successfully.
- Ran unit tests `pytest -q tests/test_automations_service.py tests/test_tickets_service_create.py tests/test_ticket_details_updated_event.py` and all tests passed (`40 passed`, with non-blocking warnings).
- Verified the new test specifically (and the previously failing scenario) now passes under CI-local test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a597e07074083329dd516df7b1541dc)