### PR TITLE
Add quote magic PDF links

### DIFF
--- a/app/api/routes/quotes.py
+++ b/app/api/routes/quotes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from app.api.dependencies.auth import get_current_user, require_super_admin
 from app.api.dependencies.database import require_database
@@ -10,64 +10,84 @@ from app.repositories import companies as company_repo
 from app.repositories import shop as shop_repo
 from app.repositories import user_companies as user_company_repo
 from app.repositories import users as users_repo
-from app.schemas.quotes import QuoteAssignRequest, QuoteDetailResponse, QuoteSummaryResponse, QuoteUpdateRequest
+from app.schemas.quotes import (
+    QuoteAssignRequest,
+    QuoteDetailResponse,
+    QuoteMagicLinkResponse,
+    QuoteSummaryResponse,
+    QuoteUpdateRequest,
+)
 from app.services import xero as xero_service
 
 router = APIRouter(prefix="/api/quotes", tags=["Quotes"])
 
 
-async def _resolve_company_id(company_id: int | None, company_id_alt: int | None) -> int:
+async def _resolve_company_id(
+    company_id: int | None, company_id_alt: int | None
+) -> int:
     value = company_id if company_id is not None else company_id_alt
     if value is None:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="companyId is required")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="companyId is required"
+        )
     try:
         return int(value)
     except (TypeError, ValueError) as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid companyId") from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid companyId"
+        ) from exc
 
 
 async def _ensure_company(company_id: int) -> None:
     company = await company_repo.get_company_by_id(company_id)
     if not company:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Company not found"
+        )
 
 
-async def _ensure_quote_access(user: dict, company_id: int, quote_summary: dict | None = None) -> None:
+async def _ensure_quote_access(
+    user: dict, company_id: int, quote_summary: dict | None = None
+) -> None:
     """Ensure user has access to quotes for this company.
-    
+
     Access is granted if:
     1. User is a super admin, OR
     2. User has can_access_quotes permission for the company.
     """
     if user.get("is_super_admin"):
         return
-    
+
     user_id = user.get("id")
     if user_id is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
-    
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found"
+        )
+
     # Check company membership and permissions
     membership = await user_company_repo.get_user_company(int(user_id), company_id)
     if not membership or not bool(membership.get("can_access_quotes")):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Quotes access denied")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Quotes access denied"
+        )
 
 
 async def _can_assign_quotes(user: dict, company_id: int) -> bool:
     """Check if user can assign quotes.
-    
+
     Only super admins and users with is_admin permission for the company can assign quotes.
     """
     if user.get("is_super_admin"):
         return True
-    
+
     user_id = user.get("id")
     if user_id is None:
         return False
-    
+
     membership = await user_company_repo.get_user_company(int(user_id), company_id)
     if not membership:
         return False
-    
+
     return bool(membership.get("is_admin"))
 
 
@@ -97,7 +117,9 @@ async def get_quote(
     await _ensure_company(resolved_company_id)
     summary = await shop_repo.get_quote_summary(quote_number, resolved_company_id)
     if not summary:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found"
+        )
     await _ensure_quote_access(current_user, resolved_company_id, summary)
     items = await shop_repo.list_quote_items(quote_number, resolved_company_id)
     summary["items"] = items
@@ -131,7 +153,9 @@ async def update_quote(
 
     summary = await shop_repo.update_quote(quote_number, resolved_company_id, **updates)
     if not summary:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found"
+        )
     items = await shop_repo.list_quote_items(quote_number, resolved_company_id)
     summary["items"] = items
     return QuoteDetailResponse.model_validate(summary)
@@ -149,7 +173,9 @@ async def delete_quote(
     await _ensure_company(resolved_company_id)
     summary = await shop_repo.get_quote_summary(quote_number, resolved_company_id)
     if not summary:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found"
+        )
     await shop_repo.delete_quote(quote_number, resolved_company_id)
     return None
 
