### PR TITLE
Fix Huntress SAT learner sync for current Curricula tenants

### DIFF
--- a/app/services/huntress.py
+++ b/app/services/huntress.py
@@ -350,6 +350,23 @@ async def get_sat_learner_breakdown(org_id: str) -> list[dict[str, Any]] | None:
             {"include": "assignments,progress", "page[size]": 100},
             allow_not_found=True,
         )
+        if payload is None:
+            # Curricula's partner API exposes learners as a top-level JSON:API
+            # collection.  Older tenants accepted the nested account URL, but
+            # current tenants return 404 for it even when the account is visible
+            # from /accounts.  Keep the nested request for backwards
+            # compatibility, then use the account filter supported by the
+            # collection endpoint.
+            payload = await _get_json(
+                client,
+                "/learners",
+                {
+                    "filter[account_id]": org_id,
+                    "include": "assignments,progress",
+                    "page[size]": 100,
+                },
+                allow_not_found=True,
+            )
     if payload is None:
         return None
     learners = _extract_list(payload, key="learners")

--- a/tests/test_huntress_service.py
+++ b/tests/test_huntress_service.py
@@ -281,6 +281,64 @@ async def test_get_sat_learner_breakdown_returns_none_on_404(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_sat_learner_breakdown_falls_back_to_filtered_collection(
+    monkeypatch,
+):
+    """Current Curricula tenants expose learners through the collection URL."""
+    from app.services import huntress as huntress_service
+
+    _set_credentials(monkeypatch)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.endswith("/accounts/57777/learners"):
+            return httpx.Response(404)
+        if request.url.path.endswith("/learners"):
+            assert request.url.params["filter[account_id]"] == "57777"
+            return httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "learner-1",
+                            "type": "learners",
+                            "attributes": {
+                                "email": "learner@example.com",
+                                "name": "Example Learner",
+                                "progress": 75,
+                            },
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(500)
+
+    with _patch_client(httpx.MockTransport(handler)):
+        result = await huntress_service.get_sat_learner_breakdown("57777")
+
+    assert [request.url.path for request in requests] == [
+        "/api/v1/accounts/57777/learners",
+        "/api/v1/learners",
+    ]
+    assert result == [
+        {
+            "learner_external_id": "learner-1",
+            "learner_email": "learner@example.com",
+            "learner_name": "Example Learner",
+            "assignment_id": "learner-summary",
+            "assignment_name": None,
+            "status": None,
+            "completion_percent": 75.0,
+            "score": 0.0,
+            "click_rate": 0.0,
+            "compromise_rate": 0.0,
+            "report_rate": 0.0,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_refresh_company_reports_inaccessible_sat_account(monkeypatch):
     """A SAT 404 must be visible in task output rather than looking successful."""
     from app.services import huntress as huntress_service


### PR DESCRIPTION
### Motivation
- Curricula tenant responses vary and some tenants return 404 from the legacy `/accounts/{id}/learners` endpoint, causing Huntress SAT data to be missing in daily syncs.
- Provide a robust fallback to reliably fetch SAT learners for tenants that expose learners via the top-level collection endpoint.

### Description
- Update `get_sat_learner_breakdown` to fall back to the top-level `/learners` collection when `/accounts/{org_id}/learners` returns no payload, and scope the fallback using `filter[account_id]` so results remain account-scoped (`app/services/huntress.py`).
- Preserve existing JSON:API normalization by continuing to pass the returned payload through the existing `_extract_list` and `_normalise_sat_learner` helpers.
- Add a regression test `test_get_sat_learner_breakdown_falls_back_to_filtered_collection` which simulates a 404 on the nested endpoint and validates the filtered collection fallback and normalization (`tests/test_huntress_service.py`).

### Testing
- Ran `pytest -q tests/test_huntress_service.py tests/test_huntress_sat_company_id.py` and all tests passed (`17 passed`).
- Ran the repository lint/check (`ruff check` on modified files) with no reported issues.
- Added targeted regression coverage for the observed nested-endpoint 404 scenario which verifies the new behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a684b3ee61c8332a82dea3ef0936a8a)