### PR TITLE
Ensure Unbilled Tickets By Company appears in reporting

### DIFF
--- a/migrations/306_ensure_unbilled_tickets_by_company_report.sql
+++ b/migrations/306_ensure_unbilled_tickets_by_company_report.sql
@@ -1,0 +1,21 @@
+-- Ensure the company summary exists on installations that already recorded an
+-- older version of migration 302. That version renamed the ticket-level report
+-- instead of inserting this report, so later UPDATE-only migrations could not
+-- make it appear in the Reporting dropdown.
+INSERT IGNORE INTO reporting_queries (slug, name, description, sql_query, is_system)
+VALUES (
+    'unbilled-tickets-by-company',
+    'Unbilled Tickets By Company',
+    'Unbilled billable ticket time by company and labour type, including the number of tickets represented in each total.',
+    'SELECT c.id AS company_id, COALESCE(c.name, ''(no company)'') AS company, COALESCE(NULLIF(TRIM(lt.name), ''''), ''(unspecified)'') AS labour_type, COUNT(DISTINCT t.id) AS ticket_count, SUM(tr.minutes_spent) AS billable_minutes FROM ticket_replies tr JOIN tickets t ON t.id = tr.ticket_id LEFT JOIN companies c ON c.id = t.company_id LEFT JOIN ticket_labour_types lt ON lt.id = tr.labour_type_id WHERE tr.is_billable = 1 AND tr.minutes_spent IS NOT NULL AND tr.minutes_spent > 0 AND NOT EXISTS (SELECT 1 FROM ticket_billed_time_entries bte WHERE bte.reply_id = tr.id) GROUP BY c.id, c.name, lt.id, lt.name ORDER BY company ASC, labour_type ASC',
+    1
+);
+
+-- Also repair the definition if a row with this slug already exists.
+UPDATE reporting_queries
+SET
+    name = 'Unbilled Tickets By Company',
+    description = 'Unbilled billable ticket time by company and labour type, including the number of tickets represented in each total.',
+    sql_query = 'SELECT c.id AS company_id, COALESCE(c.name, ''(no company)'') AS company, COALESCE(NULLIF(TRIM(lt.name), ''''), ''(unspecified)'') AS labour_type, COUNT(DISTINCT t.id) AS ticket_count, SUM(tr.minutes_spent) AS billable_minutes FROM ticket_replies tr JOIN tickets t ON t.id = tr.ticket_id LEFT JOIN companies c ON c.id = t.company_id LEFT JOIN ticket_labour_types lt ON lt.id = tr.labour_type_id WHERE tr.is_billable = 1 AND tr.minutes_spent IS NOT NULL AND tr.minutes_spent > 0 AND NOT EXISTS (SELECT 1 FROM ticket_billed_time_entries bte WHERE bte.reply_id = tr.id) GROUP BY c.id, c.name, lt.id, lt.name ORDER BY company ASC, labour_type ASC',
+    is_system = 1
+WHERE slug = 'unbilled-tickets-by-company';

--- a/tests/test_unbilled_tickets_reporting_migration.py
+++ b/tests/test_unbilled_tickets_reporting_migration.py
@@ -21,6 +21,11 @@ REPORT_COLUMNS_MIGRATION = (
     / "migrations"
     / "304_unbilled_tickets_by_company_columns.sql"
 )
+ENSURE_REPORT_MIGRATION = (
+    Path(__file__).parent.parent
+    / "migrations"
+    / "306_ensure_unbilled_tickets_by_company_report.sql"
+)
 
 
 def test_unbilled_tickets_report_groups_unbilled_time_by_company_and_labour_type():
@@ -64,3 +69,14 @@ def test_company_summary_exposes_company_id_and_preserves_labour_grouping():
     assert "GROUP BY c.id, c.name, lt.id, lt.name" in sql
     assert "WHERE slug = 'unbilled-tickets-by-company'" in sql
     assert "AND is_system = 1" in sql
+
+
+def test_company_summary_is_inserted_for_installations_that_ran_old_migration():
+    sql = ENSURE_REPORT_MIGRATION.read_text(encoding="utf-8")
+
+    assert "INSERT IGNORE INTO reporting_queries" in sql
+    assert "'unbilled-tickets-by-company'" in sql
+    assert "'Unbilled Tickets By Company'" in sql
+    assert "SELECT c.id AS company_id" in sql
+    assert "UPDATE reporting_queries" in sql
+    assert "WHERE slug = 'unbilled-tickets-by-company'" in sql


### PR DESCRIPTION
### Motivation
- Some installations that applied an older version of migration `302` ended up with the ticket-level report renamed instead of inserting the company-summary report, so the `Unbilled Tickets By Company` system report did not appear in the `/reporting` dropdown.
- A forward, idempotent repair is needed to ensure the company-summary report exists and has the correct columns so administrators and technicians can run it.

### Description
- Add a forward migration `migrations/306_ensure_unbilled_tickets_by_company_report.sql` that `INSERT IGNORE` the `unbilled-tickets-by-company` system report and `UPDATE`s an existing row with the expected `company_id`, `company`, `labour_type`, `ticket_count`, and `billable_minutes` SQL definition while ensuring `is_system = 1`.
- Update `tests/test_unbilled_tickets_reporting_migration.py` to include `ENSURE_REPORT_MIGRATION` and add `test_company_summary_is_inserted_for_installations_that_ran_old_migration()` verifying the new migration inserts or repairs the report definition.
- Keep the added migration idempotent so re-running migrations does not create duplicates and will repair existing rows when necessary.

### Testing
- Ran `pytest -q tests/test_unbilled_tickets_reporting_migration.py tests/test_reporting_page_handler.py`, and the targeted tests passed (`7 passed` for the invoked suites) with warnings only; the new migration test passed.
- Confirmed the repository diffs and test additions produce no linting/diff-check failures when running `git diff --check` as part of the validation steps (automated checks completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a68981813608332914720a8dcacb074)