### PR TITLE
Require explicit configuration for staff workflows

### DIFF
--- a/app/repositories/staff_onboarding_workflows.py
+++ b/app/repositories/staff_onboarding_workflows.py
@@ -81,6 +81,7 @@ def _normalise_policy(row: dict[str, Any] | None, *, default_workflow_key: str =
         "is_enabled": bool(int(row.get("is_enabled") or 0)),
         "max_retries": max(0, int(row.get("max_retries") or 0)),
         "config": _deserialise_json(row.get("config_json")),
+        "is_configured": True,
     }
 
 
@@ -161,7 +162,7 @@ async def get_company_workflow_policy(
 ) -> dict[str, Any]:
     """Return the first (primary) workflow policy for a company and direction.
 
-    Falls back to a synthetic default policy when none is configured.
+    Falls back to a disabled synthetic policy when none is configured.
     This function is retained for backward compatibility with callers that
     expect a single policy dict.
     """
@@ -191,7 +192,8 @@ async def get_company_workflow_policy(
             "workflow_name": None,
             "delay_type": "scheduled",
             "sort_order": 0,
-            "is_enabled": True,
+            "is_enabled": False,
+            "is_configured": False,
             "max_retries": 2,
             "config": {},
         }
@@ -204,7 +206,8 @@ async def get_company_workflow_policy(
         "workflow_name": None,
         "delay_type": "scheduled",
         "sort_order": 0,
-        "is_enabled": True,
+        "is_enabled": False,
+        "is_configured": False,
         "max_retries": 2,
         "config": {},
     }

