### PR TITLE
Normalize email lookups, carry external author metadata into tickets, and improve staff resolution

### DIFF
--- a/app/repositories/users.py
+++ b/app/repositories/users.py
@@ -35,7 +35,18 @@ def _build_safe_update_clause(updates: dict[str, Any]) -> tuple[str, list[Any]]:
 
 
 async def get_user_by_email(email: str) -> Optional[dict[str, Any]]:
-    row = await db.fetch_one("SELECT * FROM users WHERE email = %s", (email,))
+    clean_email = str(email or "").strip()
+    if not clean_email:
+        return None
+    row = await db.fetch_one(
+        """
+        SELECT * FROM users
+        WHERE LOWER(email) = LOWER(%s)
+        ORDER BY id ASC
+        LIMIT 1
+        """,
+        (clean_email,),
+    )
     return row
 
 

--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -713,6 +713,24 @@ def _search_message_uids(
     return [], last_error
 
 
+def _select_staff_contact(
+    staff_records: list[Mapping[str, Any]],
+    *,
+    preferred_company_id: int | None = None,
+) -> tuple[int | None, int | None]:
+    if not staff_records:
+        return None, None
+    selected: Mapping[str, Any] | None = None
+    if preferred_company_id is not None:
+        for staff_record in staff_records:
+            if _int_or_none(staff_record.get("company_id")) == preferred_company_id:
+                selected = staff_record
+                break
+    if selected is None:
+        selected = staff_records[0]
+    return _int_or_none(selected.get("company_id")), _extract_record_id(selected)
+
+
 async def _resolve_ticket_entities(
     from_header: str | None,
     *,
@@ -766,7 +784,25 @@ async def _resolve_ticket_entities(
             return company_id, None, requester_staff_id
         return company_id, None, None
 
-    company_id = _int_or_none(default_company_id)
+    default_company_id_int = _int_or_none(default_company_id)
+
+    for email_address in email_addresses:
+        try:
+            staff_records = await staff_repo.list_staff_by_email(email_address)
+        except RuntimeError as exc:  # pragma: no cover - defensive fallback
+            log_error(
+                "Failed to resolve staff contact by email",
+                email=email_address,
+                error=str(exc),
+            )
+            staff_records = []
+        staff_company_id, staff_id = _select_staff_contact(
+            staff_records, preferred_company_id=default_company_id_int
+        )
+        if staff_id is not None:
+            return staff_company_id or default_company_id_int, None, staff_id
+
+    company_id = default_company_id_int
     requester_id: int | None = None
     requester_staff_id: int | None = None
 
@@ -1881,6 +1917,12 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                         external_reference=_normalise_ticket_external_reference(message_id),
                         initial_reply_author_id=requester_id,
                         requester_email=from_email_addr if requester_id is None else None,
+                        initial_reply_author_email=(
+                            from_email_addr if requester_id is None else None
+                        ),
+                        initial_reply_author_display_name=(
+                            from_address if requester_id is None else None
+                        ),
                     )
                     is_new_ticket = True
                     ticket_id = ticket.get("id") if isinstance(ticket, Mapping) else None

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -1448,6 +1448,12 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                             requester_email=(
                                 from_email_addr if requester_id is None else None
                             ),
+                            initial_reply_author_email=(
+                                from_email_addr if requester_id is None else None
+                            ),
+                            initial_reply_author_display_name=(
+                                (from_header or from_address) if requester_id is None else None
+                            ),
                             record_initial_reply=not create_initial_reply_after_inline_persist,
                         )
                         is_new_ticket = True

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -1195,6 +1195,8 @@ async def create_ticket(
     initial_reply_author_id: int | None = None,
     id: int | None = None,
     requester_email: str | None = None,
+    initial_reply_author_email: str | None = None,
+    initial_reply_author_display_name: str | None = None,
     send_creation_notification: bool = True,
     record_initial_reply: bool = True,
 ) -> TicketRecord:
@@ -1248,6 +1250,10 @@ async def create_ticket(
                 author_id=author_id,
                 body=original_description,
                 is_internal=False,
+                author_email=initial_reply_author_email if author_id is None else None,
+                author_display_name=(
+                    initial_reply_author_display_name if author_id is None else None
+                ),
             )
         except Exception as exc:  # pragma: no cover - defensive logging
             log_error(

--- a/tests/test_imap_service.py
+++ b/tests/test_imap_service.py
@@ -212,6 +212,44 @@ async def test_resolve_ticket_entities_handles_staff_without_user(monkeypatch):
     assert requester_staff_id == 123
 
 
+async def test_resolve_ticket_entities_falls_back_to_existing_staff_contact_company(monkeypatch):
+    async def fake_get_company_by_email_domain(domain: str):
+        assert domain == "example.com"
+        return None
+
+    async def fake_get_user_by_email(email: str):
+        assert email == "sender@example.com"
+        return None
+
+    async def fake_list_staff_by_email(email: str):
+        assert email == "sender@example.com"
+        return [{"id": 321, "company_id": 654}]
+
+    async def fake_get_staff_by_company_and_email(company_id: int, email: str):
+        raise AssertionError("staff should be resolved from existing contacts globally")
+
+    monkeypatch.setattr(
+        imap.company_repo,
+        "get_company_by_email_domain",
+        fake_get_company_by_email_domain,
+    )
+    monkeypatch.setattr(imap.users_repo, "get_user_by_email", fake_get_user_by_email)
+    monkeypatch.setattr(imap.staff_repo, "list_staff_by_email", fake_list_staff_by_email)
+    monkeypatch.setattr(
+        imap.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
+    )
+
+    company_id, requester_id, requester_staff_id = await imap._resolve_ticket_entities(
+        "Sender <sender@example.com>"
+    )
+
+    assert company_id == 654
+    assert requester_id is None
+    assert requester_staff_id == 321
+
+
 async def test_sync_account_does_not_mark_as_read_on_ticket_failure(monkeypatch):
     recorded_messages: list[dict[str, object]] = []
     account_updates: list[tuple[int, dict[str, object]]] = []

--- a/tests/test_tickets_service_create.py
+++ b/tests/test_tickets_service_create.py
@@ -38,9 +38,13 @@ async def test_create_ticket_triggers_automations(monkeypatch):
 
     monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
-    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(
+        tickets_service.company_repo, "get_company_by_id", fake_get_company
+    )
     monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
-    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
+    monkeypatch.setattr(
+        tickets_service, "resolve_status_or_default", fake_resolve_status
+    )
 
     ticket = await tickets_service.create_ticket(
         subject="Printer offline",
@@ -88,9 +92,13 @@ async def test_create_ticket_can_skip_automations(monkeypatch):
 
     monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
-    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(
+        tickets_service.company_repo, "get_company_by_id", fake_get_company
+    )
     monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
-    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
+    monkeypatch.setattr(
+        tickets_service, "resolve_status_or_default", fake_resolve_status
+    )
 
     ticket = await tickets_service.create_ticket(
         subject="Laptop setup",
@@ -193,9 +201,13 @@ async def test_create_ticket_truncates_long_description(monkeypatch):
 
     monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
-    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(
+        tickets_service.company_repo, "get_company_by_id", fake_get_company
+    )
     monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
-    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
+    monkeypatch.setattr(
+        tickets_service, "resolve_status_or_default", fake_resolve_status
+    )
 
     long_description = "A" * (tickets_service._MAX_TICKET_DESCRIPTION_BYTES + 512)
 
@@ -252,9 +264,13 @@ async def test_create_ticket_initial_reply_uses_full_description(monkeypatch):
     monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
-    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(
+        tickets_service.company_repo, "get_company_by_id", fake_get_company
+    )
     monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
-    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
+    monkeypatch.setattr(
+        tickets_service, "resolve_status_or_default", fake_resolve_status
+    )
 
     long_description = "B" * (tickets_service._MAX_TICKET_DESCRIPTION_BYTES + 128)
 
@@ -315,9 +331,13 @@ async def test_create_ticket_records_initial_reply(monkeypatch):
     monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
-    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(
+        tickets_service.company_repo, "get_company_by_id", fake_get_company
+    )
     monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
-    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
+    monkeypatch.setattr(
+        tickets_service, "resolve_status_or_default", fake_resolve_status
+    )
 
     ticket = await tickets_service.create_ticket(
         subject="VPN issue",
@@ -368,9 +388,13 @@ async def test_create_ticket_records_initial_reply_without_author(monkeypatch):
     monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
     monkeypatch.setattr(automations_service, "handle_event", fake_handle_event)
-    monkeypatch.setattr(tickets_service.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(
+        tickets_service.company_repo, "get_company_by_id", fake_get_company
+    )
     monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
-    monkeypatch.setattr(tickets_service, "resolve_status_or_default", fake_resolve_status)
+    monkeypatch.setattr(
+        tickets_service, "resolve_status_or_default", fake_resolve_status
+    )
 
     ticket = await tickets_service.create_ticket(
         subject="Automation created",
@@ -594,3 +618,62 @@ async def test_emit_ticket_updated_event_auto_detects_requester(monkeypatch):
     actor_meta = context["ticket_update"]
     assert actor_meta["actor_type"] == "requester"
     assert actor_meta["actor_label"] == "Requester"
+
+
+@pytest.mark.anyio
+async def test_create_ticket_records_initial_reply_external_author(monkeypatch):
+    async def fake_create_ticket(**kwargs):
+        return {**kwargs, "id": 88}
+
+    async def fake_create_reply(**kwargs):
+        created_replies.append(kwargs)
+        return {"id": 1, **kwargs}
+
+    async def fake_get_company(_company_id):
+        return None
+
+    async def fake_get_user(_user_id):
+        return None
+
+    async def fake_resolve_status(value):
+        return value or "open"
+
+    created_replies: list[dict[str, object]] = []
+    monkeypatch.setattr(tickets_repo, "create_ticket", fake_create_ticket)
+    monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
+    monkeypatch.setattr(
+        tickets_service.company_repo, "get_company_by_id", fake_get_company
+    )
+    monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user)
+    monkeypatch.setattr(
+        tickets_service, "resolve_status_or_default", fake_resolve_status
+    )
+
+    await tickets_service.create_ticket(
+        subject="Imported email",
+        description="From: Sender <sender@example.com>\n\nPlease help",
+        requester_id=None,
+        requester_staff_id=None,
+        company_id=12,
+        assigned_user_id=None,
+        priority="normal",
+        status="open",
+        category="email",
+        module_slug="imap",
+        external_reference="msg-1",
+        ticket_number=None,
+        trigger_automations=False,
+        initial_reply_author_email="sender@example.com",
+        initial_reply_author_display_name="Sender <sender@example.com>",
+    )
+
+    assert created_replies == [
+        {
+            "ticket_id": 88,
+            "author_id": None,
+            "body": "From: Sender <sender@example.com>\n\nPlease help",
+            "is_internal": False,
+            "author_email": "sender@example.com",
+            "author_display_name": "Sender <sender@example.com>",
+        }
+    ]

--- a/tests/test_users_repository_sql_safety.py
+++ b/tests/test_users_repository_sql_safety.py
@@ -63,3 +63,35 @@ async def test_get_user_by_phone_ignores_empty_normalised_values(monkeypatch):
 
     assert await users.get_user_by_phone("+ - ()") is None
     assert not queried
+
+
+@pytest.mark.anyio
+async def test_get_user_by_email_is_case_insensitive_and_trims(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_one(query, params):
+        captured["query"] = query
+        captured["params"] = params
+        return {"id": 7, "email": "Sender@Example.com"}
+
+    monkeypatch.setattr(users.db, "fetch_one", fake_fetch_one)
+
+    result = await users.get_user_by_email(" sender@example.COM ")
+
+    assert result == {"id": 7, "email": "Sender@Example.com"}
+    assert captured["params"] == ("sender@example.COM",)
+    assert "LOWER(email) = LOWER(%s)" in captured["query"]
+
+
+@pytest.mark.anyio
+async def test_get_user_by_email_ignores_empty_values(monkeypatch):
+    queried = False
+
+    async def fake_fetch_one(*args, **kwargs):
+        nonlocal queried
+        queried = True
+
+    monkeypatch.setattr(users.db, "fetch_one", fake_fetch_one)
+
+    assert await users.get_user_by_email("   ") is None
+    assert not queried


### PR DESCRIPTION
### Motivation

- Ensure user lookups by email are robust by trimming input and making comparisons case-insensitive so imported or user-provided addresses match stored records.
- Preserve external email author metadata (email and display name) when creating tickets from inbound mail so the initial reply can record the external sender when no local user exists.
- Improve resolution of staff contacts for inbound messages by checking global staff records and preferring contacts belonging to a provided company, with a defensive fallback and logging on errors.

### Description

- Updated `get_user_by_email` to trim input, return `None` for empty input, and query using case-insensitive comparison (`LOWER(email) = LOWER(%s)`) with an `ORDER BY id LIMIT 1` fallback. 
- Added `_select_staff_contact` helper and updated `_resolve_ticket_entities` to call `staff_repo.list_staff_by_email` as a global fallback, prefer a staff record matching `preferred_company_id`, and log errors when the list call fails. 
- Propagated external author metadata through IMAP and M365 sync flows by passing `initial_reply_author_email` and `initial_reply_author_display_name` into `tickets_service.create_ticket`. 
- Extended `create_ticket` to accept `initial_reply_author_email` and `initial_reply_author_display_name` and to forward those values into the initial reply created by `tickets_repo.create_reply` when `initial_reply_author_id` is not set. 
- Added and adjusted unit tests to verify case-insensitive email lookups, staff contact fallback resolution, and that initial replies record external author email and display name; also normalized some test monkeypatch formatting.

### Testing

- Ran the async unit test suite with `pytest` focusing on `tests/test_imap_service.py`, `tests/test_tickets_service_create.py`, and `tests/test_users_repository_sql_safety.py` which include the new and updated tests. 
- Tests verifying email normalization, staff fallback resolution, and external author reply recording were executed and passed. 
- Overall test run with `pytest` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5dba0e933c83328ce4f492746a4120)