### PR TITLE
Add dedicated Tactical RMM ticket webhook endpoint

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -31,6 +31,8 @@ from app.core.errors import (
 from app.core.logging import log_error
 from loguru import logger
 from app.repositories import company_memberships as membership_repo
+from app.repositories import companies as companies_repo
+from app.repositories import assets as assets_repo
 from app.repositories import staff as staff_repo
 from app.repositories import ticket_attachments as attachments_repo
 from app.repositories import ticket_tasks as ticket_tasks_repo
@@ -44,8 +46,8 @@ from app.schemas.tickets import (
     LabourTypeUpdateRequest,
     SyncroTicketImportRequest,
     SyncroTicketImportSummary,
+    TacticalRMMTicketCreate,
     TicketAttachment,
-    TicketAttachmentCreate,
     TicketAttachmentListResponse,
     TicketAttachmentUpdate,
     TicketCreate,
@@ -725,7 +727,9 @@ async def create_ticket(
             try:
                 status_value = await tickets_service.validate_status_choice(
                     payload.status,
-                    allow_hidden=bool(current_user.get("is_super_admin")),
+                    allow_hidden=bool(
+                        current_user and current_user.get("is_super_admin")
+                    ),
                 )
             except ValueError as exc:
                 error_id = new_error_id()
@@ -788,6 +792,99 @@ async def create_ticket(
             else None
         ),
     )
+    return await _build_ticket_detail(ticket["id"], detail_user)
+
+
+@router.post(
+    "/tacticalrmm", response_model=TicketDetail, status_code=status.HTTP_201_CREATED
+)
+async def create_tacticalrmm_ticket(
+    payload: TacticalRMMTicketCreate,
+    request: Request,
+    actor: dict = Depends(_resolve_ticket_actor),
+) -> TicketDetail:
+    """Create a ticket from TRMM identifiers rather than MyPortal IDs."""
+    tactical_client_id = str(payload.company_id).strip()
+    company = await companies_repo.get_company_by_tactical_id(tactical_client_id)
+    if not company:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                "No MyPortal company is mapped to Tactical RMM client ID "
+                f"'{tactical_client_id}'."
+            ),
+        )
+
+    asset: dict | None = None
+    tactical_agent_id: str | None = None
+    if payload.agent_id is not None:
+        tactical_agent_id = str(payload.agent_id).strip()
+        asset = await assets_repo.get_asset_by_tactical_id(
+            int(company["id"]), tactical_agent_id
+        )
+        if not asset:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    "No MyPortal asset is mapped to Tactical RMM agent ID "
+                    f"'{tactical_agent_id}' for this company."
+                ),
+            )
+
+    try:
+        status_value = await tickets_service.validate_status_choice(
+            payload.status, allow_hidden=False
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid ticket status.",
+        ) from exc
+
+    ticket = await tickets_service.create_ticket(
+        subject=payload.subject,
+        description=payload.description,
+        requester_id=None,
+        company_id=int(company["id"]),
+        assigned_user_id=None,
+        priority=payload.priority,
+        status=status_value,
+        category=payload.category,
+        module_slug="tacticalrmm",
+        external_reference=payload.external_reference,
+        trigger_automations=True,
+        initial_reply_author_id=None,
+    )
+
+    if asset:
+        await tickets_repo.replace_ticket_assets(ticket["id"], [int(asset["id"])])
+
+    try:
+        await tickets_service.refresh_ticket_ai_summary(ticket["id"])
+    except RuntimeError as exc:
+        log_error(
+            f"Failed to refresh AI summary for ticket {ticket['id']}: {exc}",
+            exc_info=True,
+        )
+    await tickets_service.refresh_ticket_ai_tags(ticket["id"])
+
+    current_user = actor.get("user")
+    api_key_record = actor.get("api_key")
+    await audit_service.record(
+        action="ticket.create",
+        request=request,
+        user_id=int(current_user["id"]) if current_user else None,
+        entity_type="ticket",
+        entity_id=int(ticket["id"]),
+        before=None,
+        after=_audit_ticket_view(ticket),
+        api_key=(
+            str(api_key_record.get("name") or api_key_record.get("id"))
+            if api_key_record
+            else None
+        ),
+    )
+    detail_user = current_user or {"id": None, "is_super_admin": False}
     return await _build_ticket_detail(ticket["id"], detail_user)
 
 

--- a/app/repositories/assets.py
+++ b/app/repositories/assets.py
@@ -47,6 +47,15 @@ async def get_asset_by_id(asset_id: int) -> dict[str, Any] | None:
     )
 
 
+async def get_asset_by_tactical_id(
+    company_id: int, tactical_asset_id: str
+) -> dict[str, Any] | None:
+    return await db.fetch_one(
+        "SELECT * FROM assets WHERE company_id = %s AND tactical_asset_id = %s",
+        (company_id, tactical_asset_id),
+    )
+
+
 async def delete_asset(asset_id: int) -> None:
     await db.execute("DELETE FROM assets WHERE id = %s", (asset_id,))
 

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -24,6 +24,32 @@ class TicketCreate(TicketBase):
     requester_id: Optional[int] = None
 
 
