### PR TITLE
Support selecting a default labour type for new (unsaved) rows and propagate is_default through service

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -957,6 +957,14 @@ def _build_ticket_status_payloads(
     return statuses
 
 
+def _is_default_labour_type(identifier: Any, default_value: Any, index: int) -> bool:
+    """Match the selected radio value to an existing or unsaved labour type."""
+    return bool(
+        (identifier and str(identifier) == str(default_value))
+        or str(default_value) == f"new-{index}"
+    )
+
+
 @router.post("/admin/tickets/statuses", response_class=HTMLResponse)
 async def admin_replace_ticket_statuses(request: Request):
     main_module = _main()
@@ -1023,7 +1031,7 @@ async def admin_replace_labour_types(request: Request):
                 rate_value = float(rate_str.strip())
             except (ValueError, TypeError):
                 rate_value = None
-        is_default = identifier and str(identifier) == str(default_id)
+        is_default = _is_default_labour_type(identifier, default_id, index)
         definitions.append(
             {
                 "id": identifier,

--- a/app/services/labour_types.py
+++ b/app/services/labour_types.py
@@ -93,6 +93,7 @@ async def replace_labour_types(definitions: Sequence[dict[str, Any]]) -> list[di
         raw_code = _clean_code(str(entry.get("code")) if entry.get("code") is not None else None)
         raw_name = _clean_name(str(entry.get("name")) if entry.get("name") is not None else None)
         raw_rate = entry.get("rate")
+        is_default = bool(entry.get("is_default"))
         identifier = entry.get("id")
         labour_type_id: int | None = None
         if identifier is not None:
@@ -106,6 +107,7 @@ async def replace_labour_types(definitions: Sequence[dict[str, Any]]) -> list[di
                 "code": raw_code,
                 "name": raw_name,
                 "rate": raw_rate,
+                "is_default": is_default,
             }
         )
     return await labour_types_repo.replace_labour_types(cleaned_definitions)

--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -2851,21 +2851,34 @@
     function updateRowIdentifiers() {
       const rows = Array.from(list.querySelectorAll('[data-labour-row]'));
       rows.forEach((row, index) => {
+        const defaultInput = row.querySelector('input[name="defaultLabourType"]');
         const codeInput = row.querySelector('input[name="labourCode"]');
         const nameInput = row.querySelector('input[name="labourName"]');
+        const idInput = row.querySelector('input[name="labourId"]');
         const labels = Array.from(row.querySelectorAll('label'));
+        if (defaultInput) {
+          const defaultId = `labour-default-${index}`;
+          defaultInput.id = defaultId;
+          // New labour types do not have a database ID yet. Give their radio
+          // buttons a row-specific value so the server can identify which new
+          // record was selected as the default.
+          defaultInput.value = idInput && idInput.value ? idInput.value : `new-${index}`;
+          if (labels[0]) {
+            labels[0].setAttribute('for', defaultId);
+          }
+        }
         if (codeInput) {
           const codeId = `labour-code-${index}`;
           codeInput.id = codeId;
-          if (labels[0]) {
-            labels[0].setAttribute('for', codeId);
+          if (labels[1]) {
+            labels[1].setAttribute('for', codeId);
           }
         }
         if (nameInput) {
           const nameId = `labour-name-${index}`;
           nameInput.id = nameId;
-          if (labels[1]) {
-            labels[1].setAttribute('for', nameId);
+          if (labels[2]) {
+            labels[2].setAttribute('for', nameId);
           }
         }
       });

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -1200,7 +1200,7 @@
               <tr data-labour-row>
                 <td data-label="Default" style="text-align: center;">
                   <label class="visually-hidden" for="labour-default-0">Default</label>
-                  <input id="labour-default-0" name="defaultLabourType" type="radio" value="" checked required data-labour-default />
+                  <input id="labour-default-0" name="defaultLabourType" type="radio" value="new-0" checked required data-labour-default />
                 </td>
                 <td data-label="Code">
                   <label class="visually-hidden" for="labour-code-0">Code</label>

--- a/tests/test_admin_labour_types.py
+++ b/tests/test_admin_labour_types.py
@@ -1,0 +1,17 @@
+"""Tests for labour type form handling in the ticket admin."""
+
+from app.features.tickets.admin_routes import _is_default_labour_type
+
+
+def test_existing_labour_type_is_matched_by_database_id():
+    assert _is_default_labour_type("42", "42", 0) is True
+    assert _is_default_labour_type("43", "42", 1) is False
+
+
+def test_new_labour_type_is_matched_by_row_marker():
+    assert _is_default_labour_type("", "new-1", 1) is True
+    assert _is_default_labour_type("", "new-1", 0) is False
+
+
+def test_empty_radio_value_does_not_select_new_labour_type():
+    assert _is_default_labour_type("", "", 0) is False

--- a/tests/test_labour_types_service.py
+++ b/tests/test_labour_types_service.py
@@ -253,14 +253,21 @@ async def test_replace_labour_types_cleans_definitions(monkeypatch):
 
     await labour_types_service.replace_labour_types(
         [
-            {"code": "  STD  ", "name": "  Standard  ", "rate": 80.0},
+            {
+                "code": "  STD  ",
+                "name": "  Standard  ",
+                "rate": 80.0,
+                "is_default": True,
+            },
             {"code": "ADV", "name": "Advanced", "id": "3"},
         ]
     )
 
     assert captured[0]["code"] == "STD"
     assert captured[0]["name"] == "Standard"
+    assert captured[0]["is_default"] is True
     assert captured[1]["id"] == 3  # coerced from string
+    assert captured[1]["is_default"] is False
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Motivation
- Allow the admin UI to mark a newly added (unsaved) labour type row as the default and let the server identify which new row was chosen.
- Ensure the `is_default` flag is preserved when cleaning and replacing labour type definitions in the service layer.

### Description
- Add `_is_default_labour_type` helper in `admin_routes.py` and use it to determine default selection for labour types when processing the form (`admin_replace_labour_types`).
- Update `labour_types_service.replace_labour_types` to include a boolean `is_default` in the cleaned definitions before calling the repo.
- Update client JS in `app/static/js/admin.js` to assign each default radio a value of the existing `labourId` or `new-{index}` for unsaved rows and to correctly set radio `id` and label `for` attributes when rows are updated.
- Change the empty initial template in `app/templates/admin/tickets.html` so the initial default radio has `value="new-0"` to match the client-side behavior.
- Add unit tests in `tests/test_admin_labour_types.py` to validate `_is_default_labour_type` logic and update `tests/test_labour_types_service.py` to assert that `is_default` is forwarded and `id` coercion still works.

### Testing
- Ran the unit tests covering the new helper: `tests/test_admin_labour_types.py`, and the labour types service tests: `tests/test_labour_types_service.py`; all assertions succeeded.
- Executed the modified test suite under `pytest` for the changed areas and the updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a700694e9848332bd960fe9fe2cd175)