### PR TITLE
Move ticket status filter into table header

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -6896,6 +6896,93 @@ dialog.modal:not([open]) {
   user-select: none;
 }
 
+/* Status filtering lives beside the Status table heading. */
+.ticket-status-filter {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.ticket-status-filter__toggle {
+  display: inline-grid;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0.35rem;
+  place-items: center;
+  color: var(--color-text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.4rem;
+  cursor: pointer;
+}
+
+.ticket-status-filter__toggle svg {
+  width: 1rem;
+  height: 1rem;
+  fill: currentColor;
+}
+
+.ticket-status-filter__toggle:hover,
+.ticket-status-filter__toggle:focus-visible,
+.ticket-status-filter--open .ticket-status-filter__toggle {
+  color: var(--color-text);
+  background: var(--color-surface-3);
+  border-color: var(--color-border);
+  outline: none;
+}
+
+.ticket-status-filter__panel {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  display: grid;
+  width: max-content;
+  min-width: 13rem;
+  max-height: 20rem;
+  padding: 0.65rem;
+  gap: 0.25rem;
+  overflow-y: auto;
+  color: var(--color-text);
+  text-align: left;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: 0.6rem;
+  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.35);
+}
+
+.ticket-status-filter__panel[hidden] {
+  display: none;
+}
+
+.ticket-status-filter__title {
+  padding: 0.25rem 0.4rem 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ticket-status-filter__option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem;
+  border-radius: 0.4rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ticket-status-filter__option:hover {
+  background: var(--color-surface-3);
+}
+
+.ticket-status-filter__option input {
+  margin: 0;
+}
+
 /* Horizontal Section for Grouping and Search */
 .ticket-filters__section--horizontal {
   display: grid;

--- a/app/static/js/ticket_views.js
+++ b/app/static/js/ticket_views.js
@@ -49,6 +49,7 @@
       // that fire while async initialization (loadViews) is in progress.
       this.setupEventListeners();
       this.setupStatusFilters();
+      this.setupStatusFilterMenu();
       this.setupGroupingControls();
       await this.loadViews();
       this.updateViewActions();
@@ -181,6 +182,41 @@
           }
           this.applyFilters();
         });
+      });
+    }
+
+    /**
+     * Setup the status column's filter menu without triggering table sorting.
+     */
+    setupStatusFilterMenu() {
+      const menu = this.container.querySelector('[data-ticket-status-filter-menu]');
+      if (!menu) return;
+      const toggle = menu.querySelector('[data-ticket-status-filter-toggle]');
+      const panel = menu.querySelector('[data-ticket-status-filter-panel]');
+      if (!toggle || !panel) return;
+
+      const closeMenu = () => {
+        panel.hidden = true;
+        menu.classList.remove('ticket-status-filter--open');
+        toggle.setAttribute('aria-expanded', 'false');
+      };
+
+      toggle.addEventListener('click', (event) => {
+        event.stopPropagation();
+        const willOpen = panel.hidden;
+        panel.hidden = !willOpen;
+        menu.classList.toggle('ticket-status-filter--open', willOpen);
+        toggle.setAttribute('aria-expanded', String(willOpen));
+      });
+      panel.addEventListener('click', (event) => event.stopPropagation());
+      document.addEventListener('click', (event) => {
+        if (!menu.contains(event.target)) closeMenu();
+      });
+      menu.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeMenu();
+          toggle.focus();
+        }
       });
     }
 

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -357,24 +357,6 @@
                 </div>
               </div>
 
-              <!-- Filters Section -->
-              <div class="ticket-filters__section">
-                <h3 class="ticket-filters__section-title">Filter by Status</h3>
-                <div class="ticket-filters__status-grid">
-                  {% for status_option in ticket_filter_status_definitions | default(ticket_status_definitions) %}
-                    <label class="ticket-filters__status-item">
-                      <input
-                        type="checkbox"
-                        value="{{ status_option.tech_status }}"
-                        data-status-filter
-                        checked
-                      />
-                      <span class="ticket-filters__status-label">{{ status_option.tech_label }}</span>
-                    </label>
-                  {% endfor %}
-                </div>
-              </div>
-
               <!-- Phone Number Search Section -->
               <div class="ticket-filters__section">
                 <h3 class="ticket-filters__section-title">Search by Phone Number</h3>
@@ -630,7 +612,34 @@
                 >
                   Subject
                 </th>
