### PR TITLE
Store thumbnails for attachment blocklist entries

### DIFF
--- a/app/features/tickets/admin_routes.py
+++ b/app/features/tickets/admin_routes.py
@@ -22,6 +22,7 @@ Mirrors the routes that used to live in ``app/main.py``:
 from __future__ import annotations
 
 import asyncio
+import base64
 import re
 from collections.abc import Sequence
 from datetime import date, datetime, timezone
@@ -403,6 +404,13 @@ async def admin_attachment_blocklist_page(request: Request):
     entries = await attachment_blocklist_repo.list_entries()
     for entry in entries:
         entry["created_iso"] = _iso_utc(entry.get("created_at"))
+        thumbnail_data = entry.pop("thumbnail_data", None)
+        thumbnail_mime_type = entry.pop("thumbnail_mime_type", None)
+        entry["thumbnail_data_uri"] = (
+            f"data:{thumbnail_mime_type};base64,{base64.b64encode(thumbnail_data).decode('ascii')}"
+            if thumbnail_data and thumbnail_mime_type == "image/jpeg"
+            else None
+        )
     return await main_module._render_template(
         "admin/attachment_blocklist.html",
         request,

--- a/app/repositories/attachment_blocklist.py
+++ b/app/repositories/attachment_blocklist.py
@@ -21,18 +21,31 @@ async def add(
     file_size: int,
     mime_type: str | None,
     created_by_user_id: int | None,
+    thumbnail_data: bytes | None = None,
+    thumbnail_mime_type: str | None = None,
 ) -> dict[str, Any]:
     await db.execute(
         """
         INSERT INTO ticket_attachment_blocklist
-          (sha256_hash, original_filename, file_size, mime_type, created_by_user_id)
-        VALUES (?, ?, ?, ?, ?)
+          (sha256_hash, original_filename, file_size, mime_type, created_by_user_id,
+           thumbnail_data, thumbnail_mime_type)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
         ON DUPLICATE KEY UPDATE
           original_filename = COALESCE(original_filename, VALUES(original_filename)),
           file_size = COALESCE(file_size, VALUES(file_size)),
-          mime_type = COALESCE(mime_type, VALUES(mime_type))
+          mime_type = COALESCE(mime_type, VALUES(mime_type)),
+          thumbnail_data = COALESCE(thumbnail_data, VALUES(thumbnail_data)),
+          thumbnail_mime_type = COALESCE(thumbnail_mime_type, VALUES(thumbnail_mime_type))
         """,
-        (sha256_hash, original_filename, file_size, mime_type, created_by_user_id),
+        (
+            sha256_hash,
+            original_filename,
+            file_size,
+            mime_type,
+            created_by_user_id,
+            thumbnail_data,
+            thumbnail_mime_type,
+        ),
     )
     row = await db.fetch_one(
         "SELECT * FROM ticket_attachment_blocklist WHERE sha256_hash = ?",

--- a/app/services/ticket_attachments.py
+++ b/app/services/ticket_attachments.py
@@ -7,12 +7,14 @@ import hashlib
 import os
 import re
 import secrets
+from io import BytesIO
 from pathlib import Path
 from typing import Any
 
 import importlib
 from fastapi import UploadFile
 from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
+from PIL import Image, UnidentifiedImageError
 
 from app.core.config import get_settings
 from app.core.logging import log_debug, log_error, log_info
@@ -82,6 +84,27 @@ _INLINE_IMAGE_EXTENSIONS = {
     "image/gif": "gif",
     "image/webp": "webp",
 }
+
+_BLOCKLIST_THUMBNAIL_SIZE = (256, 256)
+
+
+def create_blocklist_thumbnail(contents: bytes, mime_type: str | None) -> tuple[bytes | None, str | None]:
+    """Create a small, inert JPEG preview for blocklisted raster images."""
+    if not mime_type or not mime_type.lower().startswith("image/"):
+        return None, None
+    try:
+        with Image.open(BytesIO(contents)) as image:
+            image.thumbnail(_BLOCKLIST_THUMBNAIL_SIZE)
+            # Flatten transparency onto white so every Pillow-supported raster
+            # mode can be represented consistently as a compact RGB JPEG.
+            rgba = image.convert("RGBA")
+            flattened = Image.new("RGB", rgba.size, "white")
+            flattened.paste(rgba, mask=rgba.getchannel("A"))
+            output = BytesIO()
+            flattened.save(output, format="JPEG", quality=80, optimize=True)
+            return output.getvalue(), "image/jpeg"
+    except (UnidentifiedImageError, OSError, ValueError):
+        return None, None
 
 
 def content_hash(contents: bytes) -> str:
@@ -417,13 +440,19 @@ async def block_attachment(
     path = attachment_path(attachment)
     if not path.exists():
         raise FileNotFoundError("Attachment file not found")
-    digest = content_hash(path.read_bytes())
+    contents = path.read_bytes()
+    digest = content_hash(contents)
+    thumbnail_data, thumbnail_mime_type = create_blocklist_thumbnail(
+        contents, attachment.get("mime_type")
+    )
     entry = await blocklist_repo.add(
         digest,
         original_filename=attachment.get("original_filename"),
         file_size=int(attachment.get("file_size") or path.stat().st_size),
         mime_type=attachment.get("mime_type"),
         created_by_user_id=created_by_user_id,
+        thumbnail_data=thumbnail_data,
+        thumbnail_mime_type=thumbnail_mime_type,
     )
     removed = 0
     targets = await attachments_repo.list_all_attachments() if remove_existing else [attachment]

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -10018,6 +10018,20 @@ textarea:focus-visible,
   color: rgba(148, 163, 184, 0.5);
 }
 
+.attachment-blocklist__thumbnail {
+  display: block;
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.375rem;
+  background: #fff;
+}
+
+.attachment-blocklist__no-preview {
+  color: var(--color-text-muted, #94a3b8);
+}
+
 /* Image preview modal */
 .modal__content--image-preview {
   width: auto;

--- a/app/templates/admin/attachment_blocklist.html
+++ b/app/templates/admin/attachment_blocklist.html
@@ -19,10 +19,17 @@
           </header>
           <div class="table-wrapper">
             <table class="table table--stack-mobile" data-table data-table-id="attachment-blocklist-table">
-              <thead><tr><th>File</th><th>Size / type</th><th>Content hash</th><th>Blocked</th><th>Actions</th></tr></thead>
+              <thead><tr><th>Preview</th><th>File</th><th>Size / type</th><th>Content hash</th><th>Blocked</th><th>Actions</th></tr></thead>
               <tbody>
                 {% for entry in entries %}
                   <tr>
+                    <td data-label="Preview">
+                      {% if entry.thumbnail_data_uri %}
+                        <img class="attachment-blocklist__thumbnail" src="{{ entry.thumbnail_data_uri }}" alt="Thumbnail of {{ entry.original_filename or 'blocked attachment' }}" />
+                      {% else %}
+                        <span class="attachment-blocklist__no-preview" aria-label="No image preview available">—</span>
+                      {% endif %}
+                    </td>
                     <td data-label="File">{{ entry.original_filename or 'Unknown file' }}</td>
                     <td data-label="Size / type">{{ entry.file_size | filesizeformat if entry.file_size is not none else '—' }} · {{ entry.mime_type or 'unknown' }}</td>
                     <td data-label="Content hash"><code title="{{ entry.sha256_hash }}">{{ entry.sha256_hash[:12] }}…</code></td>
@@ -35,7 +42,7 @@
                     </td>
                   </tr>
                 {% else %}
-                  <tr><td colspan="5" class="table__empty">No attachment content has been blocked.</td></tr>
+                  <tr><td colspan="6" class="table__empty">No attachment content has been blocked.</td></tr>
                 {% endfor %}
               </tbody>
             </table>

--- a/migrations/313_attachment_blocklist_thumbnails.sql
+++ b/migrations/313_attachment_blocklist_thumbnails.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ticket_attachment_blocklist
+  ADD COLUMN IF NOT EXISTS thumbnail_data MEDIUMBLOB NULL AFTER mime_type,
+  ADD COLUMN IF NOT EXISTS thumbnail_mime_type VARCHAR(64) NULL AFTER thumbnail_data;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "python-multipart",
     "nh3",
     "python-magic",
+    "Pillow>=10.0.0",
     "markdown-it-py",
     "mutagen",
     "phonenumbers",

--- a/tests/test_attachment_blocklist.py
+++ b/tests/test_attachment_blocklist.py
@@ -4,6 +4,8 @@ import hashlib
 import asyncio
 
 import pytest
+from PIL import Image
+from io import BytesIO
 
 from app.services import ticket_attachments
 
@@ -30,3 +32,21 @@ def test_ensure_not_blocked_allows_new_content(monkeypatch) -> None:
 
     monkeypatch.setattr(ticket_attachments.blocklist_repo, "is_blocked", not_blocked)
     assert asyncio.run(ticket_attachments.ensure_not_blocked(b"new")) == hashlib.sha256(b"new").hexdigest()
+
+
+def test_create_blocklist_thumbnail_resizes_image() -> None:
+    source = BytesIO()
+    Image.new("RGB", (800, 400), "red").save(source, format="PNG")
+
+    thumbnail, mime_type = ticket_attachments.create_blocklist_thumbnail(
+        source.getvalue(), "image/png"
+    )
+
+    assert thumbnail is not None
+    assert mime_type == "image/jpeg"
+    with Image.open(BytesIO(thumbnail)) as image:
+        assert image.size == (256, 128)
+
+
+def test_create_blocklist_thumbnail_ignores_non_images() -> None:
+    assert ticket_attachments.create_blocklist_thumbnail(b"document", "application/pdf") == (None, None)


### PR DESCRIPTION
### Motivation

- Technicians need an easy visual cue to identify blocked attachments when deciding whether to remove them from the attachment blocklist. 
- Storing a compact preview avoids persisting full user images in a public context while still aiding human review. 
- Thumbnails should be inert (raster-only, flattened) to avoid introducing executable content or XSS vectors. 
- The system should persist preview bytes alongside the existing content-hash blocklist entry so previews survive restarts and queries.

### Description

- Add a Pillow-based thumbnail generator `create_blocklist_thumbnail` in `app/services/ticket_attachments.py` that produces compact, flattened JPEG previews up to `256×256` for raster image MIME types and returns `(bytes, mime_type)` or `(None, None)` for non-images. 
- Persist thumbnail bytes and MIME type by extending the `ticket_attachment_blocklist` table (new migration `migrations/313_attachment_blocklist_thumbnails.sql`) and updating the repository API `app/repositories/attachment_blocklist.py` to accept and upsert `thumbnail_data` and `thumbnail_mime_type`. 
- When an attachment is blocklisted (`block_attachment`), compute thumbnail bytes from the file before deletion and pass them to the repository so the blocklist entry stores the preview. 
- Surface stored previews in the admin UI by encoding JPEG bytes as a data URI in `app/features/tickets/admin_routes.py`, adding a Preview column and markup in `app/templates/admin/attachment_blocklist.html`, and adding presentation styles in `app/static/css/app.css`. 
- Declare `Pillow>=10.0.0` in `pyproject.toml` and add unit tests in `tests/test_attachment_blocklist.py` that validate resizing, JPEG output, and non-image handling.

### Testing

- Ran `git diff --check` and it reported no whitespace or diff problems. 
- Verified code compiles with `python -m compileall -q app` with no errors. 
- Executed `pytest -q tests/test_attachment_blocklist.py tests/test_assets_route_order.py` and all tests passed (6 passed, with unrelated warnings). 
- Smoke-checked template and admin route behavior locally by rendering entries with `thumbnail_data_uri` present, and no browser-based screenshot tooling was required for the automated test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7008b146708332bbe89e7b102cd166)