### PR TITLE
Add per-user Grandstream click-to-call

### DIFF
--- a/app/api/routes/click_to_call.py
+++ b/app/api/routes/click_to_call.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import ipaddress
+import re
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+
+from app.api.dependencies.auth import get_current_user
+from app.api.dependencies.database import require_database
+from app.repositories import click_to_call as click_to_call_repo
+from app.security.encryption import decrypt_secret, encrypt_secret
+
+router = APIRouter(prefix="/api/click-to-call", tags=["Users"])
+
+
+class ClickToCallSettingsUpdate(BaseModel):
+    enabled: bool = False
+    phone_ip: str | None = Field(default=None, max_length=255)
+    login_username: str | None = Field(default=None, max_length=255)
+    password: str | None = Field(default=None, max_length=255)
+
+    @field_validator("phone_ip")
+    @classmethod
+    def validate_phone_ip(cls, value: str | None) -> str | None:
+        value = str(value or "").strip() or None
+        if value is None:
+            return None
+        try:
+            address = ipaddress.ip_address(value)
+        except ValueError as exc:
+            raise ValueError("Enter a valid phone IP address") from exc
+        if address.is_loopback or address.is_link_local or address.is_multicast or address.is_unspecified:
+            raise ValueError("This phone IP address is not allowed")
+        return value
+
+    @field_validator("login_username", "password")
+    @classmethod
+    def strip_optional_values(cls, value: str | None) -> str | None:
+        return str(value or "").strip() or None
+
+
+class MakeCallRequest(BaseModel):
+    phone_number: str = Field(min_length=3, max_length=40)
+
+
+def _public_settings(record: dict | None) -> dict[str, object]:
+    record = record or {}
+    return {
+        "enabled": bool(record.get("enabled")),
+        "phone_ip": record.get("phone_ip") or "",
+        "login_username": record.get("login_username") or "",
+        "password_configured": bool(record.get("password_encrypted")),
+    }
+
+
+@router.get("/settings")
+async def get_settings(
+    _: None = Depends(require_database),
+    current_user: dict = Depends(get_current_user),
+):
+    record = await click_to_call_repo.get_settings(int(current_user["id"]))
+    return _public_settings(record)
+
+
+@router.put("/settings")
+async def update_settings(
+    payload: ClickToCallSettingsUpdate,
+    _: None = Depends(require_database),
+    current_user: dict = Depends(get_current_user),
+):
+    existing = await click_to_call_repo.get_settings(int(current_user["id"]))
+    has_password = bool(payload.password or (existing or {}).get("password_encrypted"))
+    if payload.enabled and not (payload.phone_ip and payload.login_username and has_password):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Phone IP, login username, and password are required when click to call is enabled",
+        )
+    saved = await click_to_call_repo.upsert_settings(
+        int(current_user["id"]),
+        enabled=payload.enabled,
+        phone_ip=payload.phone_ip,
+        login_username=payload.login_username,
+        password_encrypted=encrypt_secret(payload.password) if payload.password else None,
+    )
+    return _public_settings(saved)
+
+
+@router.post("/call")
+async def make_call(
+    payload: MakeCallRequest,
+    _: None = Depends(require_database),
+    current_user: dict = Depends(get_current_user),
+):
+    number = re.sub(r"[^0-9+]", "", payload.phone_number)
+    if not re.fullmatch(r"\+?[0-9]{3,15}", number):
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid phone number")
+
+    settings = await click_to_call_repo.get_settings(int(current_user["id"]))
+    if not settings or not settings.get("enabled"):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Click to call is not enabled")
+    try:
+        password = decrypt_secret(str(settings.get("password_encrypted") or ""))
+        async with httpx.AsyncClient(verify=False, timeout=10.0) as client:
+            response = await client.get(
+                f"https://{settings['phone_ip']}/cgi-bin/api-make_call",
+                params={
+                    "phonenumber": number,
+                    "account": 0,
+                    "login": settings["login_username"],
+                    "password": password,
+                },
+            )
+        response.raise_for_status()
+    except (httpx.HTTPError, ValueError, KeyError):
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="The Grandstream phone could not be reached")
+    return {"ok": True, "phone_number": number}

