### PR TITLE
Fix M365 ticket reply matching and improve sync diagnostics

### DIFF
--- a/app/services/imap.py
+++ b/app/services/imap.py
@@ -1365,8 +1365,8 @@ async def _find_existing_ticket_for_reply(
     Find an existing ticket that this email is likely a reply to.
 
     Priority order:
-    1. Match In-Reply-To/References message IDs against ticket and reply external references
-    2. Extract ticket number from subject, including resolved tickets
+    1. Extract ticket number from subject, including resolved tickets
+    2. Match In-Reply-To/References message IDs against ticket and reply external references
     3. Fuzzy subject match for non-closed tickets where sender is requester or watcher.
 
     Args:
@@ -1378,6 +1378,35 @@ async def _find_existing_ticket_for_reply(
     Returns:
         Ticket record if found, None otherwise
     """
+    # The visible, explicit ticket number is authoritative. Reply headers can
+    # legitimately point at a different ticket when a thread was forwarded or
+    # reused, so checking those first can silently append to the wrong ticket.
+    ticket_number = _extract_ticket_number_from_subject(subject)
+    if ticket_number:
+        try:
+            rows = await db.fetch_all(
+                "SELECT * FROM tickets WHERE ticket_number = %s LIMIT 1",
+                (ticket_number,),
+            )
+            if rows:
+                from app.repositories.tickets import _normalise_ticket
+
+                return _normalise_ticket(rows[0])
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+        try:
+            rows = await db.fetch_all(
+                "SELECT * FROM tickets WHERE id = %s LIMIT 1",
+                (int(ticket_number),),
+            )
+            if rows:
+                from app.repositories.tickets import _normalise_ticket
+
+                return _normalise_ticket(rows[0])
+        except Exception:  # pragma: no cover - defensive
+            pass
+
     related_ids = _expand_ticket_external_references(related_message_ids)
 
     if related_ids:
@@ -1418,36 +1447,6 @@ async def _find_existing_ticket_for_reply(
         except Exception:  # pragma: no cover - defensive logging
             pass
 
-    # First, try to extract ticket number from subject
-    ticket_number = _extract_ticket_number_from_subject(subject)
-    if ticket_number:
-        # Try to find ticket by ticket_number field
-        try:
-            rows = await db.fetch_all(
-                "SELECT * FROM tickets WHERE ticket_number = %s LIMIT 1",
-                (ticket_number,)
-            )
-            if rows:
-                from app.repositories.tickets import _normalise_ticket
-                ticket = _normalise_ticket(rows[0])
-                return ticket
-        except Exception:  # pragma: no cover - defensive
-            pass
-
-        # Also try by ID if ticket_number is numeric
-        try:
-            ticket_id = int(ticket_number)
-            rows = await db.fetch_all(
-                "SELECT * FROM tickets WHERE id = %s LIMIT 1",
-                (ticket_id,)
-            )
-            if rows:
-                from app.repositories.tickets import _normalise_ticket
-                ticket = _normalise_ticket(rows[0])
-                return ticket
-        except (ValueError, Exception):  # pragma: no cover - defensive
-            pass
-    
     # If no ticket number found, try to match by normalized subject
     # Only match non-closed tickets where sender is requester or watcher
     normalized_subject = _normalize_subject_for_matching(subject)

--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -31,6 +31,7 @@ from app.services.imap import (
     _extract_domains,
     _extract_email_addresses,
     _extract_message_ids,
+    _extract_ticket_number_from_subject,
     _find_existing_ticket_for_reply,
     _resolve_existing_reply_author_id,
     _int_or_none,
@@ -1253,53 +1254,75 @@ async def sync_account(account_id: int) -> dict[str, Any]:
 
                 # Check if already processed
                 existing_message = await mail_repo.get_message(int(account_id), msg_id)
+                stale_import_ticket: Mapping[str, Any] | None = None
                 if existing_message and existing_message.get("status") == "imported":
-                    # A previous run may have successfully imported the message but
-                    # failed while marking it read.  Avoid duplicate ticket activity,
-                    # but still repair the mailbox read state on subsequent syncs.
-                    read_state_repaired = False
-                    if mark_as_read and not msg.get("isRead", False):
-                        try:
-                            patch_url = (
-                                f"{_GRAPH_BASE}/users/{quote(upn, safe='')}/messages/"
-                                f"{quote(msg_id, safe='')}"
-                            )
-                            await _graph_patch(
-                                access_token, patch_url, {"isRead": True}
-                            )
-                            read_state_repaired = True
-                        except Exception:  # pragma: no cover - Graph API errors
-                            log_error(
-                                "Unable to mark already-imported M365 message as read",
-                                account_id=account_id,
-                                message_id=msg_id,
-                            )
                     existing_ticket_id = existing_message.get("ticket_id")
                     existing_ticket = None
                     if isinstance(existing_ticket_id, int):
-                        existing_ticket = await tickets_repo.get_ticket(
-                            existing_ticket_id
-                        )
-                    _remember_message_action(
-                        {
-                            **message_log_base,
-                            "outcome": "ignored",
-                            "reason": "already_imported",
-                            "ticket_id": existing_ticket_id,
-                            "ticket_number": (
-                                existing_ticket.get("ticket_number")
-                                if isinstance(existing_ticket, Mapping)
-                                else None
-                            ),
-                            "ticket_subject": (
-                                existing_ticket.get("subject")
-                                if isinstance(existing_ticket, Mapping)
-                                else None
-                            ),
-                            "read_state_repaired": read_state_repaired,
-                        }
+                        existing_ticket = await tickets_repo.get_ticket(existing_ticket_id)
+
+                    subject_ticket_number = _extract_ticket_number_from_subject(
+                        message_log_base["subject"]
                     )
-                    continue
+                    recorded_ticket_number = (
+                        str(existing_ticket.get("ticket_number") or existing_ticket_id)
+                        if isinstance(existing_ticket, Mapping)
+                        else str(existing_ticket_id or "")
+                    )
+                    import_marker_conflicts = bool(
+                        subject_ticket_number
+                        and recorded_ticket_number
+                        and subject_ticket_number != recorded_ticket_number
+                    )
+                    if import_marker_conflicts:
+                        # Graph message IDs are used as the import idempotency key.
+                        # If that marker points at a different explicit ticket than
+                        # the current subject, it is unsafe to suppress the email.
+                        # Process it normally and replace the stale marker below.
+                        stale_import_ticket = existing_ticket
+                    else:
+                        # A previous run may have successfully imported the message
+                        # but failed while marking it read. Avoid duplicate ticket
+                        # activity, but still repair the read state on later syncs.
+                        read_state_repaired = False
+                        if mark_as_read and not msg.get("isRead", False):
+                            try:
+                                patch_url = (
+                                    f"{_GRAPH_BASE}/users/{quote(upn, safe='')}/messages/"
+                                    f"{quote(msg_id, safe='')}"
+                                )
+                                await _graph_patch(access_token, patch_url, {"isRead": True})
+                                read_state_repaired = True
+                            except Exception:  # pragma: no cover - Graph API errors
+                                log_error(
+                                    "Unable to mark already-imported M365 message as read",
+                                    account_id=account_id,
+                                    message_id=msg_id,
+                                )
+                        _remember_message_action(
+                            {
+                                **message_log_base,
+                                "outcome": "ignored",
+                                "reason": "already_imported",
+                                "ticket_id": existing_ticket_id,
+                                "ticket_number": (
+                                    existing_ticket.get("ticket_number")
+                                    if isinstance(existing_ticket, Mapping)
+                                    else None
+                                ),
+                                "ticket_subject": (
+                                    existing_ticket.get("subject")
+                                    if isinstance(existing_ticket, Mapping)
+                                    else None
+                                ),
+                                "reason_detail": (
+                                    "This exact Microsoft Graph message ID was already "
+                                    "recorded as imported, so no duplicate reply was added."
+                                ),
+                                "read_state_repaired": read_state_repaired,
+                            }
+                        )
+                        continue
 
                 # Extract message details
                 subject = msg.get("subject") or f"Email from {upn}"
@@ -1691,6 +1714,12 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                         "matched_by_related_message_ids": bool(related_message_ids),
                         "related_message_ids": (
                             related_message_ids[:10] if related_message_ids else None
+                        ),
+                        "corrected_stale_import_marker": stale_import_ticket is not None,
+                        "previous_ticket_number": (
+                            stale_import_ticket.get("ticket_number")
+                            if isinstance(stale_import_ticket, Mapping)
+                            else None
                         ),
                     }
                 )

--- a/app/templates/admin/m365_mail.html
+++ b/app/templates/admin/m365_mail.html
@@ -518,8 +518,14 @@
                           <a href="/admin/tickets/{{ action.ticket_id }}">#{{ action.ticket_number or action.ticket_id }}</a>
                           {% if action.ticket_subject %}<div class="table__meta">{{ action.ticket_subject }}</div>{% endif %}
                           {% if action.reply_outcome %}<div class="table__meta">{{ action.reply_outcome|replace('_', ' ') }}</div>{% endif %}
+                          {% if action.reason_detail %}<div class="table__meta">{{ action.reason_detail }}</div>{% endif %}
+                          {% if action.read_state_repaired %}<div class="table__meta">Mailbox read state was repaired.</div>{% endif %}
+                          {% if action.corrected_stale_import_marker %}
+                            <div class="table__meta">Corrected a stale import record previously linked to ticket #{{ action.previous_ticket_number or 'unknown' }}.</div>
+                          {% endif %}
                         {% elif action.reason %}
                           {{ action.reason|replace('_', ' ') }}
+                          {% if action.reason_detail %}<div class="table__meta">{{ action.reason_detail }}</div>{% endif %}
                         {% elif action.error %}
                           <span class="text-danger">{{ action.error }}</span>
                         {% else %}

--- a/tests/test_email_ticket_replies.py
+++ b/tests/test_email_ticket_replies.py
@@ -340,6 +340,35 @@ class TestFindExistingTicket:
         assert "COALESCE(t.description" in str(captured["query"])
         assert "%support@ideagen.example%" in captured["params"]
 
+    async def test_subject_ticket_number_wins_over_reply_header(self, monkeypatch):
+        """A reused thread must not override the explicit ticket in the subject."""
+        from app.core import database
+        from app.services import imap
+
+        async def mock_get_ticket_by_external_reference(_external_reference):
+            return {"id": 222, "ticket_number": "222"}
+
+        async def mock_fetch_all(query, params):
+            if "ticket_number" in query and params == ("111",):
+                return [{"id": 111, "ticket_number": "111", "subject": "Actual ticket"}]
+            return []
+
+        monkeypatch.setattr(
+            imap.tickets_repo,
+            "get_ticket_by_external_reference",
+            mock_get_ticket_by_external_reference,
+        )
+        monkeypatch.setattr(database.db, "fetch_all", mock_fetch_all)
+
+        result = await imap._find_existing_ticket_for_reply(
+            subject="RE: Ticket #111 - Actual ticket",
+            from_email="user@example.com",
+            related_message_ids=["reply-from-ticket-222@example.com"],
+        )
+
+        assert result is not None
+        assert result["ticket_number"] == "111"
+
     async def test_find_ticket_by_in_reply_to_header(self, monkeypatch):
         """Test finding ticket by matching Message-ID references."""
 

--- a/tests/test_m365_mail_service.py
+++ b/tests/test_m365_mail_service.py
@@ -1216,7 +1216,7 @@ async def test_sync_account_matches_existing_ticket(monkeypatch):
 
 
 async def test_sync_account_attaches_m365_reply_to_resolved_ticket_number(monkeypatch):
-    """Graph mail replies should use the shared ticket matcher for resolved tickets."""
+    """An explicit subject ticket overrides a stale import marker for another ticket."""
     monkeypatch.setattr(m365_mail.system_state, "is_restart_pending", lambda: False)
 
     async def fake_get_module(slug: str, *, redact: bool = True):
@@ -1261,7 +1261,15 @@ async def test_sync_account_attaches_m365_reply_to_resolved_ticket_number(monkey
         }
 
     async def fake_get_message(account_id: int, message_uid: str):
-        return None
+        return {"status": "imported", "ticket_id": 25224}
+
+    async def fake_get_ticket(ticket_id: int):
+        assert ticket_id == 25224
+        return {
+            "id": 25224,
+            "ticket_number": "25224",
+            "subject": "Julie's mailbox",
+        }
 
     async def fake_resolve_ticket_entities(from_header, *, default_company_id=None):
         return 5, 42
@@ -1309,6 +1317,7 @@ async def test_sync_account_attaches_m365_reply_to_resolved_ticket_number(monkey
     monkeypatch.setattr(m365_mail.m365_service, "acquire_access_token", fake_acquire_token)
     monkeypatch.setattr(m365_mail, "_graph_get", fake_graph_get)
     monkeypatch.setattr(m365_mail.mail_repo, "get_message", fake_get_message)
+    monkeypatch.setattr(m365_mail.tickets_repo, "get_ticket", fake_get_ticket)
     monkeypatch.setattr(m365_mail.mail_repo, "upsert_message", fake_upsert_message)
     monkeypatch.setattr(m365_mail.mail_repo, "update_account", fake_update_account)
     monkeypatch.setattr(m365_mail, "_resolve_ticket_entities", fake_resolve_ticket_entities)
@@ -1326,6 +1335,8 @@ async def test_sync_account_attaches_m365_reply_to_resolved_ticket_number(monkey
     assert len(replies_added) == 1
     assert replies_added[0]["ticket_id"] == 24417
     assert recorded_messages[-1]["ticket_id"] == 24417
+    assert result["message_actions"][-1]["corrected_stale_import_marker"] is True
+    assert result["message_actions"][-1]["previous_ticket_number"] == "25224"
 
 
 async def test_persist_m365_inline_images_for_ticket_rewrites_data_uri(monkeypatch):


### PR DESCRIPTION
### Motivation

- Prevent replies from being attached to the wrong ticket when a reused email thread contains In-Reply-To/References headers that point at a different ticket than the visible subject number.
- Make the M365 sync UI more informative so admins can see why a message was ignored or when a stale import marker was corrected.

### Description

- Change reply-matching priority in `_find_existing_ticket_for_reply` so an explicit ticket number extracted from the subject is checked first before using `In-Reply-To`/`References` message IDs. (modified `app/services/imap.py`)
- Update M365 sync processing to detect when an existing imported message record references a different ticket number than the current subject, treat that as a conflict (process the message rather than silently ignoring it), and surface details about the stale mapping. New fields in recorded `message_actions` include `reason_detail`, `corrected_stale_import_marker`, and `previous_ticket_number`. (modified `app/services/m365_mail.py`)
- Improve the admin sync details modal to show the new diagnostics: duplicate-import explanation, repaired mailbox read state, and corrected stale import mappings so operators see why a message was ignored or corrected. (modified `app/templates/admin/m365_mail.html`)
- Add regression tests covering subject-ticket-number precedence over reply headers and the stale-import-marker scenario, and update existing M365 mail tests to assert the new behavior. (modified `tests/test_email_ticket_replies.py`, `tests/test_m365_mail_service.py`)

### Testing

- Ran the focussed pytest suite: `pytest -q tests/test_email_ticket_replies.py tests/test_m365_mail_service.py`, all tests passed (82 passed, with existing warnings unrelated to this change). 
- Verified Python syntax by running `python -m py_compile` on the modified modules, which completed without errors.
- Ran code-style check with `black --check` which reported pre-existing formatting differences and an environment target mismatch (project targets Py3.14 while the runner used Py3.12); this is informational and not related to the functional changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a67efffa2b88332888b400e5033c0cf)