### PR TITLE
Prevent Solidtime sync attempts when module is disabled

### DIFF
--- a/app/services/solidtime.py
+++ b/app/services/solidtime.py
@@ -1467,6 +1467,14 @@ def schedule_ticket_sync(ticket_id: int) -> None:
         settings_snapshot: Mapping[str, Any] | None = None
         try:
             settings_snapshot = await _load_module_settings()
+            if settings_snapshot is not None and not bool(
+                settings_snapshot.get("enabled")
+            ):
+                log_info(
+                    "Solidtime ticket sync not scheduled because module is disabled",
+                    ticket_id=ticket_id,
+                )
+                return
             result = await sync_ticket_to_project(int(ticket_id))
             reason = _ticket_sync_outcome_reason(
                 settings=settings_snapshot, sync_result=result

--- a/tests/test_solidtime.py
+++ b/tests/test_solidtime.py
@@ -768,7 +768,7 @@ async def test_sync_ticket_logs_reason_when_ticket_push_toggle_off(
 
 
 @pytest.mark.anyio
-async def test_schedule_ticket_sync_records_skipped_outcome_when_module_disabled(
+async def test_schedule_ticket_sync_does_not_create_webhook_when_module_disabled(
     reset_solidtime_caches,
 ):
     async def fake_get_module(slug):
@@ -782,41 +782,21 @@ async def test_schedule_ticket_sync_records_skipped_outcome_when_module_disabled
 
     reset_solidtime_caches.setattr(solidtime.module_repo, "get_module", fake_get_module)
 
-    created_events: list[dict[str, object]] = []
-    failure_records: list[dict[str, object]] = []
-    completion_event = asyncio.Event()
-
     async def fake_create_manual_event(**kwargs):
-        created_events.append(kwargs)
-        return {"id": 901}
+        pytest.fail("disabled Solidtime module created a webhook event")
 
-    async def fake_record_manual_success(event_id, **kwargs):
-        return {"id": event_id, **kwargs}
-
-    async def fake_record_manual_failure(event_id, **kwargs):
-        failure_records.append({"event_id": event_id, **kwargs})
-        completion_event.set()
-        return {"id": event_id, **kwargs}
+    async def fake_sync_ticket_to_project(ticket_id):
+        pytest.fail("disabled Solidtime module attempted to sync a ticket")
 
     reset_solidtime_caches.setattr(
         solidtime.webhook_monitor, "create_manual_event", fake_create_manual_event
     )
     reset_solidtime_caches.setattr(
-        solidtime.webhook_monitor, "record_manual_success", fake_record_manual_success
-    )
-    reset_solidtime_caches.setattr(
-        solidtime.webhook_monitor, "record_manual_failure", fake_record_manual_failure
+        solidtime, "sync_ticket_to_project", fake_sync_ticket_to_project
     )
 
     solidtime.schedule_ticket_sync(77)
-    await asyncio.wait_for(completion_event.wait(), timeout=1.0)
-
-    assert created_events
-    assert created_events[0]["name"] == "solidtime.ticket.sync"
-    assert failure_records
-    assert failure_records[0]["event_id"] == 901
-    assert failure_records[0]["status"] == "skipped"
-    assert "disabled" in str(failure_records[0]["error_message"]).lower()
+    await asyncio.gather(*solidtime._BACKGROUND_TASKS)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- Stop Solidtime from attempting ticket syncs (and creating webhook-monitor events) when the integration module is disabled so we don't produce misleading failures or make unnecessary API calls.

### Description
- Add an early check inside `schedule_ticket_sync` to bail out and emit a `log_info` when the module settings are present but `enabled` is false, preventing `sync_ticket_to_project` from being invoked. (`app/services/solidtime.py`)
- Update regression test to assert that no webhook event is created and no sync is attempted for a disabled Solidtime module by making `create_manual_event` and `sync_ticket_to_project` fail the test if called, and awaiting background tasks. (`tests/test_solidtime.py`)

### Testing
- Ran `python -m pytest -q tests/test_solidtime.py` and observed the Solidtime tests pass (42 passed).
- Verified the change prevents both the sync call and webhook event creation in the updated regression test.
- Note: running the project tests from the bundled virtualenv failed due to a missing `aiosqlite` dependency in that environment, while the system Python test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69d7d963e0833292abef5e59cc028d)