### PR TITLE
Show company phone on admin ticket details

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9221,6 +9221,9 @@ async def _render_ticket_detail(
             ticket_requester_phone_display = _format_ticket_requester_phone(
                 requester_record.get("mobile_phone")
             )
+    ticket_company_phone_display = _format_ticket_requester_phone(
+        company.get("phone") if company else None
+    )
 
     default_priorities = ["urgent", "high", "normal", "low"]
     current_priority = str(ticket.get("priority") or "normal")
@@ -9392,6 +9395,7 @@ async def _render_ticket_detail(
         "ticket_user_options": technician_users,
         "ticket_requester_options": requester_options,
         "ticket_requester_phone_display": ticket_requester_phone_display,
+        "ticket_company_phone_display": ticket_company_phone_display,
         "ticket_watcher_staff_options": watcher_staff_options,
         "ticket_mention_staff_options": ticket_mention_staff_options,
         "ticket_priority_options": priority_options,

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -182,7 +182,15 @@
               </div>
               <div class="form-field">
                 <span class="form-label">Requester phone</span>
-                <p class="form-help">{{ ticket_requester_phone_display or '—' }}</p>
+                {% if ticket_requester_phone_display %}
+                  <p class="form-help">Mobile: {{ ticket_requester_phone_display }}</p>
+                {% endif %}
+                {% if ticket_company_phone_display %}
+                  <p class="form-help">Company: {{ ticket_company_phone_display }}</p>
+                {% endif %}
+                {% if not ticket_requester_phone_display and not ticket_company_phone_display %}
+                  <p class="form-help">—</p>
+                {% endif %}
               </div>
               <div class="form-field">
                 <label class="form-label" for="ticket-review-date-detail">Review Date</label>

--- a/tests/test_admin_ticket_detail.py
+++ b/tests/test_admin_ticket_detail.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import AsyncMock, patch
 import io
+from pathlib import Path
 from urllib.parse import parse_qs, unquote, urlparse
 
 import pytest
@@ -25,6 +26,16 @@ def _make_request(path: str = "/admin/tickets/1") -> Request:
     scope = {"type": "http", "method": "GET", "path": path, "headers": []}
     request = Request(scope, _dummy_receive)
     return request
+
+
+def test_requester_phone_field_renders_mobile_and_company_on_separate_lines() -> None:
+    template = Path("app/templates/admin/ticket_detail.html").read_text(encoding="utf-8")
+
+    assert "Mobile: {{ ticket_requester_phone_display }}" in template
+    assert "Company: {{ ticket_company_phone_display }}" in template
+    assert template.index("Mobile: {{ ticket_requester_phone_display }}") < template.index(
+        "Company: {{ ticket_company_phone_display }}"
+    )
 
 
 @pytest.fixture
@@ -84,11 +95,36 @@ async def test_render_ticket_detail_with_tactical_module_and_ai_tags(monkeypatch
     monkeypatch.setattr(main, "sanitize_rich_text", fake_sanitize)
     monkeypatch.setattr(main.tickets_repo, "get_ticket", AsyncMock(return_value=ticket))
     monkeypatch.setattr(main.tickets_repo, "list_replies", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        main.tickets_repo,
+        "list_split_replies_for_original",
+        AsyncMock(return_value=[]),
+    )
     monkeypatch.setattr(main.tickets_repo, "list_watchers", AsyncMock(return_value=[]))
     monkeypatch.setattr(main.attachments_repo, "list_attachments", AsyncMock(return_value=[]))
     monkeypatch.setattr(main.tickets_repo, "list_ticket_assets", AsyncMock(return_value=[]))
-    monkeypatch.setattr(main.user_repo, "get_user_by_id", AsyncMock(return_value={"id": 1, "email": "test@example.com"}))
-    monkeypatch.setattr(main.company_repo, "get_company_by_id", AsyncMock(return_value={"id": 1, "name": "Test Company"}))
+    monkeypatch.setattr(
+        main.user_repo,
+        "get_user_by_id",
+        AsyncMock(
+            return_value={
+                "id": 1,
+                "email": "test@example.com",
+                "mobile_phone": "0412 345 678",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        main.company_repo,
+        "get_company_by_id",
+        AsyncMock(
+            return_value={
+                "id": 1,
+                "name": "Test Company",
+                "phone": "+61 2 9876 5432",
+            }
+        ),
+    )
     monkeypatch.setattr(main.modules_service, "list_modules", AsyncMock(return_value=modules))
     monkeypatch.setattr(main.labour_types_service, "list_labour_types", AsyncMock(return_value=[]))
     monkeypatch.setattr(main.tickets_service, "list_status_definitions", AsyncMock(return_value=statuses))
@@ -105,6 +141,7 @@ async def test_render_ticket_detail_with_tactical_module_and_ai_tags(monkeypatch
             "first_name": "Requester",
             "last_name": "Example",
             "email": "requester@example.com",
+            "mobile_phone": "0412 345 678",
         }
     ]
     monkeypatch.setattr(
@@ -159,6 +196,8 @@ async def test_render_ticket_detail_with_tactical_module_and_ai_tags(monkeypatch
     assert captured["extra"]["ticket_mention_staff_options"] == [
         {"id": 2, "label": "Requester Example", "email": "requester@example.com"}
     ]
+    assert captured["extra"]["ticket_requester_phone_display"] == "0412 345 678"
+    assert captured["extra"]["ticket_company_phone_display"] == "02 9876 5432"
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
### Motivation
- Admin ticket detail should display the linked company's primary phone number in addition to the requester mobile number so support staff can easily reach the company contact. 

### Description
- Add `ticket_company_phone_display` to the admin ticket detail template context by formatting the company `phone` with the existing `_format_ticket_requester_phone` helper in `_render_ticket_detail` (`app/main.py`).
- Update `app/templates/admin/ticket_detail.html` to render the requester mobile as `Mobile: ...` and the company phone as `Company: ...` on separate lines and preserve the existing dash when neither number is present.
- Extend and adjust `tests/test_admin_ticket_detail.py` to assert the new template strings, include a small helper test `test_requester_phone_field_renders_mobile_and_company_on_separate_lines`, and add necessary test mocks for `list_split_replies_for_original` and phone fields to avoid DB-backed calls in the unit tests.

### Testing
- Ran targeted unit tests: `pytest -q tests/test_admin_ticket_detail.py::test_requester_phone_field_renders_mobile_and_company_on_separate_lines tests/test_company_phone.py` which passed.
- Verified compilation with `python -m compileall -q app/main.py tests/test_admin_ticket_detail.py` and `git diff --check`; both checks succeeded.
- Note: an initial full run of `pytest -q tests/test_admin_ticket_detail.py` exposed unrelated existing failures due to unmocked DB-backed calls and some reply mocks returning `None`; those are pre-existing and outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6a9f1a365c83328757959f34bccca7)