### PR TITLE
Add separate Huntress Managed SAT company ID and lookup/routing

### DIFF
--- a/app/api/routes/companies.py
+++ b/app/api/routes/companies.py
@@ -103,6 +103,7 @@ async def update_company(
         not updated.get("tacticalrmm_client_id") or
         not updated.get("xero_id") or
         not updated.get("huntress_organization_id")
+        or not updated.get("huntress_sat_account_id")
     )
     
     final_record: dict[str, Any] = updated
@@ -590,3 +591,23 @@ async def lookup_huntress_organization_id(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error looking up Huntress organisation ID: {str(exc)}"
         )
+
+
+@router.post("/{company_id}/lookup-huntress-sat-id")
+async def lookup_huntress_sat_account_id(
+    company_id: int,
+    _: None = Depends(require_database),
+    __: dict = Depends(require_super_admin),
+):
+    """Lookup a Managed SAT account ID by the company's name."""
+    company = await company_repo.get_company_by_id(company_id)
+    if not company:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
+    company_name = company.get("name", "")
+    if not company_name:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Company name is required")
+    sat_id = await company_id_lookup._lookup_huntress_sat_account_id(company_name)
+    if sat_id:
+        await company_repo.update_company(company_id, huntress_sat_account_id=sat_id)
+        return {"status": "found", "id": sat_id}
+    return {"status": "not_found", "id": None}

--- a/app/features/companies/handlers.py
+++ b/app/features/companies/handlers.py
@@ -535,6 +535,10 @@ async def _render_company_edit_page(
             "huntress_organization_id",
             (company_record.get("huntress_organization_id") or "").strip(),
         ),
