### PR TITLE
Add per-technician Microsoft 365 contact lookups

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -183,6 +183,7 @@ from app.services import company_access
 from app.services import dashboard as dashboard_service
 from app.services import email as email_service
 from app.services import m365_mail as m365_mail_service
+from app.services import user_m365_contacts as user_m365_contacts_service
 from app.services import rag_relationships as rag_relationship_service
 from app.services import m365 as m365_service
 from app.services import cis_benchmark as cis_benchmark_service
@@ -4576,6 +4577,8 @@ async def m365_callback(request: Request, code: str | None = None, state: str | 
                 state_data = oauth_state_serializer.loads(state)
                 if state_data.get("flow") == "m365_mail_auth":
                     error_redirect = "/admin/modules/m365-mail"
+                elif state_data.get("flow") == "user_m365_contacts":
+                    error_redirect = "/admin/profile"
             except Exception:
                 pass
         # AADSTS700016 means the PKCE app registration no longer exists in the
@@ -4625,6 +4628,37 @@ async def m365_callback(request: Request, code: str | None = None, state: str | 
     except (TypeError, ValueError):
         company_id = 0
     flow = state_data.get("flow", "connect")
+
+    if flow == "user_m365_contacts":
+        current_user, auth_redirect = await _require_authenticated_user(request)
+        if auth_redirect or not current_user or int(current_user["id"]) != int(state_data.get("user_id") or 0):
+            return flash_redirect("/admin/profile", "The Microsoft sign-in session is not valid.", "error")
+        verifier = await _pop_m365_provision_code_verifier(state_data.get("pkce_handle"))
+        if not verifier:
+            return flash_redirect("/admin/profile", "The Microsoft sign-in verifier is missing.", "error")
+        redirect_uri = _build_m365_redirect_uri(request)
+        token_data = {
+            "client_id": await m365_service.get_effective_pkce_client_id(redirect_uri=redirect_uri),
+            "grant_type": "authorization_code", "code": code, "redirect_uri": redirect_uri,
+            "code_verifier": verifier, "scope": user_m365_contacts_service.CONTACTS_SCOPE,
+        }
+        async with httpx.AsyncClient(timeout=30) as client:
+            token_response = await client.post(
+                "https://login.microsoftonline.com/organizations/oauth2/v2.0/token", data=token_data
+            )
+        if token_response.status_code != 200:
+            return flash_redirect("/admin/profile", "Microsoft 365 contact sign-in failed.", "error")
+        payload = token_response.json()
+        access_token, refresh_token = payload.get("access_token"), payload.get("refresh_token")
+        if not access_token or not refresh_token:
+            return flash_redirect("/admin/profile", "Microsoft did not grant offline contact access.", "error")
+        tenant_id = m365_service.extract_tenant_id_from_token(str(access_token))
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=float(payload.get("expires_in") or 3600))
+        await user_m365_contacts_service.store_tokens(
+            int(current_user["id"]), tenant_id=tenant_id, account_email=str(current_user.get("email") or "") or None,
+            refresh_token=str(refresh_token), access_token=str(access_token), expires_at=expires_at,
+        )
+        return flash_redirect("/admin/profile", "Outlook contacts connected.", "success")
 
     if flow == "m365_mail_auth":
         from app.features.m365_mail.oauth import handle_m365_mail_auth_callback as _pack_handler
@@ -5531,6 +5565,7 @@ async def admin_profile_page(request: Request):
         totp_devices.append({"id": identifier, "name": name})
 
     totp_devices.sort(key=lambda entry: entry["name"].lower())
+    m365_contacts_status = await user_m365_contacts_service.status_for_user(int(user["id"]))
 
     context = await _build_base_context(
         request,
@@ -5540,9 +5575,56 @@ async def admin_profile_page(request: Request):
             "profile_membership": membership,
             "profile_show_technician_tools": _can_edit_profile_technician_tools(user, membership),
             "profile_totp_devices": totp_devices,
+            "profile_m365_contacts": m365_contacts_status,
         },
     )
     return templates.TemplateResponse(context["request"], "admin/profile.html", context)
