### PR TITLE
Add active user account list (with O365 last sign-in) to company overview report

### DIFF
--- a/app/services/reports.py
+++ b/app/services/reports.py
@@ -196,9 +196,42 @@ async def _build_assets(company_id: int) -> dict[str, Any]:
     }
 
 
+def _staff_row_to_account(row: Mapping[str, Any]) -> dict[str, Any]:
+    first_name = row.get("first_name") or ""
+    last_name = row.get("last_name") or ""
+    name = row.get("name") or f"{first_name} {last_name}".strip()
+    return {
+        "first_name": first_name,
+        "last_name": last_name,
+        "name": name,
+        "email": row.get("email"),
+        "department": row.get("department"),
+        "job_title": row.get("position") or row.get("job_title"),
+        "mobile_phone": row.get("mobile_phone"),
+        "onboarding_status": row.get("onboarding_status"),
+        "m365_last_sign_in": _datetime_to_iso(row.get("m365_last_sign_in")),
+    }
+
+
+async def _list_active_staff_accounts(company_id: int) -> list[dict[str, Any]]:
+    rows = await db.fetch_all(
+        """
+        SELECT first_name, last_name, name, email, department, position, job_title,
+               mobile_phone, onboarding_status, m365_last_sign_in
+        FROM staff
+        WHERE company_id = %s
+          AND enabled = 1
+          AND NOT (LOWER(SUBSTR(email, 1, 8)) = 'package_')
+        ORDER BY LOWER(last_name), LOWER(first_name), LOWER(email)
+        """,
+        (company_id,),
+    )
+    return [_staff_row_to_account(row) for row in rows or []]
+
+
 async def _build_staff(company_id: int) -> dict[str, Any]:
-    total = await staff_repo.count_staff(company_id, enabled=True, exclude_package_staff=True)
-    return {"total_active": int(total)}
+    accounts = await _list_active_staff_accounts(company_id)
+    return {"total_active": len(accounts), "accounts": accounts}
 
 
 async def _build_m365_best_practices(company_id: int) -> dict[str, Any]:
@@ -640,23 +673,7 @@ async def _build_assets_detail(company_id: int) -> dict[str, Any]:
 
 async def _build_staff_detail(company_id: int) -> dict[str, Any]:
     """Full list of enabled staff for the detail page."""
-    rows = await staff_repo.list_staff(
-        company_id, enabled=True, exclude_package_staff=True, page_size=500
-    )
-    staff: list[dict[str, Any]] = []
-    for row in rows:
-        staff.append(
-            {
-                "name": row.get("name") or (
-                    f"{row.get('first_name', '')} {row.get('last_name', '')}".strip()
-                ),
-                "email": row.get("email"),
-                "mobile_phone": row.get("mobile_phone"),
-                "department": row.get("department"),
-                "position": row.get("position") or row.get("job_title"),
-                "onboarding_status": row.get("onboarding_status"),
-            }
-        )
+    staff = await _list_active_staff_accounts(company_id)
     return {"staff": staff, "total": len(staff)}
 
 

--- a/app/templates/reports/_sections/staff.html
+++ b/app/templates/reports/_sections/staff.html
@@ -1,11 +1,43 @@
 {% from "macros/counters.html" import counter_strip %}
 <section class="card card--panel" data-report-section="staff">
   <header class="card__header report-section__header">
-    <h2>Active staff</h2>
+    <h2>Active user accounts</h2>
+    <span class="report-section__meta">{{ section.data.total_active or 0 }} active users</span>
   </header>
   <div class="card__body">
     {{ counter_strip(items=[
-      {'label': 'Active staff', 'value': section.data.total_active or 0, 'variant': 'info'}
+      {'label': 'Active users', 'value': section.data.total_active or 0, 'variant': 'info'}
     ]) }}