+        "huntress_sat_account_id": _string_value(
+            "huntress_sat_account_id",
+            (company_record.get("huntress_sat_account_id") or "").strip(),
+        ),
         "email_domains": _string_value("email_domains", default_email_domains),
         "is_vip": _bool_value("is_vip", bool(company_record.get("is_vip"))),
         "default_ticket_replies_billable": _bool_value(
@@ -1391,6 +1395,7 @@ async def admin_update_company(company_id: int, request: Request):
     xero_id_raw = str(form.get("xeroId", "")).strip()
     hudu_id_raw = str(form.get("huduId", "")).strip()
     huntress_organization_id_raw = str(form.get("huntressOrganizationId", "")).strip()
+    huntress_sat_account_id_raw = str(form.get("huntressSatAccountId", "")).strip()
     trello_board_id_raw = str(form.get("trelloBoardId", "")).strip()
     trello_api_key_raw = str(form.get("trelloApiKey", "")).strip()
     trello_token_raw = str(form.get("trelloToken", "")).strip()
@@ -1458,6 +1463,7 @@ async def admin_update_company(company_id: int, request: Request):
         "xero_id": xero_id_raw,
         "hudu_id": hudu_id_raw,
         "huntress_organization_id": huntress_organization_id_raw,
+        "huntress_sat_account_id": huntress_sat_account_id_raw,
         "trello_board_id": trello_board_id_raw,
         "trello_api_key": trello_api_key_raw or existing.get("trello_api_key"),
         "trello_token": trello_token_raw or existing.get("trello_token"),
@@ -1507,6 +1513,7 @@ async def admin_update_company(company_id: int, request: Request):
     xero_id = xero_id_raw or None
     hudu_id = hudu_id_raw or None
     huntress_organization_id = huntress_organization_id_raw or None
+    huntress_sat_account_id = huntress_sat_account_id_raw or None
     trello_board_id = trello_board_id_raw or None
     trello_api_key: str | None = (
         trello_api_key_raw
@@ -1524,6 +1531,7 @@ async def admin_update_company(company_id: int, request: Request):
         "xero_id": xero_id,
         "hudu_id": hudu_id,
         "huntress_organization_id": huntress_organization_id,
+        "huntress_sat_account_id": huntress_sat_account_id,
         "trello_board_id": trello_board_id,
         "trello_api_key": trello_api_key,
         "trello_token": trello_token,

--- a/app/schemas/companies.py
+++ b/app/schemas/companies.py
@@ -15,6 +15,7 @@ class CompanyBase(BaseModel):
     tacticalrmm_client_id: Optional[str] = None
     xero_id: Optional[str] = None
     huntress_organization_id: Optional[str] = None
+    huntress_sat_account_id: Optional[str] = None
     archived: Optional[int] = None
     default_ticket_replies_billable: Optional[int] = 1
     email_domains: list[str] = Field(default_factory=list)
@@ -43,6 +44,7 @@ class CompanyUpdate(BaseModel):
     tacticalrmm_client_id: Optional[str] = None
     xero_id: Optional[str] = None
     huntress_organization_id: Optional[str] = None
+    huntress_sat_account_id: Optional[str] = None
     archived: Optional[int] = None
     default_ticket_replies_billable: Optional[int] = None
     email_domains: Optional[list[str]] = None

--- a/app/services/company_id_lookup.py
+++ b/app/services/company_id_lookup.py
@@ -201,6 +201,19 @@ async def lookup_missing_company_ids(company_id: int) -> dict[str, Any]:
             )
             results["huntress_lookup"] = "error"
             results["huntress_error"] = str(exc)
+
+    if not company.get("huntress_sat_account_id"):
+        try:
+            sat_id = await _lookup_huntress_sat_account_id(company_name)
+            if sat_id:
+                updates["huntress_sat_account_id"] = sat_id
+                results["huntress_sat_lookup"] = "found"
+                results["updates"]["huntress_sat_account_id"] = sat_id
+            else:
+                results["huntress_sat_lookup"] = "not_found"
+        except Exception as exc:
+            log_error("Failed to lookup Huntress SAT account ID", company_id=company_id, error=str(exc))
+            results["huntress_sat_lookup"] = "error"
     
     # Apply updates if any IDs were found
     if updates:
@@ -478,6 +491,28 @@ async def _lookup_huntress_organization_id(company_name: str) -> str | None:
                 return str(org_id)
 
     log_info("No exact-match Huntress organisation found", company_name=company_name)
+    return None
+
+
+async def _lookup_huntress_sat_account_id(company_name: str) -> str | None:
+    """Search Managed SAT accounts and return the exact name match's ID."""
+    try:
+        accounts = await huntress_service.list_sat_accounts()
+    except huntress_service.HuntressConfigurationError:
+        log_info("Huntress SAT integration not configured, skipping lookup")
+        return None
+    except Exception as exc:
+        log_error("Error fetching Huntress SAT accounts", company_name=company_name, error=str(exc))
+        return None
+    search_name = _normalize_company_name(company_name)
+    for account in accounts:
+        if not isinstance(account, dict):
+            continue
+        candidate = account.get("name") or account.get("display_name") or account.get("account_name") or ""
+        if _normalize_company_name(candidate) == search_name:
+            account_id = account.get("id") or account.get("external_id")
+            if account_id is not None:
+                return str(account_id)
     return None
 
 

--- a/app/services/huntress.py
+++ b/app/services/huntress.py
@@ -185,6 +185,34 @@ async def list_organizations() -> list[dict[str, Any]]:
     return organisations
 
 
+async def list_sat_accounts() -> list[dict[str, Any]]:
+    """Return Managed SAT accounts available to the Curricula API client."""
+    credentials = _get_curricula_credentials()
+    if not credentials:
+        raise HuntressConfigurationError(
+            "Curricula credentials are not configured (set CURRICULA_API_KEY and "
+            "CURRICULA_API_SECRET)."
+        )
+
+    accounts: list[dict[str, Any]] = []
+    async with _client(credentials) as client:
+        page = 1
+        for _ in range(50):
+            payload = await _get_json(
+                client, "/accounts", {"page[number]": page, "page[size]": 100}
+            )
+            chunk = _extract_list(payload, key="accounts")
+            if not chunk:
+                break
+            accounts.extend(
+                _jsonapi_attrs(row) for row in chunk if isinstance(row, Mapping)
+            )
+            if len(chunk) < 100:
+                break
+            page += 1
+    return accounts
+
+
 async def get_latest_summary_report(
     org_id: str, report_type: str = "monthly_summary"
 ) -> dict[str, Any] | None:
@@ -395,10 +423,15 @@ async def refresh_company(company: Mapping[str, Any]) -> dict[str, Any]:
         }
     company_id = int(company_id_raw)
     org_id = str(org_id)
