### PR TITLE
Fix scheduled ticket automation scan coverage

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -580,7 +580,9 @@ async def mark_replies_non_billable(reply_ids: Sequence[int]) -> int:
     )
 
 
-async def list_tickets_for_automation_scan(*, limit: int = 1000) -> list[TicketRecord]:
+async def list_tickets_for_automation_scan(
+    *, limit: int = 1000, offset: int = 0
+) -> list[TicketRecord]:
     """Return recent ticket records with reply timestamps for scheduled automations.
 
     Scheduled automations apply their filter JSON in Python so the same nested
@@ -590,6 +592,7 @@ async def list_tickets_for_automation_scan(*, limit: int = 1000) -> list[TicketR
     """
 
     safe_limit = max(1, min(int(limit or 1000), 5000))
+    safe_offset = max(0, int(offset or 0))
     rows = await db.fetch_all(
         """
         SELECT
@@ -602,9 +605,9 @@ async def list_tickets_for_automation_scan(*, limit: int = 1000) -> list[TicketR
         FROM tickets t
         WHERE t.merged_into_ticket_id IS NULL
         ORDER BY COALESCE(t.status_changed_at, t.created_at, t.updated_at) ASC, t.updated_at ASC, t.id ASC
-        LIMIT %s
+        LIMIT %s OFFSET %s
         """,
-        (safe_limit,),
+        (safe_limit, safe_offset),
     )
     records: list[TicketRecord] = []
     for row in rows:

--- a/app/services/automations.py
+++ b/app/services/automations.py
@@ -19,6 +19,9 @@ from app.repositories import tickets as tickets_repo
 from app.services import modules as modules_service
 from app.services import value_templates
 
