### PR TITLE
Allow technicians to customise ticket dashboard stats

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5757,6 +5757,26 @@ dialog.modal:not([open]) {
   }
 }
 
+.ticket-dashboard__stats {
+  min-width: 0;
+  position: relative;
+}
+
+.ticket-dashboard__stats-strip {
+  margin-bottom: 0;
+}
+
+.ticket-stat-controls {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.5rem;
+}
+
+.ticket-stat-controls__panel {
+  max-height: min(420px, 70vh);
+  overflow-y: auto;
+}
+
 @media (max-width: 640px) {
   .ticket-dashboard__filters {
     flex-direction: column;

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1131,12 +1131,12 @@
         }
         const tile = element.closest('.stat-strip__stat');
         if (tile) {
-          tile.hidden = !Number.isFinite(value) || value <= 0;
+          tile.hidden = tile.dataset.ticketStatSelected !== 'true';
         }
       });
       if (statElements.total) {
         const visibleTotal = Object.keys(statElements)
-          .filter((key) => key !== 'total')
+          .filter((key) => key !== 'total' && statElements[key].dataset.ticketStatSelected === 'true')
           .reduce((sum, key) => sum + Number(normalised[key] ?? 0), 0);
         const totalValueElement = statElements.total.querySelector('.stat-strip__stat-value');
         if (totalValueElement) {

--- a/app/static/js/ticket_stats.js
+++ b/app/static/js/ticket_stats.js
@@ -1,0 +1,118 @@
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'portal.tickets.stats';
+
+  function loadSelectedStatuses(defaultStatuses) {
+    try {
+      const storedValue = localStorage.getItem(STORAGE_KEY);
+      if (storedValue === null) {
+        return defaultStatuses;
+      }
+      const stored = JSON.parse(storedValue);
+      if (Array.isArray(stored) && stored.every((item) => typeof item === 'string')) {
+        return stored;
+      }
+    } catch (err) {
+      console.warn('Failed to read stored ticket stat preferences', err);
+    }
+    return defaultStatuses;
+  }
+
+  function saveSelectedStatuses(statuses) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(statuses));
+    } catch (err) {
+      console.warn('Failed to persist ticket stat preferences', err);
+    }
+  }
+
+  function initialiseStatControls() {
+    const statsContainer = document.querySelector('[data-ticket-stats]');
+    const controls = document.querySelector('[data-ticket-stat-controls]');
+    if (!statsContainer || !controls) {
+      return;
+    }
+
+    const toggleButton = controls.querySelector('[data-ticket-stats-toggle]');
+    const panel = controls.querySelector('[data-ticket-stats-panel]');
+    const toggles = Array.from(controls.querySelectorAll('[data-ticket-stat-toggle]'));
+    if (!toggleButton || !panel || !toggles.length) {
+      return;
+    }
+
+    function closePanel() {
+      controls.classList.remove('ticket-columns--open');
+      panel.hidden = true;
+      toggleButton.setAttribute('aria-expanded', 'false');
+    }
+
+    function updateTotal() {
+      const totalValue = statsContainer.querySelector('[data-ticket-stat="total"] .stat-strip__stat-value');
+      if (!totalValue) {
+        return;
+      }
+      const total = Array.from(statsContainer.querySelectorAll('[data-ticket-stat]:not([data-ticket-stat="total"])'))
+        .filter((tile) => tile.dataset.ticketStatSelected === 'true')
+        .reduce((sum, tile) => {
+          const value = Number(tile.querySelector('.stat-strip__stat-value')?.textContent || 0);
+          return sum + (Number.isFinite(value) ? value : 0);
+        }, 0);
+      totalValue.textContent = String(total);
+    }
+
+    function applySelection(selectedStatuses) {
+      const selected = new Set(selectedStatuses);
+      toggles.forEach((input) => {
+        const status = input.dataset.ticketStatToggle;
+        const isSelected = Boolean(status && selected.has(status));
+        input.checked = isSelected;
+        const tile = statsContainer.querySelector(`[data-ticket-stat="${CSS.escape(status || '')}"]`);
+        if (tile) {
+          tile.dataset.ticketStatSelected = isSelected ? 'true' : 'false';
+          tile.hidden = !isSelected;
+        }
+      });
+      updateTotal();
+    }
+
+    const defaultStatuses = toggles
+      .filter((input) => input.checked)
+      .map((input) => input.dataset.ticketStatToggle)
+      .filter(Boolean);
+    applySelection(loadSelectedStatuses(defaultStatuses));
+
+    toggleButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const isOpen = controls.classList.toggle('ticket-columns--open');
+      panel.hidden = !isOpen;
+      toggleButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!controls.contains(event.target)) {
+        closePanel();
+      }
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !panel.hidden) {
+        closePanel();
+        toggleButton.focus();
+      }
+    });
+
+    toggles.forEach((input) => {
+      input.addEventListener('change', () => {
+        const selectedStatuses = toggles
+          .filter((toggle) => toggle.checked)
+          .map((toggle) => toggle.dataset.ticketStatToggle)
+          .filter(Boolean);
+        saveSelectedStatuses(selectedStatuses);
+        applySelection(selectedStatuses);
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', initialiseStatControls);
+})();

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -524,21 +524,54 @@
               {% set status_count = ticket_status_counts.get(definition.tech_status, 0) %}
               {% if status_count > 0 %}
                 {% set visible_ticket_total.value = visible_ticket_total.value + status_count %}
-                {% set _ = ticket_stat_items.append({
+              {% endif %}
+              {% set _ = ticket_stat_items.append({
                   'label': definition.tech_label,
                   'value': status_count,
                   'variant': ticket_stat_variants.get(definition.tech_status, ['info', 'warning', 'success', 'neutral'][loop.index0 % 4]),
-                  'attrs': {'data-ticket-stat': definition.tech_status}
+                  'attrs': {
+                    'data-ticket-stat': definition.tech_status,
+                    'data-ticket-stat-selected': 'true' if status_count > 0 else 'false',
+                    'hidden': status_count <= 0,
+                  }
                 }) %}
-              {% endif %}
             {% endfor %}
-            <div data-ticket-stats>
+            <div class="ticket-dashboard__stats" data-ticket-stats>
+              <div class="ticket-stat-controls ticket-columns" data-ticket-stat-controls>
+                <button
+                  type="button"
+                  class="button button--ghost button--compact ticket-columns__toggle"
+                  data-ticket-stats-toggle
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  <span>Stats</span>
+                  <span class="ticket-columns__chevron" aria-hidden="true">▾</span>
+                </button>
+                <div class="ticket-columns__panel ticket-stat-controls__panel" data-ticket-stats-panel hidden>
+                  <p class="ticket-columns__title">Show ticket stats</p>
+                  <div class="ticket-columns__options">
+                    {% for definition in ticket_status_definitions %}
+                      {% set status_count = ticket_status_counts.get(definition.tech_status, 0) %}
+                      <label class="ticket-columns__option">
+                        <input
+                          type="checkbox"
+                          class="ticket-stat-toggle"
+                          data-ticket-stat-toggle="{{ definition.tech_status }}"
+                          {% if status_count > 0 %}checked{% endif %}
+                        />
+                        <span>{{ definition.tech_label }}</span>
+                      </label>
+                    {% endfor %}
+                  </div>
+                </div>
+              </div>
               {{ counter_strip(
                 ticket_stat_items,
                 total=visible_ticket_total.value,
                 total_label='All tickets',
                 total_attrs={'data-ticket-stat': 'total'},
-                class='ticket-dashboard__stats',
+                class='ticket-dashboard__stats-strip',
               ) }}
             </div>
 
@@ -1283,6 +1316,7 @@
   <script src="{{ static_url('/static/js/tables.js') }}" defer></script>
   <script src="{{ static_url('/static/js/ticket_views.js') }}" defer></script>
   <script src="{{ static_url('/static/js/ticket_columns.js') }}" defer></script>
+  <script src="{{ static_url('/static/js/ticket_stats.js') }}" defer></script>
   <script src="{{ static_url('/static/js/admin.js') }}" defer></script>
 
   <script>

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -45,16 +45,30 @@ def test_dashboard_controls_precede_stats_and_full_width_table():
     assert "grid-column: 1 / -1;" in css
 
 
-def test_ticket_stats_render_visible_non_zero_statuses_with_counter_strip():
-    """Ticket KPIs use the service-status treatment without exposing hidden statuses."""
+def test_ticket_stats_render_every_status_with_customisation_controls():
+    """Every configured status is available for a technician to show or hide."""
     html = _template_html()
 
     assert 'from "macros/counters.html" import counter_strip' in html
     assert "{% for definition in ticket_status_definitions %}" in html
-    assert "{% if status_count > 0 %}" in html
-    assert "'attrs': {'data-ticket-stat': definition.tech_status}" in html
+    assert 'data-ticket-stat-controls' in html
+    assert 'data-ticket-stat-toggle="{{ definition.tech_status }}"' in html
+    assert "'data-ticket-stat-selected': 'true' if status_count > 0 else 'false'" in html
+    assert "'data-ticket-stat': definition.tech_status" in html
     assert "total_label='All tickets'" in html
-    assert "class='ticket-dashboard__stats'" in html
+    assert "class='ticket-dashboard__stats-strip'" in html
+
+
+def test_ticket_stat_preferences_are_persisted_and_allow_empty_selection():
+    """A technician's chosen status tiles persist locally, including hiding all."""
+    javascript = (
+        TEMPLATE_PATH.parent.parent.parent / "static" / "js" / "ticket_stats.js"
+    ).read_text(encoding="utf-8")
+
+    assert "portal.tickets.stats" in javascript
+    assert "storedValue === null" in javascript
+    assert "saveSelectedStatuses(selectedStatuses)" in javascript
+    assert "tile.hidden = !isSelected" in javascript
 
 
 def test_ticket_stats_refresh_preserves_counter_labels():
@@ -68,6 +82,7 @@ def test_ticket_stats_refresh_preserves_counter_labels():
     update_stats = javascript[update_stats_start:update_stats_end]
     assert "element.querySelector('.stat-strip__stat-value')" in update_stats
     assert "statElements.total.querySelector('.stat-strip__stat-value')" in update_stats
+    assert "statElements[key].dataset.ticketStatSelected === 'true'" in update_stats
     assert "element.textContent =" not in update_stats
     assert "statElements.total.textContent =" not in update_stats
 


### PR DESCRIPTION
### Motivation
- Technicians need to control which ticket status KPI tiles are visible on the dashboard so they can surface statuses that are normally hidden (for example reminder statuses) or hide ones they don't care about.
- The dashboard should render every configured status as an available option and let each browser persist a technician's chosen selection.
- The global "All tickets" counter must reflect only the currently selected status tiles and remain correct across automatic refreshes.

### Description
- Render every configured status in the dashboard and add a `Stats` selector UI in `app/templates/admin/tickets.html` with per-status checkboxes and data attributes (`data-ticket-stat`, `data-ticket-stat-selected`).
- Add a new client script `app/static/js/ticket_stats.js` that persists selections to localStorage under `portal.tickets.stats`, supports toggling/hiding any status (including all hidden), and handles panel open/close and Escape/outside-click dismissal.
- Update `app/static/js/admin.js` to respect per-tile selection when hiding/showing status tiles and to compute the `All tickets` total from only the selected statuses during refreshes.
- Add CSS rules in `app/static/css/app.css` to style/position the stats selector and ensure the controls are scrollable on small viewports.
- Add/adjust tests in `tests/test_ticket_column_customisation.py` to assert presence of the controls, persistence behavior, and that refresh code preserves labels and uses the selected-status total.

### Testing
- Ran `git diff --check` with no issues.
- Ran `node --check app/static/js/ticket_stats.js` and `node --check app/static/js/admin.js`, both passed static JS checks.
- Ran `pytest -q tests/test_ticket_column_customisation.py` and the updated tests passed (`22 passed`).
- Ran broader test groups (`tests/test_ticket_portal_pages.py`, `tests/test_ticket_column_customisation.py`, `tests/test_tickets_dashboard_api.py`) during development and observed unrelated failures in a few tests caused by test startup/database state, but the ticket-stats related tests and targeted assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69d375d86c8332a6de01b0fd70752a)