### PR TITLE
Fix empty company automation edit modal

### DIFF
--- a/app/templates/admin/company_edit.html
+++ b/app/templates/admin/company_edit.html
@@ -1562,6 +1562,13 @@
                 <span>Automation active</span>
               </label>
             </div>
+            <div class="form-field form-field--checkbox">
+              <label class="form-checkbox">
+                <input type="checkbox" id="task-exclude-calendar" name="excludeFromCalendar" />
+                <span>Hide from cron calendar</span>
+              </label>
+              <p class="form-help">Use for high-frequency jobs that would otherwise fill the calendar.</p>
+            </div>
             <div class="form-actions">
               <div class="form-actions__group">
                 <button type="submit" class="button">Save automation</button>

--- a/changes/18cf708e-d728-4304-84db-05fa3f7106f1.json
+++ b/changes/18cf708e-d728-4304-84db-05fa3f7106f1.json
@@ -1,0 +1,7 @@
+{
+  "guid": "18cf708e-d728-4304-84db-05fa3f7106f1",
+  "occurred_at": "2026-07-31T00:00Z",
+  "change_type": "Fix",
+  "summary": "Fixed company automation editing so the modal loads existing task details and preserves cron calendar visibility.",
+  "content_hash": "0fa56340293e9ebfa75ce905b8526d4250279a0294f55241653c5b6735a49f44"
+}

--- a/tests/test_company_edit_automation_form.py
+++ b/tests/test_company_edit_automation_form.py
@@ -1,0 +1,22 @@
+"""Regression tests for the company automation editor form."""
+
+from pathlib import Path
+
+
+def test_company_automation_editor_has_every_field_required_by_populator():
+    """Editing must not abort because a field expected by automation.js is absent."""
+    template = Path("app/templates/admin/company_edit.html").read_text()
+
+    required_field_ids = (
+        "task-id",
+        "task-command",
+        "task-cron",
+        "task-description",
+        "task-max-retries",
+        "task-backoff",
+        "task-active",
+        "task-exclude-calendar",
+    )
+
+    for field_id in required_field_ids:
+        assert f'id="{field_id}"' in template


### PR DESCRIPTION
### Motivation

- The company automation edit modal opened empty because the shared scheduled-task form populator expected a checkbox field for calendar visibility that was missing from the company modal, causing the JS to not populate existing values.

### Description

- Add the `task-exclude-calendar` checkbox and help text to `app/templates/admin/company_edit.html` so the modal exposes the cron-calendar visibility field expected by `automation.js`.
- Add a regression test `tests/test_company_edit_automation_form.py` that asserts the company editor template contains every field required by the JavaScript populator.
- Add a change-log entry in `changes/18cf708e-d728-4304-84db-05fa3f7106f1.json` documenting the fix.
- Ensure the existing form-population and submit logic in `app/static/js/automation.js` can now populate and preserve the calendar visibility flag for edited automations.

### Testing

- Ran `pytest -q tests/test_company_edit_automation_form.py`, which passed (1 passed).
- Ran `pytest -q tests/test_company_edit_automation_form.py tests/test_automation_form_parsing.py`, which passed (9 passed).
- Running `pytest -q tests/test_company_edit_automation_form.py tests/test_company_edit_automation_tasks_sorting.py` surfaced a pre-existing test failure unrelated to this change because that test attempts to patch a non-existent `_get_company_management_scope` on `app.main`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6c55ba9ec08332b97af8e14533048c)