### PR TITLE
Hide zero-value ticket status stats

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1131,7 +1131,7 @@
         }
         const tile = element.closest('.stat-strip__stat');
         if (tile) {
-          tile.hidden = tile.dataset.ticketStatSelected !== 'true';
+          tile.hidden = tile.dataset.ticketStatSelected !== 'true' || !Number.isFinite(value) || value === 0;
         }
       });
       if (statElements.total) {

--- a/app/static/js/ticket_stats.js
+++ b/app/static/js/ticket_stats.js
@@ -70,7 +70,8 @@
         const tile = statsContainer.querySelector(`[data-ticket-stat="${CSS.escape(status || '')}"]`);
         if (tile) {
           tile.dataset.ticketStatSelected = isSelected ? 'true' : 'false';
-          tile.hidden = !isSelected;
+          const value = Number(tile.querySelector('.stat-strip__stat-value')?.textContent || 0);
+          tile.hidden = !isSelected || !Number.isFinite(value) || value === 0;
         }
       });
       updateTotal();

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -59,8 +59,8 @@ def test_ticket_stats_render_every_status_with_customisation_controls():
     assert "class='ticket-dashboard__stats-strip'" in html
 
 
-def test_ticket_stat_preferences_are_persisted_and_allow_empty_selection():
-    """A technician's chosen status tiles persist locally, including hiding all."""
+def test_ticket_stat_preferences_are_persisted_and_zero_counts_stay_hidden():
+    """Saved status choices persist, but a selected status with no tickets stays hidden."""
     javascript = (
         TEMPLATE_PATH.parent.parent.parent / "static" / "js" / "ticket_stats.js"
     ).read_text(encoding="utf-8")
@@ -68,7 +68,7 @@ def test_ticket_stat_preferences_are_persisted_and_allow_empty_selection():
     assert "portal.tickets.stats" in javascript
     assert "storedValue === null" in javascript
     assert "saveSelectedStatuses(selectedStatuses)" in javascript
-    assert "tile.hidden = !isSelected" in javascript
+    assert "tile.hidden = !isSelected || !Number.isFinite(value) || value === 0" in javascript
 
     css = (
         TEMPLATE_PATH.parent.parent.parent / "static" / "css" / "app.css"
@@ -90,6 +90,21 @@ def test_ticket_stats_refresh_preserves_counter_labels():
     assert "statElements[key].dataset.ticketStatSelected === 'true'" in update_stats
     assert "element.textContent =" not in update_stats
     assert "statElements.total.textContent =" not in update_stats
+
+
+def test_ticket_stats_refresh_hides_zero_count_statuses():
+    """A refresh automatically hides selected status tiles when their count reaches zero."""
+    javascript = (
+        TEMPLATE_PATH.parent.parent.parent / "static" / "js" / "admin.js"
+    ).read_text(encoding="utf-8")
+
+    update_stats_start = javascript.index("function updateStats(counts)")
+    update_stats_end = javascript.index("function formatReviewDate", update_stats_start)
+    update_stats = javascript[update_stats_start:update_stats_end]
+    assert (
+        "tile.dataset.ticketStatSelected !== 'true' || !Number.isFinite(value) || value === 0"
+        in update_stats
+    )
 
 
 def test_ticket_stats_refresh_uses_global_status_total():


### PR DESCRIPTION
### Motivation
- The ticket stats UI should not show status tiles that have a value of zero even if the user has them selected, to simplify the view.
- Live dashboard refreshes must keep zero-count statuses hidden while preserving the user’s saved selection.

### Description
- In `app/static/js/ticket_stats.js` updated `applySelection` to hide a status tile when its displayed numeric value is `0` or non-finite in addition to being deselected by the user.
- In `app/static/js/admin.js` updated `updateStats` to hide a status tile after a refresh when the refreshed count is `0` or non-finite while still respecting the saved selection flag `data-ticket-stat-selected`.
- Updated `tests/test_ticket_column_customisation.py` to reflect the new behaviour by renaming one assertion test and adding a new test `test_ticket_stats_refresh_hides_zero_count_statuses` that verifies refreshed zero-count statuses are hidden.

### Testing
- Ran `pytest -q tests/test_ticket_column_customisation.py` and all tests passed (`23 passed`).
- Verified the diffs and lint checks with `git diff --check` and confirmed the working tree was clean after committing the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69d84a9f9c8332b42bf6ccd24d9300)