+class TacticalRMMTicketCreate(BaseModel):
+    """Ticket payload accepted from a Tactical RMM alert webhook.
+
+    ``company_id`` is deliberately a string-compatible external identifier: it
+    refers to Tactical RMM's client ID, not the MyPortal company primary key.
+    The two user ID fields are accepted for compatibility with existing alert
+    templates, but are not used because Tactical RMM user IDs cannot safely be
+    mapped to MyPortal users.
+    """
+
+    subject: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = None
+    status: str = Field(default="open", max_length=32)
+    priority: str = Field(default="normal", max_length=32)
+    category: Optional[str] = Field(default=None, max_length=64)
+    company_id: str | int = Field(..., description="Tactical RMM client ID")
+    agent_id: str | int | None = Field(
+        default=None,
+        validation_alias=AliasChoices("agent_id", "tactical_agent_id"),
+        description="Optional Tactical RMM agent ID to link to the ticket",
+    )
+    requester_id: str | int | None = None
+    assigned_user_id: str | int | None = None
+    external_reference: Optional[str] = Field(default=None, max_length=128)
+
+
 class TicketUpdate(BaseModel):
     subject: Optional[str] = Field(default=None, min_length=1, max_length=255)
     description: Optional[str] = None

--- a/docs/wiki/integrations/Tactical RMM Ticket Webhook.md
+++ b/docs/wiki/integrations/Tactical RMM Ticket Webhook.md
@@ -1,0 +1,36 @@
+# Tactical RMM ticket webhook
+
+Tactical RMM alerts can create MyPortal tickets with:
+
+```text
+POST /api/tickets/tacticalrmm
+X-API-Key: <MyPortal API key>
+Content-Type: application/json
+```
+
+Unlike the general ticket endpoint, `company_id` on this endpoint is the
+**Tactical RMM client ID**. MyPortal resolves it through the company's Tactical
+RMM mapping. `agent_id` is optional; when supplied, it is treated as a Tactical
+RMM agent ID and the corresponding imported MyPortal asset is linked to the
+ticket.
+
+Example alert body:
+
+```json
+{
+  "subject": "{{alert.alert_type}} on {{alert.agent}}",
+  "description": "{{alert.message}}",
+  "status": "new",
+  "priority": "normal",
+  "category": "{{alert.alert_type}}",
+  "company_id": "{{alert.client.id}}"
+}
+```
+
+`requester_id` and `assigned_user_id` are optional and should normally be
+omitted. If an existing Tactical RMM template sends them, the endpoint accepts
+but ignores them because Tactical RMM user IDs are not MyPortal user IDs.
+
+The request returns `404` without creating a ticket when the Tactical RMM
+client mapping (or optional agent mapping) cannot be found. Configure company
+mappings and import Tactical RMM assets before using the corresponding IDs.

