### PR TITLE
Improve permission-aware ticket status stats

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1120,21 +1120,22 @@
 
     function updateStats(counts, total) {
       const normalised = normaliseCounts(counts);
-      if (statElements.open) {
-        const value = Number(normalised.open ?? 0);
-        statElements.open.textContent = String(Number.isFinite(value) ? value : 0);
-      }
-      if (statElements.in_progress) {
-        const value = Number(normalised.in_progress ?? 0) + Number(normalised.pending ?? 0);
-        statElements.in_progress.textContent = String(Number.isFinite(value) ? value : 0);
-      }
-      if (statElements.resolved) {
-        const value = Number(normalised.resolved ?? 0) + Number(normalised.closed ?? 0);
-        statElements.resolved.textContent = String(Number.isFinite(value) ? value : 0);
-      }
+      Object.entries(statElements).forEach(([key, element]) => {
+        if (key === 'total') {
+          return;
+        }
+        const value = Number(normalised[key] ?? 0);
+        element.textContent = String(Number.isFinite(value) ? value : 0);
+        const tile = element.closest('.stat-strip__stat');
+        if (tile) {
+          tile.hidden = !Number.isFinite(value) || value <= 0;
+        }
+      });
       if (statElements.total) {
-        const safeTotal = Number(total);
-        statElements.total.textContent = String(Number.isFinite(safeTotal) ? safeTotal : 0);
+        const visibleTotal = Object.keys(statElements)
+          .filter((key) => key !== 'total')
+          .reduce((sum, key) => sum + Number(normalised[key] ?? 0), 0);
+        statElements.total.textContent = String(Number.isFinite(visibleTotal) ? visibleTotal : 0);
       }
     }
 

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/counters.html" import counter_strip %}
 
 {% block header_title %}
   {% set show_ticket_automations = is_super_admin %}
@@ -510,28 +511,36 @@
           </aside>
 
           <div class="ticket-dashboard__right-column">
-            <div class="ticket-dashboard__stats management__stats" data-ticket-stats>
-            <article class="stat-card">
-              <h3 class="stat-card__title">Open tickets</h3>
-              <p class="stat-card__value" data-ticket-stat="open">{{ ticket_status_counts.get('open', 0) }}</p>
-            </article>
-            <article class="stat-card">
-              <h3 class="stat-card__title">In progress</h3>
-              <p class="stat-card__value" data-ticket-stat="in_progress">
-                {{ ticket_status_counts.get('in_progress', 0) + ticket_status_counts.get('pending', 0) }}
-              </p>
-            </article>
-            <article class="stat-card">
-              <h3 class="stat-card__title">Resolved</h3>
-              <p class="stat-card__value" data-ticket-stat="resolved">
-                {{ ticket_status_counts.get('resolved', 0) + ticket_status_counts.get('closed', 0) }}
-              </p>
-            </article>
-            <article class="stat-card">
-              <h3 class="stat-card__title">Total</h3>
-              <p class="stat-card__value" data-ticket-stat="total">{{ ticket_total }}</p>
-            </article>
-          </div>
+            {% set ticket_stat_items = [] %}
+            {% set visible_ticket_total = namespace(value=0) %}
+            {% set ticket_stat_variants = {
+              'open': 'info',
+              'in_progress': 'warning',
+              'pending': 'maintenance',
+              'resolved': 'success',
+              'closed': 'neutral'
+            } %}
+            {% for definition in ticket_status_definitions %}
+              {% set status_count = ticket_status_counts.get(definition.tech_status, 0) %}
+              {% if status_count > 0 %}
+                {% set visible_ticket_total.value = visible_ticket_total.value + status_count %}
+                {% set _ = ticket_stat_items.append({
+                  'label': definition.tech_label,
+                  'value': status_count,
+                  'variant': ticket_stat_variants.get(definition.tech_status, ['info', 'warning', 'success', 'neutral'][loop.index0 % 4]),
+                  'attrs': {'data-ticket-stat': definition.tech_status}
+                }) %}
+              {% endif %}
+            {% endfor %}
+            <div data-ticket-stats>
+              {{ counter_strip(
+                ticket_stat_items,
+                total=visible_ticket_total.value,
+                total_label='Visible tickets',
+                total_attrs={'data-ticket-stat': 'total'},
+                class='ticket-dashboard__stats',
+              ) }}
+            </div>
 
 
 

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -45,6 +45,18 @@ def test_dashboard_controls_precede_stats_and_full_width_table():
     assert "grid-column: 1 / -1;" in css
 
 
+def test_ticket_stats_render_visible_non_zero_statuses_with_counter_strip():
+    """Ticket KPIs use the service-status treatment without exposing hidden statuses."""
+    html = _template_html()
+
+    assert 'from "macros/counters.html" import counter_strip' in html
+    assert "{% for definition in ticket_status_definitions %}" in html
+    assert "{% if status_count > 0 %}" in html
+    assert "'attrs': {'data-ticket-stat': definition.tech_status}" in html
+    assert "total_label='Visible tickets'" in html
+    assert "class='ticket-dashboard__stats'" in html
+
+
 def test_next_ticket_number_handler_is_always_rendered():
     """The menu item handler must not depend on header-block scoped Jinja variables."""
     html = _template_html()


### PR DESCRIPTION
### Motivation
- The admin ticket dashboard should show only the ticket statuses the current technician is permitted to see and avoid leaking counts for hidden/zero-value statuses.
- The ticket KPI tiles should use the shared Service Status counter-strip visual treatment for consistent colour-coding.

### Description
- Replace the fixed set of hard-coded KPI tiles in `app/templates/admin/tickets.html` with a permission-aware `counter_strip` rendered from `ticket_status_definitions`, omitting any status with a zero count and mapping statuses to the Service Status colour variants.
- Wrap the generated counter strip in a `data-ticket-stats` container and expose each tile with `data-ticket-stat` attributes so they can be updated by the client.
- Update `app/static/js/admin.js` to refresh individual status tiles on dashboard updates, hide tiles whose count reaches zero, and recalculate the visible total using only the shown tiles. 
- Add a regression test in `tests/test_ticket_column_customisation.py` to assert the template renders a non-zero, permission-aware counter strip and that the new markup uses the shared `counter_strip` macro.

### Testing
- Ran `pytest -q tests/test_ticket_column_customisation.py` and all tests passed (17 passed). 
- Performed static checks: `node --check app/static/js/admin.js` succeeded and the Jinja template was compiled using `Environment(...).get_template('admin/tickets.html')` successfully. 
- Ran a combined test run `pytest -q tests/test_ticket_column_customisation.py tests/test_tickets_dashboard_api.py` which exercised the new UI regression and reported the UI tests passing; the run also surfaced two pre-existing, unrelated API assertions in ticket status endpoint tests which do not touch the changed template or JavaScript.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a699635e25c8332a1a69c0f2242ac94)