### PR TITLE
Respect warning log level for WebSocket lifecycle messages

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -133,7 +133,7 @@ def configure_logging() -> None:
     log_level = settings.log_level or ("DEBUG" if settings.verbose_logging else "INFO")
 
     logger.add(sink=lambda msg: print(msg, end=""), format=_format_console_record, level=log_level)
-    _configure_uvicorn_access_logging(verbose=settings.verbose_logging)
+    _configure_uvicorn_logging(log_level=log_level, verbose=settings.verbose_logging)
 
     app_log_path = getattr(settings, "app_log_path", None)
     if app_log_path:
@@ -226,6 +226,14 @@ def _configure_uvicorn_access_logging(*, verbose: bool) -> None:
     ]
     if not verbose:
         access_logger.addFilter(_UvicornHeartbeatAccessFilter())
+
+
+def _configure_uvicorn_logging(*, log_level: str, verbose: bool) -> None:
+    """Keep Uvicorn and its WebSocket implementation at the configured level."""
+
+    for logger_name in ("uvicorn", "uvicorn.error", "uvicorn.access", "websockets.server"):
+        logging.getLogger(logger_name).setLevel(log_level)
+    _configure_uvicorn_access_logging(verbose=verbose)
 
 
 def _coerce_optional(value: Any) -> Any:

--- a/changes/9bb4459e-a815-4749-a21a-42ff9786a61c.json
+++ b/changes/9bb4459e-a815-4749-a21a-42ff9786a61c.json
@@ -1,0 +1,7 @@
+{
+  "guid": "9bb4459e-a815-4749-a21a-42ff9786a61c",
+  "occurred_at": "2026-07-29T00:00Z",
+  "change_type": "Fix",
+  "summary": "Apply LOG_LEVEL to Uvicorn and WebSocket lifecycle loggers so INFO messages such as accepted connections and connection open are suppressed at WARNING.",
+  "content_hash": "40fbab956d01e9665e86cc67fa30505f2add5fe96b56d604882e6e7471afdd22"
+}

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 from loguru import logger
 from app.core.logging import configure_logging, log_debug, log_error, log_info, log_warning
 
@@ -222,4 +221,27 @@ def test_uvicorn_access_filter_allows_heartbeat_when_verbose():
 
         assert access_logger.filter(heartbeat_record)
     finally:
+        access_logger.filters = original_filters
+
+
+def test_uvicorn_logging_uses_configured_warning_level():
+    """Warning logging suppresses Uvicorn's WebSocket lifecycle INFO messages."""
+    import logging
+
+    from app.core.logging import _configure_uvicorn_logging
+
+    logger_names = ("uvicorn", "uvicorn.error", "uvicorn.access", "websockets.server")
+    original_levels = {name: logging.getLogger(name).level for name in logger_names}
+    access_logger = logging.getLogger("uvicorn.access")
+    original_filters = list(access_logger.filters)
+    try:
+        _configure_uvicorn_logging(log_level="WARNING", verbose=False)
+
+        for name in logger_names:
+            target = logging.getLogger(name)
+            assert not target.isEnabledFor(logging.INFO)
+            assert target.isEnabledFor(logging.WARNING)
+    finally:
+        for name, level in original_levels.items():
+            logging.getLogger(name).setLevel(level)
         access_logger.filters = original_filters


### PR DESCRIPTION
### Motivation

- Uvicorn and the WebSocket implementation were emitting high-volume INFO messages (e.g. accepted connections / "connection open") even when the configured `LOG_LEVEL` was `WARNING`, causing noisy server logs.

### Description

- Apply the configured `LOG_LEVEL` to Uvicorn-related loggers by adding `_configure_uvicorn_logging` and calling it from `configure_logging` so `uvicorn`, `uvicorn.error`, `uvicorn.access`, and `websockets.server` obey the central log level.
- Preserve the existing endpoint-specific heartbeat filtering via `_configure_uvicorn_access_logging` and call it from the new `_configure_uvicorn_logging` helper when `verbose` is unset.
- Add a regression test `test_uvicorn_logging_uses_configured_warning_level` to verify WebSocket/uvicorn loggers suppress `INFO` while allowing `WARNING` at the configured level in `tests/test_logging.py`.
- Add a change log entry in `changes/9bb4459e-a815-4749-a21a-42ff9786a61c.json` documenting the fix.

### Testing

- Ran `python -m ruff check app/core/logging.py tests/test_logging.py` and it passed with no issues.
- Ran `pytest -q tests/test_start_with_auto_update.py tests/test_logging.py` and all tests passed (`18 passed`, with warnings reported); the logging regression test passed.
- Ran `git diff --check` to validate diffs and style, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a697bd82a04833285332376555fe5d2)