+    sat_id_raw = company.get("huntress_sat_account_id")
+    sat_id = (
+        sat_id_raw.strip() if isinstance(sat_id_raw, str) else sat_id_raw
+    ) or None
     snapshot_at = datetime.utcnow()
     summary: dict[str, Any] = {
         "company_id": company_id,
         "huntress_organization_id": org_id,
+        "huntress_sat_account_id": str(sat_id) if sat_id else None,
         "errors": {},
     }
 
@@ -446,7 +479,7 @@ async def refresh_company(company: Mapping[str, Any]) -> dict[str, Any]:
         )
         summary["itdr"] = itdr
 
-    sat = await _safe("sat", get_sat_summary(org_id))
+    sat = await _safe("sat", get_sat_summary(str(sat_id))) if sat_id else None
     if sat is not None:
         await huntress_repo.upsert_sat_stats(
             company_id,
@@ -460,7 +493,11 @@ async def refresh_company(company: Mapping[str, Any]) -> dict[str, Any]:
         )
         summary["sat"] = sat
 
-    sat_rows = await _safe("sat_learners", get_sat_learner_breakdown(org_id))
+    sat_rows = (
+        await _safe("sat_learners", get_sat_learner_breakdown(str(sat_id)))
+        if sat_id
+        else None
+    )
     if sat_rows is not None:
         await huntress_repo.replace_sat_learner_progress(
             company_id, sat_rows, snapshot_at=snapshot_at
@@ -695,6 +732,7 @@ __all__ = [
     "get_soc_event_count",
     "is_module_enabled",
     "list_organizations",
+    "list_sat_accounts",
     "refresh_all_companies",
     "refresh_company",
 ]

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -3272,12 +3272,14 @@
     const onedriveSitesButton = document.querySelector('[data-lookup-onedrive-export-sites]');
     const createOffboardedStaffSiteButton = document.querySelector('[data-create-offboarded-staff-site]');
     const huntressButton = document.querySelector('[data-lookup-huntress-id]');
+    const huntressSatButton = document.querySelector('[data-lookup-huntress-sat-id]');
     const tacticalInput = document.getElementById('edit-company-tactical');
     const xeroInput = document.getElementById('edit-company-xero');
     const huduInput = document.getElementById('edit-company-hudu');
     const onedriveSitesSelect = document.querySelector('[data-onedrive-export-sites-select]');
     const onedriveSitesError = document.querySelector('[data-onedrive-export-sites-error]');
     const huntressInput = document.getElementById('edit-company-huntress');
+    const huntressSatInput = document.getElementById('edit-company-huntress-sat');
 
     const offboardedStaffSiteName = 'Offboarded Staff';
 
@@ -3527,6 +3529,30 @@
         } finally {
           huntressButton.disabled = false;
           huntressButton.innerHTML = originalText;
+        }
+      });
+    }
+
+    if (huntressSatButton && huntressSatInput) {
+      huntressSatButton.addEventListener('click', async () => {
+        const originalText = huntressSatButton.innerHTML;
+        huntressSatButton.disabled = true;
+        huntressSatButton.innerHTML = spinnerHtml;
+        try {
+          const result = await requestJson(`/api/companies/${companyId}/lookup-huntress-sat-id`, { method: 'POST' });
+          if (result.status === 'found' && result.id) {
+            huntressSatInput.value = result.id;
+            huntressSatInput.classList.add('form-input--success');
+            setTimeout(() => huntressSatInput.classList.remove('form-input--success'), 2000);
+          } else {
+            alert('Huntress SAT account ID not found. Please ensure the company name matches exactly in Managed SAT.');
+          }
+        } catch (error) {
+          console.error('Failed to lookup Huntress SAT account ID:', error);
+          alert(error instanceof Error ? error.message : 'Failed to lookup ID. Please try again.');
+        } finally {
+          huntressSatButton.disabled = false;
+          huntressSatButton.innerHTML = originalText;
         }
       });
     }

