### PR TITLE
Enable retry for successful webhooks

### DIFF
--- a/app/templates/admin/webhooks.html
+++ b/app/templates/admin/webhooks.html
@@ -175,7 +175,6 @@
                       class="header-title-menu__link"
                       role="menuitem"
                       data-webhook-retry
-                      {% if event.status == 'succeeded' %}disabled{% endif %}
                     >
                       Retry
                     </button>

--- a/tests/test_webhook_monitor_cleanup.py
+++ b/tests/test_webhook_monitor_cleanup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from datetime import datetime, timedelta, timezone
 
 from app.services import webhook_monitor
@@ -45,3 +46,11 @@ def test_purge_completed_events_skips_logging_when_empty(monkeypatch):
 
     assert deleted == 0
     assert log_calls == []
+
+
+def test_webhook_retry_action_enabled_for_succeeded_events():
+    template = Path("app/templates/admin/webhooks.html").read_text()
+    retry_button = template.split("data-webhook-retry", 1)[1].split(">", 1)[0]
+
+    assert "event.status == 'succeeded'" not in retry_button
+    assert "disabled" not in retry_button


### PR DESCRIPTION
### Motivation
- The UI exposed a Retry action but it was disabled for events with `succeeded` status; sometimes a delivery was reported as succeeded but the external side (e.g. Trello) did not observe the change, so operators need to be able to re-run delivery manually.

### Description
- Remove the `disabled` condition from the row-level Retry button in `app/templates/admin/webhooks.html` and add a regression test `test_webhook_retry_action_enabled_for_succeeded_events` in `tests/test_webhook_monitor_cleanup.py` to assert the retry button markup is no longer disabled for succeeded events.

### Testing
- Ran `pytest tests/test_webhook_monitor_cleanup.py` and the test suite passed (3 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5f289b27988332ba46455da224656a)