### PR TITLE
Let Xero apply client invoice due dates

### DIFF
--- a/app/services/xero.py
+++ b/app/services/xero.py
@@ -2385,9 +2385,8 @@ async def sync_company(
             "Date": date.today().isoformat(),
             "Status": "AUTHORISED" if auto_send else "DRAFT",
         }
-        due_date_value = invoice.get("due_date")
-        if isinstance(due_date_value, date):
-            invoice_payload["DueDate"] = due_date_value.isoformat()
+        # Do not send MyPortal's due date. When DueDate is omitted, Xero applies
+        # the payment terms configured for the contact to the new invoice.
         if auto_send:
             invoice_payload["SentToContact"] = True
 

--- a/tests/test_xero_sync_company_labour_rates.py
+++ b/tests/test_xero_sync_company_labour_rates.py
@@ -111,7 +111,9 @@ async def test_sync_company_uploads_unsynchronised_invoice_lines_to_xero():
         invoice_payload = call_args[1]["json"]["Invoices"][0]
         assert invoice_payload["Contact"]["ContactID"] == "xero-test-123"
         assert "Reference" not in invoice_payload
-        assert invoice_payload["DueDate"] == "2026-04-01"
+        # Xero must calculate the due date from the contact's payment terms,
+        # regardless of the due date stored on the MyPortal invoice.
+        assert "DueDate" not in invoice_payload
         assert invoice_payload["LineItems"] == [
             {
                 "Description": "Managed services",


### PR DESCRIPTION
### Motivation
- Ensure invoices sent to Xero do not override the contact's payment terms by using MyPortal's stored `due_date` value.
- Allow Xero to calculate the invoice `DueDate` from the contact settings so client-specific payment terms are respected.

### Description
- Remove sending MyPortal `due_date` in the Xero invoice payload and add a clarifying comment in `app/services/xero.py` explaining that omitting `DueDate` lets Xero apply the contact's payment terms.
- Update `tests/test_xero_sync_company_labour_rates.py` to assert that `DueDate` is not present in the payload sent to Xero.
- Modified files: `app/services/xero.py` and `tests/test_xero_sync_company_labour_rates.py`.

### Testing
- Ran `pytest -q tests/test_xero_sync_company_labour_rates.py` and the suite passed with `5 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69838189bc833294753a15d872cd52)