### PR TITLE
Paginate unbill preview and include billed time-entry markers in ticket query

### DIFF
--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1161,20 +1161,27 @@ async def replace_ticket_assets(
 
 
 async def list_billed_tickets_older_than(
-    cutoff: datetime, *, limit: int = 10000
+    cutoff: datetime, *, limit: int = 1000, offset: int = 0
 ) -> list[TicketRecord]:
-    """Return billed, unmerged tickets created before the supplied UTC cutoff."""
+    """Return tickets with billing markers created before the supplied UTC cutoff."""
     rows = await db.fetch_all(
         """
         SELECT *
         FROM tickets
-        WHERE merged_into_ticket_id IS NULL
-          AND created_at < %s
-          AND (billed_at IS NOT NULL OR COALESCE(TRIM(xero_invoice_number), '') <> '')
+        WHERE created_at < %s
+          AND (
+              billed_at IS NOT NULL
+              OR COALESCE(TRIM(xero_invoice_number), '') <> ''
+              OR EXISTS (
+                  SELECT 1
+                  FROM ticket_billed_time_entries bte
+                  WHERE bte.ticket_id = tickets.id
+              )
+          )
         ORDER BY created_at ASC, id ASC
-        LIMIT %s
+        LIMIT %s OFFSET %s
         """,
-        (cutoff, int(max(1, limit))),
+        (cutoff, int(max(1, limit)), int(max(0, offset))),
     )
     return [_normalise_ticket(row) for row in rows]
 

--- a/app/services/unbill_tickets.py
+++ b/app/services/unbill_tickets.py
@@ -7,7 +7,7 @@ from app.repositories import ticket_billed_time_entries as billed_time_repo
 from app.repositories import tickets as tickets_repo
 
 _DATE_FORMAT = "%Y%m%d"
-_MAX_TICKETS_PER_RUN = 10000
+_DEFAULT_TICKETS_PAGE_SIZE = 1000
 
 
 def parse_unbill_cutoff_date(value: str) -> datetime:
@@ -34,12 +34,30 @@ def _ticket_label(ticket: Mapping[str, Any]) -> str:
     return f"Ticket #{ticket.get('id')}"
 
 
-async def preview_unbill_tickets(cutoff_date: datetime) -> dict[str, Any]:
-    """Preview billed tickets created before the UTC cutoff date."""
-    tickets = await tickets_repo.list_billed_tickets_older_than(
-        cutoff_date,
-        limit=_MAX_TICKETS_PER_RUN,
-    )
+async def preview_unbill_tickets(
+    cutoff_date: datetime, *, limit: int = _DEFAULT_TICKETS_PAGE_SIZE
+) -> dict[str, Any]:
+    """Preview billed tickets created before the UTC cutoff date.
+
+    Billed tickets are read in pages so old tickets are not skipped when the
+    matching set is larger than a single query limit.
+    """
+    page_size = max(1, int(limit or _DEFAULT_TICKETS_PAGE_SIZE))
+    offset = 0
+    tickets: list[Mapping[str, Any]] = []
+    while True:
+        page = await tickets_repo.list_billed_tickets_older_than(
+            cutoff_date,
+            limit=page_size,
+            offset=offset,
+        )
+        if not page:
+            break
+        tickets.extend(page)
+        if len(page) < page_size:
+            break
+        offset += page_size
+
     items = [
         {
             "type": "ticket",

--- a/tests/test_unbill_tickets.py
+++ b/tests/test_unbill_tickets.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import timezone
 import importlib.util
 from pathlib import Path
@@ -46,3 +47,66 @@ def test_parse_unbill_cutoff_date_accepts_yyyymmdd_as_utc_start():
 def test_parse_unbill_cutoff_date_rejects_invalid_values(value):
     with pytest.raises(ValueError):
         unbill_tickets.parse_unbill_cutoff_date(value)
+
+
+def test_preview_unbill_tickets_scans_all_ticket_pages(monkeypatch):
+    calls = []
+
+    async def fake_tickets(cutoff_date, limit, offset=0):
+        calls.append((limit, offset))
+        pages = {
+            0: [
+                {
+                    "id": 1,
+                    "ticket_number": "T-1",
+                    "subject": "Old billed ticket",
+                    "created_at": cutoff_date,
+                    "billed_at": cutoff_date,
+                    "xero_invoice_number": "INV-1",
+                },
+            ],
+            1: [
+                {
+                    "id": 2,
+                    "ticket_number": "T-2",
+                    "subject": "Older billed ticket",
+                    "created_at": cutoff_date,
+                    "billed_at": cutoff_date,
+                    "xero_invoice_number": "INV-2",
+                },
+            ],
+        }
+        return pages.get(offset, [])
+
+    monkeypatch.setattr(
+        unbill_tickets.tickets_repo,
+        "list_billed_tickets_older_than",
+        fake_tickets,
+        raising=False,
+    )
+
+    preview = asyncio.run(
+        unbill_tickets.preview_unbill_tickets(
+            unbill_tickets.parse_unbill_cutoff_date("20260530"),
+            limit=1,
+        )
+    )
+
+    assert preview["status"] == "ready"
+    assert preview["totals"] == {"ticketCount": 2}
+    assert [item["id"] for item in preview["items"]] == [1, 2]
+    assert calls == [(1, 0), (1, 1), (1, 2)]
+
+
+def test_billed_ticket_query_includes_billed_time_markers():
+    query_source = (
+        Path(__file__).resolve().parents[1] / "app" / "repositories" / "tickets.py"
+    ).read_text()
+
+    function_source = query_source.split(
+        "async def list_billed_tickets_older_than", 1
+    )[1].split("async def clear_ticket_billing_fields", 1)[0]
+
+    assert "EXISTS" in function_source
+    assert "ticket_billed_time_entries" in function_source
+    assert "merged_into_ticket_id IS NULL" not in function_source


### PR DESCRIPTION
### Motivation
- Prevent missing billed tickets when the matched set exceeds a single query limit by reading billed tickets in pages. 
- Ensure tickets are considered billed if they have billed time-entry markers in `ticket_billed_time_entries`, not only when `billed_at` or `xero_invoice_number` are present.
- Reduce the default page size to a reasonable value to avoid large single-query loads.

### Description
- Changed `list_billed_tickets_older_than` in `app/repositories/tickets.py` to accept an `offset` parameter and use `LIMIT %s OFFSET %s` while expanding the billed criteria to include an `EXISTS` subquery against `ticket_billed_time_entries` and removed the `merged_into_ticket_id IS NULL` condition. 
- Replaced `_MAX_TICKETS_PER_RUN` with `_DEFAULT_TICKETS_PAGE_SIZE = 1000` in `app/services/unbill_tickets.py` and updated `preview_unbill_tickets` to page through results using `limit` and `offset`, aggregating pages until exhausted. 
- Adjusted `preview_unbill_tickets` signature to `preview_unbill_tickets(cutoff_date, *, limit: int = _DEFAULT_TICKETS_PAGE_SIZE)` and added a brief docstring noting pagination behavior. 
- Extended tests in `tests/test_unbill_tickets.py` to cover pagination (`test_preview_unbill_tickets_scans_all_ticket_pages`) and to assert the repository query now references `ticket_billed_time_entries` and `EXISTS` (`test_billed_ticket_query_includes_billed_time_markers`).

### Testing
- Ran the unit tests in `tests/test_unbill_tickets.py` with `pytest`, and the added tests `test_preview_unbill_tickets_scans_all_ticket_pages` and `test_billed_ticket_query_includes_billed_time_markers` passed. 
- Existing parsing tests for `parse_unbill_cutoff_date` were also run and passed under `pytest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a61bdba77248332847cfb720da6bf39)