### PR TITLE
Fix RAG indexing jobs remaining in Running state

### DIFF
--- a/app/api/routes/agent.py
+++ b/app/api/routes/agent.py
@@ -136,6 +136,14 @@ async def _run_rag_index_job(
             message="Indexing stopped by an administrator.",
             finished=True,
         )
+    except asyncio.CancelledError:
+        await rag_index_repo.update_job(
+            job_id,
+            status="cancelled",
+            message="Indexing task was cancelled.",
+            finished=True,
+        )
+        raise
     except Exception as exc:  # pragma: no cover - defensive background job guard
         if await rag_index_repo.job_stop_requested(job_id):
             await rag_index_repo.update_job(
@@ -221,15 +229,24 @@ async def stop_rag_index(
     await rag_index_repo.request_job_stop(job_id)
     task = _RAG_INDEX_TASKS.get(job_id)
     if task and not task.done():
-        task.cancel()
         await rag_index_repo.update_job(
             job_id,
             status="cancelled",
             message="Indexing force-stopped by an administrator.",
             finished=True,
         )
+        task.cancel()
         return {"job_id": job_id, "status": "cancelled"}
-    return {"job_id": job_id, "status": "cancelling"}
+    # Background tasks are process-local, so an API request handled by another
+    # worker cannot access the Task object.  Mark the persisted job terminal;
+    # the indexing loop observes cancelled as a stop request on its next check.
+    await rag_index_repo.update_job(
+        job_id,
+        status="cancelled",
+        message="Indexing stopped by an administrator.",
+        finished=True,
+    )
+    return {"job_id": job_id, "status": "cancelled"}
 
 
 @router.post("/rag/matching/pause")

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -1913,6 +1913,12 @@ async def execute_agent_query(
             job_id=rag_index_job_id,
             cleanup_missing=cleanup_rag_index,
         )
+        # A maintenance indexing run only needs to collect and persist sources.
+        # Continuing through retrieval and final-answer generation makes the job
+        # wait on an unrelated LLM request (with an empty query), which can leave
+        # an otherwise completed index marked as running indefinitely.
+        if rag_index_job_id is not None and allow_empty_query:
+            return {"sources": assembled_sources}
         raw_rag_candidates = await rag_retrieval.retrieve_candidates(
             query_text,
             user,
@@ -1920,6 +1926,11 @@ async def execute_agent_query(
             memberships=resolved_memberships,
             source_filters=sorted(allowed_rag_sources),
         )
+    except rag_index_service.RagIndexCancelled:
+        # Cancellation is job control, not a retrieval failure.  Let the job
+        # runner record the terminal cancelled state instead of continuing into
+        # answer generation.
+        raise
     except Exception as exc:  # pragma: no cover - defensive guard
         log_error("Agent RAG retrieval failed", error=str(exc))
         raw_rag_candidates = []

--- a/tests/test_rag_index_routes.py
+++ b/tests/test_rag_index_routes.py
@@ -1,0 +1,53 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from app.api.routes import agent
+
+
+def test_stop_rag_index_finishes_job_when_task_runs_on_another_worker(monkeypatch):
+    monkeypatch.setattr(
+        agent.rag_index_repo,
+        "get_job",
+        AsyncMock(return_value={"id": 42, "status": "running"}),
+    )
+    request_stop = AsyncMock(return_value=True)
+    update_job = AsyncMock()
+    monkeypatch.setattr(agent.rag_index_repo, "request_job_stop", request_stop)
+    monkeypatch.setattr(agent.rag_index_repo, "update_job", update_job)
+    agent._RAG_INDEX_TASKS.pop(42, None)
+
+    result = asyncio.run(
+        agent.stop_rag_index(42, current_user={"is_super_admin": True})
+    )
+
+    assert result == {"job_id": 42, "status": "cancelled"}
+    request_stop.assert_awaited_once_with(42)
+    update_job.assert_awaited_once_with(
+        42,
+        status="cancelled",
+        message="Indexing stopped by an administrator.",
+        finished=True,
+    )
+
+
+def test_rag_index_runner_records_task_cancellation(monkeypatch):
+    update_job = AsyncMock()
+    monkeypatch.setattr(agent.rag_index_repo, "update_job", update_job)
+    monkeypatch.setattr(
+        agent.agent_service,
+        "execute_agent_query",
+        AsyncMock(side_effect=asyncio.CancelledError),
+    )
+
+    try:
+        asyncio.run(agent._run_rag_index_job(7, {"is_super_admin": True}))
+    except asyncio.CancelledError:
+        pass
+    else:
+        raise AssertionError("RAG index runner did not propagate task cancellation")
+
+    assert update_job.await_args_list[-1].kwargs == {
+        "status": "cancelled",
+        "message": "Indexing task was cancelled.",
+        "finished": True,
+    }


### PR DESCRIPTION
### Motivation

- Maintenance RAG indexing runs could remain `running` because the maintenance path continued into an unrelated empty-query LLM call, which left jobs marked Running even after sources were persisted.
- Cancellation and cross-worker stop requests were not consistently persisted, so administrators could not reliably stop jobs from other processes.

### Description

- Short-circuit maintenance-only indexing in `app/services/agent.py` so that when `rag_index_job_id` is set and `allow_empty_query` is true the function returns immediately after `index_agent_sources` completes instead of continuing to retrieval/final-answer generation.
- Propagate cooperative cancellation by re-raising `rag_index_service.RagIndexCancelled` from the retrieval block in `app/services/agent.py` so the job runner can handle it as a cancel event.
- Add `asyncio.CancelledError` handling in `app/api/routes/agent.py::_run_rag_index_job` to persist a terminal `cancelled` status and re-raise the cancellation so the DB reflects the true task state when the task is cancelled.
- Make the stop endpoint in `app/api/routes/agent.py` mark the persisted job as `cancelled` even when the in-memory `Task` is not present (cross-worker scenario), and cancel the in-memory `Task` when available before returning.
- Add regression tests `tests/test_rag_index_routes.py` that cover cross-worker stop behavior and task cancellation recording.

### Testing

- Ran unit tests with `pytest -q tests/test_rag_index_service.py tests/test_rag_index_routes.py` and all tests passed (`4 passed`).
- Ran a lint/check pass with `python -m ruff check app/api/routes/agent.py app/services/agent.py tests/test_rag_index_routes.py` which produced no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6988103fa48332b309055e564d2d70)