### PR TITLE
Group payment/OneDrive settings into collapsible sections and persist section state

### DIFF
--- a/app/static/js/company_edit_sections.js
+++ b/app/static/js/company_edit_sections.js
@@ -1,0 +1,50 @@
+(function () {
+  'use strict';
+
+  const STORAGE_KEY = 'myportal:company-edit:sections';
+
+  function sectionKey(section) {
+    if (section.dataset.companyEditSection) {
+      return section.dataset.companyEditSection;
+    }
+
+    const title = section.querySelector(':scope > summary .card__title');
+    return title ? title.textContent.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-') : null;
+  }
+
+  function loadState() {
+    try {
+      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}');
+      return stored && typeof stored === 'object' && !Array.isArray(stored) ? stored : {};
+    } catch (error) {
+      return {};
+    }
+  }
+
+  function saveState(state) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      // Storage can be unavailable in private browsing or under a restrictive policy.
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const sections = document.querySelectorAll('.company-edit-page details.card-collapsible');
+    const state = loadState();
+
+    sections.forEach(function (section) {
+      const key = sectionKey(section);
+      if (!key) return;
+
+      if (Object.prototype.hasOwnProperty.call(state, key)) {
+        section.open = Boolean(state[key]);
+      }
+
+      section.addEventListener('toggle', function () {
+        state[key] = section.open;
+        saveState(state);
+      });
+    });
+  });
+})();

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -23,7 +23,7 @@
         </div>
       </header>
       <div class="card__body card__body--stacked">
-        <form action="/admin/companies/{{ company.id }}" method="post" class="form" autocomplete="off">
+        <form id="company-settings-form" action="/admin/companies/{{ company.id }}" method="post" class="form" autocomplete="off">
           {% include "partials/csrf.html" %}
           <div class="form-field">
             <label class="form-label" for="edit-company-name">Company name</label>
@@ -275,31 +275,6 @@
             <p class="form-help">Use commas to list domains. Domains are matched case-insensitively.</p>
           </div>
           <div class="form-field form-field--checkbox">
-            <label class="checkbox" for="edit-company-vip">
-              <input
-                id="edit-company-vip"
-                type="checkbox"
-                name="isVip"
-                value="1"
-                {% if form_data.is_vip %}checked{% endif %}
-              />
-              <span>VIP pricing</span>
-            </label>
-          </div>
-          <div class="form-field form-field--checkbox">
-            <label class="checkbox" for="edit-company-default-ticket-replies-billable">
-              <input
-                id="edit-company-default-ticket-replies-billable"
-                type="checkbox"
-                name="defaultTicketRepliesBillable"
-                value="1"
-                {% if form_data.default_ticket_replies_billable %}checked{% endif %}
-              />
-              <span>Default ticket replies to Billable</span>
-            </label>
-            <p class="form-help">When enabled, the Billable checkbox is ticked automatically for new technician ticket replies. Technicians can untick it on individual replies when needed.</p>
-          </div>
-          <div class="form-field form-field--checkbox">
             <label class="checkbox" for="edit-company-offboarding-email-forwarding">
               <input
                 id="edit-company-offboarding-email-forwarding"
@@ -311,98 +286,6 @@
               <span>Enable email forwarding on offboarding requests</span>
             </label>
             <p class="form-help">When enabled, admins can select a staff member to forward emails to when submitting an offboarding request. Disable if your company uses a fixed forwarding address configured in the workflow step.</p>
