### PR TITLE
Fix requester phone display on admin tickets

### DIFF
--- a/app/repositories/staff.py
+++ b/app/repositories/staff.py
@@ -283,6 +283,7 @@ async def list_enabled_staff_users(company_id: int) -> List[dict[str, Any]]:
             COALESCE(NULLIF(u.email, ''), s.email) AS email,
             COALESCE(NULLIF(u.first_name, ''), s.first_name) AS first_name,
             COALESCE(NULLIF(u.last_name, ''), s.last_name) AS last_name,
+            s.mobile_phone AS mobile_phone,
             s.company_id AS company_id,
             s.created_at AS created_at,
             s.updated_at AS updated_at,

--- a/tests/test_staff_repository.py
+++ b/tests/test_staff_repository.py
@@ -32,7 +32,12 @@ def anyio_backend():
 @pytest.mark.anyio
 async def test_list_enabled_staff_users_returns_rows(monkeypatch):
     dummy_rows = [
-        {"staff_id": 11, "user_id": 101, "email": "bravo@example.com"},
+        {
+            "staff_id": 11,
+            "user_id": 101,
+            "email": "bravo@example.com",
+            "mobile_phone": "0412 345 678",
+        },
         {"staff_id": 5, "user_id": None, "email": "alpha@example.com"},
     ]
     dummy_db = _DummyStaffDB(dummy_rows)
@@ -44,11 +49,13 @@ async def test_list_enabled_staff_users_returns_rows(monkeypatch):
     assert "FROM staff AS s" in (dummy_db.last_sql or "")
     assert "s.created_at AS created_at" in (dummy_db.last_sql or "")
     assert "s.updated_at AS updated_at" in (dummy_db.last_sql or "")
+    assert "s.mobile_phone AS mobile_phone" in (dummy_db.last_sql or "")
     assert "u.created_at" not in (dummy_db.last_sql or "")
     assert "u.updated_at" not in (dummy_db.last_sql or "")
     assert result[0]["id"] == 101
     assert result[0]["requester_value"] == "user:101"
     assert result[0]["is_registered_user"] is True
+    assert result[0]["mobile_phone"] == "0412 345 678"
     assert result[1]["id"] == 5
     assert result[1]["requester_value"] == "staff:5"
     assert result[1]["is_registered_user"] is False


### PR DESCRIPTION
### Motivation
- Ensure the admin ticket detail page shows the Requester Phone when the requester is a staff member who has a mobile number on their staff record, because the phone value was not being included in enabled requester option records.

### Description
- Add `s.mobile_phone AS mobile_phone` to the `list_enabled_staff_users` query in `app/repositories/staff.py` and update `tests/test_staff_repository.py` to assert the mobile number is selected and preserved in the returned requester option.

### Testing
- Ran `pytest -q tests/test_staff_repository.py` and the suite succeeded (8 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6a9dc002cc833294a86b613ffb88bf)