+
+
+@app.get("/admin/profile/m365-contacts/connect")
+async def profile_m365_contacts_connect(request: Request):
+    user, redirect = await _require_authenticated_user(request)
+    if redirect:
+        return redirect
+    redirect_uri = _build_m365_redirect_uri(request)
+    verifier, challenge = m365_service.generate_pkce_pair()
+    verifier_id = await _store_m365_provision_code_verifier(verifier)
+    state = oauth_state_serializer.dumps({
+        "flow": "user_m365_contacts", "user_id": int(user["id"]), "pkce_handle": verifier_id,
+    })
+    client_id = await m365_service.get_effective_pkce_client_id(redirect_uri=redirect_uri)
+    params = {
+        "client_id": client_id, "response_type": "code", "redirect_uri": redirect_uri,
+        "response_mode": "query", "scope": user_m365_contacts_service.CONTACTS_SCOPE,
+        "state": state, "prompt": "select_account", "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    return RedirectResponse(
+        "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?" + urlencode(params),
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
+
+
+@app.post("/admin/profile/m365-contacts/disconnect")
+async def profile_m365_contacts_disconnect(request: Request):
+    user, redirect = await _require_authenticated_user(request)
+    if redirect:
+        return redirect
+    from app.repositories import user_m365_contacts as user_contacts_repo
+    await user_contacts_repo.delete_integration(int(user["id"]))
+    return flash_redirect("/admin/profile", "Outlook contacts disconnected.", "success")
+
+
+@app.get("/api/profile/m365-contacts/phones", response_class=JSONResponse)
+async def profile_m365_contact_phones(request: Request, name: str = Query(..., min_length=1, max_length=200)):
+    user, redirect = await _require_authenticated_user(request)
+    if redirect:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+    try:
+        phones = await user_m365_contacts_service.lookup_phones(int(user["id"]), name.strip())
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return JSONResponse({"phones": phones})
 
 
 @app.get("/api/rag/relationships/metrics", response_class=JSONResponse)
@@ -9224,6 +9306,16 @@ async def _render_ticket_detail(
     ticket_company_phone_display = _format_ticket_requester_phone(
         company.get("phone") if company else None
     )
+    ticket_requester_lookup_name = ""
+    for requester_option in requester_options:
+        if (_same_identifier(requester_option.get("staff_id"), requester_staff_id)
+                or _same_identifier(requester_option.get("user_id"), requester_user_id)
+                or _same_identifier(requester_option.get("id"), requester_user_id)):
+            ticket_requester_lookup_name = " ".join(filter(None, (
+                str(requester_option.get("first_name") or "").strip(),
+                str(requester_option.get("last_name") or "").strip(),
+            )))
+            break
 
     default_priorities = ["urgent", "high", "normal", "low"]
     current_priority = str(ticket.get("priority") or "normal")
@@ -9396,6 +9488,7 @@ async def _render_ticket_detail(
         "ticket_requester_options": requester_options,
         "ticket_requester_phone_display": ticket_requester_phone_display,
         "ticket_company_phone_display": ticket_company_phone_display,
+        "ticket_requester_lookup_name": ticket_requester_lookup_name,
         "ticket_watcher_staff_options": watcher_staff_options,
         "ticket_mention_staff_options": ticket_mention_staff_options,
         "ticket_priority_options": priority_options,

--- a/app/repositories/user_m365_contacts.py
+++ b/app/repositories/user_m365_contacts.py
@@ -1,0 +1,51 @@
+"""Persistence for per-user Microsoft 365 contact integrations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from app.core.database import db
+
+
+def _normalise(row: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not row:
+        return None
+    result = dict(row)
+    expires = result.get("token_expires_at")
+    if isinstance(expires, datetime) and expires.tzinfo is None:
+        result["token_expires_at"] = expires.replace(tzinfo=timezone.utc)
+    return result
+
+
+async def get_integration(user_id: int) -> dict[str, Any] | None:
+    return _normalise(await db.fetch_one(
+        "SELECT * FROM user_m365_contact_integrations WHERE user_id = %s", (user_id,)
+    ))
+
+
+async def upsert_integration(
+    user_id: int, *, tenant_id: str, account_email: str | None,
+    refresh_token: str, access_token: str | None, token_expires_at: datetime | None,
+) -> None:
+    expires = token_expires_at.replace(tzinfo=None) if token_expires_at else None
+    existing = await get_integration(user_id)
+    if existing:
+        await db.execute(
+            """UPDATE user_m365_contact_integrations
+               SET tenant_id = %s, account_email = %s, refresh_token = %s,
+                   access_token = %s, token_expires_at = %s, updated_at = UTC_TIMESTAMP(6)
+               WHERE user_id = %s""",
+            (tenant_id, account_email, refresh_token, access_token, expires, user_id),
+        )
+        return
+    await db.execute(
+        """INSERT INTO user_m365_contact_integrations
+           (user_id, tenant_id, account_email, refresh_token, access_token, token_expires_at)
+           VALUES (%s, %s, %s, %s, %s, %s)""",
+        (user_id, tenant_id, account_email, refresh_token, access_token, expires),
+    )
+
+
+async def delete_integration(user_id: int) -> None:
+    await db.execute("DELETE FROM user_m365_contact_integrations WHERE user_id = %s", (user_id,))

--- a/app/services/user_m365_contacts.py
+++ b/app/services/user_m365_contacts.py
@@ -1,0 +1,101 @@
+"""Delegated Microsoft Graph contact lookup for an individual technician."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping
+
+import httpx
+
+from app.repositories import user_m365_contacts as contacts_repo
+from app.security.encryption import decrypt_secret, encrypt_secret
+from app.services import m365 as m365_service
+
+CONTACTS_SCOPE = "openid profile email offline_access https://graph.microsoft.com/Contacts.Read"
+GRAPH_CONTACTS_URL = (
+    "https://graph.microsoft.com/v1.0/me/contacts"
+    "?$select=displayName,givenName,surname,mobilePhone,businessPhones,homePhones&$top=100"
+)
+
+
+async def status_for_user(user_id: int) -> dict[str, Any]:
+    record = await contacts_repo.get_integration(user_id)
+    return {"connected": bool(record), "account_email": record.get("account_email") if record else None}
+
+
+async def store_tokens(user_id: int, *, tenant_id: str, account_email: str | None,
+                       refresh_token: str, access_token: str, expires_at: datetime | None) -> None:
+    await contacts_repo.upsert_integration(
+        user_id, tenant_id=tenant_id, account_email=account_email,
+        refresh_token=encrypt_secret(refresh_token), access_token=encrypt_secret(access_token),
+        token_expires_at=expires_at,
+    )
+
+
+async def acquire_access_token(user_id: int) -> str:
+    record = await contacts_repo.get_integration(user_id)
+    if not record:
+        raise ValueError("Microsoft 365 contacts are not connected")
+    expires = record.get("token_expires_at")
+    if record.get("access_token") and expires and expires > datetime.now(timezone.utc) + timedelta(minutes=5):
+        return decrypt_secret(record["access_token"])
+    data = {
+        "client_id": await m365_service.get_effective_pkce_client_id(),
+        "grant_type": "refresh_token",
+        "refresh_token": decrypt_secret(record["refresh_token"]),
+        "scope": CONTACTS_SCOPE,
+    }
+    url = f"https://login.microsoftonline.com/{record['tenant_id']}/oauth2/v2.0/token"
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.post(url, data=data)
+    if response.status_code != 200:
+        raise ValueError("Microsoft 365 sign-in expired; reconnect it from your profile")
+    payload = response.json()
+    access_token = str(payload.get("access_token") or "")
+    if not access_token:
+        raise ValueError("Microsoft 365 did not return an access token")
+    expires_in = payload.get("expires_in")
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=float(expires_in or 3600))
+    refresh_token = str(payload.get("refresh_token") or decrypt_secret(record["refresh_token"]))
+    await store_tokens(user_id, tenant_id=record["tenant_id"], account_email=record.get("account_email"),
+                       refresh_token=refresh_token, access_token=access_token, expires_at=expires_at)
+    return access_token
+
+
+def _words(value: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9]+", value.casefold()))
+
+
+def match_contact_phones(requester_name: str, contacts: list[Mapping[str, Any]]) -> list[dict[str, str]]:
+    """Return de-duplicated phones from contacts whose name matches the requester."""
+    wanted = _words(requester_name)
+    if not wanted:
+        return []
+    matches: list[tuple[int, str, str]] = []
+    seen: set[str] = set()
+    for contact in contacts:
+        display_name = str(contact.get("displayName") or "").strip()
+        contact_words = _words(display_name or f"{contact.get('givenName', '')} {contact.get('surname', '')}")
+        overlap = len(wanted & contact_words)
+        if not overlap or (len(wanted) > 1 and overlap < len(wanted)):
+            continue
+        phones = [contact.get("mobilePhone"), *(contact.get("businessPhones") or []), *(contact.get("homePhones") or [])]
+        for phone in phones:
+            value = str(phone or "").strip()
+            key = re.sub(r"\D", "", value)
+            if not value or not key or key in seen:
+                continue
+            seen.add(key)
+            matches.append((overlap, display_name or requester_name, value))
+    matches.sort(key=lambda item: (-item[0], item[1].casefold(), item[2]))
+    return [{"name": name, "phone": phone} for _, name, phone in matches[:10]]
+
+
+async def lookup_phones(user_id: int, requester_name: str) -> list[dict[str, str]]:
+    token = await acquire_access_token(user_id)
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.get(GRAPH_CONTACTS_URL, headers={"Authorization": f"Bearer {token}"})
+    if response.status_code != 200:
+        raise ValueError("Unable to read Outlook contacts")
+    return match_contact_phones(requester_name, response.json().get("value") or [])

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -1,5 +1,43 @@
 (function () {
 
+  function initialiseOutlookContactLookup() {
+    const root = document.querySelector('[data-outlook-contact-phones]');
+    if (!root) return;
+    const button = root.querySelector('[data-outlook-contact-load]');
+    const status = root.querySelector('[data-outlook-contact-status]');
+    const results = root.querySelector('[data-outlook-contact-results]');
+    if (!button || !status || !results) return;
+    button.addEventListener('click', async () => {
+      button.disabled = true;
+      status.hidden = false;
+      status.textContent = 'Checking your Outlook contacts…';
+      results.replaceChildren();
+      try {
+        const name = root.dataset.requesterName || '';
+        const response = await fetch(`/api/profile/m365-contacts/phones?name=${encodeURIComponent(name)}`);
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(payload.detail || 'Unable to check Outlook contacts');
+        const phones = Array.isArray(payload.phones) ? payload.phones : [];
+        status.textContent = phones.length ? 'Outlook contact options:' : 'No matching Outlook contact phone numbers found.';
+        phones.forEach((item) => {
+          const line = document.createElement('p');
+          line.className = 'form-help';
+          const link = document.createElement('a');
+          link.href = `tel:${item.phone}`;
+          link.textContent = item.phone;
+          line.append(`${item.name}: `, link);
+          results.appendChild(line);
+        });
+      } catch (error) {
+        status.textContent = error.message || 'Unable to check Outlook contacts.';
+      } finally {
+        button.disabled = false;
+      }
+    });
+  }
+
+  initialiseOutlookContactLookup();
+
   const TICKET_SECTION_STATE_STORAGE_KEY = 'myportal.admin.ticketDetail.sectionState.v1';
 
   function formatApiErrorDetail(detail) {

--- a/app/templates/admin/profile.html
+++ b/app/templates/admin/profile.html
@@ -25,6 +25,27 @@
         <section class="card card--panel">
           <header class="card__header card__header--stacked">
             <div>
+              <h2 class="card__title">Outlook contacts</h2>
+              <p class="card__subtitle">Connect your own Microsoft 365 account to show phone numbers from your Outlook contacts when viewing a requester.</p>
+            </div>
+          </header>
+          <div class="card__body">
+            {% if profile_m365_contacts.connected %}
+              <p class="form-help">Connected{% if profile_m365_contacts.account_email %} as {{ profile_m365_contacts.account_email }}{% endif %}. MyPortal only requests read access to your contacts.</p>
+              <form method="post" action="/admin/profile/m365-contacts/disconnect" class="form-actions">
+                <button type="submit" class="button button--ghost">Disconnect Outlook contacts</button>
+              </form>
+            {% else %}
+              <p class="form-help">Not connected. Contact lookups are private to your technician account.</p>
+              <div class="form-actions">
+                <a class="button" href="/admin/profile/m365-contacts/connect">Connect Microsoft 365</a>
+              </div>
+            {% endif %}
+          </div>
+        </section>
+        <section class="card card--panel">
+          <header class="card__header card__header--stacked">
+            <div>
               <h2 class="card__title">Click to call</h2>
               <p class="card__subtitle">Use your Grandstream phone to call phone numbers shown throughout the portal.</p>
             </div>

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -191,6 +191,13 @@
                 {% if not ticket_requester_phone_display and not ticket_company_phone_display %}
                   <p class="form-help">—</p>
                 {% endif %}
+                {% if ticket_requester_lookup_name %}
+                  <div data-outlook-contact-phones data-requester-name="{{ ticket_requester_lookup_name }}">
+                    <button type="button" class="button button--ghost button--small" data-outlook-contact-load>Check Outlook contacts</button>
+                    <p class="form-help" data-outlook-contact-status hidden></p>
+                    <div data-outlook-contact-results></div>
+                  </div>
+                {% endif %}
               </div>
               <div class="form-field">
                 <label class="form-label" for="ticket-review-date-detail">Review Date</label>

--- a/migrations/308_user_m365_contact_integrations.sql
+++ b/migrations/308_user_m365_contact_integrations.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS user_m365_contact_integrations (
+    user_id BIGINT NOT NULL PRIMARY KEY,
+    tenant_id VARCHAR(64) NOT NULL,
+    account_email VARCHAR(320) NULL,
+    refresh_token TEXT NOT NULL,
+    access_token TEXT NULL,
+    token_expires_at DATETIME NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_user_m365_contacts_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/tests/test_user_m365_contacts.py
+++ b/tests/test_user_m365_contacts.py
@@ -1,0 +1,22 @@
+from app.services import user_m365_contacts
+
+
+def test_match_contact_phones_requires_requester_name_match():
+    contacts = [
+        {"displayName": "Ada Lovelace", "mobilePhone": "0400 111 222", "businessPhones": ["02 1234 5678"]},
+        {"displayName": "Grace Hopper", "mobilePhone": "0400 999 999"},
+    ]
+    assert user_m365_contacts.match_contact_phones("Ada Lovelace", contacts) == [
+        {"name": "Ada Lovelace", "phone": "02 1234 5678"},
+        {"name": "Ada Lovelace", "phone": "0400 111 222"},
+    ]
+
+
+def test_match_contact_phones_deduplicates_formatted_numbers():
+    contacts = [{
+        "displayName": "Ada Lovelace", "mobilePhone": "+61 400 111 222",
+        "businessPhones": ["+61 (400) 111-222"], "homePhones": [],
+    }]
+    assert user_m365_contacts.match_contact_phones("Ada Lovelace", contacts) == [
+        {"name": "Ada Lovelace", "phone": "+61 400 111 222"},
+    ]


### PR DESCRIPTION
### Motivation
- Provide technicians a per-user Microsoft 365 (Outlook) connection so they can match a ticket requester by name against their own Outlook contacts and surface extra phone options without adding contacts to MyPortal or using their phones.

### Description
- Add a DB migration `migrations/308_user_m365_contact_integrations.sql` and repository `app/repositories/user_m365_contacts.py` to persist per-user encrypted delegated OAuth tokens and metadata. 
- Implement `app/services/user_m365_contacts.py` to refresh per-user tokens, call the Graph contacts API, and match/de-duplicate phone numbers via `match_contact_phones`. 
- Expose profile-level connect/disconnect flows and a lookup API by adding profile routes and OAuth handling in `app/main.py` and a connect/disconnect UI in `app/templates/admin/profile.html`. 
- Integrate ticket-detail UI/JS changes (`app/templates/admin/ticket_detail.html`, `app/static/js/ticket_detail.js`) to allow on-demand Outlook contact phone lookups and present de-duplicated phone options beside stored requester/company numbers. 
- Use the existing encryption helpers (`encrypt_secret`/`decrypt_secret`) and the app PKCE helper flow (store/pop PKCE handle) for secure delegated sign-in, and add unit tests for the contact-matching logic in `tests/test_user_m365_contacts.py`.

### Testing
- Verified Python syntax with `python -m py_compile app/main.py app/services/user_m365_contacts.py app/repositories/user_m365_contacts.py` which succeeded. 
- Ran `pytest -q tests/test_user_m365_contacts.py` which passed (2 tests). 
- Ran repository-level checks (`git diff --check`) with no issues. 
- Note: running the broader `tests/test_admin_ticket_detail.py` concurrently surfaced unrelated failures in some ticket-detail tests due to test fixtures/mocks for shipment/split-reply and reply-return dependencies; these failures are external to the new contact-lookup logic and do not affect the new unit tests added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6aa064e3908332ad2c2c5e55f3cba6)