### PR TITLE
Restrict click-to-call detection to configured phone prefixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ SESSION_COOKIE_NAME=myportal_session
 # WARNING: Never use * in production as it allows any website to access your API
 ALLOWED_ORIGINS=
 
+# Comma-separated prefixes eligible for automatic click-to-call detection.
+# Include the exact forms used in your portal (for example, +61 and 61 are
+# distinct). Restricting detection prevents dates and timestamps being linked.
+CLICK_TO_CALL_PHONE_PREFIXES=+61,617,614,04
+
 # Trusted Proxies: Comma-separated list of IPs or CIDR ranges that are
 # allowed to set the X-Forwarded-For / X-Real-IP headers. Requests from
 # other origins will have these headers ignored and the direct socket

--- a/app/api/routes/click_to_call.py
+++ b/app/api/routes/click_to_call.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from app.api.dependencies.auth import get_current_user
 from app.api.dependencies.database import require_database
+from app.core.config import get_settings as get_app_settings
 from app.repositories import click_to_call as click_to_call_repo
 from app.security.encryption import decrypt_secret, encrypt_secret
 
@@ -52,6 +53,11 @@ def _public_settings(record: dict | None) -> dict[str, object]:
         "phone_ip": record.get("phone_ip") or "",
         "login_username": record.get("login_username") or "",
         "password_configured": bool(record.get("password_encrypted")),
+        "phone_prefixes": [
+            prefix.strip()
+            for prefix in get_app_settings().click_to_call_phone_prefixes.split(",")
+            if prefix.strip()
+        ],
     }
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -87,6 +87,14 @@ class Settings(BaseSettings):
         default="",
         validation_alias="ALLOWED_ORIGINS",
     )
+    click_to_call_phone_prefixes: str = Field(
+        default="+61,617,614,04",
+        validation_alias="CLICK_TO_CALL_PHONE_PREFIXES",
+        description=(
+            "Comma-separated phone prefixes eligible for automatic click-to-call "
+            "detection. Prefixes are compared after removing display formatting."
+        ),
+    )
     smtp_host: str | None = Field(default=None, validation_alias="SMTP_HOST")
     smtp_port: int = Field(default=587, validation_alias="SMTP_PORT")
     smtp_user: str | None = Field(default=None, validation_alias="SMTP_USER")

--- a/app/static/js/click_to_call.js
+++ b/app/static/js/click_to_call.js
@@ -2,6 +2,7 @@
   const PHONE_PATTERN = /(?:\+?\d[\d\s().-]{5,}\d)/g;
   const SKIPPED_TAGS = new Set(['A', 'BUTTON', 'INPUT', 'OPTION', 'SCRIPT', 'STYLE', 'TEXTAREA']);
   let enabled = false;
+  let phonePrefixes = [];
 
   function toast(message, variant) {
     if (window.__portalToast && typeof window.__portalToast.show === 'function') {
@@ -14,7 +15,16 @@
   function validNumber(text) {
     const normalized = text.replace(/[^0-9+]/g, '');
     const digits = normalized.replace(/\D/g, '');
-    return digits.length >= 7 && digits.length <= 15 ? normalized : null;
+    if (digits.length < 7 || digits.length > 15) return null;
+
+    // Only link values beginning with an operator-approved prefix. This avoids
+    // interpreting dates, timestamps, invoice numbers, and other digit strings
+    // as telephone numbers merely because they have a plausible length.
+    const hasAllowedPrefix = phonePrefixes.some((prefix) => {
+      const normalizedPrefix = prefix.replace(/[^0-9+]/g, '');
+      return normalizedPrefix && normalized.startsWith(normalizedPrefix);
+    });
+    return hasAllowedPrefix ? normalized : null;
   }
 
   async function call(number) {
@@ -77,7 +87,9 @@
     try {
       const response = await fetch('/api/click-to-call/settings', { credentials: 'same-origin' });
       if (!response.ok) return;
-      enabled = Boolean((await response.json()).enabled);
+      const settings = await response.json();
+      enabled = Boolean(settings.enabled);
+      phonePrefixes = Array.isArray(settings.phone_prefixes) ? settings.phone_prefixes : [];
       if (!enabled) return;
       linkify(document.body);
       new MutationObserver((mutations) => mutations.forEach((mutation) => {

--- a/tests/test_click_to_call.py
+++ b/tests/test_click_to_call.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from app.api.routes import click_to_call
 from app.api.routes.click_to_call import ClickToCallSettingsUpdate, _public_settings
 
 
@@ -37,7 +38,12 @@ def test_click_to_call_settings_reject_unsafe_phone_ip(phone_ip):
         ClickToCallSettingsUpdate(phone_ip=phone_ip)
 
 
-def test_public_settings_never_exposes_encrypted_password():
+def test_public_settings_never_exposes_encrypted_password(monkeypatch):
+    monkeypatch.setattr(
+        click_to_call,
+        "get_app_settings",
+        lambda: type("Settings", (), {"click_to_call_phone_prefixes": "+61, 04"})(),
+    )
     result = _public_settings(
         {
             "enabled": 1,
@@ -52,5 +58,18 @@ def test_public_settings_never_exposes_encrypted_password():
         "phone_ip": "10.0.0.20",
         "login_username": "phone-user",
         "password_configured": True,
+        "phone_prefixes": ["+61", "04"],
     }
     assert "password_encrypted" not in result
+
+
+def test_public_settings_ignores_empty_phone_prefixes(monkeypatch):
+    monkeypatch.setattr(
+        click_to_call,
+        "get_app_settings",
+        lambda: type(
+            "Settings", (), {"click_to_call_phone_prefixes": " +61, , 617, "}
+        )(),
+    )
+
+    assert _public_settings(None)["phone_prefixes"] == ["+61", "617"]


### PR DESCRIPTION
### Motivation

- Click-to-call was incorrectly highlighting dates, timestamps and other digit strings as phone numbers; restricting detection by prefix reduces misclassification.
- Provide operators a configurable, environment-backed safe list of phone prefixes so detection can be tuned to local numbering formats (examples: `+61`, `617`, `614`, `04`).
- Surface the configured prefixes to the client so the browser-side enhancer can use the same approved list as the server.

### Description

- Add a new settings field `click_to_call_phone_prefixes` (env alias `CLICK_TO_CALL_PHONE_PREFIXES`) with a default of `+61,617,614,04` in `app/core/config.py` and document it in `.env.example`.
- Include the sanitized list as `phone_prefixes` in the authenticated click-to-call settings response by calling `get_settings()` in `app/api/routes/click_to_call.py`.
- Update the client script `app/static/js/click_to_call.js` to fetch the server settings and only convert detected digit-strings into call buttons when the normalized number both has 7–15 digits and begins with an approved prefix.
- Add tests in `tests/test_click_to_call.py` to verify prefix serialization, trimming/empty-entry handling, and that encrypted credentials remain hidden from `_public_settings`.

### Testing

- Ran `pytest -q tests/test_click_to_call.py tests/test_config_secret_validation.py` and all tests passed (16 passed). 
- Compiled the Python package with `python -m compileall -q app` with no syntax errors. 
- Performed `git diff --check` to ensure no trailing whitespace or other diff issues were introduced and the working tree was clean after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6b4ba51a9c8332a66f303adc545aa5)