--- a/app/templates/admin/companies.html
+++ b/app/templates/admin/companies.html
@@ -18,6 +18,7 @@
   {"key": "tacticalrmm_client_id",     "label": "Tactical RMM client ID",      "default_visible": false},
   {"key": "hudu_id",                   "label": "Hudu ID",                      "default_visible": false},
   {"key": "huntress_organization_id",  "label": "Huntress organisation ID",     "default_visible": false},
+  {"key": "huntress_sat_account_id",  "label": "Huntress SAT account ID",     "default_visible": false},
   {"key": "trello_board_id",           "label": "Trello board ID",              "default_visible": false},
   {"key": "payment_method",            "label": "Payment Methods",              "default_visible": false},
   {"key": "require_po",                "label": "Require PO",                   "default_visible": false},
@@ -68,6 +69,7 @@
                 <th scope="col" data-sort="string" data-column-key="tacticalrmm_client_id">Tactical RMM client ID</th>
                 <th scope="col" data-sort="string" data-column-key="hudu_id">Hudu ID</th>
                 <th scope="col" data-sort="string" data-column-key="huntress_organization_id">Huntress organisation ID</th>
+                <th scope="col" data-sort="string" data-column-key="huntress_sat_account_id">Huntress SAT account ID</th>
                 <th scope="col" data-sort="string" data-column-key="trello_board_id">Trello board ID</th>
                 <th scope="col" data-sort="string" data-column-key="payment_method">Payment Methods</th>
                 <th scope="col" data-sort="string" data-column-key="require_po">Require PO</th>
@@ -125,6 +127,7 @@
                         <span class="text-muted">—</span>
                       {% endif %}
                     </td>
+                    <td data-label="Huntress SAT account ID" data-value="{{ company.huntress_sat_account_id or '' }}" data-column-key="huntress_sat_account_id">{{ company.huntress_sat_account_id or '—' }}</td>
                     <td data-label="Trello board ID" data-value="{{ company.trello_board_id or '' }}" data-column-key="trello_board_id">
                       {% if company.trello_board_id %}
                         {{ company.trello_board_id }}

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -158,7 +158,19 @@
                 </span>
               </button>
             </div>
-            <p class="form-help">Optional. Links this company to a Huntress organisation so EDR / ITDR / SAT / SIEM / SOC report data can be synced once per day. The nightly company-ID lookup task can also populate this automatically when the name matches.</p>
+            <p class="form-help">Optional. Links this company to a Huntress organisation for EDR / ITDR / SIEM / SOC data. The nightly company-ID lookup task can populate it when the name matches.</p>
+          </div>
+          <div class="form-field">
+            <label class="form-label" for="edit-company-huntress-sat">Huntress SAT account ID</label>
+            <div class="form-field__group">
+              <input id="edit-company-huntress-sat" name="huntressSatAccountId" class="form-input"
+                value="{{ form_data.huntress_sat_account_id }}" maxlength="64" placeholder="e.g. 67890" />
+              <button type="button" class="button button--ghost" data-lookup-huntress-sat-id
+                title="Lookup Huntress SAT account ID" aria-label="Lookup Huntress SAT account ID from API">
+                <span class="button__icon" aria-hidden="true"><svg viewBox="0 0 24 24" focusable="false"><path d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8z"/><path d="M20 12h2a10 10 0 0 0-10-10v2a8 8 0 0 1 8 8z"/><path d="M12 20v2a10 10 0 0 0 10-10h-2a8 8 0 0 1-8 8z"/><path d="M4 12H2a10 10 0 0 0 10 10v-2a8 8 0 0 1-8-8z"/></svg></span>
+              </button>
+            </div>
+            <p class="form-help">Optional. Links this company to its separate Huntress Managed SAT account. SAT API calls use this ID rather than the EDR organisation ID.</p>
           </div>
           <div class="form-field">
             <label class="form-label" for="edit-company-trello-board">Trello board ID</label>

--- a/migrations/305_huntress_sat_account_id.sql
+++ b/migrations/305_huntress_sat_account_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE companies ADD COLUMN IF NOT EXISTS huntress_sat_account_id VARCHAR(64) DEFAULT NULL;
+ALTER TABLE companies ADD KEY IF NOT EXISTS companies_huntress_sat_account_id (huntress_sat_account_id);

