### PR TITLE
Add Edit report link and Test changes preview for reporting editor

### DIFF
--- a/app/features/reporting/handlers.py
+++ b/app/features/reporting/handlers.py
@@ -368,6 +368,7 @@ async def admin_reporting_edit(
         "eligible_users": eligible,
         "granted_user_ids": granted_ids,
         "max_rows": reporting_service.MAX_RESULT_ROWS,
+        "test_action": f"/admin/reporting/{int(report_id)}",
     }
     return await _main()._render_template("admin/reporting_form.html", request, user, extra=extra)
 
@@ -424,6 +425,43 @@ async def admin_reporting_update(request: Request, report_id: int):
     form = await request.form()
     payload = _parse_reporting_form(form)
     error = _validate_reporting_input(payload)
+    if form.get("action") == "test":
+        from app.services import reporting as reporting_service
+
+        test_result = None
+        test_error = error
+        if not test_error:
+            try:
+                test_result = await reporting_service.run_query_with_context(
+                    payload["sql_query"],
+                    company_id=getattr(request.state, "active_company_id", None),
+                )
+            except reporting_service.ReportingQueryError as exc:
+                test_error = f"Report query is invalid: {exc}"
+            except Exception as exc:  # pragma: no cover - defensive
+                from app.core.logging import log_error
+
+                log_error("Reporting test query execution failed", error=str(exc))
+                test_error = f"Report failed to execute: {exc}"
+
+        eligible = await _list_reporting_eligible_users()
+        preview_report = {**record, **payload}
+        extra = {
+            "title": f"Edit report · {record['name']}",
+            "form_heading": f"Edit report · {record['name']}",
+            "submit_label": "Save changes",
+            "form_action": f"/admin/reporting/{int(report_id)}",
+            "test_action": f"/admin/reporting/{int(report_id)}",
+            "report": preview_report,
+            "eligible_users": eligible,
+            "granted_user_ids": set(payload["user_ids"]),
+            "max_rows": reporting_service.MAX_RESULT_ROWS,
+            "test_result": test_result,
+            "test_error": test_error,
+        }
+        return await _main()._render_template(
+            "admin/reporting_form.html", request, user, extra=extra
+        )
     if error:
         return flash_redirect(f"/admin/reporting/{int(report_id)}/edit", error, "error")
     if payload["slug"] != record.get("slug"):

--- a/app/templates/admin/reporting_form.html
+++ b/app/templates/admin/reporting_form.html
@@ -59,8 +59,49 @@
 
       <div class="form-actions">
         <button type="submit" class="button button--primary">{{ submit_label }}</button>
+        {% if test_action %}
+          <button type="submit" class="button button--ghost" name="action" value="test">Test changes</button>
+        {% endif %}
         <a class="button button--ghost" href="/admin/reporting">Cancel</a>
       </div>
     </form>
   </section>
+
+  {% if test_error %}
+    <section class="card card--panel" aria-labelledby="test-results-heading">
+      <header class="card__header">
+        <h2 class="card__title" id="test-results-heading">Test results</h2>
+      </header>
+      <p class="form-error">{{ test_error }}</p>
+    </section>
+  {% elif test_result %}
+    <section class="card card--panel" aria-labelledby="test-results-heading">
+      <header class="card__header">
+        <h2 class="card__title" id="test-results-heading">Test results</h2>
+        <p class="card__description">{{ test_result.row_count }} row(s){% if test_result.truncated %} (capped at {{ max_rows }}){% endif %}. These unsaved changes have not been applied.</p>
+      </header>
+      <div class="table-container">
+        <table class="data-table" role="table" aria-label="Test report results">
+          <thead>
+            <tr>
+              {% for column in test_result.columns %}<th scope="col">{{ column }}</th>{% endfor %}
+              {% if not test_result.columns %}<th scope="col">No columns</th>{% endif %}
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in test_result.rows %}
+              <tr>
+                {% for column in test_result.columns %}
+                  {% set value = row.get(column) %}
+                  <td>{% if value is none %}<span class="text-muted">—</span>{% else %}{{ value }}{% endif %}</td>
+                {% endfor %}
+              </tr>
+            {% else %}
+              <tr><td class="table__empty" colspan="{{ test_result.columns|length or 1 }}">No rows returned.</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  {% endif %}
 {% endblock %}

--- a/app/templates/reporting/index.html
+++ b/app/templates/reporting/index.html
@@ -35,6 +35,9 @@
       </div>
       <div class="form-actions">
         <button type="submit" class="button button--primary" {% if not available_reports %}disabled{% endif %}>Run report</button>
