### PR TITLE
Skip invalid email addresses in ticket requester list

### DIFF
--- a/app/api/routes/companies.py
+++ b/app/api/routes/companies.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import EmailStr, TypeAdapter, ValidationError
 
 from app.api.dependencies.auth import get_current_user, require_helpdesk_technician, require_super_admin
 from app.api.dependencies.database import require_database
@@ -25,6 +26,7 @@ from app.services import company_id_lookup
 from app.services import m365 as m365_service
 
 router = APIRouter(prefix="/api/companies", tags=["Companies"])
+EMAIL_ADAPTER = TypeAdapter(EmailStr)
 
 
 @router.get("", response_model=list[CompanyResponse])
@@ -216,7 +218,14 @@ async def list_company_staff_users(
     if not company:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Company not found")
     users = await staff_repo.list_enabled_staff_users(company_id)
-    return [StaffRequesterOption.model_validate(user) for user in users]
+    requester_options: list[StaffRequesterOption] = []
+    for user in users:
+        try:
+            EMAIL_ADAPTER.validate_python(user.get("email"))
+        except ValidationError:
+            continue
+        requester_options.append(StaffRequesterOption.model_validate(user))
+    return requester_options
 
 
 

--- a/tests/test_ticket_requester_api.py
+++ b/tests/test_ticket_requester_api.py
@@ -83,6 +83,54 @@ async def test_list_company_staff_users_returns_all_enabled_staff(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_list_company_staff_users_omits_invalid_email_addresses(monkeypatch):
+    """Invalid staff email addresses must not prevent valid requesters loading."""
+    from app.api.routes import companies
+    from app.repositories import companies as company_repo
+    from app.repositories import staff as staff_repo
+
+    monkeypatch.setattr(
+        company_repo,
+        "get_company_by_id",
+        AsyncMock(return_value={"id": 1, "name": "Test Company"}),
+    )
+    monkeypatch.setattr(
+        staff_repo,
+        "list_enabled_staff_users",
+        AsyncMock(
+            return_value=[
+                {
+                    "id": 10,
+                    "staff_id": 10,
+                    "requester_value": "staff:10",
+                    "email": "valid@example.com",
+                },
+                {
+                    "id": 11,
+                    "staff_id": 11,
+                    "requester_value": "staff:11",
+                    "email": "",
+                },
+                {
+                    "id": 12,
+                    "staff_id": 12,
+                    "requester_value": "staff:12",
+                    "email": "not-an-email",
+                },
+            ]
+        ),
+    )
+
+    result = await companies.list_company_staff_users(
+        company_id=1,
+        _=None,
+        __={"id": 1, "is_super_admin": True},
+    )
+
+    assert [option.email for option in result] == ["valid@example.com"]
+
+
+@pytest.mark.anyio
 async def test_list_company_staff_users_company_not_found(monkeypatch):
     """Verify that the endpoint returns 404 for non-existent company."""
     from app.api.routes import companies


### PR DESCRIPTION
### Motivation
- Prevent the ticket requester list endpoint from failing when staff records contain blank or malformed email addresses by skipping invalid entries.

### Description
- Use Pydantic's `EmailStr` via `TypeAdapter` to validate staff `email` values before constructing requester options in `list_company_staff_users`.
- Build a filtered `requester_options` list and skip any staff rows whose `email` fails validation, then return validated `StaffRequesterOption` objects.
- Add a regression test `test_list_company_staff_users_omits_invalid_email_addresses` to verify that valid addresses are preserved while empty or malformed addresses are omitted.

### Testing
- Ran `python -m pytest -q tests/test_ticket_requester_api.py` which executed the updated test suite and returned `3 passed`.
- Added test coverage ensures mixed valid/invalid requester records are handled without raising validation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6c490ed74c8332b9beaf37ba14c7ae)