### PR TITLE
Follow Microsoft Graph pagination for Outlook contact lookups

### DIFF
--- a/app/services/user_m365_contacts.py
+++ b/app/services/user_m365_contacts.py
@@ -108,8 +108,16 @@ def match_contact_phones(requester_name: str, contacts: list[Mapping[str, Any]])
 
 async def lookup_phones(user_id: int, requester_name: str) -> list[dict[str, str]]:
     token = await acquire_access_token(user_id)
+    contacts: list[Mapping[str, Any]] = []
+    next_url: str | None = GRAPH_CONTACTS_URL
+    visited_urls: set[str] = set()
     async with httpx.AsyncClient(timeout=30) as client:
-        response = await client.get(GRAPH_CONTACTS_URL, headers={"Authorization": f"Bearer {token}"})
-    if response.status_code != 200:
-        raise ValueError("Unable to read Outlook contacts")
-    return match_contact_phones(requester_name, response.json().get("value") or [])
+        while next_url and next_url not in visited_urls:
+            visited_urls.add(next_url)
+            response = await client.get(next_url, headers={"Authorization": f"Bearer {token}"})
+            if response.status_code != 200:
+                raise ValueError("Unable to read Outlook contacts")
+            payload = response.json()
+            contacts.extend(payload.get("value") or [])
+            next_url = payload.get("@odata.nextLink")
+    return match_contact_phones(requester_name, contacts)

--- a/tests/test_user_m365_contacts.py
+++ b/tests/test_user_m365_contacts.py
@@ -63,6 +63,41 @@ async def test_lookup_phones_reads_the_authenticated_technicians_contacts(monkey
     assert phones == [{"name": "Ada Lovelace", "phone": "0400 111 222"}]
 
 
+@pytest.mark.anyio
+async def test_lookup_phones_follows_graph_contact_pages(monkeypatch):
+    monkeypatch.setattr(
+        user_m365_contacts,
+        "acquire_access_token",
+        AsyncMock(return_value="technician-access-token"),
+    )
+    async_client = httpx.AsyncClient
+    requested_urls: list[str] = []
+
+    async def graph_contacts(request: httpx.Request) -> httpx.Response:
+        requested_urls.append(str(request.url))
+        assert request.headers["Authorization"] == "Bearer technician-access-token"
+        if "$skiptoken" not in request.url.params:
+            return httpx.Response(200, json={
+                "value": [{"displayName": "Grace Hopper", "mobilePhone": "0400 999 999"}],
+                "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/contacts?$skiptoken=next-page",
+            })
+        return httpx.Response(200, json={"value": [{
+            "displayName": "Ada Lovelace",
+            "mobilePhone": "0400 111 222",
+        }]})
+
+    monkeypatch.setattr(
+        user_m365_contacts.httpx,
+        "AsyncClient",
+        lambda **kwargs: async_client(transport=httpx.MockTransport(graph_contacts), **kwargs),
+    )
+
+    phones = await user_m365_contacts.lookup_phones(42, "Ada Lovelace")
+
+    assert phones == [{"name": "Ada Lovelace", "phone": "0400 111 222"}]
+    assert len(requested_urls) == 2
+
+
 def test_tenant_id_uses_id_token_when_graph_access_token_is_opaque(monkeypatch):
     """The OAuth callback must not require Microsoft Graph access tokens to be JWTs."""
     seen: list[str] = []


### PR DESCRIPTION
### Motivation

- Outlook contact phone lookups only requested the initial Graph page, so matches on later pages were missed and the UI showed "No matching Outlook contact phone numbers found.".
- The Graph API returns results paginated via `@odata.nextLink`, so the lookup must follow those links to be reliable.

### Description

- Update `lookup_phones` in `app/services/user_m365_contacts.py` to iterate Graph pages by following `@odata.nextLink` and accumulate `value` entries before matching names and phone numbers via `match_contact_phones`.
- Add a `visited_urls` set to guard against repeated/invalid pagination links and prevent infinite request loops while paginating.
- Add a regression test `test_lookup_phones_follows_graph_contact_pages` to `tests/test_user_m365_contacts.py` which verifies that subsequent pages are requested and a matching contact returned from a later page is discovered.

### Testing

- Ran `pytest -q tests/test_user_m365_contacts.py` and all tests passed (`7 passed`).
- The new pagination test exercises the `@odata.nextLink` handling and confirmed the lookup returns phone numbers from later pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a717d2c7ae88332a9e2b462328bdd9a)