### PR TITLE
Fix admin ticket stats when ticket table is filtered

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -373,6 +373,7 @@ async def get_ticket_dashboard(
         limit=None if all_tickets else limit,
         include_reference_data=False,
     )
+    global_status_counts = await tickets_repo.count_tickets_by_status()
     rows: list[TicketDashboardRow] = []
     ticket_ids: list[int] = []
     for ticket in state.tickets:
@@ -514,7 +515,7 @@ async def get_ticket_dashboard(
     return TicketDashboardResponse(
         items=rows,
         total=state.total,
-        status_counts=dict(state.status_counts),
+        status_counts=global_status_counts,
         filters=filters,
     )
 

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1118,7 +1118,7 @@
       return output;
     }
 
-    function updateStats(counts, total) {
+    function updateStats(counts) {
       const normalised = normaliseCounts(counts);
       Object.entries(statElements).forEach(([key, element]) => {
         if (key === 'total') {
@@ -1377,7 +1377,7 @@
       const state = getTicketTableState(table);
       const items = Array.isArray(response?.items) ? response.items : [];
       state.renderTable(items);
-      state.updateStats(response?.status_counts, response?.total);
+      state.updateStats(response?.status_counts);
       table.dispatchEvent(new CustomEvent('table:rows-updated'));
       bindTicketStatusAutoSubmit();
       bindTicketBulkDelete();

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -536,7 +536,7 @@
               {{ counter_strip(
                 ticket_stat_items,
                 total=visible_ticket_total.value,
-                total_label='Visible tickets',
+                total_label='All tickets',
                 total_attrs={'data-ticket-stat': 'total'},
                 class='ticket-dashboard__stats',
               ) }}

--- a/changes/4ad63509-5c9f-4cf2-9418-3994151381bc.json
+++ b/changes/4ad63509-5c9f-4cf2-9418-3994151381bc.json
@@ -1,0 +1,7 @@
+{
+  "guid": "4ad63509-5c9f-4cf2-9418-3994151381bc",
+  "occurred_at": "2026-07-29T00:00Z",
+  "change_type": "Fix",
+  "summary": "Keep admin ticket status statistics based on all tickets when the ticket table is filtered.",
+  "content_hash": "40a66348ae101b152c96630ba75640a4b8499834c60bbdd9a4cd1ffd900164b8"
+}

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -53,7 +53,7 @@ def test_ticket_stats_render_visible_non_zero_statuses_with_counter_strip():
     assert "{% for definition in ticket_status_definitions %}" in html
     assert "{% if status_count > 0 %}" in html
     assert "'attrs': {'data-ticket-stat': definition.tech_status}" in html
-    assert "total_label='Visible tickets'" in html
+    assert "total_label='All tickets'" in html
     assert "class='ticket-dashboard__stats'" in html
 
 
@@ -63,13 +63,23 @@ def test_ticket_stats_refresh_preserves_counter_labels():
         TEMPLATE_PATH.parent.parent.parent / "static" / "js" / "admin.js"
     ).read_text(encoding="utf-8")
 
-    update_stats_start = javascript.index("function updateStats(counts, total)")
+    update_stats_start = javascript.index("function updateStats(counts)")
     update_stats_end = javascript.index("function formatReviewDate", update_stats_start)
     update_stats = javascript[update_stats_start:update_stats_end]
     assert "element.querySelector('.stat-strip__stat-value')" in update_stats
     assert "statElements.total.querySelector('.stat-strip__stat-value')" in update_stats
     assert "element.textContent =" not in update_stats
     assert "statElements.total.textContent =" not in update_stats
+
+
+def test_ticket_stats_refresh_uses_global_status_total():
+    """The KPI total is derived from global counts, not the filtered row total."""
+    javascript = (
+        TEMPLATE_PATH.parent.parent.parent / "static" / "js" / "admin.js"
+    ).read_text(encoding="utf-8")
+
+    assert "state.updateStats(response?.status_counts);" in javascript
+    assert "state.updateStats(response?.status_counts, response?.total);" not in javascript
 
 
 def test_next_ticket_number_handler_is_always_rendered():

--- a/tests/test_tickets_dashboard_api.py
+++ b/tests/test_tickets_dashboard_api.py
@@ -108,8 +108,12 @@ def test_ticket_dashboard_endpoint(monkeypatch):
             }
         }
     )
+    global_status_counts_mock = AsyncMock(
+        return_value={"open": 7, "waiting_on_client_no_reminder": 4}
+    )
     monkeypatch.setattr(tickets_service, "load_dashboard_state", load_state_mock)
     monkeypatch.setattr(tickets_repo, "get_automation_filter_context_by_ticket_ids", automation_context_mock)
+    monkeypatch.setattr(tickets_repo, "count_tickets_by_status", global_status_counts_mock)
 
     app.dependency_overrides[require_helpdesk_technician] = lambda: {"id": 1, "is_super_admin": True}
     try:
@@ -120,7 +124,10 @@ def test_ticket_dashboard_endpoint(monkeypatch):
     assert response.status_code == 200
     payload = response.json()
     assert payload["total"] == 1
-    assert payload["status_counts"] == {"open": 1}
+    assert payload["status_counts"] == {
+        "open": 7,
+        "waiting_on_client_no_reminder": 4,
+    }
     assert payload["filters"]["status"] == ["open"]
     assert payload["filters"]["module_slug"] == "ops"
     assert payload["items"][0]["company_name"] == "Acme Corp"
@@ -145,6 +152,7 @@ def test_ticket_dashboard_endpoint(monkeypatch):
     assert kwargs["status_filter"] == ["open"]
     assert kwargs["module_filter"] == "ops"
     automation_context_mock.assert_awaited_once_with([41])
+    global_status_counts_mock.assert_awaited_once_with()
 
 
 def test_list_ticket_statuses_endpoint(monkeypatch):


### PR DESCRIPTION
### Motivation

- The ticket dashboard KPIs in the admin UI were reflecting only the visible/filtered ticket rows rather than the true aggregate counts for each status, causing statuses hidden by the active filters to show as zero.
- The goal is to display honest global status counts in the sidebar KPIs even when the ticket table rows are filtered, and to ensure client-side refresh uses those global counts.

### Description

- The dashboard API now returns global, unfiltered status counts from `tickets_repo.count_tickets_by_status()` and includes them as `status_counts` in the `/api/tickets/dashboard` response instead of the filtered state counts (modified `app/api/routes/tickets.py`).
- The client-side refresh handler and `updateStats` function were updated to accept and use the server-provided `status_counts` only, removing reliance on the filtered `total` value (modified `app/static/js/admin.js`).
- The KPI aggregate label in the admin tickets template was updated from `Visible tickets` to `All tickets` to reflect the unfiltered nature of the counts (modified `app/templates/admin/tickets.html`).
- Added/updated regression tests to assert the dashboard returns global counts and the frontend refresh behavior expects only the global `status_counts` (changes in `tests/test_tickets_dashboard_api.py` and `tests/test_ticket_column_customisation.py`).
- Added a changelog entry for the fix (`changes/4ad63509-5c9f-4cf2-9418-3994151381bc.json`).

### Testing

- Ran the focused tests: `pytest -q tests/test_tickets_dashboard_api.py::test_ticket_dashboard_endpoint tests/test_ticket_column_customisation.py`, and the modified/dashboard-related tests passed (targeted run passed).
- Ran a broader invocation `pytest -q tests/test_tickets_dashboard_api.py tests/test_ticket_column_customisation.py`; the new dashboard and template regressions passed, while two pre-existing, unrelated tests in `tests/test_tickets_dashboard_api.py` that assert legacy string error messages for ticket-status updates failed (these failures are not caused by the dashboard/status-count changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69ac01b7c08332b1e8aecbce4c2ddb)