### PR TITLE
Fix cron calendar event duration

### DIFF
--- a/app/static/js/cron_calendar.js
+++ b/app/static/js/cron_calendar.js
@@ -3,7 +3,6 @@
   if (!root) return;
 
   const DISPLAY_MINUTES = 1;
-  const VISUAL_DURATION_MINUTES = 6;
   const MINUTE_SLOTS_PER_HOUR = 60;
   const MINUTE_SLOT_HEIGHT = 6;
   const DAY_START_HOUR = 0;
@@ -33,17 +32,13 @@
     return sorted.map(event => {
       const startsAt = new Date(event.start);
       const endsAt = new Date(startsAt.getTime() + DISPLAY_MINUTES * 60000);
-      const visualEndsAt = new Date(startsAt.getTime() + VISUAL_DURATION_MINUTES * 60000);
       for (let idx = active.length - 1; idx >= 0; idx -= 1) {
         if (active[idx].end <= startsAt) active.splice(idx, 1);
       }
-      // The timeline uses one vertical slot per minute.  Events are visually
-      // taller than one minute so titles remain readable, so keep nearby
-      // entries active for their rendered height to prevent visual overlap.
       const usedColumns = new Set(active.map(item => item.column));
       let column = 0;
       while (usedColumns.has(column)) column += 1;
-      const entry = { event, startsAt, endsAt, end: visualEndsAt, column, clusterSize: column + 1 };
+      const entry = { event, startsAt, endsAt, end: endsAt, column, clusterSize: column + 1 };
       active.push(entry);
       const clusterSize = Math.max(...active.map(item => item.column), column) + 1;
       active.forEach(item => { item.clusterSize = Math.max(item.clusterSize, clusterSize); });
@@ -123,7 +118,7 @@
         return `<div class="cron-calendar__day-column${isSameDay(day, now) ? ' is-today' : ''}">${items.map(item => {
           const { event, startsAt, endsAt, column, clusterSize } = item;
           const top = Math.max(0, Math.min(timelineHeight - MINUTE_SLOT_HEIGHT, (minutesSinceStart(startsAt) / 60) * HOUR_HEIGHT));
-          const height = Math.max(MINUTE_SLOT_HEIGHT, (VISUAL_DURATION_MINUTES / 60) * HOUR_HEIGHT);
+          const height = (DISPLAY_MINUTES / 60) * HOUR_HEIGHT;
           const width = `calc(${100 / clusterSize}% - .3rem)`;
           const left = `calc(${(100 / clusterSize) * column}% + .15rem)`;
           return `<a class="cron-calendar__timeline-event" href="${escapeHtml(event.url)}" style="top:${top}px;height:${height}px;left:${left};width:${width}" title="${escapeHtml(event.title)} ${formatTime(startsAt)} - ${formatTime(endsAt)}">


### PR DESCRIPTION
### Motivation
- The timeline view rendered scheduled runs taller than their actual one-minute duration which caused adjacent minute-by-minute events to appear to overlap and reduced usable horizontal space.

### Description
- Update `app/static/js/cron_calendar.js` to stop using the inflated visual duration and set each event's `end` to its real `endsAt` value so overlap calculations use the actual run end time.
- Compute rendered event height from `DISPLAY_MINUTES` (one minute) instead of the previous visual duration so timeline entries occupy exactly the one-minute slot.

### Testing
- Ran `node --check app/static/js/cron_calendar.js` with no syntax errors.
- Ran `pytest -q tests/test_cron_calendar.py` and all tests passed (`6 passed`).
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69d9d29730833284e4b46688846ec3)