### PR TITLE
Show M365 mail sync history in a modal and format completed timestamp in local YYYY-MM-DD hh:mm

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -4438,6 +4438,10 @@ dialog.modal:not([open]) {
   box-shadow: 0 30px 80px -24px rgba(2, 6, 23, 0.95), 0 0 0 1px rgba(15, 23, 42, 0.7);
 }
 
+.modal__dialog--wide {
+  width: min(96vw, 80rem);
+}
+
 .modal__dialog .modal__header {
   display: flex;
   align-items: flex-start;

--- a/app/templates/admin/m365_mail.html
+++ b/app/templates/admin/m365_mail.html
@@ -119,112 +119,6 @@
 
       <div class="management__body">
 
-        {% if history_account %}
-          <section class="panel" aria-labelledby="m365-sync-history-heading">
-            <div class="panel__header">
-              <div>
-                <h2 class="panel__title" id="m365-sync-history-heading">Sync history for {{ history_account.name or history_account.user_principal_name }}</h2>
-                <p class="panel__subtitle">Review past mailbox sync runs, imported-message decisions, and failure details.</p>
-              </div>
-              <a class="button button--small button--ghost" href="/admin/modules/m365-mail">Close history</a>
-            </div>
-            {% if history_runs %}
-              <div class="table-wrapper">
-                <table class="table" id="m365-mail-sync-history-table" data-table data-table-id="m365-mail-sync-history">
-                  <thead>
-                    <tr>
-                      <th scope="col" data-sort="string" data-column-key="completed">Completed</th>
-                      <th scope="col" data-sort="string" data-column-key="status">Status</th>
-                      <th scope="col" data-sort="number" data-column-key="processed">Imported</th>
-                      <th scope="col" data-sort="number" data-column-key="created">Created</th>
-                      <th scope="col" data-sort="number" data-column-key="attached">Attached</th>
-                      <th scope="col" data-sort="number" data-column-key="ignored">Ignored</th>
-                      <th scope="col" data-sort="number" data-column-key="errors">Errors</th>
-                      <th scope="col" data-column-key="details">Details</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {% for run in history_runs %}
-                      {% set run_actions = run.message_actions or [] %}
-                      <tr>
-                        <td data-column-key="completed">{{ run.completed_at.isoformat() if run.completed_at else '—' }}</td>
-                        <td data-column-key="status">
-                          <span class="badge {% if run.status == 'succeeded' %}badge--success{% elif run.status == 'completed_with_errors' or run.status == 'error' %}badge--danger{% elif run.status == 'skipped' %}badge--muted{% else %}badge--warning{% endif %}">{{ (run.status or 'unknown')|replace('_', ' ')|title }}</span>
-                        </td>
-                        <td data-column-key="processed">{{ run.processed or 0 }}</td>
-                        <td data-column-key="created">{{ run.created_count or 0 }}</td>
-                        <td data-column-key="attached">{{ run.attached_count or 0 }}</td>
-                        <td data-column-key="ignored">{{ run.ignored_count or 0 }}</td>
-                        <td data-column-key="errors">{{ run.error_count or 0 }}</td>
-                        <td data-column-key="details">
-                          <details>
-                            <summary>{{ run_actions|length }} message decision{{ 's' if run_actions|length != 1 else '' }}</summary>
-                            {% if run.errors %}
-                              <div class="alert alert--error" role="alert">
-                                <strong>Sync errors</strong>
-                                <ul>
-                                  {% for err in run.errors %}
-                                    <li>{{ err.error or err }}</li>
-                                  {% endfor %}
-                                </ul>
-                              </div>
-                            {% endif %}
-                            {% if run_actions %}
-                              <div class="table-wrapper">
-                                <table class="table">
-                                  <thead>
-                                    <tr>
-                                      <th scope="col">Received</th>
-                                      <th scope="col">Outcome</th>
-                                      <th scope="col">Message</th>
-                                      <th scope="col">Sender</th>
-                                      <th scope="col">Ticket / reason</th>
-                                    </tr>
-                                  </thead>
-                                  <tbody>
-                                    {% for action in run_actions %}
-                                      <tr>
-                                        <td>{{ action.received_at or '—' }}</td>
-                                        <td>{{ (action.outcome or 'unknown')|replace('_', ' ')|title }}</td>
-                                        <td>
-                                          <strong>{{ action.subject or 'No subject' }}</strong>
-                                          <div class="table__meta">Graph: <code>{{ action.message_id or '—' }}</code></div>
-                                          <div class="table__meta">Internet: <code>{{ action.internet_message_id or '—' }}</code></div>
-                                        </td>
-                                        <td>{{ action.from_address or action.mailbox or '—' }}</td>
-                                        <td>
-                                          {% if action.ticket_id %}
-                                            <a href="/admin/tickets/{{ action.ticket_id }}">#{{ action.ticket_number or action.ticket_id }}</a>
-                                            {% if action.ticket_subject %}<div class="table__meta">{{ action.ticket_subject }}</div>{% endif %}
-                                          {% elif action.reason %}
-                                            {{ action.reason|replace('_', ' ') }}
-                                          {% elif action.error %}
-                                            <span class="text-danger">{{ action.error }}</span>
-                                          {% else %}
-                                            —
-                                          {% endif %}
-                                        </td>
-                                      </tr>
-                                    {% endfor %}
-                                  </tbody>
-                                </table>
-                              </div>
-                            {% else %}
-                              <p class="text-muted">No per-message decisions were recorded for this run.</p>
-                            {% endif %}
-                          </details>
-                        </td>
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
-              </div>
-            {% else %}
-              <p class="empty-state">No sync history has been recorded for this mailbox yet.</p>
-            {% endif %}
-          </section>
-        {% endif %}
-
         {% if sync_result %}
           {% set sync_actions = sync_result.message_actions or [] %}
           <section class="panel" aria-labelledby="m365-sync-results-heading">
@@ -441,6 +335,131 @@
       </div>
     </section>
   </div>
+  {% if history_account %}
+    <div class="modal" id="m365-mail-sync-history-modal" role="dialog" aria-modal="true" aria-labelledby="m365-sync-history-heading" aria-describedby="m365-sync-history-description">
+      <div class="modal__dialog modal__dialog--wide">
+        <a class="modal__close" href="/admin/modules/m365-mail" aria-label="Close sync history">
+          <span aria-hidden="true">&times;</span>
+          <span class="visually-hidden">Close sync history</span>
+        </a>
+        <h2 class="modal__title" id="m365-sync-history-heading">Sync history for {{ history_account.name or history_account.user_principal_name }}</h2>
+        <div class="modal__body stack-sm">
+          <p class="text-muted" id="m365-sync-history-description">Review past mailbox sync runs, imported-message decisions, and failure details.</p>
+          {% if history_runs %}
+            <div class="table-wrapper">
+              <table class="table" id="m365-mail-sync-history-table" data-table data-table-id="m365-mail-sync-history">
+                <thead>
+                  <tr>
+                    <th scope="col" data-sort="string" data-column-key="completed">Completed</th>
+                    <th scope="col" data-sort="string" data-column-key="status">Status</th>
+                    <th scope="col" data-sort="number" data-column-key="processed">Imported</th>
+                    <th scope="col" data-sort="number" data-column-key="created">Created</th>
+                    <th scope="col" data-sort="number" data-column-key="attached">Attached</th>
+                    <th scope="col" data-sort="number" data-column-key="ignored">Ignored</th>
+                    <th scope="col" data-sort="number" data-column-key="errors">Errors</th>
+                    <th scope="col" data-column-key="details">Details</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for run in history_runs %}
+                    {% set run_actions = run.message_actions or [] %}
+                    <tr>
+                      <td data-column-key="completed">
+                        {% if run.completed_at %}
+                          <time datetime="{{ run.completed_at.isoformat() }}" data-m365-history-completed>{{ run.completed_at.isoformat() }}</time>
+                        {% else %}
+                          —
+                        {% endif %}
+                      </td>
+                      <td data-column-key="status">
+                        <span class="badge {% if run.status == 'succeeded' %}badge--success{% elif run.status == 'completed_with_errors' or run.status == 'error' %}badge--danger{% elif run.status == 'skipped' %}badge--muted{% else %}badge--warning{% endif %}">{{ (run.status or 'unknown')|replace('_', ' ')|title }}</span>
+                      </td>
+                      <td data-column-key="processed">{{ run.processed or 0 }}</td>
+                      <td data-column-key="created">{{ run.created_count or 0 }}</td>
+                      <td data-column-key="attached">{{ run.attached_count or 0 }}</td>
+                      <td data-column-key="ignored">{{ run.ignored_count or 0 }}</td>
+                      <td data-column-key="errors">{{ run.error_count or 0 }}</td>
+                      <td data-column-key="details">
+                        <details>
+                          <summary>{{ run_actions|length }} message decision{{ 's' if run_actions|length != 1 else '' }}</summary>
+                          {% if run.errors %}
+                            <div class="alert alert--error" role="alert">
+                              <strong>Sync errors</strong>
+                              <ul>
+                                {% for err in run.errors %}
+                                  <li>{{ err.error or err }}</li>
+                                {% endfor %}
+                              </ul>
+                            </div>
+                          {% endif %}
+                          {% if run_actions %}
+                            <div class="table-wrapper">
+                              <table class="table">
+                                <thead>
+                                  <tr>
+                                    <th scope="col">Received</th>
+                                    <th scope="col">Outcome</th>
+                                    <th scope="col">Message</th>
+                                    <th scope="col">Sender</th>
+                                    <th scope="col">Ticket / reason</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  {% for action in run_actions %}
+                                    <tr>
+                                      <td>{{ action.received_at or '—' }}</td>
+                                      <td>{{ (action.outcome or 'unknown')|replace('_', ' ')|title }}</td>
+                                      <td>
+                                        <strong>{{ action.subject or 'No subject' }}</strong>
+                                        <div class="table__meta">Graph: <code>{{ action.message_id or '—' }}</code></div>
+                                        <div class="table__meta">Internet: <code>{{ action.internet_message_id or '—' }}</code></div>
+                                      </td>
+                                      <td>{{ action.from_address or action.mailbox or '—' }}</td>
+                                      <td>
+                                        {% if action.ticket_id %}
+                                          <a href="/admin/tickets/{{ action.ticket_id }}">#{{ action.ticket_number or action.ticket_id }}</a>
+                                          {% if action.ticket_subject %}<div class="table__meta">{{ action.ticket_subject }}</div>{% endif %}
+                                        {% elif action.reason %}
+                                          {{ action.reason|replace('_', ' ') }}
+                                        {% elif action.error %}
+                                          <span class="text-danger">{{ action.error }}</span>
+                                        {% else %}
+                                          —
+                                        {% endif %}
+                                      </td>
+                                    </tr>
+                                  {% endfor %}
+                                </tbody>
+                              </table>
+                            </div>
+                          {% else %}
+                            <p class="text-muted">No per-message decisions were recorded for this run.</p>
+                          {% endif %}
+                        </details>
+                      </td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% else %}
+            <p class="empty-state">No sync history has been recorded for this mailbox yet.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    <script>
+      (() => {
+        const pad = (value) => String(value).padStart(2, '0');
+        document.querySelectorAll('[data-m365-history-completed]').forEach((element) => {
+          const completedAt = new Date(element.dateTime);
+          if (Number.isNaN(completedAt.getTime())) return;
+          element.textContent = `${completedAt.getFullYear()}-${pad(completedAt.getMonth() + 1)}-${pad(completedAt.getDate())} ${pad(completedAt.getHours())}:${pad(completedAt.getMinutes())}`;
+        });
+      })();
+    </script>
+  {% endif %}
+
   {% if sync_result %}
     {% set sync_account = sync_result.account or {} %}
     {% set sync_actions = sync_result.message_actions or [] %}