--- a/app/main.py
+++ b/app/main.py
@@ -67,6 +67,7 @@ from app.api.routes import (
     bcp,
     business_continuity_plans as bc_plans_api,
     call_recordings as call_recordings_api,
+    click_to_call as click_to_call_api,
     companies,
     essential8 as essential8_api,
     compliance_checks as compliance_checks_api,
@@ -1096,6 +1097,7 @@ async def authenticated_swagger_ui(request: Request) -> Response:
 app.include_router(auth.router)
 app.include_router(agent.router)
 app.include_router(users.router)
+app.include_router(click_to_call_api.router)
 app.include_router(call_recordings_api.router)
 app.include_router(companies.router)
 app.include_router(essential8_api.router)

--- a/app/repositories/click_to_call.py
+++ b/app/repositories/click_to_call.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.database import db
+
+
+async def get_settings(user_id: int) -> dict[str, Any] | None:
+    return await db.fetch_one(
+        "SELECT * FROM user_click_to_call_settings WHERE user_id = %s",
+        (user_id,),
+    )
+
+
+async def upsert_settings(
+    user_id: int,
+    *,
+    enabled: bool,
+    phone_ip: str | None,
+    login_username: str | None,
+    password_encrypted: str | None,
+) -> dict[str, Any]:
+    await db.execute(
+        """
+        INSERT INTO user_click_to_call_settings
+            (user_id, enabled, phone_ip, login_username, password_encrypted)
+        VALUES (%s, %s, %s, %s, %s)
+        ON DUPLICATE KEY UPDATE
+            enabled = VALUES(enabled),
+            phone_ip = VALUES(phone_ip),
+            login_username = VALUES(login_username),
+            password_encrypted = COALESCE(VALUES(password_encrypted), password_encrypted)
+        """,
+        (user_id, 1 if enabled else 0, phone_ip, login_username, password_encrypted),
+    )
+    result = await get_settings(user_id)
+    if result is None:  # pragma: no cover - database invariant
+        raise RuntimeError("Click-to-call settings were not saved")
+    return result

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5538,6 +5538,23 @@ dialog.modal:not([open]) {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.click-to-call {
+  appearance: none;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-primary, #60a5fa);
+  font: inherit;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  cursor: pointer;
+}
+
+.click-to-call:hover,
+.click-to-call:focus-visible {
+  text-decoration-style: solid;
+}
+
 .profile-columns--standard {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }

--- a/app/static/js/click_to_call.js
+++ b/app/static/js/click_to_call.js
@@ -1,0 +1,92 @@
+(function () {
+  const PHONE_PATTERN = /(?:\+?\d[\d\s().-]{5,}\d)/g;
+  const SKIPPED_TAGS = new Set(['A', 'BUTTON', 'INPUT', 'OPTION', 'SCRIPT', 'STYLE', 'TEXTAREA']);
+  let enabled = false;
+
+  function toast(message, variant) {
+    if (window.__portalToast && typeof window.__portalToast.show === 'function') {
+      window.__portalToast.show(message, { variant });
+    } else {
+      window.alert(message);
+    }
+  }
+
+  function validNumber(text) {
+    const normalized = text.replace(/[^0-9+]/g, '');
+    const digits = normalized.replace(/\D/g, '');
+    return digits.length >= 7 && digits.length <= 15 ? normalized : null;
+  }
+
+  async function call(number) {
+    if (!window.confirm(`Call ${number}?`)) {
+      return;
+    }
+    try {
+      const response = await fetch('/api/click-to-call/call', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phone_number: number }),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.detail || 'Unable to start the call.');
+      }
+      toast(`Calling ${number}.`, 'success');
+    } catch (error) {
+      toast(error.message || 'Unable to start the call.', 'error');
+    }
+  }
+
+  function linkify(root) {
+    if (!enabled || !root || root.nodeType !== Node.ELEMENT_NODE) return;
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    const nodes = [];
+    while (walker.nextNode()) nodes.push(walker.currentNode);
+    nodes.forEach((node) => {
+      const parent = node.parentElement;
+      if (!parent || SKIPPED_TAGS.has(parent.tagName) || parent.closest('[contenteditable], .click-to-call')) return;
+      const text = node.nodeValue || '';
+      PHONE_PATTERN.lastIndex = 0;
+      let match;
+      let offset = 0;
+      let changed = false;
+      const fragment = document.createDocumentFragment();
+      while ((match = PHONE_PATTERN.exec(text))) {
+        const number = validNumber(match[0]);
+        if (!number) continue;
+        fragment.append(document.createTextNode(text.slice(offset, match.index)));
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'click-to-call';
+        button.textContent = match[0];
+        button.title = `Call ${number}`;
+        button.addEventListener('click', () => call(number));
+        fragment.append(button);
+        offset = match.index + match[0].length;
+        changed = true;
+      }
+      if (changed) {
+        fragment.append(document.createTextNode(text.slice(offset)));
+        node.replaceWith(fragment);
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', async () => {
+    try {
+      const response = await fetch('/api/click-to-call/settings', { credentials: 'same-origin' });
+      if (!response.ok) return;
+      enabled = Boolean((await response.json()).enabled);
+      if (!enabled) return;
+      linkify(document.body);
+      new MutationObserver((mutations) => mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (node.nodeType === Node.ELEMENT_NODE) linkify(node);
+        });
+      })).observe(document.body, { childList: true, subtree: true });
+    } catch (error) {
+      // Click-to-call is an enhancement; pages remain usable if settings cannot load.
+    }
+  });
+})();

