### PR TITLE
Fix encoded HTML leaking into Trello card comments

### DIFF
--- a/app/services/trello.py
+++ b/app/services/trello.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from html import unescape
 from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import quote, urljoin, urlsplit, urlunsplit
@@ -166,6 +167,14 @@ def _strip_html(value: str, *, image_base_url: str | None = None) -> str:
     """Convert HTML to plain text/Markdown suitable for a Trello comment."""
     if not value:
         return ""
+
+    # Rich-text replies can reach this integration with their markup entity-
+    # encoded (for example ``&lt;/span&gt;&lt;/div&gt;``).  HTMLParser decodes
+    # character references only while emitting text, so feeding that value
+    # directly would expose the decoded tags in the Trello comment instead of
+    # treating them as markup.  Decode once before parsing so block elements
+    # and ``br`` tags are handled by the parser and rendered as line breaks.
+    value = unescape(value)
     parser = _TrelloCommentHTMLParser(image_base_url=image_base_url)
     parser.feed(value)
     parser.close()

--- a/tests/test_trello_comment_formatting.py
+++ b/tests/test_trello_comment_formatting.py
@@ -15,6 +15,15 @@ def test_strip_html_removes_formatting_and_preserves_text():
     )
 
 
+def test_strip_html_parses_entity_encoded_markup_and_preserves_line_breaks():
+    body = (
+        "&lt;div&gt;&lt;span&gt;First line&lt;/span&gt;&lt;/div&gt;"
+        "&lt;div&gt;&lt;span&gt;Second line&lt;/span&gt;&lt;br&gt;Third line&lt;/div&gt;"
+    )
+
+    assert trello_service._strip_html(body) == "First line\nSecond line\nThird line"
+
+
 def test_strip_html_renders_ticket_images_as_absolute_markdown():
     body = '<div>Screenshot attached</div><img src="/api/tickets/25055/attachments/9977/download" alt="">'
 


### PR DESCRIPTION
### Motivation
- Rich-text replies sometimes arrive entity-encoded (e.g. `&lt;/span&gt;`), which caused decoded tags to appear literally on Trello cards instead of being interpreted as markup and producing line breaks.

### Description
- Decode entity-encoded markup before parsing by adding `from html import unescape` and calling `value = unescape(value)` in `_strip_html` so block tags and `<br>` are handled by the parser.
- Add a regression test `test_strip_html_parses_entity_encoded_markup_and_preserves_line_breaks` in `tests/test_trello_comment_formatting.py` to assert encoded `<div>`, `<span>`, and `<br>` produce the expected line breaks.

### Testing
- Ran `pytest -q tests/test_trello_comment_formatting.py` and the test suite for that file passed (3 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6ae0f4789483329bfb16d9fda23f09)