### PR TITLE
Guard integration routes when modules are disabled

### DIFF
--- a/app/api/dependencies/modules.py
+++ b/app/api/dependencies/modules.py
@@ -1,0 +1,42 @@
+"""Runtime guards for integration-module HTTP surfaces.
+
+Disabled and unknown integrations deliberately share the same stable ``503``
+contract.  Routes remain mounted so toggling a module takes effect immediately;
+callers receive ``{"detail": "Integration module '<slug>' is unavailable"}``
+until the catalogue entry exists and is enabled.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fastapi import HTTPException, status
+
+from app.services import modules as modules_service
+
+
+def require_module_enabled(
+    slug: str,
+) -> Callable[[], Awaitable[dict[str, Any]]]:
+    """Build a FastAPI dependency requiring an enabled integration module.
+
+    The unredacted module is returned so downstream dependencies can reuse its
+    runtime settings.  A 503 (rather than a 404) is intentional: these are
+    stable integration endpoints and their callers need to distinguish a
+    temporarily disabled integration from a nonexistent HTTP route.
+    """
+
+    async def dependency() -> dict[str, Any]:
+        module = await modules_service.get_module(slug, redact=False)
+        if not module or not module.get("enabled"):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=f"Integration module '{slug}' is unavailable",
+            )
+        return module
+
+    return dependency
+
+
+__all__ = ["require_module_enabled"]

--- a/app/api/routes/solidtime.py
+++ b/app/api/routes/solidtime.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 
 from app.api.dependencies.auth import require_super_admin
+from app.api.dependencies.modules import require_module_enabled
 from app.repositories import tickets as tickets_repo
 from app.schemas.solidtime import (
     SolidtimeOrganisation,
@@ -22,6 +23,7 @@ from app.services import webhook_monitor
 router = APIRouter(
     prefix="/api/v1/solidtime",
     tags=["Solidtime"],
+    dependencies=[Depends(require_module_enabled("solidtime"))],
 )
 
 

--- a/app/api/routes/trello.py
+++ b/app/api/routes/trello.py
@@ -8,12 +8,13 @@ from fastapi.responses import JSONResponse
 from loguru import logger
 
 from app.api.dependencies.auth import require_super_admin
+from app.api.dependencies.modules import require_module_enabled
 from app.core.config import get_settings
 from app.services import tickets as tickets_service
 from app.services import trello as trello_service
 from app.services import webhook_monitor
 
-router = APIRouter(prefix="/api/integration-modules/trello", tags=["Trello"])
+router = APIRouter(prefix="/api/integration-modules/trello", tags=["Trello"], dependencies=[Depends(require_module_enabled("trello"))])
 
 # ---------------------------------------------------------------------------
 # Webhook endpoint (Trello verification + event ingestion)

--- a/app/api/routes/xero.py
+++ b/app/api/routes/xero.py
@@ -10,12 +10,13 @@ from urllib.parse import urlencode
 from uuid import UUID
 
 import httpx
-from fastapi import APIRouter, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.responses import RedirectResponse
 from itsdangerous import URLSafeSerializer
 from itsdangerous import BadSignature
 from loguru import logger
 
+from app.api.dependencies.modules import require_module_enabled
 from app.core.config import Settings, get_settings
 from app.security.flash import flash_redirect
 from app.core.logging import log_error, log_info
@@ -25,8 +26,9 @@ from app.security.session import session_manager
 from app.services import modules as modules_service
 from app.services import audit as audit_service
 
-router = APIRouter(prefix="/api/integration-modules/xero", tags=["Xero"])
-oauth_router = APIRouter(prefix="/xero", tags=["Xero OAuth"])
+_require_xero_enabled = require_module_enabled("xero")
+router = APIRouter(prefix="/api/integration-modules/xero", tags=["Xero"], dependencies=[Depends(_require_xero_enabled)])
+oauth_router = APIRouter(prefix="/xero", tags=["Xero OAuth"], dependencies=[Depends(_require_xero_enabled)])
 
 _settings: Settings | None = None
 
@@ -186,13 +188,8 @@ async def _apply_xero_invoice_event(event: dict[str, Any], request: Request) -> 
 
 
 async def _ensure_module_enabled() -> dict[str, Any]:
-    module = await modules_service.get_module("xero", redact=False)
-    if not module or not module.get("enabled"):
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Xero module is disabled",
-        )
-    return module
+    """Backward-compatible alias for callers of the former local guard."""
+    return await _require_xero_enabled()
 
 
 @router.post(

--- a/app/features/calls/routes.py
+++ b/app/features/calls/routes.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
+from app.api.dependencies.modules import require_module_enabled
 from app.repositories import calls as calls_repo
 
 
-router = APIRouter(tags=["Calls"])
+router = APIRouter(tags=["Calls"], dependencies=[Depends(require_module_enabled("calls"))])
 
 
 def _main():

--- a/app/features/imap/api_routes.py
+++ b/app/features/imap/api_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from app.api.dependencies.auth import require_super_admin
+from app.api.dependencies.modules import require_module_enabled
 from app.api.dependencies.database import require_database
 from app.core.errors import build_client_http_error, log_exception_with_error_id, new_error_id
 from app.schemas.imap import (
@@ -14,7 +15,7 @@ from app.schemas.imap import (
 from app.services import audit as audit_service
 from app.services import imap as imap_service
 
-router = APIRouter(prefix="/imap", tags=["IMAP"])
+router = APIRouter(prefix="/imap", tags=["IMAP"], dependencies=[Depends(require_module_enabled("imap"))])
 
 
 # Audit IMAP account snapshots intentionally exclude any field that could

--- a/app/features/m365_mail/api_routes.py
+++ b/app/features/m365_mail/api_routes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.api.dependencies.auth import require_super_admin
+from app.api.dependencies.modules import require_module_enabled
 from app.api.dependencies.database import require_database
 from app.core.errors import build_client_http_error, log_exception_with_error_id, new_error_id
 from app.schemas.m365_mail import (
@@ -15,7 +16,7 @@ from app.schemas.m365_mail import (
 )
 from app.services import m365_mail as m365_mail_service
 
-router = APIRouter(prefix="/m365-mail", tags=["Office365 Mail"])
+router = APIRouter(prefix="/m365-mail", tags=["Office365 Mail"], dependencies=[Depends(require_module_enabled("m365-mail"))])
 
 
 @router.get("/accounts", response_model=list[M365MailAccountResponse])

--- a/app/features/receive_sms/routes.py
+++ b/app/features/receive_sms/routes.py
@@ -9,13 +9,14 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
 from app.api.dependencies.api_keys import require_api_key
+from app.api.dependencies.modules import require_module_enabled
 from app.core.database import db
 from app.core.logging import log_error
 from app.repositories import tickets as tickets_repo
 from app.services import tickets as tickets_service
 from app.services.sanitization import sanitize_rich_text
 
-router = APIRouter(prefix="/api/integration-modules/receive-sms", tags=["Receive SMS"])
+router = APIRouter(prefix="/api/integration-modules/receive-sms", tags=["Receive SMS"], dependencies=[Depends(require_module_enabled("receive-sms"))])
 
 
 class ReceiveSMSPayload(BaseModel):

--- a/app/features/smtp/routes.py
+++ b/app/features/smtp/routes.py
@@ -8,12 +8,14 @@ import hmac
 import json
 from typing import Annotated
 
-from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+
+from app.api.dependencies.modules import require_module_enabled
 from loguru import logger
 
 from app.services import smtp2go
 
-router = APIRouter(prefix="/api/webhooks/smtp2go", tags=["SMTP2Go Webhooks"])
+router = APIRouter(prefix="/api/webhooks/smtp2go", tags=["SMTP2Go Webhooks"], dependencies=[Depends(require_module_enabled("smtp2go"))])
 
 
 def _parse_timestamp_signature(signature: str) -> tuple[str | None, str | None]:

--- a/app/features/uptimekuma/routes.py
+++ b/app/features/uptimekuma/routes.py
@@ -4,6 +4,8 @@ import json
 from urllib.parse import parse_qs, parse_qsl, urlencode, urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+
+from app.api.dependencies.modules import require_module_enabled
 from loguru import logger
 from pydantic import ValidationError
 
@@ -16,7 +18,7 @@ from app.schemas.uptimekuma import (
 from app.services import uptimekuma as uptimekuma_service
 from app.services import webhook_monitor
 
-router = APIRouter(prefix="/api/integration-modules/uptimekuma", tags=["Uptime Kuma"])
+router = APIRouter(prefix="/api/integration-modules/uptimekuma", tags=["Uptime Kuma"], dependencies=[Depends(require_module_enabled("uptimekuma"))])
 
 
 @router.post(

--- a/app/services/modules.py
+++ b/app/services/modules.py
@@ -872,6 +872,20 @@ DEFAULT_MODULES: list[dict[str, Any]] = [
         },
     },
     {
+        "slug": "receive-sms",
+        "name": "Receive SMS",
+        "description": "Create and update tickets from inbound SMS webhooks.",
+        "icon": "📱",
+        "settings": {},
+    },
+    {
+        "slug": "calls",
+        "name": "Calls",
+        "description": "Receive and review phone call webhook events.",
+        "icon": "☎️",
+        "settings": {},
+    },
+    {
         "slug": "m365-mail",
         "name": "Office 365 Mailbox Import",
         "description": "Import support emails from Microsoft 365 mailboxes into the ticketing queue.",

--- a/tests/test_module_enabled_dependency.py
+++ b/tests/test_module_enabled_dependency.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.api.dependencies.modules import require_module_enabled
+from app.features.calls.routes import router as calls_router
+from app.repositories import calls as calls_repo
+from app.services import modules as modules_service
+
+
+def test_enabled_module_dependency_returns_unredacted_module(monkeypatch):
+    expected = {"slug": "trello", "enabled": True, "settings": {"secret": "visible"}}
+    calls = []
+
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        calls.append((slug, redact))
+        return expected
+
+    monkeypatch.setattr(modules_service, "get_module", fake_get_module)
+
+    assert asyncio.run(require_module_enabled("trello")()) is expected
+    assert calls == [("trello", False)]
+
+
+@pytest.mark.parametrize("module", [None, {"slug": "trello", "enabled": False}])
+def test_missing_and_disabled_modules_share_documented_503(monkeypatch, module):
+    async def fake_get_module(slug: str, *, redact: bool = True):
+        return module
+
+    monkeypatch.setattr(modules_service, "get_module", fake_get_module)
+
+    with pytest.raises(HTTPException) as raised:
+        asyncio.run(require_module_enabled("trello")())
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == "Integration module 'trello' is unavailable"
+
+
+def test_receive_sms_is_associated_with_module_catalogue():
+    assert any(
+        module["slug"] == "receive-sms" for module in modules_service.DEFAULT_MODULES
+    )
+
+
+def test_disabled_check_runs_before_call_webhook_side_effects(monkeypatch):
+    async def disabled_module(slug: str, *, redact: bool = True):
+        return {"slug": slug, "enabled": False}
+
+    async def unexpected_create(**kwargs):
+        pytest.fail("disabled webhook created a call event")
+
+    monkeypatch.setattr(modules_service, "get_module", disabled_module)
+    monkeypatch.setattr(calls_repo, "create_call_event", unexpected_create)
+    app = FastAPI()
+    app.include_router(calls_router)
+
+    response = TestClient(app).get("/phonewebhook/token/?event=ringing")
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Integration module 'calls' is unavailable"}


### PR DESCRIPTION
### Motivation
- Provide a single, reusable runtime guard that ensures integration HTTP surfaces reject requests when the corresponding integration-module is missing or disabled.
- Keep routes mounted so toggles take effect immediately without requiring a restart while returning a stable, machine-readable error to callers.
- Ensure disabled integrations cannot cause side effects (create events, tickets, replies, alerts, or webhook-monitor success records) before signature/auth checks run.

### Description
- Added a FastAPI dependency factory `require_module_enabled(slug)` in `app/api/dependencies/modules.py` that calls `modules_service.get_module(..., redact=False)` and raises `HTTP 503` with the stable message `"Integration module '<slug>' is unavailable"` for missing or disabled modules, otherwise returning the unredacted module for downstream use.
- Applied the guard at router level (router `dependencies`) for the requested integration surfaces: `calls`, `solidtime`, `trello`, `uptimekuma`, `smtp2go` (SMTP2Go webhooks), `receive-sms`, `imap`, `m365-mail`, and `xero` (including the OAuth routes); kept `xero`'s `_ensure_module_enabled()` as a backward-compatible alias to the shared guard.
- Registered `receive-sms` and `calls` in the integration-module catalogue (`app/services/modules.py`) so their enabled state can be stored and toggled via the existing module management interfaces.
- Added tests in `tests/test_module_enabled_dependency.py` verifying: the dependency returns the unredacted module when enabled, the documented 503 contract for both missing and disabled modules, that `receive-sms` is present in `DEFAULT_MODULES`, and that a disabled `calls` module prevents call-webhook side effects (no call events created).

### Testing
- Ran `python -m pytest -q tests/test_module_enabled_dependency.py`, which passed (`5 passed`).
- During development the new dependency was exercised against the feature-pack router mounting and reload logic to confirm routes remain mounted and the guard executes at request-time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a693b171c3083328a21f2d2cc1adb65)