### PR TITLE
Fix Huntress SAT Client Credentials authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -348,7 +348,9 @@ HUNTRESS_BASE_URL=https://api.huntress.io/v1
 
 # Curricula / Huntress Managed SAT API
 # These are separate from HUNTRESS_API_KEY / HUNTRESS_API_SECRET. Use a parent
-# (channel-partner) Curricula API client that can list all managed child accounts;
+# (channel-partner) Curricula Client Credentials API client that can list all
+# managed child accounts; the key and secret are used as OAuth client_id and
+# client_secret values (not an Authorization Code client);
 # the integration has one global credential pair and does not store per-client keys.
 # A child account ID must still be mapped to each company in the portal.
 # Required for SAT enrolled learner counts, average progress, and per-user stats.

--- a/app/services/huntress.py
+++ b/app/services/huntress.py
@@ -133,8 +133,11 @@ async def _curricula_oauth_client(
     async with _oauth_token_client() as token_client:
         response = await token_client.post(
             credentials["token_url"],
-            data={"grant_type": "client_credentials"},
-            auth=(credentials["api_key"], credentials["api_secret"]),
+            data={
+                "grant_type": "client_credentials",
+                "client_id": credentials["api_key"],
+                "client_secret": credentials["api_secret"],
+            },
             headers={"Accept": "application/json"},
         )
     if response.status_code >= 400:
@@ -250,7 +253,7 @@ async def list_sat_accounts() -> list[dict[str, Any]]:
         )
 
     accounts: list[dict[str, Any]] = []
-    async with _client(credentials) as client:
+    async with await _curricula_oauth_client(credentials) as client:
         page = 1
         for _ in range(50):
             payload = await _get_json(

--- a/changes/7f0363e1-bf41-4db4-82c0-d61cd4d08b9c.json
+++ b/changes/7f0363e1-bf41-4db4-82c0-d61cd4d08b9c.json
@@ -1,0 +1,7 @@
+{
+  "guid": "7f0363e1-bf41-4db4-82c0-d61cd4d08b9c",
+  "occurred_at": "2026-07-31T00:00:00Z",
+  "change_type": "fix",
+  "summary": "Corrected Huntress SAT OAuth authentication to use the Curricula Client Credentials flow.",
+  "content_hash": "dce42f547db2481efef5e5619b72905e2a9e60b18f3628fee43398545d8616e9"
+}

--- a/tests/test_huntress_service.py
+++ b/tests/test_huntress_service.py
@@ -413,8 +413,29 @@ async def test_curricula_oauth_uses_client_credentials_and_returns_bearer_client
     assert len(token_requests) == 1
     request = token_requests[0]
     assert str(request.url) == "https://dev.curricula.com/oauth/token"
-    assert request.headers["authorization"].startswith("Basic ")
-    assert request.content == b"grant_type=client_credentials"
+    assert "authorization" not in request.headers
+    assert request.content == (
+        b"grant_type=client_credentials&client_id=oauth-client-id&"
+        b"client_secret=oauth-client-secret"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_sat_accounts_uses_oauth_bearer_client(monkeypatch):
+    from app.services import huntress as huntress_service
+
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json={"data": []})
+
+    _set_credentials(monkeypatch)
+    with _patch_curricula_oauth_client(httpx.MockTransport(handler)):
+        assert await huntress_service.list_sat_accounts() == []
+
+    assert len(requests) == 1
+    assert requests[0].headers["authorization"] == "Bearer test-access-token"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- Curricula (Huntress Managed SAT) requires the OAuth2 Client Credentials flow using `client_id`/`client_secret` form fields, and the previous implementation sent credentials in a way that caused 401s when acquiring tokens.

### Description

- Send `client_id` and `client_secret` in the token request body along with `grant_type=client_credentials` in `_curricula_oauth_client` instead of relying on HTTP Basic auth.
- Use the bearer-authenticated client returned by `_curricula_oauth_client` when calling `list_sat_accounts` so SAT account discovery uses OAuth bearer tokens.
- Update `.env.example` to clarify that Curricula requires a Client Credentials API client (not an Authorization Code client).
- Add regression tests in `tests/test_huntress_service.py` that assert the token request payload contains `client_id`/`client_secret`, that no Basic `Authorization` header is sent, and that SAT account requests use the returned bearer token, and add a change-log entry under `changes/`.

### Testing

- Ran `uv run pytest -q tests/test_huntress_service.py` and the file's tests all passed (`17 passed`).
- Verified Python syntax with `python -m py_compile` on the modified files and ensured `git diff --check` reported no issues.
- Unit tests specifically validate token request content and that the SAT account listing is performed with the OAuth bearer client and these assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6c2cc8c18c83329c39c67edb51752f)