--- a/app/static/js/profile.js
+++ b/app/static/js/profile.js
@@ -70,6 +70,37 @@
   }
 
   const userId = root.dataset.userId;
+  const clickToCallForm = document.getElementById('click-to-call-form');
+  if (clickToCallForm) {
+    const enabledInput = clickToCallForm.querySelector('#click-to-call-enabled');
+    const phoneIpInput = clickToCallForm.querySelector('#click-to-call-phone-ip');
+    const usernameInput = clickToCallForm.querySelector('#click-to-call-username');
+    const passwordInput = clickToCallForm.querySelector('#click-to-call-password');
+    requestJson('/api/click-to-call/settings').then((settings) => {
+      enabledInput.checked = Boolean(settings.enabled);
+      phoneIpInput.value = settings.phone_ip || '';
+      usernameInput.value = settings.login_username || '';
+    }).catch(() => showMessage({ variant: 'error' }, 'Unable to load click-to-call settings.'));
+
+    clickToCallForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      try {
+        await requestJson('/api/click-to-call/settings', {
+          method: 'PUT',
+          body: JSON.stringify({
+            enabled: enabledInput.checked,
+            phone_ip: phoneIpInput.value.trim() || null,
+            login_username: usernameInput.value.trim() || null,
+            password: passwordInput.value || null,
+          }),
+        });
+        passwordInput.value = '';
+        showMessage({ variant: 'success' }, 'Click-to-call settings saved.');
+      } catch (error) {
+        showMessage({ variant: 'error' }, error.message || 'Unable to save click-to-call settings.');
+      }
+    });
+  }
   let totpDevices = [];
   try {
     const parsed = JSON.parse(root.dataset.totpDevices || '[]');

--- a/app/templates/admin/profile.html
+++ b/app/templates/admin/profile.html
@@ -25,6 +25,32 @@
         <section class="card card--panel">
           <header class="card__header card__header--stacked">
             <div>
+              <h2 class="card__title">Click to call</h2>
+              <p class="card__subtitle">Use your Grandstream phone to call phone numbers shown throughout the portal.</p>
+            </div>
+          </header>
+          <div class="card__body">
+            <form class="form" id="click-to-call-form">
+              <label class="form-checkbox"><input type="checkbox" id="click-to-call-enabled" /> Enable click to call</label>
+              <div class="form-field">
+                <label class="form-label" for="click-to-call-phone-ip">Phone IP</label>
+                <input class="form-input" id="click-to-call-phone-ip" inputmode="decimal" placeholder="192.168.1.50" />
+              </div>
+              <div class="form-field">
+                <label class="form-label" for="click-to-call-username">Login username</label>
+                <input class="form-input" id="click-to-call-username" autocomplete="username" />
+              </div>
+              <div class="form-field">
+                <label class="form-label" for="click-to-call-password">Password</label>
+                <input class="form-input" type="password" id="click-to-call-password" autocomplete="new-password" placeholder="Leave blank to keep current password" />
+              </div>
+              <div class="form-actions"><button type="submit" class="button">Save click-to-call settings</button></div>
+            </form>
+          </div>
+        </section>
+        <section class="card card--panel">
+          <header class="card__header card__header--stacked">
+            <div>
               <h2 class="card__title">Notification Contact</h2>
               <p class="card__subtitle">Provide a mobile number for SMS alerts. Numbers are stored in E.164 format for secure delivery.</p>
             </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -798,6 +798,9 @@
     <script src="{{ static_url('/static/js/header_menu.js') }}" defer></script>
     <script src="{{ static_url('/static/js/table_columns.js') }}" defer></script>
     <script src="{{ static_url('/static/js/main.js') }}" defer></script>
+    {% if has_authenticated_user %}
+    <script src="{{ static_url('/static/js/click_to_call.js') }}" defer></script>
+    {% endif %}
     <script>
       (function () {
         const tokenMeta = document.querySelector('meta[name="csrf-token"]');

--- a/migrations/307_user_click_to_call_settings.sql
+++ b/migrations/307_user_click_to_call_settings.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS user_click_to_call_settings (
+    user_id BIGINT NOT NULL PRIMARY KEY,
+    enabled TINYINT(1) NOT NULL DEFAULT 0,
+    phone_ip VARCHAR(255) NULL,
+    login_username VARCHAR(255) NULL,
+    password_encrypted TEXT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_user_click_to_call_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/tests/test_click_to_call.py
+++ b/tests/test_click_to_call.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.api.routes.click_to_call import ClickToCallSettingsUpdate, _public_settings
+
+
+def test_click_to_call_settings_accept_private_phone_ip():
+    payload = ClickToCallSettingsUpdate(
+        enabled=True,
+        phone_ip="192.168.1.50",
+        login_username="admin",
+        password="secret",
+    )
+
+    assert payload.phone_ip == "192.168.1.50"
+    assert payload.login_username == "admin"
+
+
+@pytest.mark.parametrize("phone_ip", ["localhost", "127.0.0.1", "169.254.1.1"])
+def test_click_to_call_settings_reject_unsafe_phone_ip(phone_ip):
+    with pytest.raises(ValidationError):
+        ClickToCallSettingsUpdate(phone_ip=phone_ip)
+
+
+def test_public_settings_never_exposes_encrypted_password():
+    result = _public_settings(
+        {
+            "enabled": 1,
+            "phone_ip": "10.0.0.20",
+            "login_username": "phone-user",
+            "password_encrypted": "encrypted-value",
+        }
+    )
+
+    assert result == {
+        "enabled": True,
+        "phone_ip": "10.0.0.20",
+        "login_username": "phone-user",
+        "password_configured": True,
+    }
+    assert "password_encrypted" not in result


### PR DESCRIPTION
### Motivation
- Provide technicians a per-user "click to call" feature that uses their Grandstream phone to dial numbers seen in the portal. 
- Persist settings on the user's profile and keep credentials server-side encrypted. 
- Make calls via a backend proxy endpoint to avoid exposing device credentials in the browser and require user confirmation before dialing.

### Description
- Add a migration to create `user_click_to_call_settings` to store per-user enablement, `phone_ip`, `login_username`, and an encrypted `password_encrypted` column. 
- Implement repository helpers in `app/repositories/click_to_call.py` to read and upsert user settings. 
- Add API routes in `app/api/routes/click_to_call.py` to `GET`/`PUT /settings` and `POST /call`, including IP address validation, input validation, encryption (`encrypt_secret`/`decrypt_secret`), and proxying calls to the Grandstream `api-make_call` endpoint using `httpx`. 
- Add frontend support: `app/static/js/click_to_call.js` auto-detects phone numbers and turns them into clickable controls that show a browser confirmation before issuing an API call, plus UI elements on the profile page (`app/templates/admin/profile.html`) and integration in `app/static/js/profile.js`, CSS styles, and inclusion in `base.html`. 

### Testing
- Ran the new unit tests with `pytest` for the feature in `tests/test_click_to_call.py` and they passed (`5 passed`).
- Verified Python files compile with `python -m compileall -q app` with no errors.
- Performed a `git diff --check` equivalent check (no whitespace issues reported).
- Note: running a broader subset of existing sidebar/profile tests produced unrelated failures due to test fixture/template mocking differences (`module_enabled` / mocked services), which are not caused by the click-to-call changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6a9c8495f88332a633cdbb7fd2960b)