### PR TITLE
Remove the redundant ticket table Actions column

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2561,9 +2561,7 @@ button.header-title-menu__link,
   .tickets-table__column--assigned,
   .tickets-table__cell--assigned,
   .tickets-table__column--updated,
-  .tickets-table__cell--updated,
-  .tickets-table__column--actions,
-  .tickets-table__cell--actions {
+  .tickets-table__cell--updated {
     display: none;
   }
 

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -685,7 +685,6 @@
                 <th scope="col" data-sort="string" data-column="latest-reply-internal" class="tickets-table__column tickets-table__column--latest-reply-internal">reply.is_internal</th>
                 <th scope="col" data-sort="string" data-column="latest-reply-kind" class="tickets-table__column tickets-table__column--latest-reply-kind">reply.kind</th>
                 <th scope="col" data-sort="string" data-column="ticket-update-actor-type" class="tickets-table__column tickets-table__column--ticket-update-actor-type">ticket_update.actor_type</th>
-                <th scope="col" class="table__actions tickets-table__column tickets-table__column--actions">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -783,14 +782,11 @@
                     <td data-label="reply.is_internal" data-column="latest-reply-internal" class="tickets-table__cell tickets-table__cell--latest-reply-internal">{{ 'true' if automation_data.get('latest_reply_is_internal') else ('false' if automation_data.get('latest_reply_id') else '—') }}</td>
                     <td data-label="reply.kind" data-column="latest-reply-kind" class="tickets-table__cell tickets-table__cell--latest-reply-kind">{{ automation_data.get('latest_reply_kind') or '—' }}</td>
                     <td data-label="ticket_update.actor_type" data-column="ticket-update-actor-type" class="tickets-table__cell tickets-table__cell--ticket-update-actor-type">{{ automation_data.get('ticket_update_actor_type') or '—' }}</td>
-                    <td class="table__actions tickets-table__cell tickets-table__cell--actions">
-                      <a href="/admin/tickets/{{ ticket.id }}" class="button button--ghost">Open</a>
-                    </td>
                   </tr>
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="{{ 39 + (1 if can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
+                  <td colspan="{{ 38 + (1 if can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
                 </tr>
               {% endif %}
             </tbody>

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -170,6 +170,17 @@ def test_table_header_data_column_attributes():
         )
 
 
+def test_ticket_table_does_not_render_actions_column():
+    """Ticket subjects link to details, so the table needs no actions column."""
+    html = _template_html()
+    table = html[html.index('id="tickets-table"'):]
+    table = table[:table.index("</table>")]
+
+    assert 'tickets-table__column--actions' not in table
+    assert 'tickets-table__cell--actions' not in table
+    assert '>Actions</th>' not in table
+
+
 def test_status_filter_is_in_status_column_header_with_funnel_icon():
     """Status choices should open from an accessible funnel in the Status heading."""
     html = _template_html()


### PR DESCRIPTION
### Motivation
- The Tickets admin list renders an empty per-row Actions column while the ticket subject already links to the detail page, so the Actions column is redundant and should be removed.
- The responsive CSS still referenced the Actions selectors, which are no longer needed and could cause layout confusion on small screens.

### Description
- Removed the `Actions` header `<th>` and the per-ticket actions `<td>` (the Open button) from `app/templates/admin/tickets.html`.
- Updated the empty-state colspan calculation in `app/templates/admin/tickets.html` from `39` to `38` to match the removed column.
- Removed obsolete responsive selectors for `.tickets-table__column--actions` and `.tickets-table__cell--actions` from `app/static/css/app.css`.
- Added a regression test `test_ticket_table_does_not_render_actions_column` to `tests/test_ticket_column_customisation.py` which asserts the table no longer contains the actions column or cell classes.

### Testing
- Ran `pytest -q tests/test_ticket_column_customisation.py` and the test suite passed with `26 passed`.
- The newly added regression test confirms the `Actions` header and per-row action cells are not rendered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69ed8a211883328b83a8968761db1b)