### PR TITLE
Move offboarding email forwarding into Microsoft 365 section and remove duplicate Back button

### DIFF
--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -19,7 +19,6 @@
           <p class="card__subtitle">Manage general settings and email domains for this company.</p>
         </div>
         <div class="card__controls">
-          <a class="button button--ghost" href="/admin/companies">Back to companies</a>
           <span class="card__toggle-icon" aria-hidden="true"></span>
         </div>
       </summary>
@@ -60,19 +59,6 @@
               value="{{ form_data.email_domains }}"
             />
             <p class="form-help">Use commas to list domains. Domains are matched case-insensitively.</p>
-          </div>
-          <div class="form-field form-field--checkbox">
-            <label class="checkbox" for="edit-company-offboarding-email-forwarding">
-              <input
-                id="edit-company-offboarding-email-forwarding"
-                type="checkbox"
-                name="offboardingEmailForwardingEnabled"
-                value="1"
-                {% if form_data.offboarding_email_forwarding_enabled %}checked{% endif %}
-              />
-              <span>Enable email forwarding on offboarding requests</span>
-            </label>
-            <p class="form-help">When enabled, admins can select a staff member to forward emails to when submitting an offboarding request. Disable if your company uses a fixed forwarding address configured in the workflow step.</p>
           </div>
           <div class="form-actions">
             <button type="submit" class="button">Save changes</button>
@@ -721,6 +707,20 @@
           </div>
         </summary>
         <div class="card-collapsible__content">
+          <div class="form-field form-field--checkbox">
+            <label class="checkbox" for="edit-company-offboarding-email-forwarding">
+              <input
+                id="edit-company-offboarding-email-forwarding"
+                type="checkbox"
+                name="offboardingEmailForwardingEnabled"
+                form="company-settings-form"
+                value="1"
+                {% if form_data.offboarding_email_forwarding_enabled %}checked{% endif %}
+              />
+              <span>Enable email forwarding on offboarding requests</span>
+            </label>
+            <p class="form-help">When enabled, admins can select a staff member to forward emails to when submitting an offboarding request. Disable if your company uses a fixed forwarding address configured in the workflow step.</p>
+          </div>
           {% if m365_credential %}
           <dl class="definition-list">
             <div class="definition-list__item">

--- a/tests/test_company_edit_m365_layout.py
+++ b/tests/test_company_edit_m365_layout.py
@@ -1,0 +1,28 @@
+"""Regression tests for the Microsoft 365 company settings layout."""
+
+from pathlib import Path
+
+
+TEMPLATE = Path("app/templates/admin/company_edit.html")
+
+
+def test_offboarding_email_forwarding_is_inside_microsoft_365_section():
+    template = TEMPLATE.read_text()
+    m365_section_start = template.index("data-m365-credentials-panel")
+    forwarding_setting = template.index(
+        'id="edit-company-offboarding-email-forwarding"'
+    )
+    credentials_form = template.index(
+        'action="/admin/companies/{{ company.id }}/m365-credentials"'
+    )
+
+    assert m365_section_start < forwarding_setting < credentials_form
+    assert template.count('id="edit-company-offboarding-email-forwarding"') == 1
+    assert 'name="offboardingEmailForwardingEnabled"\n                form="company-settings-form"' in template
+
+
+def test_back_to_companies_only_appears_in_page_header():
+    template = TEMPLATE.read_text()
+
+    assert template.count('"label": "Back to companies"') == 1
+    assert '>Back to companies</a>' not in template


### PR DESCRIPTION
### Motivation
- Keep company-level offboarding forwarding controlled by the Microsoft 365 configuration UI rather than the General section to group related mailbox settings together.
- Remove the duplicated lower “Back to companies” link in the General card header to rely on the single page-header navigation action.

### Description
- Moved the `offboardingEmailForwardingEnabled` checkbox from the General settings card into the Microsoft 365 card in `app/templates/admin/company_edit.html` and preserved form submission by adding `form="company-settings-form"` to the relocated input.
- Removed the duplicate `<a class="button button--ghost" href="/admin/companies">Back to companies</a>` from the General card header so the page-header action is the only navigation link.
- Added regression tests in `tests/test_company_edit_m365_layout.py` that assert the forwarding toggle is inside the Microsoft 365 section, is associated with the `company-settings-form`, and that the inline page link no longer appears in the card body.

### Testing
- Ran `python -m pytest tests/test_company_edit_m365_layout.py tests/test_company_edit_onedrive_section.py -q` and all tests passed (4 passed).
- Ran `git diff --check` to validate whitespace/patch issues; no problems found.
- Performed a Playwright visual smoke verification (local preview using the app stylesheet); a screenshot was produced and confirmed the page header contains a single “Back to companies” action and the offboarding forwarding checkbox appears in the Microsoft 365 card.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69ebacc5b48332a6d3bc2cfb5f7589)