### PR TITLE
Restrict generated invoice tickets to Xero billable statuses

### DIFF
--- a/app/services/invoice_generator.py
+++ b/app/services/invoice_generator.py
@@ -3,6 +3,7 @@
 Generates invoices from company recurring invoice items and billable tickets,
 storing them locally in MyPortal (no external accounting system required).
 """
+
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta, timezone
@@ -24,16 +25,33 @@ from app.repositories import users as users_repo
 from app.services import modules as modules_service
 from app.services import xero as xero_service
 
-
-DEFAULT_XERO_LINE_ITEM_TEMPLATE = "Ticket {ticket_id}: {ticket_subject} {labour_suffix} ({labour_duration})"
+DEFAULT_XERO_LINE_ITEM_TEMPLATE = (
+    "Ticket {ticket_id}: {ticket_subject} {labour_suffix} ({labour_duration})"
+)
 
 
 def _env_xero_line_item_template() -> str:
     return str(os.getenv("XERO_LINE_ITEM_TEMPLATE", "")).strip()
 
 
+def _get_env_xero_billable_statuses() -> set[str]:
+    """Return ticket statuses that may be billed by local invoice generation.
+
+    The Generate Invoice scheduled task must follow the XERO_BILLABLE_STATUSES
+    environment setting so tickets in other workflow states are not pulled into
+    local invoices just because they have unbilled time or expenses.
+    """
+
+    return (
+        xero_service._normalise_status_filter(os.getenv("XERO_BILLABLE_STATUSES", ""))
+        or set()
+    )
+
+
 def _minutes_to_hours(minutes: int) -> Decimal:
-    return (Decimal(minutes) / Decimal(60)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return (Decimal(minutes) / Decimal(60)).quantize(
+        Decimal("0.01"), rounding=ROUND_HALF_UP
+    )
 
 
 def _coerce_minutes(value: Any) -> int:
@@ -61,7 +79,10 @@ async def _get_xero_line_item_template() -> str:
         settings = await modules_service.get_module_settings("xero") or {}
     except RuntimeError:
         settings = {}
-    return str(settings.get("line_item_description_template") or "").strip() or DEFAULT_XERO_LINE_ITEM_TEMPLATE
+    return (
+        str(settings.get("line_item_description_template") or "").strip()
+        or DEFAULT_XERO_LINE_ITEM_TEMPLATE
+    )
 
 
 def _strip_empty_description_segments(description: str) -> str:
@@ -112,7 +133,11 @@ def _build_expense_line_description(
     if not expense_descriptions:
         return base_description
     if len(expense_descriptions) == 1:
-        return f"{base_description} - {expense_descriptions[0]}" if base_description else expense_descriptions[0]
+        return (
+            f"{base_description} - {expense_descriptions[0]}"
+            if base_description
+            else expense_descriptions[0]
+        )
     expenses_text = "\n".join(expense_descriptions)
     return f"{base_description}\n{expenses_text}" if base_description else expenses_text
 
@@ -167,7 +192,9 @@ async def _get_xero_rate_lookup_credentials() -> tuple[str | None, str | None]:
     try:
         module = await modules_service.get_module("xero", redact=False)
     except Exception as exc:
-        logger.warning("Failed to load Xero module for recurring item price lookup", error=str(exc))
+        logger.warning(
+            "Failed to load Xero module for recurring item price lookup", error=str(exc)
+        )
         return None, None
 
     if not module or not module.get("enabled"):
@@ -177,17 +204,25 @@ async def _get_xero_rate_lookup_credentials() -> tuple[str | None, str | None]:
     try:
         credentials = await modules_service.get_xero_credentials() or {}
     except Exception as exc:
-        logger.warning("Failed to load Xero credentials for recurring item price lookup", error=str(exc))
+        logger.warning(
+            "Failed to load Xero credentials for recurring item price lookup",
+            error=str(exc),
+        )
         credentials = {}
 
-    tenant_id = str(credentials.get("tenant_id") or settings.get("tenant_id") or "").strip()
+    tenant_id = str(
+        credentials.get("tenant_id") or settings.get("tenant_id") or ""
+    ).strip()
     if not tenant_id:
         return None, None
 
     try:
         access_token = await modules_service.acquire_xero_access_token()
     except Exception as exc:
-        logger.warning("Failed to acquire Xero access token for recurring item price lookup", error=str(exc))
+        logger.warning(
+            "Failed to acquire Xero access token for recurring item price lookup",
+            error=str(exc),
+        )
         return None, None
 
     return tenant_id, access_token
@@ -241,6 +276,8 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
     ticket_numbers: list[str] = []
     billable_tickets_found = 0
 
+    billable_statuses = _get_env_xero_billable_statuses()
+
     # Fetch all tickets for the company and find unbilled ones
     try:
         all_tickets = await tickets_repo.list_tickets(company_id=company_id, limit=1000)
@@ -253,13 +290,22 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
         all_tickets = []
 
     for ticket in all_tickets:
+        ticket_status = str(ticket.get("status") or "").strip().lower()
+        if ticket_status not in billable_statuses:
+            continue
+
         ticket_id = ticket.get("id")
         if not ticket_id:
             continue
 
         unbilled_reply_ids = await billed_time_repo.get_unbilled_reply_ids(ticket_id)
-        unbilled_expenses = await expenses_repo.list_expenses(ticket_id, unbilled_only=True)
-        expense_total = sum((_to_decimal(expense.get("amount")) or Decimal("0")) for expense in unbilled_expenses)
+        unbilled_expenses = await expenses_repo.list_expenses(
+            ticket_id, unbilled_only=True
+        )
+        expense_total = sum(
+            (_to_decimal(expense.get("amount")) or Decimal("0"))
+            for expense in unbilled_expenses
+        )
         if not unbilled_reply_ids and expense_total <= 0:
             continue
 
@@ -336,7 +382,11 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
                 "labour_groups": labour_groups,
                 "requester_name": requester_name,
                 "requester_email": requester_email,
-                "expense_ids": [int(expense["id"]) for expense in unbilled_expenses if expense.get("id")],
+                "expense_ids": [
+                    int(expense["id"])
+                    for expense in unbilled_expenses
+                    if expense.get("id")
+                ],
             }
         )
 
@@ -348,13 +398,21 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
                 requester_name=requester_name,
                 requester_email=requester_email,
             )
-            ticket_line_items.append({
-                "Description": description,
-                "Quantity": 1.0,
-                "UnitAmount": float(expense_total.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)),
-                "ItemCode": "",
-                "MyPortalTicketExpenseIds": [int(expense["id"]) for expense in unbilled_expenses if expense.get("id")],
-            })
+            ticket_line_items.append(
+                {
+                    "Description": description,
+                    "Quantity": 1.0,
+                    "UnitAmount": float(
+                        expense_total.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+                    ),
+                    "ItemCode": "",
+                    "MyPortalTicketExpenseIds": [
+                        int(expense["id"])
+                        for expense in unbilled_expenses
+                        if expense.get("id")
+                    ],
+                }
+            )
 
         ticket_num = str(ticket_id)
         if ticket_num not in ticket_numbers:
@@ -443,7 +501,9 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
     ]
     now = datetime.now(timezone.utc)
     try:
-        await recurring_items_repo.mark_recurring_invoice_items_billed(recurring_item_ids, billed_at=now)
+        await recurring_items_repo.mark_recurring_invoice_items_billed(
+            recurring_item_ids, billed_at=now
+        )
     except Exception as exc:
         logger.error(
             "Failed to update recurring invoice item billing timestamps",
@@ -491,9 +551,17 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
                 )
 
         try:
-            await expenses_repo.mark_expenses_billed(list(ticket_ctx.get("expense_ids") or []), invoice_number=invoice_number, billed_at=now)
+            await expenses_repo.mark_expenses_billed(
+                list(ticket_ctx.get("expense_ids") or []),
+                invoice_number=invoice_number,
+                billed_at=now,
+            )
         except Exception as exc:
-            logger.error("Failed to mark ticket expenses billed", ticket_id=ticket_id, error=str(exc))
+            logger.error(
+                "Failed to mark ticket expenses billed",
+                ticket_id=ticket_id,
+                error=str(exc),
+            )
 
         # Update ticket: mark as billed and move to the configured invoiced status.
         invoiced_status = xero_service.resolve_invoiced_ticket_status()

--- a/app/services/scheduled_task_preview.py
+++ b/app/services/scheduled_task_preview.py
@@ -25,7 +25,9 @@ PREVIEWABLE_COMMANDS = {
 
 def _money(value: Any) -> str:
     try:
-        return str(Decimal(str(value or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+        return str(
+            Decimal(str(value or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        )
     except Exception:
         return "0.00"
 
@@ -39,7 +41,12 @@ async def preview_task(task: Mapping[str, Any]) -> dict[str, Any]:
             "summary": "Preview is not available for this scheduled task command.",
             "items": [],
         }
-    if command in {"sync_to_xero", "sync_to_xero_auto_send", "generate_invoice", "unbill_time_entries"}:
+    if command in {
+        "sync_to_xero",
+        "sync_to_xero_auto_send",
+        "generate_invoice",
+        "unbill_time_entries",
+    }:
         company_id = task.get("company_id")
         if not company_id and command != "unbill_time_entries":
             return {
@@ -49,7 +56,9 @@ async def preview_task(task: Mapping[str, Any]) -> dict[str, Any]:
                 "items": [],
             }
         if command == "unbill_time_entries":
-            return await unbill_time_entries_service.preview_unbill_time_entries(int(company_id) if company_id else None)
+            return await unbill_time_entries_service.preview_unbill_time_entries(
+                int(company_id) if company_id else None
+            )
         company = await company_repo.get_company_by_id(int(company_id))
         if not company:
             return {
@@ -61,28 +70,42 @@ async def preview_task(task: Mapping[str, Any]) -> dict[str, Any]:
             }
         if command == "generate_invoice":
             return await _preview_generate_invoice(int(company_id), company)
-        return await _preview_sync_to_xero(int(company_id), company, auto_send=command == "sync_to_xero_auto_send")
+        return await _preview_sync_to_xero(
+            int(company_id), company, auto_send=command == "sync_to_xero_auto_send"
+        )
     return await _preview_price_change_notifications()
 
 
-async def _preview_sync_to_xero(company_id: int, company: Mapping[str, Any], *, auto_send: bool) -> dict[str, Any]:
+async def _preview_sync_to_xero(
+    company_id: int, company: Mapping[str, Any], *, auto_send: bool
+) -> dict[str, Any]:
     invoices = await invoice_repo.list_unsynced_company_invoices(company_id)
     items: list[dict[str, Any]] = []
     total = Decimal("0.00")
     for invoice in invoices:
         invoice_id = int(invoice.get("id") or 0)
-        lines = await invoice_lines_repo.list_invoice_lines(invoice_id) if invoice_id else []
+        lines = (
+            await invoice_lines_repo.list_invoice_lines(invoice_id)
+            if invoice_id
+            else []
+        )
         amount = Decimal(str(invoice.get("amount") or 0))
         total += amount
-        items.append({
-            "type": "invoice",
-            "id": invoice_id,
-            "label": str(invoice.get("invoice_number") or f"Invoice #{invoice_id}"),
-            "amount": _money(amount),
-            "lineCount": len(lines),
-            "dueDate": invoice.get("due_date"),
-            "action": "Authorise and send to Xero" if auto_send else "Create draft invoice in Xero",
-        })
+        items.append(
+            {
+                "type": "invoice",
+                "id": invoice_id,
+                "label": str(invoice.get("invoice_number") or f"Invoice #{invoice_id}"),
+                "amount": _money(amount),
+                "lineCount": len(lines),
+                "dueDate": invoice.get("due_date"),
+                "action": (
+                    "Authorise and send to Xero"
+                    if auto_send
+                    else "Create draft invoice in Xero"
+                ),
+            }
+        )
     return {
         "status": "ready" if items else "skipped",
         "command": "sync_to_xero_auto_send" if auto_send else "sync_to_xero",
@@ -91,21 +114,31 @@ async def _preview_sync_to_xero(company_id: int, company: Mapping[str, Any], *, 
         "summary": (
             f"{len(items)} unsynchronised MyPortal invoice(s) will be uploaded to Xero"
             + (" and sent automatically." if auto_send else " as draft invoices.")
-            if items else "No unsynchronised MyPortal invoices were found."
+            if items
+            else "No unsynchronised MyPortal invoices were found."
         ),
         "totals": {"invoiceCount": len(items), "amount": _money(total)},
         "items": items,
     }
 
 
-async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any]) -> dict[str, Any]:
+async def _preview_generate_invoice(
+    company_id: int, company: Mapping[str, Any]
+) -> dict[str, Any]:
     line_item_template = await invoice_generator_service._get_xero_line_item_template()
     context = await xero_service.build_invoice_context(company_id)
-    recurring_items = await xero_service.build_recurring_invoice_items(company_id, tax_type=None, context=context)
+    recurring_items = await xero_service.build_recurring_invoice_items(
+        company_id, tax_type=None, context=context
+    )
     tickets = await tickets_repo.list_tickets(company_id=company_id, limit=1000)
+    billable_statuses = invoice_generator_service._get_env_xero_billable_statuses()
     ticket_items: list[dict[str, Any]] = []
     billable_reply_count = 0
     for ticket in tickets:
+        ticket_status = str(ticket.get("status") or "").strip().lower()
+        if ticket_status not in billable_statuses:
+            continue
+
         ticket_id = ticket.get("id")
         if not ticket_id:
             continue
@@ -113,15 +146,23 @@ async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any])
         if not unbilled_ids:
             continue
         replies = await tickets_repo.list_replies(ticket_id, include_internal=True)
-        minutes = sum(invoice_generator_service._coerce_minutes(r.get("minutes_spent")) for r in replies if r.get("id") in unbilled_ids and r.get("is_billable"))
+        minutes = sum(
+            invoice_generator_service._coerce_minutes(r.get("minutes_spent"))
+            for r in replies
+            if r.get("id") in unbilled_ids and r.get("is_billable")
+        )
         if minutes <= 0:
             continue
-        billable_reply_count += len([r for r in replies if r.get("id") in unbilled_ids and r.get("is_billable")])
+        billable_reply_count += len(
+            [r for r in replies if r.get("id") in unbilled_ids and r.get("is_billable")]
+        )
         labour_map: dict[tuple[str | None, str | None], dict[str, Any]] = {}
         for reply in replies:
             if reply.get("id") not in unbilled_ids or not reply.get("is_billable"):
                 continue
-            reply_minutes = invoice_generator_service._coerce_minutes(reply.get("minutes_spent"))
+            reply_minutes = invoice_generator_service._coerce_minutes(
+                reply.get("minutes_spent")
+            )
             if reply_minutes <= 0:
                 continue
             labour_code = str(reply.get("labour_type_code") or "").strip() or None
@@ -130,10 +171,17 @@ async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any])
             key = (labour_code, labour_name)
             bucket = labour_map.get(key)
             if not bucket:
-                bucket = {"minutes": 0, "code": labour_code, "name": labour_name, "rate": labour_rate}
+                bucket = {
+                    "minutes": 0,
+                    "code": labour_code,
+                    "name": labour_name,
+                    "rate": labour_rate,
+                }
                 labour_map[key] = bucket
             bucket["minutes"] += reply_minutes
-        requester_name, requester_email = await invoice_generator_service.resolve_ticket_requester(dict(ticket))
+        requester_name, requester_email = (
+            await invoice_generator_service.resolve_ticket_requester(dict(ticket))
+        )
         for group in labour_map.values():
             group_minutes = int(group.get("minutes") or 0)
             if group_minutes <= 0:
@@ -148,7 +196,9 @@ async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any])
                 requester_name=requester_name,
                 requester_email=requester_email,
             )
-            unit_amount = invoice_generator_service._to_decimal(group.get("rate")) or Decimal("0")
+            unit_amount = invoice_generator_service._to_decimal(
+                group.get("rate")
+            ) or Decimal("0")
             labour_code = str(group.get("code") or "").strip()
             ticket_item: dict[str, Any] = {
                 "type": "ticket",
@@ -164,32 +214,67 @@ async def _preview_generate_invoice(company_id: int, company: Mapping[str, Any])
             if labour_code:
                 ticket_item["xeroItemCode"] = labour_code
             ticket_items.append(ticket_item)
-    recurring_total = sum(Decimal(str(i.get("Quantity") or 0)) * Decimal(str(i.get("UnitAmount") or 0)) for i in recurring_items)
+    recurring_total = sum(
+        Decimal(str(i.get("Quantity") or 0)) * Decimal(str(i.get("UnitAmount") or 0))
+        for i in recurring_items
+    )
     return {
         "status": "ready" if recurring_items or ticket_items else "skipped",
         "command": "generate_invoice",
         "company_id": company_id,
         "company_name": company.get("name") or f"Company #{company_id}",
-        "summary": "A draft MyPortal invoice will be generated." if recurring_items or ticket_items else "No active recurring invoice items or billable tickets were found.",
-        "totals": {"recurringLineCount": len(recurring_items), "ticketLineCount": len(ticket_items), "billableReplyCount": billable_reply_count, "recurringAmount": _money(recurring_total)},
-        "items": [{"type": "recurring", "label": i.get("Description") or i.get("ItemCode") or "Recurring item", "amount": _money(Decimal(str(i.get("Quantity") or 0)) * Decimal(str(i.get("UnitAmount") or 0))), "action": "Add recurring line to the generated invoice"} for i in recurring_items] + ticket_items,
+        "summary": (
+            "A draft MyPortal invoice will be generated."
+            if recurring_items or ticket_items
+            else "No active recurring invoice items or billable tickets were found."
+        ),
+        "totals": {
+            "recurringLineCount": len(recurring_items),
+            "ticketLineCount": len(ticket_items),
+            "billableReplyCount": billable_reply_count,
+            "recurringAmount": _money(recurring_total),
+        },
+        "items": [
+            {
+                "type": "recurring",
+                "label": i.get("Description") or i.get("ItemCode") or "Recurring item",
+                "amount": _money(
+                    Decimal(str(i.get("Quantity") or 0))
+                    * Decimal(str(i.get("UnitAmount") or 0))
+                ),
+                "action": "Add recurring line to the generated invoice",
+            }
+            for i in recurring_items
+        ]
+        + ticket_items,
     }
 
 
 async def _preview_price_change_notifications() -> dict[str, Any]:
-    products = await subscription_price_changes.get_products_with_pending_price_changes()
-    items = [{
-        "type": "product",
-        "id": int(product.get("id") or 0),
-        "label": product.get("name") or product.get("sku") or f"Product #{product.get('id')}",
-        "category": product.get("category_name"),
-        "effectiveDate": product.get("price_change_date"),
-        "action": "Notify subscribed billing contacts about the scheduled price change",
-    } for product in products]
+    products = (
+        await subscription_price_changes.get_products_with_pending_price_changes()
+    )
+    items = [
+        {
+            "type": "product",
+            "id": int(product.get("id") or 0),
+            "label": product.get("name")
+            or product.get("sku")
+            or f"Product #{product.get('id')}",
+            "category": product.get("category_name"),
+            "effectiveDate": product.get("price_change_date"),
+            "action": "Notify subscribed billing contacts about the scheduled price change",
+        }
+        for product in products
+    ]
     return {
         "status": "ready" if items else "skipped",
         "command": "send_price_change_notifications",
-        "summary": f"{len(items)} product(s) have pending price change notifications." if items else "No pending price change notifications were found.",
+        "summary": (
+            f"{len(items)} product(s) have pending price change notifications."
+            if items
+            else "No pending price change notifications were found."
+        ),
         "totals": {"productCount": len(items)},
         "items": items,
     }

--- a/tests/test_invoice_generator.py
+++ b/tests/test_invoice_generator.py
@@ -1,4 +1,5 @@
 """Tests for the local invoice generator service."""
+
 from __future__ import annotations
 
 import asyncio
@@ -10,7 +11,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.services import invoice_generator
-
 
 # ---------------------------------------------------------------------------
 # Helper fixtures
@@ -43,8 +43,12 @@ def _mock_ticket_expenses(monkeypatch):
     """Keep invoice generator tests isolated from the ticket expense database."""
 
     monkeypatch.delenv("XERO_LINE_ITEM_TEMPLATE", raising=False)
-    monkeypatch.setattr(invoice_generator.expenses_repo, "list_expenses", AsyncMock(return_value=[]))
-    monkeypatch.setattr(invoice_generator.expenses_repo, "mark_expenses_billed", AsyncMock())
+    monkeypatch.setattr(
+        invoice_generator.expenses_repo, "list_expenses", AsyncMock(return_value=[])
+    )
+    monkeypatch.setattr(
+        invoice_generator.expenses_repo, "mark_expenses_billed", AsyncMock()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -58,7 +62,9 @@ def test_generate_invoice_number_first(monkeypatch):
     async def fake_get_max_seq(prefix: str) -> int:
         return 0
 
-    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", fake_get_max_seq)
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "get_max_invoice_seq", fake_get_max_seq
+    )
 
     from datetime import datetime, timezone
 
@@ -77,7 +83,9 @@ def test_generate_invoice_number_increments(monkeypatch):
     async def fake_get_max_seq(prefix: str) -> int:
         return 12
 
-    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", fake_get_max_seq)
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "get_max_invoice_seq", fake_get_max_seq
+    )
 
     from datetime import datetime, timezone
 
@@ -99,7 +107,9 @@ def test_generate_invoice_company_not_found(monkeypatch):
     async def fake_get_company(company_id):
         return None
 
-    monkeypatch.setattr(invoice_generator.company_repo, "get_company_by_id", fake_get_company)
+    monkeypatch.setattr(
+        invoice_generator.company_repo, "get_company_by_id", fake_get_company
+    )
 
     result = asyncio.run(invoice_generator.generate_invoice(99))
 
@@ -183,9 +193,15 @@ def test_generate_invoice_recurring_items_only(monkeypatch):
         "list_tickets",
         AsyncMock(return_value=[]),
     )
-    monkeypatch.setattr(invoice_generator.invoice_repo, "create_invoice", fake_create_invoice)
-    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", fake_get_max_seq)
-    monkeypatch.setattr(invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line)
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "create_invoice", fake_create_invoice
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "get_max_invoice_seq", fake_get_max_seq
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line
+    )
 
     from datetime import datetime, timezone
 
@@ -209,7 +225,9 @@ def test_generate_invoice_recurring_items_only(monkeypatch):
     assert created_invoices[0]["company_id"] == 1
 
 
-def test_generate_invoice_passes_xero_credentials_for_recurring_price_lookup(monkeypatch):
+def test_generate_invoice_passes_xero_credentials_for_recurring_price_lookup(
+    monkeypatch,
+):
     build_recurring = AsyncMock(return_value=_make_recurring_items())
 
     async def fake_create_invoice(**kwargs):
@@ -218,13 +236,28 @@ def test_generate_invoice_passes_xero_credentials_for_recurring_price_lookup(mon
     async def fake_create_line(**kwargs):
         return {"id": 1, **kwargs}
 
-    monkeypatch.setattr(invoice_generator.company_repo, "get_company_by_id", AsyncMock(return_value=_make_company()))
-    monkeypatch.setattr(invoice_generator.xero_service, "build_invoice_context", AsyncMock(return_value={}))
-    monkeypatch.setattr(invoice_generator.xero_service, "build_recurring_invoice_items", build_recurring)
+    monkeypatch.setattr(
+        invoice_generator.company_repo,
+        "get_company_by_id",
+        AsyncMock(return_value=_make_company()),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service,
+        "build_invoice_context",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service, "build_recurring_invoice_items", build_recurring
+    )
     monkeypatch.setattr(
         invoice_generator.modules_service,
         "get_module",
-        AsyncMock(return_value={"enabled": True, "settings": {"tenant_id": "tenant-from-settings"}}),
+        AsyncMock(
+            return_value={
+                "enabled": True,
+                "settings": {"tenant_id": "tenant-from-settings"},
+            }
+        ),
     )
     monkeypatch.setattr(
         invoice_generator.modules_service,
@@ -236,10 +269,18 @@ def test_generate_invoice_passes_xero_credentials_for_recurring_price_lookup(mon
         "acquire_xero_access_token",
         AsyncMock(return_value="access-token"),
     )
-    monkeypatch.setattr(invoice_generator.tickets_repo, "list_tickets", AsyncMock(return_value=[]))
-    monkeypatch.setattr(invoice_generator.invoice_repo, "create_invoice", fake_create_invoice)
-    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0))
-    monkeypatch.setattr(invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line)
+    monkeypatch.setattr(
+        invoice_generator.tickets_repo, "list_tickets", AsyncMock(return_value=[])
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "create_invoice", fake_create_invoice
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0)
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line
+    )
 
     result = asyncio.run(invoice_generator.generate_invoice(1))
 
@@ -251,6 +292,7 @@ def test_generate_invoice_passes_xero_credentials_for_recurring_price_lookup(mon
 
 
 def test_generate_invoice_billable_ticket_uses_hours_and_minutes(monkeypatch):
+    monkeypatch.setenv("XERO_BILLABLE_STATUSES", "resolved")
     created_lines: list[dict[str, Any]] = []
 
     async def fake_create_invoice(**kwargs):
@@ -260,28 +302,82 @@ def test_generate_invoice_billable_ticket_uses_hours_and_minutes(monkeypatch):
         created_lines.append(kwargs)
         return {"id": len(created_lines), **kwargs}
 
-    monkeypatch.setattr(invoice_generator.company_repo, "get_company_by_id", AsyncMock(return_value=_make_company()))
-    monkeypatch.setattr(invoice_generator.xero_service, "build_invoice_context", AsyncMock(return_value={}))
-    monkeypatch.setattr(invoice_generator.xero_service, "build_recurring_invoice_items", AsyncMock(return_value=[]))
-    monkeypatch.setattr(invoice_generator.tickets_repo, "list_tickets", AsyncMock(return_value=[{"id": 55, "subject": "VPN help"}]))
-    monkeypatch.setattr(invoice_generator.billed_time_repo, "get_unbilled_reply_ids", AsyncMock(return_value=[1, 2]))
-    monkeypatch.setattr(invoice_generator.tickets_repo, "list_replies", AsyncMock(return_value=[
-        {"id": 1, "minutes_spent": 120, "is_billable": True, "labour_type_name": "Remote", "labour_type_code": "REMOTE", "labour_type_rate": "100"},
-        {"id": 2, "minutes_spent": 30, "is_billable": True, "labour_type_name": "Remote", "labour_type_code": "REMOTE", "labour_type_rate": "100"},
-    ]))
-    monkeypatch.setattr(invoice_generator.invoice_repo, "create_invoice", fake_create_invoice)
-    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0))
-    monkeypatch.setattr(invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line)
-    monkeypatch.setattr(invoice_generator.billed_time_repo, "create_billed_time_entry", AsyncMock())
+    monkeypatch.setattr(
+        invoice_generator.company_repo,
+        "get_company_by_id",
+        AsyncMock(return_value=_make_company()),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service,
+        "build_invoice_context",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service,
+        "build_recurring_invoice_items",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        invoice_generator.tickets_repo,
+        "list_tickets",
+        AsyncMock(
+            return_value=[{"id": 55, "subject": "VPN help", "status": "resolved"}]
+        ),
+    )
+    monkeypatch.setattr(
+        invoice_generator.billed_time_repo,
+        "get_unbilled_reply_ids",
+        AsyncMock(return_value=[1, 2]),
+    )
+    monkeypatch.setattr(
+        invoice_generator.tickets_repo,
+        "list_replies",
+        AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "minutes_spent": 120,
+                    "is_billable": True,
+                    "labour_type_name": "Remote",
+                    "labour_type_code": "REMOTE",
+                    "labour_type_rate": "100",
+                },
+                {
+                    "id": 2,
+                    "minutes_spent": 30,
+                    "is_billable": True,
+                    "labour_type_name": "Remote",
+                    "labour_type_code": "REMOTE",
+                    "labour_type_rate": "100",
+                },
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "create_invoice", fake_create_invoice
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0)
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line
+    )
+    monkeypatch.setattr(
+        invoice_generator.billed_time_repo, "create_billed_time_entry", AsyncMock()
+    )
     monkeypatch.setattr(invoice_generator.tickets_repo, "update_ticket", AsyncMock())
 
     result = asyncio.run(invoice_generator.generate_invoice(1))
 
     assert result["status"] == "succeeded"
-    assert created_lines[0]["description"] == "Ticket 55: VPN help Remote (2 Hours 30 Mins)"
+    assert (
+        created_lines[0]["description"]
+        == "Ticket 55: VPN help Remote (2 Hours 30 Mins)"
+    )
 
 
 def test_generate_invoice_resolves_requester_name_for_template(monkeypatch):
+    monkeypatch.setenv("XERO_BILLABLE_STATUSES", "resolved")
     created_lines: list[dict[str, Any]] = []
 
     async def fake_create_invoice(**kwargs):
@@ -291,28 +387,84 @@ def test_generate_invoice_resolves_requester_name_for_template(monkeypatch):
         created_lines.append(kwargs)
         return {"id": len(created_lines), **kwargs}
 
-    monkeypatch.setenv("XERO_LINE_ITEM_TEMPLATE", "Ticket {ticket_id}: {ticket_subject} - {requester_name}")
-    monkeypatch.setattr(invoice_generator.company_repo, "get_company_by_id", AsyncMock(return_value=_make_company()))
-    monkeypatch.setattr(invoice_generator.xero_service, "build_invoice_context", AsyncMock(return_value={}))
-    monkeypatch.setattr(invoice_generator.xero_service, "build_recurring_invoice_items", AsyncMock(return_value=[]))
+    monkeypatch.setenv(
+        "XERO_LINE_ITEM_TEMPLATE",
+        "Ticket {ticket_id}: {ticket_subject} - {requester_name}",
+    )
+    monkeypatch.setattr(
+        invoice_generator.company_repo,
+        "get_company_by_id",
+        AsyncMock(return_value=_make_company()),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service,
+        "build_invoice_context",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service,
+        "build_recurring_invoice_items",
+        AsyncMock(return_value=[]),
+    )
     monkeypatch.setattr(
         invoice_generator.tickets_repo,
         "list_tickets",
-        AsyncMock(return_value=[{"id": 55, "subject": "VPN help", "requester_id": 99}]),
+        AsyncMock(
+            return_value=[
+                {
+                    "id": 55,
+                    "subject": "VPN help",
+                    "status": "resolved",
+                    "requester_id": 99,
+                }
+            ]
+        ),
     )
     monkeypatch.setattr(
         invoice_generator.xero_service.users_repo,
         "get_user_by_id",
-        AsyncMock(return_value={"id": 99, "first_name": "Jane", "last_name": "Requester", "email": "jane@example.com"}),
+        AsyncMock(
+            return_value={
+                "id": 99,
+                "first_name": "Jane",
+                "last_name": "Requester",
+                "email": "jane@example.com",
+            }
+        ),
     )
-    monkeypatch.setattr(invoice_generator.billed_time_repo, "get_unbilled_reply_ids", AsyncMock(return_value=[1]))
-    monkeypatch.setattr(invoice_generator.tickets_repo, "list_replies", AsyncMock(return_value=[
-        {"id": 1, "minutes_spent": 60, "is_billable": True, "labour_type_name": "Remote", "labour_type_code": "REMOTE", "labour_type_rate": "100"},
-    ]))
-    monkeypatch.setattr(invoice_generator.invoice_repo, "create_invoice", fake_create_invoice)
-    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0))
-    monkeypatch.setattr(invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line)
-    monkeypatch.setattr(invoice_generator.billed_time_repo, "create_billed_time_entry", AsyncMock())
+    monkeypatch.setattr(
+        invoice_generator.billed_time_repo,
+        "get_unbilled_reply_ids",
+        AsyncMock(return_value=[1]),
+    )
+    monkeypatch.setattr(
+        invoice_generator.tickets_repo,
+        "list_replies",
+        AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "minutes_spent": 60,
+                    "is_billable": True,
+                    "labour_type_name": "Remote",
+                    "labour_type_code": "REMOTE",
+                    "labour_type_rate": "100",
+                },
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "create_invoice", fake_create_invoice
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0)
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line
+    )
+    monkeypatch.setattr(
+        invoice_generator.billed_time_repo, "create_billed_time_entry", AsyncMock()
+    )
     monkeypatch.setattr(invoice_generator.tickets_repo, "update_ticket", AsyncMock())
 
     result = asyncio.run(invoice_generator.generate_invoice(1))
@@ -321,7 +473,88 @@ def test_generate_invoice_resolves_requester_name_for_template(monkeypatch):
     assert created_lines[0]["description"] == "Ticket 55: VPN help - Jane Requester"
 
 
+def test_generate_invoice_only_includes_env_billable_statuses(monkeypatch):
+    created_lines: list[dict[str, Any]] = []
+
+    async def fake_create_invoice(**kwargs):
+        return {"id": 404, **kwargs}
+
+    async def fake_create_line(**kwargs):
+        created_lines.append(kwargs)
+        return {"id": len(created_lines), **kwargs}
+
+    monkeypatch.setenv("XERO_BILLABLE_STATUSES", "resolved")
+    monkeypatch.setattr(
+        invoice_generator.company_repo,
+        "get_company_by_id",
+        AsyncMock(return_value=_make_company()),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service,
+        "build_invoice_context",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service,
+        "build_recurring_invoice_items",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        invoice_generator.tickets_repo,
+        "list_tickets",
+        AsyncMock(
+            return_value=[
+                {"id": 55, "subject": "VPN help", "status": "resolved"},
+                {"id": 56, "subject": "Do not bill yet", "status": "open"},
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        invoice_generator.billed_time_repo,
+        "get_unbilled_reply_ids",
+        AsyncMock(return_value=[1]),
+    )
+    monkeypatch.setattr(
+        invoice_generator.tickets_repo,
+        "list_replies",
+        AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "minutes_spent": 60,
+                    "is_billable": True,
+                    "labour_type_name": "Remote",
+                    "labour_type_code": "REMOTE",
+                    "labour_type_rate": "100",
+                },
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "create_invoice", fake_create_invoice
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0)
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line
+    )
+    monkeypatch.setattr(
+        invoice_generator.billed_time_repo, "create_billed_time_entry", AsyncMock()
+    )
+    update_ticket = AsyncMock()
+    monkeypatch.setattr(invoice_generator.tickets_repo, "update_ticket", update_ticket)
+
+    result = asyncio.run(invoice_generator.generate_invoice(1))
+
+    assert result["status"] == "succeeded"
+    update_ticket.assert_awaited_once()
+    assert update_ticket.await_args.args[0] == 55
+    assert len(created_lines) == 1
+
+
 def test_generate_invoice_expense_description_excludes_minutes_and_amount(monkeypatch):
+    monkeypatch.setenv("XERO_BILLABLE_STATUSES", "resolved")
     created_lines: list[dict[str, Any]] = []
 
     async def fake_create_invoice(**kwargs):
@@ -335,35 +568,87 @@ def test_generate_invoice_expense_description_excludes_minutes_and_amount(monkey
         "XERO_LINE_ITEM_TEMPLATE",
         "Ticket #{ticket_id}: {ticket_subject} - {labour_name} - ({labour_duration})",
     )
-    monkeypatch.setattr(invoice_generator.company_repo, "get_company_by_id", AsyncMock(return_value=_make_company()))
-    monkeypatch.setattr(invoice_generator.xero_service, "build_invoice_context", AsyncMock(return_value={}))
-    monkeypatch.setattr(invoice_generator.xero_service, "build_recurring_invoice_items", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        invoice_generator.company_repo,
+        "get_company_by_id",
+        AsyncMock(return_value=_make_company()),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service,
+        "build_invoice_context",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        invoice_generator.xero_service,
+        "build_recurring_invoice_items",
+        AsyncMock(return_value=[]),
+    )
     monkeypatch.setattr(
         invoice_generator.tickets_repo,
         "list_tickets",
-        AsyncMock(return_value=[{"id": 25136, "subject": "Expenses test 2"}]),
+        AsyncMock(
+            return_value=[
+                {"id": 25136, "subject": "Expenses test 2", "status": "resolved"}
+            ]
+        ),
     )
-    monkeypatch.setattr(invoice_generator.billed_time_repo, "get_unbilled_reply_ids", AsyncMock(return_value=[1]))
+    monkeypatch.setattr(
+        invoice_generator.billed_time_repo,
+        "get_unbilled_reply_ids",
+        AsyncMock(return_value=[1]),
+    )
     monkeypatch.setattr(
         invoice_generator.expenses_repo,
         "list_expenses",
-        AsyncMock(return_value=[{"id": 10, "description": "Laptop return freight 2", "amount": "43.75"}]),
+        AsyncMock(
+            return_value=[
+                {"id": 10, "description": "Laptop return freight 2", "amount": "43.75"}
+            ]
+        ),
     )
-    monkeypatch.setattr(invoice_generator.tickets_repo, "list_replies", AsyncMock(return_value=[
-        {"id": 1, "minutes_spent": 10, "is_billable": True, "labour_type_name": "Remote", "labour_type_code": "REMOTE", "labour_type_rate": "100"},
-    ]))
-    monkeypatch.setattr(invoice_generator.invoice_repo, "create_invoice", fake_create_invoice)
-    monkeypatch.setattr(invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0))
-    monkeypatch.setattr(invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line)
-    monkeypatch.setattr(invoice_generator.billed_time_repo, "create_billed_time_entry", AsyncMock())
-    monkeypatch.setattr(invoice_generator.expenses_repo, "mark_expenses_billed", AsyncMock())
+    monkeypatch.setattr(
+        invoice_generator.tickets_repo,
+        "list_replies",
+        AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "minutes_spent": 10,
+                    "is_billable": True,
+                    "labour_type_name": "Remote",
+                    "labour_type_code": "REMOTE",
+                    "labour_type_rate": "100",
+                },
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "create_invoice", fake_create_invoice
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_repo, "get_max_invoice_seq", AsyncMock(return_value=0)
+    )
+    monkeypatch.setattr(
+        invoice_generator.invoice_lines_repo, "create_invoice_line", fake_create_line
+    )
+    monkeypatch.setattr(
+        invoice_generator.billed_time_repo, "create_billed_time_entry", AsyncMock()
+    )
+    monkeypatch.setattr(
+        invoice_generator.expenses_repo, "mark_expenses_billed", AsyncMock()
+    )
     monkeypatch.setattr(invoice_generator.tickets_repo, "update_ticket", AsyncMock())
 
     result = asyncio.run(invoice_generator.generate_invoice(1))
 
     assert result["status"] == "succeeded"
-    expense_line = next(line for line in created_lines if line["unit_amount"] == Decimal("43.75"))
-    assert expense_line["description"] == "Ticket #25136: Expenses test 2 - Expenses - Laptop return freight 2"
+    expense_line = next(
+        line for line in created_lines if line["unit_amount"] == Decimal("43.75")
+    )
+    assert (
+        expense_line["description"]
+        == "Ticket #25136: Expenses test 2 - Expenses - Laptop return freight 2"
+    )
     assert "10 Mins" not in expense_line["description"]
     assert "43.75" not in expense_line["description"]
 

--- a/tests/test_scheduled_task_preview.py
+++ b/tests/test_scheduled_task_preview.py
@@ -5,14 +5,20 @@ from app.services import scheduled_task_preview
 
 
 def test_preview_requires_company_for_generate_invoice():
-    preview = asyncio.run(scheduled_task_preview.preview_task({"command": "generate_invoice", "company_id": None}))
+    preview = asyncio.run(
+        scheduled_task_preview.preview_task(
+            {"command": "generate_invoice", "company_id": None}
+        )
+    )
 
     assert preview["status"] == "skipped"
     assert "Company context" in preview["summary"]
 
 
 def test_preview_unsupported_command():
-    preview = asyncio.run(scheduled_task_preview.preview_task({"command": "sync_staff"}))
+    preview = asyncio.run(
+        scheduled_task_preview.preview_task({"command": "sync_staff"})
+    )
 
     assert preview["status"] == "unsupported"
     assert preview["items"] == []
@@ -36,7 +42,11 @@ def test_preview_price_change_notifications(monkeypatch):
         fake_products,
     )
 
-    preview = asyncio.run(scheduled_task_preview.preview_task({"command": "send_price_change_notifications"}))
+    preview = asyncio.run(
+        scheduled_task_preview.preview_task(
+            {"command": "send_price_change_notifications"}
+        )
+    )
 
     assert preview["status"] == "ready"
     assert preview["totals"]["productCount"] == 1
@@ -44,6 +54,8 @@ def test_preview_price_change_notifications(monkeypatch):
 
 
 def test_generate_invoice_preview_uses_xero_line_item_template(monkeypatch):
+    monkeypatch.setenv("XERO_BILLABLE_STATUSES", "resolved")
+
     async def fake_company(company_id):
         return {"id": company_id, "name": "Acme"}
 
@@ -76,20 +88,43 @@ def test_generate_invoice_preview_uses_xero_line_item_template(monkeypatch):
             }
         ]
 
-    monkeypatch.setattr(scheduled_task_preview.company_repo, "get_company_by_id", fake_company)
-    monkeypatch.setattr(scheduled_task_preview.modules_service, "get_module_settings", fake_settings)
-    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_invoice_context", fake_context)
-    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_recurring_invoice_items", fake_recurring)
-    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_tickets", fake_tickets)
-    monkeypatch.setattr(scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled)
-    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_replies", fake_replies)
+    monkeypatch.setattr(
+        scheduled_task_preview.company_repo, "get_company_by_id", fake_company
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.modules_service, "get_module_settings", fake_settings
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.xero_service, "build_invoice_context", fake_context
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.xero_service,
+        "build_recurring_invoice_items",
+        fake_recurring,
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.tickets_repo, "list_tickets", fake_tickets
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.tickets_repo, "list_replies", fake_replies
+    )
 
-    preview = asyncio.run(scheduled_task_preview.preview_task({"command": "generate_invoice", "company_id": 1}))
+    preview = asyncio.run(
+        scheduled_task_preview.preview_task(
+            {"command": "generate_invoice", "company_id": 1}
+        )
+    )
 
     assert preview["status"] == "ready"
     assert preview["totals"]["ticketLineCount"] == 1
     item = preview["items"][0]
-    assert item["xeroDescription"] == "Ticket #42 - Broken printer - Remote Support - 1 Hour 30 Mins"
+    assert (
+        item["xeroDescription"]
+        == "Ticket #42 - Broken printer - Remote Support - 1 Hour 30 Mins"
+    )
     assert item["xeroQuantity"] == "1.50"
     assert item["xeroUnitAmount"] == "125.50"
     assert item["xeroItemCode"] == "LAB"
@@ -98,6 +133,8 @@ def test_generate_invoice_preview_uses_xero_line_item_template(monkeypatch):
 
 
 def test_generate_invoice_preview_prefers_env_xero_line_item_template(monkeypatch):
+    monkeypatch.setenv("XERO_BILLABLE_STATUSES", "resolved")
+
     async def fake_company(company_id):
         return {"id": company_id, "name": "Acme"}
 
@@ -113,7 +150,14 @@ def test_generate_invoice_preview_prefers_env_xero_line_item_template(monkeypatc
         return []
 
     async def fake_tickets(company_id, limit):
-        return [{"id": 42, "subject": "Broken printer", "status": "Resolved", "requester_name": "Jane Requester"}]
+        return [
+            {
+                "id": 42,
+                "subject": "Broken printer",
+                "status": "Resolved",
+                "requester_name": "Jane Requester",
+            }
+        ]
 
     async def fake_unbilled(ticket_id):
         return [100]
@@ -134,15 +178,35 @@ def test_generate_invoice_preview_prefers_env_xero_line_item_template(monkeypatc
         "XERO_LINE_ITEM_TEMPLATE",
         "Ticket {ticket_id}: {ticket_subject} {labour_suffix} {requester_name} ({labour_duration})",
     )
-    monkeypatch.setattr(scheduled_task_preview.company_repo, "get_company_by_id", fake_company)
-    monkeypatch.setattr(scheduled_task_preview.modules_service, "get_module_settings", fake_settings)
-    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_invoice_context", fake_context)
-    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_recurring_invoice_items", fake_recurring)
-    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_tickets", fake_tickets)
-    monkeypatch.setattr(scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled)
-    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_replies", fake_replies)
+    monkeypatch.setattr(
+        scheduled_task_preview.company_repo, "get_company_by_id", fake_company
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.modules_service, "get_module_settings", fake_settings
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.xero_service, "build_invoice_context", fake_context
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.xero_service,
+        "build_recurring_invoice_items",
+        fake_recurring,
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.tickets_repo, "list_tickets", fake_tickets
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.tickets_repo, "list_replies", fake_replies
+    )
 
-    preview = asyncio.run(scheduled_task_preview.preview_task({"command": "generate_invoice", "company_id": 1}))
+    preview = asyncio.run(
+        scheduled_task_preview.preview_task(
+            {"command": "generate_invoice", "company_id": 1}
+        )
+    )
 
     assert preview["status"] == "ready"
     assert preview["items"][0]["xeroDescription"] == (
@@ -151,6 +215,8 @@ def test_generate_invoice_preview_prefers_env_xero_line_item_template(monkeypatc
 
 
 def test_generate_invoice_preview_resolves_requester_name_for_template(monkeypatch):
+    monkeypatch.setenv("XERO_BILLABLE_STATUSES", "resolved")
+
     async def fake_company(company_id):
         return {"id": company_id, "name": "Acme"}
 
@@ -161,7 +227,14 @@ def test_generate_invoice_preview_resolves_requester_name_for_template(monkeypat
         return []
 
     async def fake_tickets(company_id, limit):
-        return [{"id": 42, "subject": "Broken printer", "status": "Resolved", "requester_id": 99}]
+        return [
+            {
+                "id": 42,
+                "subject": "Broken printer",
+                "status": "Resolved",
+                "requester_id": 99,
+            }
+        ]
 
     async def fake_unbilled(ticket_id):
         return [100]
@@ -178,35 +251,94 @@ def test_generate_invoice_preview_resolves_requester_name_for_template(monkeypat
             }
         ]
 
-    monkeypatch.setenv("XERO_LINE_ITEM_TEMPLATE", "Ticket {ticket_id}: {ticket_subject} - {requester_name}")
-    monkeypatch.setattr(scheduled_task_preview.company_repo, "get_company_by_id", fake_company)
-    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_invoice_context", fake_context)
-    monkeypatch.setattr(scheduled_task_preview.xero_service, "build_recurring_invoice_items", fake_recurring)
-    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_tickets", fake_tickets)
-    monkeypatch.setattr(scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled)
-    monkeypatch.setattr(scheduled_task_preview.tickets_repo, "list_replies", fake_replies)
+    monkeypatch.setenv(
+        "XERO_LINE_ITEM_TEMPLATE",
+        "Ticket {ticket_id}: {ticket_subject} - {requester_name}",
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.company_repo, "get_company_by_id", fake_company
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.xero_service, "build_invoice_context", fake_context
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.xero_service,
+        "build_recurring_invoice_items",
+        fake_recurring,
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.tickets_repo, "list_tickets", fake_tickets
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.tickets_repo, "list_replies", fake_replies
+    )
     monkeypatch.setattr(
         scheduled_task_preview.invoice_generator_service.xero_service.users_repo,
         "get_user_by_id",
-        AsyncMock(return_value={"id": 99, "first_name": "Jane", "last_name": "Requester", "email": "jane@example.com"}),
+        AsyncMock(
+            return_value={
+                "id": 99,
+                "first_name": "Jane",
+                "last_name": "Requester",
+                "email": "jane@example.com",
+            }
+        ),
     )
 
-    preview = asyncio.run(scheduled_task_preview.preview_task({"command": "generate_invoice", "company_id": 1}))
+    preview = asyncio.run(
+        scheduled_task_preview.preview_task(
+            {"command": "generate_invoice", "company_id": 1}
+        )
+    )
 
     assert preview["status"] == "ready"
-    assert preview["items"][0]["xeroDescription"] == "Ticket 42: Broken printer - Jane Requester"
+    assert (
+        preview["items"][0]["xeroDescription"]
+        == "Ticket 42: Broken printer - Jane Requester"
+    )
 
 
 def test_unbill_time_entries_preview_lists_billable_entries(monkeypatch):
     async def fake_entries(company_id, limit, offset=0):
-        return [
-            {"id": 100, "ticket_id": 42, "ticket_number": "T-42", "subject": "AYCE support", "is_billable": True, "minutes_spent": 45, "labour_type_name": "Remote Support"},
-            {"id": 101, "ticket_id": 42, "ticket_number": "T-42", "subject": "AYCE support", "is_billable": True, "minutes_spent": 30, "labour_type_name": "Remote Support"},
-        ] if offset == 0 else []
+        return (
+            [
+                {
+                    "id": 100,
+                    "ticket_id": 42,
+                    "ticket_number": "T-42",
+                    "subject": "AYCE support",
+                    "is_billable": True,
+                    "minutes_spent": 45,
+                    "labour_type_name": "Remote Support",
+                },
+                {
+                    "id": 101,
+                    "ticket_id": 42,
+                    "ticket_number": "T-42",
+                    "subject": "AYCE support",
+                    "is_billable": True,
+                    "minutes_spent": 30,
+                    "labour_type_name": "Remote Support",
+                },
+            ]
+            if offset == 0
+            else []
+        )
 
-    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.tickets_repo, "list_billable_time_entries", fake_entries)
+    monkeypatch.setattr(
+        scheduled_task_preview.unbill_time_entries_service.tickets_repo,
+        "list_billable_time_entries",
+        fake_entries,
+    )
 
-    preview = asyncio.run(scheduled_task_preview.preview_task({"command": "unbill_time_entries", "company_id": 1}))
+    preview = asyncio.run(
+        scheduled_task_preview.preview_task(
+            {"command": "unbill_time_entries", "company_id": 1}
+        )
+    )
 
     assert preview["status"] == "ready"
     assert preview["totals"] == {"timeEntryCount": 2, "minutes": 75}
@@ -217,15 +349,39 @@ def test_unbill_time_entries_preview_lists_billable_entries(monkeypatch):
 def test_unbill_time_entries_preview_scans_all_ticket_pages(monkeypatch):
     async def fake_entries(company_id, limit, offset=0):
         pages = {
-            0: [{"id": 420, "ticket_id": 42, "ticket_number": "T-42", "subject": "First page", "minutes_spent": 30, "labour_type_name": "Remote Support"}],
-            1: [{"id": 840, "ticket_id": 84, "ticket_number": "T-84", "subject": "Second page", "minutes_spent": 30, "labour_type_name": "Remote Support"}],
+            0: [
+                {
+                    "id": 420,
+                    "ticket_id": 42,
+                    "ticket_number": "T-42",
+                    "subject": "First page",
+                    "minutes_spent": 30,
+                    "labour_type_name": "Remote Support",
+                }
+            ],
+            1: [
+                {
+                    "id": 840,
+                    "ticket_id": 84,
+                    "ticket_number": "T-84",
+                    "subject": "Second page",
+                    "minutes_spent": 30,
+                    "labour_type_name": "Remote Support",
+                }
+            ],
         }
         return pages.get(offset, [])
 
-    monkeypatch.setattr(scheduled_task_preview.unbill_time_entries_service.tickets_repo, "list_billable_time_entries", fake_entries)
+    monkeypatch.setattr(
+        scheduled_task_preview.unbill_time_entries_service.tickets_repo,
+        "list_billable_time_entries",
+        fake_entries,
+    )
 
     preview = asyncio.run(
-        scheduled_task_preview.unbill_time_entries_service.preview_unbill_time_entries(1, limit=1)
+        scheduled_task_preview.unbill_time_entries_service.preview_unbill_time_entries(
+            1, limit=1
+        )
     )
 
     assert preview["status"] == "ready"


### PR DESCRIPTION
### Motivation
- Ensure the local Generate Invoice flow only includes tickets whose status is explicitly allowed by the `XERO_BILLABLE_STATUSES` setting so tickets in other workflow states are not pulled into invoices just because they have unbilled time or expenses.

### Description
- Added `invoice_generator._get_env_xero_billable_statuses()` which returns the normalized set from `XERO_BILLABLE_STATUSES` and falls back to an empty set when unset. (`app/services/invoice_generator.py`)
- Applied the billable-status filter in `generate_invoice()` so tickets are skipped unless their `status` is in the environment-configured billable statuses. (`app/services/invoice_generator.py`)
- Applied the same billable-status filter to the scheduled task preview `_preview_generate_invoice()` so previews match actual generation behaviour. (`app/services/scheduled_task_preview.py`)
- Updated/extended unit tests to explicitly set `XERO_BILLABLE_STATUSES` where required and added a regression test that verifies non-billable-status tickets are excluded from generated invoices. (`tests/test_invoice_generator.py`, `tests/test_scheduled_task_preview.py`)

### Testing
- Ran formatter: `python -m black app/services/invoice_generator.py app/services/scheduled_task_preview.py tests/test_invoice_generator.py tests/test_scheduled_task_preview.py` which completed successfully.
- Ran unit tests for the modified areas: `pytest -q tests/test_invoice_generator.py tests/test_scheduled_task_preview.py` and all tests in those files passed (`20 passed`, with warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a61cc08485c8332955875096ebfe93c)