### PR TITLE
Fix license product dashboard report

### DIFF
--- a/migrations/314_fix_dashboard_license_product_query.sql
+++ b/migrations/314_fix_dashboard_license_product_query.sql
@@ -1,0 +1,6 @@
+-- The licenses table stores the product label in `name`; it has no
+-- `product_name` column. Repair the bundled report for existing installations.
+UPDATE reporting_queries
+SET sql_query = 'SELECT COALESCE(name, ''Other'') AS X, COUNT(*) AS Y FROM licenses WHERE company_id = {{current.company}} GROUP BY name ORDER BY Y DESC'
+WHERE slug = 'dashboard-licenses-by-product'
+  AND is_system = 1;

--- a/tests/test_configurable_dashboard.py
+++ b/tests/test_configurable_dashboard.py
@@ -75,6 +75,17 @@ def test_dashboard_seed_catalog_has_at_least_30_prefixed_queries():
     assert sql.count("'Dashboard -") >= 30
 
 
+def test_license_product_dashboard_query_uses_license_name_column():
+    sql = Path("migrations/314_fix_dashboard_license_product_query.sql").read_text()
+    query_update = next(
+        line for line in sql.splitlines() if line.startswith("SET sql_query")
+    )
+
+    assert "COALESCE(name, ''Other'') AS X" in query_update
+    assert "GROUP BY name ORDER BY Y DESC" in query_update
+    assert "product_name" not in query_update
+
+
 def test_client_dashboard_example_is_valid():
     import json
 


### PR DESCRIPTION
### Motivation
- The bundled dashboard query referenced a nonexistent `product_name` column in `licenses`, causing the dashboard report to fail for installations using the shipped report.
- Ensure existing installations are repaired automatically and regressions are covered by tests.

### Description
- Add a corrective migration `migrations/314_fix_dashboard_license_product_query.sql` that updates the system `reporting_queries.sql_query` to use `COALESCE(name, 'Other') AS X` and `GROUP BY name` instead of `product_name`. 
- Add a regression test in `tests/test_configurable_dashboard.py` which asserts the migration SQL contains the corrected `SET sql_query` text, groups by `name`, and does not reference `product_name`.

### Testing
- `pytest -q tests/test_configurable_dashboard.py` — all tests in that file passed (10 passed). 
- Verified the new migration file `migrations/314_fix_dashboard_license_product_query.sql` and the added test were committed and included in the change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a701040e6b08332bbd4f0aa5ccbf595)