### PR TITLE
Trello webhooks: prefer HTTPS for public hosts and deduplicate http/https hooks

### DIFF
--- a/app/api/routes/trello.py
+++ b/app/api/routes/trello.py
@@ -206,7 +206,10 @@ def _build_public_callback_url(request: Request) -> str:
        callback. Trello would then follow the proxy's HTTP→HTTPS ``301``
        redirect and downgrade its event ``POST`` to a ``GET``, so MyPortal
        would never receive real webhook events.
-    4. Fall back to ``request.base_url``.
+    4. For public-looking hosts, prefer ``https`` even when the ASGI request
+       scheme is ``http``. This protects deployments where the proxy does not
+       forward any ``X-Forwarded-*`` headers.
+    5. Fall back to ``request.base_url``.
     """
 
     settings = get_settings()
@@ -242,6 +245,17 @@ def _build_public_callback_url(request: Request) -> str:
     host = forwarded_host or request.headers.get("host") or request.url.netloc
     # Strip any path/query that a malformed header might contain.
     host = host.split("/")[0].strip()
+
+    hostname = host.rsplit("@", 1)[-1].split(":", 1)[0].strip().lower()
+    is_local_host = hostname in {"localhost", "127.0.0.1", "::1"} or hostname.endswith(
+        ".local"
+    )
+    if scheme == "http" and host and not is_local_host:
+        # A public host reached over the internal HTTP hop should still be
+        # registered with Trello as HTTPS. Trello does not preserve POST
+        # requests across Cloudflare/proxy 301 redirects, so an http://
+        # callback makes event delivery fail before the request reaches us.
+        scheme = "https"
     if not host:
         # Last-resort fallback to the ASGI base URL.
         return f"{str(request.base_url).rstrip('/')}{_WEBHOOK_PATH}"

--- a/app/services/trello.py
+++ b/app/services/trello.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from html.parser import HTMLParser
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urlsplit, urlunsplit, urljoin
 
 from app.core.config import get_settings
 
@@ -157,6 +157,72 @@ def _strip_html(value: str, *, image_base_url: str | None = None) -> str:
     parser.feed(value)
     parser.close()
     return parser.get_text()
+
+
+def _canonical_webhook_callback_url(callback_url: str) -> str:
+    """Return a normalized callback URL for webhook de-duplication."""
+    value = str(callback_url or "").strip()
+    if not value:
+        return ""
+    parsed = urlsplit(value)
+    scheme = parsed.scheme.lower() or "https"
+    hostname = (parsed.hostname or "").lower()
+    port = parsed.port
+    netloc = hostname
+    if port and not ((scheme == "https" and port == 443) or (scheme == "http" and port == 80)):
+        netloc = f"{netloc}:{port}"
+    path = parsed.path.rstrip("/") or "/"
+    return urlunsplit((scheme, netloc, path, "", ""))
+
+
+def _same_callback_except_scheme(left: str, right: str) -> bool:
+    """Return true when two callback URLs only differ by http/https scheme."""
+    left_canonical = _canonical_webhook_callback_url(left)
+    right_canonical = _canonical_webhook_callback_url(right)
+    if not left_canonical or not right_canonical:
+        return False
+    left_parts = urlsplit(left_canonical)
+    right_parts = urlsplit(right_canonical)
+    return (
+        left_parts.netloc == right_parts.netloc
+        and left_parts.path == right_parts.path
+        and left_parts.query == right_parts.query
+    )
+
+
+async def _reconcile_existing_webhooks(
+    board_id: str,
+    callback_url: str,
+    api_key: str,
+    token: str,
+) -> dict[str, Any] | None:
+    """Return the matching webhook and remove stale http:// duplicates."""
+    existing = await list_webhooks(api_key, token)
+    matching_hook: dict[str, Any] | None = None
+    stale_ids: list[str] = []
+    for hook in existing:
+        if str(hook.get("idModel") or "") != board_id:
+            continue
+        existing_callback = str(hook.get("callbackURL") or "")
+        if _canonical_webhook_callback_url(existing_callback) == _canonical_webhook_callback_url(
+            callback_url
+        ):
+            matching_hook = hook
+            continue
+        if _same_callback_except_scheme(existing_callback, callback_url):
+            hook_id = str(hook.get("id") or "").strip()
+            if hook_id:
+                stale_ids.append(hook_id)
+
+    for hook_id in stale_ids:
+        logger.info(
+            "Trello register_webhook: deleting stale duplicate webhook {} for board {}",
+            hook_id,
+            board_id,
+        )
+        await delete_webhook(hook_id, api_key, token)
+
+    return matching_hook
 
 
 # ---------------------------------------------------------------------------
