### PR TITLE
Move Trello settings into collapsible section and persist section state

### DIFF
--- a/app/static/js/company_edit_sections.js
+++ b/app/static/js/company_edit_sections.js
@@ -30,7 +30,7 @@
   }
 
   document.addEventListener('DOMContentLoaded', function () {
-    const sections = document.querySelectorAll('.company-edit-page details.card-collapsible');
+    const sections = document.querySelectorAll('.company-edit-page > .admin-grid > details.card-collapsible');
     const state = loadState();
 
     sections.forEach(function (section) {

--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -12,17 +12,18 @@
 {% block content %}
   <div class="company-edit-page" data-company-id="{{ company.id }}">
   <div class="admin-grid admin-grid--columns">
-    <section class="card card--panel admin-grid__full">
-      <header class="card__header card__header--actions">
+    <details class="card card--panel card-collapsible admin-grid__full" data-company-edit-section="general" open>
+      <summary class="card__header card__header--collapsible card__header--actions">
         <div class="stacked">
           <h2 class="card__title">{{ form_data.name or company.name }}</h2>
           <p class="card__subtitle">Manage identifiers, email domains, and VIP status for this company.</p>
         </div>
         <div class="card__controls">
           <a class="button button--ghost" href="/admin/companies">Back to companies</a>
+          <span class="card__toggle-icon" aria-hidden="true"></span>
         </div>
-      </header>
-      <div class="card__body card__body--stacked">
+      </summary>
+      <div class="card-collapsible__content card__body card__body--stacked">
         <form id="company-settings-form" action="/admin/companies/{{ company.id }}" method="post" class="form" autocomplete="off">
           {% include "partials/csrf.html" %}
           <div class="form-field">
@@ -184,84 +185,6 @@
             <p class="form-help">Optional. Links this company to its separate Huntress Managed SAT account. SAT API calls use this ID rather than the EDR organisation ID.</p>
           </div>
           {% endif %}
-          {% if module_enabled.get('trello', false) %}
-          <div class="form-field">
-            <label class="form-label" for="edit-company-trello-board">Trello board ID</label>
-            <input
-              id="edit-company-trello-board"
-              name="trelloBoardId"
-              class="form-input"
-              value="{{ form_data.trello_board_id or '' }}"
-              maxlength="255"
-              placeholder="e.g. 5abbe4b7ddc1b351ef961414"
-            />
-            <p class="form-help">Link this company to a Trello board. Cards created on the board will become tickets. Find the board ID in the board URL or via the Trello API.</p>
-          </div>
-          {% endif %}
-          {% if module_enabled.get('trello', false) %}
-          <div class="form-field">
-            <label class="form-label" for="edit-company-trello-api-key">Trello API key</label>
-            <input
-              id="edit-company-trello-api-key"
-              name="trelloApiKey"
-              class="form-input"
-              type="password"
-              autocomplete="off"
-              placeholder="{% if form_data.trello_api_key %}Key saved — enter to replace{% else %}Enter API key{% endif %}"
-              maxlength="255"
-            />
-            <p class="form-help">Stored securely. Leave blank to keep the existing value. Copy the <strong>Key</strong> (not the Secret) from <a href="https://trello.com/app-key" target="_blank" rel="noopener noreferrer">trello.com/app-key</a>.</p>
-          </div>
-          {% endif %}
-          {% if module_enabled.get('trello', false) %}
-          <div class="form-field">
-            <label class="form-label" for="edit-company-trello-token">Trello OAuth token</label>
-            <input
-              id="edit-company-trello-token"
-              name="trelloToken"
-              class="form-input"
-              type="password"
-              autocomplete="off"
-              placeholder="{% if form_data.trello_token %}Token saved — enter to replace{% else %}Enter OAuth token{% endif %}"
-              maxlength="255"
-            />
-            <p class="form-help">Stored securely. Leave blank to keep the existing value. This is the <strong>OAuth Token</strong> — <em>not</em> the Secret shown on the app-key page. Go to <a href="https://trello.com/app-key" target="_blank" rel="noopener noreferrer">trello.com/app-key</a>, then click <strong>Token</strong> and authorise the app to generate it.</p>
-          </div>
-          {% if form_data.trello_board_id %}
-          {% endif %}
-          <div class="form-field">
-            <label class="form-label">Register Trello webhook</label>
-            <div class="form-field__group">
-              <button
-                type="button"
-                class="button button--ghost"
-                id="trello-register-webhook-btn"
-                data-board-id="{{ form_data.trello_board_id or '' }}"
-              >Register webhook</button>
-            </div>
-            <p class="form-help" id="trello-register-status">Register this company's board with Trello so incoming card events create tickets.</p>
-          </div>
-          <script>
-            (function () {
-              var btn = document.getElementById('trello-register-webhook-btn');
-              if (!btn) return;
-              btn.addEventListener('click', async function () {
-                var boardId = btn.dataset.boardId;
-                var statusEl = document.getElementById('trello-register-status');
-                if (!boardId) { statusEl.textContent = 'Save the board ID first, then register the webhook.'; return; }
-                btn.disabled = true;
-                statusEl.textContent = 'Registering…';
-                try {
-                  var resp = await fetch('/api/integration-modules/trello/boards/' + encodeURIComponent(boardId) + '/register-webhook', {method: 'POST', headers: {'X-CSRF-Token': document.querySelector('meta[name=csrf-token]')?.content || ''}});
-                  var data = await resp.json();
-                  if (resp.ok) { statusEl.textContent = 'Webhook registered successfully.'; }
-                  else { statusEl.textContent = 'Error: ' + (data.detail || 'Unknown error'); }
-                } catch (e) { statusEl.textContent = 'Request failed: ' + e.message; }
-                btn.disabled = false;
-              });
-            })();
-          </script>
-          {% endif %}
           <div class="form-field">
             <label class="form-label" for="edit-company-email-domains">Email domains</label>
             <input
@@ -307,7 +230,69 @@
           </div>
         </form>
       </div>
-    </section>
+    </details>
+    {% if module_enabled.get('trello', false) %}
+    <details class="card card--panel card-collapsible admin-grid__full" data-company-edit-section="trello">
+      <summary class="card__header card__header--collapsible card__header--stacked">
+        <div>
+          <h2 class="card__title">Trello</h2>
+          <p class="card__subtitle">Configure this company's Trello board, credentials, and webhook.</p>
+        </div>
+        <div class="card__collapsible-meta" aria-hidden="true"><span class="card__toggle-icon"></span></div>
+      </summary>
+      <div class="card-collapsible__content">
+        <div class="form-field">
+          <label class="form-label" for="edit-company-trello-board">Trello board ID</label>
+          <input id="edit-company-trello-board" name="trelloBoardId" form="company-settings-form" class="form-input"
+            value="{{ form_data.trello_board_id or '' }}" maxlength="255" placeholder="e.g. 5abbe4b7ddc1b351ef961414" />
+          <p class="form-help">Link this company to a Trello board. Cards created on the board will become tickets. Find the board ID in the board URL or via the Trello API.</p>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="edit-company-trello-api-key">Trello API key</label>
+          <input id="edit-company-trello-api-key" name="trelloApiKey" form="company-settings-form" class="form-input" type="password"
+            autocomplete="off" placeholder="{% if form_data.trello_api_key %}Key saved — enter to replace{% else %}Enter API key{% endif %}" maxlength="255" />
+          <p class="form-help">Stored securely. Leave blank to keep the existing value. Copy the <strong>Key</strong> (not the Secret) from <a href="https://trello.com/app-key" target="_blank" rel="noopener noreferrer">trello.com/app-key</a>.</p>
+        </div>
+        <div class="form-field">
+          <label class="form-label" for="edit-company-trello-token">Trello OAuth token</label>
+          <input id="edit-company-trello-token" name="trelloToken" form="company-settings-form" class="form-input" type="password"
+            autocomplete="off" placeholder="{% if form_data.trello_token %}Token saved — enter to replace{% else %}Enter OAuth token{% endif %}" maxlength="255" />
+          <p class="form-help">Stored securely. Leave blank to keep the existing value. This is the <strong>OAuth Token</strong> — <em>not</em> the Secret shown on the app-key page. Go to <a href="https://trello.com/app-key" target="_blank" rel="noopener noreferrer">trello.com/app-key</a>, then click <strong>Token</strong> and authorise the app to generate it.</p>
+        </div>
+        <div class="form-field">
+          <label class="form-label">Register Trello webhook</label>
+          <div class="form-field__group">
+            <button type="button" class="button button--ghost" id="trello-register-webhook-btn"
+              data-board-id="{{ form_data.trello_board_id or '' }}">Register webhook</button>
+          </div>
+          <p class="form-help" id="trello-register-status">Register this company's board with Trello so incoming card events create tickets.</p>
+        </div>
+        <div class="form-actions">
+          <button type="submit" class="button" form="company-settings-form">Save company settings</button>
+        </div>
+      </div>
+    </details>
+    <script>
+      (function () {
+        var btn = document.getElementById('trello-register-webhook-btn');
+        if (!btn) return;
+        btn.addEventListener('click', async function () {
+          var boardId = btn.dataset.boardId;
+          var statusEl = document.getElementById('trello-register-status');
+          if (!boardId) { statusEl.textContent = 'Save the board ID first, then register the webhook.'; return; }
+          btn.disabled = true;
+          statusEl.textContent = 'Registering…';
+          try {
+            var resp = await fetch('/api/integration-modules/trello/boards/' + encodeURIComponent(boardId) + '/register-webhook', {method: 'POST', headers: {'X-CSRF-Token': document.querySelector('meta[name=csrf-token]')?.content || ''}});
+            var data = await resp.json();
+            if (resp.ok) { statusEl.textContent = 'Webhook registered successfully.'; }
+            else { statusEl.textContent = 'Error: ' + (data.detail || 'Unknown error'); }
+          } catch (e) { statusEl.textContent = 'Request failed: ' + e.message; }
+          btn.disabled = false;
+        });
+      })();
+    </script>
+    {% endif %}
     <details class="card card--panel card-collapsible admin-grid__full" data-company-edit-section="payments">
       <summary class="card__header card__header--collapsible card__header--stacked">
         <div>

--- a/tests/test_company_edit_trello_section.py
+++ b/tests/test_company_edit_trello_section.py
@@ -1,0 +1,43 @@
+"""Regression tests for collapsible company edit sections."""
+
+from pathlib import Path
+
+
+TEMPLATE = Path("app/templates/admin/company_edit.html")
+SCRIPT = Path("app/static/js/company_edit_sections.js")
+
+
+def _section(template: str, key: str) -> str:
+    start = template.index(f'data-company-edit-section="{key}"')
+    end = template.index("</details>", start)
+    return template[start:end]
+
+
+def test_trello_settings_are_grouped_in_their_own_collapsible_section():
+    template = TEMPLATE.read_text()
+    section = _section(template, "trello")
+
+    assert '<h2 class="card__title">Trello</h2>' in section
+    for field_name in ("trelloBoardId", "trelloApiKey", "trelloToken"):
+        assert template.count(f'name="{field_name}"') == 1
+        assert f'name="{field_name}"' in section
+        assert f'name="{field_name}" form="company-settings-form"' in section
+    assert 'id="trello-register-webhook-btn"' in section
+
+
+def test_general_company_settings_are_collapsible():
+    template = TEMPLATE.read_text()
+    section = _section(template, "general")
+
+    assert section.startswith('data-company-edit-section="general" open>')
+    assert 'id="company-settings-form"' in section
+
+
+def test_section_state_is_shared_across_company_pages():
+    script = SCRIPT.read_text()
+
+    assert "myportal:company-edit:sections" in script
+    assert "data-company-id" not in script
+    assert "window.localStorage.getItem(STORAGE_KEY)" in script
+    assert "window.localStorage.setItem(STORAGE_KEY" in script
+    assert ".company-edit-page > .admin-grid > details.card-collapsible" in script


### PR DESCRIPTION
### Motivation
- Make the Trello integration settings on the company edit page easier to discover and manage by grouping them into their own collapsible panel. 
- Convert the top-level general company settings into a collapsible panel so the page has consistent top-level sections. 
- Remember each top-level section’s expanded/collapsed state across different company records and page reloads to improve UX.

### Description
- Moved Trello inputs and webhook registration UI out of the main form block into a dedicated collapsible section at `data-company-edit-section="trello"` in `app/templates/admin/company_edit.html` while keeping the inputs submitted with the main `company-settings-form` via `form="company-settings-form"` attributes. 
- Converted the former top-level settings card into a collapsible `details` at `data-company-edit-section="general"` and updated markup to use `.card-collapsible__content` for consistent behaviour. 
- Persisted per-section expanded/collapsed state in `localStorage` with a single shared key `myportal:company-edit:sections` and scoped selector change to only target top-level sections in `app/static/js/company_edit_sections.js`. 
- Added regression tests in `tests/test_company_edit_trello_section.py` to assert Trello fields are grouped, remain associated with the main form, general settings are collapsible, and the JS persistence key and selector exist.

### Testing
- Ran focused tests for the new behaviour with `pytest -q tests/test_company_edit_trello_section.py tests/test_company_edit_payments_section.py tests/test_company_edit_onedrive_section.py` which passed (`8 passed`).
- Ran a broader related test run with `pytest -q tests/test_company_edit_trello_section.py tests/test_company_edit_payments_section.py tests/test_company_edit_onedrive_section.py tests/test_company_payment_method.py tests/test_trello_register_webhook.py` which produced additional failures (total: `14 passed, 9 failed`); the failures are unrelated to the UI changes and are due to a removed helper (`_get_company_management_scope`) referenced by older tests and the test environment missing an async pytest plugin (`pytest-asyncio`).
- Performed `git diff --check` and local sanity checks; attempting to start the app for visual verification failed because required runtime env vars (`SESSION_SECRET`, `TOTP_ENCRYPTION_KEY`) are not available in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69e817f8f083329b89e8902ce0d7b5)