### PR TITLE
Fix ticket stat visibility toggles

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10165,6 +10165,10 @@ textarea:focus-visible,
   color: inherit;
 }
 
+.stat-strip__stat[hidden] {
+  display: none;
+}
+
 a.stat-strip__stat:focus-visible {
   outline: 2px solid var(--color-accent, #38bdf8);
   outline-offset: 2px;

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -70,6 +70,11 @@ def test_ticket_stat_preferences_are_persisted_and_allow_empty_selection():
     assert "saveSelectedStatuses(selectedStatuses)" in javascript
     assert "tile.hidden = !isSelected" in javascript
 
+    css = (
+        TEMPLATE_PATH.parent.parent.parent / "static" / "css" / "app.css"
+    ).read_text(encoding="utf-8")
+    assert ".stat-strip__stat[hidden] {\n  display: none;\n}" in css
+
 
 def test_ticket_stats_refresh_preserves_counter_labels():
     """Refreshing counts updates values without replacing each complete stat tile."""


### PR DESCRIPTION
### Motivation

- Technician toggles were only adjusting the "All tickets" count while tiles remained in the stat strip layout, causing hidden selections to still occupy space.

### Description

- Add a CSS rule in `app/static/css/app.css` to ensure elements matching `.stat-strip__stat[hidden]` are removed from layout with `display: none;`.
- Add regression coverage in `tests/test_ticket_column_customisation.py` to assert the CSS rule exists and that the JavaScript persists and toggles the tile `hidden` state.
- Changes affect `app/static/css/app.css` and `tests/test_ticket_column_customisation.py` only.

### Testing

- Ran `pytest -q tests/test_ticket_column_customisation.py` and all tests passed (`22 passed`).
- Verified the new test asserts the presence of the `.stat-strip__stat[hidden] {\n  display: none;\n}` rule and the JS behavior that sets `tile.hidden = !isSelected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69d641e8ac83328079a051f78c13e6)