### PR TITLE
Fix saving newly added default labour types

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -957,6 +957,14 @@ def _build_ticket_status_payloads(
     return statuses
 
 
+def _is_default_labour_type(identifier: Any, default_value: Any, index: int) -> bool:
+    """Match the selected radio value to an existing or unsaved labour type."""
+    return bool(
+        (identifier and str(identifier) == str(default_value))
+        or str(default_value) == f"new-{index}"
+    )
+
+
 @router.post("/admin/tickets/statuses", response_class=HTMLResponse)
 async def admin_replace_ticket_statuses(request: Request):
     main_module = _main()
@@ -1023,7 +1031,7 @@ async def admin_replace_labour_types(request: Request):
                 rate_value = float(rate_str.strip())
             except (ValueError, TypeError):
                 rate_value = None
-        is_default = identifier and str(identifier) == str(default_id)
+        is_default = _is_default_labour_type(identifier, default_id, index)
         definitions.append(
             {
                 "id": identifier,

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -2851,21 +2851,34 @@
     function updateRowIdentifiers() {
       const rows = Array.from(list.querySelectorAll('[data-labour-row]'));
       rows.forEach((row, index) => {
+        const defaultInput = row.querySelector('input[name="defaultLabourType"]');
         const codeInput = row.querySelector('input[name="labourCode"]');
         const nameInput = row.querySelector('input[name="labourName"]');
+        const idInput = row.querySelector('input[name="labourId"]');
         const labels = Array.from(row.querySelectorAll('label'));
+        if (defaultInput) {
+          const defaultId = `labour-default-${index}`;
+          defaultInput.id = defaultId;
+          // New labour types do not have a database ID yet. Give their radio
+          // buttons a row-specific value so the server can identify which new
+          // record was selected as the default.
+          defaultInput.value = idInput && idInput.value ? idInput.value : `new-${index}`;
+          if (labels[0]) {
+            labels[0].setAttribute('for', defaultId);
+          }
+        }
         if (codeInput) {
           const codeId = `labour-code-${index}`;
           codeInput.id = codeId;
-          if (labels[0]) {
-            labels[0].setAttribute('for', codeId);
+          if (labels[1]) {
+            labels[1].setAttribute('for', codeId);
           }
         }
         if (nameInput) {
           const nameId = `labour-name-${index}`;
           nameInput.id = nameId;
-          if (labels[1]) {
-            labels[1].setAttribute('for', nameId);
+          if (labels[2]) {
+            labels[2].setAttribute('for', nameId);
           }
         }
       });

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -1200,7 +1200,7 @@
               <tr data-labour-row>
                 <td data-label="Default" style="text-align: center;">
                   <label class="visually-hidden" for="labour-default-0">Default</label>
-                  <input id="labour-default-0" name="defaultLabourType" type="radio" value="" checked required data-labour-default />
+                  <input id="labour-default-0" name="defaultLabourType" type="radio" value="new-0" checked required data-labour-default />
                 </td>
                 <td data-label="Code">
                   <label class="visually-hidden" for="labour-code-0">Code</label>

--- a/tests/test_admin_labour_types.py
+++ b/tests/test_admin_labour_types.py
@@ -1,0 +1,17 @@
+"""Tests for labour type form handling in the ticket admin."""
+
+from app.features.tickets.admin_routes import _is_default_labour_type
+
+
+def test_existing_labour_type_is_matched_by_database_id():
+    assert _is_default_labour_type("42", "42", 0) is True
+    assert _is_default_labour_type("43", "42", 1) is False
+
+
+def test_new_labour_type_is_matched_by_row_marker():
+    assert _is_default_labour_type("", "new-1", 1) is True
+    assert _is_default_labour_type("", "new-1", 0) is False
+
+
+def test_empty_radio_value_does_not_select_new_labour_type():
+    assert _is_default_labour_type("", "", 0) is False


### PR DESCRIPTION
### Motivation
- Users could not save a default when adding new labour types because the form submitted an empty radio value for unsaved rows, causing server-side validation to raise "At least one labour type must be set as default.".
- The intent is to allow the UI to mark an unsaved labour row as the default and for the server to recognise that selection when building labour type definitions.

### Description
- Assign a stable, row-specific value to default radio inputs for unsaved rows by setting each new row's radio `value` to `new-<index>` in `app/static/js/admin.js` and update its `id` for correct label association.
- Update server-side form handling in `app/features/tickets/admin_routes.py` by adding `_is_default_labour_type(identifier, default_value, index)` and using it when building labour type `definitions` so it recognises both existing IDs and `new-<index>` markers.
- Ensure the empty-state template provides a matching initial marker by changing the initial radio value to `new-0` in `app/templates/admin/tickets.html`.
- Add regression tests `tests/test_admin_labour_types.py` covering matching by existing DB id, matching new-row markers, and ensuring empty radio values do not falsely select a new labour type.

### Testing
- Ran `python -m pytest -q tests/test_admin_labour_types.py` and all tests passed (3/3).
- Ran `node --check app/static/js/admin.js` and `git diff --check` with no issues reported.
- Attempted to run the broader async labour-type test suite `tests/test_labour_type_default.py`, but those async tests could not execute in this environment because `pytest-asyncio` is not installed (tests skipped/failed due to missing plugin).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a700694e9848332bd960fe9fe2cd175)