### PR TITLE
Add Curricula Managed SAT support to Huntress integration (enrolled learners + per-learner breakdown)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -338,6 +338,13 @@ HUNTRESS_API_KEY=
 HUNTRESS_API_SECRET=
 HUNTRESS_BASE_URL=https://api.huntress.io/v1
 
+# Curricula / Huntress Managed SAT API
+# Use the API client credentials supplied in the Curricula admin portal.
+# Required for SAT enrolled learner counts, average progress, and per-user stats.
+CURRICULA_API_KEY=
+CURRICULA_API_SECRET=
+CURRICULA_BASE_URL=https://mycurricula.com/api/v1
+
 # Xero OAuth2 integration
 # To set up Xero integration:
 # 1. Create an OAuth2 app at https://developer.xero.com/

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -595,6 +595,20 @@ class Settings(BaseSettings):
         default="https://api.huntress.io/v1",
         validation_alias="HUNTRESS_BASE_URL",
     )
+    # Curricula / Huntress Managed SAT API. Kept separate from the Huntress
+    # partner API because Managed SAT is served from mycurricula.com.
+    curricula_api_key: str | None = Field(
+        default=None,
+        validation_alias="CURRICULA_API_KEY",
+    )
+    curricula_api_secret: str | None = Field(
+        default=None,
+        validation_alias="CURRICULA_API_SECRET",
+    )
+    curricula_base_url: str = Field(
+        default="https://mycurricula.com/api/v1",
+        validation_alias="CURRICULA_BASE_URL",
+    )
 
     # GitHub integration (used for fetching the latest tray MSI on startup)
     github_token: str | None = Field(

--- a/app/features/huntress/__init__.py
+++ b/app/features/huntress/__init__.py
@@ -3,8 +3,10 @@
 This pack makes the Huntress integration a first-class hot-reloadable
 feature-pack unit.  Credentials are read from the environment
 (``HUNTRESS_API_KEY`` / ``HUNTRESS_API_SECRET`` / ``HUNTRESS_BASE_URL``)
-and the module is gated by the standard ``integration_modules``
-enable/disable toggle — so no standalone routes are needed here.
+plus Curricula Managed SAT credentials (``CURRICULA_API_KEY`` /
+``CURRICULA_API_SECRET`` / ``CURRICULA_BASE_URL``), and the module is gated
+by the standard ``integration_modules`` enable/disable toggle — so no standalone
+routes are needed here.
 
 The daily sync is triggered by the scheduler (``sync_huntress`` command).
 """

--- a/app/repositories/huntress.py
+++ b/app/repositories/huntress.py
@@ -240,6 +240,7 @@ async def get_sat_stats(company_id: int) -> dict[str, Any] | None:
 async def upsert_sat_stats(
     company_id: int,
     *,
+    enrolled_learners: int = 0,
     avg_completion_rate: float,
     avg_score: float,
     phishing_clicks: int,
@@ -256,7 +257,8 @@ async def upsert_sat_stats(
         await db.execute(
             """
             UPDATE huntress_sat_stats
-               SET avg_completion_rate = %s,
+               SET enrolled_learners = %s,
+                   avg_completion_rate = %s,
                    avg_score = %s,
                    phishing_clicks = %s,
                    phishing_compromises = %s,
@@ -265,6 +267,7 @@ async def upsert_sat_stats(
              WHERE company_id = %s
             """,
             (
+                int(enrolled_learners),
                 float(avg_completion_rate),
                 float(avg_score),
                 int(phishing_clicks),
@@ -278,12 +281,13 @@ async def upsert_sat_stats(
         await db.execute(
             """
             INSERT INTO huntress_sat_stats
-                (company_id, avg_completion_rate, avg_score,
+                (company_id, enrolled_learners, avg_completion_rate, avg_score,
                  phishing_clicks, phishing_compromises, phishing_reports, snapshot_at)
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 int(company_id),
+                int(enrolled_learners),
                 float(avg_completion_rate),
                 float(avg_score),
                 int(phishing_clicks),

--- a/app/services/dynamic_variables.py
+++ b/app/services/dynamic_variables.py
@@ -7,6 +7,7 @@ from typing import Any
 from app.repositories import assets as assets_repo
 from app.repositories import asset_custom_fields as asset_custom_fields_repo
 from app.repositories import issues as issues_repo
+from app.repositories import huntress as huntress_repo
 from app.repositories import reporting as reporting_repo
 from app.services import reporting as reporting_service
 
@@ -209,6 +210,14 @@ async def build_dynamic_token_map(
     issue_count_requests = _extract_issue_count_requests(tokens)
     issue_list_requests = _extract_issue_list_requests(tokens)
     report_requests = _extract_report_requests(tokens)
+    huntress_sat_variable_names = {
+        "huntress.sat.learners.enrolled",
+        "huntress_sat_enrolled_learners",
+        "huntress_sat_learner_count",
+    }
+    huntress_sat_count_requests = {
+        token for token in tokens if token.lower() in huntress_sat_variable_names
+    }
 
     all_requests = [
         active_asset_requests,
@@ -217,6 +226,7 @@ async def build_dynamic_token_map(
         issue_count_requests,
         issue_list_requests,
         report_requests,
+        huntress_sat_count_requests,
     ]
     if not any(all_requests):
         return {}
@@ -287,6 +297,17 @@ async def build_dynamic_token_map(
                 company_id=company_id,
             )
             result[token] = ", ".join(assets)
+
+    # Handle Huntress SAT active learner count variables
+    if huntress_sat_count_requests:
+        stats = (
+            await huntress_repo.get_sat_stats(company_id)
+            if company_id is not None
+            else None
+        )
+        enrolled = int((stats or {}).get("enrolled_learners") or 0)
+        for token in huntress_sat_count_requests:
+            result[token] = str(enrolled)
 
     # Handle saved reporting query variables
     if report_requests:

--- a/app/services/huntress.py
+++ b/app/services/huntress.py
@@ -2,8 +2,10 @@
 
 The Huntress integration has no UI settings — credentials are read from the
 environment (``HUNTRESS_API_KEY`` / ``HUNTRESS_API_SECRET`` /
-``HUNTRESS_BASE_URL``) and the module is gated by the standard
-``integration_modules`` enable/disable toggle.
+``HUNTRESS_BASE_URL`` plus ``CURRICULA_API_KEY`` /
+``CURRICULA_API_SECRET`` / ``CURRICULA_BASE_URL`` for Managed SAT)
+and the module is gated by the standard ``integration_modules``
+enable/disable toggle.
 
 The service exposes thin wrappers per Huntress endpoint family and a
 ``refresh_company`` orchestrator that pulls every product (EDR, ITDR, SAT,
@@ -59,6 +61,17 @@ def _get_credentials() -> dict[str, str] | None:
     return {"api_key": api_key, "api_secret": api_secret, "base_url": base_url}
 
 
+
+def _get_curricula_credentials() -> dict[str, str] | None:
+    settings = get_settings()
+    api_key = (settings.curricula_api_key or "").strip()
+    api_secret = (settings.curricula_api_secret or "").strip()
+    base_url = (settings.curricula_base_url or "").strip().rstrip("/")
+    if not api_key or not api_secret or not base_url:
+        return None
+    return {"api_key": api_key, "api_secret": api_secret, "base_url": base_url}
+
+
 def credentials_status() -> dict[str, bool]:
     """Lightweight, non-secret status used by the modules admin page."""
     settings = get_settings()
@@ -66,6 +79,13 @@ def credentials_status() -> dict[str, bool]:
         "api_key_present": bool((settings.huntress_api_key or "").strip()),
         "api_secret_present": bool((settings.huntress_api_secret or "").strip()),
         "base_url_present": bool((settings.huntress_base_url or "").strip()),
+        "curricula_api_key_present": bool((settings.curricula_api_key or "").strip()),
+        "curricula_api_secret_present": bool(
+            (settings.curricula_api_secret or "").strip()
+        ),
+        "curricula_base_url_present": bool(
+            (settings.curricula_base_url or "").strip()
+        ),
     }
 
 
@@ -213,13 +233,73 @@ async def get_itdr_summary(org_id: str) -> dict[str, int]:
 
 
 async def get_sat_summary(org_id: str) -> dict[str, Any] | None:
-    """SAT endpoints are not currently exposed in Huntress public API docs."""
-    return None
+    """Return Huntress Managed SAT learner and progress rollups for an account.
+
+    Curricula/Huntress Managed SAT uses the JSON:API REST API at
+    ``https://mycurricula.com/api/v1`` with client-credentials API clients. The
+    useful billing/reporting metric exposed by third-party reconciliation docs
+    is the active learner count; where assignment progress is returned, we also
+    calculate average completion and score from the learner rows.
+    """
+    rows = await get_sat_learner_breakdown(org_id)
+    if rows is None:
+        return None
+
+    learner_ids = {
+        str(row.get("learner_external_id") or row.get("learner_email") or "").strip()
+        for row in rows
+        if row.get("learner_external_id") or row.get("learner_email")
+    }
+    completions = [float(row.get("completion_percent") or 0) for row in rows]
+    scores = [
+        float(row.get("score") or 0)
+        for row in rows
+        if row.get("score") is not None
+    ]
+    return {
+        "enrolled_learners": len(learner_ids) or len(rows),
+        "avg_completion_rate": (
+            (sum(completions) / len(completions)) if completions else 0
+        ),
+        "avg_score": (sum(scores) / len(scores)) if scores else 0,
+        "phishing_clicks": sum(
+            1 for row in rows if float(row.get("click_rate") or 0) > 0
+        ),
+        "phishing_compromises": sum(
+            1 for row in rows if float(row.get("compromise_rate") or 0) > 0
+        ),
+        "phishing_reports": sum(
+            1 for row in rows if float(row.get("report_rate") or 0) > 0
+        ),
+    }
 
 
 async def get_sat_learner_breakdown(org_id: str) -> list[dict[str, Any]] | None:
-    """SAT learner detail endpoints are not currently exposed in public API docs."""
-    return None
+    """Return per-learner SAT progress rows from the Curricula JSON:API.
+
+    The public Stoplight docs describe Curricula as a JSON:API REST API for
+    channel partners. Tenant responses can vary by API version, so this parser
+    accepts common JSON:API shapes and normalises learner/account assignment
+    fields into the snapshot table schema used by reports.
+    """
+    credentials = _get_curricula_credentials()
+    if not credentials:
+        raise HuntressConfigurationError(
+            "Curricula credentials are not configured (set CURRICULA_API_KEY and "
+            "CURRICULA_API_SECRET)."
+        )
+
+    async with _client(credentials) as client:
+        payload = await _get_json(
+            client,
+            f"/accounts/{org_id}/learners",
+            {"include": "assignments,progress", "page[size]": 100},
+            allow_not_found=True,
+        )
+    if payload is None:
+        return None
+    learners = _extract_list(payload, key="learners")
+    return [_normalise_sat_learner(row) for row in learners if isinstance(row, Mapping)]
 
 
 async def get_siem_data_volume(org_id: str, days: int = 30) -> dict[str, Any] | None:
@@ -318,6 +398,7 @@ async def refresh_company(company: Mapping[str, Any]) -> dict[str, Any]:
     if sat is not None:
         await huntress_repo.upsert_sat_stats(
             company_id,
+            enrolled_learners=sat.get("enrolled_learners", 0),
             avg_completion_rate=sat["avg_completion_rate"],
             avg_score=sat["avg_score"],
             phishing_clicks=sat["phishing_clicks"],
@@ -437,6 +518,60 @@ def _extract_list(payload: Any, *, key: str) -> list[Any]:
                 return [item for item in value if isinstance(item, (dict, list))]
     return []
 
+
+
+def _jsonapi_attrs(row: Mapping[str, Any]) -> dict[str, Any]:
+    attrs = row.get("attributes")
+    if isinstance(attrs, Mapping):
+        merged = dict(attrs)
+        if row.get("id") is not None:
+            merged.setdefault("id", row.get("id"))
+        return merged
+    return dict(row)
+
+
+def _first_value(payload: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in payload and payload.get(key) is not None:
+            return payload.get(key)
+    return None
+
+
+def _normalise_sat_learner(row: Mapping[str, Any]) -> dict[str, Any]:
+    data = _jsonapi_attrs(row)
+    learner_id = _first_value(
+        data, "learner_external_id", "learner_id", "user_id", "id", "uuid"
+    )
+    assignment_id = _first_value(
+        data, "assignment_id", "training_assignment_id", "campaign_id", "course_id"
+    )
+    if not assignment_id:
+        assignment_id = "learner-summary"
+    completion = _first_value(
+        data,
+        "completion_percent",
+        "progress",
+        "progress_percent",
+        "percent_complete",
+        "completion_rate",
+    )
+    return {
+        "learner_external_id": str(learner_id or data.get("email") or "").strip(),
+        "learner_email": _first_value(data, "learner_email", "email", "user_email"),
+        "learner_name": _first_value(
+            data, "learner_name", "name", "full_name", "display_name"
+        ),
+        "assignment_id": str(assignment_id),
+        "assignment_name": _first_value(
+            data, "assignment_name", "training_name", "course_name", "campaign_name"
+        ),
+        "status": _first_value(data, "status", "state", "enrollment_status"),
+        "completion_percent": _coerce_float(completion),
+        "score": _coerce_float(_first_value(data, "score", "average_score", "quiz_score")),
+        "click_rate": _coerce_float(_first_value(data, "click_rate", "phishing_click_rate")),
+        "compromise_rate": _coerce_float(_first_value(data, "compromise_rate", "phishing_compromise_rate")),
+        "report_rate": _coerce_float(_first_value(data, "report_rate", "phishing_report_rate")),
+    }
 
 def _extract_next_page_token(payload: Any) -> str | None:
     """Return the ``next_page_token`` from a Huntress paginated response, or ``None``."""

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -1045,7 +1045,12 @@ DEFAULT_MODULES: list[dict[str, Any]] = [
     {
         "slug": "huntress",
         "name": "Huntress",
-        "description": "Huntress EDR / ITDR / SAT / SIEM / SOC statistics for company reports. Credentials are read from environment variables (HUNTRESS_API_KEY, HUNTRESS_API_SECRET).",
+        "description": (
+            "Huntress EDR / ITDR / SAT / SIEM / SOC statistics for company reports. "
+            "Credentials are read from environment variables (HUNTRESS_API_KEY, "
+            "HUNTRESS_API_SECRET, and CURRICULA_API_KEY/CURRICULA_API_SECRET "
+            "for Managed SAT)."
+        ),
         "icon": "🛡️",
         "settings": {},
     },

--- a/app/services/reports.py
+++ b/app/services/reports.py
@@ -126,7 +126,7 @@ REPORT_SECTIONS: tuple[ReportSection, ...] = (
     ReportSection(
         key="huntress_sat",
         label="Huntress Security Awareness Training",
-        description="Average completion / score across SAT learners and phishing simulation outcomes.",
+        description="Enrolled learners, average progress, scores, and phishing simulation outcomes.",
     ),
     ReportSection(
         key="huntress_siem",
@@ -1039,6 +1039,7 @@ async def _build_huntress_sat(company_id: int) -> dict[str, Any]:
     if not stats:
         return {}
     return {
+        "enrolled_learners": int(stats.get("enrolled_learners") or 0),
         "avg_completion_rate": float(stats.get("avg_completion_rate") or 0),
         "avg_score": float(stats.get("avg_score") or 0),
         "phishing_clicks": int(stats.get("phishing_clicks") or 0),
@@ -1072,6 +1073,10 @@ async def _build_huntress_sat_detail(company_id: int) -> dict[str, Any]:
         )
     summary["learners"] = learners
     summary["total_assignments"] = len(learners)
+    if not summary.get("enrolled_learners"):
+        summary["enrolled_learners"] = len(
+            {row.get("learner_external_id") or row.get("learner_email") for row in learners}
+        )
     return summary
 
 

--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -17,6 +17,7 @@ from app.repositories import asset_custom_fields as asset_custom_fields_repo
 from app.repositories import companies as company_repo
 from app.repositories import company_recurring_invoice_items as recurring_items_repo
 from app.repositories import invoice_lines as invoice_lines_repo
+from app.repositories import huntress as huntress_repo
 from app.repositories import staff as staff_repo
 from app.repositories import invoices as invoice_repo
 from app.repositories import ticket_billed_time_entries as billed_time_repo
@@ -1567,6 +1568,13 @@ async def build_invoice_context(company_id: int) -> dict[str, Any]:
         "active_users": user_count,
         "total_assets": total_assets,
     }
+
+    huntress_sat_stats = await huntress_repo.get_sat_stats(company_id)
+    enrolled_learners = int((huntress_sat_stats or {}).get("enrolled_learners") or 0)
+    context.update({
+        "huntress_sat_enrolled_learners": enrolled_learners,
+        "huntress_sat_learner_count": enrolled_learners,
+    })
 
     # Add custom field checkbox counts for all defined checkbox fields.
     # Variables are exposed as {cf_total_FIELDNAME} and {cf_active_FIELDNAME}

--- a/app/templates/reports/_sections/huntress_sat.html
+++ b/app/templates/reports/_sections/huntress_sat.html
@@ -10,7 +10,8 @@
   </header>
   <div class="card__body">
     {{ counter_strip(items=[
-      {'label': 'Avg completion', 'value': '%.1f%%' | format(section.data.avg_completion_rate or 0), 'variant': 'info'},
+      {'label': 'Enrolled learners', 'value': section.data.enrolled_learners or 0, 'variant': 'info'},
+      {'label': 'Avg progress', 'value': '%.1f%%' | format(section.data.avg_completion_rate or 0), 'variant': 'info'},
       {'label': 'Avg score', 'value': '%.1f' | format(section.data.avg_score or 0), 'variant': 'info'},
       {'label': 'Phishing clicks', 'value': section.data.phishing_clicks or 0, 'variant': 'danger'},
       {'label': 'Phishing compromises', 'value': section.data.phishing_compromises or 0, 'variant': 'danger'},

--- a/app/templates/reports/_sections/huntress_sat_detail.html
+++ b/app/templates/reports/_sections/huntress_sat_detail.html
@@ -10,7 +10,8 @@
   </header>
   <div class="card__body">
     {{ counter_strip(items=[
-      {'label': 'Avg completion', 'value': '%.1f%%' | format(section.detail_data.avg_completion_rate or 0), 'variant': 'info'},
+      {'label': 'Enrolled learners', 'value': section.detail_data.enrolled_learners or 0, 'variant': 'info'},
+      {'label': 'Avg progress', 'value': '%.1f%%' | format(section.detail_data.avg_completion_rate or 0), 'variant': 'info'},
       {'label': 'Avg score', 'value': '%.1f' | format(section.detail_data.avg_score or 0), 'variant': 'info'},
       {'label': 'Phishing clicks', 'value': section.detail_data.phishing_clicks or 0, 'variant': 'danger'},
       {'label': 'Phishing compromises', 'value': section.detail_data.phishing_compromises or 0, 'variant': 'danger'},

--- a/docs/wiki/administration/Automation Variables.md
+++ b/docs/wiki/administration/Automation Variables.md
@@ -330,3 +330,13 @@ Adjustment methods accept `days`, `weeks`, `months`, and `years` as integer argu
 - Use `${vars.now.local...}` when the ticket text should follow the portal/server local timezone.
 - Use `${vars.now.utc...}` when the ticket text must be timezone-neutral or match UTC audit/reporting periods.
 - `${vars.now...}` without `local` or `utc` resolves like local time for these payload expressions.
+
+### Huntress Managed SAT learner count variables
+
+When the Huntress integration is enabled and a company has a Huntress organisation/account ID, the daily Huntress sync stores Managed Security Awareness Training learner snapshots from the Curricula JSON:API. Use these variables in invoice quantities, invoice descriptions, scheduled tickets, automations, and message templates:
+
+- `{{ huntress.sat.learners.enrolled }}` – active/enrolled learner count for the current company.
+- `{{ huntress_sat_enrolled_learners }}` – invoice-friendly alias for the same learner count.
+- `{{ huntress_sat_learner_count }}` – legacy-style alias for the same learner count.
+
+The value is read from the last successful Huntress sync snapshot, so rendering templates never makes live Curricula API calls.

--- a/migrations/300_huntress_sat_enrolled_learners.sql
+++ b/migrations/300_huntress_sat_enrolled_learners.sql
@@ -1,0 +1,3 @@
+-- Store Huntress Managed SAT active learner counts for reporting and billing variables.
+ALTER TABLE huntress_sat_stats
+  ADD COLUMN enrolled_learners INT NOT NULL DEFAULT 0 AFTER company_id;


### PR DESCRIPTION
### Motivation
- Introduce support for Huntress Managed SAT (Curricula) so enrolled learner counts, average progress/score and phishing simulation outcomes can be stored and used for reporting and billing. 
- Expose the enrolled-learner metric to templates, invoices, automation variables and reports without making live API calls at render time.

### Description
- Add environment variables for Curricula (`CURRICULA_API_KEY`, `CURRICULA_API_SECRET`, `CURRICULA_BASE_URL`) in ` .env.example` and new config fields `curricula_api_key`, `curricula_api_secret`, `curricula_base_url` in `app/core/config.py`.
- Implement Curricula client and parsing in `app/services/huntress.py` with `_get_curricula_credentials`, `get_sat_learner_breakdown`, `get_sat_summary`, JSON:API normalisation helpers (`_jsonapi_attrs`, `_first_value`, `_normalise_sat_learner`), and include Curricula credential presence in `credentials_status`.
- Persist an `enrolled_learners` column (DB migration `migrations/300_huntress_sat_enrolled_learners.sql`) and update repository functions in `app/repositories/huntress.py` to accept and store `enrolled_learners` when upserting SAT stats.
- Surface the enrolled-learner metric to template/reporting and invoice contexts by updating `app/services/reports.py`, `app/templates/reports/_sections/huntress_sat.html` and `_detail.html`, `app/services/dynamic_variables.py` (dynamic tokens), and `app/services/xero.py` (invoice context keys `huntress_sat_enrolled_learners` / `huntress_sat_learner_count`).
- Update the default module description in `app/services/modules.py` and add documentation for the new automation variables in `docs/wiki/administration/Automation Variables.md`.

### Testing
- Ran the project's automated test suite and template rendering checks against the modified codebase, and all tests passed.
- Confirmed database migration file `migrations/300_huntress_sat_enrolled_learners.sql` was added for schema change and included in migration checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6183d8a6e48332abb81dbfbbacf5b6)