### PR TITLE
Fix stock feed decimal coercion

### DIFF
--- a/app/services/products.py
+++ b/app/services/products.py
@@ -5,7 +5,7 @@ import html
 import socket
 from ipaddress import ip_address
 from datetime import date, datetime, timezone
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from pathlib import Path
 from typing import Any, Mapping
 from urllib.parse import urlparse
@@ -89,6 +89,25 @@ def _to_decimal(value: Any, *, default: Decimal | None = None) -> Decimal | None
         return Decimal(str(value))
     except (TypeError, ValueError, ArithmeticError):
         return default
+
+
+def _to_stock_feed_decimal(
+    value: Any, *, default: Decimal | None = None
+) -> Decimal | None:
+    """Coerce feed numbers to the stock_feed DECIMAL(10,2) column shape."""
+
+    decimal_value = _to_decimal(value, default=default)
+    if decimal_value is None:
+        return default
+
+    try:
+        rounded = decimal_value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    except (InvalidOperation, ValueError, ArithmeticError):
+        return default
+
+    if abs(rounded) >= Decimal("100000000"):
+        return default
+    return rounded
 
 
 def _parse_stock_date(value: Any) -> date | None:
@@ -319,7 +338,7 @@ def _parse_feed_item(element: Element) -> dict[str, Any] | None:
         "sku": sku_cleaned,
         "product_name": product_name,
         "product_name2": product_name2,
-        "rrp": _to_decimal(_get_feed_value(element, "RRP", "rrp")),
+        "rrp": _to_stock_feed_decimal(_get_feed_value(element, "RRP", "rrp")),
         "category_name": category_name,
         "on_hand_nsw": _coerce_feed_int(
             _get_feed_value(element, "OnHandChanelNsw", "on_hand_nsw")
@@ -333,11 +352,11 @@ def _parse_feed_item(element: Element) -> dict[str, Any] | None:
         "on_hand_sa": _coerce_feed_int(
             _get_feed_value(element, "OnHandChanelSa", "on_hand_sa")
         ),
-        "dbp": _to_decimal(_get_feed_value(element, "DBP", "dbp")),
-        "weight": _to_decimal(_get_feed_value(element, "Weight", "weight")),
-        "length": _to_decimal(_get_feed_value(element, "Length", "length")),
-        "width": _to_decimal(_get_feed_value(element, "Width", "width")),
-        "height": _to_decimal(_get_feed_value(element, "Height", "height")),
+        "dbp": _to_stock_feed_decimal(_get_feed_value(element, "DBP", "dbp")),
+        "weight": _to_stock_feed_decimal(_get_feed_value(element, "Weight", "weight")),
+        "length": _to_stock_feed_decimal(_get_feed_value(element, "Length", "length")),
+        "width": _to_stock_feed_decimal(_get_feed_value(element, "Width", "width")),
+        "height": _to_stock_feed_decimal(_get_feed_value(element, "Height", "height")),
         "pub_date": pub_date,
         "warranty_length": warranty_length,
         "manufacturer": manufacturer,

--- a/tests/test_products_service.py
+++ b/tests/test_products_service.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call
 
@@ -250,6 +251,42 @@ def test_parse_stock_feed_xml_reports_parse_error_details():
     assert "mismatched tag" in message
     assert "line 1" in message
     assert "column" in message
+
+
+def test_parse_stock_feed_xml_rounds_weight_to_column_scale():
+    xml_payload = """
+        <rss>
+          <channel>
+            <item>
+              <StockCode>ROUND1</StockCode>
+              <ProductName>Rounded Weight</ProductName>
+              <Weight>0.125</Weight>
+            </item>
+          </channel>
+        </rss>
+    """
+
+    items = products_service._parse_stock_feed_xml(xml_payload)
+
+    assert items[0]["weight"] == Decimal("0.13")
+
+
+def test_parse_stock_feed_xml_ignores_weight_too_large_for_column():
+    xml_payload = """
+        <rss>
+          <channel>
+            <item>
+              <StockCode>HEAVY1</StockCode>
+              <ProductName>Too Heavy</ProductName>
+              <Weight>100000000</Weight>
+            </item>
+          </channel>
+        </rss>
+    """
+
+    items = products_service._parse_stock_feed_xml(xml_payload)
+
+    assert items[0]["weight"] is None
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation

- Prevent MySQL "Data truncated for column 'weight'" warnings by ensuring feed numeric values match the `stock_feed` table's `DECIMAL(10,2)` shape before persistence.
- Ensure high-precision or out-of-range feed values do not cause silent truncation or database warnings during imports.
- Add regression coverage for rounding and out-of-range scenarios so parsing behavior is explicit and tested.

### Description

- Added a new helper `_to_stock_feed_decimal` in `app/services/products.py` that coerces values to two-decimal `Decimal` using `ROUND_HALF_UP`, rejects uncoercible values, and drops values outside the column range. 
- Applied `_to_stock_feed_decimal` to feed numeric fields (`rrp`, `dbp`, `weight`, `length`, `width`, `height`) during XML parsing in `app/services/products.py`.
- Imported the required decimal symbols (`InvalidOperation`, `ROUND_HALF_UP`) and kept the generic `_to_decimal` helper for non-column-coercion uses.
- Added two regression tests in `tests/test_products_service.py` to validate rounding to two decimals and ignoring out-of-range weight values.

### Testing

- Ran `pytest tests/test_products_service.py -q` and all tests in that file passed.
- The change is exercised by the new tests `test_parse_stock_feed_xml_rounds_weight_to_column_scale` and `test_parse_stock_feed_xml_ignores_weight_too_large_for_column`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5e986e5f2483328654b7c0406594e7)