### PR TITLE
Allow offboarding removals without explicit target IDs

### DIFF
--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -1425,13 +1425,24 @@ async def _execute_policy_step(
             or _resolve_template_value(step.get("group_ids_csv"), vars_map=vars_map)
             or _resolve_template_value(step.get("group_id"), vars_map=vars_map)
         )
-        if not group_ids:
+        if not group_ids and step_type == "m365_add_teams_group_member":
             raise WorkflowStepError(f"{step_type} requires one or more group IDs")
         m365_user_id = await _resolve_step_user_id()
         encoded_user_id = quote(m365_user_id, safe="")
         access_token = await m365_service.acquire_access_token(
             company_id, force_client_credentials=True
         )
+        if not group_ids:
+            memberships = await m365_service._graph_get_all(  # pyright: ignore[reportPrivateUsage]
+                access_token,
+                f"https://graph.microsoft.com/v1.0/users/{encoded_user_id}/memberOf/microsoft.graph.group?$select=id,groupTypes",
+            )
+            group_ids = [
+                str(item.get("id")).strip()
+                for item in memberships
+                if item.get("id")
+                and "DynamicMembership" not in (item.get("groupTypes") or [])
+            ]
         changed_group_ids: list[str] = []
         for group_id in group_ids:
             if step_type == "m365_add_teams_group_member":
@@ -1465,7 +1476,7 @@ async def _execute_policy_step(
             or _resolve_template_value(step.get("site_ids_csv"), vars_map=vars_map)
             or _resolve_template_value(step.get("site_id"), vars_map=vars_map)
         )
-        if not site_ids:
+        if not site_ids and step_type == "m365_add_sharepoint_site_member":
             raise WorkflowStepError(f"{step_type} requires one or more site IDs")
         m365_user_id = await _resolve_step_user_id()
         encoded_user_id = quote(m365_user_id, safe="")
@@ -1482,12 +1493,19 @@ async def _execute_policy_step(
         )
         if site_role not in {"read", "write"}:
             raise WorkflowStepError("site_role must be either 'read' or 'write'")
+        if not site_ids:
+            sites = await m365_service._graph_get_all(  # pyright: ignore[reportPrivateUsage]
+                access_token,
+                "https://graph.microsoft.com/v1.0/sites?search=*&$select=id&$top=200",
+            )
+            site_ids = [str(site.get("id")).strip() for site in sites if site.get("id")]
         changed_site_ids: list[str] = []
         for site_id in site_ids:
