### PR TITLE
Add ticket-style column filters to shared tables

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -2384,6 +2384,57 @@ button.header-title-menu__link,
 .ticket-column-filter__title { color: var(--color-text); font-weight: 600; }
 .ticket-column-filter__actions { display: flex; gap: 0.4rem; }
 
+/* Shared table filters mirror the ticket workspace's compact header menus. */
+.table-column-filter {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.3rem;
+  position: relative;
+}
+
+.table-column-filter__toggle {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  padding: 0.15rem;
+}
+
+.table-column-filter__toggle svg {
+  fill: currentColor;
+  height: 0.9rem;
+  width: 0.9rem;
+}
+
+.table-column-filter__toggle:hover,
+.table-column-filter__toggle:focus-visible,
+.table-column-filter--active .table-column-filter__label,
+.table-column-filter--active .table-column-filter__toggle {
+  color: var(--color-primary, #2563eb);
+}
+
+.table-column-filter__panel {
+  background: var(--color-surface-2, #0f172a);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  box-shadow: 0 0.75rem 1.75rem rgb(15 23 42 / 18%);
+  display: grid;
+  gap: 0.6rem;
+  left: 0;
+  min-width: 15rem;
+  padding: 0.75rem;
+  position: absolute;
+  text-align: left;
+  top: calc(100% + 0.4rem);
+  z-index: 30;
+}
+
+.table-column-filter__panel[hidden] { display: none; }
+.table-column-filter__title { color: var(--color-text); font-weight: 600; }
+.table-column-filter__actions { display: flex; gap: 0.4rem; }
+
 .ticket-group-by__hint {
   margin: -0.25rem 0 0.75rem;
   color: var(--muted-text, #64748b);

--- a/app/static/js/tables.js
+++ b/app/static/js/tables.js
@@ -144,6 +144,7 @@
       }
 
       this.restorePersistedFilters();
+      this.setupColumnFilters();
       this.updateFilterState();
       if (this.paginationElement) {
         this.paginationElement.classList.add('table-pagination--active');
@@ -307,10 +308,129 @@
         this.columnFilters = Object.entries(state.columns).reduce((filters, [key, value]) => {
           if (typeof value === 'string' && value) {
             filters[key] = value.trim().toLowerCase();
+          } else if (value && typeof value === 'object' && value.value !== '') {
+            filters[key] = value;
           }
           return filters;
         }, {});
       }
+    }
+
+    /** Add the ticket-list filter popover to each usable column. */
+    setupColumnFilters() {
+      if (!this.table || !this.table.tHead || this.table.hasAttribute('data-table-column-filters-disabled')) {
+        return;
+      }
+      // The ticket workspace owns richer saved-view filters and builds these menus itself.
+      if (this.table.hasAttribute('data-ticket-status-options')) {
+        return;
+      }
+      const headerRow = this.table.tHead.rows[0];
+      if (!headerRow) {
+        return;
+      }
+      Array.from(headerRow.cells).forEach((header, index) => {
+        if (header.matches('.table__actions, .table__select, [data-column-filter-disabled]') || header.querySelector('input, button')) {
+          return;
+        }
+        const label = (header.textContent || '').trim();
+        if (!label) {
+          return;
+        }
+        const key = header.getAttribute('data-column-key') || `column-${index}`;
+        const sortType = (header.getAttribute('data-filter-type') || header.getAttribute('data-sort') || 'text').toLowerCase();
+        const type = sortType === 'number' || sortType === 'int' ? 'number' : sortType === 'date' ? 'date' : 'text';
+        header.setAttribute('data-column-key', key);
+        Array.from(this.table.tBodies).forEach((tbody) => {
+          Array.from(tbody.rows).forEach((row) => {
+            if (row.cells[index]) row.cells[index].setAttribute('data-column-key', key);
+          });
+        });
+
+        const wrapper = document.createElement('span');
+        wrapper.className = 'table-column-filter';
+        wrapper.dataset.tableColumnFilterMenu = key;
+        const labelNode = document.createElement('span');
+        labelNode.className = 'table-column-filter__label';
+        labelNode.textContent = label;
+        const toggle = document.createElement('button');
+        toggle.type = 'button';
+        toggle.className = 'table-column-filter__toggle';
+        toggle.setAttribute('aria-label', `Filter ${label}`);
+        toggle.setAttribute('aria-haspopup', 'true');
+        toggle.setAttribute('aria-expanded', 'false');
+        toggle.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3.5 5.25A1.25 1.25 0 0 1 4.75 4h14.5a1.25 1.25 0 0 1 .96 2.05L14.5 12.9v5.35a1.25 1.25 0 0 1-.69 1.12l-2.5 1.25a1.25 1.25 0 0 1-1.81-1.12v-6.6L3.79 6.05a1.25 1.25 0 0 1-.29-.8Z"/></svg>';
+        const panel = document.createElement('span');
+        panel.className = 'table-column-filter__panel';
+        panel.hidden = true;
+        const operators = type === 'text'
+          ? [['contains', 'Contains'], ['not_contains', 'Does not contain'], ['equals', 'Equals'], ['not_equals', 'Does not equal'], ['starts_with', 'Starts with'], ['ends_with', 'Ends with']]
+          : type === 'number'
+            ? [['equals', 'Equals'], ['not_equals', 'Does not equal'], ['greater', 'Greater than'], ['greater_equal', 'At least'], ['less', 'Less than'], ['less_equal', 'At most']]
+            : [['on', 'On'], ['before', 'Before'], ['after', 'After'], ['on_or_before', 'On or before'], ['on_or_after', 'On or after']];
+        const title = document.createElement('span');
+        title.className = 'table-column-filter__title';
+        title.textContent = `Filter ${label}`;
+        const operator = document.createElement('select');
+        operator.className = 'form-input';
+        operator.setAttribute('aria-label', `Filter operation for ${label}`);
+        operators.forEach(([value, text]) => operator.add(new Option(text, value)));
+        const valueInput = document.createElement('input');
+        valueInput.className = 'form-input';
+        valueInput.type = type === 'number' ? 'number' : type === 'date' ? 'date' : 'text';
+        valueInput.setAttribute('aria-label', `Filter value for ${label}`);
+        const actions = document.createElement('span');
+        actions.className = 'table-column-filter__actions';
+        actions.innerHTML = '<button type="button" class="button button--primary button--compact" data-table-column-filter-apply>Apply</button><button type="button" class="button button--ghost button--compact" data-table-column-filter-clear>Clear</button>';
+        panel.append(title, operator, valueInput, actions);
+        wrapper.append(labelNode, toggle, panel);
+        header.textContent = '';
+        header.appendChild(wrapper);
+
+        const current = this.columnFilters[key];
+        if (current && typeof current === 'object') {
+          operator.value = current.operator;
+          valueInput.value = current.value;
+          wrapper.classList.add('table-column-filter--active');
+        }
+        const close = () => { panel.hidden = true; toggle.setAttribute('aria-expanded', 'false'); };
+        toggle.addEventListener('click', (event) => {
+          event.stopPropagation();
+          document.querySelectorAll('[data-table-column-filter-menu]').forEach((menu) => {
+            if (menu !== wrapper) menu.querySelector('.table-column-filter__panel')?.setAttribute('hidden', '');
+          });
+          panel.hidden = !panel.hidden;
+          toggle.setAttribute('aria-expanded', String(!panel.hidden));
+        });
+        panel.addEventListener('click', (event) => event.stopPropagation());
+        actions.querySelector('[data-table-column-filter-apply]').addEventListener('click', () => {
+          const value = valueInput.value.trim();
+          if (value) this.columnFilters[key] = { type, operator: operator.value, value };
+          else delete this.columnFilters[key];
+          wrapper.classList.toggle('table-column-filter--active', Boolean(value));
+          this.page = 0;
+          this.updateFilterState();
+          this.persistFilterState();
+          this.render();
+          close();
+        });
+        actions.querySelector('[data-table-column-filter-clear]').addEventListener('click', () => {
+          valueInput.value = '';
+          delete this.columnFilters[key];
+          wrapper.classList.remove('table-column-filter--active');
+          this.page = 0;
+          this.updateFilterState();
+          this.persistFilterState();
+          this.render();
+          close();
+        });
+      });
+      document.addEventListener('click', () => {
+        this.table.querySelectorAll('[data-table-column-filter-menu]').forEach((menu) => {
+          menu.querySelector('.table-column-filter__panel').hidden = true;
+          menu.querySelector('.table-column-filter__toggle').setAttribute('aria-expanded', 'false');
+        });
+      });
     }
 
     getColumnCellValue(row, columnKey) {
@@ -320,16 +440,50 @@
       const escapedKey = window.CSS && typeof window.CSS.escape === 'function'
         ? window.CSS.escape(columnKey)
         : columnKey.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-      const cell = row.querySelector(`[data-column-key="${escapedKey}"]`);
+      let cell = row.querySelector(`[data-column-key="${escapedKey}"]`);
+      if (!cell && this.table?.tHead?.rows?.[0]) {
+        const headers = Array.from(this.table.tHead.rows[0].cells);
+        const index = headers.findIndex((header) => header.getAttribute('data-column-key') === columnKey);
+        cell = index >= 0 ? row.cells[index] : null;
+      }
       return cell ? (cell.getAttribute('data-value') || cell.textContent || '').trim().toLowerCase() : '';
     }
 
     rowMatchesColumnFilters(row) {
-      return Object.entries(this.columnFilters).every(([columnKey, term]) => {
-        if (!term) {
+      return Object.entries(this.columnFilters).every(([columnKey, filter]) => {
+        if (!filter) {
           return true;
         }
-        return this.getColumnCellValue(row, columnKey).includes(term);
+        const cellValue = this.getColumnCellValue(row, columnKey);
+        if (typeof filter === 'string') return cellValue.includes(filter);
+        const expected = String(filter.value || '').toLowerCase();
+        if (filter.type === 'number') {
+          const actualNumber = Number.parseFloat(cellValue);
+          const expectedNumber = Number.parseFloat(expected);
+          if (Number.isNaN(actualNumber) || Number.isNaN(expectedNumber)) return false;
+          return filter.operator === 'greater' ? actualNumber > expectedNumber
+            : filter.operator === 'greater_equal' ? actualNumber >= expectedNumber
+              : filter.operator === 'less' ? actualNumber < expectedNumber
+                : filter.operator === 'less_equal' ? actualNumber <= expectedNumber
+                  : filter.operator === 'not_equals' ? actualNumber !== expectedNumber
+                    : actualNumber === expectedNumber;
+        }
+        if (filter.type === 'date') {
+          const actualDate = Date.parse(cellValue);
+          const expectedDate = Date.parse(expected);
+          if (Number.isNaN(actualDate) || Number.isNaN(expectedDate)) return false;
+          return filter.operator === 'before' ? actualDate < expectedDate
+            : filter.operator === 'after' ? actualDate > expectedDate
+              : filter.operator === 'on_or_before' ? actualDate <= expectedDate
+                : filter.operator === 'on_or_after' ? actualDate >= expectedDate
+                  : new Date(actualDate).toISOString().slice(0, 10) === expected;
+        }
+        return filter.operator === 'not_contains' ? !cellValue.includes(expected)
+          : filter.operator === 'equals' ? cellValue === expected
+            : filter.operator === 'not_equals' ? cellValue !== expected
+              : filter.operator === 'starts_with' ? cellValue.startsWith(expected)
+                : filter.operator === 'ends_with' ? cellValue.endsWith(expected)
+                  : cellValue.includes(expected);
       });
     }
 

--- a/tests/test_table_column_filters.py
+++ b/tests/test_table_column_filters.py
@@ -1,0 +1,26 @@
+"""Regression coverage for the shared, ticket-style table column filters."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_shared_tables_build_typed_column_filter_menus() -> None:
+    javascript = (ROOT / "app/static/js/tables.js").read_text(encoding="utf-8")
+
+    assert "setupColumnFilters()" in javascript
+    assert "data-table-column-filters-disabled" in javascript
+    assert "table-column-filter__toggle" in javascript
+    assert "data-table-column-filter-apply" in javascript
+    assert "['greater', 'Greater than']" in javascript
+    assert "['before', 'Before']" in javascript
+
+
+def test_shared_table_filters_use_ticket_filter_visual_language() -> None:
+    css = (ROOT / "app/static/css/app.css").read_text(encoding="utf-8")
+
+    assert ".table-column-filter__panel" in css
+    assert ".table-column-filter--active .table-column-filter__toggle" in css
+    assert "var(--color-primary, #2563eb)" in css
+


### PR DESCRIPTION
### Motivation
- Provide the same compact, per-column filtering UX used by the admin tickets workspace to other `data-table` instances across the app while preserving the ticket workspace's richer saved-view filters.

### Description
- Add `setupColumnFilters()` to `app/static/js/tables.js` to automatically attach typed filter popovers (text/number/date) to usable table headers and to persist/restore column filters via the existing per-table storage key.
- Extend persisted-state handling so object-shaped filters (operator/value/type) are restored and applied alongside legacy string filters, and add a fallback header->cell index lookup so filters work when rows are appended dynamically.
- Skip injecting filters for tables that set `data-ticket-status-options` or opt out with `data-table-column-filters-disabled`, and avoid action/select columns when installing menus.
- Add matching CSS in `app/static/css/app.css` to mirror the ticket workspace's compact filter icons, panels, focus states, and active-filter styling.
- Add regression tests in `tests/test_table_column_filters.py` to ensure the new JS/CSS hooks and operators exist.

### Testing
- Ran `node --check app/static/js/tables.js` to validate JS syntax; check passed. 
- Ran `pytest -q tests/test_table_column_filters.py tests/test_layout_macros.py tests/test_ticket_column_customisation.py`; all tests passed (36 passed).
- Ran `pytest -q tests/test_table_column_filters.py`; the new test file passed (2 passed).
- Ran `git diff --check`; no whitespace or diff errors reported.
- Note: a larger template/mobile compliance suite run earlier showed unrelated pre-existing template/mobile failures in files outside the scope of this change; those were not introduced by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6c4aa20f648332bdeab3d935915b38)