### PR TITLE
Fix admin ticket column filter backgrounds

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2365,7 +2365,7 @@ button.header-title-menu__link,
 }
 
 .ticket-column-filter__panel {
-  background: var(--color-surface, #fff);
+  background: var(--color-surface-2, #0f172a);
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   box-shadow: 0 0.75rem 1.75rem rgb(15 23 42 / 18%);

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -201,6 +201,14 @@ def test_status_filter_panel_has_an_opaque_background():
     assert "background: var(--color-surface-2, #0f172a);" in panel_rule
 
 
+def test_column_filter_panels_match_the_status_filter_background():
+    """Every floating column filter should use the status menu surface colour."""
+    css = (TEMPLATE_PATH.parent.parent.parent / "static" / "css" / "app.css").read_text(encoding="utf-8")
+    panel_rule = css[css.index(".ticket-column-filter__panel {"):]
+    panel_rule = panel_rule[:panel_rule.index("}")]
+    assert "background: var(--color-surface-2, #0f172a);" in panel_rule
+
+
 def test_table_cell_data_column_attributes():
     """Table <td> elements for customisable columns should carry data-column."""
     html = _template_html()


### PR DESCRIPTION
### Motivation

- Column filter dropdowns in the admin tickets list used a different, semi-transparent background than the Status filter which reduced readability; the change makes all floating ticket column filter panels share the same opaque surface colour as the Status filter.

### Description

- Update `app/static/css/app.css` to set `.ticket-column-filter__panel` background to `var(--color-surface-2, #0f172a)` so it matches the Status filter surface.
- Add a regression test `test_column_filter_panels_match_the_status_filter_background` to `tests/test_ticket_column_customisation.py` that verifies the column filter panel uses the same `--color-surface-2` background as the status menu.

### Testing

- Ran `pytest -q tests/test_ticket_column_customisation.py` and all tests passed (`24 passed`).
- Verified the CSS rule is present in `app/static/css/app.css` and the new test asserts the expected background property.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69dbe40ff883328ccffeb680dd7d57)