--- a/tests/test_m365_mail_history_template.py
+++ b/tests/test_m365_mail_history_template.py
@@ -1,0 +1,27 @@
+"""Regression checks for the M365 mail sync-history dialog."""
+
+from pathlib import Path
+
+
+TEMPLATE = (
+    Path(__file__).resolve().parents[1] / "app/templates/admin/m365_mail.html"
+).read_text(encoding="utf-8")
+
+
+def test_sync_history_is_rendered_as_a_modal_after_the_account_list():
+    history_modal = TEMPLATE.index('id="m365-mail-sync-history-modal"')
+    account_table = TEMPLATE.index('id="m365-mail-accounts-table"')
+
+    assert history_modal > account_table
+    assert 'role="dialog"' in TEMPLATE[history_modal - 100 : history_modal + 200]
+    assert 'aria-modal="true"' in TEMPLATE[history_modal - 100 : history_modal + 200]
+    assert 'href="/admin/modules/m365-mail" aria-label="Close sync history"' in TEMPLATE
+
+
+def test_sync_history_completed_time_is_formatted_in_browser_local_time():
+    assert 'datetime="{{ run.completed_at.isoformat() }}"' in TEMPLATE
+    assert "new Date(element.dateTime)" in TEMPLATE
+    assert "completedAt.getFullYear()" in TEMPLATE
+    assert "completedAt.getMonth() + 1" in TEMPLATE
+    assert "completedAt.getHours()" in TEMPLATE
+    assert "completedAt.getMinutes()" in TEMPLATE


