### PR TITLE
Clarify Huntress SAT parent credential failures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -339,7 +339,10 @@ HUNTRESS_API_SECRET=
 HUNTRESS_BASE_URL=https://api.huntress.io/v1
 
 # Curricula / Huntress Managed SAT API
-# Use the API client credentials supplied in the Curricula admin portal.
+# These are separate from HUNTRESS_API_KEY / HUNTRESS_API_SECRET. Use a parent
+# (channel-partner) Curricula API client that can list all managed child accounts;
+# the integration has one global credential pair and does not store per-client keys.
+# A child account ID must still be mapped to each company in the portal.
 # Required for SAT enrolled learner counts, average progress, and per-user stats.
 CURRICULA_API_KEY=
 CURRICULA_API_SECRET=

--- a/app/services/huntress.py
+++ b/app/services/huntress.py
@@ -492,6 +492,13 @@ async def refresh_company(company: Mapping[str, Any]) -> dict[str, Any]:
             snapshot_at=snapshot_at,
         )
         summary["sat"] = sat
+    elif sat_id and "sat" not in summary["errors"]:
+        summary["errors"]["sat"] = (
+            "Managed SAT account was not accessible with the configured Curricula "
+            "API credentials (the learners endpoint returned 404). Confirm that "
+            "huntress_sat_account_id identifies an account visible to the parent "
+            "Curricula API client."
+        )
 
     sat_rows = (
         await _safe("sat_learners", get_sat_learner_breakdown(str(sat_id)))
@@ -503,6 +510,11 @@ async def refresh_company(company: Mapping[str, Any]) -> dict[str, Any]:
             company_id, sat_rows, snapshot_at=snapshot_at
         )
         summary["sat_learner_rows"] = len(sat_rows)
+    elif sat_id and "sat_learners" not in summary["errors"]:
+        summary["errors"]["sat_learners"] = (
+            "Managed SAT learners were not accessible with the configured Curricula "
+            "API credentials (the learners endpoint returned 404)."
+        )
 
     siem = await _safe("siem", get_siem_data_volume(org_id, days=30))
     if siem is not None:

--- a/tests/test_huntress_service.py
+++ b/tests/test_huntress_service.py
@@ -126,7 +126,11 @@ async def test_missing_curricula_credentials_do_not_abort_edr_sync(monkeypatch):
     monkeypatch.setattr(repo, "upsert_itdr_stats", AsyncMock())
 
     result = await huntress_service.refresh_company(
-        {"id": 42, "huntress_organization_id": "org-1"}
+        {
+            "id": 42,
+            "huntress_organization_id": "org-1",
+            "huntress_sat_account_id": "sat-1",
+        }
     )
 
     assert result["status"] == "partial"
@@ -277,6 +281,37 @@ async def test_get_sat_learner_breakdown_returns_none_on_404(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_refresh_company_reports_inaccessible_sat_account(monkeypatch):
+    """A SAT 404 must be visible in task output rather than looking successful."""
+    from app.services import huntress as huntress_service
+
+    monkeypatch.setattr(huntress_service, "get_edr_summary", AsyncMock(return_value=None))
+    monkeypatch.setattr(huntress_service, "get_itdr_summary", AsyncMock(return_value=None))
+    monkeypatch.setattr(huntress_service, "get_sat_summary", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        huntress_service, "get_sat_learner_breakdown", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        huntress_service, "get_siem_data_volume", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        huntress_service, "get_soc_event_count", AsyncMock(return_value=None)
+    )
+
+    result = await huntress_service.refresh_company(
+        {
+            "id": 20,
+            "huntress_organization_id": "559776",
+            "huntress_sat_account_id": "57778",
+        }
+    )
+
+    assert result["status"] == "partial"
+    assert set(result["errors"]) == {"sat", "sat_learners"}
+    assert "parent Curricula API client" in result["errors"]["sat"]
+
+
+@pytest.mark.asyncio
 async def test_get_soc_event_count_returns_none_on_404(monkeypatch):
     """If the SOC product is not enabled, 404 should return None silently."""
     from app.services import huntress as huntress_service
@@ -360,7 +395,11 @@ async def test_refresh_company_tolerates_partial_failure(monkeypatch):
     monkeypatch.setattr(repo, "upsert_soc_stats", AsyncMock())
 
     result = await huntress_service.refresh_company(
-        {"id": 42, "huntress_organization_id": "org-1"}
+        {
+            "id": 42,
+            "huntress_organization_id": "org-1",
+            "huntress_sat_account_id": "sat-1",
+        }
     )
 
     assert result["status"] == "partial"


### PR DESCRIPTION
### Motivation
- SAT (Huntress Managed SAT) uses a separate Curricula client and can return a 404 when the configured SAT account is not accessible to the parent/channel-partner credentials, which was previously treated silently and produced an empty `errors` payload.
- The integration docs in `.env.example` did not explicitly state that SAT uses separate global Curricula credentials rather than per-client Huntress keys.

### Description
- Update `.env.example` to document that `CURRICULA_API_KEY`/`CURRICULA_API_SECRET` are separate from `HUNTRESS_API_KEY`/`HUNTRESS_API_SECRET` and should be a parent/channel-partner Curricula client that can list child accounts.
- Modify `app/services/huntress.py` so `refresh_company` records explicit `sat` and `sat_learners` errors (and yields a `partial` status) when a configured `huntress_sat_account_id` is inaccessible (e.g. learners endpoint returns 404).
- Add a regression test `test_refresh_company_reports_inaccessible_sat_account` and update existing fixtures in `tests/test_huntress_service.py` to include `huntress_sat_account_id` so inaccessible SAT account behavior is covered.

### Testing
- Ran `uv run --with pytest-asyncio pytest -q tests/test_huntress_service.py` and observed `13 passed` (with warnings), demonstrating the new error-path and existing behaviors are covered.
- Ran `git diff --check` and repository checks for modified files (`.env.example`, `app/services/huntress.py`, `tests/test_huntress_service.py`) with no outstanding issues.
- The change was committed with message `Clarify Huntress SAT credential failures` and unit tests passed as above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6844bc31a483329bbac0fecf3540d3)