### PR TITLE
Huntress: Fix Curricula Managed SAT OAuth, derive endpoints, and update docs/tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -351,6 +351,9 @@ HUNTRESS_BASE_URL=https://api.huntress.io/v1
 # (channel-partner) Curricula Client Credentials API client that can list all
 # managed child accounts; the key and secret are used as OAuth client_id and
 # client_secret values (not an Authorization Code client);
+# OAuth endpoints are derived from this base URL by removing /api/v1 and adding
+# /oauth/authorize (CURRICULA_AUTH_URL) or /oauth/token (CURRICULA_TOKEN_URL).
+# Tokens request the account, assignment activity, and learner read scopes;
 # the integration has one global credential pair and does not store per-client keys.
 # A child account ID must still be mapped to each company in the portal.
 # Required for SAT enrolled learner counts, average progress, and per-user stats.

--- a/app/features/huntress/__init__.py
+++ b/app/features/huntress/__init__.py
@@ -18,7 +18,7 @@ from app.core.features import FeaturePack
 
 PACK = FeaturePack(
     slug="huntress",
-    version="1.0.0",
+    version="1.0.2",
 )
 
 

--- a/app/services/huntress.py
+++ b/app/services/huntress.py
@@ -38,6 +38,13 @@ REQUEST_TIMEOUT = 30.0
 _REQUEST_INTERVAL_SECONDS = 1.1
 _request_lock = asyncio.Lock()
 
+CURRICULA_READ_SCOPES = (
+    "account:read",
+    "assignments:read",
+    "assignments:learner-activity",
+    "learners:read",
+)
+
 
 # ---------------------------------------------------------------------------
 # Configuration / client helpers
@@ -73,6 +80,7 @@ def _get_curricula_credentials() -> dict[str, str] | None:
         "api_key": api_key,
         "api_secret": api_secret,
         "base_url": base_url,
+        "auth_url": f"{oauth_base_url}/oauth/authorize",
         "token_url": f"{oauth_base_url}/oauth/token",
     }
 
@@ -135,9 +143,9 @@ async def _curricula_oauth_client(
             credentials["token_url"],
             data={
                 "grant_type": "client_credentials",
-                "client_id": credentials["api_key"],
-                "client_secret": credentials["api_secret"],
+                "scope": " ".join(CURRICULA_READ_SCOPES),
             },
+            auth=(credentials["api_key"], credentials["api_secret"]),
             headers={"Accept": "application/json"},
         )
     if response.status_code >= 400:

--- a/changes/3e730a1d-14b4-438e-aad9-bca6b743e1c9.json
+++ b/changes/3e730a1d-14b4-438e-aad9-bca6b743e1c9.json
@@ -1,0 +1,7 @@
+{
+  "guid": "3e730a1d-14b4-438e-aad9-bca6b743e1c9",
+  "occurred_at": "2026-07-31T00:00Z",
+  "change_type": "Fix",
+  "summary": "Correct Huntress SAT OAuth authentication to use the documented token endpoint, read scopes, and bearer tokens.",
+  "content_hash": "5f790d1c8dc9098a77a8a841fae665f1ab9378ebc4f45d6507cade5d91b8a422"
+}

--- a/changes/60be8645-c248-4e17-aa70-b2c3270c2665.json
+++ b/changes/60be8645-c248-4e17-aa70-b2c3270c2665.json
@@ -1,0 +1,7 @@
+{
+  "guid": "60be8645-c248-4e17-aa70-b2c3270c2665",
+  "occurred_at": "2026-07-31T00:00Z",
+  "change_type": "Fix",
+  "summary": "Derive Curricula authorization and token endpoints from the configured SAT API base URL.",
+  "content_hash": "1aa15449470b50891646f17041bac63a4d22b426f837aee73e06b585d8cc4e5e"
+}

--- a/tests/test_huntress_service.py
+++ b/tests/test_huntress_service.py
@@ -99,7 +99,7 @@ async def test_credentials_status_reflects_environment(monkeypatch):
     }
 
 
-def test_curricula_oauth_token_url_is_derived_from_base_url(monkeypatch):
+def test_curricula_oauth_endpoints_are_derived_from_base_url(monkeypatch):
     from app.services import huntress as huntress_service
 
     monkeypatch.setattr(
@@ -120,6 +120,7 @@ def test_curricula_oauth_token_url_is_derived_from_base_url(monkeypatch):
         "api_key": "oauth-client-id",
         "api_secret": "oauth-client-secret",
         "base_url": "https://sat.example.com/partner/api/v1",
+        "auth_url": "https://sat.example.com/partner/oauth/authorize",
         "token_url": "https://sat.example.com/partner/oauth/token",
     }
 
