### PR TITLE
Fix click-to-call settings foreign key migration

### DIFF
--- a/migrations/307_user_click_to_call_settings.sql
+++ b/migrations/307_user_click_to_call_settings.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS user_click_to_call_settings (
-    user_id BIGINT NOT NULL PRIMARY KEY,
+    -- Keep this type identical to users.id so MySQL can create the foreign key.
+    user_id INT NOT NULL PRIMARY KEY,
     enabled TINYINT(1) NOT NULL DEFAULT 0,
     phone_ip VARCHAR(255) NULL,
     login_username VARCHAR(255) NULL,

--- a/tests/test_click_to_call.py
+++ b/tests/test_click_to_call.py
@@ -1,9 +1,22 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
 from app.api.routes.click_to_call import ClickToCallSettingsUpdate, _public_settings
+
+
+def test_click_to_call_migration_matches_user_id_type():
+    migration = (
+        Path(__file__).resolve().parents[1]
+        / "migrations"
+        / "307_user_click_to_call_settings.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "user_id INT NOT NULL PRIMARY KEY" in migration
+    assert "user_id BIGINT" not in migration
 
 
 def test_click_to_call_settings_accept_private_phone_ip():


### PR DESCRIPTION
### Motivation

- MySQL could not create the `user_click_to_call_settings` table because the `user_id` column was defined as `BIGINT` while `users.id` is an `INT`, causing a foreign key constraint formation error. 
- The migration must use the same column type as `users.id` so the foreign key can be created and application startup succeeds.

### Description

- Update `migrations/307_user_click_to_call_settings.sql` to change `user_id` from `BIGINT` to `INT` and add a clarifying comment so the type matches `users.id` (`INT`).
- Add a regression test to `tests/test_click_to_call.py` that asserts the migration contains `user_id INT NOT NULL PRIMARY KEY` and does not contain `user_id BIGINT` to prevent future regressions.

### Testing

- Ran `pytest -q tests/test_click_to_call.py`, which passed (all tests in that file succeeded). 
- Ran `ruff check tests/test_click_to_call.py`, which completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6aa1be5ad483329062575f4273a82e)