-          </div>
-          <div class="form-field">
-            <label class="form-label" for="edit-company-onedrive-export-site">OneDrive export SharePoint site</label>
-            {% if m365_has_credentials %}
-              <div class="form-field__group">
-                <select
-                  id="edit-company-onedrive-export-site"
-                  name="onedriveExportSite"
-                  class="form-input"
-                  data-onedrive-export-sites-select
-                >
-                  <option value="">Do not enable manual OneDrive exports</option>
-                  {% if form_data.onedrive_export_drive_id %}
-                    {% set saved_site_payload = {
-                      'site_id': form_data.onedrive_export_site_id,
-                      'site_name': form_data.onedrive_export_site_name,
-                      'drive_id': form_data.onedrive_export_drive_id
-                    } %}
-                    <option value="{{ saved_site_payload | tojson | forceescape }}" selected>
-                      Current: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}
-                    </option>
-                  {% endif %}
-                </select>
-                <button
-                  type="button"
-                  class="button button--ghost"
-                  data-lookup-onedrive-export-sites
-                  title="Lookup SharePoint sites for OneDrive exports"
-                  aria-label="Lookup SharePoint sites for OneDrive exports from Microsoft Graph"
-                >
-                  <span class="button__icon" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" focusable="false">
-                      <path d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8z"/>
-                      <path d="M20 12h2a10 10 0 0 0-10-10v2a8 8 0 0 1 8 8z"/>
-                      <path d="M12 20v2a10 10 0 0 0 10-10h-2a8 8 0 0 1-8 8z"/>
-                      <path d="M4 12H2a10 10 0 0 0 10 10v-2a8 8 0 0 1-8-8z"/>
-                    </svg>
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  class="button button--ghost"
-                  data-create-offboarded-staff-site
-                  title="Create the Offboarded Staff SharePoint site for OneDrive exports"
-                  aria-label="Create Offboarded Staff SharePoint site"
-                  hidden
-                >
-                  Create Offboarded Staff
-                </button>
-              </div>
-              <p class="form-help">Click the lookup button to load SharePoint sites/default document libraries, then select the destination that will receive OneDrive export folders. If Offboarded Staff is missing after lookup, use the create button to add it.</p>
-              {% if form_data.onedrive_export_drive_id %}
-                <p class="form-help">Current saved export site: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}</p>
-              {% endif %}
-              <p class="form-help form-help--error" data-onedrive-export-sites-error hidden></p>
-            {% else %}
-              <input class="form-input" id="edit-company-onedrive-export-site" value="Configure Microsoft 365 credentials first" readonly />
-              <p class="form-help">Complete this company's Office 365 configuration before selecting a OneDrive export destination.</p>
-            {% endif %}
-          </div>
-          <div class="form-field">
-            <label class="form-label">Payment method</label>
-            <div class="form-checkbox-group">
-              <label class="form-checkbox__label">
-                <input
-                  type="checkbox"
-                  name="invoicePrepay"
-                  value="1"
-                  {% if 'invoice_prepay' in form_data.payment_method %}checked{% endif %}
-                />
-                <span>Invoice Prepay</span>
-              </label>
-              <label class="form-checkbox__label">
-                <input
-                  type="checkbox"
-                  name="invoicePostpay"
-                  value="1"
-                  {% if 'invoice_postpay' in form_data.payment_method %}checked{% endif %}
-                />
-                <span>Invoice Postpay</span>
-              </label>
-              <label class="form-checkbox__label">
-                <input
-                  type="checkbox"
-                  name="stripeEnabled"
-                  value="1"
-                  {% if 'stripe' in form_data.payment_method %}checked{% endif %}
-                />
-                <span>Stripe (coming soon)</span>
-              </label>
-            </div>
-            <p class="form-help">Select at least one payment method. Invoice Prepay sends an invoice before service is rendered. Invoice Postpay sends an invoice after the billing period. Stripe will take payment immediately (coming soon).</p>
           </div>
           <div class="form-field">
             <label class="form-label">Purchase order options</label>
@@ -425,6 +308,85 @@
         </form>
       </div>
     </section>
+    <details class="card card--panel card-collapsible admin-grid__full" data-company-edit-section="payments">
+      <summary class="card__header card__header--collapsible card__header--stacked">
+        <div>
+          <h2 class="card__title">Payments</h2>
+          <p class="card__subtitle">Configure payment methods, VIP pricing, and billable ticket reply defaults.</p>
+        </div>
+        <div class="card__collapsible-meta" aria-hidden="true">
+          <span class="card__toggle-icon"></span>
+        </div>
+      </summary>
+      <div class="card-collapsible__content">
+      <div class="form-field form-field--checkbox">
+        <label class="checkbox" for="edit-company-vip">
+          <input
+            id="edit-company-vip"
+            type="checkbox"
+            name="isVip"
+            form="company-settings-form"
+            value="1"
+            {% if form_data.is_vip %}checked{% endif %}
+          />
+          <span>VIP pricing</span>
+        </label>
+      </div>
+      <div class="form-field form-field--checkbox">
+        <label class="checkbox" for="edit-company-default-ticket-replies-billable">
+          <input
+            id="edit-company-default-ticket-replies-billable"
+            type="checkbox"
+            name="defaultTicketRepliesBillable"
+            form="company-settings-form"
+            value="1"
+            {% if form_data.default_ticket_replies_billable %}checked{% endif %}
+          />
+          <span>Default ticket replies to Billable</span>
+        </label>
+        <p class="form-help">When enabled, the Billable checkbox is ticked automatically for new technician ticket replies. Technicians can untick it on individual replies when needed.</p>
+      </div>
+      <div class="form-field">
+        <label class="form-label">Payment method</label>
+        <div class="form-checkbox-group">
+          <label class="form-checkbox__label">
+            <input
+              type="checkbox"
+              name="invoicePrepay"
+              form="company-settings-form"
+              value="1"
+              {% if 'invoice_prepay' in form_data.payment_method %}checked{% endif %}
+            />
+            <span>Invoice Prepay</span>
+          </label>
+          <label class="form-checkbox__label">
+            <input
+              type="checkbox"
+              name="invoicePostpay"
+              form="company-settings-form"
+              value="1"
+              {% if 'invoice_postpay' in form_data.payment_method %}checked{% endif %}
+            />
+            <span>Invoice Postpay</span>
+          </label>
+          <label class="form-checkbox__label">
+            <input
+              type="checkbox"
+              name="stripeEnabled"
+              form="company-settings-form"
+              value="1"
+              {% if 'stripe' in form_data.payment_method %}checked{% endif %}
+            />
+            <span>Stripe (coming soon)</span>
+          </label>
+        </div>
+        <p class="form-help">Select at least one payment method. Invoice Prepay sends an invoice before service is rendered. Invoice Postpay sends an invoice after the billing period. Stripe will take payment immediately (coming soon).</p>
+      </div>
+        <div class="form-actions">
+          <button type="submit" class="button" form="company-settings-form">Save company settings</button>
+        </div>
+      </div>
+    </details>
     {% if is_super_admin %}
       <details class="card card--panel card-collapsible admin-grid__full" data-staff-field-config-panel>
         <summary class="card__header card__header--collapsible card__header--stacked">
