### PR TITLE
Fix M365 inline-only email images

### DIFF
--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -1291,7 +1291,11 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                 body = body_content.get("content") or ""
                 if not body:
                     body = msg.get("bodyPreview") or ""
-                if msg.get("hasAttachments") and body:
+                # Graph deliberately excludes inline-only attachments from
+                # ``hasAttachments``.  Key this off the body instead so a
+                # message whose only attachment is a pasted screenshot still
+                # has its CID URL resolved before sanitisation.
+                if body and "cid:" in body.lower():
                     body = await _embed_graph_inline_images(
                         access_token=access_token,
                         upn=upn,

--- a/tests/test_m365_mail_service.py
+++ b/tests/test_m365_mail_service.py
@@ -747,7 +747,10 @@ async def test_sync_account_processes_messages(monkeypatch):
                 "id": "msg-001",
                 "internetMessageId": "<msg001@example.com>",
                 "subject": "Test ticket",
-                "body": {"contentType": "html", "content": "<p>Please help</p>"},
+                "body": {
+                    "contentType": "html",
+                    "content": '<p>Please help</p><img src="cid:screenshot@outlook">',
+                },
                 "from": {
                     "emailAddress": {"name": "User", "address": "requester@example.com"}
                 },
@@ -799,6 +802,12 @@ async def test_sync_account_processes_messages(monkeypatch):
         created_tickets.append(kwargs)
         return {"id": 100, "ticket_number": "T-100"}
 
+    embedded_bodies: list[str] = []
+
+    async def fake_embed_graph_inline_images(**kwargs):
+        embedded_bodies.append(kwargs["html_body"])
+        return '<p>Please help</p><img src="/api/tickets/100/attachments/1/download">'
+
     async def fake_refresh_ai_summary(ticket_id):
         pass
 
@@ -815,6 +824,7 @@ async def test_sync_account_processes_messages(monkeypatch):
     monkeypatch.setattr(m365_mail.mail_repo, "update_account", fake_update_account)
     monkeypatch.setattr(m365_mail, "_resolve_ticket_entities", fake_resolve_ticket_entities)
     monkeypatch.setattr(m365_mail, "_find_existing_ticket_for_reply", fake_find_existing_ticket)
+    monkeypatch.setattr(m365_mail, "_embed_graph_inline_images", fake_embed_graph_inline_images)
     monkeypatch.setattr(m365_mail.tickets_service, "create_ticket", fake_create_ticket)
     monkeypatch.setattr(m365_mail.tickets_service, "refresh_ticket_ai_summary", fake_refresh_ai_summary)
     monkeypatch.setattr(m365_mail.tickets_service, "refresh_ticket_ai_tags", fake_refresh_ai_tags)
@@ -826,6 +836,9 @@ async def test_sync_account_processes_messages(monkeypatch):
     assert len(created_tickets) == 1
     assert created_tickets[0]["subject"] == "Test ticket"
     assert created_tickets[0]["module_slug"] == "m365-mail"
+    assert embedded_bodies == [
+        '<p>Please help</p><img src="cid:screenshot@outlook">'
+    ]
     assert len(recorded_messages) == 1
     assert recorded_messages[0]["status"] == "imported"
 


### PR DESCRIPTION
### Motivation

- Inline images coming from M365 (pasted screenshots) were rendered as empty boxes because Microsoft Graph can report `hasAttachments: false` for messages whose only images are inline `cid:` references.

### Description

- Replace the `hasAttachments` check with a body-based detection and resolve step by calling `_embed_graph_inline_images` when the HTML `body` contains `cid:` so inline-only images are embedded before sanitisation in `app/services/m365_mail.py`.
- Add a regression test in `tests/test_m365_mail_service.py` that includes a `cid:` image in the Graph message body and monkeypatches `_embed_graph_inline_images` to capture and assert the embedded HTML was passed through and used.
- Small test scaffolding updated to validate the embed path is exercised for messages where `hasAttachments` is `False` but the body contains inline images.

### Testing

- Ran `pytest -q tests/test_m365_mail_service.py` and the targeted tests passed (`41 passed`, with warnings reported). 
- Ran `git diff --check` to validate there are no whitespace or diff errors and verified the working tree changes are limited to the two edited files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a66ba9cbd00833290375e1753001a90)