### PR TITLE
Generate report slugs automatically and make them immutable

### DIFF
--- a/app/features/reporting/handlers.py
+++ b/app/features/reporting/handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import unicodedata
 from datetime import datetime, timezone
 from typing import Any
 
@@ -107,6 +108,12 @@ def _parse_reporting_form(form: FormData) -> dict[str, Any]:
         "sql_query": sql_query,
         "user_ids": user_ids,
     }
+
+
+def _reporting_slug(name: str) -> str:
+    """Build the stable, URL-safe identifier used when a report is created."""
+    ascii_name = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()
+    return re.sub(r"[^a-z0-9]+", "-", ascii_name.lower()).strip("-")[:120]
 
 
 def _validate_reporting_input(payload: dict[str, Any]) -> str | None:
@@ -382,6 +389,7 @@ async def admin_reporting_create(request: Request):
         return redirect
     form = await request.form()
     payload = _parse_reporting_form(form)
+    payload["slug"] = _reporting_slug(payload["name"])
     error = _validate_reporting_input(payload)
     if error:
         return flash_redirect("/admin/reporting/new", error, "error")
@@ -424,6 +432,9 @@ async def admin_reporting_update(request: Request, report_id: int):
         return flash_redirect("/admin/reporting", "Report not found", "error")
     form = await request.form()
     payload = _parse_reporting_form(form)
+    # A report slug is a permanent identifier. Ignore any forged or stale form
+    # value so existing integrations cannot be broken by an edit.
+    payload["slug"] = record["slug"]
     error = _validate_reporting_input(payload)
     if form.get("action") == "test":
         from app.services import reporting as reporting_service
@@ -464,10 +475,6 @@ async def admin_reporting_update(request: Request, report_id: int):
         )
     if error:
         return flash_redirect(f"/admin/reporting/{int(report_id)}/edit", error, "error")
