### PR TITLE
Scope DMARC best-practice checks to company email domains

### DIFF
--- a/app/services/m365_best_practices.py
+++ b/app/services/m365_best_practices.py
@@ -1311,26 +1311,25 @@ async def _check_spf_records_published(token: str) -> dict[str, Any]:
                    + ". Publish: v=spf1 include:spf.protection.outlook.com -all")
 
 
-async def _check_dmarc_records_published(token: str) -> dict[str, Any]:
+async def _check_dmarc_records_published(
+    _token: str, email_domains: list[str]
+) -> dict[str, Any]:
     check_id = "bp_dmarc_records_published"
-    check_name = "DMARC records for all Exchange Online domains are published"
-    domains_data = await _safe_graph_get_all(token, _DOMAINS_URL)
-    if domains_data is None:
-        return _result(check_id, check_name, STATUS_UNKNOWN,
-                       "Unable to enumerate accepted domains from Microsoft Graph.")
-    exchange_domains = [
-        d.get("id") or d.get("name") or ""
-        for d in domains_data
-        if isinstance(d, dict)
-        and d.get("isVerified") is True
-        and not str(d.get("id") or "").endswith(".onmicrosoft.com")
-    ]
-    if not exchange_domains:
+    check_name = "DMARC records for all MyPortal Email domains are published"
+    configured_domains = sorted(
+        {
+            str(domain).strip().lower()
+            for domain in email_domains
+            if str(domain).strip()
+        }
+    )
+    if not configured_domains:
         return _result(check_id, check_name, STATUS_PASS,
-                       "No custom verified domains found; DMARC records are not required.")
+                       "No Email domains are configured for this company in MyPortal; "
+                       "DMARC records are not required.")
     missing: list[str] = []
     errored: list[str] = []
-    for domain in exchange_domains:
+    for domain in configured_domains:
         records = await _dns_txt_records(f"_dmarc.{domain}")
         if records is None:
             errored.append(domain)
@@ -1343,8 +1342,12 @@ async def _check_dmarc_records_published(token: str) -> dict[str, Any]:
                        f"DNS lookup failed for {len(errored)} domain(s); "
                        "verify DMARC records manually: " + ", ".join(errored[:5]))
     if not missing:
-        return _result(check_id, check_name, STATUS_PASS,
-                       f"DMARC records found for all {len(exchange_domains)} verified domain(s).")
+        return _result(
+            check_id,
+            check_name,
+            STATUS_PASS,
+            f"DMARC records found for all {len(configured_domains)} MyPortal Email domain(s).",
+        )
     suffix = f" (DNS errors for {len(errored)} domain(s))" if errored else ""
     return _result(check_id, check_name, STATUS_FAIL,
                    f"DMARC TXT record missing for {len(missing)} domain(s): "
@@ -4629,7 +4632,7 @@ _BEST_PRACTICES: list[dict[str, Any]] = [
     },
     {
         "id": "bp_dmarc_records_published",
-        "name": "DMARC records for all Exchange Online domains are published",
+        "name": "DMARC records for all MyPortal Email domains are published",
         "description": (
             "DMARC policies tell receivers what to do with mail that fails "
             "SPF/DKIM and provides aggregate reporting on spoof attempts."
@@ -4640,6 +4643,7 @@ _BEST_PRACTICES: list[dict[str, Any]] = [
         ),
         "source": _check_dmarc_records_published,
         "source_type": "graph",
+        "uses_company_email_domains": True,
         "default_enabled": True,
         "has_remediation": False,
         "requires_licenses": [CAP_EXCHANGE_ONLINE],
@@ -5434,7 +5438,9 @@ async def run_best_practices(company_id: int) -> list[dict[str, Any]]:
                     if exo_token is None:
                         exo_token, exo_tenant_id = await _acquire_exo_access_token(company_id)
                     if bp.get("uses_company_email_domains"):
-                        email_domains = await companies_repo.get_email_domains_for_company(company_id)
+                        email_domains = (
+                            await companies_repo.get_email_domains_for_company(company_id)
+                        )
                         raw = await _call_check_with_retry(
                             lambda r=runner: r(  # type: ignore[call-arg,misc]
                                 exo_token, exo_tenant_id, email_domains
@@ -5449,11 +5455,19 @@ async def run_best_practices(company_id: int) -> list[dict[str, Any]]:
                             check_id=check_id,
                         )
                 else:
-                    raw = await _call_check_with_retry(
-                        lambda r=runner: r(graph_token),  # type: ignore[call-arg,misc]
-                        company_id=company_id,
-                        check_id=check_id,
-                    )
+                    if bp.get("uses_company_email_domains"):
+                        email_domains = await companies_repo.get_email_domains_for_company(company_id)
+                        raw = await _call_check_with_retry(
+                            lambda r=runner: r(graph_token, email_domains),  # type: ignore[call-arg,misc]
+                            company_id=company_id,
+                            check_id=check_id,
+                        )
+                    else:
+                        raw = await _call_check_with_retry(
+                            lambda r=runner: r(graph_token),  # type: ignore[call-arg,misc]
+                            company_id=company_id,
+                            check_id=check_id,
+                        )
                 status = raw.get("status", STATUS_UNKNOWN)
                 details = raw.get("details") or ""
             except M365Error as exc:
@@ -5598,7 +5612,9 @@ async def run_single_check(company_id: int, check_id: str) -> dict[str, Any]:
             if source_type == "exo":
                 exo_token, exo_tenant_id = await _acquire_exo_access_token(company_id)
                 if bp.get("uses_company_email_domains"):
-                    email_domains = await companies_repo.get_email_domains_for_company(company_id)
+                    email_domains = (
+                        await companies_repo.get_email_domains_for_company(company_id)
+                    )
                     raw = await _call_check_with_retry(
                         lambda r=runner: r(  # type: ignore[call-arg,misc]
                             exo_token, exo_tenant_id, email_domains
@@ -5613,11 +5629,19 @@ async def run_single_check(company_id: int, check_id: str) -> dict[str, Any]:
                         check_id=check_id,
                     )
             else:
-                raw = await _call_check_with_retry(
-                    lambda r=runner: r(graph_token),  # type: ignore[call-arg,misc]
-                    company_id=company_id,
-                    check_id=check_id,
-                )
+                if bp.get("uses_company_email_domains"):
+                    email_domains = await companies_repo.get_email_domains_for_company(company_id)
+                    raw = await _call_check_with_retry(
+                        lambda r=runner: r(graph_token, email_domains),  # type: ignore[call-arg,misc]
+                        company_id=company_id,
+                        check_id=check_id,
+                    )
+                else:
+                    raw = await _call_check_with_retry(
+                        lambda r=runner: r(graph_token),  # type: ignore[call-arg,misc]
+                        company_id=company_id,
+                        check_id=check_id,
+                    )
             status = raw.get("status", STATUS_UNKNOWN)
             details = raw.get("details") or ""
         except M365Error as exc:

--- a/changes/22d5537b-7a98-463f-b211-7078ee3f38fd.json
+++ b/changes/22d5537b-7a98-463f-b211-7078ee3f38fd.json
@@ -1,0 +1,7 @@
+{
+  "guid": "22d5537b-7a98-463f-b211-7078ee3f38fd",
+  "occurred_at": "2026-07-29T00:00:00Z",
+  "change_type": "fix",
+  "summary": "Evaluate the Microsoft 365 DMARC best-practice check against company Email domains instead of every domain in the tenant.",
+  "content_hash": "dmarc-company-email-domains"
+}

--- a/tests/test_m365_best_practices.py
+++ b/tests/test_m365_best_practices.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
@@ -3641,60 +3641,67 @@ async def test_check_spf_records_published_skips_onmicrosoft_domains():
 
 @pytest.mark.anyio("asyncio")
 async def test_check_dmarc_records_published_pass():
-    domains = [{"id": "contoso.com", "isVerified": True}]
-    with (
-        patch(
-            "app.services.m365_best_practices._graph_get_all",
-            new_callable=AsyncMock,
-            return_value=domains,
-        ),
-        patch(
+    with patch(
             "app.services.m365_best_practices._dns_txt_records",
             new_callable=AsyncMock,
             return_value=["v=DMARC1; p=quarantine; rua=mailto:dmarc@contoso.com"],
-        ),
-    ):
-        result = await bp_service._check_dmarc_records_published("token")
+        ):
+        result = await bp_service._check_dmarc_records_published("token", ["contoso.com"])
     assert result["status"] == "pass"
 
 
 @pytest.mark.anyio("asyncio")
 async def test_check_dmarc_records_published_fail_when_missing():
-    domains = [{"id": "contoso.com", "isVerified": True}]
-    with (
-        patch(
-            "app.services.m365_best_practices._graph_get_all",
-            new_callable=AsyncMock,
-            return_value=domains,
-        ),
-        patch(
+    with patch(
             "app.services.m365_best_practices._dns_txt_records",
             new_callable=AsyncMock,
             return_value=[],
-        ),
-    ):
-        result = await bp_service._check_dmarc_records_published("token")
+        ):
+        result = await bp_service._check_dmarc_records_published("token", ["contoso.com"])
     assert result["status"] == "fail"
     assert re.search(r"\bcontoso\.com\b", result["details"])
 
 
 @pytest.mark.anyio("asyncio")
 async def test_check_dmarc_records_published_unknown_on_dns_failure():
-    domains = [{"id": "contoso.com", "isVerified": True}]
-    with (
-        patch(
-            "app.services.m365_best_practices._graph_get_all",
-            new_callable=AsyncMock,
-            return_value=domains,
-        ),
-        patch(
+    with patch(
             "app.services.m365_best_practices._dns_txt_records",
             new_callable=AsyncMock,
             return_value=None,
-        ),
-    ):
-        result = await bp_service._check_dmarc_records_published("token")
+        ):
+        result = await bp_service._check_dmarc_records_published("token", ["contoso.com"])
     assert result["status"] == "unknown"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_check_dmarc_records_published_only_checks_company_email_domains():
+    with patch(
+        "app.services.m365_best_practices._dns_txt_records",
+        new_callable=AsyncMock,
+        return_value=["v=DMARC1; p=reject"],
+    ) as dns_lookup:
+        result = await bp_service._check_dmarc_records_published(
+            "token", ["Company.COM", " company.com ", "mail.company.com"]
+        )
+
+    assert result["status"] == "pass"
+    assert dns_lookup.await_args_list == [
+        call("_dmarc.company.com"),
+        call("_dmarc.mail.company.com"),
+    ]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_check_dmarc_records_published_passes_without_company_email_domains():
+    with patch(
+        "app.services.m365_best_practices._dns_txt_records",
+        new_callable=AsyncMock,
+    ) as dns_lookup:
+        result = await bp_service._check_dmarc_records_published("token", [])
+
+    assert result["status"] == "pass"
+    assert "No Email domains are configured" in result["details"]
+    dns_lookup.assert_not_awaited()
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation

- The DMARC best-practice previously enumerated every verified tenant domain via Graph, which caused the check to report on domains outside a company's configured sending domains; the intent is to evaluate DMARC only for the company’s configured Email domains in MyPortal.

### Description

- Change `_check_dmarc_records_published` to accept `email_domains` and normalize/deduplicate them before performing `_dns_txt_records` lookups and to return clearer messages scoped to MyPortal Email domains. 
- Rename the check name and catalog entry to indicate the MyPortal Email domain scope and add `uses_company_email_domains: True` for the entry. 
- Update `run_best_practices` and `run_single_check` to fetch and pass company `email_domains` to any best-practice runner that opts into company-domain scope. 
- Update and add unit tests to cover normalization/deduplication, scoped DNS lookups, missing records, DNS failures, and companies with no configured email domains, and add a change-log entry describing the fix.

### Testing

- `python -m py_compile app/services/m365_best_practices.py tests/test_m365_best_practices.py` completed successfully. 
- Targeted unit tests for the DMARC check (`pytest -q tests/test_m365_best_practices.py -k 'dmarc_records_published'`) passed (5 tests). 
- Full `tests/test_m365_best_practices.py` run exercised the modified code with 262 passed and 3 unrelated pre-existing failures that existed prior to these changes. 
- `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69eddea6ac8332aaea2c27fe6b7da6)