+    {% set accounts = section.data.accounts or [] %}
+    {% if accounts %}
+      <div class="table-wrapper">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Email Address</th>
+            <th>Department</th>
+            <th>Job Title</th>
+            <th>O365 Last Sign In</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for account in accounts %}
+            <tr>
+              <td>{{ account.first_name or '—' }}</td>
+              <td>{{ account.last_name or '—' }}</td>
+              <td>{{ account.email or '—' }}</td>
+              <td>{{ account.department or '—' }}</td>
+              <td>{{ account.job_title or '—' }}</td>
+              <td data-utc="{{ account.m365_last_sign_in or '' }}">{{ account.m365_last_sign_in or '—' }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      </div>
+    {% else %}
+      <p class="report-empty">No active user accounts are recorded for this company.</p>
+    {% endif %}
   </div>
 </section>

--- a/app/templates/reports/_sections/staff_detail.html
+++ b/app/templates/reports/_sections/staff_detail.html
@@ -1,7 +1,7 @@
 <section class="card card--panel" data-report-section="staff_detail">
   <header class="card__header report-section__header">
-    <h2>Staff — Full list</h2>
-    <span class="report-section__meta">{{ section.detail_data.total or 0 }} active staff</span>
+    <h2>Active user accounts — Full list</h2>
+    <span class="report-section__meta">{{ section.detail_data.total or 0 }} active users</span>
   </header>
   <div class="card__body">
     {% set staff = section.detail_data.staff or [] %}
@@ -10,22 +10,24 @@
       <table class="table">
         <thead>
           <tr>
-            <th>Name</th>
-            <th>Email</th>
-            <th>Mobile</th>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Email Address</th>
             <th>Department</th>
-            <th>Position</th>
+            <th>Job Title</th>
+            <th>O365 Last Sign In</th>
             <th>Onboarding status</th>
           </tr>
         </thead>
         <tbody>
           {% for member in staff %}
             <tr>
-              <td>{{ member.name or '—' }}</td>
+              <td>{{ member.first_name or '—' }}</td>
+              <td>{{ member.last_name or '—' }}</td>
               <td>{{ member.email or '—' }}</td>
-              <td>{{ member.mobile_phone or '—' }}</td>
               <td>{{ member.department or '—' }}</td>
-              <td>{{ member.position or '—' }}</td>
+              <td>{{ member.job_title or '—' }}</td>
+              <td data-utc="{{ member.m365_last_sign_in or '' }}">{{ member.m365_last_sign_in or '—' }}</td>
               <td>{{ member.onboarding_status or '—' }}</td>
             </tr>
           {% endfor %}
@@ -33,7 +35,7 @@
       </table>
       </div>
     {% else %}
-      <p class="report-empty">No active staff are recorded for this company.</p>
+      <p class="report-empty">No active user accounts are recorded for this company.</p>
     {% endif %}
   </div>
 </section>

--- a/app/templates/reports/pdf.html
+++ b/app/templates/reports/pdf.html
@@ -166,8 +166,31 @@
 
     {% elif section.key == 'staff' %}
       <section class="report-section">
-        <h2>Active staff</h2>
-        {{ stats([{'label': 'Active staff', 'value': section.data.total_active or 0, 'variant': 'info'}]) }}
+        <h2>Active user accounts</h2>
+        {{ stats([{'label': 'Active users', 'value': section.data.total_active or 0, 'variant': 'info'}]) }}
+        {% set accounts = section.data.accounts or [] %}
+        {% if accounts %}
+          <table class="report-table">
+            <thead><tr>
+              <th>First Name</th><th>Last Name</th><th>Email Address</th>
+              <th>Department</th><th>Job Title</th><th>O365 Last Sign In</th>
+            </tr></thead>
+            <tbody>
+              {% for account in accounts %}
+                <tr>
+                  <td>{{ account.first_name or '—' }}</td>
+                  <td>{{ account.last_name or '—' }}</td>
+                  <td>{{ account.email or '—' }}</td>
+                  <td>{{ account.department or '—' }}</td>
+                  <td>{{ account.job_title or '—' }}</td>
+                  <td>{{ account.m365_last_sign_in or '—' }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% else %}
+          <p class="empty">No active user accounts are recorded for this company.</p>
+        {% endif %}
       </section>
 
     {% elif section.key == 'm365_best_practices' %}
@@ -513,27 +536,29 @@
 
       {% elif section.key == 'staff' %}
         <section class="report-section" style="{{ pb }}">
-          <h2>Staff — Full list</h2>
+          <h2>Active user accounts — Full list</h2>
           {% set staff = dd.staff or [] %}
           {% if staff %}
             <table class="report-table">
               <thead><tr>
-                <th>Name</th><th>Email</th><th>Mobile</th><th>Department</th><th>Position</th>
+                <th>First Name</th><th>Last Name</th><th>Email Address</th>
+                <th>Department</th><th>Job Title</th><th>O365 Last Sign In</th>
               </tr></thead>
               <tbody>
                 {% for member in staff %}
                   <tr>
-                    <td>{{ member.name or '—' }}</td>
+                    <td>{{ member.first_name or '—' }}</td>
+                    <td>{{ member.last_name or '—' }}</td>
                     <td>{{ member.email or '—' }}</td>
-                    <td>{{ member.mobile_phone or '—' }}</td>
                     <td>{{ member.department or '—' }}</td>
-                    <td>{{ member.position or '—' }}</td>
+                    <td>{{ member.job_title or '—' }}</td>
+                    <td>{{ member.m365_last_sign_in or '—' }}</td>
                   </tr>
                 {% endfor %}
               </tbody>
             </table>
           {% else %}
-            <p class="empty">No active staff recorded.</p>
+            <p class="empty">No active user accounts recorded.</p>
           {% endif %}
         </section>
 


### PR DESCRIPTION
### Motivation
- Provide a full list of active user accounts in the Company Overview report including Office 365 last sign-in so auditors and admins can see account-level sign-in state in both the web and PDF views.

### Description
- Add helper functions ` _staff_row_to_account` and `_list_active_staff_accounts` and update ` _build_staff` and `_build_staff_detail` in `app/services/reports.py` to return active non-package staff with `first_name`, `last_name`, `email`, `department`, `job_title`, and `m365_last_sign_in`.
- Update the web report templates `app/templates/reports/_sections/staff.html` and `app/templates/reports/_sections/staff_detail.html` to render the active user account table and show `O365 Last Sign In` timestamps (with `data-utc` attributes for client-side formatting).
- Update the PDF template `app/templates/reports/pdf.html` to include the same active user account table in the summary and detailed staff sections so the exported PDF contains the new fields.

### Testing
- Ran `git diff --check` with no issues detected (success).
- Compiled the modified module with `python -m compileall app/services/reports.py` (success).
- Parsed Jinja templates by loading `reports/_sections/staff.html`, `reports/_sections/staff_detail.html`, and `reports/pdf.html` via `jinja2.Environment` (all templates loaded successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5ee0b7aac083328eeb3ce97f5a421e)