+        {% if can_admin_reporting and selected_report %}
+          <a class="button button--ghost" href="/admin/reporting/{{ selected_report.id }}/edit">Edit report</a>
+        {% endif %}
       </div>
     </form>
     {% if not available_reports %}

--- a/tests/test_reporting_admin_preview.py
+++ b/tests/test_reporting_admin_preview.py
@@ -1,0 +1,91 @@
+"""Regression coverage for testing unsaved reporting query changes."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from starlette.datastructures import FormData
+
+from app.features.reporting import handlers as reporting_handlers
+from app.repositories import reporting as reporting_repo
+from app.services import reporting as reporting_service
+
+
+def test_admin_reporting_test_renders_unsaved_query_without_updating(monkeypatch):
+    captured: dict[str, object] = {}
+    request = SimpleNamespace(
+        state=SimpleNamespace(active_company_id=42),
+        form=lambda: None,
+    )
+
+    async def fake_form():
+        return FormData(
+            [
+                ("name", "Preview name"),
+                ("slug", "preview-slug"),
+                ("description", "Unsaved description"),
+                ("sql_query", "SELECT 2 AS changed"),
+                ("permission_user_ids", "7"),
+                ("action", "test"),
+            ]
+        )
+
+    request.form = fake_form
+
+    async def fake_require_super_admin_page(_request):
+        return {"id": 1, "is_super_admin": True}, None
+
+    async def fake_get_query(report_id):
+        assert report_id == 12
+        return {
+            "id": 12,
+            "name": "Saved name",
+            "slug": "saved-slug",
+            "description": None,
+            "sql_query": "SELECT 1 AS saved",
+        }
+
+    async def fake_run_query(sql_query, *, company_id):
+        assert sql_query == "SELECT 2 AS changed"
+        assert company_id == 42
+        return {
+            "columns": ["changed"],
+            "rows": [{"changed": 2}],
+            "row_count": 1,
+            "truncated": False,
+        }
+
+    async def fake_render_template(template, _request, user, *, extra):
+        captured.update(template=template, user=user, extra=extra)
+        return SimpleNamespace(status_code=200)
+
+    async def fail_update(*args, **kwargs):
+        raise AssertionError("Testing changes must not persist the report")
+
+    monkeypatch.setattr(
+        reporting_handlers,
+        "_main",
+        lambda: SimpleNamespace(
+            _require_super_admin_page=fake_require_super_admin_page,
+            _render_template=fake_render_template,
+        ),
+    )
+    monkeypatch.setattr(reporting_handlers, "_list_reporting_eligible_users", lambda: _empty_users())
+    monkeypatch.setattr(reporting_repo, "get_query", fake_get_query)
+    monkeypatch.setattr(reporting_repo, "update_query", fail_update)
+    monkeypatch.setattr(reporting_service, "run_query_with_context", fake_run_query)
+
+    response = asyncio.run(reporting_handlers.admin_reporting_update(request, 12))
+
+    assert response.status_code == 200
+    assert captured["template"] == "admin/reporting_form.html"
+    extra = captured["extra"]
+    assert extra["report"]["sql_query"] == "SELECT 2 AS changed"
+    assert extra["granted_user_ids"] == {7}
+    assert extra["test_result"]["rows"] == [{"changed": 2}]
+    assert extra["test_error"] is None
+
+
+async def _empty_users():
+    return []


### PR DESCRIPTION
### Motivation

- Make it easier for admins to jump from the public reporting UI to edit a selected report and to safely preview SQL changes before saving.

### Description

- Add an admin-only `Edit report` action beside the `Run report` button on the `/reporting` page by updating `app/templates/reporting/index.html`.
- Add a `Test changes` button to the report edit form in `app/templates/admin/reporting_form.html` and render preview results or errors below the form when used.
- Implement server-side handling to validate and execute the submitted SQL without persisting changes in `app/features/reporting/handlers.py`, preserving unsaved form values and permission selections while returning `test_result`/`test_error` to the template.
- Add a regression test `tests/test_reporting_admin_preview.py` that verifies the preview uses the unsaved query, returns results, preserves permissions, and does not call the update persistence path.

### Testing

- Ran targeted tests with `python -m pytest -q tests/test_reporting_admin_preview.py tests/test_reporting_page_handler.py tests/test_reporting_feature_pack.py` and all tests passed (`7 passed`).
- Ran static checks with `python -m ruff check app/features/reporting/handlers.py tests/test_reporting_admin_preview.py` which passed without errors.
- Ran `git diff --check` to ensure no whitespace or diff issues and it passed cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a701614f4a08332a14657d218d5690b)