### PR TITLE
Add SHA-256 ticket attachment blocklist and historical cleanup

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -2109,6 +2109,42 @@ async def delete_ticket_attachment(
         )
 
 
+@router.post("/{ticket_id}/attachments/{attachment_id}/blocklist")
+async def blocklist_ticket_attachment(
+    ticket_id: int,
+    attachment_id: int,
+    request: Request,
+    remove_existing: bool = Query(default=False),
+    current_user: dict = Depends(require_helpdesk_technician),
+) -> dict[str, Any]:
+    """Block matching attachment bytes and discard this attachment."""
+    attachment = await attachments_repo.get_attachment(attachment_id)
+    if not attachment or attachment.get("ticket_id") != ticket_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Attachment not found")
+    if remove_existing and not current_user.get("is_super_admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only super admins can remove matching historical attachments",
+        )
+    try:
+        entry, removed = await attachments_service.block_attachment(
+            attachment,
+            created_by_user_id=current_user.get("id"),
+            remove_existing=remove_existing,
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    await audit_service.record(
+        action="ticket.attachment_blocked",
+        request=request,
+        user_id=int(current_user["id"]),
+        entity_type="ticket_attachment_blocklist",
+        entity_id=int(entry["id"]),
+        after={"sha256_hash": entry["sha256_hash"]},
+        metadata={"ticket_id": ticket_id, "attachment_id": attachment_id, "removed": removed},
+    )
+    return {"blocklist_id": entry["id"], "removed": removed}
+
 @router.get("/{ticket_id}/attachments/{attachment_id}/token")
 async def get_open_access_token(
     ticket_id: int,

--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -48,6 +48,7 @@ from app.repositories import ticket_expenses as expenses_repo
 from app.repositories import ticket_clocks as ticket_clocks_repo
 from app.repositories import tickets as tickets_repo
 from app.repositories import email_blocklist as email_blocklist_repo
+from app.repositories import attachment_blocklist as attachment_blocklist_repo
 from app.repositories import users as user_repo
 from app.repositories import site_settings as site_settings_repo
 from app.services import agent as agent_service
@@ -58,6 +59,7 @@ from app.services import tickets as tickets_service
 from app.services import ticket_shipment_tracking as shipment_watch_service
 from app.services import message_templates as message_template_service
 from app.services import unbill_tickets as unbill_tickets_service
+from app.services import audit as audit_service
 from app.services import tray as tray_service
 from app.services.sanitization import sanitize_rich_text
 
@@ -390,6 +392,44 @@ async def admin_delete_email_blocklist_entry(entry_id: int, request: Request):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Super admin access required")
     await email_blocklist_repo.delete_entry(entry_id)
     return flash_redirect("/admin/tickets/email-blocklist", "Email address removed from the blocklist.", "success")
+
+
+@router.get("/admin/tickets/attachment-blocklist", response_class=HTMLResponse)
+async def admin_attachment_blocklist_page(request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        return redirect
+    entries = await attachment_blocklist_repo.list_entries()
+    for entry in entries:
+        entry["created_iso"] = _iso_utc(entry.get("created_at"))
+    return await main_module._render_template(
+        "admin/attachment_blocklist.html",
+        request,
+        current_user,
+        extra={"title": "Attachment blocklist", "entries": entries},
+    )
+
+
+@router.post("/admin/tickets/attachment-blocklist/{entry_id:int}/delete")
+async def admin_delete_attachment_blocklist_entry(entry_id: int, request: Request):
+    main_module = _main()
+    current_user, redirect = await main_module._require_helpdesk_page(request)
+    if redirect:
+        return redirect
+    await attachment_blocklist_repo.delete(entry_id)
+    await audit_service.record(
+        action="ticket.attachment_blocklist_removed",
+        request=request,
+        user_id=int(current_user["id"]),
+        entity_type="ticket_attachment_blocklist",
+        entity_id=entry_id,
+    )
+    return flash_redirect(
+        "/admin/tickets/attachment-blocklist",
+        "Attachment removed from the blocklist.",
+        "success",
+    )
 
 @router.get("/admin/tickets", response_class=HTMLResponse)
 async def admin_tickets_page(

--- a/app/repositories/attachment_blocklist.py
+++ b/app/repositories/attachment_blocklist.py
@@ -1,0 +1,56 @@
+"""Data access for content-hash based ticket attachment blocking."""
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.database import db
+
+
+async def is_blocked(sha256_hash: str) -> bool:
+    row = await db.fetch_one(
+        "SELECT id FROM ticket_attachment_blocklist WHERE sha256_hash = ? LIMIT 1",
+        (sha256_hash,),
+    )
+    return row is not None
+
+
+async def add(
+    sha256_hash: str,
+    *,
+    original_filename: str | None,
+    file_size: int,
+    mime_type: str | None,
+    created_by_user_id: int | None,
+) -> dict[str, Any]:
+    await db.execute(
+        """
+        INSERT INTO ticket_attachment_blocklist
+          (sha256_hash, original_filename, file_size, mime_type, created_by_user_id)
+        VALUES (?, ?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+          original_filename = COALESCE(original_filename, VALUES(original_filename)),
+          file_size = COALESCE(file_size, VALUES(file_size)),
+          mime_type = COALESCE(mime_type, VALUES(mime_type))
+        """,
+        (sha256_hash, original_filename, file_size, mime_type, created_by_user_id),
+    )
+    row = await db.fetch_one(
+        "SELECT * FROM ticket_attachment_blocklist WHERE sha256_hash = ?",
+        (sha256_hash,),
+    )
+    return dict(row)
+
+
+async def list_entries() -> list[dict[str, Any]]:
+    rows = await db.fetch_all(
+        "SELECT * FROM ticket_attachment_blocklist ORDER BY created_at DESC, id DESC"
+    )
+    return [dict(row) for row in rows]
+
+
+async def delete(entry_id: int) -> bool:
+    return (
+        await db.execute_rowcount(
+            "DELETE FROM ticket_attachment_blocklist WHERE id = ?", (entry_id,)
+        )
+    ) > 0

--- a/app/repositories/ticket_attachments.py
+++ b/app/repositories/ticket_attachments.py
@@ -114,3 +114,13 @@ async def count_attachments(ticket_id: int) -> int:
     query = "SELECT COUNT(*) as count FROM ticket_attachments WHERE ticket_id = ?"
     row = await db.fetch_one(query, (ticket_id,))
     return row["count"] if row else 0
+
+
+async def list_all_attachments() -> list[dict[str, Any]]:
+    """List attachment records across tickets for super-admin storage cleanup."""
+    rows = await db.fetch_all(
+        """SELECT id, ticket_id, filename, original_filename, file_size,
+                  mime_type, access_level, uploaded_by_user_id, uploaded_at
+           FROM ticket_attachments ORDER BY id"""
+    )
+    return [dict(row) for row in rows]

--- a/app/services/ticket_attachments.py
+++ b/app/services/ticket_attachments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import hashlib
 import os
 import re
 import secrets
@@ -16,6 +17,7 @@ from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 from app.core.config import get_settings
 from app.core.logging import log_debug, log_error, log_info
 from app.repositories import ticket_attachments as attachments_repo
+from app.repositories import attachment_blocklist as blocklist_repo
 
 
 # Maximum file size: 50 MB
@@ -80,6 +82,19 @@ _INLINE_IMAGE_EXTENSIONS = {
     "image/gif": "gif",
     "image/webp": "webp",
 }
+
+
+def content_hash(contents: bytes) -> str:
+    """Return the stable, non-reversible identifier used by the blocklist."""
+    return hashlib.sha256(contents).hexdigest()
+
+
+async def ensure_not_blocked(contents: bytes) -> str:
+    """Reject content already flagged by a technician, regardless of its name."""
+    digest = content_hash(contents)
+    if await blocklist_repo.is_blocked(digest):
+        raise ValueError("This attachment is on the attachment blocklist and was discarded")
+    return digest
 
 
 def _get_upload_directory() -> Path:
@@ -194,6 +209,8 @@ async def save_uploaded_file(
         if file_size > MAX_FILE_SIZE:
             raise ValueError(f"File size {file_size} exceeds maximum")
 
+        await ensure_not_blocked(contents)
+
         # Validate MIME type from actual file bytes (defeats spoofed Content-Type).
         actual_mime = _sniff_mime_type(contents[:_MAGIC_HEADER_BYTES])
         if actual_mime and actual_mime not in ALLOWED_MIME_TYPES:
@@ -257,6 +274,8 @@ async def save_file_bytes(
     file_size = len(contents)
     if file_size > MAX_FILE_SIZE:
         raise ValueError(f"File size {file_size} exceeds maximum")
+
+    await ensure_not_blocked(contents)
 
     # Validate MIME type from actual file bytes.
     actual_mime = _sniff_mime_type(contents[:_MAGIC_HEADER_BYTES])
@@ -379,6 +398,41 @@ async def delete_attachment_file(attachment: dict[str, Any]) -> None:
         except Exception as e:
             log_error(f"Failed to delete file {filename}: {e}")
             # Don't raise - file might already be gone, record is deleted
+
+
+def attachment_path(attachment: dict[str, Any]) -> Path:
+    """Locate an attachment in current or legacy private storage."""
+    path = get_attachment_file_path(str(attachment.get("filename") or ""))
+    if not path.exists():
+        legacy = get_legacy_attachment_file_path(str(attachment.get("filename") or ""))
+        if legacy.exists():
+            return legacy
+    return path
+
+
+async def block_attachment(
+    attachment: dict[str, Any], *, created_by_user_id: int | None, remove_existing: bool
+) -> tuple[dict[str, Any], int]:
+    """Block an attachment's bytes and optionally purge every historical match."""
+    path = attachment_path(attachment)
+    if not path.exists():
+        raise FileNotFoundError("Attachment file not found")
+    digest = content_hash(path.read_bytes())
+    entry = await blocklist_repo.add(
+        digest,
+        original_filename=attachment.get("original_filename"),
+        file_size=int(attachment.get("file_size") or path.stat().st_size),
+        mime_type=attachment.get("mime_type"),
+        created_by_user_id=created_by_user_id,
+    )
+    removed = 0
+    targets = await attachments_repo.list_all_attachments() if remove_existing else [attachment]
+    for candidate in targets:
+        candidate_path = attachment_path(candidate)
+        if candidate_path.exists() and content_hash(candidate_path.read_bytes()) == digest:
+            await delete_attachment_file(candidate)
+            removed += 1
+    return entry, removed
 
 
 def _safe_attachment_path(base_dir: Path, filename: str) -> Path:

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -8490,6 +8490,12 @@ a.service-card__ai-icon:hover {
   flex-shrink: 0;
 }
 
+.attachment-card__block-icon {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: currentColor;
+}
+
 .dropdown {
   position: relative;
 }

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -2650,6 +2650,32 @@
         handleRemove(button);
       });
     });
+
+    const blockButtons = container.querySelectorAll('[data-block-attachment]');
+    blockButtons.forEach((button) => {
+      button.addEventListener('click', async () => {
+        const attachmentId = button.getAttribute('data-attachment-id');
+        if (!attachmentId || !ticketId || !window.confirm('Block this file content and discard this attachment? Future identical files will not be saved.')) return;
+        const removeExisting = button.getAttribute('data-can-remove-existing') === 'true'
+          && window.confirm('Also permanently remove identical attachments from all past tickets to reclaim storage?');
+        button.disabled = true;
+        try {
+          const response = await fetch(`/api/tickets/${ticketId}/attachments/${attachmentId}/blocklist?remove_existing=${removeExisting}`, {
+            method: 'POST',
+            headers: {'X-CSRF-Token': getCsrfToken()},
+          });
+          if (!response.ok) {
+            const payload = await response.json().catch(() => ({}));
+            throw new Error(payload.detail || 'Failed to block attachment');
+          }
+          button.closest('[data-attachment-id]')?.remove();
+          updateEmptyState();
+        } catch (error) {
+          alert(error instanceof Error ? error.message : 'Failed to block attachment');
+          button.disabled = false;
+        }
+      });
+    });
   }
 
   function getTicketIdFromPath() {

--- a/app/templates/admin/attachment_blocklist.html
+++ b/app/templates/admin/attachment_blocklist.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% from "macros/header.html" import page_header_actions %}
+
+{% block header_title %}Attachment blocklist{% endblock %}
+{% block header_actions %}
+  {{ page_header_actions([{"label": "Back to tickets", "type": "link", "href": "/admin/tickets"}]) }}
+{% endblock %}
+
+{% block content %}
+  <div class="management management--single" data-layout>
+    <section class="management__content">
+      <div class="management__body">
+        <section class="card card--panel">
+          <header class="card__header">
+            <div>
+              <h2 class="card__title">Blocked attachment content</h2>
+              <p class="card__subtitle">Files are identified by a SHA-256 hash of their exact contents. Removing an item permits future matching attachments; it does not restore discarded files.</p>
+            </div>
+          </header>
+          <div class="table-wrapper">
+            <table class="table table--stack-mobile" data-table data-table-id="attachment-blocklist-table">
+              <thead><tr><th>File</th><th>Size / type</th><th>Content hash</th><th>Blocked</th><th>Actions</th></tr></thead>
+              <tbody>
+                {% for entry in entries %}
+                  <tr>
+                    <td data-label="File">{{ entry.original_filename or 'Unknown file' }}</td>
+                    <td data-label="Size / type">{{ entry.file_size | filesizeformat if entry.file_size is not none else '—' }} · {{ entry.mime_type or 'unknown' }}</td>
+                    <td data-label="Content hash"><code title="{{ entry.sha256_hash }}">{{ entry.sha256_hash[:12] }}…</code></td>
+                    <td data-label="Blocked">{% if entry.created_iso %}<span data-utc="{{ entry.created_iso }}"></span>{% else %}—{% endif %}</td>
+                    <td data-label="Actions">
+                      <form method="post" action="/admin/tickets/attachment-blocklist/{{ entry.id }}/delete" onsubmit="return confirm('Allow future files matching this content?');">
+                        {% include "partials/csrf.html" %}
+                        <button type="submit" class="button button--ghost button--compact">Remove</button>
+                      </form>
+                    </td>
+                  </tr>
+                {% else %}
+                  <tr><td colspan="5" class="table__empty">No attachment content has been blocked.</td></tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </section>
+  </div>
+{% endblock %}

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -1067,6 +1067,18 @@
                           <button
                             type="button"
                             class="button button--ghost button--small attachment-card__action"
+                            data-block-attachment
+                            data-attachment-id="{{ attachment.id }}"
+                            data-can-remove-existing="{{ 'true' if is_super_admin else 'false' }}"
+                            aria-label="Block this attachment content"
+                            title="Block this file so matching attachments are discarded"
+                          >
+                            <svg class="attachment-card__block-icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 2a7.96 7.96 0 0 1 5.13 1.87L5.87 17.13A8 8 0 0 1 12 4Zm0 16a7.96 7.96 0 0 1-5.13-1.87L18.13 6.87A8 8 0 0 1 12 20Z"/></svg>
+                            <span class="visually-hidden">Block</span>
+                          </button>
+                          <button
+                            type="button"
+                            class="button button--ghost button--small attachment-card__action"
                             data-remove-attachment
                             data-attachment-id="{{ attachment.id }}"
                             aria-label="Remove attachment"

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -10,10 +10,11 @@
   {% set show_next_ticket_number = is_super_admin %}
   {% set show_unbill_tickets = is_super_admin %}
   {% set show_email_blocklist = is_super_admin %}
+  {% set show_attachment_blocklist = is_helpdesk_technician | default(false) %}
   {% set can_create_canned_response = is_helpdesk_technician | default(false) %}
   {% set can_merge_tickets = is_helpdesk_technician | default(false) %}
   {% set can_bulk_edit_tickets = is_helpdesk_technician | default(false) %}
-  {% set show_ticket_tools = show_ticket_automations or show_syncro_import or show_ticket_status_editor or show_labour_type_editor or show_next_ticket_number or show_unbill_tickets or show_email_blocklist or show_tag_exclusions or can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets or can_create_canned_response %}
+  {% set show_ticket_tools = show_ticket_automations or show_syncro_import or show_ticket_status_editor or show_labour_type_editor or show_next_ticket_number or show_unbill_tickets or show_email_blocklist or show_attachment_blocklist or show_tag_exclusions or can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets or can_create_canned_response %}
   <div class="header-title-menu">
     <span class="header-title-menu__label">Ticketing workspace</span>
     <button
@@ -115,6 +116,11 @@
           {% if show_email_blocklist %}
             <li class="header-title-menu__item" role="none">
               <a href="/admin/tickets/email-blocklist" class="header-title-menu__link" role="menuitem">Email blocklist</a>
+            </li>
+          {% endif %}
+          {% if show_attachment_blocklist %}
+            <li class="header-title-menu__item" role="none">
+              <a href="/admin/tickets/attachment-blocklist" class="header-title-menu__link" role="menuitem">Attachment blocklist</a>
             </li>
           {% endif %}
           {% if show_tag_exclusions %}

--- a/migrations/312_ticket_attachment_blocklist.sql
+++ b/migrations/312_ticket_attachment_blocklist.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS ticket_attachment_blocklist (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  sha256_hash CHAR(64) NOT NULL,
+  original_filename VARCHAR(255) NULL,
+  file_size BIGINT NULL,
+  mime_type VARCHAR(255) NULL,
+  created_by_user_id INT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_ticket_attachment_blocklist_hash (sha256_hash),
+  CONSTRAINT fk_ticket_attachment_blocklist_user
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/tests/test_attachment_blocklist.py
+++ b/tests/test_attachment_blocklist.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import hashlib
+import asyncio
+
+import pytest
+
+from app.services import ticket_attachments
+
+
+def test_content_hash_uses_sha256() -> None:
+    contents = b"repeated email signature image"
+    assert ticket_attachments.content_hash(contents) == hashlib.sha256(contents).hexdigest()
+
+
+def test_ensure_not_blocked_rejects_matching_content(monkeypatch) -> None:
+    async def blocked(digest: str) -> bool:
+        assert digest == hashlib.sha256(b"signature").hexdigest()
+        return True
+
+    monkeypatch.setattr(ticket_attachments.blocklist_repo, "is_blocked", blocked)
+
+    with pytest.raises(ValueError, match="blocklist.*discarded"):
+        asyncio.run(ticket_attachments.ensure_not_blocked(b"signature"))
+
+
+def test_ensure_not_blocked_allows_new_content(monkeypatch) -> None:
+    async def not_blocked(_digest: str) -> bool:
+        return False
+
+    monkeypatch.setattr(ticket_attachments.blocklist_repo, "is_blocked", not_blocked)
+    assert asyncio.run(ticket_attachments.ensure_not_blocked(b"new")) == hashlib.sha256(b"new").hexdigest()


### PR DESCRIPTION
### Motivation

- Provide technicians a way to mark recurring/unwanted attachments (e.g. email signature images) so identical files are discarded on upload and imports to reduce noise and storage growth. 
- Allow super admins to optionally purge historical matching files to reclaim storage while keeping an auditable record of blocklist changes.

### Description

- Add a new migration and table `ticket_attachment_blocklist` to persist blocked content hashes and metadata. 
- Add `app/repositories/attachment_blocklist.py` and helper DB functions including `is_blocked`, `add`, `list_entries`, and `delete`. 
- Compute a stable file identifier with `content_hash` (SHA-256) and enforce it via `ensure_not_blocked` in the shared attachment saver (`save_uploaded_file` and `save_file_bytes`) so blocked bytes are rejected regardless of filename. 
- Implement `block_attachment` to record a blocklist entry and optionally remove matching historical attachments, plus `list_all_attachments` in the attachments repo to support retrospective cleanup. 
- Expose a technician API endpoint `POST /admin/tickets/{ticket_id}/attachments/{attachment_id}/blocklist` that records an audit event and supports `remove_existing` (super-admin only) to purge historical matches. 
- UI changes: add a block icon button on each attachment card with JS handler to call the blocklist endpoint, add an "Attachment blocklist" entry under the Ticket tools menu, and add an admin management page at `/admin/tickets/attachment-blocklist` to review and remove blocked hashes. 
- Add focused tests `tests/test_attachment_blocklist.py` that validate deterministic hashing and `ensure_not_blocked` behavior.

### Testing

- Ran `pytest -q tests/test_attachment_blocklist.py`, which passed. 
- Verified `python -m compileall -q app` and `node --check app/static/js/ticket_detail.js`, both of which completed without errors. 
- Ran repository static checks (`git diff --check`) with no new issues reported. 
- Note: running the wider suite in this environment surfaced unrelated, pre-existing failures (async pytest plugin missing for some async tests and an unrelated sanitization assertion) and the repo’s global audit allowlist previously flagged unrelated routes; the new blocklist mutation handlers include `audit_service.record` so they are auditable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6ff7de2c308332bc7fe23ca0db70e5)