--- a/tests/test_tacticalrmm_ticket_api.py
+++ b/tests/test_tacticalrmm_ticket_api.py
@@ -1,0 +1,125 @@
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from starlette.requests import Request
+
+from app.api.routes import tickets as tickets_routes
+from app.schemas.tickets import TacticalRMMTicketCreate
+
+
+def _request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/tickets/tacticalrmm",
+            "headers": [],
+        }
+    )
+
+
+def test_tacticalrmm_ticket_maps_external_company_and_agent_ids(monkeypatch):
+    asyncio.run(_test_tacticalrmm_ticket_maps_external_company_and_agent_ids(monkeypatch))
+
+
+async def _test_tacticalrmm_ticket_maps_external_company_and_agent_ids(monkeypatch):
+    now = datetime.now(timezone.utc)
+    created = {
+        "id": 91,
+        "subject": "Disk alert on workstation",
+        "status": "new",
+        "priority": "normal",
+        "requester_id": None,
+        "company_id": 42,
+        "assigned_user_id": None,
+        "category": "disk",
+        "module_slug": "tacticalrmm",
+        "external_reference": "alert-123",
+        "created_at": now,
+        "updated_at": now,
+    }
+    create_ticket = AsyncMock(return_value=created)
+    replace_assets = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(
+        tickets_routes.companies_repo,
+        "get_company_by_tactical_id",
+        AsyncMock(return_value={"id": 42}),
+    )
+    monkeypatch.setattr(
+        tickets_routes.assets_repo,
+        "get_asset_by_tactical_id",
+        AsyncMock(return_value={"id": 73}),
+    )
+    monkeypatch.setattr(
+        tickets_routes.tickets_service,
+        "validate_status_choice",
+        AsyncMock(return_value="new"),
+    )
+    monkeypatch.setattr(tickets_routes.tickets_service, "create_ticket", create_ticket)
+    monkeypatch.setattr(
+        tickets_routes.tickets_service, "refresh_ticket_ai_summary", AsyncMock()
+    )
+    monkeypatch.setattr(
+        tickets_routes.tickets_service, "refresh_ticket_ai_tags", AsyncMock()
+    )
+    monkeypatch.setattr(tickets_routes.tickets_repo, "replace_ticket_assets", replace_assets)
+    monkeypatch.setattr(tickets_routes.audit_service, "record", AsyncMock())
+    monkeypatch.setattr(
+        tickets_routes, "_build_ticket_detail", AsyncMock(return_value=created)
+    )
+
+    payload = TacticalRMMTicketCreate(
+        subject="Disk alert on workstation",
+        description="Disk is almost full",
+        status="new",
+        category="disk",
+        company_id=1007,
+        tactical_agent_id="agent-9",
+        requester_id=888,
+        assigned_user_id=999,
+        external_reference="alert-123",
+    )
+    result = await tickets_routes.create_tacticalrmm_ticket(
+        payload, _request(), {"user": None, "api_key": {"id": 3, "name": "TRMM"}}
+    )
+
+    assert result == created
+    tickets_routes.companies_repo.get_company_by_tactical_id.assert_awaited_once_with(
+        "1007"
+    )
+    tickets_routes.assets_repo.get_asset_by_tactical_id.assert_awaited_once_with(
+        42, "agent-9"
+    )
+    replace_assets.assert_awaited_once_with(91, [73])
+    assert create_ticket.await_args.kwargs["company_id"] == 42
+    assert create_ticket.await_args.kwargs["requester_id"] is None
+    assert create_ticket.await_args.kwargs["assigned_user_id"] is None
+    assert create_ticket.await_args.kwargs["module_slug"] == "tacticalrmm"
+
+
+def test_tacticalrmm_ticket_rejects_unmapped_company_before_creation(monkeypatch):
+    asyncio.run(_test_tacticalrmm_ticket_rejects_unmapped_company_before_creation(monkeypatch))
+
+
+async def _test_tacticalrmm_ticket_rejects_unmapped_company_before_creation(monkeypatch):
+    create_ticket = AsyncMock()
+    monkeypatch.setattr(
+        tickets_routes.companies_repo,
+        "get_company_by_tactical_id",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(tickets_routes.tickets_service, "create_ticket", create_ticket)
+
+    with pytest.raises(Exception) as exc_info:
+        await tickets_routes.create_tacticalrmm_ticket(
+            TacticalRMMTicketCreate(subject="Alert", company_id="missing-client"),
+            _request(),
+            {"user": None, "api_key": {"id": 3}},
+        )
+
+    assert getattr(exc_info.value, "status_code", None) == 404
+    assert "missing-client" in str(getattr(exc_info.value, "detail", ""))
+    create_ticket.assert_not_awaited()


### PR DESCRIPTION
### Motivation
- Provide a dedicated API for Tactical RMM alerts that accepts Tactical RMM IDs (client and agent) rather than MyPortal primary keys so TRMM templates can post alerts without sending incorrect internal IDs.
- Prevent external TRMM user IDs from being interpreted as MyPortal `requester_id` / `assigned_user_id`, and return clear errors when a client or agent mapping is missing.

### Description
- Add `TacticalRMMTicketCreate` schema in `app/schemas/tickets.py` which accepts string-or-int `company_id` (TRMM client ID), optional `agent_id` (with alias `tactical_agent_id`), and preserves legacy requester/assigned fields for compatibility but does not use them.
- Add `POST /api/tickets/tacticalrmm` handler in `app/api/routes/tickets.py` which resolves the incoming `company_id` via `companies_repo.get_company_by_tactical_id`, creates a ticket scoped to the resolved MyPortal company with `module_slug='tacticalrmm'`, and optionally resolves and links an asset by Tactical RMM agent ID using `assets_repo.get_asset_by_tactical_id` and `tickets_repo.replace_ticket_assets`.
- Add `get_asset_by_tactical_id` to `app/repositories/assets.py` and wire the new repositories/imports into the tickets route; make the `validate_status_choice` call defensive against a missing `current_user`.
- Add documentation at `docs/wiki/integrations/Tactical RMM Ticket Webhook.md` and focused unit tests in `tests/test_tacticalrmm_ticket_api.py` covering company mapping, agent->asset linking, ignored external user IDs, and unmapped company rejection.

### Testing
- Ran linter: `python -m ruff check app/api/routes/tickets.py app/repositories/assets.py app/schemas/tickets.py tests/test_tacticalrmm_ticket_api.py` and applied fixes; this passed.
- Ran unit tests for the new endpoint: `python -m pytest tests/test_tacticalrmm_ticket_api.py -q` which passed (2 tests).
- Ran related ticket tests: `python -m pytest tests/test_ticket_api_key_create.py -q` and fixed an incompatibility in the status validation call; these tests passed after the fix.
- Verified compilation: `python -m compileall -q app/api/routes/tickets.py app/repositories/assets.py app/schemas/tickets.py` and `git diff --check` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6808bbf8c48332bd70c334d3c0099c)