### PR TITLE
Refine Unbilled Tickets By Company reporting

### DIFF
--- a/migrations/304_unbilled_tickets_by_company_columns.sql
+++ b/migrations/304_unbilled_tickets_by_company_columns.sql
@@ -1,0 +1,10 @@
+-- Keep the Unbilled Tickets By Company system report consistent on both new
+-- and upgraded installations. Include the company identifier so companies
+-- with the same display name remain distinguishable in exports.
+UPDATE reporting_queries
+SET
+    name = 'Unbilled Tickets By Company',
+    description = 'Unbilled billable ticket time by company and labour type, including the number of tickets represented in each total.',
+    sql_query = 'SELECT c.id AS company_id, COALESCE(c.name, ''(no company)'') AS company, COALESCE(NULLIF(TRIM(lt.name), ''''), ''(unspecified)'') AS labour_type, COUNT(DISTINCT t.id) AS ticket_count, SUM(tr.minutes_spent) AS billable_minutes FROM ticket_replies tr JOIN tickets t ON t.id = tr.ticket_id LEFT JOIN companies c ON c.id = t.company_id LEFT JOIN ticket_labour_types lt ON lt.id = tr.labour_type_id WHERE tr.is_billable = 1 AND tr.minutes_spent IS NOT NULL AND tr.minutes_spent > 0 AND NOT EXISTS (SELECT 1 FROM ticket_billed_time_entries bte WHERE bte.reply_id = tr.id) GROUP BY c.id, c.name, lt.id, lt.name ORDER BY company ASC, labour_type ASC'
+WHERE slug = 'unbilled-tickets-by-company'
+  AND is_system = 1;

--- a/tests/test_unbilled_tickets_reporting_migration.py
+++ b/tests/test_unbilled_tickets_reporting_migration.py
@@ -16,6 +16,11 @@ RESTORE_MIGRATION = (
     / "migrations"
     / "303_restore_unbilled_tickets_report.sql"
 )
+REPORT_COLUMNS_MIGRATION = (
+    Path(__file__).parent.parent
+    / "migrations"
+    / "304_unbilled_tickets_by_company_columns.sql"
+)
 
 
 def test_unbilled_tickets_report_groups_unbilled_time_by_company_and_labour_type():
@@ -47,4 +52,15 @@ def test_original_report_is_restored_for_installations_with_old_migration():
 
     assert "name = 'Unbilled Tickets'" in sql
     assert "WHERE slug = 'unbilled-tickets'" in sql
+    assert "AND is_system = 1" in sql
+
+
+def test_company_summary_exposes_company_id_and_preserves_labour_grouping():
+    sql = REPORT_COLUMNS_MIGRATION.read_text(encoding="utf-8")
+
+    assert "name = 'Unbilled Tickets By Company'" in sql
+    assert "SELECT c.id AS company_id" in sql
+    assert "SUM(tr.minutes_spent) AS billable_minutes" in sql
+    assert "GROUP BY c.id, c.name, lt.id, lt.name" in sql
+    assert "WHERE slug = 'unbilled-tickets-by-company'" in sql
     assert "AND is_system = 1" in sql


### PR DESCRIPTION
### Motivation
- Provide an additional system report that aggregates unbilled, billable ticket minutes by company and labour type and keep companies with identical names distinguishable in exports by including the company identifier.
- Ensure existing ticket-level `Unbilled Tickets` system report is preserved for upgraded installations while adding the new company-level summary.

### Description
- Add migration `migrations/304_unbilled_tickets_by_company_columns.sql` which updates the `unbilled-tickets-by-company` system seed to include `c.id AS company_id` and a SQL body that `COUNT(DISTINCT t.id)` and `SUM(tr.minutes_spent)` grouped by company and labour type (and applied only for `is_system = 1`).
- Extend `tests/test_unbilled_tickets_reporting_migration.py` with a `REPORT_COLUMNS_MIGRATION` reference and a new test `test_company_summary_exposes_company_id_and_preserves_labour_grouping()` that asserts the migration exposes `company_id`, preserves the labour-type grouping, and ensures the system-report guard (`WHERE slug = 'unbilled-tickets-by-company'` and `AND is_system = 1`).
- The change complements the existing `302_unbilled_tickets_by_company_report.sql` and `303_restore_unbilled_tickets_report.sql` migrations by making the company-id exposure explicit for upgraded installs.

### Testing
- Ran `pytest -q tests/test_unbilled_tickets_reporting_migration.py tests/test_reporting_service.py` and the test suite completed successfully with all tests passing (`56 passed`).
- Project checks (test run) passed with only non-actionable deprecation/warning output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a671511db608332b26859836fd4075e)