### PR TITLE
Add Unbilled Tickets By Company report

### DIFF
--- a/migrations/302_unbilled_tickets_by_company_report.sql
+++ b/migrations/302_unbilled_tickets_by_company_report.sql
@@ -1,0 +1,11 @@
+-- Replace the ticket-level sample with a billing summary that shows all
+-- unbilled, billable time grouped by company and labour type.  A reply is
+-- unbilled until it has a matching ticket_billed_time_entries row; the
+-- ticket-level invoice fields cannot represent partially billed tickets.
+UPDATE reporting_queries
+SET
+    name = 'Unbilled Tickets By Company',
+    description = 'Unbilled billable ticket time by company and labour type, including the number of tickets represented in each total.',
+    sql_query = 'SELECT COALESCE(c.name, ''(no company)'') AS company, COALESCE(NULLIF(TRIM(lt.name), ''''), ''(unspecified)'') AS labour_type, COUNT(DISTINCT t.id) AS ticket_count, SUM(tr.minutes_spent) AS billable_minutes FROM ticket_replies tr JOIN tickets t ON t.id = tr.ticket_id LEFT JOIN companies c ON c.id = t.company_id LEFT JOIN ticket_labour_types lt ON lt.id = tr.labour_type_id WHERE tr.is_billable = 1 AND tr.minutes_spent IS NOT NULL AND tr.minutes_spent > 0 AND NOT EXISTS (SELECT 1 FROM ticket_billed_time_entries bte WHERE bte.reply_id = tr.id) GROUP BY c.id, c.name, lt.id, lt.name ORDER BY company ASC, labour_type ASC'
+WHERE slug = 'unbilled-tickets'
+  AND is_system = 1;

--- a/tests/test_unbilled_tickets_reporting_migration.py
+++ b/tests/test_unbilled_tickets_reporting_migration.py
@@ -1,0 +1,29 @@
+"""Regression coverage for the Unbilled Tickets By Company system report."""
+
+from pathlib import Path
+
+
+MIGRATION = (
+    Path(__file__).parent.parent
+    / "migrations"
+    / "302_unbilled_tickets_by_company_report.sql"
+)
+
+
+def test_unbilled_tickets_report_groups_unbilled_time_by_company_and_labour_type():
+    sql = MIGRATION.read_text(encoding="utf-8")
+
+    assert "name = 'Unbilled Tickets By Company'" in sql
+    assert "SUM(tr.minutes_spent) AS billable_minutes" in sql
+    assert "GROUP BY c.id, c.name, lt.id, lt.name" in sql
+    assert "tr.is_billable = 1" in sql
+    assert "tr.minutes_spent > 0" in sql
+    assert "NOT EXISTS" in sql
+    assert "bte.reply_id = tr.id" in sql
+
+
+def test_unbilled_tickets_report_only_updates_the_system_seed():
+    sql = MIGRATION.read_text(encoding="utf-8")
+
+    assert "WHERE slug = 'unbilled-tickets'" in sql
+    assert "AND is_system = 1" in sql


### PR DESCRIPTION
### Motivation
- Replace the existing ticket-level Unbilled Tickets sample with a company-scoped billing summary that groups unbilled billable time by company and labour type to better support partially-billed tickets.

### Description
- Add migration `migrations/302_unbilled_tickets_by_company_report.sql` which updates the system seed for `slug = 'unbilled-tickets'` and `is_system = 1` to a new `Unbilled Tickets By Company` query. 
- The seeded SQL returns `company`, `labour_type`, `COUNT(DISTINCT t.id) AS ticket_count`, and `SUM(tr.minutes_spent) AS billable_minutes` grouped by `c.id, c.name, lt.id, lt.name` and ordered by company and labour type. 
- The query filters for `tr.is_billable = 1`, positive `tr.minutes_spent`, and excludes replies already recorded in `ticket_billed_time_entries` using a `NOT EXISTS` subquery to avoid double-counting billed time. 
- Add regression coverage in `tests/test_unbilled_tickets_reporting_migration.py` that asserts the migration contains the expected name, aggregation, grouping, and billed-entry exclusion clauses.

### Testing
- Ran `pytest -q tests/test_unbilled_tickets_reporting_migration.py tests/test_reporting_service.py tests/test_reporting_feature_pack.py`, and the suite completed successfully with all tests passing (58 passed).
- The new migration file and test were added and exercised by the targeted test run without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a67045378788332b44531474832cabf)