### PR TITLE
Move OneDrive export destination into Microsoft 365 settings

### DIFF
--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -23,7 +23,7 @@
         </div>
       </header>
       <div class="card__body card__body--stacked">
-        <form action="/admin/companies/{{ company.id }}" method="post" class="form" autocomplete="off">
+        <form id="company-settings-form" action="/admin/companies/{{ company.id }}" method="post" class="form" autocomplete="off">
           {% include "partials/csrf.html" %}
           <div class="form-field">
             <label class="form-label" for="edit-company-name">Company name</label>
@@ -311,65 +311,6 @@
               <span>Enable email forwarding on offboarding requests</span>
             </label>
             <p class="form-help">When enabled, admins can select a staff member to forward emails to when submitting an offboarding request. Disable if your company uses a fixed forwarding address configured in the workflow step.</p>
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="edit-company-onedrive-export-site">OneDrive export SharePoint site</label>
-            {% if m365_has_credentials %}
-              <div class="form-field__group">
-                <select
-                  id="edit-company-onedrive-export-site"
-                  name="onedriveExportSite"
-                  class="form-input"
-                  data-onedrive-export-sites-select
-                >
-                  <option value="">Do not enable manual OneDrive exports</option>
-                  {% if form_data.onedrive_export_drive_id %}
-                    {% set saved_site_payload = {
-                      'site_id': form_data.onedrive_export_site_id,
-                      'site_name': form_data.onedrive_export_site_name,
-                      'drive_id': form_data.onedrive_export_drive_id
-                    } %}
-                    <option value="{{ saved_site_payload | tojson | forceescape }}" selected>
-                      Current: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}
-                    </option>
-                  {% endif %}
-                </select>
-                <button
-                  type="button"
-                  class="button button--ghost"
-                  data-lookup-onedrive-export-sites
-                  title="Lookup SharePoint sites for OneDrive exports"
-                  aria-label="Lookup SharePoint sites for OneDrive exports from Microsoft Graph"
-                >
-                  <span class="button__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false">
-                      <path d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8z"/>
-                      <path d="M20 12h2a10 10 0 0 0-10-10v2a8 8 0 0 1 8 8z"/>
-                      <path d="M12 20v2a10 10 0 0 0 10-10h-2a8 8 0 0 1-8 8z"/>
-                      <path d="M4 12H2a10 10 0 0 0 10 10v-2a8 8 0 0 1-8-8z"/>
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  class="button button--ghost"
-                  data-create-offboarded-staff-site
-                  title="Create the Offboarded Staff SharePoint site for OneDrive exports"
-                  aria-label="Create Offboarded Staff SharePoint site"
-                  hidden
-                >
-                  Create Offboarded Staff
-                </button>
-              </div>
-              <p class="form-help">Click the lookup button to load SharePoint sites/default document libraries, then select the destination that will receive OneDrive export folders. If Offboarded Staff is missing after lookup, use the create button to add it.</p>
-              {% if form_data.onedrive_export_drive_id %}
-                <p class="form-help">Current saved export site: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}</p>
-              {% endif %}
-              <p class="form-help form-help--error" data-onedrive-export-sites-error hidden></p>
-            {% else %}
-              <input class="form-input" id="edit-company-onedrive-export-site" value="Configure Microsoft 365 credentials first" readonly />
-              <p class="form-help">Complete this company's Office 365 configuration before selecting a OneDrive export destination.</p>
-            {% endif %}
           </div>
           <div class="form-field">
             <label class="form-label">Payment method</label>
@@ -827,6 +768,70 @@
             >Remove credentials</button>
           </form>
           {% endif %}
