### PR TITLE
Move ticket clock history to header Actions and fix SQL/JS for history dialog

### DIFF
--- a/app/repositories/ticket_clocks.py
+++ b/app/repositories/ticket_clocks.py
@@ -42,7 +42,8 @@ async def list_clocks(ticket_id: int) -> list[dict[str, Any]]:
     rows = await db.fetch_all(
         """
         SELECT c.id, c.started_at, c.last_seen_at, c.ended_at,
-               u.email AS user_email, u.display_name AS user_display_name
+               u.email AS user_email,
+               NULLIF(TRIM(CONCAT(COALESCE(u.first_name, ''), ' ', COALESCE(u.last_name, ''))), '') AS user_display_name
         FROM ticket_page_clocks c
         LEFT JOIN users u ON u.id = c.user_id
         WHERE c.ticket_id = %s

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -285,7 +285,7 @@
 
     const ticketId = clock.dataset.ticketId;
     const display = clock.querySelector('[data-ticket-page-clock-display]');
-    const historyButton = clock.querySelector('[data-ticket-page-clock-history]');
+    const historyButton = document.querySelector('[data-ticket-page-clock-history]');
     const dialog = document.querySelector('[data-ticket-page-clock-dialog]');
     const historyContent = dialog && dialog.querySelector('[data-ticket-page-clock-history-content]');
     const closeButton = dialog && dialog.querySelector('[data-ticket-page-clock-close]');

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -6,6 +6,7 @@
 
 {% block header_actions %}
   {{ page_header_actions([
+    {"label": "Clock history", "type": "button", "attrs": {"data-ticket-page-clock-history": true}},
     {"label": "Audit Trail", "type": "button", "attrs": {"data-ticket-automation-history-open": true, "data-ticket-id": ticket.id}},
     {"label": "All tickets", "type": "link", "href": "/admin/tickets"}
   ]) }}
@@ -1310,12 +1311,6 @@
                 <div class="ticket-page-clock" data-ticket-page-clock data-ticket-id="{{ ticket.id }}" aria-live="polite">
                   <span class="ticket-page-clock__label">Time open</span>
                   <strong data-ticket-page-clock-display>0:00:00</strong>
-                  <details class="ticket-page-clock__menu">
-                    <summary class="button button--secondary button--small">Actions</summary>
-                    <div class="ticket-page-clock__menu-content">
-                      <button type="button" class="button button--ghost button--small" data-ticket-page-clock-history>View clock history</button>
-                    </div>
-                  </details>
                 </div>
                 <div class="ticket-reply-submit" data-ticket-reply-submit>
                   <input type="hidden" name="replyStatus" value="" data-ticket-reply-status-input />

--- a/tests/test_ticket_page_clocks.py
+++ b/tests/test_ticket_page_clocks.py
@@ -1,12 +1,16 @@
 from pathlib import Path
 
 
-def test_ticket_page_clock_is_available_in_reply_form():
+def test_ticket_page_clock_history_is_available_from_the_header_actions_menu():
     template = Path("app/templates/admin/ticket_detail.html").read_text()
 
     assert 'data-ticket-page-clock data-ticket-id="{{ ticket.id }}"' in template
     assert "Time open" in template
-    assert "data-ticket-page-clock-history" in template
+    assert '"label": "Clock history"' in template
+    assert '"data-ticket-page-clock-history": true' in template
+    assert 'clock.querySelector(\'[data-ticket-page-clock-history]\')' not in Path(
+        "app/static/js/ticket_detail.js"
+    ).read_text()
 
 
 def test_ticket_page_clock_script_records_and_displays_clock_history():
@@ -16,6 +20,14 @@ def test_ticket_page_clock_script_records_and_displays_clock_history():
     assert "/page-clocks" in script
     assert "navigator.wakeLock.request('screen')" in script
     assert "pagehide" in script
+
+
+def test_ticket_clock_history_uses_the_users_name_columns():
+    repository = Path("app/repositories/ticket_clocks.py").read_text()
+
+    assert "u.display_name" not in repository
+    assert "u.first_name" in repository
+    assert "u.last_name" in repository
 
 
 def test_ticket_page_clock_routes_are_registered():


### PR DESCRIPTION
### Motivation
- Place the existing "Clock history" action alongside "Audit Trail" in the page header so the control is in the top-right actions menu where other ticket-level actions live.
- Fix the runtime error when loading clock history caused by selecting a non-existent `users.display_name` column in the clocks query.

### Description
- Added a header action for Clock history in `app/templates/admin/ticket_detail.html` via `page_header_actions` and removed the duplicate inline history button from the reply form. 
- Updated the client script in `app/static/js/ticket_detail.js` to bind the history dialog to the header action using `document.querySelector('[data-ticket-page-clock-history]')` while keeping the in-form active clock display intact. 
- Replaced the invalid `u.display_name` reference with a derived `user_display_name` built from `u.first_name` and `u.last_name` in `app/repositories/ticket_clocks.py` to avoid the SQL error. 
- Added and adjusted tests in `tests/test_ticket_page_clocks.py` to assert the action placement and that the repository uses `u.first_name`/`u.last_name` for display names.

### Testing
- Ran `pytest -q tests/test_ticket_page_clocks.py` and observed `4 passed` indicating the new/updated tests succeeded. 
- Ran `python -m compileall -q app/repositories/ticket_clocks.py app/features/tickets/admin_routes.py` which completed without errors. 
- Ran `git diff --check` which produced no whitespace or trailing-eol issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a59cfb399dc8332830882193438e416)