### PR TITLE
Fix M365 contacts migration foreign key type

### DIFF
--- a/migrations/308_user_m365_contact_integrations.sql
+++ b/migrations/308_user_m365_contact_integrations.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS user_m365_contact_integrations (
-    user_id BIGINT NOT NULL PRIMARY KEY,
+    -- Keep this type identical to users.id so MySQL can create the foreign key.
+    user_id INT NOT NULL PRIMARY KEY,
     tenant_id VARCHAR(64) NOT NULL,
     account_email VARCHAR(320) NULL,
     refresh_token TEXT NOT NULL,

--- a/tests/test_user_m365_contact_integrations_migration.py
+++ b/tests/test_user_m365_contact_integrations_migration.py
@@ -1,0 +1,30 @@
+"""Tests for the per-user Microsoft 365 contacts migration."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+MIGRATION = (
+    Path(__file__).resolve().parent.parent
+    / "migrations"
+    / "308_user_m365_contact_integrations.sql"
+)
+
+
+def test_user_id_matches_referenced_users_id_type():
+    """The foreign-key column must match the INT type of users.id in MySQL."""
+    content = MIGRATION.read_text(encoding="utf-8")
+
+    column = re.search(r"\buser_id\s+(INT|BIGINT)\b", content, re.IGNORECASE)
+    assert column, "Could not find the user_id column definition"
+    assert column.group(1).upper() == "INT", (
+        "user_m365_contact_integrations.user_id must be INT to match users.id"
+    )
+
+    foreign_key = re.search(
+        r"FOREIGN\s+KEY\s*\(user_id\)\s+REFERENCES\s+users\s*\(id\)",
+        content,
+        re.IGNORECASE,
+    )
+    assert foreign_key, "Could not find the foreign key from user_id to users.id"


### PR DESCRIPTION
### Motivation
- Fix a MySQL startup failure caused by an incorrectly-formed foreign key where the migration declared `user_id` with a type that did not match the referenced `users.id`, preventing the FK from being created.

### Description
- Change `user_m365_contact_integrations.user_id` from `BIGINT` to `INT` in `migrations/308_user_m365_contact_integrations.sql` and add a clarifying comment to ensure the type matches `users.id`.
- Add a regression test `tests/test_user_m365_contact_integrations_migration.py` that verifies the `user_id` column is `INT` and that a foreign key to `users(id)` is declared.
- Keep the migration otherwise unchanged and ensure the new test is isolated to the migration file contents.

### Testing
- Ran `pytest -q tests/test_user_m365_contact_integrations_migration.py tests/test_user_sidebar_preferences_migration.py` and the test suite completed successfully with `2 passed`.
- Ran `pytest -q tests/test_user_m365_contacts.py tests/test_user_m365_contact_integrations_migration.py` and the tests completed successfully with `3 passed` (some deprecation warnings from unrelated schemas were observed but do not affect the change).
- Ran `python -m compileall -q app tests/test_user_m365_contact_integrations_migration.py` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6aa338126083329067b4ae22604743)