@@ -166,7 +192,9 @@ async def sync_quote_to_xero(
     await _ensure_company(resolved_company_id)
     summary = await shop_repo.get_quote_summary(quote_number, resolved_company_id)
     if not summary:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found"
+        )
     await _ensure_quote_access(current_user, resolved_company_id, summary)
     if not await _can_assign_quotes(current_user, resolved_company_id):
         raise HTTPException(
@@ -177,7 +205,11 @@ async def sync_quote_to_xero(
     first_name = str(current_user.get("first_name") or "").strip()
     last_name = str(current_user.get("last_name") or "").strip()
     email = str(current_user.get("email") or "").strip()
-    user_name = f"{first_name} {last_name}".strip() if (first_name or last_name) else (email or None)
+    user_name = (
+        f"{first_name} {last_name}".strip()
+        if (first_name or last_name)
+        else (email or None)
+    )
 
     result = await xero_service.send_quote_to_xero(
         quote_number=quote_number,
@@ -186,12 +218,62 @@ async def sync_quote_to_xero(
     )
     result_status = str(result.get("status") or "").strip().lower()
     if result_status in {"failed", "error"}:
-        error_message = str(result.get("error") or result.get("reason") or "Quote sync failed")
+        error_message = str(
+            result.get("error") or result.get("reason") or "Quote sync failed"
+        )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"Quote sync to Xero failed: {error_message}",
         )
     return result
+
+
+@router.post("/{quote_number}/magic-link", response_model=QuoteMagicLinkResponse)
+async def create_quote_magic_link(
+    quote_number: str,
+    request: Request,
+    company_id: int | None = Query(default=None, alias="companyId"),
+    company_id_alt: int | None = Query(default=None, alias="company_id"),
+    _: None = Depends(require_database),
+    current_user: dict = Depends(get_current_user),
+) -> QuoteMagicLinkResponse:
+    resolved_company_id = await _resolve_company_id(company_id, company_id_alt)
+    await _ensure_company(resolved_company_id)
+    summary = await shop_repo.get_quote_summary(quote_number, resolved_company_id)
+    if not summary:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found"
+        )
+    await _ensure_quote_access(current_user, resolved_company_id, summary)
+
+    token = str(summary.get("magic_link_token") or "").strip()
+    if not token:
+        import secrets
+
+        for _attempt in range(5):
+            candidate = secrets.token_urlsafe(48)
+            existing = await shop_repo.get_quote_summary_by_magic_link_token(candidate)
+            if existing:
+                continue
+            updated_summary = await shop_repo.set_quote_magic_link_token(
+                quote_number, resolved_company_id, candidate
+            )
+            if not updated_summary:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found"
+                )
+            token = candidate
+            break
+        if not token:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Unable to generate quote link",
+            )
+
+    url = str(request.url_for("download_quote_magic_pdf", token=token))
+    return QuoteMagicLinkResponse.model_validate(
+        {"quote_number": quote_number, "company_id": resolved_company_id, "url": url}
+    )
 
 
 @router.post("/{quote_number}/assign", response_model=QuoteDetailResponse)
@@ -204,47 +286,57 @@ async def assign_quote(
     current_user: dict = Depends(get_current_user),
 ) -> QuoteDetailResponse:
     """Assign a quote to a specific user or unassign it.
-    
+
     Only super admins and company admins can assign quotes.
     The assigned user must be a member of the company.
     """
     resolved_company_id = await _resolve_company_id(company_id, company_id_alt)
     await _ensure_company(resolved_company_id)
-    
+
     # Check if user can assign quotes
     if not await _can_assign_quotes(current_user, resolved_company_id):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only super admins and company admins can assign quotes"
+            detail="Only super admins and company admins can assign quotes",
         )
-    
+
     # Check if quote exists
     summary = await shop_repo.get_quote_summary(quote_number, resolved_company_id)
     if not summary:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
-    
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found"
+        )
+
     assigned_user_id = payload.assigned_user_id
-    
+
     # If assigning to a user, verify they are a member of the company
     if assigned_user_id is not None:
         # Verify user exists
         assigned_user = await users_repo.get_user_by_id(assigned_user_id)
         if not assigned_user:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
-        
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+            )
+
         # Verify user has access to this company
-        membership = await user_company_repo.get_user_company(assigned_user_id, resolved_company_id)
+        membership = await user_company_repo.get_user_company(
+            assigned_user_id, resolved_company_id
+        )
         if not membership:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="User is not a member of this company"
+                detail="User is not a member of this company",
             )
-    
+
     # Assign the quote
-    updated_summary = await shop_repo.assign_quote(quote_number, resolved_company_id, assigned_user_id)
+    updated_summary = await shop_repo.assign_quote(
+        quote_number, resolved_company_id, assigned_user_id
+    )
     if not updated_summary:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found")
