### PR TITLE
Fix unbill tickets cutoff pagination

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1161,7 +1161,7 @@ async def replace_ticket_assets(
 
 
 async def list_billed_tickets_older_than(
-    cutoff: datetime, *, limit: int = 10000
+    cutoff: datetime, *, limit: int = 1000, offset: int = 0
 ) -> list[TicketRecord]:
     """Return billed, unmerged tickets created before the supplied UTC cutoff."""
     rows = await db.fetch_all(
@@ -1172,9 +1172,9 @@ async def list_billed_tickets_older_than(
           AND created_at < %s
           AND (billed_at IS NOT NULL OR COALESCE(TRIM(xero_invoice_number), '') <> '')
         ORDER BY created_at ASC, id ASC
-        LIMIT %s
+        LIMIT %s OFFSET %s
         """,
-        (cutoff, int(max(1, limit))),
+        (cutoff, int(max(1, limit)), int(max(0, offset))),
     )
     return [_normalise_ticket(row) for row in rows]
 

--- a/app/services/unbill_tickets.py
+++ b/app/services/unbill_tickets.py
@@ -7,7 +7,7 @@ from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import tickets as tickets_repo
 
 _DATE_FORMAT = "%Y%m%d"
-_MAX_TICKETS_PER_RUN = 10000
+_DEFAULT_TICKETS_PAGE_SIZE = 1000
 
 
 def parse_unbill_cutoff_date(value: str) -> datetime:
@@ -34,12 +34,30 @@ def _ticket_label(ticket: Mapping[str, Any]) -> str:
     return f"Ticket #{ticket.get('id')}"
 
 
-async def preview_unbill_tickets(cutoff_date: datetime) -> dict[str, Any]:
-    """Preview billed tickets created before the UTC cutoff date."""
-    tickets = await tickets_repo.list_billed_tickets_older_than(
-        cutoff_date,
-        limit=_MAX_TICKETS_PER_RUN,
-    )
+async def preview_unbill_tickets(
+    cutoff_date: datetime, *, limit: int = _DEFAULT_TICKETS_PAGE_SIZE
+) -> dict[str, Any]:
+    """Preview billed tickets created before the UTC cutoff date.
+
+    Billed tickets are read in pages so old tickets are not skipped when the
+    matching set is larger than a single query limit.
+    """
+    page_size = max(1, int(limit or _DEFAULT_TICKETS_PAGE_SIZE))
+    offset = 0
+    tickets: list[Mapping[str, Any]] = []
+    while True:
+        page = await tickets_repo.list_billed_tickets_older_than(
+            cutoff_date,
+            limit=page_size,
+            offset=offset,
+        )
+        if not page:
+            break
+        tickets.extend(page)
+        if len(page) < page_size:
+            break
+        offset += page_size
+
     items = [
         {
             "type": "ticket",

--- a/tests/test_unbill_tickets.py
+++ b/tests/test_unbill_tickets.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import timezone
 import importlib.util
 from pathlib import Path
@@ -46,3 +47,52 @@ def test_parse_unbill_cutoff_date_accepts_yyyymmdd_as_utc_start():
 def test_parse_unbill_cutoff_date_rejects_invalid_values(value):
     with pytest.raises(ValueError):
         unbill_tickets.parse_unbill_cutoff_date(value)
+
+
+def test_preview_unbill_tickets_scans_all_ticket_pages(monkeypatch):
+    calls = []
+
+    async def fake_tickets(cutoff_date, limit, offset=0):
+        calls.append((limit, offset))
+        pages = {
+            0: [
+                {
+                    "id": 1,
+                    "ticket_number": "T-1",
+                    "subject": "Old billed ticket",
+                    "created_at": cutoff_date,
+                    "billed_at": cutoff_date,
+                    "xero_invoice_number": "INV-1",
+                },
+            ],
+            1: [
+                {
+                    "id": 2,
+                    "ticket_number": "T-2",
+                    "subject": "Older billed ticket",
+                    "created_at": cutoff_date,
+                    "billed_at": cutoff_date,
+                    "xero_invoice_number": "INV-2",
+                },
+            ],
+        }
+        return pages.get(offset, [])
+
+    monkeypatch.setattr(
+        unbill_tickets.tickets_repo,
+        "list_billed_tickets_older_than",
+        fake_tickets,
+        raising=False,
+    )
+
+    preview = asyncio.run(
+        unbill_tickets.preview_unbill_tickets(
+            unbill_tickets.parse_unbill_cutoff_date("20260530"),
+            limit=1,
+        )
+    )
+
+    assert preview["status"] == "ready"
+    assert preview["totals"] == {"ticketCount": 2}
+    assert [item["id"] for item in preview["items"]] == [1, 2]
+    assert calls == [(1, 0), (1, 1), (1, 2)]


### PR DESCRIPTION
### Motivation
- The un-bill-by-date flow was capped by a single-query result limit and could miss very old billed tickets (e.g. 2022) when running against a cutoff date like `20260530`.
- The repository query lacked offset support so preview/unbill runs could not page through multiple result pages.

### Description
- Read billed tickets in pages when previewing by cutoff date by adding a paged loop to `preview_unbill_tickets` in `app/services/unbill_tickets.py` and a configurable `limit` parameter with a `_DEFAULT_TICKETS_PAGE_SIZE` default.
- Add `offset` parameter support and a `LIMIT ... OFFSET ...` clause to `list_billed_tickets_older_than` in `app/repositories/tickets.py` so the repository can return paged results.
- Add a regression test `test_preview_unbill_tickets_scans_all_ticket_pages` in `tests/test_unbill_tickets.py` that verifies multiple pages are fetched and combined for a cutoff run.

### Testing
- Ran `pytest tests/test_unbill_tickets.py -q` and the suite passed (all tests succeeded).
- Ran `pytest tests/test_scheduled_task_preview.py::test_unbill_time_entries_preview_scans_all_ticket_pages -q` and the targeted test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a61bdba77248332847cfb720da6bf39)