-    if payload["slug"] != record.get("slug"):
-        clash = await reporting_repo.get_query_by_slug(payload["slug"])
-        if clash and int(clash["id"]) != int(report_id):
-            return flash_redirect(f"/admin/reporting/{int(report_id)}/edit", "That slug is already in use.", "error")
     before_snapshot = {
         "slug": record.get("slug"),
         "name": record.get("name"),
@@ -476,7 +483,6 @@ async def admin_reporting_update(request: Request, report_id: int):
     }
     await reporting_repo.update_query(
         int(report_id),
-        slug=payload["slug"],
         name=payload["name"],
         description=payload["description"],
         sql_query=payload["sql_query"],

--- a/app/repositories/reporting.py
+++ b/app/repositories/reporting.py
@@ -72,15 +72,14 @@ async def create_query(
 async def update_query(
     query_id: int,
     *,
-    slug: str,
     name: str,
     description: str | None,
     sql_query: str,
 ) -> None:
     await db.execute(
-        "UPDATE reporting_queries SET slug = %s, name = %s, description = %s, "
+        "UPDATE reporting_queries SET name = %s, description = %s, "
         "sql_query = %s WHERE id = %s",
-        (slug, name, description, sql_query, int(query_id)),
+        (name, description, sql_query, int(query_id)),
     )
 
 

--- a/app/repositories/reporting.py
+++ b/app/repositories/reporting.py
@@ -76,6 +76,7 @@ async def update_query(
     description: str | None,
     sql_query: str,
 ) -> None:
+    """Update editable fields while leaving the report's existing slug intact."""
     await db.execute(
         "UPDATE reporting_queries SET name = %s, description = %s, "
         "sql_query = %s WHERE id = %s",

--- a/app/templates/admin/reporting_form.html
+++ b/app/templates/admin/reporting_form.html
@@ -26,8 +26,9 @@
       <div class="form-field">
         <label class="form-label required" for="report-slug">Slug</label>
         <input class="form-input" id="report-slug" name="slug" required maxlength="120"
-               pattern="[A-Za-z0-9_-]+" value="{{ report.slug or '' }}" />
-        <p class="form-hint">Letters, digits, underscores, and hyphens only. Used in URLs and exports.</p>
+               pattern="[A-Za-z0-9_-]+" value="{{ report.slug or '' }}"
+               {% if report.id %}readonly aria-readonly="true"{% endif %} />
+        <p class="form-hint">{% if report.id %}The slug is permanent after the report is saved.{% else %}Generated automatically from the report name. Used in URLs and exports.{% endif %}</p>
       </div>
       <div class="form-field">
         <label class="form-label" for="report-description">Description</label>
@@ -103,5 +104,27 @@
         </table>
       </div>
     </section>
+  {% endif %}
+{% endblock %}
+
+{% block scripts %}
+  {% if not report.id %}
+    <script>
+      (() => {
+        const nameInput = document.getElementById('report-name');
+        const slugInput = document.getElementById('report-slug');
+        const slugify = (value) => value
+          .normalize('NFKD')
+          .replace(/[\u0300-\u036f]/g, '')
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, '')
+          .slice(0, 120);
+
+        nameInput.addEventListener('input', () => {
+          slugInput.value = slugify(nameInput.value);
+        });
+      })();
+    </script>
   {% endif %}
 {% endblock %}

--- a/tests/test_reporting_admin_preview.py
+++ b/tests/test_reporting_admin_preview.py
@@ -82,6 +82,7 @@ def test_admin_reporting_test_renders_unsaved_query_without_updating(monkeypatch
     assert captured["template"] == "admin/reporting_form.html"
     extra = captured["extra"]
     assert extra["report"]["sql_query"] == "SELECT 2 AS changed"
+    assert extra["report"]["slug"] == "saved-slug"
     assert extra["granted_user_ids"] == {7}
     assert extra["test_result"]["rows"] == [{"changed": 2}]
     assert extra["test_error"] is None

--- a/tests/test_reporting_slug.py
+++ b/tests/test_reporting_slug.py
@@ -1,0 +1,12 @@
+"""Regression coverage for stable, automatically generated report slugs."""
+
+from app.features.reporting.handlers import _reporting_slug
+
+
+def test_reporting_slug_is_generated_from_name():
+    assert _reporting_slug("  Monthly Résumé / Totals  ") == "monthly-resume-totals"
+
+
+def test_reporting_slug_removes_unsupported_characters_and_limits_length():
+    assert _reporting_slug("Revenue & Cost!!!") == "revenue-cost"
+    assert len(_reporting_slug("A" * 200)) == 120

--- a/tests/test_reporting_slug.py
+++ b/tests/test_reporting_slug.py
@@ -1,6 +1,9 @@
 """Regression coverage for stable, automatically generated report slugs."""
 
+import asyncio
+
 from app.features.reporting.handlers import _reporting_slug
+from app.repositories import reporting as reporting_repo
 
 
 def test_reporting_slug_is_generated_from_name():
@@ -10,3 +13,30 @@ def test_reporting_slug_is_generated_from_name():
 def test_reporting_slug_removes_unsupported_characters_and_limits_length():
     assert _reporting_slug("Revenue & Cost!!!") == "revenue-cost"
     assert len(_reporting_slug("A" * 200)) == 120
+
+
+def test_updating_existing_report_does_not_write_its_slug(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def fake_execute(sql, params):
+        captured["sql"] = sql
+        captured["params"] = params
+
+    monkeypatch.setattr(reporting_repo.db, "execute", fake_execute)
+
+    asyncio.run(
+        reporting_repo.update_query(
+            41,
+            name="Renamed report",
+            description="Updated without changing its existing slug",
+            sql_query="SELECT 1",
+        )
+    )
+
+    assert "slug" not in captured["sql"].lower()
+    assert captured["params"] == (
+        "Renamed report",
+        "Updated without changing its existing slug",
+        "SELECT 1",
+        41,
+    )


### PR DESCRIPTION
### Motivation
- Ensure new reports receive a stable, URL-safe slug derived from the report name to avoid manual mistakes and inconsistent identifiers.
- Prevent accidental or malicious changes to a report's slug after creation because the slug is used by integrations, exports, and URLs.

### Description
- Added `_reporting_slug` which normalises Unicode, strips accents, lowercases, replaces unsupported characters with `-`, trims leading/trailing dashes, and enforces the 120-character limit in `app/features/reporting/handlers.py`.
- Generate the slug server-side on creation by setting `payload["slug"] = _reporting_slug(payload["name"])` in `admin_reporting_create` and validate it as before via ` _validate_reporting_input`.
- Treat slugs as permanent on update by ignoring the submitted slug and keeping `payload["slug"] = record["slug"]` in `admin_reporting_update`, and removed slug mutation from `update_query` in `app/repositories/reporting.py` so updates no longer change the stored slug.
- Make the slug readonly in the edit form and add client-side live slug generation for the new-report form in `app/templates/admin/reporting_form.html` to give immediate feedback while creating a report.
- Added regression tests `tests/test_reporting_slug.py` and updated `tests/test_reporting_admin_preview.py` to cover slug generation, character filtering, length limits, and preview behaviour.

### Testing
- Ran `pytest -q tests/test_reporting_slug.py tests/test_reporting_admin_preview.py tests/test_reporting_feature_pack.py tests/test_reporting_service.py` and the selected reporting-related tests passed (`59 passed`).
- Ran `pytest -q tests/test_reporting_slug.py tests/test_reporting_admin_preview.py` and the focused tests passed (`3 passed`).
- New tests added: `tests/test_reporting_slug.py`, and `tests/test_reporting_admin_preview.py` was updated to assert the saved slug is preserved during preview rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a701f66d3108332a90222f2468aff6e)