### PR TITLE
Fix Microsoft 365 / Outlook Contacts OAuth completion

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4654,7 +4654,19 @@ async def m365_callback(request: Request, code: str | None = None, state: str | 
         access_token, refresh_token = payload.get("access_token"), payload.get("refresh_token")
         if not access_token or not refresh_token:
             return flash_redirect("/admin/profile", "Microsoft did not grant offline contact access.", "error")
-        tenant_id = m365_service.extract_tenant_id_from_token(str(access_token))
+        # Graph access tokens are intended for Microsoft Graph and are not
+        # guaranteed to be JWTs that this application can decode.  The ID
+        # token, on the other hand, is issued to this client and is the stable
+        # source for the signed-in tenant.  Keep the access-token fallback for
+        # older responses which did not include an ID token.
+        try:
+            tenant_id = user_m365_contacts_service.tenant_id_from_token_response(payload)
+        except ValueError:
+            return flash_redirect(
+                "/admin/profile",
+                "Microsoft did not return a usable account identity.",
+                "error",
+            )
         expires_at = datetime.now(timezone.utc) + timedelta(seconds=float(payload.get("expires_in") or 3600))
         await user_m365_contacts_service.store_tokens(
             int(current_user["id"]), tenant_id=tenant_id, account_email=str(current_user.get("email") or "") or None,

--- a/app/services/user_m365_contacts.py
+++ b/app/services/user_m365_contacts.py
@@ -19,6 +19,20 @@ GRAPH_CONTACTS_URL = (
 )
 
 
+def tenant_id_from_token_response(payload: Mapping[str, Any]) -> str:
+    """Return the tenant from an OAuth response without assuming Graph tokens are JWTs."""
+    id_token = str(payload.get("id_token") or "")
+    access_token = str(payload.get("access_token") or "")
+    for token in (id_token, access_token):
+        if not token:
+            continue
+        try:
+            return m365_service.extract_tenant_id_from_token(token)
+        except (TypeError, ValueError):
+            continue
+    raise ValueError("Microsoft did not return a usable account identity")
+
+
 async def status_for_user(user_id: int) -> dict[str, Any]:
     record = await contacts_repo.get_integration(user_id)
     return {"connected": bool(record), "account_email": record.get("account_email") if record else None}

--- a/tests/test_user_m365_contacts.py
+++ b/tests/test_user_m365_contacts.py
@@ -61,3 +61,35 @@ async def test_lookup_phones_reads_the_authenticated_technicians_contacts(monkey
 
     acquire_access_token.assert_awaited_once_with(42)
     assert phones == [{"name": "Ada Lovelace", "phone": "0400 111 222"}]
+
+
+def test_tenant_id_uses_id_token_when_graph_access_token_is_opaque(monkeypatch):
+    """The OAuth callback must not require Microsoft Graph access tokens to be JWTs."""
+    seen: list[str] = []
+
+    def extract(token: str) -> str:
+        seen.append(token)
+        if token == "signed-id-token":
+            return "tenant-123"
+        raise ValueError("opaque token")
+
+    monkeypatch.setattr(user_m365_contacts.m365_service, "extract_tenant_id_from_token", extract)
+
+    tenant_id = user_m365_contacts.tenant_id_from_token_response(
+        {"access_token": "opaque-graph-token", "id_token": "signed-id-token"}
+    )
+
+    assert tenant_id == "tenant-123"
+    assert seen == ["signed-id-token"]
+
+
+def test_tenant_id_falls_back_to_access_token_for_older_responses(monkeypatch):
+    monkeypatch.setattr(
+        user_m365_contacts.m365_service,
+        "extract_tenant_id_from_token",
+        lambda token: "tenant-legacy" if token == "jwt-access-token" else "unexpected",
+    )
+
+    assert user_m365_contacts.tenant_id_from_token_response(
+        {"access_token": "jwt-access-token"}
+    ) == "tenant-legacy"


### PR DESCRIPTION
### Motivation
- The per-user Microsoft 365 Contacts connect flow could fail to complete when the Graph access token returned by Azure was opaque (not a JWT), preventing extraction of the tenant ID and leaving Outlook Contacts "Not connected".
- The flow needs a robust way to derive the tenant identity from the OAuth response that prefers the ID token but falls back to older access-token-only responses.

### Description
- Add `tenant_id_from_token_response(payload)` to `app/services/user_m365_contacts.py` to derive the tenant from `id_token` first and fall back to `access_token`, raising a clear `ValueError` when neither is usable.
- Update the user-contacts branch of the OAuth callback in `app/main.py` to call the new helper and show a controlled profile error when no usable tenant identity is returned, before storing tokens.
- Add regression tests in `tests/test_user_m365_contacts.py` to cover opaque Graph access tokens (ID token preferred) and legacy responses that only include a JWT access token.

### Testing
- Ran `pytest -q tests/test_user_m365_contacts.py tests/test_user_m365_contact_integrations_migration.py` and all tests passed (7 passed).
- Unit tests exercise the new helper and the lookup flow and confirm tenant extraction and phone-lookup behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a717306c9a083329a56631dc7368ade)