### PR TITLE
Add Huntress SAT Callback URL helper to Integration Modules admin page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9466,6 +9466,7 @@ async def _render_modules_dashboard(
         "smtp2go": f"{public_base}/api/webhooks/smtp2go/events",
         "trello": f"{public_base}/api/integration-modules/trello/webhook",
         "uptimekuma": f"{public_base}/api/integration-modules/uptimekuma/alerts",
+        "huntress": f"{public_base}/api/integration-modules/huntress/callback",
         "xero": f"{public_base}/api/integration-modules/xero/callback",
         "xero_webhook": f"{public_base}/api/integration-modules/xero/webhook",
     }

--- a/app/templates/admin/modules.html
+++ b/app/templates/admin/modules.html
@@ -107,9 +107,14 @@
                               role="menuitem"
                               data-webhook-url-open
                               data-webhook-url="{{ webhook_url | e }}"
-                              aria-label="View webhook URL for {{ module.name }}"
+                              {% if module.slug == "huntress" %}
+                                data-webhook-url-title="SAT Callback URL"
+                                data-webhook-url-description="Copy this URL and enter it as the Callback URL in your Huntress SAT configuration."
+                                data-webhook-url-label="SAT Callback URL"
+                              {% endif %}
+                              aria-label="View {% if module.slug == 'huntress' %}SAT callback{% else %}webhook{% endif %} URL for {{ module.name }}"
                             >
-                              {% if module.slug == "xero" %}Callback URL{% else %}Webhook URL{% endif %}
+                              {% if module.slug == "huntress" %}SAT Callback URL{% elif module.slug == "xero" %}Callback URL{% else %}Webhook URL{% endif %}
                             </button>
                           </li>
                         {% endif %}
@@ -157,8 +162,8 @@
     <div class="modal__content modal__content--compact" role="dialog" aria-modal="true" aria-labelledby="webhook-url-modal-title">
       <button type="button" class="modal__close" data-modal-close aria-label="Close webhook URL modal">&times;</button>
       <h2 class="modal__title" id="webhook-url-modal-title">Webhook URL</h2>
-      <p class="modal__text">Copy this URL and use it in your external app.</p>
-      <label for="webhook-url-value" class="form-label">Webhook URL</label>
+      <p class="modal__text" id="webhook-url-modal-description">Copy this URL and use it in your external app.</p>
+      <label for="webhook-url-value" class="form-label" id="webhook-url-modal-label">Webhook URL</label>
       <input id="webhook-url-value" type="text" class="input webhook-url-modal__input" readonly />
       <p id="webhook-url-copy-status" class="webhook-url-modal__status" aria-live="polite"></p>
       <div class="webhook-url-modal__actions">
@@ -204,6 +209,9 @@
       if (!modal) return;
 
       var urlInput = document.getElementById('webhook-url-value');
+      var modalTitle = document.getElementById('webhook-url-modal-title');
+      var modalDescription = document.getElementById('webhook-url-modal-description');
+      var modalLabel = document.getElementById('webhook-url-modal-label');
       var copyButton = document.getElementById('webhook-url-copy');
       var status = document.getElementById('webhook-url-copy-status');
       var previousActive = null;
@@ -225,6 +233,12 @@
       function openModal(trigger) {
         var webhookUrl = trigger.getAttribute('data-webhook-url');
         if (!webhookUrl || !urlInput) return;
+        var title = trigger.getAttribute('data-webhook-url-title') || 'Webhook URL';
+        var description = trigger.getAttribute('data-webhook-url-description') || 'Copy this URL and use it in your external app.';
+        var label = trigger.getAttribute('data-webhook-url-label') || title;
+        if (modalTitle) modalTitle.textContent = title;
+        if (modalDescription) modalDescription.textContent = description;
+        if (modalLabel) modalLabel.textContent = label;
         urlInput.value = webhookUrl;
         modal.hidden = false;
         modal.setAttribute('aria-hidden', 'false');

--- a/tests/test_admin_modules_page.py
+++ b/tests/test_admin_modules_page.py
@@ -123,6 +123,7 @@ def test_modules_page_renders_module_quick_actions_and_helpers(super_admin_conte
             {"slug": "smtp2go", "name": "SMTP2Go", "description": "", "enabled": True, "settings": {}},
             {"slug": "trello", "name": "Trello", "description": "", "enabled": True, "settings": {}},
             {"slug": "uptimekuma", "name": "Uptime Kuma", "description": "", "enabled": True, "settings": {}},
+            {"slug": "huntress", "name": "Huntress", "description": "", "enabled": True, "settings": {}},
             {"slug": "xero", "name": "Xero", "description": "", "enabled": True, "settings": {}},
         ]
 
@@ -138,6 +139,10 @@ def test_modules_page_renders_module_quick_actions_and_helpers(super_admin_conte
     assert "/api/webhooks/smtp2go/events" in response.text
     assert "/api/integration-modules/trello/webhook" in response.text
     assert "/api/integration-modules/uptimekuma/alerts" in response.text
+    assert "/api/integration-modules/huntress/callback" in response.text
+    assert "SAT Callback URL" in response.text
+    assert 'data-webhook-url-title="SAT Callback URL"' in response.text
+    assert "enter it as the Callback URL in your Huntress SAT configuration" in response.text
     assert "/api/integration-modules/xero/callback" in response.text
     assert "data-webhook-url-open" in response.text
     assert 'id="webhook-url-modal"' in response.text


### PR DESCRIPTION
### Motivation
- Expose the correct public callback URL for Huntress SAT on the `/admin/modules` dashboard so admins can easily copy and paste the required Callback URL into Huntress SAT configuration.

### Description
- Add the Huntress callback URL to the `module_webhook_urls` map derived from `public_base` as `"/api/integration-modules/huntress/callback"` in `_render_modules_dashboard` (`app/main.py`).
- Add a Huntress-specific action in the modules row that renders a `SAT Callback URL` button and attaches descriptive attributes (`data-webhook-url-title`, `data-webhook-url-description`, `data-webhook-url-label`) (`app/templates/admin/modules.html`).
- Make the reusable webhook URL modal support dynamic title, description and label and update the open logic in JS to set those values when present, preserving existing behaviour for other modules (`app/templates/admin/modules.html`).
- Add coverage for the Huntress action and generated URL in the admin modules tests by updating `tests/test_admin_modules_page.py`.

### Testing
- Ran `pytest -q tests/test_admin_modules_page.py` and all tests in that file passed (4 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a681fee570883328d39849ae4a89e96)