### PR TITLE
Add 'Unbilled Tickets By Company' report, restore original report for older installs, and add tests

### DIFF
--- a/migrations/302_unbilled_tickets_by_company_report.sql
+++ b/migrations/302_unbilled_tickets_by_company_report.sql
@@ -1,0 +1,11 @@
+-- Add a company and labour type summary alongside the existing ticket-level
+-- Unbilled Tickets report. A reply is unbilled until it has a matching
+-- ticket_billed_time_entries row, which also supports partially billed tickets.
+INSERT IGNORE INTO reporting_queries (slug, name, description, sql_query, is_system)
+VALUES (
+    'unbilled-tickets-by-company',
+    'Unbilled Tickets By Company',
+    'Unbilled billable ticket time by company and labour type, including the number of tickets represented in each total.',
+    'SELECT COALESCE(c.name, ''(no company)'') AS company, COALESCE(NULLIF(TRIM(lt.name), ''''), ''(unspecified)'') AS labour_type, COUNT(DISTINCT t.id) AS ticket_count, SUM(tr.minutes_spent) AS billable_minutes FROM ticket_replies tr JOIN tickets t ON t.id = tr.ticket_id LEFT JOIN companies c ON c.id = t.company_id LEFT JOIN ticket_labour_types lt ON lt.id = tr.labour_type_id WHERE tr.is_billable = 1 AND tr.minutes_spent IS NOT NULL AND tr.minutes_spent > 0 AND NOT EXISTS (SELECT 1 FROM ticket_billed_time_entries bte WHERE bte.reply_id = tr.id) GROUP BY c.id, c.name, lt.id, lt.name ORDER BY company ASC, labour_type ASC',
+    1
+);

--- a/migrations/303_restore_unbilled_tickets_report.sql
+++ b/migrations/303_restore_unbilled_tickets_report.sql
@@ -1,0 +1,10 @@
+-- Restore the original ticket-level report for installations that applied an
+-- earlier version of migration 302, which renamed this system seed in place.
+-- The company summary now has its own slug and is inserted by migration 302.
+UPDATE reporting_queries
+SET
+    name = 'Unbilled Tickets',
+    description = 'Closed tickets that have billable time entries but have not yet been linked to a Xero invoice.',
+    sql_query = 'SELECT t.id AS ticket_id, c.name AS company, t.subject, t.status, COALESCE(SUM(CASE WHEN tr.is_billable = 1 THEN tr.minutes_spent ELSE 0 END), 0) AS billable_minutes, t.closed_at, t.created_at FROM tickets t LEFT JOIN companies c ON c.id = t.company_id LEFT JOIN ticket_replies tr ON tr.ticket_id = t.id WHERE t.xero_invoice_number IS NULL GROUP BY t.id, c.name, t.subject, t.status, t.closed_at, t.created_at HAVING billable_minutes > 0 ORDER BY t.closed_at DESC, t.id DESC'
+WHERE slug = 'unbilled-tickets'
+  AND is_system = 1;

--- a/tests/test_unbilled_tickets_reporting_migration.py
+++ b/tests/test_unbilled_tickets_reporting_migration.py
@@ -1,0 +1,50 @@
+"""Regression coverage for the Unbilled Tickets By Company system report."""
+
+from pathlib import Path
+
+
+MIGRATION = (
+    Path(__file__).parent.parent
+    / "migrations"
+    / "302_unbilled_tickets_by_company_report.sql"
+)
+ORIGINAL_REPORT_MIGRATION = (
+    Path(__file__).parent.parent / "migrations" / "246_reporting_queries.sql"
+)
+RESTORE_MIGRATION = (
+    Path(__file__).parent.parent
+    / "migrations"
+    / "303_restore_unbilled_tickets_report.sql"
+)
+
+
+def test_unbilled_tickets_report_groups_unbilled_time_by_company_and_labour_type():
+    sql = MIGRATION.read_text(encoding="utf-8")
+
+    assert "'Unbilled Tickets By Company'," in sql
+    assert "SUM(tr.minutes_spent) AS billable_minutes" in sql
+    assert "GROUP BY c.id, c.name, lt.id, lt.name" in sql
+    assert "tr.is_billable = 1" in sql
+    assert "tr.minutes_spent > 0" in sql
+    assert "NOT EXISTS" in sql
+    assert "bte.reply_id = tr.id" in sql
+
+
+def test_company_summary_is_added_without_replacing_unbilled_tickets_report():
+    sql = MIGRATION.read_text(encoding="utf-8")
+    original_sql = ORIGINAL_REPORT_MIGRATION.read_text(encoding="utf-8")
+
+    assert "INSERT IGNORE INTO reporting_queries" in sql
+    assert "'unbilled-tickets-by-company'" in sql
+    assert "WHERE slug = 'unbilled-tickets'" not in sql
+    assert "UPDATE reporting_queries" not in sql
+    assert "'unbilled-tickets'," in original_sql
+    assert "'Unbilled Tickets'," in original_sql
+
+
+def test_original_report_is_restored_for_installations_with_old_migration():
+    sql = RESTORE_MIGRATION.read_text(encoding="utf-8")
+
+    assert "name = 'Unbilled Tickets'" in sql
+    assert "WHERE slug = 'unbilled-tickets'" in sql
+    assert "AND is_system = 1" in sql


### PR DESCRIPTION
### Motivation

- Provide a company- and labour-type-level summary of unbilled billable time alongside the existing ticket-level Unbilled Tickets report. 
- Ensure installations that previously applied an earlier migration which renamed the system seed keep the original ticket-level report. 
- Add regression coverage to prevent accidental removal or modification of the original system seed when introducing the new report.

### Description

- Add migration `302_unbilled_tickets_by_company_report.sql` which inserts a new `reporting_queries` row with slug `unbilled-tickets-by-company` and a SQL query that groups unbilled billable minutes by company and labour type using `NOT EXISTS` against `ticket_billed_time_entries`. 
- Add migration `303_restore_unbilled_tickets_report.sql` which restores the original ticket-level `unbilled-tickets` system seed via an `UPDATE reporting_queries` for installs that applied the older migration. 
- Add `tests/test_unbilled_tickets_reporting_migration.py` to assert the presence and structure of the new migration SQL and the restore migration SQL.

### Testing

- Ran the new regression file with `pytest tests/test_unbilled_tickets_reporting_migration.py`. 
- The added test assertions all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a67045378788332b44531474832cabf)