@@ -401,6 +402,7 @@ async def test_curricula_oauth_uses_client_credentials_and_returns_bearer_client
         "api_key": "oauth-client-id",
         "api_secret": "oauth-client-secret",
         "base_url": "https://dev.curricula.com/api/v1",
+        "auth_url": "https://dev.curricula.com/oauth/authorize",
         "token_url": "https://dev.curricula.com/oauth/token",
     }
 
@@ -413,10 +415,10 @@ async def test_curricula_oauth_uses_client_credentials_and_returns_bearer_client
     assert len(token_requests) == 1
     request = token_requests[0]
     assert str(request.url) == "https://dev.curricula.com/oauth/token"
-    assert "authorization" not in request.headers
+    assert request.headers["authorization"].startswith("Basic ")
     assert request.content == (
-        b"grant_type=client_credentials&client_id=oauth-client-id&"
-        b"client_secret=oauth-client-secret"
+        b"grant_type=client_credentials&scope=account%3Aread+assignments%3Aread+"
+        b"assignments%3Alearner-activity+learners%3Aread"
     )
 
 

--- a/wiki/Huntress-Integration.md
+++ b/wiki/Huntress-Integration.md
@@ -39,12 +39,18 @@ CURRICULA_BASE_URL=https://dev.curricula.com/api/v1
 ```
 
 If Huntress supplies a tenant-specific API URL, use that as
-`CURRICULA_BASE_URL`. MyPortal derives the OAuth endpoint by replacing the
-trailing `/api/v1` with `/oauth/token`. At sync time MyPortal posts
-`grant_type=client_credentials` to that token URL using the client ID and
+`CURRICULA_BASE_URL`. MyPortal derives both OAuth2 endpoints from that URL by
+removing the trailing `/api/v1`: `CURRICULA_AUTH_URL` is
+`<base>/oauth/authorize`, and `CURRICULA_TOKEN_URL` is `<base>/oauth/token`.
+The authorization endpoint is available for applications using the
+Authorization Code flow; MyPortal's unattended SAT synchronisation uses the
+token endpoint directly with the Client Credentials flow. At sync time
+MyPortal posts `grant_type=client_credentials` and the required read scopes
+(`account:read`, `assignments:read`,
+`assignments:learner-activity`, and `learners:read`) using the client ID and
 secret as HTTP Basic credentials. It then sends the returned access token as
-`Authorization: Bearer ...` when requesting the learner list. Tokens and
-secrets are never stored in the database or written to logs.
+`Authorization: Bearer ...` on every Curricula API request. Tokens and secrets
+are never stored in the database or written to logs.
 
 In each company's edit page, set **Huntress SAT account ID** to the child
 account ID used in the learner URL. This is distinct from the Huntress


### PR DESCRIPTION
### Motivation

- Correct the Curricula (Managed SAT) OAuth2 client credentials flow to match the API documentation by using the token endpoint, requesting read scopes, and authenticating with HTTP Basic.
- Derive OAuth endpoints from the configured SAT API base URL to avoid requiring separate endpoint configuration.
- Document the behaviour in `.env.example` and the Huntress integration wiki so operators understand how to configure SAT integration.

### Description

- Add `CURRICULA_READ_SCOPES` and include `auth_url`/`token_url` keys derived from `CURRICULA_BASE_URL` in `_get_curricula_credentials` and expose the auth URL for documentation purposes.
- Update `_curricula_oauth_client` to post `grant_type=client_credentials` with the required `scope` parameter and use HTTP Basic auth via `auth=(client_id, client_secret)`, then return a bearer client using the returned access token.
- Update tests in `tests/test_huntress_service.py` to assert that OAuth endpoints are derived, that the token request uses Basic auth and the expected scope payload, and to reflect the new behaviour; also rename the test to reflect endpoint derivation.
- Bump the Huntress feature pack version to `1.0.2`, add explanatory comments to `.env.example`, update `wiki/Huntress-Integration.md` to document `CURRICULA_AUTH_URL` and `CURRICULA_TOKEN_URL`, and add `changes/*.json` entries describing the fix.

### Testing

- Ran `pytest tests/test_huntress_service.py` which exercises the Curricula OAuth client and related Huntress service flows, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6c340a06b083328efbe0aad4d43909)