### PR TITLE
Fix enrichment of latest technician replies in templates

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -1780,7 +1780,8 @@ async def admin_list_ticket_canned_responses(ticket_id: int, request: Request):
     ticket = await tickets_repo.get_ticket(ticket_id)
     if not ticket:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket not found")
-    context = _ticket_template_context(ticket)
+    enriched_ticket = await tickets_service._enrich_ticket_context(ticket)
+    context = _ticket_template_context(enriched_ticket)
     responses = []
     for response in await canned_responses_repo.list_responses():
         responses.append({

--- a/app/services/tickets.py
+++ b/app/services/tickets.py
@@ -571,17 +571,43 @@ async def _enrich_ticket_context(ticket: Mapping[str, Any]) -> TicketRecord:
                 continue
             initial_body = str(reply_body)
             break
-        reply = dict(replies[-1])
-        author_value = reply.get("author") if isinstance(reply.get("author"), Mapping) else None
-        author_id = reply.get("author_id")
-        author_user = await _resolve_user_snapshot(author_value, author_id)
-        author_snapshot = _build_user_snapshot(author_user)
-        reply["author"] = author_snapshot
-        snapshot_email = author_snapshot.get("email") if author_snapshot else None
-        snapshot_display = author_snapshot.get("display_name") if author_snapshot else None
-        reply["author_email"] = snapshot_email or reply.get("author_email")
-        reply["author_display_name"] = snapshot_display or reply.get("author_display_name")
-        latest_reply = reply
+        requester_id = enriched.get("requester_id")
+        assigned_user_id = enriched.get("assigned_user_id")
+        technician_reply: Mapping[str, Any] | None = None
+        technician_author: Mapping[str, Any] | None = None
+        for reply_record in reversed(replies):
+            if bool(reply_record.get("is_internal")):
+                continue
+            author_id = reply_record.get("author_id")
+            if author_id is None or author_id == requester_id:
+                continue
+            author_value = (
+                reply_record.get("author")
+                if isinstance(reply_record.get("author"), Mapping)
+                else None
+            )
+            author_user = await _resolve_user_snapshot(author_value, author_id)
+            permissions = author_user.get("permissions") if author_user else []
+            if isinstance(permissions, str):
+                permissions = [permissions]
+            is_technician = (
+                author_id == assigned_user_id
+                or bool(author_user and author_user.get("is_super_admin"))
+                or HELPDESK_PERMISSION_KEY in set(permissions or [])
+            )
+            if is_technician:
+                technician_reply = reply_record
+                technician_author = author_user
+                break
+        if technician_reply is not None:
+            reply = dict(technician_reply)
+            author_snapshot = _build_user_snapshot(technician_author)
+            reply["author"] = author_snapshot
+            snapshot_email = author_snapshot.get("email") if author_snapshot else None
+            snapshot_display = author_snapshot.get("display_name") if author_snapshot else None
+            reply["author_email"] = snapshot_email or reply.get("author_email")
+            reply["author_display_name"] = snapshot_display or reply.get("author_display_name")
+            latest_reply = reply
     enriched["latest_reply"] = latest_reply
     if initial_body is None and enriched.get("description") is not None:
         initial_body = str(enriched.get("description"))

--- a/tests/test_tickets_service_create.py
+++ b/tests/test_tickets_service_create.py
@@ -533,6 +533,34 @@ async def test_enrich_ticket_context_includes_relationship_details(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_enrich_ticket_context_uses_latest_public_technician_reply(monkeypatch):
+    ticket = {"id": 99, "requester_id": 7, "assigned_user_id": 11}
+    replies = [
+        {"id": 1, "author_id": 11, "body": "First technician reply", "is_internal": False},
+        {"id": 2, "author_id": 11, "body": "Private note", "is_internal": True},
+        {"id": 3, "author_id": 7, "body": "Latest customer reply", "is_internal": False},
+    ]
+
+    async def fake_list_replies(ticket_id, include_internal=True):
+        return replies
+
+    async def fake_list_watchers(ticket_id):
+        return []
+
+    async def fake_get_user_by_id(user_id):
+        return {"id": user_id, "email": "tech@example.com"}
+
+    monkeypatch.setattr(tickets_repo, "list_replies", fake_list_replies)
+    monkeypatch.setattr(tickets_repo, "list_watchers", fake_list_watchers)
+    monkeypatch.setattr(tickets_service.user_repo, "get_user_by_id", fake_get_user_by_id)
+
+    enriched = await tickets_service._enrich_ticket_context(ticket)
+
+    assert enriched["latest_reply"]["body"] == "First technician reply"
+    assert enriched["latest_reply"]["id"] == 1
+
+
+@pytest.mark.anyio
 async def test_emit_ticket_updated_event_includes_actor_metadata(monkeypatch):
     ticket_record = {"id": 55, "status": "open"}
 


### PR DESCRIPTION
### Motivation
- Message templates and canned responses using `{{ ticket.latest_reply.body }}` were rendered with incomplete context and could pick the wrong reply when a customer had replied after the technician or when internal notes existed.
- The intent is to ensure templates receive a fully enriched ticket context and that `ticket.latest_reply` reflects the latest public reply authored by a technician (assigned technician, super-admin, or a user with helpdesk permissions).

### Description
- Render canned/message-template variables with an enriched ticket by calling `tickets_service._enrich_ticket_context(ticket)` before building the template context in `app/features/tickets/admin_routes.py`.
- Change `_enrich_ticket_context` in `app/services/tickets.py` to choose `ticket.latest_reply` by scanning replies newest-first and selecting the newest public reply from a recognized technician, skipping internal notes and requester/customer replies, and preserving author snapshot details (email/display_name).
- Recognize technicians by `assigned_user_id`, `is_super_admin`, or presence of the helpdesk permission key when deciding the latest technician reply in `app/services/tickets.py`.
- Add a regression test `test_enrich_ticket_context_uses_latest_public_technician_reply` in `tests/test_tickets_service_create.py` that verifies a newer customer reply and an internal technician note do not override the intended latest public technician reply.

### Testing
- Ran `git diff --check` to verify no whitespace/git-diff issues and it passed.
- Ran `pytest -q tests/test_tickets_service_create.py -k 'enrich_ticket_context'` and the focused tests passed (2 passed, 10 deselected).
- Ran `pytest -q tests/test_tickets_service_create.py tests/test_ticket_automation_variables.py tests/test_ticket_number_rendering_issue.py tests/test_notification_variable_rendering.py` and the suite passed (27 passed, with warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a66a2250ac4833284956e386cf48e62)