### PR TITLE
Redesign cron calendar as an accessible schedule board

### DIFF
--- a/app/static/js/cron_calendar.js
+++ b/app/static/js/cron_calendar.js
@@ -2,12 +2,8 @@
   const root = document.querySelector('[data-cron-calendar]');
   if (!root) return;
 
-  const DISPLAY_MINUTES = 1;
-  const MINUTE_SLOTS_PER_HOUR = 60;
-  const MINUTE_SLOT_HEIGHT = 6;
-  const DAY_START_HOUR = 0;
-  const DAY_END_HOUR = 24;
-  const HOUR_HEIGHT = MINUTE_SLOTS_PER_HOUR * MINUTE_SLOT_HEIGHT;
+  const RUN_DURATION_MINUTES = 1;
+  const MIN_AVAILABLE_MINUTES = 15;
   const state = { view: 'week', anchor: new Date(), events: [], search: '', includeInactive: false };
   const grid = root.querySelector('[data-calendar-grid]');
   const rangeLabel = root.querySelector('[data-calendar-range]');
@@ -16,34 +12,18 @@
   const searchInput = root.querySelector('[data-calendar-search]');
   const inactiveInput = root.querySelector('[data-calendar-inactive]');
 
-  function startOfDay(date) { const d = new Date(date); d.setHours(0, 0, 0, 0); return d; }
-  function addDays(date, days) { const d = new Date(date); d.setDate(d.getDate() + days); return d; }
-  function startOfWeek(date) { const d = startOfDay(date); d.setDate(d.getDate() - d.getDay()); return d; }
-  function escapeHtml(value) { return String(value || '').replace(/[&<>'"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;',"'":'&#39;','"':'&quot;'}[c])); }
-  function formatDate(date, opts) { return new Intl.DateTimeFormat(undefined, opts).format(date); }
-  function formatTime(date) { return new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' }).format(date); }
-  function formatHour(hour) { const d = new Date(); d.setHours(hour, 0, 0, 0); return new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).format(d).replace(' ', ''); }
-  function minutesSinceStart(date) { return (date.getHours() - DAY_START_HOUR) * 60 + date.getMinutes(); }
+  function startOfDay(date) { const result = new Date(date); result.setHours(0, 0, 0, 0); return result; }
+  function addDays(date, days) { const result = new Date(date); result.setDate(result.getDate() + days); return result; }
+  function startOfWeek(date) { const result = startOfDay(date); result.setDate(result.getDate() - result.getDay()); return result; }
+  function escapeHtml(value) { return String(value || '').replace(/[&<>'"]/g, char => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' }[char])); }
+  function formatDate(date, options) { return new Intl.DateTimeFormat(undefined, options).format(date); }
+  function formatTime(date) { return new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(date); }
   function isSameDay(left, right) { return startOfDay(left).getTime() === startOfDay(right).getTime(); }