+            encoded_site_id = quote(site_id, safe="")
             if step_type == "m365_add_sharepoint_site_member":
                 await m365_service._graph_post(  # pyright: ignore[reportPrivateUsage]
                     access_token,
-                    f"https://graph.microsoft.com/v1.0/sites/{site_id}/permissions",
+                    f"https://graph.microsoft.com/v1.0/sites/{encoded_site_id}/permissions",
                     {
                         "roles": [site_role],
                         "grantedToIdentitiesV2": [
@@ -1498,7 +1516,7 @@ async def _execute_policy_step(
             else:
                 permissions = await m365_service._graph_get(  # pyright: ignore[reportPrivateUsage]
                     access_token,
-                    f"https://graph.microsoft.com/v1.0/sites/{site_id}/permissions",
+                    f"https://graph.microsoft.com/v1.0/sites/{encoded_site_id}/permissions",
                 )
                 for permission in permissions.get("value") or []:
                     permission_id = str(permission.get("id") or "").strip()

--- a/tests/test_staff_onboarding_workflow_policy_steps.py
+++ b/tests/test_staff_onboarding_workflow_policy_steps.py
@@ -514,6 +514,43 @@ async def test_execute_policy_step_adds_user_to_teams_groups(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_execute_policy_step_removes_user_from_all_teams_groups_when_ids_blank(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        workflows, "_resolve_staff_m365_user", AsyncMock(return_value={"id": "user-1"})
+    )
+    monkeypatch.setattr(
+        workflows.m365_service, "acquire_access_token", AsyncMock(return_value="token")
+    )
+    monkeypatch.setattr(
+        workflows.m365_service,
+        "_graph_get_all",
+        AsyncMock(
+            return_value=[
+                {"id": "group-a", "groupTypes": []},
+                {"id": "group-dynamic", "groupTypes": ["DynamicMembership"]},
+                {"id": "group-b", "groupTypes": ["Unified"]},
+            ]
+        ),
+    )
+    graph_delete = AsyncMock(return_value={})
+    monkeypatch.setattr(workflows.m365_service, "_graph_delete", graph_delete)
+
+    result = await workflows._execute_policy_step(
+        step={"type": "m365_remove_teams_group_member", "group_ids_csv": ""},
+        company_id=9,
+        staff={"id": 703, "email": "old.user@example.com"},
+        policy_config={},
+        vars_map={},
+    )
+
+    assert result["operation"] == "remove"
+    assert result["group_ids"] == ["group-a", "group-b"]
+    assert graph_delete.await_count == 2
+
+
+@pytest.mark.anyio
 async def test_execute_policy_step_removes_user_from_sharepoint_sites(monkeypatch):
     monkeypatch.setattr(
         workflows, "_resolve_staff_m365_user", AsyncMock(return_value={"id": "user-2"})
@@ -548,6 +585,51 @@ async def test_execute_policy_step_removes_user_from_sharepoint_sites(monkeypatc
 
     assert result["operation"] == "remove"
     assert result["site_ids"] == ["site-a"]
+    graph_delete.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_execute_policy_step_removes_user_from_all_sharepoint_sites_when_ids_blank(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        workflows, "_resolve_staff_m365_user", AsyncMock(return_value={"id": "user-2"})
+    )
+    monkeypatch.setattr(
+        workflows.m365_service, "acquire_access_token", AsyncMock(return_value="token")
+    )
+
+    graph_get_all = AsyncMock(return_value=[{"id": "site-a"}, {"id": "site-b"}])
+    monkeypatch.setattr(workflows.m365_service, "_graph_get_all", graph_get_all)
+
+    async def fake_graph_get(_token: str, url: str):
+        if "/sites/site-a/permissions" in url:
+            return {
+                "value": [
+                    {
+                        "id": "perm-1",
+                        "grantedToIdentitiesV2": [{"user": {"id": "user-2"}}],
+                    }
+                ]
+            }
+        return {"value": [{"id": "perm-2", "grantedToIdentitiesV2": []}]}
+
+    monkeypatch.setattr(
+        workflows.m365_service, "_graph_get", AsyncMock(side_effect=fake_graph_get)
+    )
+    graph_delete = AsyncMock(return_value={})
+    monkeypatch.setattr(workflows.m365_service, "_graph_delete", graph_delete)
+
+    result = await workflows._execute_policy_step(
+        step={"type": "m365_remove_sharepoint_site_member", "site_ids_csv": ""},
+        company_id=9,
+        staff={"id": 704, "email": "offboard.user@example.com"},
+        policy_config={},
+        vars_map={},
+    )
+
+    assert result["operation"] == "remove"
+    assert result["site_ids"] == ["site-a", "site-b"]
     graph_delete.assert_awaited_once()
 
 


### PR DESCRIPTION
### Motivation
- Offboarding removal steps should not fail when administrators omit explicit team/group or SharePoint site IDs and should instead remove the staff member from all applicable assignments.

### Description
- Change `_execute_policy_step` so `m365_remove_teams_group_member` will enumerate the user's current group memberships via `m365_service._graph_get_all` and remove the user from every non-dynamic group when no `group_ids` are provided, while `m365_add_teams_group_member` still requires explicit IDs. 
- Change `_execute_policy_step` so `m365_remove_sharepoint_site_member` will list tenant sites via `m365_service._graph_get_all` and remove direct user permissions for each site when no `site_ids` are provided, while `m365_add_sharepoint_site_member` still requires explicit IDs; also ensure site IDs are URL-encoded when calling site endpoints. 
- Add unit tests `test_execute_policy_step_removes_user_from_all_teams_groups_when_ids_blank` and `test_execute_policy_step_removes_user_from_all_sharepoint_sites_when_ids_blank` to cover the new behaviors. Files changed: `app/services/staff_onboarding_workflows.py`, `tests/test_staff_onboarding_workflow_policy_steps.py`.

### Testing
- Ran `pytest tests/test_staff_onboarding_workflow_policy_steps.py -q` and the file's test suite passed (35 passed, 108 warnings). 
- Ran formatter (`black`) and ensured no diff/check warnings remained (`git diff --check` reported clean).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a62b57f20148332bb041c77f3b898d7)