### PR TITLE
Rework admin tickets into two-row dashboard layout

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5673,8 +5673,36 @@ dialog.modal:not([open]) {
 
 @media (min-width: 960px) {
   .ticket-dashboard__overview {
-    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+    grid-template-columns: minmax(260px, 320px) minmax(260px, 340px) minmax(0, 1fr);
     align-items: start;
+  }
+
+  .ticket-dashboard__overview > .ticket-filters-panel,
+  .ticket-dashboard__overview > .ticket-filters-panel > .ticket-filters,
+  .ticket-dashboard__overview > .ticket-dashboard__right-column {
+    display: contents;
+  }
+
+  .ticket-dashboard__overview .ticket-filters__section:first-child {
+    grid-column: 1;
+    grid-row: 1;
+    height: 100%;
+  }
+
+  .ticket-dashboard__overview .ticket-filters__section--horizontal {
+    grid-column: 2;
+    grid-row: 1;
+    height: 100%;
+  }
+
+  .ticket-dashboard__stats {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .ticket-dashboard__overview .management__toolbar-info,
+  .ticket-dashboard__overview .table-wrapper {
+    grid-column: 1 / -1;
   }
 }
 
@@ -6957,10 +6985,14 @@ dialog.modal:not([open]) {
 
 /* Horizontal Section for Grouping and Search */
 .ticket-filters__section--horizontal {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
   padding: 1rem 1.25rem;
+}
+
+.ticket-dashboard__dropdowns {
+  justify-content: flex-start;
 }
 
 .ticket-filters__group-control,
@@ -6982,10 +7014,6 @@ dialog.modal:not([open]) {
   flex-direction: column;
   gap: 1.5rem;
   min-width: 0;
-}
-
-.ticket-dashboard__right-column .management__toolbar {
-  margin-top: -0.5rem;
 }
 
 .ticket-dashboard__right-column .management__toolbar-info {

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -343,36 +343,7 @@
                     data-table-filter="tickets-table" data-ticket-dashboard-search
                   />
                 </div>
-              </div>
-
-            </div>
-          </aside>
-
-          <div class="ticket-dashboard__right-column">
-            <div class="ticket-dashboard__stats management__stats" data-ticket-stats>
-            <article class="stat-card">
-              <h3 class="stat-card__title">Open tickets</h3>
-              <p class="stat-card__value" data-ticket-stat="open">{{ ticket_status_counts.get('open', 0) }}</p>
-            </article>
-            <article class="stat-card">
-              <h3 class="stat-card__title">In progress</h3>
-              <p class="stat-card__value" data-ticket-stat="in_progress">
-                {{ ticket_status_counts.get('in_progress', 0) + ticket_status_counts.get('pending', 0) }}
-              </p>
-            </article>
-            <article class="stat-card">
-              <h3 class="stat-card__title">Resolved</h3>
-              <p class="stat-card__value" data-ticket-stat="resolved">
-                {{ ticket_status_counts.get('resolved', 0) + ticket_status_counts.get('closed', 0) }}
-              </p>
-            </article>
-            <article class="stat-card">
-              <h3 class="stat-card__title">Total</h3>
-              <p class="stat-card__value" data-ticket-stat="total">{{ ticket_total }}</p>
-            </article>
-          </div>
-
-          <div class="management__toolbar">
+                <div class="management__toolbar ticket-dashboard__dropdowns">
             {% if can_bulk_delete_tickets %}
               {% set current_query = request.url.query %}
               <form
@@ -533,6 +504,36 @@
               </div>
             </div>
           </div>
+              </div>
+
+            </div>
+          </aside>
+
+          <div class="ticket-dashboard__right-column">
+            <div class="ticket-dashboard__stats management__stats" data-ticket-stats>
+            <article class="stat-card">
+              <h3 class="stat-card__title">Open tickets</h3>
+              <p class="stat-card__value" data-ticket-stat="open">{{ ticket_status_counts.get('open', 0) }}</p>
+            </article>
+            <article class="stat-card">
+              <h3 class="stat-card__title">In progress</h3>
+              <p class="stat-card__value" data-ticket-stat="in_progress">
+                {{ ticket_status_counts.get('in_progress', 0) + ticket_status_counts.get('pending', 0) }}
+              </p>
+            </article>
+            <article class="stat-card">
+              <h3 class="stat-card__title">Resolved</h3>
+              <p class="stat-card__value" data-ticket-stat="resolved">
+                {{ ticket_status_counts.get('resolved', 0) + ticket_status_counts.get('closed', 0) }}
+              </p>
+            </article>
+            <article class="stat-card">
+              <h3 class="stat-card__title">Total</h3>
+              <p class="stat-card__value" data-ticket-stat="total">{{ ticket_total }}</p>
+            </article>
+          </div>
+
+
 
           <div class="management__toolbar-info">
             <span data-table-info>Showing {{ tickets|length }} tickets</span>

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -27,6 +27,24 @@ def test_columns_toggle_button_present():
     assert '>Columns<' in html
 
 
+def test_dashboard_controls_precede_stats_and_full_width_table():
+    """The dashboard uses one control row followed by the full-width ticket list."""
+    html = _template_html()
+    quick_search_index = html.index('id="ticket-quick-filter"')
+    group_by_index = html.index('data-ticket-group-by')
+    columns_index = html.index('data-ticket-columns')
+    stats_index = html.index('data-ticket-stats')
+    table_index = html.index('id="tickets-table"')
+
+    assert quick_search_index < group_by_index < stats_index < table_index
+    assert quick_search_index < columns_index < stats_index
+
+    css = (TEMPLATE_PATH.parent.parent.parent / "static" / "css" / "app.css").read_text(encoding="utf-8")
+    assert "grid-template-columns: minmax(260px, 320px) minmax(260px, 340px) minmax(0, 1fr);" in css
+    assert ".ticket-dashboard__overview .table-wrapper" in css
+    assert "grid-column: 1 / -1;" in css
+
+
 def test_next_ticket_number_handler_is_always_rendered():
     """The menu item handler must not depend on header-block scoped Jinja variables."""
     html = _template_html()


### PR DESCRIPTION
### Motivation
- Consolidate the tickets admin UI into a single two-row layout where the top row holds controls and stats and the second row contains the ticket table full width. 
- Surface Saved Views and Quick Search together and make Group By / Columns easily discoverable under the search control for faster filtering and configuration. 
- Allow ticket statistics to occupy the remaining right-side space of the top row so they are visible without reducing table width. 

### Description
- Rearranged the `app/templates/admin/tickets.html` markup so Saved Views and Quick Search are on the left of the first row, with `Group By` and `Columns` dropdowns placed directly beneath the Quick Search, and ticket stats placed to the right of that row. 
- Adjusted `app/static/css/app.css` to use a three-part grid on wide screens with `grid-template-columns: minmax(260px, 320px) minmax(260px, 340px) minmax(0, 1fr);` and rules that let the ticket table and info span the full width on the second row. 
- Kept stacked/vertical flow for narrow screens by preserving column breakpoint behaviour and switching the search/dropdown region to a column layout. 
- Added a test `tests/test_ticket_column_customisation.py` that asserts the control ordering and that the CSS grid and full-width table rules exist. 

### Testing
- Ran `git diff --check` to validate diffs and formatting and found no issues. 
- Ran `pytest -q tests/test_ticket_column_customisation.py` and observed `16 passed`. 
- Ran `pytest -q tests/test_ticket_column_customisation.py tests/test_template_compliance.py`; the ticket-dashboard tests passed but `tests/test_template_compliance.py` reported 7 pre-existing template compliance failures unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6994e9a51c8332bbc407aea007790d)