### PR TITLE
Prevent new ticket events from refreshing open ticket editors

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -195,7 +195,26 @@
       }
     }
 
+    function shouldIgnoreRefresh(payload) {
+      const ticketDetail = document.querySelector('[data-admin-ticket-detail]');
+      if (!ticketDetail || !payload || typeof payload !== 'object') {
+        return false;
+      }
+
+      const topics = Array.isArray(payload.topics) ? payload.topics : [];
+      const data = payload.data && typeof payload.data === 'object' ? payload.data : {};
+      const action = typeof data.action === 'string' ? data.action.trim().toLowerCase() : '';
+
+      return topics.includes('tickets') && (action === 'create' || action === 'created');
+    }
+
     function handleRefreshMessage(payload) {
+      // A newly created ticket changes ticket lists, but not an already-open ticket.
+      // Reloading this page would discard an in-progress reply and selected attachments.
+      if (shouldIgnoreRefresh(payload)) {
+        return;
+      }
+
       const detail = {
         ...(payload && typeof payload === 'object' ? payload : {}),
         showToast(message, options) {

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -17,7 +17,12 @@
 {% endblock %}
 
 {% block content %}
-  <div class="management management--single" data-layout>
+  <div
+    class="management management--single"
+    data-layout
+    data-admin-ticket-detail
+    data-ticket-id="{{ ticket.id }}"
+  >
     <section class="management__content">
       <header class="management__header">
         <div>

--- a/tests/test_ticket_detail_realtime_refresh.py
+++ b/tests/test_ticket_detail_realtime_refresh.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def test_admin_ticket_detail_identifies_itself_to_realtime_refresh_handler():
+    template = Path("app/templates/admin/ticket_detail.html").read_text()
+
+    assert "data-admin-ticket-detail" in template
+    assert 'data-ticket-id="{{ ticket.id }}"' in template
+
+
+def test_new_ticket_refresh_does_not_reload_an_open_admin_ticket():
+    script = Path("app/static/js/main.js").read_text()
+
+    assert "function shouldIgnoreRefresh(payload)" in script
+    assert "document.querySelector('[data-admin-ticket-detail]')" in script
+    assert "topics.includes('tickets')" in script
+    assert "action === 'create' || action === 'created'" in script
+    assert "if (shouldIgnoreRefresh(payload))" in script


### PR DESCRIPTION
### Motivation
- While editing a ticket on `/admin/tickets/{id}`, incoming new-ticket broadcasts would trigger the global refresh and clear in-progress reply text and attachments, so new ticket events should not force a reload of an open admin ticket editor.

### Description
- Mark admin ticket detail pages with `data-admin-ticket-detail` and `data-ticket-id` in `app/templates/admin/ticket_detail.html` so the frontend can detect when a ticket editor is open.
- Add `shouldIgnoreRefresh(payload)` to `app/static/js/main.js` which detects `tickets` refresh messages with `action` of `create` or `created` and prevents the reload for open admin ticket pages.
- Short-circuit the existing `handleRefreshMessage` flow to skip calling `window.location.reload()` when a new-ticket event should be ignored.
- Add `tests/test_ticket_detail_realtime_refresh.py` with assertions that the template marker and the JS filtering logic are present.

### Testing
- Ran `pytest -q tests/test_ticket_detail_realtime_refresh.py tests/services/test_realtime.py`, which completed successfully with the tests passing (4 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6be8b96ee88332bdd4a831be7919c6)