-                <th scope="col" data-sort="string" data-column="status" class="tickets-table__column tickets-table__column--status">Status</th>
+                <th scope="col" data-sort="string" data-column="status" class="tickets-table__column tickets-table__column--status">
+                  <span class="ticket-status-filter" data-ticket-status-filter-menu>
+                    <span>Status</span>
+                    <button
+                      type="button"
+                      class="ticket-status-filter__toggle"
+                      data-ticket-status-filter-toggle
+                      aria-label="Filter tickets by status"
+                      aria-haspopup="true"
+                      aria-expanded="false"
+                      aria-controls="ticket-status-filter-options"
+                      title="Filter by status"
+                    >
+                      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        <path d="M3.5 5.25A1.25 1.25 0 0 1 4.75 4h14.5a1.25 1.25 0 0 1 .96 2.05L14.5 12.9v5.35a1.25 1.25 0 0 1-.69 1.12l-2.5 1.25a1.25 1.25 0 0 1-1.81-1.12v-6.6L3.79 6.05a1.25 1.25 0 0 1-.29-.8Z" />
+                      </svg>
+                    </button>
+                    <span class="ticket-status-filter__panel" id="ticket-status-filter-options" data-ticket-status-filter-panel hidden>
+                      <span class="ticket-status-filter__title">Filter by status</span>
+                      {% for status_option in ticket_filter_status_definitions | default(ticket_status_definitions) %}
+                        <label class="ticket-status-filter__option">
+                          <input type="checkbox" value="{{ status_option.tech_status }}" data-status-filter checked />
+                          <span>{{ status_option.tech_label }}</span>
+                        </label>
+                      {% endfor %}
+                    </span>
+                  </span>
+                </th>
                 <th scope="col" data-sort="string" data-column="priority" class="tickets-table__column tickets-table__column--priority">Priority</th>
                 <th scope="col" data-sort="string" data-column="company" class="tickets-table__column tickets-table__column--company">Company</th>
                 <th scope="col" data-sort="string" data-column="assigned" class="tickets-table__column tickets-table__column--assigned">Assigned</th>

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -80,6 +80,20 @@ def test_table_header_data_column_attributes():
         )
 
 
+def test_status_filter_is_in_status_column_header_with_funnel_icon():
+    """Status choices should open from an accessible funnel in the Status heading."""
+    html = _template_html()
+    status_header = html[html.index('data-column="status"', html.index('<thead>')):]
+    status_header = status_header[:status_header.index('</th>')]
+
+    assert 'data-ticket-status-filter-toggle' in status_header
+    assert 'aria-label="Filter tickets by status"' in status_header
+    assert '<svg viewBox="0 0 24 24"' in status_header
+    assert 'data-ticket-status-filter-panel' in status_header
+    assert 'data-status-filter' in status_header
+    assert '<h3 class="ticket-filters__section-title">Filter by Status</h3>' not in html
+
+
 def test_table_cell_data_column_attributes():
     """Table <td> elements for customisable columns should carry data-column."""
     html = _template_html()
@@ -130,4 +144,3 @@ def test_subject_column_always_visible_in_js():
     )
     js_content = js_path.read_text(encoding="utf-8")
     assert "'subject'" in js_content
-


### PR DESCRIPTION
### Motivation
- Improve discoverability and ergonomics by moving the ticket status filter out of the left filter panel and into the `Status` table-column header as a compact funnel control.
- Make the header filter accessible and prevent accidental column sorting when interacting with the filter controls.

### Description
- Moved the multi-select status checkboxes from the left filter panel into the `Status` column header and added a funnel button and dropdown markup in `app/templates/admin/tickets.html` (uses `data-ticket-status-filter-menu`, `data-ticket-status-filter-toggle`, and `data-ticket-status-filter-panel`).
- Added `setupStatusFilterMenu()` to `app/static/js/ticket_views.js` to manage the header menu open/close behavior, stop event propagation so interactions don't trigger column sorting, support outside-click dismissal, and close on `Escape`.
- Kept existing checkbox inputs using `data-status-filter` and preserved `setupStatusFilters()` so filter state and API interactions remain unchanged.
- Added styling for the funnel button and dropdown in `app/static/css/app.css` to match existing UI states (hover, focus, open, scrolling).
- Added a regression test in `tests/test_ticket_column_customisation.py` asserting the filter, funnel SVG and panel are present in the `Status` header and that the original sidebar header is removed.

### Testing
- Ran `node --check app/static/js/ticket_views.js` to validate the modified JS syntax and it completed without errors.
- Ran `pytest -q tests/test_ticket_column_customisation.py tests/test_ticket_views_api.py` and all tests passed (`19 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6991e8aac08332a7f363227e11d3c3)