### PR TITLE
Add Tactical RMM ticket URL Action

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -25,8 +25,8 @@ from decimal import Decimal
 from typing import Any
 from urllib.parse import quote
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
 from app.api.dependencies.auth import (
     get_current_tray_device,
@@ -909,6 +909,44 @@ async def issue_ticket_token(
     ticket_url = _ticket_form_url(token, request)
     return TrayTicketTokenResponse(
         token=token, expires_in=_TICKET_TOKEN_TTL_SECONDS, ticket_url=ticket_url
+    )
+
+
+@router.get(
+    "/ticket-form/url-action",
+    response_class=RedirectResponse,
+    include_in_schema=False,
+)
+async def tacticalrmm_ticket_url_action(
+    request: Request,
+    tray_agent_id: str = Query(alias="TrayAgentID", min_length=1, max_length=255),
+) -> RedirectResponse:
+    """Launch an asset-linked ticket form from a Tactical RMM URL Action.
+
+    ``TrayAgentID`` is the agent custom field populated by MyPortal's Tactical
+    RMM asset sync.  Exchange it for the same short-lived encrypted form token
+    used by the tray application rather than exposing an internal device ID in
+    the form URL.
+    """
+
+    device_uid = tray_agent_id.strip()
+    device = await tray_repo.get_device_by_uid(device_uid)
+    if not device or device.get("status") == "revoked":
+        raise HTTPException(status_code=404, detail="Tray device not found")
+    if not device.get("asset_id"):
+        raise HTTPException(
+            status_code=409, detail="Tray device is not linked to an asset"
+        )
+
+    token, _csrf = _issue_ticket_form_token(device, "myportal")
+    log_info(
+        "Tactical RMM URL Action launched tray ticket form",
+        device_uid=device_uid,
+        asset_id=device.get("asset_id"),
+    )
+    return RedirectResponse(
+        url=_ticket_form_url(token, request),
+        status_code=status.HTTP_303_SEE_OTHER,
     )
 
 

--- a/docs/wiki/getting-started/Tray App.md
+++ b/docs/wiki/getting-started/Tray App.md
@@ -261,6 +261,23 @@ If you need advanced nesting, you can still use the **Advanced JSON** toggle to 
 
 ## 6. RMM deployment
 
+### Tactical RMM ticket URL Action
+
+MyPortal can open its ticket form directly from a Tactical RMM agent and link
+the resulting ticket to that agent's synced asset. First import the Tactical
+RMM assets so that the `TrayAgentID` agent custom field contains the enrolled
+MyPortal tray device UID. Then add a URL Action under **Settings → Global
+Settings → URL Actions** with this pattern (replace the hostname):
+
+```text
+https://portal.example.com/api/tray/ticket-form/url-action?TrayAgentID={{agent.TrayAgentID}}
+```
+
+The variable name is case-sensitive. Tactical RMM URL-encodes the custom-field
+value. MyPortal accepts only an active tray device that is linked to an asset,
+then redirects the browser to a short-lived encrypted MyPortal ticket form.
+The URL Action never exposes the internal asset or device database ID.
+
 ### Windows (PowerShell)
 
 ```powershell

--- a/tests/test_tacticalrmm_ticket_url_action.py
+++ b/tests/test_tacticalrmm_ticket_url_action.py
@@ -1,0 +1,70 @@
+"""Tests for launching the tray ticket form from a Tactical RMM URL Action."""
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.api.routes import tray
+
+
+def _request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "https",
+            "server": ("portal.example.com", 443),
+            "path": "/api/tray/ticket-form/url-action",
+            "query_string": b"",
+            "headers": [],
+        }
+    )
+
+
+@pytest.mark.anyio
+async def test_url_action_redirects_to_asset_linked_ticket_form(monkeypatch):
+    device = {"id": 42, "device_uid": "tray-uid", "asset_id": 7, "status": "active"}
+
+    async def get_device_by_uid(device_uid: str):
+        assert device_uid == "tray-uid"
+        return device
+
+    monkeypatch.setattr(tray.tray_repo, "get_device_by_uid", get_device_by_uid)
+    monkeypatch.setattr(tray._settings, "public_base_url", "https://portal.example.com")
+
+    response = await tray.tacticalrmm_ticket_url_action(
+        _request(), tray_agent_id="  tray-uid  "
+    )
+
+    assert response.status_code == 303
+    location = response.headers["location"]
+    assert urlparse(location).path == "/api/tray/ticket-form"
+    session = tray._parse_ticket_form_token(parse_qs(urlparse(location).query)["token"][0])
+    assert session is not None
+    assert session["device_id"] == 42
+    assert session["mode"] == "myportal"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("device", "status_code"),
+    [
+        (None, 404),
+        ({"id": 42, "asset_id": 7, "status": "revoked"}, 404),
+        ({"id": 42, "asset_id": None, "status": "active"}, 409),
+    ],
+)
+async def test_url_action_rejects_unavailable_or_unlinked_devices(
+    monkeypatch, device, status_code
+):
+    async def get_device_by_uid(_device_uid: str):
+        return device
+
+    monkeypatch.setattr(tray.tray_repo, "get_device_by_uid", get_device_by_uid)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await tray.tacticalrmm_ticket_url_action(_request(), tray_agent_id="tray-uid")
+
+    assert exc_info.value.status_code == status_code


### PR DESCRIPTION
### Motivation

- Allow Tactical RMM URL Actions to launch a MyPortal ticket form for an agent-linked asset by using the `TrayAgentID` custom field so technicians can create tickets directly from the RMM UI.

### Description

- Add a new device-facing endpoint `GET /api/tray/ticket-form/url-action` that accepts the case-sensitive `TrayAgentID` query parameter, looks up the corresponding tray device by UID, validates the device is active and linked to an asset, issues a short-lived encrypted form token, and redirects to the existing tray ticket form URL using `_ticket_form_url` in `app/api/routes/tray.py`.
- Use `Query` and `RedirectResponse` imports and keep the redirect as a `303` to the tokenised `GET /api/tray/ticket-form` flow so internal IDs are not exposed.
- Document the Tactical RMM URL Action pattern and setup steps in `docs/wiki/getting-started/Tray App.md` with the example URL: `https://portal.example.com/api/tray/ticket-form/url-action?TrayAgentID={{agent.TrayAgentID}}`.
- Add `tests/test_tacticalrmm_ticket_url_action.py` to validate successful tokenised redirects and rejection behavior for missing, revoked, or unlinked devices.

### Testing

- Ran `pytest -q tests/test_tacticalrmm_ticket_url_action.py tests/test_tray_ticket_questions.py` and `pytest -q tests/test_tacticalrmm_ticket_url_action.py`, and all tests passed (`4 passed`).
- Ran `python -m ruff check app/api/routes/tray.py tests/test_tacticalrmm_ticket_url_action.py` with no issues reported.
- Confirmed the new endpoint issues a short-lived token that `_parse_ticket_form_token` can decode and that the redirect location points to `/api/tray/ticket-form` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a67f49b7530833288a7d7d3d0faed9b)