### PR TITLE
Fix Outlook contact lookup POST route

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5615,7 +5615,11 @@ async def profile_m365_contacts_disconnect(request: Request):
     return flash_redirect("/admin/profile", "Outlook contacts disconnected.", "success")
 
 
-@app.get("/api/profile/m365-contacts/phones", response_class=JSONResponse)
+@app.api_route(
+    "/api/profile/m365-contacts/phones",
+    methods=["GET", "POST"],
+    response_class=JSONResponse,
+)
 async def profile_m365_contact_phones(request: Request, name: str = Query(..., min_length=1, max_length=200)):
     user, redirect = await _require_authenticated_user(request)
     if redirect:

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -14,7 +14,10 @@
       results.replaceChildren();
       try {
         const name = root.dataset.requesterName || '';
-        const response = await fetch(`/api/profile/m365-contacts/phones?name=${encodeURIComponent(name)}`);
+        const response = await fetch(
+          `/api/profile/m365-contacts/phones?name=${encodeURIComponent(name)}`,
+          { method: 'POST' },
+        );
         const payload = await response.json().catch(() => ({}));
         if (!response.ok) throw new Error(payload.detail || 'Unable to check Outlook contacts');
         const phones = Array.isArray(payload.phones) ? payload.phones : [];

--- a/changes/6d214d65-0e98-4cef-bd03-2be474d753dc.json
+++ b/changes/6d214d65-0e98-4cef-bd03-2be474d753dc.json
@@ -1,0 +1,7 @@
+{
+  "guid": "6d214d65-0e98-4cef-bd03-2be474d753dc",
+  "occurred_at": "2026-07-30T00:00:00Z",
+  "change_type": "fix",
+  "summary": "Fixed Outlook contact phone lookups so POST requests reach the technician's connected Microsoft 365 contacts.",
+  "content_hash": ""
+}

--- a/tests/audit_coverage_allowlist.json
+++ b/tests/audit_coverage_allowlist.json
@@ -175,6 +175,7 @@
   "POST /api/notifications",
   "POST /api/notifications/acknowledge",
   "POST /api/notifications/{notification_id}/read",
+  "POST /api/profile/m365-contacts/phones",
   "POST /api/quotes/{quote_number}/assign",
   "POST /api/service-status/services",
   "POST /api/service-status/services/{service_id}/check-now",

--- a/tests/test_user_m365_contacts.py
+++ b/tests/test_user_m365_contacts.py
@@ -1,3 +1,9 @@
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from app.main import app
 from app.services import user_m365_contacts
 
 
@@ -20,3 +26,38 @@ def test_match_contact_phones_deduplicates_formatted_numbers():
     assert user_m365_contacts.match_contact_phones("Ada Lovelace", contacts) == [
         {"name": "Ada Lovelace", "phone": "+61 400 111 222"},
     ]
+
+
+def test_contact_phone_lookup_accepts_post_requests():
+    routes = [
+        route for route in app.routes
+        if getattr(route, "path", None) == "/api/profile/m365-contacts/phones"
+    ]
+
+    assert len(routes) == 1
+    assert {"GET", "POST"}.issubset(routes[0].methods)
+
+
+@pytest.mark.anyio
+async def test_lookup_phones_reads_the_authenticated_technicians_contacts(monkeypatch):
+    acquire_access_token = AsyncMock(return_value="technician-access-token")
+    monkeypatch.setattr(user_m365_contacts, "acquire_access_token", acquire_access_token)
+    async_client = httpx.AsyncClient
+
+    async def graph_contacts(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer technician-access-token"
+        return httpx.Response(200, json={"value": [{
+            "displayName": "Ada Lovelace",
+            "mobilePhone": "0400 111 222",
+        }]})
+
+    monkeypatch.setattr(
+        user_m365_contacts.httpx,
+        "AsyncClient",
+        lambda **kwargs: async_client(transport=httpx.MockTransport(graph_contacts), **kwargs),
+    )
+
+    phones = await user_m365_contacts.lookup_phones(42, "Ada Lovelace")
+
+    acquire_access_token.assert_awaited_once_with(42)
+    assert phones == [{"name": "Ada Lovelace", "phone": "0400 111 222"}]


### PR DESCRIPTION
### Motivation

- The ticket-detail Outlook contact lookup was returning 404 for POST requests because the backend endpoint only accepted GET, preventing technicians from looking up requester phone numbers from their connected Microsoft 365 contacts.
- The lookup must query the signed-in technician's delegated M365 contacts so results come from the technician who clicked "Check Outlook contacts".

### Description

- Allow both `GET` and `POST` on the lookup endpoint by changing the handler to `@app.api_route("/api/profile/m365-contacts/phones", methods=["GET","POST"], response_class=JSONResponse)` in `app/main.py`.
- Send the lookup as an explicit `POST` from the ticket-detail UI by updating `app/static/js/ticket_detail.js` to call `fetch(..., { method: 'POST' })`.
- Add regression coverage in `tests/test_user_m365_contacts.py` to assert the route supports `POST` and to verify `lookup_phones` uses the authenticated technician's delegated token via a mocked `httpx.AsyncClient` call.
- Record the fix in the change log and add the read-only POST lookup to `tests/audit_coverage_allowlist.json` to reflect this benign state-changing route.

### Testing

- Ran `pytest -q tests/test_user_m365_contacts.py` and all tests passed (`4 passed`).
- Ran `git diff --check` to ensure no whitespace or diff issues.
- `pytest -q tests/test_audit_coverage.py` initially highlighted pre-existing audit-allowlist drift; the read-only contact lookup POST was added to `tests/audit_coverage_allowlist.json` and committed to address the new route being audited.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6aa5a745a0833283c24f6ec850b724)