### PR TITLE
Include ticket expenses in Generate Invoice previews

### DIFF
--- a/app/services/invoice_generator.py
+++ b/app/services/invoice_generator.py
@@ -233,7 +233,7 @@ async def generate_invoice(company_id: int) -> dict[str, Any]:
 
     Builds invoice line items from:
     - Company recurring invoice items
-    - Billable tickets with unbilled time entries
+    - Billable tickets with unbilled time entries or expenses
 
     The generated invoice is stored locally in MyPortal and accessible
     via the /invoices page.

--- a/app/services/scheduled_task_preview.py
+++ b/app/services/scheduled_task_preview.py
@@ -7,6 +7,7 @@ from app.repositories import companies as company_repo
 from app.repositories import invoice_lines as invoice_lines_repo
 from app.repositories import invoices as invoice_repo
 from app.repositories import ticket_billed_time_entries as billed_time_repo
+from app.repositories import ticket_expenses as expenses_repo
 from app.repositories import tickets as tickets_repo
 from app.services import invoice_generator as invoice_generator_service
 from app.services import modules as modules_service
@@ -130,10 +131,12 @@ async def _preview_generate_invoice(
     recurring_items = await xero_service.build_recurring_invoice_items(
         company_id, tax_type=None, context=context
     )
-    tickets = await tickets_repo.list_tickets(company_id=company_id, limit=1000)
+    tickets = await tickets_repo.list_tickets(company_id=company_id, limit=None)
     billable_statuses = invoice_generator_service._get_env_xero_billable_statuses()
     ticket_items: list[dict[str, Any]] = []
     billable_reply_count = 0
+    expense_count = 0
+    expense_total = Decimal("0.00")
     for ticket in tickets:
         ticket_status = str(ticket.get("status") or "").strip().lower()
         if ticket_status not in billable_statuses:
@@ -143,16 +146,24 @@ async def _preview_generate_invoice(
         if not ticket_id:
             continue
         unbilled_ids = await billed_time_repo.get_unbilled_reply_ids(ticket_id)
-        if not unbilled_ids:
-            continue
-        replies = await tickets_repo.list_replies(ticket_id, include_internal=True)
+        expenses = await expenses_repo.list_expenses(ticket_id, unbilled_only=True)
+        ticket_expense_total = sum(
+            (
+                invoice_generator_service._to_decimal(expense.get("amount"))
+                or Decimal("0")
+            )
+            for expense in expenses
+        )
+        replies = (
+            await tickets_repo.list_replies(ticket_id, include_internal=True)
+            if unbilled_ids
+            else []
+        )
         minutes = sum(
             invoice_generator_service._coerce_minutes(r.get("minutes_spent"))
             for r in replies
             if r.get("id") in unbilled_ids and r.get("is_billable")
         )
-        if minutes <= 0:
-            continue
         billable_reply_count += len(
             [r for r in replies if r.get("id") in unbilled_ids and r.get("is_billable")]
         )
@@ -179,9 +190,10 @@ async def _preview_generate_invoice(
                 }
                 labour_map[key] = bucket
             bucket["minutes"] += reply_minutes
-        requester_name, requester_email = (
-            await invoice_generator_service.resolve_ticket_requester(dict(ticket))
-        )
+        (
+            requester_name,
+            requester_email,
+        ) = await invoice_generator_service.resolve_ticket_requester(dict(ticket))
         for group in labour_map.values():
             group_minutes = int(group.get("minutes") or 0)
             if group_minutes <= 0:
@@ -214,6 +226,28 @@ async def _preview_generate_invoice(
             if labour_code:
                 ticket_item["xeroItemCode"] = labour_code
             ticket_items.append(ticket_item)
+        if ticket_expense_total > 0:
+            description = invoice_generator_service._build_expense_line_description(
+                line_item_template,
+                dict(ticket),
+                expenses,
+                requester_name=requester_name,
+                requester_email=requester_email,
+            )
+            expense_count += len(expenses)
+            expense_total += ticket_expense_total
+            ticket_items.append(
+                {
+                    "type": "ticket_expense",
+                    "id": int(ticket_id),
+                    "label": description,
+                    "amount": _money(ticket_expense_total),
+                    "xeroDescription": description,
+                    "xeroQuantity": "1.00",
+                    "xeroUnitAmount": _money(ticket_expense_total),
+                    "action": "Add unbilled ticket expenses to the generated invoice",
+                }
+            )
     recurring_total = sum(
         Decimal(str(i.get("Quantity") or 0)) * Decimal(str(i.get("UnitAmount") or 0))
         for i in recurring_items
@@ -232,6 +266,8 @@ async def _preview_generate_invoice(
             "recurringLineCount": len(recurring_items),
             "ticketLineCount": len(ticket_items),
             "billableReplyCount": billable_reply_count,
+            "expenseCount": expense_count,
+            "expenseAmount": _money(expense_total),
             "recurringAmount": _money(recurring_total),
         },
         "items": [

--- a/changes/34ca09c0-c148-4f1c-9c3d-feb5fd510958.json
+++ b/changes/34ca09c0-c148-4f1c-9c3d-feb5fd510958.json
@@ -1,0 +1,7 @@
+{
+  "guid": "34ca09c0-c148-4f1c-9c3d-feb5fd510958",
+  "occurred_at": "2026-07-29T00:00Z",
+  "change_type": "Fix",
+  "summary": "Include unbilled ticket expenses, including expense-only tickets, in Generate Invoice scheduled task previews.",
+  "content_hash": "1fe1f43c76ac11f941d3b17762004003e9479867b59eee48c152bc98af60eda8"
+}

--- a/tests/test_scheduled_task_preview.py
+++ b/tests/test_scheduled_task_preview.py
@@ -109,6 +109,11 @@ def test_generate_invoice_preview_uses_xero_line_item_template(monkeypatch):
         scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled
     )
     monkeypatch.setattr(
+        scheduled_task_preview.expenses_repo,
+        "list_expenses",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
         scheduled_task_preview.tickets_repo, "list_replies", fake_replies
     )
 
@@ -199,6 +204,11 @@ def test_generate_invoice_preview_prefers_env_xero_line_item_template(monkeypatc
         scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled
     )
     monkeypatch.setattr(
+        scheduled_task_preview.expenses_repo,
+        "list_expenses",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
         scheduled_task_preview.tickets_repo, "list_replies", fake_replies
     )
 
@@ -273,6 +283,11 @@ def test_generate_invoice_preview_resolves_requester_name_for_template(monkeypat
         scheduled_task_preview.billed_time_repo, "get_unbilled_reply_ids", fake_unbilled
     )
     monkeypatch.setattr(
+        scheduled_task_preview.expenses_repo,
+        "list_expenses",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
         scheduled_task_preview.tickets_repo, "list_replies", fake_replies
     )
     monkeypatch.setattr(
@@ -299,6 +314,67 @@ def test_generate_invoice_preview_resolves_requester_name_for_template(monkeypat
         preview["items"][0]["xeroDescription"]
         == "Ticket 42: Broken printer - Jane Requester"
     )
+
+
+def test_generate_invoice_preview_includes_expense_only_ticket(monkeypatch):
+    monkeypatch.setenv("XERO_BILLABLE_STATUSES", "resolved")
+    monkeypatch.setattr(
+        scheduled_task_preview.company_repo,
+        "get_company_by_id",
+        AsyncMock(return_value={"id": 1, "name": "Acme"}),
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.xero_service,
+        "build_invoice_context",
+        AsyncMock(return_value={}),
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.xero_service,
+        "build_recurring_invoice_items",
+        AsyncMock(return_value=[]),
+    )
+    list_tickets = AsyncMock(
+        return_value=[{"id": 42, "subject": "Return laptop", "status": "Resolved"}]
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.tickets_repo, "list_tickets", list_tickets
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.billed_time_repo,
+        "get_unbilled_reply_ids",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        scheduled_task_preview.expenses_repo,
+        "list_expenses",
+        AsyncMock(
+            return_value=[{"id": 7, "description": "Return freight", "amount": "43.75"}]
+        ),
+    )
+
+    preview = asyncio.run(
+        scheduled_task_preview.preview_task(
+            {"command": "generate_invoice", "company_id": 1}
+        )
+    )
+
+    assert preview["status"] == "ready"
+    assert preview["totals"]["ticketLineCount"] == 1
+    assert preview["totals"]["expenseCount"] == 1
+    assert preview["totals"]["expenseAmount"] == "43.75"
+    assert preview["items"] == [
+        {
+            "type": "ticket_expense",
+            "id": 42,
+            "label": "Ticket 42: Return laptop Expenses - Return freight",
+            "amount": "43.75",
+            "xeroDescription": "Ticket 42: Return laptop Expenses - Return freight",
+            "xeroQuantity": "1.00",
+            "xeroUnitAmount": "43.75",
+            "action": "Add unbilled ticket expenses to the generated invoice",
+        }
+    ]
+    list_tickets.assert_awaited_once_with(company_id=1, limit=None)
 
 
 def test_unbill_time_entries_preview_lists_billable_entries(monkeypatch):


### PR DESCRIPTION
### Motivation
- The generate invoice preview did not include unbilled ticket expenses or expense-only tickets, causing preview output to differ from actual invoice generation.
- Previews were capped at 1,000 tickets which made the preview behavior diverge from the invoice generator that inspects all tickets.

### Description
- Load unbilled ticket expenses and include expense-only tickets in `_preview_generate_invoice`, building preview items using `_build_expense_line_description` so descriptions match generated invoice lines (`app/services/scheduled_task_preview.py`).
- Remove the 1,000-ticket preview cap by querying tickets with `limit=None` so previews inspect the same ticket set as invoice generation (`app/services/scheduled_task_preview.py`).
- Add expense totals and counts to preview `totals` as `expenseCount` and `expenseAmount` and update the invoice generator docstring to note expenses are considered (`app/services/scheduled_task_preview.py`, `app/services/invoice_generator.py`).
- Add regression tests covering an expense-only resolved ticket and wire up expense repo mocks in existing previews (`tests/test_scheduled_task_preview.py`).
- Add a change-log entry recording the fix (`changes/*.json`).

### Testing
- Ran `pytest -q tests/test_scheduled_task_preview.py tests/test_invoice_generator.py` and all tests in those files passed (22 passed).
- Attempted a full `pytest -q` run but collection was blocked by an external dependency (`respx`) missing in the environment and a couple of stale test imports, so full-suite run was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a698c98596c83328a10d466cfdfc80e)