@@ -827,6 +789,70 @@
             >Remove credentials</button>
           </form>
           {% endif %}
+          <hr class="divider" style="margin: 1.5rem 0;" />
+          <div class="form-field">
+            <label class="form-label" for="edit-company-onedrive-export-site">OneDrive export SharePoint site</label>
+            {% if m365_has_credentials %}
+              <div class="form-field__group">
+                <select
+                  id="edit-company-onedrive-export-site"
+                  name="onedriveExportSite"
+                  class="form-input"
+                  data-onedrive-export-sites-select
+                  form="company-settings-form"
+                >
+                  <option value="">Do not enable manual OneDrive exports</option>
+                  {% if form_data.onedrive_export_drive_id %}
+                    {% set saved_site_payload = {
+                      'site_id': form_data.onedrive_export_site_id,
+                      'site_name': form_data.onedrive_export_site_name,
+                      'drive_id': form_data.onedrive_export_drive_id
+                    } %}
+                    <option value="{{ saved_site_payload | tojson | forceescape }}" selected>
+                      Current: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}
+                    </option>
+                  {% endif %}
+                </select>
+                <button
+                  type="button"
+                  class="button button--ghost"
+                  data-lookup-onedrive-export-sites
+                  title="Lookup SharePoint sites for OneDrive exports"
+                  aria-label="Lookup SharePoint sites for OneDrive exports from Microsoft Graph"
+                >
+                  <span class="button__icon" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" focusable="false">
+                      <path d="M12 4V2A10 10 0 0 0 2 12h2a8 8 0 0 1 8-8z"/>
+                      <path d="M20 12h2a10 10 0 0 0-10-10v2a8 8 0 0 1 8 8z"/>
+                      <path d="M12 20v2a10 10 0 0 0 10-10h-2a8 8 0 0 1-8 8z"/>
+                      <path d="M4 12H2a10 10 0 0 0 10 10v-2a8 8 0 0 1-8-8z"/>
+                    </svg>
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  class="button button--ghost"
+                  data-create-offboarded-staff-site
+                  title="Create the Offboarded Staff SharePoint site for OneDrive exports"
+                  aria-label="Create Offboarded Staff SharePoint site"
+                  hidden
+                >
+                  Create Offboarded Staff
+                </button>
+              </div>
+              <p class="form-help">Click the lookup button to load SharePoint sites/default document libraries, then select the destination that will receive OneDrive export folders. If Offboarded Staff is missing after lookup, use the create button to add it.</p>
+              {% if form_data.onedrive_export_drive_id %}
+                <p class="form-help">Current saved export site: {{ form_data.onedrive_export_site_name or form_data.onedrive_export_drive_id }}</p>
+              {% endif %}
+              <p class="form-help form-help--error" data-onedrive-export-sites-error hidden></p>
+            {% else %}
+              <input class="form-input" id="edit-company-onedrive-export-site" value="Configure Microsoft 365 credentials first" readonly />
+              <p class="form-help">Complete this company's Microsoft 365 configuration before selecting a OneDrive export destination.</p>
+            {% endif %}
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="button" form="company-settings-form">Save company settings</button>
+          </div>
           {% if true %}
           <hr class="divider" style="margin: 1.5rem 0;" />
           <div>
