### PR TITLE
Add server-side search and larger history window to Webhook Monitor

### DIFF
--- a/app/features/webhooks/routes.py
+++ b/app/features/webhooks/routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse
 
 from app.repositories import webhook_events as webhook_events_repo
@@ -20,12 +20,16 @@ def _main():
 
 
 @router.get("/admin/webhooks", response_class=HTMLResponse)
-async def admin_webhooks(request: Request):
+async def admin_webhooks(
+    request: Request,
+    q: str = "",
+    event_limit: int = Query(default=1000, ge=1, le=5000),
+):
     main_module = _main()
     current_user, redirect = await main_module._require_super_admin_page(request)
     if redirect:
         return redirect
-    events = await webhook_events_repo.list_events(limit=100)
+    events = await webhook_events_repo.list_events(search=q, limit=event_limit)
     prepared_events: list[dict[str, Any]] = []
     for event in events:
         serialised_event = main_module._serialise_mapping(event)
@@ -36,6 +40,9 @@ async def admin_webhooks(request: Request):
     extra = {
         "title": "Webhook delivery queue",
         "events": prepared_events,
+        "webhook_search": q,
+        "webhook_event_limit": event_limit,
+        "webhook_event_limit_options": (200, 500, 1000, 2500, 5000),
     }
     return await main_module._render_template(
         "admin/webhooks.html",

--- a/app/repositories/webhook_events.py
+++ b/app/repositories/webhook_events.py
@@ -132,12 +132,34 @@ async def get_event(event_id: int) -> dict[str, Any] | None:
     return _normalise_event(row) if row else None
 
 
-async def list_events(*, status: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+async def list_events(
+    *,
+    status: str | None = None,
+    search: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
     params: list[Any] = []
-    where = ""
+    clauses: list[str] = []
     if status:
-        where = "WHERE status = %s"
+        clauses.append("status = %s")
         params.append(status)
+    search_term = (search or "").strip()
+    if search_term:
+        like = f"%{search_term}%"
+        clauses.append(
+            "("
+            "name LIKE %s OR "
+            "target_url LIKE %s OR "
+            "source_url LIKE %s OR "
+            "status LIKE %s OR "
+            "direction LIKE %s OR "
+            "last_error LIKE %s OR "
+            "payload LIKE %s OR "
+            "metadata LIKE %s"
+            ")"
+        )
+        params.extend([like] * 8)
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
     params.append(limit)
     rows = await db.fetch_all(
         f"SELECT * FROM webhook_events {where} ORDER BY updated_at DESC LIMIT %s",

--- a/app/templates/admin/webhooks.html
+++ b/app/templates/admin/webhooks.html
@@ -41,11 +41,32 @@
 <section class="card card--panel">
   <header class="card__header">
     <div class="card__controls">
+      <form class="card__controls" method="get" action="/admin/webhooks">
+        <input
+          type="search"
+          class="form-input"
+          name="q"
+          value="{{ webhook_search or '' }}"
+          placeholder="Search all loaded webhook events"
+          aria-label="Search webhook event history"
+        />
+        <select class="form-input" name="event_limit" aria-label="How many webhook events to load">
+          {% for option in webhook_event_limit_options %}
+            <option value="{{ option }}" {% if option == webhook_event_limit %}selected{% endif %}>
+              Latest {{ option }} events
+            </option>
+          {% endfor %}
+        </select>
+        <button type="submit" class="button button--primary">Search history</button>
+        {% if webhook_search %}
+          <a class="button button--ghost" href="/admin/webhooks?event_limit={{ webhook_event_limit }}">Clear</a>
+        {% endif %}
+      </form>
       <input
         type="search"
         class="form-input"
-        placeholder="Filter webhook events"
-        aria-label="Filter webhook events"
+        placeholder="Filter loaded webhook events"
+        aria-label="Filter loaded webhook events"
         data-table-filter="webhooks-table"
       />
       <select
@@ -104,6 +125,7 @@
       />
     </div>
   </header>
+  <p class="card__subtitle">Showing {{ events|length }} loaded webhook events{% if webhook_search %} matching “{{ webhook_search }}”{% endif %}. Increase the history window to search farther back.</p>
   <div class="table-wrapper">
     <table class="table" id="webhooks-table" data-table data-table-id="webhooks">
       <thead>

--- a/tests/test_webhooks_feature_pack.py
+++ b/tests/test_webhooks_feature_pack.py
@@ -91,3 +91,25 @@ def test_webhooks_pack_loads_and_reloads_cleanly():
         await registry.unload_all()
 
     asyncio.new_event_loop().run_until_complete(_run())
+
+
+def test_admin_webhooks_loads_larger_searchable_history_window():
+    import inspect
+
+    signature = inspect.signature(webhooks_routes.admin_webhooks)
+
+    assert signature.parameters["event_limit"].default.default == 1000
+    source = inspect.getsource(webhooks_routes.admin_webhooks)
+    assert "le=5000" in source
+    assert "search=q" in source
+
+
+def test_webhook_history_template_exposes_server_side_search_controls():
+    from pathlib import Path
+
+    template = Path("app/templates/admin/webhooks.html").read_text()
+
+    assert 'name="q"' in template
+    assert 'name="event_limit"' in template
+    assert "Search history" in template
+    assert "Increase the history window" in template


### PR DESCRIPTION
### Motivation
- Administrators need to search farther back than the previous ~200-event window and be able to locate events by fields and payload content.
- The existing UI only filtered the currently loaded page, preventing effective historical searches across many events.

### Description
- Extend `list_events` in `app/repositories/webhook_events.py` with a `search` parameter that performs a LIKE search over `name`, `target_url`, `source_url`, `status`, `direction`, `last_error`, `payload`, and `metadata`.
- Add `q` and `event_limit` query parameters to `/admin/webhooks` in `app/features/webhooks/routes.py` with a default load of 1,000 events and validation capped at 5,000 via `Query(default=1000, ge=1, le=5000)`.
- Add server-side search controls and an event-limit selector to `app/templates/admin/webhooks.html`, plus explanatory UI text that distinguishes server-side search from the client-side table filter.
- Add regression tests in `tests/test_webhooks_feature_pack.py` to assert the new handler signature and template controls are present.

### Testing
- Ran Python byte-compile on modified modules with `python -m py_compile app/features/webhooks/routes.py app/repositories/webhook_events.py`, which succeeded.
- Ran the focused test suite with `pytest -q tests/test_webhooks_feature_pack.py tests/test_webhook_monitor_cleanup.py`, and the tests passed.
- Verified template and handler changes by asserting presence of the new form fields and query validation in the added tests, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5f2a94d8b08332b92cad472e4b1929)