--- a/tests/test_huntress_sat_company_id.py
+++ b/tests/test_huntress_sat_company_id.py
@@ -1,0 +1,53 @@
+"""Coverage for the separate Huntress Managed SAT company identifier."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_sat_account_lookup_matches_jsonapi_account_name(monkeypatch):
+    from app.services import company_id_lookup
+
+    monkeypatch.setattr(
+        company_id_lookup.huntress_service,
+        "list_sat_accounts",
+        AsyncMock(return_value=[{"id": "sat-42", "name": "Acme Corp"}]),
+    )
+
+    assert await company_id_lookup._lookup_huntress_sat_account_id("acme corp") == "sat-42"
+
+
+@pytest.mark.anyio
+async def test_refresh_company_uses_sat_id_only_for_sat_calls(monkeypatch):
+    from app.services import huntress
+
+    monkeypatch.setattr(huntress, "get_edr_summary", AsyncMock(return_value=None))
+    monkeypatch.setattr(huntress, "get_itdr_summary", AsyncMock(return_value=None))
+    sat_summary = AsyncMock(return_value=None)
+    sat_learners = AsyncMock(return_value=None)
+    monkeypatch.setattr(huntress, "get_sat_summary", sat_summary)
+    monkeypatch.setattr(huntress, "get_sat_learner_breakdown", sat_learners)
+    monkeypatch.setattr(huntress, "get_siem_data_volume", AsyncMock(return_value=None))
+    monkeypatch.setattr(huntress, "get_soc_event_count", AsyncMock(return_value=None))
+
+    await huntress.refresh_company(
+        {
+            "id": 7,
+            "huntress_organization_id": "edr-11",
+            "huntress_sat_account_id": "sat-22",
+        }
+    )
+
+    sat_summary.assert_awaited_once_with("sat-22")
+    sat_learners.assert_awaited_once_with("sat-22")
+    huntress.get_edr_summary.assert_awaited_once_with("edr-11")
+
+
+def test_company_edit_exposes_sat_account_lookup():
+    template = open("app/templates/admin/company_edit.html", encoding="utf-8").read()
+    script = open("app/static/js/admin.js", encoding="utf-8").read()
+
+    assert 'name="huntressSatAccountId"' in template
+    assert "data-lookup-huntress-sat-id" in template
+    assert "lookup-huntress-sat-id" in script


### PR DESCRIPTION
### Motivation
- Huntress Managed SAT uses a different account identifier to the Huntress EDR/organization ID, so the system must store and resolve a separate SAT account ID and route SAT API calls to it.

### Description
- Add a new indexed company column `huntress_sat_account_id` and migration file to persist the Managed SAT account identifier.
- Expose the SAT ID in company schemas and admin UI including an input and `data-lookup-huntress-sat-id` lookup button, and show the field in the companies listing.
- Add `list_sat_accounts()` to the Huntress service to enumerate Curricula/SAT accounts and implement `_lookup_huntress_sat_account_id()` in the company ID lookup service, plus a new endpoint `POST /api/companies/{company_id}/lookup-huntress-sat-id` for on-demand lookup.
- Route SAT-specific calls (`get_sat_summary` / `get_sat_learner_breakdown`) to use `huntress_sat_account_id` while retaining `huntress_organization_id` for EDR/ITDR/SIEM/SOC calls, and wire up the admin JS to call the new lookup endpoint.
- Add focused tests `tests/test_huntress_sat_company_id.py` to cover SAT account name matching and that `refresh_company` uses the SAT ID for SAT calls.

### Testing
- Ran the focused test suite with `uv run pytest -q tests/test_huntress_sat_company_id.py tests/test_company_id_lookup.py` and the tests passed (`21 passed`).
- Confirmed Python modules compile with `python -m py_compile` for the modified files and ran `git diff --check` with no issues.
- Note: an earlier attempt to run the broader `tests/test_huntress_service.py` suite produced failures stemming from the test environment missing the `pytest-asyncio` plugin (async tests could not execute), not from the SAT-specific changes; focused tests demonstrating the new behaviour passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6829847c4883328be76f588313393a)