### PR DESCRIPTION
### Motivation

- Make the mailbox sync history easier to consume by moving it out of the top-of-list table into an accessible, closeable modal dialog. 
- Display the sync `completed` timestamp in the browser's local time zone using a consistent `YYYY-MM-DD hh:mm` format for readability.

### Description

- Replaced the in-page sync history panel with a wide modal dialog named `m365-mail-sync-history-modal` and preserved the existing per-run and per-message details. (template: `app/templates/admin/m365_mail.html`)
- Rendered the `completed_at` value into a `<time datetime="{{ run.completed_at.isoformat() }}" data-m365-history-completed>` element and added client-side JS to convert the ISO value to the local `YYYY-MM-DD hh:mm` format. (template JS in `app/templates/admin/m365_mail.html`)
- Added a wide modal variant `.modal__dialog--wide` to the stylesheet so the history tables have sufficient horizontal space. (CSS: `app/static/css/app.css`)
- Added regression tests (`tests/test_m365_mail_history_template.py`) that assert the modal is placed after the account list, includes the correct accessibility attributes and close affordance, and that the template contains the local-time formatting script and `datetime` attribute.

### Testing

- Ran `pytest -q tests/test_m365_mail_history_template.py` and both tests passed. 
- Parsed the updated Jinja template via `Environment().parse(...)` and parsing succeeded. 
- Ran `git diff --check` as a lint/sanity check and no issues were reported. 
- Note: running the broader `tests/test_m365_mail_feature_pack.py` in the full suite surfaced two unrelated pre-existing failures in that test (route expectations differ from the codebase), which are not caused by these UI/template changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a67edd836708332b9a2b32ab8b28271)