### PR TITLE
Fix Curricula SAT learner requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -346,7 +346,7 @@ HUNTRESS_BASE_URL=https://api.huntress.io/v1
 # Required for SAT enrolled learner counts, average progress, and per-user stats.
 CURRICULA_API_KEY=
 CURRICULA_API_SECRET=
-CURRICULA_BASE_URL=https://mycurricula.com/api/v1
+CURRICULA_BASE_URL=https://dev.curricula.com/api/v1
 
 # Xero OAuth2 integration
 # To set up Xero integration:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -596,7 +596,7 @@ class Settings(BaseSettings):
         validation_alias="HUNTRESS_BASE_URL",
     )
     # Curricula / Huntress Managed SAT API. Kept separate from the Huntress
-    # partner API because Managed SAT is served from mycurricula.com.
+    # partner API because Managed SAT is served from Curricula's API host.
     curricula_api_key: str | None = Field(
         default=None,
         validation_alias="CURRICULA_API_KEY",
@@ -606,7 +606,7 @@ class Settings(BaseSettings):
         validation_alias="CURRICULA_API_SECRET",
     )
     curricula_base_url: str = Field(
-        default="https://mycurricula.com/api/v1",
+        default="https://dev.curricula.com/api/v1",
         validation_alias="CURRICULA_BASE_URL",
     )
 

--- a/app/services/huntress.py
+++ b/app/services/huntress.py
@@ -292,7 +292,7 @@ async def get_sat_summary(org_id: str) -> dict[str, Any] | None:
     """Return Huntress Managed SAT learner and progress rollups for an account.
 
     Curricula/Huntress Managed SAT uses the JSON:API REST API at
-    ``https://mycurricula.com/api/v1`` with client-credentials API clients. The
+    ``https://dev.curricula.com/api/v1`` with client-credentials API clients. The
     useful billing/reporting metric exposed by third-party reconciliation docs
     is the active learner count; where assignment progress is returned, we also
     calculate average completion and score from the learner rows.
@@ -350,23 +350,6 @@ async def get_sat_learner_breakdown(org_id: str) -> list[dict[str, Any]] | None:
             {"include": "assignments,progress", "page[size]": 100},
             allow_not_found=True,
         )
-        if payload is None:
-            # Curricula's partner API exposes learners as a top-level JSON:API
-            # collection.  Older tenants accepted the nested account URL, but
-            # current tenants return 404 for it even when the account is visible
-            # from /accounts.  Keep the nested request for backwards
-            # compatibility, then use the account filter supported by the
-            # collection endpoint.
-            payload = await _get_json(
-                client,
-                "/learners",
-                {
-                    "filter[account_id]": org_id,
-                    "include": "assignments,progress",
-                    "page[size]": 100,
-                },
-                allow_not_found=True,
-            )
     if payload is None:
         return None
     learners = _extract_list(payload, key="learners")

--- a/tests/test_huntress_service.py
+++ b/tests/test_huntress_service.py
@@ -29,7 +29,7 @@ def _set_credentials(monkeypatch):
         lambda: {
             "api_key": "test-key",
             "api_secret": "test-secret",
-            "base_url": "https://mycurricula.com/api/v1",
+            "base_url": "https://dev.curricula.com/api/v1",
         },
     )
     # Skip the per-call sleep so tests run instantly.
@@ -69,7 +69,7 @@ async def test_credentials_status_reflects_environment(monkeypatch):
                 "huntress_base_url": "https://api.huntress.io/v1",
                 "curricula_api_key": "curricula-key",
                 "curricula_api_secret": "",
-                "curricula_base_url": "https://mycurricula.com/api/v1",
+                "curricula_base_url": "https://dev.curricula.com/api/v1",
             },
         )(),
     )
@@ -281,10 +281,10 @@ async def test_get_sat_learner_breakdown_returns_none_on_404(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_sat_learner_breakdown_falls_back_to_filtered_collection(
+async def test_get_sat_learner_breakdown_uses_documented_account_endpoint(
     monkeypatch,
 ):
-    """Current Curricula tenants expose learners through the collection URL."""
+    """Curricula exposes learners through the documented account URL."""
     from app.services import huntress as huntress_service
 
     _set_credentials(monkeypatch)
@@ -293,9 +293,6 @@ async def test_get_sat_learner_breakdown_falls_back_to_filtered_collection(
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
         if request.url.path.endswith("/accounts/57777/learners"):
-            return httpx.Response(404)
-        if request.url.path.endswith("/learners"):
-            assert request.url.params["filter[account_id]"] == "57777"
             return httpx.Response(
                 200,
                 json={
@@ -319,7 +316,6 @@ async def test_get_sat_learner_breakdown_falls_back_to_filtered_collection(
 
     assert [request.url.path for request in requests] == [
         "/api/v1/accounts/57777/learners",
-        "/api/v1/learners",
     ]
     assert result == [
         {


### PR DESCRIPTION
### Motivation
- SAT lookups were failing with 401 errors because the service used an incorrect/undocumented Curricula host and an unsupported top-level learners collection fallback that could surface misleading authorization errors.
- The goal is to use the documented account-scoped Curricula endpoint and the documented API base URL to avoid unnecessary fallbacks and authorization failures.

### Description
- Change the default Curricula API base URL from `https://mycurricula.com/api/v1` to the documented `https://dev.curricula.com/api/v1` in `app/core/config.py` and `.env.example`.
- Remove the unsupported fallback request to `/learners?filter[account_id]=...` from `app/services/huntress.py` so SAT learner requests use only the documented `/accounts/{account_id}/learners` endpoint and treat 404 as "product not enabled".
- Update the SAT-related docstring in `app/services/huntress.py` to reference the `dev.curricula.com` host.
- Update tests in `tests/test_huntress_service.py` to assert the documented account endpoint is used and switch test credentials to the `dev.curricula.com` base URL.

### Testing
- Installed `pytest-asyncio` and ran `python -m pytest tests/test_huntress_service.py tests/test_huntress_sat_company_id.py -q`, which completed successfully with `17 passed` and warnings only.
- All modified SAT-related unit tests now pass and validate that only the documented account-scoped learners endpoint is called.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a684ef0a8708332ba005e054a900223)