### PR TITLE
Prefer HTTPS for Trello webhook callback URLs on public hosts

### DIFF
--- a/app/api/routes/trello.py
+++ b/app/api/routes/trello.py
@@ -206,7 +206,10 @@ def _build_public_callback_url(request: Request) -> str:
        callback. Trello would then follow the proxy's HTTP→HTTPS ``301``
        redirect and downgrade its event ``POST`` to a ``GET``, so MyPortal
        would never receive real webhook events.
-    4. Fall back to ``request.base_url``.
+    4. For public-looking hosts, prefer ``https`` even when the ASGI request
+       scheme is ``http``. This protects deployments where the proxy does not
+       forward any ``X-Forwarded-*`` headers.
+    5. Fall back to ``request.base_url``.
     """
 
     settings = get_settings()
@@ -242,6 +245,17 @@ def _build_public_callback_url(request: Request) -> str:
     host = forwarded_host or request.headers.get("host") or request.url.netloc
     # Strip any path/query that a malformed header might contain.
     host = host.split("/")[0].strip()
+
+    hostname = host.rsplit("@", 1)[-1].split(":", 1)[0].strip().lower()
+    is_local_host = hostname in {"localhost", "127.0.0.1", "::1"} or hostname.endswith(
+        ".local"
+    )
+    if scheme == "http" and host and not is_local_host:
+        # A public host reached over the internal HTTP hop should still be
+        # registered with Trello as HTTPS. Trello does not preserve POST
+        # requests across Cloudflare/proxy 301 redirects, so an http://
+        # callback makes event delivery fail before the request reaches us.
+        scheme = "https"
     if not host:
         # Last-resort fallback to the ASGI base URL.
         return f"{str(request.base_url).rstrip('/')}{_WEBHOOK_PATH}"

--- a/tests/test_trello_callback_url.py
+++ b/tests/test_trello_callback_url.py
@@ -123,8 +123,8 @@ def test_defaults_to_https_when_proxy_detected_without_forwarded_proto():
     assert url == f"https://portal.example.com{_WEBHOOK_PATH}"
 
 
-def test_explicit_forwarded_proto_http_is_respected_even_with_xff():
-    """If the proxy explicitly says http (rare but possible), respect it."""
+def test_explicit_forwarded_proto_http_for_public_host_is_upgraded_to_https():
+    """Public webhook callbacks must not be registered as http://."""
     request = _make_request(
         {
             "host": "portal.example.com",
@@ -137,14 +137,14 @@ def test_explicit_forwarded_proto_http_is_respected_even_with_xff():
         return_value=_settings_with(None),
     ):
         url = _build_public_callback_url(request)
-    assert url == f"http://portal.example.com{_WEBHOOK_PATH}"
+    assert url == f"https://portal.example.com{_WEBHOOK_PATH}"
 
 
 # ---------------------------------------------------------------------------
-# 4. No proxy at all – fall back to the request scheme
+# 4. No proxy at all – preserve local HTTP but upgrade public hosts to HTTPS
 # ---------------------------------------------------------------------------
 
-def test_no_proxy_uses_request_scheme():
+def test_no_proxy_uses_request_scheme_for_localhost():
     request = _make_request({"host": "localhost:8000"}, scheme="http")
     with patch(
         "app.api.routes.trello.get_settings",
@@ -152,6 +152,16 @@ def test_no_proxy_uses_request_scheme():
     ):
         url = _build_public_callback_url(request)
     assert url == f"http://localhost:8000{_WEBHOOK_PATH}"
+
+
+def test_no_proxy_upgrades_public_http_host_to_https():
+    request = _make_request({"host": "portal.hawkinsit.au"}, scheme="http")
+    with patch(
+        "app.api.routes.trello.get_settings",
+        return_value=_settings_with(None),
+    ):
+        url = _build_public_callback_url(request)
+    assert url == f"https://portal.hawkinsit.au{_WEBHOOK_PATH}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Trello webhook POSTs were being downgraded to GET when the registered callback used `http://` (common when the app sees an internal HTTP hop and the reverse proxy redirects to HTTPS), causing webhook delivery to fail. 
- The callback URL builder must prefer HTTPS for public hosts while keeping localhost/dev behavior and still honoring explicit `PUBLIC_BASE_URL` or forwarded headers.

### Description
- Update `_build_public_callback_url` to parse the host and treat non-local hosts as public, upgrading the scheme to `https` when the ASGI `request` appears to be an internal HTTP hop. 
- Keep the existing resolution order: `PUBLIC_BASE_URL` override, `X-Forwarded-Proto`/`X-Forwarded-Host`, X-Forwarded-For proxy heuristic, and defensive scheme normalization. 
- Add and adjust unit tests in `tests/test_trello_callback_url.py` to cover the new public-host HTTPS upgrade, the explicit forwarded-proto=http scenario, and a real-world host (`portal.hawkinsit.au`).

### Testing
- Ran `pytest tests/test_trello_callback_url.py` and the suite passed (10 passed). 
- A prior broader run including `tests/test_trello_register_webhook.py` and `tests/test_trello_feature_pack.py` exposed unrelated environment/test harness issues (missing async pytest plugin and an existing feature-pack reload assertion); those failures are external to this callback URL change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5f2af352b88332b937fba5e78973b9)