### PR TITLE
Show actual client IPs behind Traefik

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,13 +34,16 @@ ALLOWED_ORIGINS=
 # Trusted Proxies: Comma-separated list of IPs or CIDR ranges that are
 # allowed to set the X-Forwarded-For / X-Real-IP headers. Requests from
 # other origins will have these headers ignored and the direct socket
-# address will be used as the client IP.
+# address will be used as the client IP. The systemd startup wrapper also
+# passes this value to Uvicorn so its access log displays the forwarded user IP.
 #
 # Set this to the IPs/ranges of your reverse proxy or load balancer.
 # Leave empty to always use the direct socket peer as the client IP.
 # Examples:
 #   TRUSTED_PROXIES=127.0.0.1,::1                  # local proxy only
 #   TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12       # internal load balancers
+# Do not use * or unnecessarily broad public ranges: doing so lets clients
+# spoof their address if MyPortal is reachable without the trusted proxy.
 TRUSTED_PROXIES=
 
 # SMTP configuration

--- a/docs/wiki/compliance/Logging and Audit.md
+++ b/docs/wiki/compliance/Logging and Audit.md
@@ -28,6 +28,54 @@ list. The most useful ones:
 | `LOG_RETENTION` | `30 days` | How long rotated log files are kept. |
 | `LOG_COMPRESSION` | `gz` | Compression format for rotated files. Set empty to keep them uncompressed. |
 | `ERROR_LOG_PATH` | _unset_ | Optional second sink that receives **WARNING and above only**. Useful for tailing "just the bad stuff". Inherits the same rotation settings. |
+| `TRUSTED_PROXIES` | _unset_ | Comma-separated IP addresses/CIDRs of reverse proxies allowed to supply client-IP headers. The service startup wrapper applies the same boundary to Uvicorn access logs. |
+
+### Client IPs behind Traefik
+
+Traefik sends the original connection address in `X-Forwarded-For`. MyPortal
+deliberately ignores that header until the **direct Traefik peer** is trusted;
+otherwise an Internet client could spoof log, audit, allow-list, and rate-limit
+addresses. Set `TRUSTED_PROXIES` in `/etc/myportal.env` to the narrowest address
+or network that contains the Traefik-to-MyPortal connection, for example:
+
+```dotenv
+# Traefik is 172.20.0.5 on a dedicated Docker network
+TRUSTED_PROXIES=172.20.0.5
+
+# Or, if container addressing is dynamic, trust only that dedicated subnet
+# TRUSTED_PROXIES=172.20.0.0/24
+```
+
+Restart MyPortal after changing the environment. Deployments using
+`scripts/start_with_auto_update.sh` automatically pass this value to Uvicorn's
+`--forwarded-allow-ips`, which makes both MyPortal's structured `client_ip` and
+Uvicorn's console access address show the user IP. A custom Uvicorn command must
+set the equivalent options itself:
+
+```bash
+uvicorn app.main:app --proxy-headers --forwarded-allow-ips '172.20.0.0/24'
+```
+
+No Traefik middleware is required when Traefik accepts the user connection
+directly. If another proxy or CDN sits in front, configure Traefik's static
+entry-point `forwardedHeaders.trustedIPs` with only that upstream proxy's source
+ranges so Traefik accepts its forwarded address. Do not enable the insecure
+trust-all mode. For example:
+
+```yaml
+entryPoints:
+  websecure:
+    address: ":443"
+    forwardedHeaders:
+      trustedIPs:
+        - "192.0.2.10/32" # upstream load balancer; replace with its real range
+```
+
+For Traefik's own JSON access log, retain the `ClientHost` field (and optionally
+`ClientAddr`); `ClientHost` is the resolved client IP. Treat the Traefik trust
+list and MyPortal's list as two distinct hops: Traefik trusts only its upstream,
+while MyPortal trusts only Traefik. Never expose the MyPortal/Uvicorn port
+directly to untrusted networks.
 
 ### Context enrichment
 
@@ -39,7 +87,8 @@ tagged with:
 - `user_id` — populated by the authentication dependencies
   (`get_current_user` / `get_optional_user`) once the request is identified.
 - `route` — the matched route path, e.g. `/api/tickets/{ticket_id}`.
-- `client_ip` — the originating IP, honouring `X-Forwarded-For` when present.
+- `client_ip` — the originating IP, honouring `X-Forwarded-For` only when the
+  direct peer matches `TRUSTED_PROXIES`.
 
 These are all bound through `contextvars`, so they survive across
 `async`/`await` hops within the request and are cleared automatically when

