### PR TITLE
Link tray tickets to staff requesters

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -273,7 +273,9 @@ async def get_device_config(
     if device.get("company_id"):
         company = await companies_repo.get_company_by_id(int(device["company_id"]))
         chat_enabled = bool(
-            company and company.get("tray_chat_enabled", True) and _settings.matrix_enabled
+            company
+            and company.get("tray_chat_enabled", True)
+            and _settings.matrix_enabled
         )
     return TrayConfigResponse(
         version=int(config.get("version") or 1),
@@ -478,8 +480,15 @@ async def tray_submit_ticket(
     # and they receive notifications normally. Email takes precedence over a
     # phone match, including when the phone belongs to another user.
     requester_id: int | None = None
+    requester_staff_id: int | None = None
     existing_user = await users_repo.get_user_by_email(normalised_email)
-    if existing_user is None and payload.phone:
+    if existing_user is None and company_id is not None:
+        staff_member = await staff_repo.get_staff_by_company_and_email(
+            int(company_id), normalised_email
+        )
+        if staff_member and staff_member.get("enabled"):
+            requester_staff_id = int(staff_member["id"])
+    if existing_user is None and requester_staff_id is None and payload.phone:
         existing_user = await users_repo.get_user_by_phone(payload.phone)
     if existing_user:
         requester_id = int(existing_user["id"])
@@ -503,7 +512,7 @@ async def tray_submit_ticket(
     # Contact block: include when no portal account is matched.
     # Values are HTML-escaped before embedding to prevent markdown injection.
     description_parts: list[str] = []
-    if requester_id is None:
+    if requester_id is None and requester_staff_id is None:
         safe_name = _html.escape(payload.name)
         safe_email = _html.escape(normalised_email)
         contact_line = f"**Name:** {safe_name}"
@@ -535,6 +544,7 @@ async def tray_submit_ticket(
         subject=payload.subject.strip(),
         description=description_html,
         requester_id=requester_id,
+        requester_staff_id=requester_staff_id,
         company_id=company_id,
         assigned_user_id=None,
         priority="normal",
@@ -544,7 +554,11 @@ async def tray_submit_ticket(
         external_reference=external_reference,
         trigger_automations=True,
         initial_reply_author_id=requester_id,
-        requester_email=normalised_email if requester_id is None else None,
+        requester_email=(
+            normalised_email
+            if requester_id is None and requester_staff_id is None
+            else None
+        ),
     )
 
     # Link to the device's asset when one is known.
@@ -577,6 +591,7 @@ async def tray_submit_ticket(
         device_uid=device.get("uid") or payload.device_uid,
         ticket_id=ticket.get("id"),
         requester_id=requester_id,
+        requester_staff_id=requester_staff_id,
     )
 
     return TrayTicketSubmitResponse(
@@ -753,7 +768,9 @@ def _render_ticket_form(
 ) -> str:
     values = values or {}
     title = "Create Syncro Ticket" if mode == "syncro" else "Submit Ticket"
-    brand_name = (branding_display_name or "MyPortal Helpdesk").strip() or "MyPortal Helpdesk"
+    brand_name = (
+        branding_display_name or "MyPortal Helpdesk"
+    ).strip() or "MyPortal Helpdesk"
     intro = "Create a support ticket linked to this computer."
     fields = []
     for name, label, field_type, placeholder, required in [
@@ -2106,7 +2123,9 @@ async def issue_chat_token(
     if company_id:
         company = await companies_repo.get_company_by_id(int(company_id))
         if not (
-            company and company.get("tray_chat_enabled", True) and _settings.matrix_enabled
+            company
+            and company.get("tray_chat_enabled", True)
+            and _settings.matrix_enabled
         ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/tests/test_tray_submit_ticket_auth.py
+++ b/tests/test_tray_submit_ticket_auth.py
@@ -26,6 +26,9 @@ async def test_tray_submit_ticket_uses_bearer_token_without_device_uid(monkeypat
     async def fake_get_user_by_email(email: str):
         return None
 
+    async def fake_get_staff_by_company_and_email(company_id: int, email: str):
+        return None
+
     async def fake_get_questions_for_company(company_id: int | None):
         created["questions_company_id"] = company_id
         return []
@@ -44,6 +47,11 @@ async def test_tray_submit_ticket_uses_bearer_token_without_device_uid(monkeypat
     )
     monkeypatch.setattr(
         tray_routes.users_repo, "get_user_by_email", fake_get_user_by_email
+    )
+    monkeypatch.setattr(
+        tray_routes.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
     )
     monkeypatch.setattr(
         tray_routes.tq_service,
@@ -103,6 +111,9 @@ async def test_tray_submit_ticket_matches_requester_by_phone_when_email_is_unkno
         phone_lookups.append(phone)
         return {"id": 42}
 
+    async def fake_get_staff_by_company_and_email(company_id: int, email: str):
+        return None
+
     async def fake_get_questions_for_company(company_id: int | None):
         return []
 
@@ -118,6 +129,11 @@ async def test_tray_submit_ticket_matches_requester_by_phone_when_email_is_unkno
     )
     monkeypatch.setattr(
         tray_routes.users_repo, "get_user_by_email", fake_get_user_by_email
+    )
+    monkeypatch.setattr(
+        tray_routes.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
     )
     monkeypatch.setattr(
         tray_routes.users_repo, "get_user_by_phone", fake_get_user_by_phone
@@ -148,6 +164,90 @@ async def test_tray_submit_ticket_matches_requester_by_phone_when_email_is_unkno
     assert phone_lookups == ["+1 (555) 010-1234"]
     assert created["requester_id"] == 42
     assert created["requester_email"] is None
+
+
+@pytest.mark.anyio
+async def test_tray_submit_ticket_matches_company_staff_by_email(monkeypatch):
+    from app.api.routes import tray as tray_routes
+    from app.schemas.tray import TrayTicketSubmitRequest
+
+    created: dict[str, object] = {}
+    phone_lookups: list[str] = []
+
+    async def fake_get_device_by_uid(device_uid: str):
+        return {
+            "id": 123,
+            "uid": device_uid,
+            "status": "active",
+            "company_id": 456,
+            "asset_id": None,
+        }
+
+    async def fake_get_user_by_email(email: str):
+        return None
+
+    async def fake_get_staff_by_company_and_email(company_id: int, email: str):
+        assert company_id == 456
+        assert email == "jane@example.com"
+        return {"id": 321, "email": "Jane@Example.com", "enabled": True}
+
+    async def fake_get_user_by_phone(phone: str):
+        phone_lookups.append(phone)
+        return {"id": 42}
+
+    async def fake_get_questions_for_company(company_id: int | None):
+        return []
+
+    async def fake_resolve_status_or_default(status: str | None):
+        return "open"
+
+    async def fake_create_ticket(**kwargs):
+        created.update(kwargs)
+        return {"id": 789, "ticket_number": "T-789"}
+
+    monkeypatch.setattr(
+        tray_routes.tray_repo, "get_device_by_uid", fake_get_device_by_uid
+    )
+    monkeypatch.setattr(
+        tray_routes.users_repo, "get_user_by_email", fake_get_user_by_email
+    )
+    monkeypatch.setattr(
+        tray_routes.staff_repo,
+        "get_staff_by_company_and_email",
+        fake_get_staff_by_company_and_email,
+    )
+    monkeypatch.setattr(
+        tray_routes.users_repo, "get_user_by_phone", fake_get_user_by_phone
+    )
+    monkeypatch.setattr(
+        tray_routes.tq_service,
+        "get_questions_for_company",
+        fake_get_questions_for_company,
+    )
+    monkeypatch.setattr(
+        tray_routes.tickets_service,
+        "resolve_status_or_default",
+        fake_resolve_status_or_default,
+    )
+    monkeypatch.setattr(
+        tray_routes.tickets_service, "create_ticket", fake_create_ticket
+    )
+
+    payload = TrayTicketSubmitRequest(
+        device_uid="device-abc",
+        name="Jane",
+        email="JANE@EXAMPLE.COM",
+        phone="555-0100",
+        subject="Help",
+        description="Broken",
+    )
+    await tray_routes.tray_submit_ticket(payload, SimpleNamespace(headers={}))  # type: ignore[arg-type]
+
+    assert phone_lookups == []
+    assert created["requester_id"] is None
+    assert created["requester_staff_id"] == 321
+    assert created["requester_email"] is None
+    assert "**Email:** jane@example.com" not in str(created["description"])
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- Tray-submitted tickets were linking only to portal users (or falling back to phone) which left valid company staff unmatched when the submitter had no portal account.  The change ensures the tray form ties tickets to the correct staff requester when possible. 

### Description
- When resolving the tray submitter email, check the device's `company_id` and call `staff_repo.get_staff_by_company_and_email` to match an enabled staff requester before falling back to phone lookups. 
- Introduced `requester_staff_id` and pass it into `tickets_service.create_ticket` so tickets can be created with a staff requester rather than being treated as anonymous. 
- Only include anonymous contact details (`requester_email` and the contact block) when neither a portal user nor a staff requester is matched. 
- Added regression tests in `tests/test_tray_submit_ticket_auth.py` covering bearer-token submissions, phone fallback, and the new company-staff-by-email matching path, and made minor defensive/formatting tweaks in `app/api/routes/tray.py`.

### Testing
- Ran `pytest tests/test_tray_submit_ticket_auth.py -q` and the test suite for that file passed (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a603eb994c08332af31039eeb8c560f)