### PR TITLE
Trello: include reply in automation context and emit `tickets.replied` for commentCard

### DIFF
--- a/app/api/routes/trello.py
+++ b/app/api/routes/trello.py
@@ -19,6 +19,7 @@ router = APIRouter(prefix="/api/integration-modules/trello", tags=["Trello"])
 # Webhook endpoint (Trello verification + event ingestion)
 # ---------------------------------------------------------------------------
 
+
 @router.head("/webhook", status_code=status.HTTP_200_OK)
 @router.get("/webhook", status_code=status.HTTP_200_OK)
 async def trello_webhook_verify(request: Request) -> JSONResponse:
@@ -130,6 +131,7 @@ async def trello_webhook_receive(request: Request) -> JSONResponse:
 # Admin: register a Trello webhook for a board
 # ---------------------------------------------------------------------------
 
+
 @router.post(
     "/boards/{board_id}/register-webhook",
     status_code=status.HTTP_200_OK,
@@ -169,7 +171,9 @@ async def register_trello_webhook(
         board_id,
         callback_url,
     )
-    result = await trello_service.register_webhook(board_id, callback_url, company=company)
+    result = await trello_service.register_webhook(
+        board_id, callback_url, company=company
+    )
     if not result:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -263,7 +267,6 @@ def _build_public_callback_url(request: Request) -> str:
     return f"{scheme}://{host}{_WEBHOOK_PATH}"
 
 
-
 _MAX_TICKET_SUBJECT_LENGTH = 255
 
 
@@ -295,24 +298,25 @@ def _build_trello_ticket_description(
     if safe_url:
         escaped_url = html.escape(safe_url, quote=True)
         parts.append(
-            '<p><strong>Trello card:</strong> '
+            "<p><strong>Trello card:</strong> "
             f'<a href="{escaped_url}" target="_blank" rel="noopener noreferrer">'
-            f'{escaped_url}</a></p>'
+            f"{escaped_url}</a></p>"
         )
 
     safe_desc = str(card_desc or "").strip()
     if safe_desc:
         escaped_desc = html.escape(safe_desc).replace("\n", "<br>")
         parts.append(
-            "<p><strong>Trello card content:</strong></p>"
-            f"<p>{escaped_desc}</p>"
+            "<p><strong>Trello card content:</strong></p>" f"<p>{escaped_desc}</p>"
         )
 
     return "\n".join(parts) if parts else None
 
+
 # ---------------------------------------------------------------------------
 # Internal handlers
 # ---------------------------------------------------------------------------
+
 
 async def _handle_create_card(
     board_id: str,
@@ -325,24 +329,25 @@ async def _handle_create_card(
     # Check if a ticket already exists for this card (idempotency)
     existing = await trello_service.find_ticket_for_card(card_id)
     if existing:
-        logger.debug(
-            "Trello createCard: ticket already exists for card {}", card_id
-        )
+        logger.debug("Trello createCard: ticket already exists for card {}", card_id)
         return
 
     # Resolve the company linked to this board
     company = await trello_service.get_company_for_board(board_id)
     company_id: int | None = int(company["id"]) if company else None
 
-    full_card = await trello_service.get_card(card_id, company=company) if company else None
+    full_card = (
+        await trello_service.get_card(card_id, company=company) if company else None
+    )
     card_payload = full_card or card_data
 
     raw_card_name: str = str(card_payload.get("name") or "").strip()
     card_name, original_card_name = _normalise_trello_ticket_subject(raw_card_name)
     card_desc: str | None = str(card_payload.get("desc") or "").strip() or None
-    card_url: str | None = str(
-        card_payload.get("url") or card_payload.get("shortUrl") or ""
-    ).strip() or None
+    card_url: str | None = (
+        str(card_payload.get("url") or card_payload.get("shortUrl") or "").strip()
+        or None
+    )
     ticket_description = _build_trello_ticket_description(
         card_desc,
         card_url,
@@ -373,12 +378,12 @@ async def _handle_create_card(
 
     ticket_id = ticket.get("id")
     ticket_number = ticket.get("ticket_number") or ticket_id
-    logger.info(
-        "Trello createCard: created ticket {} for card {}", ticket_id, card_id
-    )
+    logger.info("Trello createCard: created ticket {} for card {}", ticket_id, card_id)
 
     # Post confirmation comment back on the Trello card (new requirement)
-    await trello_service.post_ticket_created_comment(card_id, ticket_number, company=company)
+    await trello_service.post_ticket_created_comment(
+        card_id, ticket_number, company=company
+    )
 
 
 async def _handle_comment_card(
@@ -410,21 +415,28 @@ async def _handle_comment_card(
     ticket_id: int = int(ticket["id"])
     member_creator: dict[str, Any] = action.get("memberCreator") or {}
     author_label = (
-        str(member_creator.get("fullName") or member_creator.get("username") or "")
-        .strip()
+        str(
+            member_creator.get("fullName") or member_creator.get("username") or ""
+        ).strip()
         or "Trello"
     )
     body = f"<p><strong>{author_label} (Trello):</strong> {comment_text}</p>"
 
     try:
         from app.repositories import tickets as tickets_repo
-        await tickets_repo.create_reply(
+
+        reply = await tickets_repo.create_reply(
             ticket_id=ticket_id,
             author_id=None,
             body=body,
             is_internal=False,
         )
-        await tickets_service.emit_ticket_updated_event(ticket_id, actor_type="system")
+        await tickets_service.emit_ticket_updated_event(
+            ticket_id, actor_type="system", reply=reply
+        )
+        await tickets_service.emit_ticket_replied_event(
+            ticket_id, actor_type="system", reply=reply
+        )
         logger.info(
             "Trello commentCard: added reply to ticket {} from card {}",
             ticket_id,
@@ -469,6 +481,7 @@ async def _handle_update_card(
 
     try:
         from app.repositories import tickets as tickets_repo
+
         await tickets_repo.create_reply(
             ticket_id=ticket_id,
             author_id=None,

--- a/tests/test_trello_comment_card_automation.py
+++ b/tests/test_trello_comment_card_automation.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+import pytest
+
+from app.api.routes import trello as trello_routes
+
+
+@pytest.mark.anyio
+async def test_comment_card_emits_updated_and_replied_automation_events(monkeypatch):
+    ticket = {
+        "id": 42,
+        "status": "open",
+        "external_reference": "trello:card-123",
+    }
+    reply = {"id": 99, "is_internal": False, "body": "from Trello"}
+    emitted: list[tuple[str, int, dict[str, Any]]] = []
+
+    async def fake_find_ticket_for_card(card_id: str):
+        assert card_id == "card-123"
+        return ticket
+
+    async def fake_create_reply(**kwargs):
+        assert kwargs["ticket_id"] == 42
+        assert kwargs["author_id"] is None
+        assert kwargs["is_internal"] is False
+        assert "Client Name (Trello)" in kwargs["body"]
+        assert "Looks good" in kwargs["body"]
+        return reply
+
+    async def fake_emit_updated(ticket_id: int, **kwargs):
+        emitted.append(("updated", ticket_id, kwargs))
+
+    async def fake_emit_replied(ticket_id: int, **kwargs):
+        emitted.append(("replied", ticket_id, kwargs))
+
+    monkeypatch.setattr(
+        trello_routes.trello_service, "find_ticket_for_card", fake_find_ticket_for_card
+    )
+    monkeypatch.setattr(
+        trello_routes.tickets_service, "emit_ticket_updated_event", fake_emit_updated
+    )
+    monkeypatch.setattr(
+        trello_routes.tickets_service, "emit_ticket_replied_event", fake_emit_replied
+    )
+
+    from app.repositories import tickets as tickets_repo
+
+    monkeypatch.setattr(tickets_repo, "create_reply", fake_create_reply)
+
+    await trello_routes._handle_comment_card(
+        "card-123",
+        {"text": "Looks good"},
+        {"memberCreator": {"fullName": "Client Name"}},
+    )
+
+    assert emitted == [
+        ("updated", 42, {"actor_type": "system", "reply": reply}),
+        ("replied", 42, {"actor_type": "system", "reply": reply}),
+    ]


### PR DESCRIPTION
### Motivation
- Trello `commentCard` webhook handling created ticket replies but did not include the created reply in the `tickets.updated` automation context and did not emit a `tickets.replied` event, causing automation filters that inspect `reply`/`ticket_update` metadata to miss Trello-origin comments.

### Description
- Update `_handle_comment_card` in `app/api/routes/trello.py` to capture the created reply into a `reply` variable and pass it into `tickets_service.emit_ticket_updated_event` via the `reply` parameter.
- Emit `tickets_service.emit_ticket_replied_event` after creating the Trello comment reply so webhook-driven replies mirror normal in-app reply behavior.
- Add a regression test `tests/test_trello_comment_card_automation.py` that verifies both `tickets.updated` and `tickets.replied` are emitted with `actor_type="system"` and the reply payload.

### Testing
- Ran `pytest -q tests/test_trello_comment_card_automation.py tests/test_ticket_reply_automation_context.py` and the tests passed (4 passed, 0 failed).
- The new test exercises `_handle_comment_card` with mocked `tickets_repo.create_reply` and mocked `tickets_service` emit functions to validate the automation emissions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a618618e7dc83329e1d36406398b579)