### PR TITLE
Add Create/Update/Reply Ticket workflow steps for staff onboarding/offboarding

### DIFF
--- a/app/features/staff/handlers.py
+++ b/app/features/staff/handlers.py
@@ -846,6 +846,21 @@ _OFFBOARDING_STEP_CATALOG: list[dict[str, Any]] = [
         "description": "Sends workflow details to the requesting user using workflow/system variables.",
     },
     {
+        "type": "create_ticket",
+        "name": "Create Ticket",
+        "description": "Creates a helpdesk ticket for this workflow on behalf of the onboarding/offboarding requester and stores ticket_id/ticket_number variables for later steps.",
+    },
+    {
+        "type": "update_ticket",
+        "name": "Update Ticket",
+        "description": "Updates the workflow ticket status and/or priority using a ticket number or ID from earlier steps.",
+    },
+    {
+        "type": "reply_ticket",
+        "name": "Reply Ticket",
+        "description": "Adds a public reply or internal note to the workflow ticket as the assigned technician, or System if unassigned.",
+    },
+    {
         "type": "wait_for_webhook",
         "name": "Pause For Webhook",
         "description": (
@@ -959,6 +974,21 @@ _ONBOARDING_STEP_CATALOG: list[dict[str, Any]] = [
         "description": "Sends onboarding details (for example login/password) to the requesting user using workflow/system variables.",
     },
     {
+        "type": "create_ticket",
+        "name": "Create Ticket",
+        "description": "Creates a helpdesk ticket for this workflow on behalf of the onboarding/offboarding requester and stores ticket_id/ticket_number variables for later steps.",
+    },
+    {
+        "type": "update_ticket",
+        "name": "Update Ticket",
+        "description": "Updates the workflow ticket status and/or priority using a ticket number or ID from earlier steps.",
+    },
+    {
+        "type": "reply_ticket",
+        "name": "Reply Ticket",
+        "description": "Adds a public reply or internal note to the workflow ticket as the assigned technician, or System if unassigned.",
+    },
+    {
         "type": "wait_for_webhook",
         "name": "Pause For Webhook",
         "description": (
@@ -1039,6 +1069,87 @@ _WORKFLOW_STEP_FORM_SCHEMA: dict[str, dict[str, Any]] = {
         ],
         "retry_policy": {"max_retries": 0},
         "failure_policy": {"mode": "fail_fast", "create_ticket_on_failure": True},
+    },
+    "create_ticket": {
+        "fields": [
+            {
+                "name": "subject",
+                "label": "Subject",
+                "type": "text",
+                "default": "${vars.staff.full_name} onboarding",
+                "required": True,
+            },
+            {
+                "name": "description",
+                "label": "Description",
+                "type": "textarea",
+                "default": "Workflow started for ${vars.staff.full_name}.",
+                "required": True,
+            },
+            {
+                "name": "priority",
+                "label": "Priority",
+                "type": "select",
+                "default": "normal",
+                "options": ["low", "normal", "high", "urgent"],
+            },
+            {"name": "status", "label": "Status", "type": "text", "default": ""},
+            {
+                "name": "assigned_user_id",
+                "label": "Assigned technician user ID",
+                "type": "number",
+                "required": False,
+            },
+            {
+                "name": "store.ticket_number",
+                "label": "Store ticket number variable",
+                "type": "text",
+                "default": "ticket_number",
+            },
+        ],
+    },
+    "update_ticket": {
+        "fields": [
+            {
+                "name": "ticket_number",
+                "label": "Ticket number",
+                "type": "text",
+                "default": "${vars.ticket_number}",
+                "required": True,
+            },
+            {"name": "status", "label": "New status", "type": "text", "default": ""},
+            {
+                "name": "priority",
+                "label": "New priority",
+                "type": "select",
+                "default": "",
+                "options": ["", "low", "normal", "high", "urgent"],
+            },
+        ],
+    },
+    "reply_ticket": {
+        "fields": [
+            {
+                "name": "ticket_number",
+                "label": "Ticket number",
+                "type": "text",
+                "default": "${vars.ticket_number}",
+                "required": True,
+            },
+            {
+                "name": "body",
+                "label": "Reply body",
+                "type": "textarea",
+                "default": "Workflow update for ${vars.staff.full_name}.",
+                "required": True,
+            },
+            {
+                "name": "is_internal",
+                "label": "Internal note",
+                "type": "checkbox",
+                "default": False,
+            },
+        ],
     },
     "create_user": {
         "fields": [

--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -22,6 +22,7 @@ from app.repositories import licenses as license_repo
 from app.repositories import staff as staff_repo
 from app.repositories import staff_custom_fields as staff_custom_fields_repo
 from app.repositories import staff_onboarding_workflows as workflow_repo
+from app.repositories import tickets as tickets_repo
 from app.repositories import users as user_repo
 from app.services import audit as audit_service
 from app.services import email as email_service
@@ -502,6 +503,31 @@ async def notify_staff_approval_requested(
                 error=str(exc),
             )
     return approver_ids
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+async def _resolve_workflow_ticket(
+    step: dict[str, Any], vars_map: dict[str, Any]
+) -> dict[str, Any]:
+    ticket_ref = (
+        _resolve_template_value(step.get("ticket_id"), vars_map=vars_map)
+        or _resolve_template_value(step.get("ticket_number"), vars_map=vars_map)
+        or vars_map.get("ticket_id")
+        or vars_map.get("ticket_number")
+    )
+    ticket = await tickets_repo.get_ticket_by_number_or_id(str(ticket_ref or ""))
+    if not ticket:
+        raise WorkflowStepError(
+            "Ticket step requires an existing ticket_id or ticket_number"
+        )
+    return dict(ticket)
 
 
 async def _create_failure_ticket(
@@ -1654,20 +1680,82 @@ async def _execute_policy_step(
         description = str(
             _resolve_template_value(step.get("description"), vars_map=vars_map) or ""
         ).strip()
-        status_value = await tickets_service.resolve_status_or_default(None)
+        requester_id = _coerce_positive_int(staff.get("requested_by_user_id"))
+        assigned_user_id = _coerce_positive_int(
+            _resolve_template_value(step.get("assigned_user_id"), vars_map=vars_map)
+        )
+        status_value = await tickets_service.resolve_status_or_default(
+            _resolve_template_value(step.get("status"), vars_map=vars_map)
+        )
         ticket = await tickets_service.create_ticket(
             subject=subject,
             description=description or subject,
-            requester_id=None,
+            requester_id=requester_id,
             company_id=company_id,
-            assigned_user_id=None,
-            priority=str(step.get("priority") or "normal"),
+            assigned_user_id=assigned_user_id,
+            priority=str(
+                _resolve_template_value(step.get("priority"), vars_map=vars_map)
+                or "normal"
+            ),
             status=status_value,
             category=str(step.get("category") or "staff-onboarding"),
             module_slug=str(step.get("module_slug") or "m365"),
-            external_reference=f"staff-workflow:{staff.get('id')}:{step.get('name')}",
+            external_reference=f"staff-workflow:{staff.get('id')}:{step_name or step.get('name')}",
+            initial_reply_author_id=requester_id,
         )
-        return {"ticket_id": ticket.get("id")}
+        ticket_number = ticket.get("ticket_number") or ticket.get("id")
+        return {"ticket_id": ticket.get("id"), "ticket_number": ticket_number}
+
+    if step_type == "update_ticket":
+        ticket = await _resolve_workflow_ticket(step, vars_map)
+        update_fields: dict[str, Any] = {}
+        if step.get("status") not in (None, ""):
+            update_fields["status"] = await tickets_service.resolve_status_or_default(
+                _resolve_template_value(step.get("status"), vars_map=vars_map)
+            )
+        if step.get("priority") not in (None, ""):
+            update_fields["priority"] = str(
+                _resolve_template_value(step.get("priority"), vars_map=vars_map) or ""
+            ).strip()
+        if not update_fields:
+            raise WorkflowStepError("update_ticket requires status or priority")
+        updated = await tickets_repo.update_ticket(int(ticket["id"]), **update_fields)
+        await tickets_service.emit_ticket_updated_event(
+            updated or int(ticket["id"]), actor_type="system"
+        )
+        return {
+            "ticket_id": int(ticket["id"]),
+            "ticket_number": ticket.get("ticket_number") or ticket.get("id"),
+            "updated": update_fields,
+        }
+
+    if step_type == "reply_ticket":
+        ticket = await _resolve_workflow_ticket(step, vars_map)
+        body = str(
+            _resolve_template_value(step.get("body"), vars_map=vars_map) or ""
+        ).strip()
+        if not body:
+            raise WorkflowStepError("reply_ticket requires body")
+        author_id = _coerce_positive_int(ticket.get("assigned_user_id"))
+        reply = await tickets_repo.create_reply(
+            ticket_id=int(ticket["id"]),
+            author_id=author_id,
+            body=body,
+            is_internal=bool(step.get("is_internal") or step.get("internal_note")),
+            author_display_name="System" if author_id is None else None,
+        )
+        await tickets_service.emit_ticket_replied_event(
+            ticket, actor_type="technician" if author_id else "system", reply=reply
+        )
+        await tickets_service.emit_ticket_updated_event(
+            ticket, actor_type="technician" if author_id else "system", reply=reply
+        )
+        return {
+            "ticket_id": int(ticket["id"]),
+            "ticket_number": ticket.get("ticket_number") or ticket.get("id"),
+            "reply_id": reply.get("id"),
+            "is_internal": bool(reply.get("is_internal")),
+        }
 
     if step_type == "conditional_pause":
         left = _resolve_template_value(step.get("if"), vars_map=vars_map)

--- a/tests/test_staff_onboarding_workflow_policy_steps.py
+++ b/tests/test_staff_onboarding_workflow_policy_steps.py
@@ -1030,3 +1030,107 @@ async def test_confirm_webhook_checkpoint_marks_wait_step_success_before_resume(
     assert append_log.await_args.kwargs["step_name"] == "Pause for webhook"
     assert append_log.await_args.kwargs["status"] == "success"
     resume.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_create_ticket_step_uses_requester_and_returns_ticket_number(monkeypatch):
+    monkeypatch.setattr(
+        workflows.tickets_service,
+        "resolve_status_or_default",
+        AsyncMock(return_value="open"),
+    )
+    create_ticket = AsyncMock(return_value={"id": 123, "ticket_number": "HD-123"})
+    monkeypatch.setattr(workflows.tickets_service, "create_ticket", create_ticket)
+
+    result = await workflows._execute_policy_step(
+        step={
+            "type": "create_ticket",
+            "subject": "Onboard ${vars.staff.full_name}",
+            "description": "Started",
+            "priority": "high",
+            "assigned_user_id": "44",
+        },
+        company_id=9,
+        staff={"id": 5, "requested_by_user_id": 17},
+        policy_config={},
+        vars_map={"staff.full_name": "Jane Starter"},
+        step_name="Create Ticket",
+    )
+
+    assert result == {"ticket_id": 123, "ticket_number": "HD-123"}
+    create_ticket.assert_awaited_once()
+    assert create_ticket.await_args.kwargs["requester_id"] == 17
+    assert create_ticket.await_args.kwargs["initial_reply_author_id"] == 17
+    assert create_ticket.await_args.kwargs["assigned_user_id"] == 44
+
+
+@pytest.mark.anyio
+async def test_update_and_reply_ticket_steps_use_created_ticket_variable(monkeypatch):
+    ticket = {
+        "id": 123,
+        "ticket_number": "HD-123",
+        "assigned_user_id": 44,
+    }
+    monkeypatch.setattr(
+        workflows.tickets_repo,
+        "get_ticket_by_number_or_id",
+        AsyncMock(return_value=ticket),
+    )
+    monkeypatch.setattr(
+        workflows.tickets_service,
+        "resolve_status_or_default",
+        AsyncMock(return_value="in_progress"),
+    )
+    update_ticket = AsyncMock(return_value={**ticket, "status": "in_progress"})
+    monkeypatch.setattr(workflows.tickets_repo, "update_ticket", update_ticket)
+    emit_updated = AsyncMock()
+    monkeypatch.setattr(
+        workflows.tickets_service, "emit_ticket_updated_event", emit_updated
+    )
+    create_reply = AsyncMock(return_value={"id": 77, "is_internal": True})
+    monkeypatch.setattr(workflows.tickets_repo, "create_reply", create_reply)
+    emit_replied = AsyncMock()
+    monkeypatch.setattr(
+        workflows.tickets_service, "emit_ticket_replied_event", emit_replied
+    )
+
+    update_result = await workflows._execute_policy_step(
+        step={
+            "type": "update_ticket",
+            "ticket_number": "${vars.ticket_number}",
+            "status": "In Progress",
+            "priority": "high",
+        },
+        company_id=9,
+        staff={"id": 5},
+        policy_config={},
+        vars_map={"ticket_number": "HD-123"},
+    )
+    reply_result = await workflows._execute_policy_step(
+        step={
+            "type": "reply_ticket",
+            "ticket_number": "${vars.ticket_number}",
+            "body": "Done",
+            "is_internal": True,
+        },
+        company_id=9,
+        staff={"id": 5},
+        policy_config={},
+        vars_map={"ticket_number": "HD-123"},
+    )
+
+    assert update_result["updated"] == {"status": "in_progress", "priority": "high"}
+    update_ticket.assert_awaited_once_with(123, status="in_progress", priority="high")
+    assert reply_result == {
+        "ticket_id": 123,
+        "ticket_number": "HD-123",
+        "reply_id": 77,
+        "is_internal": True,
+    }
+    create_reply.assert_awaited_once_with(
+        ticket_id=123,
+        author_id=44,
+        body="Done",
+        is_internal=True,
+        author_display_name=None,
+    )


### PR DESCRIPTION
### Motivation
- Provide built-in workflow steps to create a helpdesk ticket during staff onboarding/offboarding and allow later steps to update or reply to that ticket as the process progresses.
- Ensure tickets created by a workflow are attributed to the original requester and expose the ticket number for use in subsequent steps.

### Description
- Added `create_ticket`, `update_ticket`, and `reply_ticket` entries to the onboarding and offboarding step catalogs in `app/features/staff/handlers.py` and added form/schema definitions for each step so they appear in the workflow UI.
- Implemented workflow ticket actions in `app/services/staff_onboarding_workflows.py`: `create_ticket` now creates a ticket on behalf of the requestor and returns both `ticket_id` and `ticket_number`; `update_ticket` looks up a ticket by number/ID and updates `status` and/or `priority`; `reply_ticket` posts a reply (public or internal) as the assigned technician or as System when unassigned and emits reply/update events.
- Added helper functions `_coerce_positive_int` and `_resolve_workflow_ticket` and wired into the step execution flow to validate/resolve ticket references and author IDs.
- Added unit tests in `tests/test_staff_onboarding_workflow_policy_steps.py` covering requester attribution, ticket number propagation, update behavior, and reply behavior.

### Testing
- Formatted changed files with `python -m black app/services/staff_onboarding_workflows.py app/features/staff/handlers.py tests/test_staff_onboarding_workflow_policy_steps.py` (succeeded).
- Ran unit tests for the workflow step file with `pytest -q tests/test_staff_onboarding_workflow_policy_steps.py -q` and all tests passed.
- Ran repository checks (`git diff --check`) with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a62b4209e0c83329b73c2fe2f1d42b4)