--- a/scripts/start_with_auto_update.sh
+++ b/scripts/start_with_auto_update.sh
@@ -60,6 +60,16 @@ has_uvicorn_log_level_arg() {
   return 1
 }
 
+has_uvicorn_forwarded_ips_arg() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --forwarded-allow-ips|--forwarded-allow-ips=*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 build_uvicorn_command() {
   UVICORN_COMMAND=("$@")
   local resolved_log_level=""
@@ -71,6 +81,14 @@ build_uvicorn_command() {
 
   if [[ -n "$resolved_log_level" ]] && ! has_uvicorn_log_level_arg "$@"; then
     UVICORN_COMMAND+=(--log-level "$resolved_log_level")
+  fi
+
+  # Keep Uvicorn's access log and request.client in sync with MyPortal's
+  # TRUSTED_PROXIES security boundary. Uvicorn otherwise trusts only localhost,
+  # so a Traefik container/network peer appears as the client on every line.
+  # An explicit CLI option remains authoritative.
+  if [[ -n "${TRUSTED_PROXIES:-}" ]] && ! has_uvicorn_forwarded_ips_arg "$@"; then
+    UVICORN_COMMAND+=(--proxy-headers --forwarded-allow-ips "$TRUSTED_PROXIES")
   fi
 }
 

--- a/tests/test_start_with_auto_update.py
+++ b/tests/test_start_with_auto_update.py
@@ -61,3 +61,31 @@ def test_wrapper_preserves_explicit_uvicorn_log_level(tmp_path: Path) -> None:
 
     assert argv.count("--log-level") == 1
     assert argv[-2:] == ["--log-level", "info"]
+
+
+def test_wrapper_configures_uvicorn_trusted_proxies(tmp_path: Path) -> None:
+    """Trusted proxy CIDRs also apply to Uvicorn access-log client addresses."""
+
+    argv = _run_wrapper(
+        tmp_path,
+        {"TRUSTED_PROXIES": "172.18.0.0/16,10.0.0.8"},
+    )
+
+    assert argv[-3:] == [
+        "--proxy-headers",
+        "--forwarded-allow-ips",
+        "172.18.0.0/16,10.0.0.8",
+    ]
+
+
+def test_wrapper_preserves_explicit_forwarded_allow_ips(tmp_path: Path) -> None:
+    """An explicit Uvicorn trust boundary takes precedence over the environment."""
+
+    argv = _run_wrapper(
+        tmp_path,
+        {"TRUSTED_PROXIES": "172.18.0.0/16"},
+        "--forwarded-allow-ips=10.0.0.8",
+    )
+
+    assert argv.count("--proxy-headers") == 0
+    assert argv.count("--forwarded-allow-ips=10.0.0.8") == 1


### PR DESCRIPTION
### Motivation

- Traefik's peer address was appearing in Uvicorn access logs and some telemetry because Uvicorn only trusts proxy headers when explicitly configured. 
- The application already honours `TRUSTED_PROXIES` for request handling, but Uvicorn's access-log client address could still show the Traefik peer unless its forwarded-IP settings match the same trust boundary. 

### Description

- Added `has_uvicorn_forwarded_ips_arg()` and updated `build_uvicorn_command()` in `scripts/start_with_auto_update.sh` to append `--proxy-headers --forwarded-allow-ips "$TRUSTED_PROXIES"` when `TRUSTED_PROXIES` is set and an explicit Uvicorn `--forwarded-allow-ips` is not provided. 
- Preserved explicit CLI precedence so any user-supplied Uvicorn `--forwarded-allow-ips` or `--proxy-headers` remains authoritative. 
- Added tests in `tests/test_start_with_auto_update.py` to cover both the automatic propagation of `TRUSTED_PROXIES` to Uvicorn and the explicit-overrides behaviour. 
- Documented the change and guidance in `.env.example` and `docs/wiki/compliance/Logging and Audit.md`, including Traefik configuration notes for chained proxies and the recommended narrow `TRUSTED_PROXIES` values. 

### Testing

- Ran `pytest -q tests/test_start_with_auto_update.py tests/test_client_ip_helper.py tests/test_logging.py` and the suite completed successfully with `26 passed`. 
- Performed a shell syntax check with `bash -n scripts/start_with_auto_update.sh` and ran `git diff --check`, both reporting no issues. 
- Verified the wrapper now emits the expected Uvicorn arguments via the new unit tests which assert the appended `--proxy-headers` and `--forwarded-allow-ips` behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6985c53d988332af2d973335f916e9)