-
-  function layoutTimelineEvents(events) {
-    const sorted = [...events].sort((left, right) => new Date(left.start) - new Date(right.start));
-    const active = [];
-    return sorted.map(event => {
-      const startsAt = new Date(event.start);
-      const endsAt = new Date(startsAt.getTime() + DISPLAY_MINUTES * 60000);
-      for (let idx = active.length - 1; idx >= 0; idx -= 1) {
-        if (active[idx].end <= startsAt) active.splice(idx, 1);
-      }
-      const usedColumns = new Set(active.map(item => item.column));
-      let column = 0;
-      while (usedColumns.has(column)) column += 1;
-      const entry = { event, startsAt, endsAt, end: endsAt, column, clusterSize: column + 1 };
-      active.push(entry);
-      const clusterSize = Math.max(...active.map(item => item.column), column) + 1;
-      active.forEach(item => { item.clusterSize = Math.max(item.clusterSize, clusterSize); });
-      return entry;
-    });
+  function durationLabel(minutes) {
+    if (minutes < 60) return `${minutes} min`;
+    const hours = Math.floor(minutes / 60);
+    const remainder = minutes % 60;
+    return remainder ? `${hours} hr ${remainder} min` : `${hours} hr`;
   }
 
   function rangeForView() {
@@ -60,8 +40,9 @@
 
   function updateRangeLabel() {
     const { start, end } = rangeForView();
-    if (state.view === 'day') rangeLabel.textContent = formatDate(start, { dateStyle: 'medium' });
-    else rangeLabel.textContent = `${formatDate(start, { month: 'short', day: 'numeric' })} - ${formatDate(addDays(end, -1), { month: 'short', day: 'numeric', year: 'numeric' })}`;
+    rangeLabel.textContent = state.view === 'day'
+      ? formatDate(start, { dateStyle: 'full' })
+      : `${formatDate(start, { month: 'short', day: 'numeric' })} – ${formatDate(addDays(end, -1), { month: 'short', day: 'numeric', year: 'numeric' })}`;
   }
 
   async function loadEvents() {
@@ -90,64 +71,62 @@
 
   function eventHtml(event) {
     const startsAt = new Date(event.start);
-    const endsAt = new Date(startsAt.getTime() + DISPLAY_MINUTES * 60000);
     return `<a class="cron-calendar__event" href="${escapeHtml(event.url)}">
-      <strong>${escapeHtml(event.title)}</strong>
-      <span class="cron-calendar__event-meta"><span>${formatTime(startsAt)} - ${formatTime(endsAt)}</span><span>${escapeHtml(event.companyName)}</span><code>${escapeHtml(event.cron)}</code><span>${escapeHtml(event.command)}</span>${event.active ? '' : '<span>Inactive</span>'}</span>
+      <time datetime="${escapeHtml(startsAt.toISOString())}">${formatTime(startsAt)}</time>
+      <span class="cron-calendar__event-body"><strong>${escapeHtml(event.title)}</strong><span>${escapeHtml(event.companyName || 'All companies')} · <code>${escapeHtml(event.cron)}</code></span><small>${escapeHtml(event.command)}</small></span>
+      ${event.active ? '<span class="cron-calendar__badge">Scheduled</span>' : '<span class="cron-calendar__badge cron-calendar__badge--inactive">Inactive</span>'}
     </a>`;
   }
 
-  function renderPeriod(label, events) {
-    return `<section class="cron-calendar__period"><div class="cron-calendar__period-header">${escapeHtml(label)}</div><div class="cron-calendar__events">${events.length ? events.map(eventHtml).join('') : '<p class="cron-calendar__empty">No scheduled runs.</p>'}</div></section>`;
+  function availabilityHtml(start, end) {
+    const minutes = Math.floor((end - start) / 60000);
+    if (minutes < MIN_AVAILABLE_MINUTES) return '';
+    return `<div class="cron-calendar__availability"><span class="cron-calendar__availability-icon" aria-hidden="true">✓</span><span><strong>Available</strong><small>${formatTime(start)} – ${formatTime(end)} · ${durationLabel(minutes)}</small></span></div>`;
   }
 
-  function renderTimeline(days) {
-    const events = filteredEvents();
-    const totalHours = DAY_END_HOUR - DAY_START_HOUR;
-    const timelineHeight = totalHours * HOUR_HEIGHT;
-    const dayList = Array.from({ length: days }, (_, idx) => addDays(days === 7 ? startOfWeek(state.anchor) : startOfDay(state.anchor), idx));
-    const now = new Date();
-    countLabel.textContent = String(events.length);
-    grid.className = `cron-calendar__grid cron-calendar__grid--timeline cron-calendar__grid--${state.view}`;
-    grid.innerHTML = `<div class="cron-calendar__timeline" style="--calendar-hour-height:${HOUR_HEIGHT}px;--calendar-timeline-height:${timelineHeight}px">
-      <div class="cron-calendar__corner" aria-hidden="true"></div>
-      <div class="cron-calendar__day-headings">${dayList.map(day => `<div class="cron-calendar__day-heading${isSameDay(day, now) ? ' is-today' : ''}"><span>${formatDate(day, { weekday: 'short' })}</span><strong>${formatDate(day, { day: '2-digit' })}</strong></div>`).join('')}</div>
-      <div class="cron-calendar__time-axis">${Array.from({ length: totalHours }, (_, idx) => `<span>${formatHour(DAY_START_HOUR + idx)}</span>`).join('')}</div>
-      <div class="cron-calendar__day-columns">${dayList.map(day => {
-        const items = layoutTimelineEvents(events.filter(event => isSameDay(new Date(event.start), day)));
-        return `<div class="cron-calendar__day-column${isSameDay(day, now) ? ' is-today' : ''}">${items.map(item => {
-          const { event, startsAt, endsAt, column, clusterSize } = item;
-          const top = Math.max(0, Math.min(timelineHeight - MINUTE_SLOT_HEIGHT, (minutesSinceStart(startsAt) / 60) * HOUR_HEIGHT));
-          const height = (DISPLAY_MINUTES / 60) * HOUR_HEIGHT;
-          const width = `calc(${100 / clusterSize}% - .3rem)`;
-          const left = `calc(${(100 / clusterSize) * column}% + .15rem)`;
-          return `<a class="cron-calendar__timeline-event" href="${escapeHtml(event.url)}" style="top:${top}px;height:${height}px;left:${left};width:${width}" title="${escapeHtml(event.title)} ${formatTime(startsAt)} - ${formatTime(endsAt)}">
-            <strong>${escapeHtml(event.title)}</strong><span>${formatTime(startsAt)} - ${formatTime(endsAt)}</span>
-          </a>`;
-        }).join('')}</div>`;
-      }).join('')}</div>
-    </div>`;
+  function dayHtml(day, events, showAvailability) {
+    const sorted = [...events].sort((left, right) => new Date(left.start) - new Date(right.start));
+    let schedule = '';
+    let cursor = startOfDay(day);
+    const dayEnd = addDays(cursor, 1);
+    sorted.forEach(event => {
+      const startsAt = new Date(event.start);
+      if (showAvailability) schedule += availabilityHtml(cursor, startsAt);
+      schedule += eventHtml(event);
+      cursor = new Date(Math.max(cursor.getTime(), startsAt.getTime() + RUN_DURATION_MINUTES * 60000));
+    });
+    if (showAvailability) schedule += availabilityHtml(cursor, dayEnd);
+    if (!schedule) schedule = '<p class="cron-calendar__empty">No scheduled runs.</p>';
+    const today = isSameDay(day, new Date());
+    return `<section class="cron-calendar__day${today ? ' is-today' : ''}">
+      <header class="cron-calendar__day-header"><div><span>${formatDate(day, { weekday: 'long' })}</span><strong>${formatDate(day, { month: 'short', day: 'numeric' })}</strong></div><span class="cron-calendar__run-count">${sorted.length} ${sorted.length === 1 ? 'run' : 'runs'}</span></header>
+      <div class="cron-calendar__schedule">${schedule}</div>
+    </section>`;
   }
 
   function render() {
     const events = filteredEvents();
-    if (state.view === 'day' || state.view === 'week') { renderTimeline(state.view === 'week' ? 7 : 1); return; }
+    const { start, end } = rangeForView();
+    const numberOfDays = Math.round((end - start) / 86400000);
+    const days = Array.from({ length: numberOfDays }, (_, index) => addDays(start, index));
     countLabel.textContent = String(events.length);
     grid.className = `cron-calendar__grid cron-calendar__grid--${state.view}`;
-    const byDay = new Map();
-    events.forEach(event => {
-      const key = formatDate(new Date(event.start), { dateStyle: 'full' });
-      byDay.set(key, [...(byDay.get(key) || []), event]);
-    });
-    grid.innerHTML = byDay.size ? Array.from(byDay.entries()).map(([label, items]) => renderPeriod(label, items)).join('') : renderPeriod('Upcoming 30 days', []);
+    grid.innerHTML = days.map(day => dayHtml(day, events.filter(event => isSameDay(new Date(event.start), day)), state.view !== 'list')).join('');
   }
 
   document.querySelectorAll('[data-calendar-view]').forEach(button => {
     const active = button.dataset.calendarView === state.view;
-    button.classList.toggle('button--primary', active); button.classList.toggle('button--ghost', !active);
+    button.classList.toggle('button--primary', active);
+    button.classList.toggle('button--ghost', !active);
+    button.setAttribute('aria-pressed', String(active));
     button.addEventListener('click', () => {
       state.view = button.dataset.calendarView;
-      document.querySelectorAll('[data-calendar-view]').forEach(btn => { btn.classList.toggle('button--primary', btn === button); btn.classList.toggle('button--ghost', btn !== button); });
+      document.querySelectorAll('[data-calendar-view]').forEach(item => {
+        const selected = item === button;
+        item.classList.toggle('button--primary', selected);
+        item.classList.toggle('button--ghost', !selected);
+        item.setAttribute('aria-pressed', String(selected));
+      });
       loadEvents();
     });
   });

--- a/app/templates/admin/cron_calendar.html
+++ b/app/templates/admin/cron_calendar.html
@@ -3,47 +3,32 @@
 
 {% block header_actions %}
   <a class="button button--ghost" href="/admin/scheduled-tasks">Manage scheduled tasks</a>
-  <div class="button-group" role="group" aria-label="Calendar views">
-    <button class="button button--ghost" type="button" data-calendar-view="day">Day</button>
-    <button class="button button--primary" type="button" data-calendar-view="week">Week</button>
-    <button class="button button--ghost" type="button" data-calendar-view="list">List</button>
-  </div>
 {% endblock %}
 
 {% block content %}
 <div class="management management--single cron-calendar" data-cron-calendar>
   <section class="management__content">
-    <header class="management__header">
+    <header class="management__header cron-calendar__intro">
       <div>
+        <p class="cron-calendar__eyebrow">Automation schedule</p>
         <h1 class="management__title">Cron Calendar</h1>
-        <p class="management__subtitle">Review upcoming scheduled task runs in your local timezone before planning new automation windows.</p>
+        <p class="management__subtitle">See every task by name and find clear gaps for new automation. Times use your browser timezone.</p>
       </div>
-      <form class="management__filters" data-calendar-filters>
-        <label class="form-field">
-          <span class="form-label">Filter</span>
-          <input class="form-input" type="search" placeholder="Task, command, company, cron" data-calendar-search />
-        </label>
-        <label class="form-checkbox-label">
-          <input class="form-checkbox" type="checkbox" data-calendar-inactive />
-          <span class="form-checkbox-text">Show inactive tasks</span>
-        </label>
+      <form class="management__filters" data-calendar-filters onsubmit="return false">
+        <label class="form-field"><span class="form-label">Find a task</span><input class="form-input" type="search" placeholder="Name, command, company, or cron" data-calendar-search /></label>
+        <label class="form-checkbox-label"><input class="form-checkbox" type="checkbox" data-calendar-inactive /><span class="form-checkbox-text">Show inactive tasks</span></label>
       </form>
     </header>
 
     <div class="card card--panel cron-calendar__toolbar">
-      <div class="cron-calendar__nav">
-        <button class="button button--ghost" type="button" data-calendar-prev>Previous</button>
-        <button class="button button--ghost" type="button" data-calendar-today>Today</button>
-        <button class="button button--ghost" type="button" data-calendar-next>Next</button>
-      </div>
-      <div>
-        <h2 class="card__title" data-calendar-range>Loading…</h2>
-        <p class="card__subtitle"><span data-calendar-count>0</span> scheduled task runs shown. Times are scheduled in the configured CRON_TIMEZONE and displayed in your browser timezone.</p>
-      </div>
+      <div class="cron-calendar__nav"><button class="button button--ghost" type="button" data-calendar-prev aria-label="Previous period">←</button><button class="button button--ghost" type="button" data-calendar-today>Today</button><button class="button button--ghost" type="button" data-calendar-next aria-label="Next period">→</button></div>
+      <div class="cron-calendar__range"><h2 class="card__title" data-calendar-range>Loading…</h2><p class="card__subtitle"><strong data-calendar-count>0</strong> scheduled runs</p></div>
+      <div class="button-group" role="group" aria-label="Calendar views"><button class="button button--ghost" type="button" data-calendar-view="day">Day</button><button class="button button--primary" type="button" data-calendar-view="week">Week</button><button class="button button--ghost" type="button" data-calendar-view="list">30 days</button></div>
     </div>
 
+    <div class="cron-calendar__legend" aria-label="Schedule legend"><span><i class="cron-calendar__legend-run"></i> Scheduled run</span><span><i class="cron-calendar__legend-free"></i> Available window (15+ minutes)</span></div>
     <div class="card card--panel cron-calendar__status" data-calendar-status hidden></div>
-    <div class="cron-calendar__grid" data-calendar-grid aria-live="polite"></div>
+    <div class="cron-calendar__grid" data-calendar-grid aria-live="polite" aria-busy="false"></div>
   </section>
 </div>
 {% endblock %}
@@ -53,34 +38,43 @@
   .button-group { display: inline-flex; gap: .35rem; flex-wrap: wrap; }
   .cron-calendar { min-height: 0; }
   .cron-calendar .management__content { min-height: 0; }
-  .cron-calendar__toolbar { display: flex; justify-content: space-between; gap: 1rem; align-items: center; margin-bottom: 1rem; }
-  .cron-calendar__nav { display: flex; gap: .5rem; flex-wrap: wrap; }
-  .cron-calendar__grid { display: grid; gap: .75rem; max-height: calc(100vh - 18rem); min-height: 24rem; overflow: auto; }
-  .cron-calendar__period { border: 1px solid var(--border-color, #d8dee9); border-radius: .75rem; background: var(--surface-color, #fff); min-height: 8rem; overflow: hidden; }
-  .cron-calendar__period-header { padding: .65rem .85rem; font-weight: 700; background: var(--surface-muted, #f8fafc); border-bottom: 1px solid var(--border-color, #d8dee9); }
-  .cron-calendar__events { display: grid; gap: .5rem; padding: .65rem; }
-  .cron-calendar__event { display: grid; gap: .25rem; border-left: .25rem solid var(--primary-color, #2563eb); padding: .55rem .65rem; background: color-mix(in srgb, var(--primary-color, #2563eb) 8%, #ffffff); border-radius: .5rem; text-decoration: none; color: var(--cron-calendar-event-text, #0f172a); }
-  .cron-calendar__event strong { color: var(--cron-calendar-event-title, #0f172a); }
-  .cron-calendar__event-meta { display: flex; gap: .5rem; flex-wrap: wrap; font-size: .82rem; color: var(--cron-calendar-event-muted, #475569); }
-  .cron-calendar__event-meta code { color: var(--cron-calendar-event-code, #334155); }
-  .cron-calendar__empty { padding: 1rem; color: var(--text-muted, #64748b); }
-  .cron-calendar__grid--list { grid-template-columns: 1fr; }
-  .cron-calendar__grid--timeline { display: block; border: 1px solid var(--border-color, #d8dee9); border-radius: .85rem; background: var(--surface-color, #fff); overflow: auto; }
-  .cron-calendar__timeline { display: grid; grid-template-columns: 4.5rem minmax(78rem, 1fr); grid-template-rows: 3rem var(--calendar-timeline-height); min-width: 84rem; }
-  .cron-calendar__corner { position: sticky; left: 0; top: 0; z-index: 5; background: var(--surface-color, #fff); border-right: 1px solid var(--border-color, #d8dee9); border-bottom: 1px solid var(--border-color, #d8dee9); }
-  .cron-calendar__day-headings { position: sticky; top: 0; z-index: 4; display: grid; grid-auto-columns: minmax(14rem, 1fr); grid-auto-flow: column; background: var(--surface-color, #fff); border-bottom: 1px solid var(--border-color, #d8dee9); }
-  .cron-calendar__day-heading { display: inline-flex; align-items: center; justify-content: center; gap: .4rem; border-right: 1px solid var(--border-color, #d8dee9); color: var(--text-muted, #64748b); font-size: .78rem; text-transform: uppercase; }
-  .cron-calendar__day-heading strong { display: inline-grid; min-width: 1.45rem; min-height: 1.45rem; place-items: center; border-radius: 999px; color: var(--text-color, #111827); }
-  .cron-calendar__day-heading.is-today strong { color: #fff; background: var(--primary-color, #2563eb); }
-  .cron-calendar__time-axis { position: sticky; left: 0; z-index: 3; display: grid; grid-template-rows: repeat(24, var(--calendar-hour-height)); background: var(--surface-color, #fff); border-right: 1px solid var(--border-color, #d8dee9); }
-  .cron-calendar__time-axis span { transform: translateY(-.45rem); padding-right: .5rem; text-align: right; color: var(--text-muted, #64748b); font-size: .78rem; }
-  .cron-calendar__day-columns { display: grid; grid-auto-columns: minmax(14rem, 1fr); grid-auto-flow: column; min-height: var(--calendar-timeline-height); background-image: repeating-linear-gradient(to bottom, transparent 0, transparent calc(var(--calendar-hour-height) - 1px), var(--border-color, #d8dee9) calc(var(--calendar-hour-height) - 1px), var(--border-color, #d8dee9) var(--calendar-hour-height)); }
-  .cron-calendar__day-column { position: relative; border-right: 1px solid var(--border-color, #d8dee9); min-height: var(--calendar-timeline-height); }
-  .cron-calendar__day-column.is-today { background: color-mix(in srgb, var(--primary-color, #2563eb) 4%, transparent); }
-  .cron-calendar__timeline-event { position: absolute; left: .15rem; width: calc(100% - .3rem); display: grid; align-content: start; gap: .1rem; overflow: hidden; border-left: .2rem solid var(--accent-color, #ec4899); border-radius: .35rem; padding: .25rem .4rem; background: color-mix(in srgb, var(--surface-muted, #f1f5f9) 90%, var(--primary-color, #2563eb)); box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-color, #d8dee9) 70%, transparent); color: var(--text-color, #111827); font-size: .78rem; line-height: 1.2; text-decoration: none; }
-  .cron-calendar__timeline-event strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .cron-calendar__timeline-event span { color: var(--text-muted, #64748b); }
-  @media (max-width: 900px) { .cron-calendar__toolbar { align-items: stretch; flex-direction: column; } .cron-calendar__timeline { grid-template-columns: 3.75rem minmax(42rem, 1fr); min-width: 46rem; } }
+  .cron-calendar__intro { align-items: end; }
+  .cron-calendar__eyebrow { margin: 0 0 .25rem; color: var(--primary-color, #2563eb); font-size: .75rem; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+  .cron-calendar__toolbar { display: grid; grid-template-columns: auto 1fr auto; gap: 1rem; align-items: center; margin-bottom: .75rem; }
+  .cron-calendar__nav { display: flex; gap: .4rem; }
+  .cron-calendar__range { text-align: center; }
+  .cron-calendar__range h2, .cron-calendar__range p { margin: 0; }
+  .cron-calendar__legend { display: flex; gap: 1.25rem; margin: 0 0 .75rem; color: var(--text-muted, #64748b); font-size: .8rem; }
+  .cron-calendar__legend span { display: inline-flex; align-items: center; gap: .4rem; }
+  .cron-calendar__legend i { width: .7rem; height: .7rem; border-radius: .2rem; }
+  .cron-calendar__legend-run { background: var(--primary-color, #2563eb); }
+  .cron-calendar__legend-free { border: 1px dashed #22a06b; background: color-mix(in srgb, #22a06b 10%, transparent); }
+  .cron-calendar__grid { display: grid; grid-template-columns: repeat(7, minmax(15rem, 1fr)); gap: .75rem; overflow-x: auto; padding-bottom: .5rem; }
+  .cron-calendar__grid--day { grid-template-columns: minmax(20rem, 52rem); justify-content: center; }
+  .cron-calendar__grid--list { grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr)); }
+  .cron-calendar__day { overflow: hidden; min-width: 0; border: 1px solid var(--border-color, #d8dee9); border-radius: .85rem; background: var(--surface-color, #fff); box-shadow: 0 2px 8px rgb(15 23 42 / 5%); }
+  .cron-calendar__day.is-today { border-color: var(--primary-color, #2563eb); box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-color, #2563eb) 15%, transparent); }
+  .cron-calendar__day-header { display: flex; justify-content: space-between; align-items: center; gap: .5rem; padding: .75rem; border-bottom: 1px solid var(--border-color, #d8dee9); background: var(--surface-muted, #f8fafc); }
+  .cron-calendar__day-header div { display: grid; gap: .1rem; }
+  .cron-calendar__day-header div span { color: var(--text-muted, #64748b); font-size: .7rem; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
+  .cron-calendar__day-header div strong { color: var(--text-color, #111827); }
+  .cron-calendar__run-count, .cron-calendar__badge { flex: none; border-radius: 999px; padding: .2rem .45rem; background: color-mix(in srgb, var(--primary-color, #2563eb) 10%, transparent); color: var(--primary-color, #2563eb); font-size: .68rem; font-weight: 700; }
+  .cron-calendar__schedule { display: grid; gap: .5rem; padding: .6rem; }
+  .cron-calendar__event { display: grid; grid-template-columns: 4.2rem minmax(0, 1fr) auto; gap: .6rem; align-items: start; min-height: 4.5rem; border: 1px solid color-mix(in srgb, var(--primary-color, #2563eb) 30%, var(--border-color, #d8dee9)); border-left: .3rem solid var(--primary-color, #2563eb); border-radius: .55rem; padding: .65rem; background: color-mix(in srgb, var(--primary-color, #2563eb) 6%, var(--surface-color, #fff)); color: var(--text-color, #111827); text-decoration: none; }
+  .cron-calendar__event:hover { border-color: var(--primary-color, #2563eb); transform: translateY(-1px); }
+  .cron-calendar__event time { color: var(--primary-color, #2563eb); font-size: .78rem; font-weight: 800; }
+  .cron-calendar__event-body { display: grid; min-width: 0; gap: .22rem; }
+  .cron-calendar__event-body strong { overflow-wrap: anywhere; color: var(--text-color, #111827); font-size: .9rem; line-height: 1.25; }
+  .cron-calendar__event-body span, .cron-calendar__event-body small { overflow: hidden; color: var(--text-muted, #64748b); font-size: .72rem; text-overflow: ellipsis; white-space: nowrap; }
+  .cron-calendar__event-body code { color: inherit; }
+  .cron-calendar__badge--inactive { background: var(--surface-muted, #e2e8f0); color: var(--text-muted, #64748b); }
+  .cron-calendar__availability { display: flex; align-items: center; gap: .5rem; min-height: 2.6rem; border: 1px dashed color-mix(in srgb, #22a06b 55%, transparent); border-radius: .5rem; padding: .45rem .65rem; background: color-mix(in srgb, #22a06b 6%, transparent); color: #16724d; }
+  .cron-calendar__availability-icon { display: grid; flex: none; width: 1.35rem; height: 1.35rem; place-items: center; border-radius: 999px; background: #22a06b; color: #fff; font-size: .7rem; }
+  .cron-calendar__availability > span:last-child { display: grid; }
+  .cron-calendar__availability strong { font-size: .76rem; }
+  .cron-calendar__availability small { color: var(--text-muted, #64748b); font-size: .68rem; }
+  .cron-calendar__empty { margin: 0; padding: 1rem; color: var(--text-muted, #64748b); text-align: center; }
+  @media (max-width: 900px) { .cron-calendar__intro { align-items: stretch; } .cron-calendar__toolbar { grid-template-columns: 1fr; } .cron-calendar__range { order: -1; text-align: left; } .cron-calendar__grid { grid-template-columns: repeat(7, minmax(18rem, 1fr)); } .cron-calendar__grid--day, .cron-calendar__grid--list { grid-template-columns: 1fr; } }
 </style>
 <script src="{{ static_url('/static/js/cron_calendar.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- The existing minute-height timeline made scheduled runs hard to read and hid task names, so the calendar was redesigned to improve visibility and be less constrained by the original timeline format.
- Super admins need a simple way to spot free automation windows and view each task by name, time, company, cron, command, and status.

### Description
- Replaced the compact timeline with a schedule-board layout implemented in `app/static/js/cron_calendar.js` that renders per-day cards showing each run as a readable event card. 
- Added availability detection that highlights gaps of at least 15 minutes between runs and renders availability tiles to help identify safe automation slots. 
- Updated the template `app/templates/admin/cron_calendar.html` with improved toolbar, legend, search/filter controls, accessible pressed states for view buttons, responsive grid CSS, run counts, and clearer copy. 
- Kept existing API fetching, search and inactive-task filtering, timezone-aware formatting, and error handling while improving accessibility and mobile layouts.

### Testing
- `node --check app/static/js/cron_calendar.js` executed and returned no syntax errors. 
- `git diff --check` executed with no whitespace/errors flagged. 
- `pytest -q tests/test_cron_calendar.py tests/test_scheduled_tasks_hide_inactive.py` ran and passed (`10` tests passed). 
- Parsed the Jinja template using `Environment().parse(...)` to validate template syntax with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69dc81a5588332b0ae59218b5a6fca)