### PR TITLE
Support shorthand saved-report tokens in recurring invoice quantities

### DIFF
--- a/app/services/dynamic_variables.py
+++ b/app/services/dynamic_variables.py
@@ -181,18 +181,25 @@ def _extract_issue_list_requests(tokens: Iterable[str]) -> dict[str, str]:
 
 
 def _extract_report_requests(tokens: Iterable[str]) -> dict[str, tuple[str, str]]:
-    """Extract report.slug.count and report.slug.list tokens."""
+    """Extract saved-report count/list tokens.
+
+    Supports both the explicit ``report.slug.count`` form and the legacy
+    ``slug.count`` shorthand used by recurring invoice item quantities.
+    """
     requests: dict[str, tuple[str, str]] = {}
     for token in tokens:
         if not token:
             continue
         parts = token.split(".")
-        if len(parts) < 3 or parts[0].lower() != "report":
+        if len(parts) < 2:
             continue
         action = parts[-1].lower()
         if action not in {"count", "list"}:
             continue
-        slug = ".".join(parts[1:-1]).strip()
+        if len(parts) >= 3 and parts[0].lower() == "report":
+            slug = ".".join(parts[1:-1]).strip()
+        else:
+            slug = ".".join(parts[:-1]).strip()
         if slug:
             requests[token] = (slug, action)
     return requests

--- a/tests/test_xero_recurring_items.py
+++ b/tests/test_xero_recurring_items.py
@@ -255,6 +255,61 @@ def test_build_recurring_invoice_items_with_custom_field_variable(monkeypatch):
     assert tl_item["Quantity"] == 25.0
 
 
+
+def test_build_recurring_invoice_items_with_shorthand_report_count(monkeypatch):
+    """Recurring quantities support legacy saved-report shorthand tokens."""
+
+    async def fake_list_items(company_id):
+        return [
+            {
+                "id": 1,
+                "company_id": company_id,
+                "product_code": "ONLINE-WORKSTATIONS",
+                "description_template": "Online workstations",
+                "qty_expression": "{{ online-workstations-last-30-days.count }}",
+                "price_override": 2.50,
+                "active": True,
+            }
+        ]
+
+    async def fake_get_query_by_slug(slug):
+        assert slug == "online-workstations-last-30-days"
+        return {
+            "slug": slug,
+            "sql_query": "SELECT name FROM assets WHERE company_id = {{current.company}}",
+        }
+
+    async def fake_count_query_rows(sql_query, *, company_id=None):
+        assert company_id == 77
+        return 80
+
+    monkeypatch.setattr(
+        xero.recurring_items_repo,
+        "list_company_recurring_invoice_items",
+        fake_list_items,
+    )
+    monkeypatch.setattr(
+        xero.value_templates.dynamic_variables.reporting_repo,
+        "get_query_by_slug",
+        fake_get_query_by_slug,
+    )
+    monkeypatch.setattr(
+        xero.value_templates.dynamic_variables.reporting_service,
+        "count_query_rows",
+        fake_count_query_rows,
+    )
+
+    result = asyncio.run(
+        xero.build_recurring_invoice_items(
+            company_id=77,
+            tax_type="OUTPUT2",
+            context={"company_name": "Acme"},
+        )
+    )
+
+    assert len(result) == 1
+    assert result[0]["Quantity"] == 80.0
+
 def test_build_recurring_invoice_items_fetches_xero_rates(monkeypatch):
     async def run_test():
         """Test that build_recurring_invoice_items fetches item rates from Xero."""


### PR DESCRIPTION
### Motivation
- Recurring invoice quantity expressions using saved-report shorthand like `{{ online-workstations-last-30-days.count }}` were resolving incorrectly (yielding `1`) because the dynamic variable extractor required the explicit `report.` prefix.

### Description
- Update `_extract_report_requests` in `app/services/dynamic_variables.py` to accept both `report.slug.count`/`report.slug.list` and the legacy `slug.count`/`slug.list` shorthand so saved-report variables resolve correctly.
- Add a regression test `test_build_recurring_invoice_items_with_shorthand_report_count` in `tests/test_xero_recurring_items.py` that verifies a recurring item's `qty_expression` using the shorthand report token resolves to the expected numeric count.

### Testing
- Ran `pytest tests/test_xero_recurring_items.py::test_build_recurring_invoice_items_with_report_variables tests/test_xero_recurring_items.py::test_build_recurring_invoice_items_with_shorthand_report_count -q`, and both tests passed.
- Ran `python -m py_compile app/services/dynamic_variables.py`, which succeeded.
- Note: running the entire `tests/test_xero_recurring_items.py -q` exposed unrelated environment issues (database pool not initialised) causing other invoice-context tests to fail; this is external to the change and the focused regression tests for the bug pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a61b8c7cd6c83328fb40a7ba9c9faf9)