### PR TITLE
Fix Huntress resolved incident sync

### DIFF
--- a/app/services/huntress.py
+++ b/app/services/huntress.py
@@ -212,28 +212,25 @@ async def get_latest_summary_report(
 
 
 async def get_edr_summary(org_id: str) -> dict[str, int]:
-    """Return EDR counters from the incident-report and signal endpoints.
+    """Return EDR counters from the incident, signal, and summary endpoints.
 
     EDR data is not part of every monthly summary response.  Querying the
     product endpoints directly also means a company sync works before its
-    first monthly report has been generated.
+    first monthly report has been generated. Huntress's incident-report API
+    accepts ``sent`` for active reports, but does not accept ``resolved`` as a
+    status filter. Resolved incidents are therefore read from the supported
+    monthly-summary counter instead of sending an invalid filtered request.
     """
     credentials = _get_credentials()
     if not credentials:
         raise HuntressConfigurationError("Huntress credentials are not configured.")
 
     async with _client(credentials) as client:
-        active, resolved, signals = await asyncio.gather(
+        active, signals = await asyncio.gather(
             _get_json(
                 client,
                 "/incident_reports",
                 {"organization_id": org_id, "status": "sent", "limit": 1},
-                allow_not_found=True,
-            ),
-            _get_json(
-                client,
-                "/incident_reports",
-                {"organization_id": org_id, "status": "resolved", "limit": 1},
                 allow_not_found=True,
             ),
             _get_json(
@@ -243,9 +240,11 @@ async def get_edr_summary(org_id: str) -> dict[str, int]:
                 allow_not_found=True,
             ),
         )
+    report = await get_latest_summary_report(org_id)
+    report_payload = report if isinstance(report, Mapping) else {}
     return {
         "active_incidents": _extract_total(active, "incident_reports"),
-        "resolved_incidents": _extract_total(resolved, "incident_reports"),
+        "resolved_incidents": _coerce_int(report_payload.get("incidents_resolved")),
         "signals_investigated": _extract_total(signals, "signals"),
     }
 

--- a/tests/test_huntress_service.py
+++ b/tests/test_huntress_service.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -33,6 +34,9 @@ def _set_credentials(monkeypatch):
     )
     # Skip the per-call sleep so tests run instantly.
     monkeypatch.setattr(huntress_service, "_REQUEST_INTERVAL_SECONDS", 0)
+    # pytest runs async tests on separate loops; avoid retaining a lock bound
+    # by a concurrent request in an earlier test.
+    monkeypatch.setattr(huntress_service, "_request_lock", asyncio.Lock())
 
 
 def _patch_client(transport):
@@ -143,12 +147,16 @@ async def test_get_edr_summary_uses_basic_auth_and_parses_totals(monkeypatch):
         captured_auth.append(request.headers.get("authorization", ""))
         path = request.url.path
         if path.endswith("/incident_reports"):
-            status_value = request.url.params.get("status")
             # API uses "sent" for active/open incidents, not "open"
-            total = 4 if status_value == "sent" else 9
-            return httpx.Response(200, json={"total": total, "incident_reports": []})
+            assert request.url.params.get("status") == "sent"
+            return httpx.Response(200, json={"total": 4, "incident_reports": []})
         if path.endswith("/signals"):
             return httpx.Response(200, json={"total": 17, "signals": []})
+        if path.endswith("/reports"):
+            return httpx.Response(
+                200,
+                json={"reports": [{"incidents_resolved": 9}]},
+            )
         return httpx.Response(404)
 
     transport = httpx.MockTransport(handler)
@@ -160,8 +168,43 @@ async def test_get_edr_summary_uses_basic_auth_and_parses_totals(monkeypatch):
         "resolved_incidents": 9,
         "signals_investigated": 17,
     }
-    # All three calls should carry HTTP Basic auth derived from the configured key/secret.
+    # All calls should carry HTTP Basic auth derived from the configured key/secret.
     assert captured_auth and all(auth.startswith("Basic ") for auth in captured_auth)
+
+
+@pytest.mark.asyncio
+async def test_get_edr_summary_does_not_filter_incidents_by_resolved(monkeypatch):
+    """Resolved is a summary metric, not a valid incident-report status filter."""
+    from app.services import huntress as huntress_service
+
+    _set_credentials(monkeypatch)
+    incident_statuses: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/incident_reports"):
+            status = request.url.params.get("status")
+            incident_statuses.append(status)
+            if status == "resolved":
+                return httpx.Response(400, json={"error": "invalid status"})
+            return httpx.Response(200, json={"total": 2, "incident_reports": []})
+        if request.url.path.endswith("/signals"):
+            return httpx.Response(200, json={"total": 3, "signals": []})
+        if request.url.path.endswith("/reports"):
+            return httpx.Response(
+                200,
+                json={"reports": [{"incidents_resolved": 11}]},
+            )
+        return httpx.Response(404)
+
+    with _patch_client(httpx.MockTransport(handler)):
+        result = await huntress_service.get_edr_summary("559776")
+
+    assert incident_statuses == ["sent"]
+    assert result == {
+        "active_incidents": 2,
+        "resolved_incidents": 11,
+        "signals_investigated": 3,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Huntress incident-report endpoint rejects `status=resolved` leading to 400 errors and partial sync failures when syncing EDR data.
- Resolved incident counts are available in the monthly summary report, so the client should avoid sending unsupported filters to the incident endpoint.

### Description
- Update `get_edr_summary` to stop querying `/incident_reports` with `status=resolved` and instead read `incidents_resolved` from `get_latest_summary_report` while keeping active incidents from `/incident_reports` with `status=sent` and signals from `/signals`.
- Add a regression test `test_get_edr_summary_does_not_filter_incidents_by_resolved` in `tests/test_huntress_service.py` that simulates the API rejecting `status=resolved` and asserts the client only sends `status=sent` and reads resolved counts from the reports endpoint.
- Adjust test setup to rebind the module-level `_request_lock` (`monkeypatch.setattr(huntress_service, "_request_lock", asyncio.Lock())`) to avoid cross-event-loop lock binding in pytest async tests and remove an unused `MagicMock` import.

### Testing
- Ran `pytest -q tests/test_huntress_service.py` and all tests in that file passed (`12 passed`).
- Ran lint/format checks with `ruff check` and `ruff format --check` on the modified files and they passed.
- Verified `git diff --check` returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6827d85d90833281165a979d6ef965)