--- a/app/services/staff_onboarding_workflows.py
+++ b/app/services/staff_onboarding_workflows.py
@@ -3479,21 +3479,22 @@ async def run_staff_onboarding_workflow(
         raise ValueError("Staff not found")
     onboarding_status = str(staff.get("onboarding_status") or "").strip().lower()
 
-    # Look up the specific policy for this workflow key, or fall back to the default.
+    # An execution naming a workflow must match that specifically configured policy;
+    # silently substituting another policy could run steps the company did not choose.
     if workflow_key:
         policy = await workflow_repo.get_company_workflow_policy_by_key(
             company_id, workflow_key, direction
-        ) or await workflow_repo.get_company_workflow_policy(
-            company_id,
-            default_workflow_key=_default_workflow_key(direction),
-            direction=direction,
         )
+        if not policy:
+            return {"state": "skipped", "reason": "workflow_not_configured"}
     else:
         policy = await workflow_repo.get_company_workflow_policy(
             company_id,
             default_workflow_key=_default_workflow_key(direction),
             direction=direction,
         )
+    if not policy.get("is_configured", True):
+        return {"state": "skipped", "reason": "workflow_not_configured"}
     if not policy.get("is_enabled", True):
         return {"state": "skipped", "reason": "workflow_disabled"}
 
@@ -3545,7 +3546,6 @@ async def run_staff_onboarding_workflow(
     resolved_workflow_key = str(
         policy.get("workflow_key") or _default_workflow_key(direction)
     )
-    max_retries = max(0, int(policy.get("max_retries") or 0))
     policy_config = (
         policy.get("config") if isinstance(policy.get("config"), dict) else {}
     )
@@ -3602,17 +3602,19 @@ async def resume_staff_onboarding_workflow_after_external_confirmation(
     if exec_workflow_key:
         policy = await workflow_repo.get_company_workflow_policy_by_key(
             company_id, exec_workflow_key, direction
-        ) or await workflow_repo.get_company_workflow_policy(
-            company_id,
-            default_workflow_key=_default_workflow_key(direction),
-            direction=direction,
         )
+        if not policy:
+            return {"state": "skipped", "reason": "workflow_not_configured"}
     else:
         policy = await workflow_repo.get_company_workflow_policy(
             company_id,
             default_workflow_key=_default_workflow_key(direction),
             direction=direction,
         )
+    if not policy.get("is_configured", True):
+        return {"state": "skipped", "reason": "workflow_not_configured"}
+    if not policy.get("is_enabled", True):
+        return {"state": "skipped", "reason": "workflow_disabled"}
     workflow_key = str(policy.get("workflow_key") or _default_workflow_key(direction))
     max_retries = max(0, int(policy.get("max_retries") or 0))
     policy_config = (
@@ -4039,15 +4041,18 @@ async def enqueue_staff_onboarding_workflow(
     policies = await workflow_repo.list_company_workflow_policies(
         company_id, direction=direction, enabled_only=True
     )
-    # If no policies configured, fall back to a single default policy
+    # A workflow must be explicitly configured for this company and direction.
+    # Do not manufacture an execution from the repository's compatibility
+    # fallback when a company has never set up a workflow.
     if not policies:
-        policies = [
-            await workflow_repo.get_company_workflow_policy(
-                company_id,
-                default_workflow_key=_default_workflow_key(direction),
-                direction=direction,
-            )
-        ]
+        log_info(
+            "Skipped queuing unconfigured staff workflow",
+            company_id=company_id,
+            staff_id=staff_id,
+            initiated_by_user_id=initiated_by_user_id,
+            direction=direction,
+        )
+        return
 
     queued_state = (
         STATE_OFFBOARDING_APPROVED

--- a/tests/test_staff_onboarding_workflows.py
+++ b/tests/test_staff_onboarding_workflows.py
@@ -112,6 +112,46 @@ def test_coerce_step_json_fields_parses_store_and_http_payload_fields():
 
 
 @pytest.mark.anyio
+async def test_run_workflow_skips_unconfigured_policy(monkeypatch):
+    monkeypatch.setattr(
+        workflows.staff_repo,
+        "get_staff_by_id",
+        AsyncMock(
+            return_value={
+                "id": 98,
+                "company_id": 7,
+                "onboarding_status": workflows.STATE_APPROVED,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        workflows.workflow_repo,
+        "get_company_workflow_policy",
+        AsyncMock(
+            return_value={
+                "is_configured": False,
+                "is_enabled": False,
+                "workflow_key": workflows.workflow_repo.DEFAULT_WORKFLOW_KEY,
+                "config": {},
+            }
+        ),
+    )
+    create_execution = AsyncMock()
+    monkeypatch.setattr(
+        workflows.workflow_repo, "create_or_reset_execution", create_execution
+    )
+
+    result = await workflows.run_staff_onboarding_workflow(
+        company_id=7,
+        staff_id=98,
+        initiated_by_user_id=None,
+    )
+
+    assert result == {"state": "skipped", "reason": "workflow_not_configured"}
+    create_execution.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_run_workflow_ignores_waiting_external_within_timeout(monkeypatch):
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     monkeypatch.setattr(
@@ -513,14 +553,9 @@ async def test_resume_uses_direction_from_execution_id_not_latest_staff_executio
 
 
 @pytest.mark.anyio
-async def test_enqueue_offboarding_uses_offboarding_workflow_key(monkeypatch):
-    """Regression: enqueue_staff_onboarding_workflow must use the direction-specific
-    workflow key when creating the queued execution for offboarding requests."""
+async def test_enqueue_offboarding_without_configured_policy_does_not_create_execution(monkeypatch):
     staff_record = {"id": 700, "date_offboarded": None}
     monkeypatch.setattr(workflows.staff_repo, "get_staff_by_id", AsyncMock(return_value=staff_record))
-    get_policy_mock = AsyncMock(return_value={"workflow_key": None})
-    monkeypatch.setattr(workflows.workflow_repo, "get_company_workflow_policy", get_policy_mock)
-    # Return empty list so the code falls back to get_company_workflow_policy
     monkeypatch.setattr(workflows.workflow_repo, "list_company_workflow_policies", AsyncMock(return_value=[]))
     create_mock = AsyncMock(return_value={"id": 88})
     monkeypatch.setattr(workflows.workflow_repo, "create_or_reset_execution", create_mock)
@@ -533,12 +568,8 @@ async def test_enqueue_offboarding_uses_offboarding_workflow_key(monkeypatch):
         direction=workflows.DIRECTION_OFFBOARDING,
     )
 
-    # Policy must be fetched with the offboarding default key.
-    assert get_policy_mock.await_args.kwargs.get("default_workflow_key") == workflows.workflow_repo.DEFAULT_OFFBOARDING_WORKFLOW_KEY
-    # Execution must be created with the offboarding default workflow key as fallback.
-    assert create_mock.await_args.kwargs["workflow_key"] == workflows.workflow_repo.DEFAULT_OFFBOARDING_WORKFLOW_KEY
-    # Execution state must be set to offboarding_approved.
-    assert workflows.workflow_repo.update_execution_state.await_args.kwargs["state"] == workflows.STATE_OFFBOARDING_APPROVED
+    create_mock.assert_not_awaited()
+    workflows.workflow_repo.update_execution_state.assert_not_awaited()
 
 
 
@@ -566,15 +597,9 @@ def test_compute_scheduled_execution_offboarding_preserves_requested_datetime():
 
 
 @pytest.mark.anyio
-async def test_enqueue_workflow_creates_approved_execution(monkeypatch):
+async def test_enqueue_workflow_without_configured_policy_does_not_create_execution(monkeypatch):
     staff_record = {"id": 333, "date_onboarded": None}
     monkeypatch.setattr(workflows.staff_repo, "get_staff_by_id", AsyncMock(return_value=staff_record))
-    monkeypatch.setattr(
-        workflows.workflow_repo,
-        "get_company_workflow_policy",
-        AsyncMock(return_value={"workflow_key": workflows.workflow_repo.DEFAULT_WORKFLOW_KEY}),
-    )
-    # Return empty list so the code falls back to get_company_workflow_policy
     monkeypatch.setattr(workflows.workflow_repo, "list_company_workflow_policies", AsyncMock(return_value=[]))
     monkeypatch.setattr(
         workflows.workflow_repo,
@@ -590,9 +615,8 @@ async def test_enqueue_workflow_creates_approved_execution(monkeypatch):
         direction=workflows.DIRECTION_ONBOARDING,
     )
 
-    workflows.workflow_repo.create_or_reset_execution.assert_awaited_once()
-    workflows.workflow_repo.update_execution_state.assert_awaited_once()
-    assert workflows.workflow_repo.update_execution_state.await_args.kwargs["state"] == workflows.STATE_APPROVED
+    workflows.workflow_repo.create_or_reset_execution.assert_not_awaited()
+    workflows.workflow_repo.update_execution_state.assert_not_awaited()
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- Prevent onboarding/offboarding workflows from running for companies that never configured them so actions are not executed by default.
- Avoid silently substituting synthetic default policies when a company has not set up a workflow.

### Description
- Persisted workflow rows now include an `is_configured` flag by returning `"is_configured": True` from `_normalise_policy` and synthetic fallbacks are returned with `is_configured: False` and `is_enabled: False` in `app/repositories/staff_onboarding_workflows.py`.
- `run_staff_onboarding_workflow` and `resume_staff_onboarding_workflow_after_external_confirmation` now skip execution when the selected policy is not configured and no substitution occurs when a named `workflow_key` cannot be resolved in `app/services/staff_onboarding_workflows.py`.
- `enqueue_staff_onboarding_workflow` no longer queues executions if there are no enabled policies for the company/direction and logs an informational message instead, preventing manufacture of default executions in `app/services/staff_onboarding_workflows.py`.
- Added regression tests to `tests/test_staff_onboarding_workflows.py` to assert that unconfigured policies are not run or queued and updated two enqueue-related tests to reflect the new behaviour.

### Testing
- Ran targeted pytest selection `pytest -q tests/test_staff_onboarding_workflows.py -k 'unconfigured or run_workflow_ignores_waiting_external or run_workflow_escalates_stale or run_workflow_allows'` and received 5 passed.
- Ran `pytest -q tests/test_staff_onboarding_workflows.py` which produced 29 passed and 1 unrelated pre-existing failure in `test_vars_map_contains_staff_extended_fields` caused by that test's mocked step signature, not by these changes.
- Ran static checks with `python -m ruff check app/repositories/staff_onboarding_workflows.py app/services/staff_onboarding_workflows.py --output-format concise` and `git diff --check`, both of which passed (format suggestions noted and files staged/committed during the rollout).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6c1c18c13c8332bb39010328743b6b)