-    
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found"
+        )
+
     # Return full quote details
     items = await shop_repo.list_quote_items(quote_number, resolved_company_id)
     updated_summary["items"] = items

--- a/app/features/quotes/routes.py
+++ b/app/features/quotes/routes.py
@@ -21,6 +21,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from app.core.config import get_settings
 from app.features.orders import routes as orders_routes
 from app.repositories import cart as cart_repo
+from app.repositories import companies as company_repo
 from app.repositories import shop as shop_repo
 from app.repositories import users as user_repo
 from app.security.session import session_manager
@@ -102,6 +103,19 @@ def _pdf_image_src(request: Request, url: str | None) -> str | None:
     return _absolute_asset_url(request, url)
 
 
+def _is_quote_expired(expires_at: datetime | str | None) -> bool:
+    if not expires_at:
+        return False
+    if isinstance(expires_at, str):
+        try:
+            expires_at = datetime.fromisoformat(expires_at)
+        except (ValueError, AttributeError):
+            return False
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return expires_at < datetime.now(timezone.utc)
+
+
 def _build_quote_pdf_html(
     *,
     request: Request,
@@ -109,6 +123,7 @@ def _build_quote_pdf_html(
     quote: dict[str, Any],
     items: list[dict[str, Any]],
     include_line_images: bool,
+    watermark_expired: bool = False,
 ) -> str:
     quote_number = escape(str(quote.get("quote_number") or ""))
     company_name = escape(str((company or {}).get("name") or ""))
@@ -148,7 +163,7 @@ def _build_quote_pdf_html(
             f'<div class="product-image-card">'
             f'<img class="detail-image" src="{escape(image_url, quote=True)}" '
             f'alt="{escape(str(item.get("product_name") or "Product"), quote=True)}">'
-            f'</div>'
+            f"</div>"
             if image_url
             else ""
         )
@@ -179,6 +194,12 @@ def _build_quote_pdf_html(
             f"{product_link_html}"
             "</section>"
         )
+
+    watermark_html = (
+        '<div class="expired-watermark" aria-hidden="true">Expired</div>'
+        if watermark_expired
+        else ""
+    )
 
     return f"""
 <!doctype html>
@@ -217,9 +238,11 @@ def _build_quote_pdf_html(
     .description iframe {{ border: 1px solid #e5e7eb; min-height: 260px; width: 100%; }}
     .product-link {{ border-top: 1px solid #e5e7eb; font-size: 12px; margin-top: 18px; padding-top: 10px; overflow-wrap: anywhere; }}
     .product-link a {{ color: #2563eb; }}
+    .expired-watermark {{ color: rgba(185, 28, 28, 0.18); font-size: 88px; font-weight: 800; left: 50%; letter-spacing: .08em; position: fixed; text-transform: uppercase; top: 50%; transform: translate(-50%, -50%) rotate(-32deg); z-index: 999; }}
   </style>
 </head>
 <body>
+  {watermark_html}
   <section>
     <div class="hero">
       <div><p class="eyebrow">Quote</p><h1>{quote_number}</h1><p>{quote_name}</p></div>
@@ -268,18 +291,6 @@ async def quotes_page(
         text = (value or "").strip()
         return text if text else "Active"
 
-    def _is_expired(expires_at: datetime | str | None) -> bool:
-        if not expires_at:
-            return False
-        if isinstance(expires_at, str):
-            try:
-                expires_at = datetime.fromisoformat(expires_at)
-            except (ValueError, AttributeError):
-                return False
-        if expires_at.tzinfo is None:
-            expires_at = expires_at.replace(tzinfo=timezone.utc)
-        return expires_at < datetime.now(timezone.utc)
-
     enriched_quotes: list[dict[str, Any]] = []
 
     user_ids_to_fetch = set()
@@ -296,7 +307,7 @@ async def quotes_page(
 
     for quote_record in quotes_raw:
         label = _label(quote_record.get("status"))
-        is_expired = _is_expired(quote_record.get("expires_at"))
+        is_expired = _is_quote_expired(quote_record.get("expires_at"))
         if is_expired and label.lower() == "active":
             label = "Expired"
         record = dict(quote_record)
@@ -395,6 +406,51 @@ async def export_quote_pdf(
         quote=quote_summary,
         items=quote_items,
         include_line_images=with_images,
+    )
+    pdf_bytes = HTML(string=html, base_url=str(request.base_url)).write_pdf()
+    filename = f"{quote_number}-{'with-images' if with_images else 'no-images'}.pdf"
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get(
+    "/quotes/magic/{token}",
+    response_class=Response,
+    name="download_quote_magic_pdf",
+    include_in_schema=False,
+)
+async def download_quote_magic_pdf(
+    request: Request,
+    token: str,
+    with_images: bool = Query(True, alias="withImages"),
+) -> Response:
+    quote_summary = await shop_repo.get_quote_summary_by_magic_link_token(token)
+    if not quote_summary:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Quote link not found"
+        )
+
+    company_id = int(quote_summary["company_id"])
+    company = await company_repo.get_company_by_id(company_id)
+    quote_items = await shop_repo.list_quote_items(
+        str(quote_summary["quote_number"]), company_id
+    )
+    if not quote_items:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Quote not found"
+        )
+
+    quote_number = str(quote_summary.get("quote_number") or "quote")
+    html = _build_quote_pdf_html(
+        request=request,
+        company=company,
+        quote=quote_summary,
+        items=quote_items,
+        include_line_images=with_images,
+        watermark_expired=_is_quote_expired(quote_summary.get("expires_at")),
     )
     pdf_bytes = HTML(string=html, base_url=str(request.base_url)).write_pdf()
     filename = f"{quote_number}-{'with-images' if with_images else 'no-images'}.pdf"

--- a/app/repositories/shop.py
+++ b/app/repositories/shop.py
@@ -2732,7 +2732,8 @@ async def list_quote_summaries(company_id: int) -> list[dict[str, Any]]:
             MAX(notes) AS notes,
             MAX(po_number) AS po_number,
             MAX(name) AS name,
-            MAX(assigned_user_id) AS assigned_user_id
+            MAX(assigned_user_id) AS assigned_user_id,
+            MAX(magic_link_token) AS magic_link_token
         FROM shop_quotes
         WHERE company_id = %s
         GROUP BY quote_number, company_id
@@ -2758,7 +2759,8 @@ async def get_quote_summary(
             MAX(notes) AS notes,
             MAX(po_number) AS po_number,
             MAX(name) AS name,
-            MAX(assigned_user_id) AS assigned_user_id
+            MAX(assigned_user_id) AS assigned_user_id,
+            MAX(magic_link_token) AS magic_link_token
         FROM shop_quotes
         WHERE quote_number = %s AND company_id = %s
         GROUP BY quote_number, company_id
@@ -2768,6 +2770,46 @@ async def get_quote_summary(
     if not row:
         return None
     return _normalise_quote_summary(row)
+
+
+async def get_quote_summary_by_magic_link_token(token: str) -> dict[str, Any] | None:
+    row = await db.fetch_one(
+        """
+        SELECT
+            quote_number,
+            company_id,
+            MAX(user_id) AS user_id,
+            MAX(created_at) AS created_at,
+            MAX(expires_at) AS expires_at,
+            MAX(status) AS status,
+            MAX(notes) AS notes,
+            MAX(po_number) AS po_number,
+            MAX(name) AS name,
+            MAX(assigned_user_id) AS assigned_user_id,
+            MAX(magic_link_token) AS magic_link_token
+        FROM shop_quotes
+        WHERE magic_link_token = %s
+        GROUP BY quote_number, company_id
+        """,
+        (token,),
+    )
+    if not row:
+        return None
+    return _normalise_quote_summary(row)
+
+
+async def set_quote_magic_link_token(
+    quote_number: str, company_id: int, token: str
+) -> dict[str, Any] | None:
+    existing = await get_quote_summary(quote_number, company_id)
+    if not existing:
+        return None
+
+    await db.execute(
+        "UPDATE shop_quotes SET magic_link_token = %s WHERE quote_number = %s AND company_id = %s",
+        (token, quote_number, company_id),
+    )
+    return await get_quote_summary(quote_number, company_id)
 
 
 async def update_quote(
@@ -2876,6 +2918,7 @@ def _normalise_quote_summary(row: dict[str, Any]) -> dict[str, Any]:
     summary["po_number"] = row.get("po_number")
     summary["name"] = row.get("name")
     summary["assigned_user_id"] = _coerce_optional_int(row.get("assigned_user_id"))
+    summary["magic_link_token"] = row.get("magic_link_token")
     summary["created_at"] = _normalise_datetime(row.get("created_at"))
     summary["expires_at"] = _normalise_datetime(row.get("expires_at"))
     return summary

--- a/app/schemas/quotes.py
+++ b/app/schemas/quotes.py
@@ -69,3 +69,11 @@ class QuoteAssignRequest(BaseModel):
     assigned_user_id: int | None = Field(alias="assignedUserId")
 
     model_config = {"populate_by_name": True}
+
+
+class QuoteMagicLinkResponse(BaseModel):
+    quote_number: str = Field(alias="quoteNumber")
+    company_id: int = Field(alias="companyId")
+    url: str
+
+    model_config = {"populate_by_name": True}

--- a/app/static/js/quotes.js
+++ b/app/static/js/quotes.js
@@ -267,6 +267,36 @@
     }
   }
 
+
+  async function openQuoteLinkModal(quoteNumber, companyId) {
+    const modal = document.getElementById('quote-link-modal');
+    const modalTitle = document.getElementById('modal-link-title');
+    const linkInput = document.getElementById('quote-link-url');
+    const errorDiv = document.getElementById('modal-link-error');
+
+    if (!modal || !modalTitle || !linkInput || !errorDiv) {
+      return;
+    }
+
+    modalTitle.textContent = `Quote Link ${quoteNumber}`;
+    linkInput.value = '';
+    errorDiv.style.display = 'none';
+    openModal(modal);
+
+    try {
+      const data = await requestJson(`/api/quotes/${quoteNumber}/magic-link?companyId=${companyId}`, {
+        method: 'POST',
+      });
+      linkInput.value = data.url || '';
+      linkInput.focus();
+      linkInput.select();
+    } catch (error) {
+      console.error('Failed to create quote link:', error);
+      errorDiv.style.display = 'block';
+      errorDiv.textContent = error.message || 'Failed to create quote link. Please try again.';
+    }
+  }
+
   function bindQuoteViewButtons() {
     document.querySelectorAll('[data-quote-view]').forEach((button) => {
       button.addEventListener('click', async (event) => {
@@ -313,6 +343,19 @@
     });
   }
 
+  function bindQuoteLinkButtons() {
+    document.querySelectorAll('[data-quote-link]').forEach((button) => {
+      button.addEventListener('click', async () => {
+        const quoteNumber = button.dataset.quoteNumber;
+        const companyId = button.dataset.companyId;
+        if (!quoteNumber || !companyId) {
+          return;
+        }
+        await openQuoteLinkModal(quoteNumber, companyId);
+      });
+    });
+  }
+
   function bindQuoteSyncButtons() {
     document.querySelectorAll('[data-quote-sync]').forEach((button) => {
       button.addEventListener('click', async () => {
@@ -331,13 +374,31 @@
     const assignModal = document.getElementById('quote-assign-modal');
     const assignForm = document.getElementById('quote-assign-form');
     const unassignButton = document.getElementById('unassign-button');
+    const linkModal = document.getElementById('quote-link-modal');
+    const copyQuoteLinkButton = document.getElementById('copy-quote-link-button');
     
     bindModalDismissal(modal);
     bindModalDismissal(assignModal);
+    bindModalDismissal(linkModal);
     bindQuoteViewButtons();
     bindQuoteDeleteButtons();
     bindQuoteAssignButtons();
+    bindQuoteLinkButtons();
     bindQuoteSyncButtons();
+
+    if (copyQuoteLinkButton) {
+      copyQuoteLinkButton.addEventListener('click', async () => {
+        const linkInput = document.getElementById('quote-link-url');
+        if (!linkInput || !linkInput.value) {
+          return;
+        }
+        await navigator.clipboard.writeText(linkInput.value);
+        copyQuoteLinkButton.textContent = 'Copied';
+        window.setTimeout(() => {
+          copyQuoteLinkButton.textContent = 'Copy link';
+        }, 1600);
+      });
+    }
 
     // Handle assign form submission
     if (assignForm) {

--- a/app/templates/shop/quotes.html
+++ b/app/templates/shop/quotes.html
@@ -157,6 +157,16 @@
                       <li class="header-title-menu__item" role="none">
                         <a class="header-title-menu__link" role="menuitem" href="/quotes/export/{{ quote.quote_number }}?withImages=true">Export Quote PDF</a>
                       </li>
+                      <li class="header-title-menu__item" role="none">
+                        <button
+                          type="button"
+                          class="header-title-menu__link"
+                          role="menuitem"
+                          data-quote-link
+                          data-quote-number="{{ quote.quote_number }}"
+                          data-company-id="{{ quote.company_id }}"
+                        >Quote Link</button>
+                      </li>
                       {% if is_admin %}
                         <li class="header-title-menu__item" role="none">
                           <button
@@ -235,6 +245,28 @@
         </div>
         <div id="modal-quote-error" style="display: none;" class="alert alert--danger" role="alert">
           Failed to load quote details. Please try again.
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Quote Link Modal -->
+  <div class="modal" id="quote-link-modal" role="dialog" aria-modal="true" hidden>
+    <div class="modal__content" role="document">
+      <button type="button" class="modal__close" data-modal-close>
+        <span aria-hidden="true">&times;</span>
+      </button>
+      <h2 class="modal__title" id="modal-link-title">Quote Link</h2>
+      <div class="modal__body">
+        <p class="text-muted">Send this magic link to the customer so they can download a PDF copy of their quote without signing in.</p>
+        <label class="form-label" for="quote-link-url">Magic link</label>
+        <input id="quote-link-url" class="form-input" type="url" readonly value="">
+        <div class="form-actions">
+          <button type="button" class="button" id="copy-quote-link-button">Copy link</button>
+          <button type="button" class="button button--ghost" data-modal-close>Close</button>
+        </div>
+        <div id="modal-link-error" style="display: none; margin-top: 1rem;" class="alert alert--danger" role="alert">
+          Failed to create quote link. Please try again.
         </div>
       </div>
     </div>

--- a/migrations/296_quote_magic_links.sql
+++ b/migrations/296_quote_magic_links.sql
@@ -1,0 +1,6 @@
+-- Add persistent unguessable public download tokens for saved quote PDFs.
+ALTER TABLE shop_quotes
+  ADD COLUMN IF NOT EXISTS magic_link_token VARCHAR(128) DEFAULT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_shop_quotes_magic_link_token
+  ON shop_quotes (magic_link_token);


### PR DESCRIPTION
### Motivation

- Provide staff with a simple, shareable, unauthenticated “magic link” that lets customers download a PDF copy of a quote. 
- Ensure the link is unguessable and persistent (survives quote expiry) so staff can distribute it reliably. 
- When a customer uses the magic link to access an expired quote, clearly mark the PDF pages with an "Expired" watermark.

### Description

- Database: add `magic_link_token` to `shop_quotes` and an index in `migrations/296_quote_magic_links.sql`.
- Repository: return and persist the token in `app/repositories/shop.py` and add `get_quote_summary_by_magic_link_token` and `set_quote_magic_link_token` helpers; include `magic_link_token` in normalized summaries.
- API: add an authenticated endpoint `POST /api/quotes/{quote_number}/magic-link` (response model `QuoteMagicLinkResponse`) that generates/reuses a URL-safe token and returns the public download URL, implemented in `app/api/routes/quotes.py`.
- Public download: add unauthenticated `GET /quotes/magic/{token}` in `app/features/quotes/routes.py` which renders the quote PDF without requiring auth and passes `watermark_expired=True` to the PDF generator when the quote is expired; `app/features/quotes/routes.py` also adds `_is_quote_expired` and updates `_build_quote_pdf_html` to support the watermark.
- UI/JS: add a "Quote Link" action to the row actions and a modal in `app/templates/shop/quotes.html`, plus client logic in `app/static/js/quotes.js` (`openQuoteLinkModal`, binding, and copy-to-clipboard behavior) to call the new API and display the magic link.
- Minor: import fixes to use `company_repo` where needed and small formatting/cleanup across affected files.

### Testing

- Formatted with `python -m black` (files reformatted) and ran `python -m compileall` against modified modules; both steps completed successfully. 
- Verified the modified modules compile without syntax errors using `compileall`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6040d171188332b5fb7f2cb9a148a9)