### PR TITLE
Wait for Uvicorn worker cleanup during shutdown

### DIFF
--- a/scripts/start_with_auto_update.sh
+++ b/scripts/start_with_auto_update.sh
@@ -118,8 +118,10 @@ if detect_bool "${UVICORN_AUTO_UPDATE_ENABLED:-1}"; then
 fi
 
 uvicorn_pid=0
+shutdown_signal=""
 forward_signal() {
   local signal="$1"
+  shutdown_signal="$signal"
   if [[ "$uvicorn_pid" -gt 0 ]]; then
     kill -s "$signal" "$uvicorn_pid" 2>/dev/null || true
   fi
@@ -133,8 +135,21 @@ run_uvicorn() {
   build_uvicorn_command "$@"
   "${UVICORN_COMMAND[@]}" &
   uvicorn_pid=$!
-  wait "$uvicorn_pid"
-  local status=$?
+  local status
+  while true; do
+    wait "$uvicorn_pid"
+    status=$?
+
+    # A trapped signal interrupts bash's wait before Uvicorn has finished
+    # draining its workers.  Keep the wrapper (and therefore the systemd
+    # cgroup) alive until the child has completed its own cleanup.  Otherwise
+    # systemd can tear down multiprocessing's resource tracker while worker
+    # semaphores are still registered, producing leaked-semaphore warnings.
+    if [[ -n "$shutdown_signal" ]] && kill -0 "$uvicorn_pid" 2>/dev/null; then
+      continue
+    fi
+    break
+  done
   uvicorn_pid=0
   return "$status"
 }

--- a/tests/test_start_with_auto_update.py
+++ b/tests/test_start_with_auto_update.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import os
+import signal
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 
@@ -89,3 +91,57 @@ def test_wrapper_preserves_explicit_forwarded_allow_ips(tmp_path: Path) -> None:
 
     assert argv.count("--proxy-headers") == 0
     assert argv.count("--forwarded-allow-ips=10.0.0.8") == 1
+
+
+def test_wrapper_waits_for_child_cleanup_after_sigterm(tmp_path: Path) -> None:
+    """A service stop lets Uvicorn finish worker and semaphore cleanup."""
+
+    ready_path = tmp_path / "ready"
+    cleanup_path = tmp_path / "cleanup-complete"
+    fake_uvicorn = tmp_path / "fake_uvicorn.py"
+    fake_uvicorn.write_text(
+        "import pathlib, signal, time\n"
+        f"ready = pathlib.Path({str(ready_path)!r})\n"
+        f"cleanup = pathlib.Path({str(cleanup_path)!r})\n"
+        "def shutdown(signum, frame):\n"
+        "    time.sleep(0.25)\n"
+        "    cleanup.write_text('done', encoding='utf-8')\n"
+        "    raise SystemExit(0)\n"
+        "signal.signal(signal.SIGTERM, shutdown)\n"
+        "ready.write_text('ready', encoding='utf-8')\n"
+        "while True:\n"
+        "    time.sleep(1)\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "UVICORN_AUTO_UPDATE_ENABLED": "false",
+            "UVICORN_AUTO_UPDATE_ATTEMPTS": "1",
+        }
+    )
+    wrapper = subprocess.Popen(
+        [str(WRAPPER), sys.executable, str(fake_uvicorn)],
+        cwd=ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not ready_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ready_path.exists(), "fake Uvicorn process did not start"
+
+        wrapper.send_signal(signal.SIGTERM)
+        assert wrapper.poll() is None
+        assert not cleanup_path.exists()
+
+        wrapper.wait(timeout=5)
+        assert wrapper.returncode == 0
+        assert cleanup_path.read_text(encoding="utf-8") == "done"
+    finally:
+        if wrapper.poll() is None:
+            wrapper.kill()
+            wrapper.wait()


### PR DESCRIPTION
### Motivation

- Prevent leaked multiprocessing semaphore warnings at process shutdown by ensuring the Uvicorn wrapper does not exit while child workers are still performing cleanup. 

### Description

- Track forwarded shutdown signals and, in `run_uvicorn`, loop-wait until the child process has fully exited to avoid leaving the wrapper (and systemd cgroup) before workers release resources in `scripts/start_with_auto_update.sh`.
- Add a regression test `test_wrapper_waits_for_child_cleanup_after_sigterm` to `tests/test_start_with_auto_update.py` which sends `SIGTERM` to the wrapper and verifies delayed child cleanup completes before the wrapper exits.
- Update the test file imports to include `signal` and `time` for the new test.

### Testing

- `pytest -q tests/test_start_with_auto_update.py` — 5 tests passed.
- `bash -n scripts/start_with_auto_update.sh` — shell syntax check passed.
- `git diff --check` — no whitespace or diff-check issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6c3790d8b88332a1422e787ff56bc4)