### PR TITLE
Add technician ticket page clocks

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -45,6 +45,7 @@ from app.repositories import ticket_statuses as ticket_status_repo
 from app.repositories import ticket_attachments as attachments_repo
 from app.repositories import ticket_canned_responses as canned_responses_repo
 from app.repositories import ticket_expenses as expenses_repo
+from app.repositories import ticket_clocks as ticket_clocks_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import email_blocklist as email_blocklist_repo
 from app.repositories import users as user_repo
@@ -430,6 +431,54 @@ async def admin_ticket_detail(
         current_user,
         ticket_id=ticket_id,
     )
+
+
+async def _ticket_clock_user(request: Request, ticket_id: int) -> tuple[dict[str, Any], int]:
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+    ticket = await tickets_repo.get_ticket(ticket_id)
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
+    user_id = int(current_user.get("id") or 0)
+    if user_id <= 0:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+    return current_user, user_id
+
+
+@router.post("/admin/tickets/{ticket_id:int}/page-clocks", response_class=JSONResponse)
+async def admin_start_ticket_page_clock(ticket_id: int, request: Request):
+    _, user_id = await _ticket_clock_user(request, ticket_id)
+    clock_id = await ticket_clocks_repo.start_clock(ticket_id, user_id)
+    return JSONResponse({"clockId": clock_id})
+
+
+@router.post("/admin/tickets/{ticket_id:int}/page-clocks/{clock_id:int}/heartbeat", response_class=JSONResponse)
+async def admin_heartbeat_ticket_page_clock(ticket_id: int, clock_id: int, request: Request):
+    _, user_id = await _ticket_clock_user(request, ticket_id)
+    if not await ticket_clocks_repo.touch_clock(clock_id, ticket_id, user_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Clock not found")
+    return JSONResponse({"ok": True})
+
+
+@router.post("/admin/tickets/{ticket_id:int}/page-clocks/{clock_id:int}/stop", response_class=JSONResponse)
+async def admin_stop_ticket_page_clock(ticket_id: int, clock_id: int, request: Request):
+    _, user_id = await _ticket_clock_user(request, ticket_id)
+    await ticket_clocks_repo.stop_clock(clock_id, ticket_id, user_id)
+    return JSONResponse({"ok": True})
+
+
+@router.get("/admin/tickets/{ticket_id:int}/page-clocks", response_class=JSONResponse)
+async def admin_list_ticket_page_clocks(ticket_id: int, request: Request):
+    await _ticket_clock_user(request, ticket_id)
+    clocks = await ticket_clocks_repo.list_clocks(ticket_id)
+    for clock in clocks:
+        for field in ("started_at", "last_seen_at", "ended_at"):
+            value = clock.get(field)
+            if isinstance(value, datetime):
+                clock[field] = value.astimezone(timezone.utc).isoformat()
+    return JSONResponse({"clocks": clocks})
 
 
 @router.post("/admin/tickets/{ticket_id:int}/expenses", response_class=HTMLResponse)

--- a/app/repositories/ticket_clocks.py
+++ b/app/repositories/ticket_clocks.py
@@ -1,0 +1,53 @@
+"""Persistence helpers for technician ticket-page clocks."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.database import db
+
+
+async def start_clock(ticket_id: int, user_id: int) -> int:
+    return await db.execute_returning_lastrowid(
+        "INSERT INTO ticket_page_clocks (ticket_id, user_id) VALUES (%s, %s)",
+        (ticket_id, user_id),
+    )
+
+
+async def touch_clock(clock_id: int, ticket_id: int, user_id: int) -> bool:
+    affected = await db.execute(
+        """
+        UPDATE ticket_page_clocks
+        SET last_seen_at = CURRENT_TIMESTAMP
+        WHERE id = %s AND ticket_id = %s AND user_id = %s AND ended_at IS NULL
+        """,
+        (clock_id, ticket_id, user_id),
+    )
+    return bool(affected)
+
+
+async def stop_clock(clock_id: int, ticket_id: int, user_id: int) -> bool:
+    affected = await db.execute(
+        """
+        UPDATE ticket_page_clocks
+        SET ended_at = CURRENT_TIMESTAMP, last_seen_at = CURRENT_TIMESTAMP
+        WHERE id = %s AND ticket_id = %s AND user_id = %s AND ended_at IS NULL
+        """,
+        (clock_id, ticket_id, user_id),
+    )
+    return bool(affected)
+
+
+async def list_clocks(ticket_id: int) -> list[dict[str, Any]]:
+    rows = await db.fetch_all(
+        """
+        SELECT c.id, c.started_at, c.last_seen_at, c.ended_at,
+               u.email AS user_email, u.display_name AS user_display_name
+        FROM ticket_page_clocks c
+        LEFT JOIN users u ON u.id = c.user_id
+        WHERE c.ticket_id = %s
+        ORDER BY c.started_at DESC, c.id DESC
+        """,
+        (ticket_id,),
+    )
+    return [dict(row) for row in rows]

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10669,6 +10669,23 @@ a.stat-strip__stat:focus-visible {
   align-items: stretch;
 }
 
+.ticket-reply-actions {
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.ticket-page-clock { display: flex; align-items: center; gap: .45rem; font-variant-numeric: tabular-nums; }
+.ticket-page-clock__label { color: var(--text-muted, #64748b); font-size: .9rem; }
+.ticket-page-clock__menu { position: relative; }
+.ticket-page-clock__menu summary { list-style: none; }
+.ticket-page-clock__menu summary::-webkit-details-marker { display: none; }
+.ticket-page-clock__menu-content { position: absolute; bottom: calc(100% + .4rem); left: 0; z-index: 20; white-space: nowrap; padding: .35rem; border: 1px solid rgba(148,163,184,.3); border-radius: .7rem; background: var(--surface, #fff); box-shadow: 0 12px 30px -16px rgba(15,23,42,.6); }
+.ticket-page-clock-dialog { width: min(38rem, calc(100vw - 2rem)); border: 0; border-radius: .9rem; padding: 1.25rem; color: var(--text-color, #0f172a); box-shadow: 0 25px 60px rgba(15,23,42,.45); }
+.ticket-page-clock-dialog::backdrop { background: rgba(15,23,42,.45); }
+.ticket-page-clock-dialog__header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1rem; }
+.ticket-page-clock-history { width: 100%; border-collapse: collapse; }
+.ticket-page-clock-history th, .ticket-page-clock-history td { padding: .55rem; border-bottom: 1px solid rgba(148,163,184,.25); text-align: left; }
+
 .ticket-reply-submit__primary {
   display: inline-flex;
   align-items: center;

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -279,6 +279,95 @@
     return getCookie('myportal_session_csrf');
   }
 
+  function initialiseTicketPageClock() {
+    const clock = document.querySelector('[data-ticket-page-clock]');
+    if (!clock) return;
+
+    const ticketId = clock.dataset.ticketId;
+    const display = clock.querySelector('[data-ticket-page-clock-display]');
+    const historyButton = clock.querySelector('[data-ticket-page-clock-history]');
+    const dialog = document.querySelector('[data-ticket-page-clock-dialog]');
+    const historyContent = dialog && dialog.querySelector('[data-ticket-page-clock-history-content]');
+    const closeButton = dialog && dialog.querySelector('[data-ticket-page-clock-close]');
+    let clockId = null;
+    const openedAt = Date.now();
+
+    const headers = () => {
+      const result = { Accept: 'application/json' };
+      const csrfToken = getCsrfToken();
+      if (csrfToken) result['X-CSRF-Token'] = csrfToken;
+      return result;
+    };
+    const formatDuration = (seconds) => {
+      const total = Math.max(0, Math.floor(seconds));
+      const hours = Math.floor(total / 3600);
+      const minutes = Math.floor((total % 3600) / 60);
+      const secs = total % 60;
+      return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+    };
+    const tick = () => { if (display) display.textContent = formatDuration((Date.now() - openedAt) / 1000); };
+    tick();
+    window.setInterval(tick, 1000);
+
+    async function send(path, keepalive) {
+      return fetch(`/admin/tickets/${encodeURIComponent(ticketId)}/page-clocks${path}`, {
+        method: 'POST', headers: headers(), keepalive: Boolean(keepalive), credentials: 'same-origin',
+      });
+    }
+    async function start() {
+      try {
+        const response = await send('');
+        if (!response.ok) return;
+        const payload = await response.json();
+        clockId = payload.clockId;
+      } catch (error) { console.warn('Unable to start ticket clock:', error); }
+    }
+    function heartbeat() {
+      if (clockId) send(`/${encodeURIComponent(clockId)}/heartbeat`).catch(() => {});
+    }
+    function stop() {
+      if (clockId) send(`/${encodeURIComponent(clockId)}/stop`, true).catch(() => {});
+    }
+    start();
+    window.setInterval(heartbeat, 60000);
+    window.addEventListener('pagehide', stop, { once: true });
+
+    // A screen wake lock reduces the chance of an actively viewed ticket page
+    // being suspended. Browsers may still suspend background tabs by design.
+    let wakeLock = null;
+    async function requestWakeLock() {
+      if (document.visibilityState !== 'visible' || !navigator.wakeLock) return;
+      try { wakeLock = await navigator.wakeLock.request('screen'); } catch (error) { /* permission/device dependent */ }
+    }
+    document.addEventListener('visibilitychange', () => { if (document.visibilityState === 'visible') requestWakeLock(); });
+    requestWakeLock();
+
+    if (historyButton && dialog && historyContent) {
+      historyButton.addEventListener('click', async () => {
+        dialog.showModal();
+        historyContent.textContent = 'Loading clock history…';
+        try {
+          const response = await fetch(`/admin/tickets/${encodeURIComponent(ticketId)}/page-clocks`, { headers: headers(), credentials: 'same-origin' });
+          if (!response.ok) throw new Error('Unable to load clock history.');
+          const payload = await response.json();
+          const rows = Array.isArray(payload.clocks) ? payload.clocks : [];
+          if (!rows.length) { historyContent.textContent = 'No ticket clock history yet.'; return; }
+          const table = document.createElement('table'); table.className = 'ticket-page-clock-history';
+          table.innerHTML = '<thead><tr><th>Technician</th><th>Opened</th><th>Duration</th></tr></thead>';
+          const body = document.createElement('tbody');
+          rows.forEach((entry) => {
+            const started = new Date(entry.started_at); const finished = new Date(entry.ended_at || entry.last_seen_at);
+            const row = document.createElement('tr');
+            [entry.user_display_name || entry.user_email || 'Unknown', Number.isNaN(started) ? '—' : started.toLocaleString(), Number.isNaN(started) || Number.isNaN(finished) ? '—' : formatDuration((finished - started) / 1000)].forEach((value) => { const cell = document.createElement('td'); cell.textContent = value; row.appendChild(cell); });
+            body.appendChild(row);
+          });
+          table.appendChild(body); historyContent.replaceChildren(table);
+        } catch (error) { historyContent.textContent = error.message || 'Unable to load clock history.'; }
+      });
+      closeButton.addEventListener('click', () => dialog.close());
+    }
+  }
+
 
   function initTicketRelated() {
     const panel = document.querySelector('[data-ticket-related]');
@@ -3070,8 +3159,9 @@
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', ready);
+    document.addEventListener('DOMContentLoaded', () => { ready(); initialiseTicketPageClock(); });
   } else {
     ready();
+    initialiseTicketPageClock();
   }
 })();

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -1306,7 +1306,17 @@
                   </label>
                 </div>
               </div>
-              <div class="form-actions">
+              <div class="form-actions ticket-reply-actions">
+                <div class="ticket-page-clock" data-ticket-page-clock data-ticket-id="{{ ticket.id }}" aria-live="polite">
+                  <span class="ticket-page-clock__label">Time open</span>
+                  <strong data-ticket-page-clock-display>0:00:00</strong>
+                  <details class="ticket-page-clock__menu">
+                    <summary class="button button--secondary button--small">Actions</summary>
+                    <div class="ticket-page-clock__menu-content">
+                      <button type="button" class="button button--ghost button--small" data-ticket-page-clock-history>View clock history</button>
+                    </div>
+                  </details>
+                </div>
                 <div class="ticket-reply-submit" data-ticket-reply-submit>
                   <input type="hidden" name="replyStatus" value="" data-ticket-reply-status-input />
                   <button type="submit" class="button button--primary ticket-reply-submit__primary">Post reply</button>
@@ -1325,6 +1335,13 @@
                 </div>
               </div>
             </form>
+            <dialog class="ticket-page-clock-dialog" data-ticket-page-clock-dialog aria-labelledby="ticket-page-clock-history-title">
+              <div class="ticket-page-clock-dialog__header">
+                <h3 id="ticket-page-clock-history-title">Ticket clock history</h3>
+                <button type="button" class="button button--ghost button--small" data-ticket-page-clock-close>Close</button>
+              </div>
+              <div data-ticket-page-clock-history-content>Loading clock history…</div>
+            </dialog>
             </div>
           </details>
 

--- a/migrations/302_ticket_page_clocks.sql
+++ b/migrations/302_ticket_page_clocks.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS ticket_page_clocks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    ticket_id INT NOT NULL,
+    user_id INT NOT NULL,
+    started_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    last_seen_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    ended_at DATETIME(6) NULL,
+    INDEX idx_ticket_page_clocks_ticket_started (ticket_id, started_at),
+    INDEX idx_ticket_page_clocks_user_open (user_id, ended_at),
+    CONSTRAINT fk_ticket_page_clocks_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
+    CONSTRAINT fk_ticket_page_clocks_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/tests/test_ticket_page_clocks.py
+++ b/tests/test_ticket_page_clocks.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_ticket_page_clock_is_available_in_reply_form():
+    template = Path("app/templates/admin/ticket_detail.html").read_text()
+
+    assert 'data-ticket-page-clock data-ticket-id="{{ ticket.id }}"' in template
+    assert "Time open" in template
+    assert "data-ticket-page-clock-history" in template
+
+
+def test_ticket_page_clock_script_records_and_displays_clock_history():
+    script = Path("app/static/js/ticket_detail.js").read_text()
+
+    assert "function initialiseTicketPageClock()" in script
+    assert "/page-clocks" in script
+    assert "navigator.wakeLock.request('screen')" in script
+    assert "pagehide" in script
+
+
+def test_ticket_page_clock_routes_are_registered():
+    routes = Path("app/features/tickets/admin_routes.py").read_text()
+
+    assert '"/admin/tickets/{ticket_id:int}/page-clocks"' in routes
+    assert '"/admin/tickets/{ticket_id:int}/page-clocks/{clock_id:int}/heartbeat"' in routes


### PR DESCRIPTION
### Motivation
- Provide technicians with a persistent page-open timer that starts when an admin ticket page is opened and stops when the page/tab is closed so they can quickly see how long they've been actively working on a ticket.
- Surface historical page-clock sessions in an Actions menu so technicians can review past open sessions for auditing or billing purposes.
- Reduce false early stops by sending periodic heartbeats and requesting a screen wake lock where available.

### Description
- Added a new repository `app/repositories/ticket_clocks.py` with helpers to `start_clock`, `touch_clock`, `stop_clock`, and `list_clocks` for persisted page clocks, and a migration `migrations/302_ticket_page_clocks.sql` to create the `ticket_page_clocks` table.
- Registered authenticated admin endpoints to manage clocks: `POST /admin/tickets/{ticket_id}/page-clocks`, `POST /admin/tickets/{ticket_id}/page-clocks/{clock_id}/heartbeat`, `POST /admin/tickets/{ticket_id}/page-clocks/{clock_id}/stop`, and `GET /admin/tickets/{ticket_id}/page-clocks` in `app/features/tickets/admin_routes.py` with request validation and ISO-8601 timestamp encoding.
- Added live UI and history dialog to the admin reply form in `app/templates/admin/ticket_detail.html` and styles in `app/static/css/app.css` to display the `Time open` clock and an Actions menu.
- Implemented `initialiseTicketPageClock()` in `app/static/js/ticket_detail.js` to auto-start a clock on page load, update a live duration every second, send one-minute heartbeats, stop the clock on `pagehide` using `keepalive`, and request a best-effort `navigator.wakeLock.request('screen')` while visible; also fetches and renders historical clocks in a modal.
- Added unit regression checks in `tests/test_ticket_page_clocks.py` to ensure template/route/script presence and basic script behaviour strings.

### Testing
- Ran Python compile checks with `python -m compileall -q app/features/tickets/admin_routes.py app/repositories/ticket_clocks.py` which succeeded.
- Ran JS syntax check with `node --check app/static/js/ticket_detail.js` which succeeded.
- Ran focused tests with `pytest -q tests/test_ticket_page_clocks.py tests/test_ticket_rename.py` which passed (`7 passed`).
- Earlier `pytest -q tests/test_ticket_rename.py tests/test_admin_ticket_detail.py` produced 4 failures due to runtime database pool initialization errors in the test environment (tests attempted DB operations), which appears related to test environment setup rather than the introduced page-clock code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a59b9031fec83328dd0f92663444be9)