### PR TITLE
Fix tray Tactical RMM script requests timing out silently

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -326,6 +326,13 @@ async def run_trmm_script(
     that an administrator did not expose in the menu designer.
     """
 
+    log_info(
+        "Tray Tactical RMM script request received",
+        device_id=device.get("id"),
+        asset_id=device.get("asset_id"),
+        script_id=payload.script_id,
+    )
+
     config = await tray_service.resolve_config_for_device(device)
     script_node = _find_trmm_script_node(
         config.get("menu") or [], int(payload.script_id)
@@ -354,8 +361,24 @@ async def run_trmm_script(
             trmm_agent_id, int(payload.script_id)
         )
     except tacticalrmm_service.TacticalRMMConfigurationError as exc:
+        log_error(
+            "Tray Tactical RMM script request rejected by integration configuration",
+            device_id=device.get("id"),
+            asset_id=asset_id,
+            trmm_agent_id=trmm_agent_id,
+            script_id=payload.script_id,
+            error=str(exc),
+        )
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except tacticalrmm_service.TacticalRMMAPIError as exc:
+        log_error(
+            "Tray Tactical RMM script request failed",
+            device_id=device.get("id"),
+            asset_id=asset_id,
+            trmm_agent_id=trmm_agent_id,
+            script_id=payload.script_id,
+            error=str(exc),
+        )
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     response = result.get("response") if isinstance(result, dict) else None

--- a/tray/ui/http_helper.go
+++ b/tray/ui/http_helper.go
@@ -10,10 +10,14 @@ import (
 )
 
 // httpClient is a shared HTTP client used for API calls from within the UI
-// process.  The timeout is kept short (5 s) so that user-facing actions such
-// as opening the chat window do not stall for a long time when the portal is
-// temporarily unreachable.
+// process. The timeout is kept short so most user-facing actions do not stall
+// for a long time when the portal is temporarily unreachable.
 var httpClient = &http.Client{Timeout: 5 * time.Second}
+
+// trmmHTTPClient allows enough time for MyPortal to validate a script and
+// submit it to Tactical RMM before replying. The portal can make two upstream
+// requests, each with a 15-second timeout, while processing this action.
+var trmmHTTPClient = &http.Client{Timeout: 35 * time.Second}
 
 // newHTTPRequest creates a POST request with the device auth token in the
 // Authorization header and a JSON body.

--- a/tray/ui/trmm_script.go
+++ b/tray/ui/trmm_script.go
@@ -12,6 +12,7 @@ import (
 )
 
 func runTRMMScriptFromMenu(node api.MenuNode) {
+	logger.Info("TRMM script menu item selected: label=%q script_id=%d", node.Label, node.ScriptID)
 	if node.ScriptID <= 0 {
 		logger.Warn("TRMM script menu item %q has no script_id", node.Label)
 		showTextWindow("Tactical RMM", "This menu item is missing a Tactical RMM script selection.")
@@ -30,13 +31,14 @@ func runTRMMScriptFromMenu(node api.MenuNode) {
 		showTextWindow("Tactical RMM", "Could not build the Tactical RMM script request.")
 		return
 	}
-	resp, err := httpClient.Do(req)
+	resp, err := trmmHTTPClient.Do(req)
 	if err != nil {
 		logger.Warn("TRMM script request failed: %v", err)
 		showTextWindow("Tactical RMM", "Could not contact MyPortal to start the script.")
 		return
 	}
 	defer resp.Body.Close()
+	logger.Info("TRMM script request received HTTP %d for script_id=%d", resp.StatusCode, node.ScriptID)
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		logger.Warn("TRMM script request HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))

--- a/tray/ui/trmm_script_test.go
+++ b/tray/ui/trmm_script_test.go
@@ -1,6 +1,18 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+func TestTRMMScriptHTTPTimeoutAllowsPortalUpstreamRequests(t *testing.T) {
+	if trmmHTTPClient.Timeout < 30*time.Second {
+		t.Fatalf("TRMM HTTP timeout is too short: %s", trmmHTTPClient.Timeout)
+	}
+	if httpClient.Timeout >= trmmHTTPClient.Timeout {
+		t.Fatalf("general HTTP client should retain a shorter timeout: %s", httpClient.Timeout)
+	}
+}
 
 func TestTRMMScriptSuccessMessageUsesAutomationScheduledNotice(t *testing.T) {
 	msg := trmmScriptSuccessMessage("Nightly Maintenance", "")


### PR DESCRIPTION
### Motivation

- Tray-initiated Tactical RMM (TRMM) script requests were timing out in the UI before MyPortal could validate and submit the script to TRMM, causing silent failures that were hard to diagnose.
- Better client- and server-side logging was needed so tray menu selections and portal responses are visible for troubleshooting.

### Description

- Introduce a dedicated `trmmHTTPClient` with a 35s timeout in `tray/ui/http_helper.go` while keeping the general `httpClient` timeout unchanged. 
- Use `trmmHTTPClient` for TRMM script requests in `tray/ui/trmm_script.go` and add info logs for menu selection and the portal HTTP response. 
- Add server-side `log_info` on receipt of a tray TRMM request and `log_error` entries when the Tactical RMM integration configuration or API calls fail in `app/api/routes/tray.py`. 
- Add a small Go unit test `TestTRMMScriptHTTPTimeoutAllowsPortalUpstreamRequests` to ensure the TRMM client timeout remains longer than the general UI client timeout.

### Testing

- Ran `go test -tags nowebview -count=1 ./...` which completed successfully for the tray packages. 
- Ran `python -m pytest -q tests/test_tacticalrmm_scripts.py` which passed (2 tests passed; only unrelated deprecation warnings reported). 
- Ran `python -m compileall -q app/api/routes/tray.py` and `git diff --check` which passed without errors. 
- The default full Go webview build failed in CI locally due to a missing system package (`ayatana-appindicator3-0.1`) unrelated to this change, and the targeted `nowebview` test suite used above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6be6f27e6c8332bbf516638534a56e)