@@ -1847,6 +1873,7 @@
   {{ super() }}
   <script src="{{ static_url('/static/js/tables.js') }}" defer></script>
   <script src="{{ static_url('/static/js/admin.js') }}" defer></script>
+  <script src="{{ static_url('/static/js/company_edit_sections.js') }}" defer></script>
   {% if is_super_admin %}
     <script src="{{ static_url('/static/js/action-payload-editor.js') }}" defer></script>
     <script src="{{ static_url('/static/js/automation.js') }}" defer></script>

--- a/tests/test_company_edit_onedrive_section.py
+++ b/tests/test_company_edit_onedrive_section.py
@@ -1,0 +1,29 @@
+"""Regression tests for the company OneDrive export setting layout."""
+
+from pathlib import Path
+
+
+TEMPLATE = Path("app/templates/admin/company_edit.html")
+
+
+def test_onedrive_export_setting_is_inside_microsoft_365_section():
+    template = TEMPLATE.read_text()
+    m365_section_start = template.index(
+        '<details class="card card--panel card-collapsible admin-grid__full" '
+        'data-m365-credentials-panel>'
+    )
+    m365_section_end = template.index("</details>", m365_section_start)
+    onedrive_setting = template.index(
+        'for="edit-company-onedrive-export-site"', m365_section_start
+    )
+
+    assert m365_section_start < onedrive_setting < m365_section_end
+    assert template.count('for="edit-company-onedrive-export-site"') == 1
+
+
+def test_onedrive_export_setting_submits_with_company_settings_form():
+    template = TEMPLATE.read_text()
+
+    assert '<form id="company-settings-form"' in template
+    assert 'data-onedrive-export-sites-select\n                  form="company-settings-form"' in template
+    assert 'form="company-settings-form">Save company settings</button>' in template

--- a/tests/test_company_edit_payments_section.py
+++ b/tests/test_company_edit_payments_section.py
@@ -1,0 +1,41 @@
+"""Regression tests for the company Payments section."""
+
+from pathlib import Path
+
+
+TEMPLATE = Path("app/templates/admin/company_edit.html")
+
+
+def _payments_section(template: str) -> str:
+    start = template.index('data-company-edit-section="payments"')
+    end = template.index("</details>", start)
+    return template[start:end]
+
+
+def test_payment_settings_are_grouped_in_payments_section():
+    template = TEMPLATE.read_text()
+    section = _payments_section(template)
+
+    assert '<h2 class="card__title">Payments</h2>' in section
+    for field_name in (
+        "invoicePrepay",
+        "invoicePostpay",
+        "stripeEnabled",
+        "isVip",
+        "defaultTicketRepliesBillable",
+    ):
+        assert template.count(f'name="{field_name}"') == 1
+        assert f'name="{field_name}"' in section
+
+
+def test_moved_payment_settings_submit_with_company_settings_form():
+    section = _payments_section(TEMPLATE.read_text())
+
+    assert section.count('form="company-settings-form"') == 6
+    assert 'form="company-settings-form">Save company settings</button>' in section
+
+
+def test_company_edit_loads_collapsible_section_state_script():
+    template = TEMPLATE.read_text()
+
+    assert "static/js/company_edit_sections.js" in template


### PR DESCRIPTION
### Motivation
- Improve the layout of the company edit page by grouping related settings (payments and OneDrive export) into logical collapsible panels. 
- Ensure inputs that were moved into collapsible sections still submit with the main company form.
- Persist user-open/closed state of collapsible sections across page loads for a better UX.

### Description
- Added `app/static/js/company_edit_sections.js` which saves and restores `<details>` open state using `localStorage` keyed by `data-company-edit-section` or a generated key. 
- Updated `app/templates/admin/company_edit.html` to add `id="company-settings-form"` to the main company form and moved payment-related inputs into a new collapsible `<details>` panel with `data-company-edit-section="payments"`. 
- Updated OneDrive export site inputs to be inside the Microsoft 365 credentials area and added `form="company-settings-form"` attributes to moved inputs and submit buttons so they post with the main company form. 
- Included the new `company_edit_sections.js` script in the template and adjusted save button placements to use the `form` attribute where appropriate.
- Added automated regression tests under `tests/` to assert the new layout and form wiring for payments and OneDrive settings.

### Testing
- Added `tests/test_company_edit_payments_section.py` which verifies the Payments section exists, fields were moved, and the moved inputs have `form="company-settings-form"`; the test passed. 
- Added `tests/test_company_edit_onedrive_section.py` which verifies the OneDrive export setting resides inside the Microsoft 365 credentials panel and submits with the main form; the test passed. 
- Ran the test suite (`pytest`) focusing on the new regression tests and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69e45717e48332b989e5abc6efb4b7)