### PR TITLE
Add Available M365 licenses dashboard report

### DIFF
--- a/changes/15e437c3-66ec-4ceb-af76-e18528486d80.json
+++ b/changes/15e437c3-66ec-4ceb-af76-e18528486d80.json
@@ -1,0 +1,7 @@
+{
+  "guid": "15e437c3-66ec-4ceb-af76-e18528486d80",
+  "occurred_at": "2026-08-03T00:00Z",
+  "change_type": "Feature",
+  "summary": "Add an Available licenses dashboard report showing spare Microsoft 365 seats by company and product while excluding hidden products.",
+  "content_hash": "f1ccecf3a90f3eca60dffb8fd7341c801424aaba96feb60ec2fed41c41df0a6f"
+}

--- a/migrations/315_available_m365_licenses_dashboard_report.sql
+++ b/migrations/315_available_m365_licenses_dashboard_report.sql
@@ -1,0 +1,12 @@
+-- Surface spare Microsoft 365 seats by company and product in the reporting
+-- catalog so the result can also be used as a configurable dashboard panel.
+-- Keep the allocation calculation aligned with the Licenses page: direct staff
+-- assignments and memberships of license-bearing office groups are de-duplicated.
+INSERT IGNORE INTO reporting_queries (slug, name, description, sql_query, is_system)
+VALUES (
+    'dashboard-global-available-licenses',
+    'Dashboard - Available licenses',
+    'Available Microsoft 365 license seats by company and product. Products hidden in the MyPortal license SKU mappings are excluded.',
+    'SELECT license_totals.company_id, license_totals.company, license_totals.product, license_totals.total_licenses, license_totals.allocated_licenses, GREATEST(license_totals.total_licenses - license_totals.allocated_licenses, 0) AS available_licenses FROM (SELECT c.id AS company_id, c.name AS company, COALESCE(NULLIF(TRIM(lsn.friendly_name), ''''), l.name) AS product, l.count AS total_licenses, (SELECT COUNT(DISTINCT s.id) FROM staff s WHERE s.id IN (SELECT sl.staff_id FROM staff_licenses sl WHERE sl.license_id = l.id UNION SELECT ogm.staff_id FROM group_licenses gl INNER JOIN office_group_members ogm ON ogm.group_id = gl.group_id WHERE gl.license_id = l.id)) AS allocated_licenses FROM licenses l INNER JOIN companies c ON c.id = l.company_id LEFT JOIN license_sku_friendly_names lsn ON lsn.sku = l.platform WHERE COALESCE(lsn.hidden, 0) = 0) license_totals ORDER BY license_totals.company ASC, license_totals.product ASC',
+    1
+);

--- a/tests/test_available_m365_licenses_reporting_migration.py
+++ b/tests/test_available_m365_licenses_reporting_migration.py
@@ -1,0 +1,37 @@
+"""Regression coverage for the Available licenses dashboard report."""
+
+from pathlib import Path
+
+
+MIGRATION = (
+    Path(__file__).parent.parent
+    / "migrations"
+    / "315_available_m365_licenses_dashboard_report.sql"
+)
+
+
+def test_available_licenses_report_is_added_to_dashboard_catalog():
+    sql = MIGRATION.read_text(encoding="utf-8")
+
+    assert "INSERT IGNORE INTO reporting_queries" in sql
+    assert "'dashboard-global-available-licenses'" in sql
+    assert "'Dashboard - Available licenses'" in sql
+    assert "GREATEST(license_totals.total_licenses - license_totals.allocated_licenses, 0)" in sql
+
+
+def test_available_licenses_report_groups_results_by_company_and_product():
+    sql = MIGRATION.read_text(encoding="utf-8")
+
+    assert "c.id AS company_id" in sql
+    assert "c.name AS company" in sql
+    assert "lsn.friendly_name" in sql
+    assert "ORDER BY license_totals.company ASC, license_totals.product ASC" in sql
+
+
+def test_available_licenses_report_excludes_hidden_products_and_counts_allocations():
+    sql = MIGRATION.read_text(encoding="utf-8")
+
+    assert "COALESCE(lsn.hidden, 0) = 0" in sql
+    assert "SELECT sl.staff_id FROM staff_licenses" in sql
+    assert "SELECT ogm.staff_id FROM group_licenses" in sql
+    assert "COUNT(DISTINCT s.id)" in sql


### PR DESCRIPTION
### Motivation

- Provide a dashboard panel and reporting query that shows per-company spare Microsoft 365 seats (total minus allocated) and exclude products hidden in the SKU mapping so admins can quickly see available licenses by product.

### Description

- Add `migrations/315_available_m365_licenses_dashboard_report.sql` which inserts a system `reporting_queries` entry `dashboard-global-available-licenses` that computes `available_licenses = GREATEST(total - allocated, 0)` and de-duplicates allocations across direct staff assignments and license-bearing office groups while filtering out hidden SKUs via `license_sku_friendly_names.hidden`.
- Add `tests/test_available_m365_licenses_reporting_migration.py` with regression assertions validating the migration registers the new report, groups results by company and product, excludes hidden products, and counts de-duplicated allocations.
- Add a feature change-log entry at `changes/15e437c3-66ec-4ceb-af76-e18528486d80.json` describing the new dashboard report.

### Testing

- Ran `pytest -q tests/test_available_m365_licenses_reporting_migration.py tests/test_configurable_dashboard.py` which completed successfully with the selected tests passing (17 passed). 
- Ran a full test run `pytest -q` which was interrupted during collection due to unrelated pre-existing environment issues: missing `respx` dependency and legacy import errors for `_pkce_verifier_store` and `_parse_staff_custom_field_condition`, so full-suite execution was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7021664ed88332a76be780000690c4)