### PR TITLE
Fix automation status label filter matching

### DIFF
--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -280,11 +280,36 @@ def _compile_like_pattern(pattern: str) -> re.Pattern[str]:
     return re.compile("".join(pieces))
 
 
+def _normalise_string_token(value: str) -> str:
+    """Return a stable token for comparing human labels with stored slugs."""
+
+    text = value.strip().casefold()
+    return re.sub(r"[^a-z0-9]+", "_", text).strip("_")
+
+
+def _has_unescaped_like_wildcard(value: str) -> bool:
+    escaped = False
+    for char in value:
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "%":
+            return True
+    return False
+
+
 def _string_value_matches(actual: Any, expected: str) -> bool:
     if not isinstance(actual, str):
         return False
     pattern = _compile_like_pattern(expected)
-    return bool(pattern.fullmatch(actual))
+    if pattern.fullmatch(actual):
+        return True
+    if _has_unescaped_like_wildcard(expected):
+        return False
+    return _normalise_string_token(actual) == _normalise_string_token(expected)
 
 
 _REGEX_PATTERN_MAX_LENGTH = 256

--- a/tests/test_automation_trigger_filters.py
+++ b/tests/test_automation_trigger_filters.py
@@ -85,6 +85,26 @@ def test_filters_match_ticket_boolean_and_time_automation_fields():
     )
 
 
+def test_filters_match_ticket_status_human_label_against_slug():
+    context = {"ticket": {"status": "waiting_on_client", "in_status_age_hours": 97}}
+    filters = {
+        "all": [
+            {"greater_than_or_equal": {"ticket.in_status_age_hours": "96"}},
+            {"match": {"ticket.status": "Waiting on client"}},
+        ]
+    }
+
+    assert automations_service._filters_match(filters, context)
+
+
+def test_filters_match_ticket_status_slug_against_human_label():
+    context = {"ticket": {"status": "Waiting on client"}}
+
+    assert automations_service._filters_match(
+        {"match": {"ticket.status": "waiting_on_client"}}, context
+    )
+
+
 def test_filters_match_string_operator_variants():
     context = {"ticket": {"subject": "Network outage for payroll"}}
 


### PR DESCRIPTION
### Motivation
- Automation filters that used exact `match` comparisons failed to treat human-readable ticket status labels (e.g. `"Waiting on client"`) as equivalent to stored slug values (e.g. `waiting_on_client`), causing scheduled/event automations to miss matching tickets.
- The change must preserve existing SQL-like `%`/`_` wildcard behaviour used by `match` patterns.

### Description
- Add `_normalise_string_token` to produce a stable token from human labels and slugs for canonical comparison.
- Add `_has_unescaped_like_wildcard` and update `_string_value_matches` so wildcard-containing patterns still use the LIKE semantics while exact-string matches fall back to comparing normalized tokens.
- Add regression tests `test_filters_match_ticket_status_human_label_against_slug` and `test_filters_match_ticket_status_slug_against_human_label` to `tests/test_automation_trigger_filters.py` to cover both directions of status label/slug matching.

### Testing
- Ran `pytest tests/test_automation_trigger_filters.py tests/test_automations_service.py -q` and the test suites passed with all tests succeeding.
- The change preserves existing wildcard `match` semantics and the new tests verify human-label/slug equivalence for automation filters.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5d7d0c53288332ad8f15cdb413c1fe)