+SCHEDULED_TICKET_SCAN_BATCH_SIZE = 1000
+SCHEDULED_TICKET_SCAN_MAX_CANDIDATES = 50000
+
 TRIGGER_EVENTS: list[dict[str, str]] = [
     {"value": "tickets.created", "label": "Ticket created"},
     {"value": "tickets.updated", "label": "Ticket updated"},
@@ -899,6 +902,42 @@ async def _invoke_automation_actions_for_context(
     return {"status": "skipped", "reason": "No action module configured"}, None
 
 
+async def _list_ticket_automation_scan_candidates(
+    *,
+    limit: int,
+    exhaustive: bool = False,
+) -> list[dict[str, Any]]:
+    """Load ordered ticket candidates for scheduled automation evaluation.
+
+    Preview endpoints preserve their caller-provided scan cap so the UI remains
+    responsive. Real scheduled runs page through a much larger bounded window so
+    stale tickets are not skipped merely because they sit beyond the first
+    repository batch.
+    """
+
+    if not exhaustive:
+        scan_limit = max(1, min(int(limit or 1000), 5000))
+        return await tickets_repo.list_tickets_for_automation_scan(limit=scan_limit)
+
+    max_candidates = max(1, int(limit or SCHEDULED_TICKET_SCAN_MAX_CANDIDATES))
+    batch_size = max(1, min(SCHEDULED_TICKET_SCAN_BATCH_SIZE, 5000, max_candidates))
+    candidates: list[dict[str, Any]] = []
+    offset = 0
+    while len(candidates) < max_candidates:
+        remaining = max_candidates - len(candidates)
+        batch = await tickets_repo.list_tickets_for_automation_scan(
+            limit=min(batch_size, remaining),
+            offset=offset,
+        )
+        if not batch:
+            break
+        candidates.extend(batch)
+        if len(batch) < min(batch_size, remaining):
+            break
+        offset += len(batch)
+    return candidates
+
+
 async def _scan_tickets_for_automation(
     automation: Mapping[str, Any],
     *,
@@ -911,7 +950,7 @@ async def _scan_tickets_for_automation(
     raw_filters = automation.get("trigger_filters")
     filters = raw_filters if isinstance(raw_filters, Mapping) else None
     scan_limit = max(1, min(int(limit or 1000), 5000))
-    scanned = await tickets_repo.list_tickets_for_automation_scan(limit=scan_limit)
+    scanned = await _list_ticket_automation_scan_candidates(limit=scan_limit)
     matches: list[dict[str, Any]] = []
 
     from app.services import tickets as tickets_service
@@ -1177,7 +1216,10 @@ async def _execute_scheduled_ticket_automation(
     now = datetime.now(timezone.utc)
     raw_filters = automation.get("trigger_filters")
     filters = raw_filters if isinstance(raw_filters, Mapping) else None
-    scanned = await tickets_repo.list_tickets_for_automation_scan(limit=1000)
+    scanned = await _list_ticket_automation_scan_candidates(
+        limit=SCHEDULED_TICKET_SCAN_MAX_CANDIDATES,
+        exhaustive=True,
+    )
     matched = 0
     succeeded = 0
     failed = 0

--- a/tests/test_automations_service.py
+++ b/tests/test_automations_service.py
@@ -235,6 +235,7 @@ def test_filters_match_accepts_human_readable_operator_keys():
         context,
     )
 
+
 @pytest.mark.anyio
 async def test_execute_automation_interpolates_context(monkeypatch):
     captured: list[tuple[str, dict[str, object]]] = []
@@ -891,9 +892,17 @@ async def test_execute_scheduled_ticket_automation_runs_actions_for_matching_tic
     ]
     captured: list[tuple[str, dict[str, object]]] = []
 
-    async def fake_list_tickets_for_automation_scan(*, limit: int = 1000):
-        assert limit == 1000
-        return scanned_tickets
+    monkeypatch.setattr(automations_service, "SCHEDULED_TICKET_SCAN_BATCH_SIZE", 1)
+
+    async def fake_list_tickets_for_automation_scan(
+        *, limit: int = 1000, offset: int = 0
+    ):
+        assert limit == 1
+        if offset == 0:
+            return scanned_tickets[:1]
+        if offset == 1:
+            return scanned_tickets[1:]
+        return []
 
     async def fake_enrich(ticket):
         return dict(ticket)
@@ -1018,7 +1027,9 @@ async def test_preview_scheduled_ticket_automation_returns_matches_without_actio
         },
     ]
 
-    async def fake_list_tickets_for_automation_scan(*, limit: int = 1000):
+    async def fake_list_tickets_for_automation_scan(
+        *, limit: int = 1000, offset: int = 0
+    ):
         assert limit == 25
         return scanned_tickets
 
@@ -1102,7 +1113,9 @@ async def test_simulate_event_ticket_automation_processes_selected_matches(monke
         assert automation_id == 13
         return automation
 
-    async def fake_list_tickets_for_automation_scan(*, limit: int = 1000):
+    async def fake_list_tickets_for_automation_scan(
+        *, limit: int = 1000, offset: int = 0
+    ):
         assert limit == 50
         return scanned_tickets
 

--- a/tests/test_tickets_repository.py
+++ b/tests/test_tickets_repository.py
@@ -180,7 +180,7 @@ async def test_create_ticket_returns_inserted_record(monkeypatch):
         "ai_summary_model": None,
         "ai_resolution_state": None,
         "ai_summary_updated_at": None,
-        "ai_tags": "[\"printer\", \"hardware\"]",
+        "ai_tags": '["printer", "hardware"]',
         "ai_tags_status": "succeeded",
         "ai_tags_model": "llama3",
         "ai_tags_updated_at": None,
@@ -292,8 +292,16 @@ async def test_replace_ticket_assets_updates_links(monkeypatch):
 
     assets = await tickets.replace_ticket_assets(77, [2, 3])
 
-    delete_calls = [call for call in dummy_db.execute_calls if call[0].startswith("DELETE FROM ticket_assets")]
-    insert_calls = [call for call in dummy_db.execute_calls if call[0].startswith("INSERT INTO ticket_assets")]
+    delete_calls = [
+        call
+        for call in dummy_db.execute_calls
+        if call[0].startswith("DELETE FROM ticket_assets")
+    ]
+    insert_calls = [
+        call
+        for call in dummy_db.execute_calls
+        if call[0].startswith("INSERT INTO ticket_assets")
+    ]
 
     assert delete_calls
     assert insert_calls
@@ -329,7 +337,10 @@ async def test_create_reply_returns_inserted_record(monkeypatch):
     assert record["is_billable"] is True
     assert "SELECT tr.*, lt.name AS labour_type_name" in dummy_db.fetch_sql
     assert "FROM ticket_replies tr" in dummy_db.fetch_sql
-    assert "LEFT JOIN ticket_labour_types lt ON tr.labour_type_id = lt.id" in dummy_db.fetch_sql
+    assert (
+        "LEFT JOIN ticket_labour_types lt ON tr.labour_type_id = lt.id"
+        in dummy_db.fetch_sql
+    )
     assert dummy_db.fetch_params == (42,)
     assert record["kind"] == "message"
 
@@ -382,7 +393,10 @@ async def test_automation_filter_context_treats_shipment_reply_as_system(monkeyp
     await tickets.get_automation_filter_context_by_ticket_ids([5])
 
     latest_query = dummy_db.fetch_calls[-1][0]
-    assert "WHEN tr.external_reference LIKE 'shipment-watch:%%' THEN 'system'" in latest_query
+    assert (
+        "WHEN tr.external_reference LIKE 'shipment-watch:%%' THEN 'system'"
+        in latest_query
+    )
 
 
 @pytest.mark.anyio
@@ -404,7 +418,10 @@ async def test_get_reply_by_id_fetches_normalised_record(monkeypatch):
 
     assert "SELECT tr.*, lt.name AS labour_type_name" in dummy_db.fetch_sql
     assert "FROM ticket_replies tr" in dummy_db.fetch_sql
-    assert "LEFT JOIN ticket_labour_types lt ON tr.labour_type_id = lt.id" in dummy_db.fetch_sql
+    assert (
+        "LEFT JOIN ticket_labour_types lt ON tr.labour_type_id = lt.id"
+        in dummy_db.fetch_sql
+    )
     assert dummy_db.fetch_params == (15,)
     assert record["id"] == 15
     assert record["minutes_spent"] == 10
@@ -436,7 +453,10 @@ async def test_update_reply_updates_minutes_and_billable(monkeypatch):
         in dummy_db.fetch_sql
     )
     assert "FROM ticket_replies tr" in dummy_db.fetch_sql
-    assert "LEFT JOIN ticket_labour_types lt ON tr.labour_type_id = lt.id" in dummy_db.fetch_sql
+    assert (
+        "LEFT JOIN ticket_labour_types lt ON tr.labour_type_id = lt.id"
+        in dummy_db.fetch_sql
+    )
     assert "WHERE tr.id = %s" in dummy_db.fetch_sql
     assert record["minutes_spent"] == 15
     assert record["is_billable"] is True
@@ -483,7 +503,7 @@ async def test_get_ticket_by_external_reference(monkeypatch):
         "ai_summary_model": None,
         "ai_resolution_state": None,
         "ai_summary_updated_at": None,
-        "ai_tags": "[\"sample\"]",
+        "ai_tags": '["sample"]',
         "ai_tags_status": None,
         "ai_tags_model": None,
         "ai_tags_updated_at": None,
@@ -593,7 +613,9 @@ async def test_delete_tickets_returns_deleted_count(monkeypatch):
     deleted = await tickets.delete_tickets([1, "2", "ignored", 0, -5, 2])
 
     assert deleted == 2
-    assert dummy_db.fetch_sql.startswith("SELECT COUNT(*) AS total FROM tickets WHERE id IN")
+    assert dummy_db.fetch_sql.startswith(
+        "SELECT COUNT(*) AS total FROM tickets WHERE id IN"
+    )
     assert dummy_db.fetch_params == (1, 2)
     assert dummy_db.execute_sql.startswith("DELETE FROM tickets WHERE id IN")
     assert dummy_db.execute_params == (1, 2)
@@ -722,7 +744,7 @@ async def test_automation_scan_orders_by_status_age_candidates(monkeypatch):
     records = await tickets.list_tickets_for_automation_scan(limit=250)
 
     assert records == []
-    assert dummy_db.fetch_params == (250,)
+    assert dummy_db.fetch_params == (250, 0)
     assert (
         "ORDER BY COALESCE(t.status_changed_at, t.created_at, t.updated_at) ASC, "
         "t.updated_at ASC, t.id ASC"


### PR DESCRIPTION
### Motivation
- Scheduled ticket automations were skipping older tickets because repository scans were limited to a single bounded batch, causing age-in-state filters (e.g. 96 hours) to miss candidates beyond the first query window.

### Description
- Added `offset` pagination to `tickets.list_tickets_for_automation_scan` so callers can request ordered pages using `LIMIT %s OFFSET %s` (file: `app/repositories/tickets.py`).
- Introduced scan constants `SCHEDULED_TICKET_SCAN_BATCH_SIZE` and `SCHEDULED_TICKET_SCAN_MAX_CANDIDATES` and a helper `_list_ticket_automation_scan_candidates` that page-through batches when `exhaustive=True`, while preserving caller-provided caps for preview runs (file: `app/services/automations.py`).
- Updated scheduled-run paths to use the new paged candidate loader and kept preview paths using the original single-batch limit to preserve UI responsiveness (file: `app/services/automations.py`).
- Updated unit tests to accept the new `offset` parameter and to exercise paginated scheduled execution and repository behavior (files: `tests/test_automations_service.py`, `tests/test_tickets_repository.py`).

### Testing
- Ran formatting with `python -m black` on modified files, which completed successfully.
- Ran targeted tests with `pytest` including `tests/test_tickets_repository.py::test_automation_scan_orders_by_status_age_candidates` and several `tests/test_automations_service.py` cases, and they all passed locally (3 passed for the final test run, full output showed warnings only).
- Verified the new behavior by mocking paged repository responses in `test_execute_scheduled_ticket_automation_runs_actions_for_matching_tickets` and confirming the scan aggregated and actioned tickets from subsequent pages (tests updated and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5e9797f60883328f9017429d4d9b20)