### PR TITLE
Do not attach all ticket files for reminder automation emails

### DIFF
--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -539,14 +539,13 @@ async def _load_ticket_email_attachments(
     """Load ticket attachments for automation email modules when possible.
 
     Explicit payload attachments are respected by callers; this helper only supplies
-    attachments automatically when the automation context identifies a ticket. Reply
-    events can provide the attachments uploaded with that reply so the outgoing
-    email does not have to fall back to every attachment on the ticket.
+    attachments automatically for ticket reply events that include the files uploaded
+    with that reply. Other ticket automations, such as reminders, must not attach
+    every file already stored on the ticket.
     """
     ticket_id = _extract_ticket_id_from_email_payload(payload)
     context = payload.get("context")
 
-    from app.repositories import ticket_attachments as attachments_repo
     from app.services import ticket_attachments as attachments_service
 
     attachments: list[Mapping[str, Any]] = []
@@ -558,19 +557,7 @@ async def _load_ticket_email_attachments(
             ]
 
     if not attachments:
-        if ticket_id is None:
-            return []
-        try:
-            attachments = await attachments_repo.list_attachments(
-                ticket_id, access_levels=("open", "closed")
-            )
-        except Exception as exc:  # pragma: no cover - defensive logging
-            logger.warning(
-                "Unable to load ticket attachments for automation email",
-                ticket_id=ticket_id,
-                error=str(exc),
-            )
-            return []
+        return []
 
     email_attachments: list[dict[str, Any]] = []
     for attachment in attachments:

--- a/tests/test_smtp2go_html_body_key.py
+++ b/tests/test_smtp2go_html_body_key.py
@@ -184,3 +184,38 @@ async def test_invoke_smtp2go_html_key_precedence(monkeypatch, mock_smtp2go_depe
     
     # 'html' should take precedence over 'html_body' and 'body'
     assert mock_smtp2go_dependencies["html_body"] == "<p>HTML content</p>"
+
+
+@pytest.mark.anyio
+async def test_invoke_smtp2go_does_not_auto_attach_ticket_files_for_reminders(
+    monkeypatch, mock_smtp2go_dependencies
+):
+    """Ticket reminder automations must not attach existing ticket files."""
+
+    async def fail_list_attachments(*args, **kwargs):
+        raise AssertionError("ticket attachment repository should not be queried")
+
+    from app.repositories import ticket_attachments as attachments_repo
+
+    monkeypatch.setattr(attachments_repo, "list_attachments", fail_list_attachments)
+
+    settings = {"api_key": "test-api-key", "enable_tracking": True}
+    payload = {
+        "to": ["requester@example.com"],
+        "cc": ["watcher@example.com"],
+        "subject": "Re: Ticket #1234",
+        "html_body": "<p>Reminder body</p>",
+        "text_body": "Reminder body",
+        "sender": "Support <support@example.com>",
+        "context": {
+            "ticket": {
+                "id": 1234,
+                "status": "waiting_on_client",
+                "has_attachments": True,
+            }
+        },
+    }
+
+    await modules._invoke_smtp2go(settings, payload)
+
+    assert mock_smtp2go_dependencies["attachments"] == []


### PR DESCRIPTION
### Motivation
- Reminder and other ticket automations were attaching every file stored on the ticket when sending automated emails, which leaks attachments that should only be included when explicitly uploaded with a reply. 
- The intent is to ensure only attachments explicitly supplied by a technician reply (reply context) are forwarded in automation emails.

### Description
- Update `modules._load_ticket_email_attachments` to only return attachments when the `context.reply.attachments` list is present, and to avoid falling back to loading all ticket attachments from the repository. 
- Remove the repository fallback and the `ticket_attachments` repository import from this helper so reminder/status-age automations do not query or attach ticket-level files. 
- Adjust the helper docstring to clarify that automatic attachments are limited to reply-supplied files. 
- Add a regression test `test_invoke_smtp2go_does_not_auto_attach_ticket_files_for_reminders` to `tests/test_smtp2go_html_body_key.py` that verifies reminder-style payloads with `context.ticket` do not cause attachment repository queries and send no attachments.

### Testing
- Ran the new test with `pytest -q tests/test_smtp2go_html_body_key.py::test_invoke_smtp2go_does_not_auto_attach_ticket_files_for_reminders`, which passed. 
- Ran selected SMTP2Go tests with `pytest -q tests/test_smtp2go.py::test_send_email_via_api_posts_fileblob_attachments tests/test_smtp2go.py::test_normalise_attachment_payloads_uses_fileblob_for_legacy_content`, which produced one passing and one failing run due to async test execution environment limitations (missing `pytest-asyncio`/async plugin); the failure is environmental and unrelated to the change in attachment selection logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a62e4b380a48332a041bd63548f1652)