### PR TITLE
Fix doubly encoded HTML leaking into Trello ticket updates

### DIFF
--- a/app/services/trello.py
+++ b/app/services/trello.py
@@ -169,12 +169,16 @@ def _strip_html(value: str, *, image_base_url: str | None = None) -> str:
         return ""
 
     # Rich-text replies can reach this integration with their markup entity-
-    # encoded (for example ``&lt;/span&gt;&lt;/div&gt;``).  HTMLParser decodes
-    # character references only while emitting text, so feeding that value
-    # directly would expose the decoded tags in the Trello comment instead of
-    # treating them as markup.  Decode once before parsing so block elements
-    # and ``br`` tags are handled by the parser and rendered as line breaks.
-    value = unescape(value)
+    # encoded, sometimes more than once after passing through the editor and
+    # sanitiser (for example ``&amp;lt;div&amp;gt;``). HTMLParser decodes
+    # character references while emitting text but does not parse the decoded
+    # text as markup, which would leak ``<div><br></div>`` into Trello. Decode
+    # boundedly before parsing so those tags are handled as HTML instead.
+    for _ in range(3):
+        decoded = unescape(value)
+        if decoded == value:
+            break
+        value = decoded
     parser = _TrelloCommentHTMLParser(image_base_url=image_base_url)
     parser.feed(value)
     parser.close()

--- a/tests/test_trello_comment_formatting.py
+++ b/tests/test_trello_comment_formatting.py
@@ -24,6 +24,15 @@ def test_strip_html_parses_entity_encoded_markup_and_preserves_line_breaks():
     assert trello_service._strip_html(body) == "First line\nSecond line\nThird line"
 
 
+def test_strip_html_parses_doubly_encoded_editor_markup():
+    body = (
+        "&amp;lt;div&amp;gt;&amp;lt;br&amp;gt;&amp;lt;/div&amp;gt;"
+        "&amp;lt;div&amp;gt;Ticket update&amp;lt;/div&amp;gt;"
+    )
+
+    assert trello_service._strip_html(body) == "Ticket update"
+
+
 def test_strip_html_renders_ticket_images_as_absolute_markdown():
     body = '<div>Screenshot attached</div><img src="/api/tickets/25055/attachments/9977/download" alt="">'
 


### PR DESCRIPTION
### Motivation
- Prevent editor/sanitiser-encoded HTML entities (for example `&amp;lt;div&amp;gt;`) from being decoded into literal markup such as `<div><br></div><div>` inside comments posted to Trello.
- Avoid noise and formatting artifacts on Trello cards by ensuring reply HTML is parsed as markup after any entity-encoding layers are removed.

### Description
- Update `_strip_html` to perform bounded repeated decoding using `unescape` (up to 3 passes) before feeding the content to the HTML parser so doubly- or triply-encoded editor markup is handled correctly.
- Preserve existing parsing logic in `_TrelloCommentHTMLParser` and only normalise decoding behaviour prior to parsing.
- Add a regression test `test_strip_html_parses_doubly_encoded_editor_markup` in `tests/test_trello_comment_formatting.py` that verifies doubly-encoded editor wrapper tags are removed and the ticket update text is preserved.

### Testing
- Ran `pytest -q tests/test_trello_comment_formatting.py tests/test_trello_create_ticket_description.py tests/test_trello_comment_card_automation.py` and all tests passed (`12 passed`).
- The new regression test confirms that doubly-encoded editor markup is now stripped before conversion to Trello-friendly text.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6fff89cd888332a4b4143d71473547)