### PR TITLE
Improve ticket attachment card layout and image previews

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -8452,9 +8452,7 @@ a.service-card__ai-icon:hover {
 }
 
 .attachment-card__header {
-  display: flex;
-  align-items: center;
-  gap: var(--space-gap-tight);
+  min-width: 0;
 }
 
 .attachment-card__name {
@@ -8480,6 +8478,21 @@ a.service-card__ai-icon:hover {
   color: rgba(148, 163, 184, 0.78);
 }
 
+.attachment-card__date {
+  min-height: 1.15rem;
+  margin: 0 0 0.55rem;
+  font-size: 0.75rem;
+  color: rgba(203, 213, 225, 0.82);
+}
+
+.attachment-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 2rem;
+  gap: var(--space-gap-tight);
+}
+
 .attachment-card__actions {
   display: flex;
   align-items: center;
@@ -8488,12 +8501,68 @@ a.service-card__ai-icon:hover {
 
 .attachment-card__action {
   flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  padding: 0.35rem;
 }
 
-.attachment-card__block-icon {
+.attachment-card__block-icon,
+.attachment-card__remove-icon {
   width: 1.15rem;
   height: 1.15rem;
   fill: currentColor;
+}
+
+.attachment-image-modal {
+  width: min(92vw, 75rem);
+  max-height: 92vh;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.85rem;
+  background: #0f172a;
+  color: #f8fafc;
+  box-shadow: 0 2rem 5rem rgba(0, 0, 0, 0.65);
+}
+
+.attachment-image-modal::backdrop {
+  background: rgba(2, 6, 23, 0.82);
+}
+
+.attachment-image-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.65rem 0.85rem;
+}
+
+.attachment-image-modal__title {
+  margin: 0;
+  overflow: hidden;
+  font-size: 0.95rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attachment-image-modal__close {
+  flex: 0 0 auto;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 1.75rem;
+  cursor: pointer;
+}
+
+.attachment-image-modal__image {
+  display: block;
+  width: 100%;
+  max-height: calc(92vh - 3.5rem);
+  object-fit: contain;
+  background: #020617;
 }
 
 .dropdown {

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -2589,6 +2589,38 @@
     const ticketId = container.getAttribute('data-ticket-id');
     const emptyMessage = document.querySelector('[data-attachments-empty]');
 
+    const imageLinks = container.querySelectorAll('[data-attachment-image-preview]');
+    if (imageLinks.length) {
+      const modal = document.createElement('dialog');
+      modal.className = 'attachment-image-modal';
+      modal.setAttribute('aria-labelledby', 'attachment-image-modal-title');
+      modal.innerHTML = `
+        <header class="attachment-image-modal__header">
+          <h2 class="attachment-image-modal__title" id="attachment-image-modal-title"></h2>
+          <button class="attachment-image-modal__close" type="button" aria-label="Close image preview">&times;</button>
+        </header>
+        <img class="attachment-image-modal__image" alt="">
+      `;
+      document.body.appendChild(modal);
+      const modalImage = modal.querySelector('.attachment-image-modal__image');
+      const modalTitle = modal.querySelector('.attachment-image-modal__title');
+      modal.querySelector('.attachment-image-modal__close').addEventListener('click', () => modal.close());
+      modal.addEventListener('click', (event) => {
+        if (event.target === modal) modal.close();
+      });
+      imageLinks.forEach((link) => {
+        link.addEventListener('click', (event) => {
+          event.preventDefault();
+          const thumbnail = link.querySelector('img');
+          const name = thumbnail?.alt.replace(/^Preview of /, '') || 'Attachment preview';
+          modalImage.src = thumbnail?.src || link.href;
+          modalImage.alt = name;
+          modalTitle.textContent = name;
+          modal.showModal();
+        });
+      });
+    }
+
     function updateEmptyState() {
       const remaining = container.querySelector('[data-attachment-id]');
       if (emptyMessage) {

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -1034,6 +1034,7 @@
                       class="attachment-card__preview"
                       href="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download"
                       title="Open {{ attachment.original_filename or attachment.filename }}"
+                      {% if attachment.mime_type and attachment.mime_type.startswith('image/') %}data-attachment-image-preview{% endif %}
                     >
                       {% if attachment.mime_type and attachment.mime_type.startswith('image/') %}
                         <img
@@ -1058,11 +1059,21 @@
                         <p class="attachment-card__name">
                           <a
                             href="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download"
+                            download
                             title="{{ attachment.original_filename or attachment.filename }}"
                           >
                             {{ attachment.original_filename or attachment.filename }}
                           </a>
                         </p>
+                      </div>
+                      <p class="attachment-card__date">
+                        {% if attachment.uploaded_iso %}
+                          <span data-utc="{{ attachment.uploaded_iso }}"></span>
+                        {% else %}
+                          <span class="visually-hidden">Upload date unavailable</span>
+                        {% endif %}
+                      </p>
+                      <div class="attachment-card__footer">
                         <div class="attachment-card__actions">
                           <button
                             type="button"
@@ -1083,16 +1094,12 @@
                             data-attachment-id="{{ attachment.id }}"
                             aria-label="Remove attachment"
                           >
-                            Remove
+                            <svg class="attachment-card__remove-icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M9 3h6l1 2h4v2H4V5h4l1-2Zm-2 6h10l-1 12H8L7 9Zm3 2v7h2v-7h-2Zm4 0v7h2v-7h-2Z"/></svg>
+                            <span class="visually-hidden">Remove</span>
                           </button>
                         </div>
+                        <p class="attachment-card__meta">{{ attachment.file_size | filesizeformat }}</p>
                       </div>
-                      <p class="attachment-card__meta">
-                        {{ attachment.file_size | filesizeformat }}
-                        {% if attachment.uploaded_iso %}
-                          · <span data-utc="{{ attachment.uploaded_iso }}"></span>
-                        {% endif %}
-                      </p>
                     </div>
                   </article>
                 {% endfor %}

--- a/app/templates/tickets/detail.html
+++ b/app/templates/tickets/detail.html
@@ -121,6 +121,7 @@
                       class="attachment-card__preview"
                       href="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download"
                       title="Open {{ attachment.original_filename or attachment.filename }}"
+                      {% if attachment.mime_type and attachment.mime_type.startswith('image/') %}data-attachment-image-preview{% endif %}
                     >
                       {% if attachment.mime_type and attachment.mime_type.startswith('image/') %}
                         <img
@@ -145,11 +146,21 @@
                         <p class="attachment-card__name">
                           <a
                             href="/api/tickets/{{ ticket.id }}/attachments/{{ attachment.id }}/download"
+                            download
                             title="{{ attachment.original_filename or attachment.filename }}"
                           >
                             {{ attachment.original_filename or attachment.filename }}
                           </a>
                         </p>
+                      </div>
+                      <p class="attachment-card__date">
+                        {% if attachment.uploaded_iso %}
+                          <span data-utc="{{ attachment.uploaded_iso }}"></span>
+                        {% else %}
+                          <span class="visually-hidden">Upload date unavailable</span>
+                        {% endif %}
+                      </p>
+                      <div class="attachment-card__footer">
                         {% if has_helpdesk_access %}
                           <div class="attachment-card__actions">
                             <button
@@ -159,17 +170,13 @@
                               data-attachment-id="{{ attachment.id }}"
                               aria-label="Remove attachment"
                             >
-                              Remove
+                              <svg class="attachment-card__remove-icon" aria-hidden="true" viewBox="0 0 24 24"><path d="M9 3h6l1 2h4v2H4V5h4l1-2Zm-2 6h10l-1 12H8L7 9Zm3 2v7h2v-7h-2Zm4 0v7h2v-7h-2Z"/></svg>
+                              <span class="visually-hidden">Remove</span>
                             </button>
                           </div>
                         {% endif %}
+                        <p class="attachment-card__meta">{{ attachment.file_size | filesizeformat }}</p>
                       </div>
-                      <p class="attachment-card__meta">
-                        {{ attachment.file_size | filesizeformat }}
-                        {% if attachment.uploaded_iso %}
-                          · <span data-utc="{{ attachment.uploaded_iso }}"></span>
-                        {% endif %}
-                      </p>
                     </div>
                   </article>
                 {% endfor %}


### PR DESCRIPTION
### Motivation
- Rework the ticket attachment card presentation to the requested order: preview (image/icon), name, date/time, action icons (block + remove), and file size, and make image thumbnails open in an on-site modal while file names download the file. 

### Description
- Updated `app/templates/tickets/detail.html` and `app/templates/admin/ticket_detail.html` to reorder card markup, add `download` to the filename link, add a date element, mark image previews with `data-attachment-image-preview`, and replace the textual `Remove` action with an accessible SVG trash icon plus a `visually-hidden` label. 
- Added CSS in `app/static/css/app.css` to style the new `.attachment-card__date`, `.attachment-card__footer`, compact icon buttons, and the fullscreen image preview modal `.attachment-image-modal` for responsive display. 
- Added JS in `app/static/js/ticket_detail.js` to initialize an accessible `<dialog>` image preview modal, attach click handlers to image preview links, prevent the default download behavior for preview clicks, and preserve existing block/remove behaviors. 
- Kept accessibility details: `aria-label` on action buttons, `visually-hidden` labels for icons, and preserved existing preview shields for PDFs. 

### Testing
- `node --check app/static/js/ticket_detail.js` passed and reported no syntax errors. 
- Parsed both updated Jinja templates using `jinja2.Environment.parse` which succeeded for `tickets/detail.html` and `admin/ticket_detail.html`. 
- Ran targeted pytest for affected areas which showed the repository test run with many passing tests but 12 unrelated failures arising from uninitialised database dependencies and pre-existing template-compliance checks; these failures are not caused by the UI changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7024deaa748332917d36ca0b005b38)