+          <hr class="divider" style="margin: 1.5rem 0;" />
+          <div class="form-field">
+            <label class="form-label" for="edit-company-onedrive-export-site">OneDrive export SharePoint site</label>
+            {% if m365_has_credentials %}
+              <div class="form-field__group">
+                <select
+                  id="edit-company-onedrive-export-site"
+                  name="onedriveExportSite"
+                  class="form-input"
+                  data-onedrive-export-sites-select
+                  form="company-settings-form"
+                >
+                  <option value="">Do not enable manual OneDrive exports</option>
+                  {% if form_data.onedrive_export_drive_id %}
+                    {% set saved_site_payload = {
+                      'site_id': form_data.onedrive_export_site_id,
+                      'site_name': form_data.onedrive_export_site_name,
+                      'drive_id': form_data.onedrive_export_drive_id
+                    } %}
+                    <option value="{{ saved_site_payload | tojson | forceescape }}" selected>
+                      Current: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}
+                    </option>
+                  {% endif %}
+                </select>
+                <button
+                  type="button"
+                  class="button button--ghost"
+                  data-lookup-onedrive-export-sites
+                  title="Lookup SharePoint sites for OneDrive exports"
+                  aria-label="Lookup SharePoint sites for OneDrive exports from Microsoft Graph"
+                >
+                  <span class="button__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8z"/>
+                      <path d="M20 12h2a10 10 0 0 0-10-10v2a8 8 0 0 1 8 8z"/>
+                      <path d="M12 20v2a10 10 0 0 0 10-10h-2a8 8 0 0 1-8 8z"/>
+                      <path d="M4 12H2a10 10 0 0 0 10 10v-2a8 8 0 0 1-8-8z"/>
+                    </svg>
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  class="button button--ghost"
+                  data-create-offboarded-staff-site
+                  title="Create the Offboarded Staff SharePoint site for OneDrive exports"
+                  aria-label="Create Offboarded Staff SharePoint site"
+                  hidden
+                >
+                  Create Offboarded Staff
+                </button>
+              </div>
+              <p class="form-help">Click the lookup button to load SharePoint sites/default document libraries, then select the destination that will receive OneDrive export folders. If Offboarded Staff is missing after lookup, use the create button to add it.</p>
+              {% if form_data.onedrive_export_drive_id %}
+                <p class="form-help">Current saved export site: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}</p>
+              {% endif %}
+              <p class="form-help form-help--error" data-onedrive-export-sites-error hidden></p>
+            {% else %}
+              <input class="form-input" id="edit-company-onedrive-export-site" value="Configure Microsoft 365 credentials first" readonly />
+              <p class="form-help">Complete this company's Microsoft 365 configuration before selecting a OneDrive export destination.</p>
+            {% endif %}
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="button" form="company-settings-form">Save company settings</button>
+          </div>
           {% if true %}
           <hr class="divider" style="margin: 1.5rem 0;" />
           <div>

--- a/tests/test_company_edit_onedrive_section.py
+++ b/tests/test_company_edit_onedrive_section.py
@@ -1,0 +1,29 @@
+"""Regression tests for the company OneDrive export setting layout."""
+
+from pathlib import Path
+
+
+TEMPLATE = Path("app/templates/admin/company_edit.html")
+
+
+def test_onedrive_export_setting_is_inside_microsoft_365_section():
+    template = TEMPLATE.read_text()
+    m365_section_start = template.index(
+        '<details class="card card--panel card-collapsible admin-grid__full" '
+        'data-m365-credentials-panel>'
+    )
+    m365_section_end = template.index("</details>", m365_section_start)
+    onedrive_setting = template.index(
+        'for="edit-company-onedrive-export-site"', m365_section_start
+    )
+
+    assert m365_section_start < onedrive_setting < m365_section_end
+    assert template.count('for="edit-company-onedrive-export-site"') == 1
+
+
+def test_onedrive_export_setting_submits_with_company_settings_form():
+    template = TEMPLATE.read_text()
+
+    assert '<form id="company-settings-form"' in template
+    assert 'data-onedrive-export-sites-select\n                  form="company-settings-form"' in template
+    assert 'form="company-settings-form">Save company settings</button>' in template


### PR DESCRIPTION
### Motivation
- Consolidate Microsoft 365 related controls by placing the OneDrive export SharePoint site selector inside the Microsoft 365 collapsible section so settings are grouped logically.
- Ensure the relocated selector still submits with the main company settings payload and provide an adjacent save action for discoverability.
- Add a regression test to prevent accidental regressions around placement and form wiring.

### Description
- Updated `app/templates/admin/company_edit.html` to add `id="company-settings-form"` to the main company form and moved the OneDrive export selector into the `data-m365-credentials-panel` details block.
- Wired the relocated selector to the main form by adding `form="company-settings-form"` to the `<select>` and added a nearby `Save company settings` button with `form="company-settings-form"` so the value is submitted to the existing endpoint.
- Adjusted the help text to refer to "Microsoft 365" consistently instead of "Office 365".
- Added a regression test `tests/test_company_edit_onedrive_section.py` that asserts the selector is inside the Microsoft 365 section, appears only once, and is associated with the `company-settings-form` submit wiring.

### Testing
- Ran the new regression test and related M365 tests with `pytest -q tests/test_company_edit_onedrive_section.py tests/test_m365_sharepoint_export_sites.py` and the suite completed successfully with all tests passing (9 passed, multiple warnings reported).
- Ran a quick check of the single new test with `pytest -q tests/test_company_edit_onedrive_section.py` which also passed (2 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69e45717e48332b989e5abc6efb4b7)