### PR TITLE
Add thumbnail previews for ticket attachments

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -1940,6 +1940,7 @@ async def download_ticket_attachment(
     ticket_id: int,
     attachment_id: int,
     current_user: dict = Depends(get_current_user),
+    preview: bool = Query(default=False),
 ):
     """Download a ticket attachment (requires authentication)"""
     attachment = await attachments_repo.get_attachment(attachment_id)
@@ -1997,13 +1998,13 @@ async def download_ticket_attachment(
                 status_code=status.HTTP_404_NOT_FOUND, detail="File not found"
             )
 
+    original_filename = attachment.get("original_filename") or "download"
+    disposition = "inline" if preview else "attachment"
     return FileResponse(
         path=file_path,
-        filename=attachment.get("original_filename"),
+        filename=original_filename,
         media_type=attachment.get("mime_type") or "application/octet-stream",
-        headers={
-            "Content-Disposition": f'attachment; filename="{attachment.get("original_filename", "download")}"'
-        },
+        content_disposition_type=disposition,
     )
 
 

--- a/app/repositories/ticket_attachments.py
+++ b/app/repositories/ticket_attachments.py
@@ -75,7 +75,9 @@ async def list_attachments(
         query += f" AND access_level IN ({placeholders})"
         params.extend(allowed_access_levels)
 
-    query += " ORDER BY uploaded_at ASC"
+    # Keep the most recently added files first everywhere attachments are used.
+    # The id provides deterministic ordering when multiple rows share a timestamp.
+    query += " ORDER BY uploaded_at DESC, id DESC"
 
     rows = await db.fetch_all(query, tuple(params))
     return [dict(row) for row in rows]

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -8394,36 +8394,61 @@ a.service-card__ai-icon:hover {
 .attachments-grid {
   display: grid;
   gap: var(--space-gap-roomy);
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
 }
 
 .attachment-card {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--space-gap-base);
-  padding: 0.9rem 1.1rem;
+  display: grid;
+  grid-template-rows: 9rem auto;
+  overflow: hidden;
   border-radius: 0.85rem;
   background: rgba(15, 23, 42, 0.75);
   border: 1px solid rgba(148, 163, 184, 0.18);
 }
 
-.attachment-card__icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  color: rgba(148, 163, 184, 0.82);
+.attachment-card__preview {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  overflow: hidden;
+  background: rgba(30, 41, 59, 0.9);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  text-decoration: none;
+}
+
+.attachment-card__preview img,
+.attachment-card__preview iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  object-fit: cover;
+}
+
+.attachment-card__preview-shield {
+  position: absolute;
+  inset: 0;
+}
+
+.attachment-card__file-type {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-}
-
-.attachment-card__icon svg {
-  width: 100%;
-  height: 100%;
+  width: 4rem;
+  height: 5rem;
+  border-radius: 0.35rem;
+  background: rgba(59, 130, 246, 0.18);
+  border: 1px solid rgba(96, 165, 250, 0.5);
+  color: #bfdbfe;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
 }
 
 .attachment-card__content {
-  flex: 1 1 auto;
   min-width: 0;
+  padding: 0.75rem 0.85rem 0.85rem;
 }
 
 .attachment-card__header {

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -1030,7 +1030,29 @@
               >
                 {% for attachment in ticket_attachments %}
                   <article class="attachment-card" data-attachment-id="{{ attachment.id }}">
-                    <div class="attachment-card__icon" aria-hidden="true">📎</div>
+                    <a
+                      class="attachment-card__preview"
+                      href="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download"
+                      title="Open {{ attachment.original_filename or attachment.filename }}"
+                    >
+                      {% if attachment.mime_type and attachment.mime_type.startswith('image/') %}
+                        <img
+                          src="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download?preview=true"
+                          alt="Preview of {{ attachment.original_filename or attachment.filename }}"
+                          loading="lazy"
+                        />
+                      {% elif attachment.mime_type == 'application/pdf' %}
+                        <iframe
+                          src="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download?preview=true#toolbar=0&navpanes=0"
+                          title="Preview of {{ attachment.original_filename or attachment.filename }}"
+                          loading="lazy"
+                          tabindex="-1"
+                        ></iframe>
+                        <span class="attachment-card__preview-shield" aria-hidden="true"></span>
+                      {% else %}
+                        <span class="attachment-card__file-type" aria-hidden="true">{{ (attachment.original_filename or attachment.filename).rsplit('.', 1)[-1][:5] | upper if '.' in (attachment.original_filename or attachment.filename) else 'FILE' }}</span>
+                      {% endif %}
+                    </a>
                     <div class="attachment-card__content">
                       <div class="attachment-card__header">
                         <p class="attachment-card__name">

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -117,7 +117,29 @@
               >
                 {% for attachment in ticket_attachments %}
                   <article class="attachment-card" data-attachment-id="{{ attachment.id }}">
-                    <div class="attachment-card__icon" aria-hidden="true">📎</div>
+                    <a
+                      class="attachment-card__preview"
+                      href="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download"
+                      title="Open {{ attachment.original_filename or attachment.filename }}"
+                    >
+                      {% if attachment.mime_type and attachment.mime_type.startswith('image/') %}
+                        <img
+                          src="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download?preview=true"
+                          alt="Preview of {{ attachment.original_filename or attachment.filename }}"
+                          loading="lazy"
+                        />
+                      {% elif attachment.mime_type == 'application/pdf' %}
+                        <iframe
+                          src="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download?preview=true#toolbar=0&navpanes=0"
+                          title="Preview of {{ attachment.original_filename or attachment.filename }}"
+                          loading="lazy"
+                          tabindex="-1"
+                        ></iframe>
+                        <span class="attachment-card__preview-shield" aria-hidden="true"></span>
+                      {% else %}
+                        <span class="attachment-card__file-type" aria-hidden="true">{{ (attachment.original_filename or attachment.filename).rsplit('.', 1)[-1][:5] | upper if '.' in (attachment.original_filename or attachment.filename) else 'FILE' }}</span>
+                      {% endif %}
+                    </a>
                     <div class="attachment-card__content">
                       <div class="attachment-card__header">
                         <p class="attachment-card__name">

--- a/tests/test_ticket_attachments.py
+++ b/tests/test_ticket_attachments.py
@@ -151,6 +151,7 @@ async def test_list_attachments():
     assert result[0]["filename"] == "file1.pdf"
     assert result[1]["filename"] == "file2.png"
     assert mock_db.fetch_all_params[0] == 5  # ticket_id
+    assert "ORDER BY uploaded_at DESC, id DESC" in mock_db.fetch_all_sql
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- Improve ticket attachment UX by showing compact thumbnail previews so technicians can quickly inspect files without opening each one, and ensure attachments are presented newest-first.

### Description

- Render attachments as thumbnail cards in both requester and admin views by updating `app/templates/tickets/detail.html` and `app/templates/admin/ticket_detail.html` to show image and PDF previews and file-type tiles for other formats while preserving download and remove actions.
- Add styling for the thumbnail grid and preview surfaces in `app/static/css/app.css` to support compact, lazy-loaded previews and consistent layout.
- Add an authenticated inline preview mode to the download endpoint by introducing a `preview` query parameter to `GET /api/tickets/{ticket_id}/attachments/{attachment_id}/download` and using `FileResponse` `content_disposition_type`/`filename` to serve `inline` previews vs `attachment` downloads in `app/api/routes/tickets.py`.
- Make attachment listing deterministic and newest-first by changing `list_attachments` ordering to `ORDER BY uploaded_at DESC, id DESC` in `app/repositories/ticket_attachments.py` and update tests to assert the new SQL ordering.

### Testing

- Ran `python -m pytest -q tests/test_ticket_attachments.py tests/test_path_traversal_prevention.py` and the test suite passed (`37 passed`).
- Validated modified Jinja templates with `jinja2.Environment().parse()` and both templates parsed successfully.
- Repository tests were updated to assert the new `ORDER BY uploaded_at DESC, id DESC` SQL clause and passed as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6fdf3dd4488332899cdabb3e6e7a25)