### PR TITLE
Fix Trello createCard ticket creation for long titles

### DIFF
--- a/app/api/routes/trello.py
+++ b/app/api/routes/trello.py
@@ -9,7 +9,6 @@ from loguru import logger
 
 from app.api.dependencies.auth import require_super_admin
 from app.core.config import get_settings
-from app.repositories import companies as company_repo
 from app.services import tickets as tickets_service
 from app.services import trello as trello_service
 from app.services import webhook_monitor
@@ -251,12 +250,33 @@ def _build_public_callback_url(request: Request) -> str:
 
 
 
+_MAX_TICKET_SUBJECT_LENGTH = 255
+
+
+def _normalise_trello_ticket_subject(card_name: str | None) -> tuple[str, str | None]:
+    """Return a DB-safe ticket subject and the original when it was shortened."""
+    subject = str(card_name or "").strip() or "(no title)"
+    if len(subject) <= _MAX_TICKET_SUBJECT_LENGTH:
+        return subject, None
+    return f"{subject[: _MAX_TICKET_SUBJECT_LENGTH - 1]}…", subject
+
+
 def _build_trello_ticket_description(
     card_desc: str | None,
     card_url: str | None,
+    *,
+    original_card_name: str | None = None,
 ) -> str | None:
     """Return safe HTML containing the Trello card link and card content."""
     parts: list[str] = []
+
+    safe_original_name = str(original_card_name or "").strip()
+    if safe_original_name:
+        escaped_name = html.escape(safe_original_name).replace("\n", "<br>")
+        parts.append(
+            "<p><strong>Original Trello card title:</strong></p>"
+            f"<p>{escaped_name}</p>"
+        )
     safe_url = str(card_url or "").strip()
     if safe_url:
         escaped_url = html.escape(safe_url, quote=True)
@@ -303,12 +323,17 @@ async def _handle_create_card(
     full_card = await trello_service.get_card(card_id, company=company) if company else None
     card_payload = full_card or card_data
 
-    card_name: str = str(card_payload.get("name") or "").strip() or "(no title)"
+    raw_card_name: str = str(card_payload.get("name") or "").strip()
+    card_name, original_card_name = _normalise_trello_ticket_subject(raw_card_name)
     card_desc: str | None = str(card_payload.get("desc") or "").strip() or None
     card_url: str | None = str(
         card_payload.get("url") or card_payload.get("shortUrl") or ""
     ).strip() or None
-    ticket_description = _build_trello_ticket_description(card_desc, card_url)
+    ticket_description = _build_trello_ticket_description(
+        card_desc,
+        card_url,
+        original_card_name=original_card_name,
+    )
 
     try:
         ticket = await tickets_service.create_ticket(
@@ -330,7 +355,7 @@ async def _handle_create_card(
             card_id,
             exc,
         )
-        return
+        raise
 
     ticket_id = ticket.get("id")
     ticket_number = ticket.get("ticket_number") or ticket_id

--- a/tests/test_trello_create_ticket_description.py
+++ b/tests/test_trello_create_ticket_description.py
@@ -80,3 +80,58 @@ def test_trello_external_reference_helpers():
     assert trello_service.card_id_from_external_reference("trello:card-1") == "card-1"
     assert trello_service.card_id_from_external_reference("card-1") == "card-1"
     assert trello_service.card_id_from_external_reference("") is None
+
+
+def test_trello_ticket_subject_is_truncated_for_database_limit():
+    long_name = "A" * 300
+
+    subject, original = trello_routes._normalise_trello_ticket_subject(long_name)
+
+    assert len(subject) == 255
+    assert subject.endswith("…")
+    assert original == long_name
+
+
+def test_build_trello_ticket_description_includes_original_title_when_truncated():
+    description = trello_routes._build_trello_ticket_description(
+        None,
+        None,
+        original_card_name="Long <title>",
+    )
+
+    assert description is not None
+    assert "Original Trello card title" in description
+    assert "Long &lt;title&gt;" in description
+
+
+def test_handle_create_card_truncates_long_webhook_title_without_full_card(monkeypatch):
+    async def run_test():
+        created_payload: dict = {}
+        long_name = "Webhook title " * 30
+
+        monkeypatch.setattr(trello_routes.trello_service, "find_ticket_for_card", AsyncMock(return_value=None))
+        monkeypatch.setattr(
+            trello_routes.trello_service,
+            "get_company_for_board",
+            AsyncMock(return_value=None),
+        )
+        monkeypatch.setattr(trello_routes.trello_service, "post_ticket_created_comment", AsyncMock())
+
+        async def fake_create_ticket(**kwargs):
+            created_payload.update(kwargs)
+            return {"id": 123, "ticket_number": "T-123"}
+
+        monkeypatch.setattr(trello_routes.tickets_service, "create_ticket", fake_create_ticket)
+
+        await trello_routes._handle_create_card(
+            "board-1",
+            "card-1",
+            {"name": long_name},
+            {},
+        )
+
+        assert len(created_payload["subject"]) == 255
+        assert created_payload["subject"].endswith("…")
+        assert long_name.strip() in created_payload["description"]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
### Motivation
- Trello cards with very long titles could exceed the `tickets.subject` DB limit and either fail silently or lose the original title.
- The webhook handler was swallowing ticket-creation errors which prevented webhook monitoring from recording failures.

### Description
- Add `_MAX_TICKET_SUBJECT_LENGTH` and `_normalise_trello_ticket_subject` to truncate card titles to the DB-safe length and return the original when truncated in `app/api/routes/trello.py`.
- Preserve the full original Trello card title in the generated ticket description via `original_card_name` when truncation occurs by updating `_build_trello_ticket_description` and the `createCard` flow to use the normalized subject and enriched description.
- Re-raise exceptions from the ticket-creation step (after logging) so webhook monitoring records failures instead of treating them as success.
- Remove an unused import and add unit tests in `tests/test_trello_create_ticket_description.py` covering subject truncation, inclusion of the original title in the description, and long-title `createCard` handling.

### Testing
- Ran linting: `python -m ruff check app/api/routes/trello.py tests/test_trello_create_ticket_description.py` which passed.
- Ran unit tests: `pytest tests/test_trello_create_ticket_description.py -q` which passed (all tests in that file succeeded).
- Verified `git diff --check` and fixed an unused import reported by the linter.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5f25f9587c833293edd40e960c0cd4)