@@ -321,6 +387,16 @@ async def register_webhook(
     except TrelloAuthError as exc:
         logger.debug("Trello register_webhook skipped: {}", exc)
         return None
+
+    existing_hook = await _reconcile_existing_webhooks(
+        board_id, callback_url, api_key, token
+    )
+    if existing_hook:
+        logger.info(
+            "Trello register_webhook: webhook {} already has correct callback URL",
+            existing_hook.get("id"),
+        )
+        return existing_hook
 
     url = f"{TRELLO_API_BASE}/webhooks"
     try:

--- a/tests/test_trello_callback_url.py
+++ b/tests/test_trello_callback_url.py
@@ -123,8 +123,8 @@ def test_defaults_to_https_when_proxy_detected_without_forwarded_proto():
     assert url == f"https://portal.example.com{_WEBHOOK_PATH}"
 
 
-def test_explicit_forwarded_proto_http_is_respected_even_with_xff():
-    """If the proxy explicitly says http (rare but possible), respect it."""
+def test_explicit_forwarded_proto_http_for_public_host_is_upgraded_to_https():
+    """Public webhook callbacks must not be registered as http://."""
     request = _make_request(
         {
             "host": "portal.example.com",
@@ -137,14 +137,14 @@ def test_explicit_forwarded_proto_http_is_respected_even_with_xff():
         return_value=_settings_with(None),
     ):
         url = _build_public_callback_url(request)
-    assert url == f"http://portal.example.com{_WEBHOOK_PATH}"
+    assert url == f"https://portal.example.com{_WEBHOOK_PATH}"
 
 
 # ---------------------------------------------------------------------------
-# 4. No proxy at all – fall back to the request scheme
+# 4. No proxy at all – preserve local HTTP but upgrade public hosts to HTTPS
 # ---------------------------------------------------------------------------
 
-def test_no_proxy_uses_request_scheme():
+def test_no_proxy_uses_request_scheme_for_localhost():
     request = _make_request({"host": "localhost:8000"}, scheme="http")
     with patch(
         "app.api.routes.trello.get_settings",
@@ -152,6 +152,16 @@ def test_no_proxy_uses_request_scheme():
     ):
         url = _build_public_callback_url(request)
     assert url == f"http://localhost:8000{_WEBHOOK_PATH}"
+
+
+def test_no_proxy_upgrades_public_http_host_to_https():
+    request = _make_request({"host": "portal.hawkinsit.au"}, scheme="http")
+    with patch(
+        "app.api.routes.trello.get_settings",
+        return_value=_settings_with(None),
+    ):
+        url = _build_public_callback_url(request)
+    assert url == f"https://portal.hawkinsit.au{_WEBHOOK_PATH}"
 
 
 # ---------------------------------------------------------------------------
@@ -172,3 +182,20 @@ def test_unexpected_forwarded_scheme_is_normalised_to_https():
     ):
         url = _build_public_callback_url(request)
     assert url == f"https://portal.example.com{_WEBHOOK_PATH}"
+
+
+def test_trello_callback_canonicalization_ignores_default_ports_and_trailing_slash():
+    from app.services import trello as trello_service
+
+    assert trello_service._canonical_webhook_callback_url(
+        "https://Portal.HawkinsIT.au:443/api/integration-modules/trello/webhook/"
+    ) == "https://portal.hawkinsit.au/api/integration-modules/trello/webhook"
+
+
+def test_trello_callback_duplicate_detection_matches_http_to_https_migration():
+    from app.services import trello as trello_service
+
+    assert trello_service._same_callback_except_scheme(
+        "http://portal.hawkinsit.au/api/integration-modules/trello/webhook",
+        "https://portal.hawkinsit.au/api/integration-modules/trello/webhook",
+    )


### PR DESCRIPTION
### Motivation
- Fix a case where proxies that did not forward `X-Forwarded-Proto` caused the app to register `http://` Trello callbacks which then got 301→HTTPS redirects and lost POST events. 
- Remove stale duplicate webhooks created during HTTP→HTTPS migrations by detecting and cleaning up the old `http://` hook before creating a new one.

### Description
- Update `app/api/routes/trello.py` in `_build_public_callback_url` to prefer `https` for public hosts when the ASGI scheme is `http`, and to treat `localhost`, `127.0.0.1`, `::1`, and `*.local` as local hosts that keep `http` (so local development is preserved). 
- Add `_canonical_webhook_callback_url`, `_same_callback_except_scheme`, and `_reconcile_existing_webhooks` to `app/services/trello.py` to normalize callback URLs, detect callbacks that only differ by scheme, and delete stale `http://` duplicates. 
- Call `_reconcile_existing_webhooks` from `register_webhook` to return an existing matching webhook or remove stale duplicates before attempting to create a new webhook. 
- Add and adjust unit tests in `tests/test_trello_callback_url.py` to cover the HTTPS upgrade heuristics and webhook callback canonicalization/duplicate detection.

### Testing
- Ran the updated unit tests in `tests/test_trello_callback_url.py`, including `test_trello_callback_canonicalization_ignores_default_ports_and_trailing_slash` and `test_trello_callback_duplicate_detection_matches_http_to_https_migration`, which passed. 
- Ran the project test suite with `pytest` and no regressions were observed; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5f2af352b88332b937fba5e78973b9)