### PR TITLE
Preserve ticket status names when counters refresh

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1125,7 +1125,10 @@
           return;
         }
         const value = Number(normalised[key] ?? 0);
-        element.textContent = String(Number.isFinite(value) ? value : 0);
+        const valueElement = element.querySelector('.stat-strip__stat-value');
+        if (valueElement) {
+          valueElement.textContent = String(Number.isFinite(value) ? value : 0);
+        }
         const tile = element.closest('.stat-strip__stat');
         if (tile) {
           tile.hidden = !Number.isFinite(value) || value <= 0;
@@ -1135,7 +1138,10 @@
         const visibleTotal = Object.keys(statElements)
           .filter((key) => key !== 'total')
           .reduce((sum, key) => sum + Number(normalised[key] ?? 0), 0);
-        statElements.total.textContent = String(Number.isFinite(visibleTotal) ? visibleTotal : 0);
+        const totalValueElement = statElements.total.querySelector('.stat-strip__stat-value');
+        if (totalValueElement) {
+          totalValueElement.textContent = String(Number.isFinite(visibleTotal) ? visibleTotal : 0);
+        }
       }
     }
 

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -57,6 +57,21 @@ def test_ticket_stats_render_visible_non_zero_statuses_with_counter_strip():
     assert "class='ticket-dashboard__stats'" in html
 
 
+def test_ticket_stats_refresh_preserves_counter_labels():
+    """Refreshing counts updates values without replacing each complete stat tile."""
+    javascript = (
+        TEMPLATE_PATH.parent.parent.parent / "static" / "js" / "admin.js"
+    ).read_text(encoding="utf-8")
+
+    update_stats_start = javascript.index("function updateStats(counts, total)")
+    update_stats_end = javascript.index("function formatReviewDate", update_stats_start)
+    update_stats = javascript[update_stats_start:update_stats_end]
+    assert "element.querySelector('.stat-strip__stat-value')" in update_stats
+    assert "statElements.total.querySelector('.stat-strip__stat-value')" in update_stats
+    assert "element.textContent =" not in update_stats
+    assert "statElements.total.textContent =" not in update_stats
+
+
 def test_next_ticket_number_handler_is_always_rendered():
     """The menu item handler must not depend on header-block scoped Jinja variables."""
     html = _template_html()


### PR DESCRIPTION
### Motivation
- The ticket dashboard was replacing entire stat tiles when refreshing counts, causing status labels (and the total label) to disappear when many statuses were present.
- The change ensures the numeric counters update without replacing surrounding markup so long lists of statuses still show their names.

### Description
- Update `app/static/js/admin.js` so `updateStats` writes only to the inner `.stat-strip__stat-value` element instead of setting `element.textContent`, and apply the same approach for the total tile.
- Keep existing tile visibility logic (`tile.hidden`) intact so zero-count statuses remain hidden while labels are preserved.
- Add `test_ticket_stats_refresh_preserves_counter_labels` to `tests/test_ticket_column_customisation.py` to assert the `updateStats` implementation updates value nodes rather than replacing entire stat tiles.

### Testing
- Ran `pytest -q tests/test_ticket_column_customisation.py` and the test suite for the modified file passed. 
- Ran `pytest -q tests/test_ticket_column_customisation.py tests/test_tickets_dashboard_api.py` and the tests executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69994924308332aa9abb98961bebc8)