### PR TITLE
Add Clone action for admin saved reports (prefills new-report form)

### DIFF
--- a/app/features/reporting/__init__.py
+++ b/app/features/reporting/__init__.py
@@ -7,6 +7,7 @@ Owns reporting page/admin routes:
 * ``GET /admin/reporting``
 * ``GET /admin/reporting/new``
 * ``GET /admin/reporting/{report_id}/edit``
+* ``GET /admin/reporting/{report_id}/clone``
 * ``POST /admin/reporting``
 * ``POST /admin/reporting/{report_id}``
 * ``POST /admin/reporting/{report_id}/delete``
@@ -21,7 +22,7 @@ from .routes import router as reporting_router
 
 PACK = FeaturePack(
     slug="reporting",
-    version="1.0.0",
+    version="1.1.0",
     routers=(reporting_router,),
 )
 

--- a/app/features/reporting/handlers.py
+++ b/app/features/reporting/handlers.py
@@ -380,6 +380,39 @@ async def admin_reporting_edit(
     return await _main()._render_template("admin/reporting_form.html", request, user, extra=extra)
 
 
+async def admin_reporting_clone(request: Request, report_id: int):
+    from app.repositories import reporting as reporting_repo
+    from app.services import reporting as reporting_service
+
+    user, redirect = await _main()._require_super_admin_page(request)
+    if redirect:
+        return redirect
+    record = await reporting_repo.get_query(int(report_id))
+    if not record:
+        return flash_redirect("/admin/reporting", "Report not found", "error")
+
+    eligible = await _list_reporting_eligible_users()
+    granted_ids = set(await reporting_repo.list_permission_user_ids(int(report_id)))
+    clone_name = f"{record['name']} (Copy)"
+    cloned_report = {
+        **record,
+        "id": None,
+        "name": clone_name,
+        "slug": _reporting_slug(clone_name),
+    }
+    extra = {
+        "title": f"Clone report · {record['name']}",
+        "form_heading": f"Clone report · {record['name']}",
+        "submit_label": "Create cloned report",
+        "form_action": "/admin/reporting",
+        "report": cloned_report,
+        "eligible_users": eligible,
+        "granted_user_ids": granted_ids,
+        "max_rows": reporting_service.MAX_RESULT_ROWS,
+    }
+    return await _main()._render_template("admin/reporting_form.html", request, user, extra=extra)
+
+
 async def admin_reporting_create(request: Request):
     from app.repositories import reporting as reporting_repo
     from app.services import audit as audit_service
@@ -542,6 +575,7 @@ __all__ = [
     "admin_reporting",
     "admin_reporting_new",
     "admin_reporting_edit",
+    "admin_reporting_clone",
     "admin_reporting_create",
     "admin_reporting_update",
     "admin_reporting_delete",

--- a/app/features/reporting/routes.py
+++ b/app/features/reporting/routes.py
@@ -24,6 +24,12 @@ _add(
     ["GET"],
     response_class=HTMLResponse,
 )
+_add(
+    "/admin/reporting/{report_id}/clone",
+    handlers.admin_reporting_clone,
+    ["GET"],
+    response_class=HTMLResponse,
+)
 _add("/admin/reporting", handlers.admin_reporting_create, ["POST"], response_class=HTMLResponse)
 _add(
     "/admin/reporting/{report_id}",

--- a/app/templates/admin/reporting.html
+++ b/app/templates/admin/reporting.html
@@ -52,6 +52,7 @@
                 <div class="table__action-buttons">
                   <a class="button button--ghost" href="/reporting?report={{ report.id }}">Run</a>
                   <a class="button button--ghost" href="/admin/reporting/{{ report.id }}/edit">Edit</a>
+                  <a class="button button--ghost" href="/admin/reporting/{{ report.id }}/clone">Clone</a>
                   <form method="post" action="/admin/reporting/{{ report.id }}/delete" onsubmit="return confirm('Delete report &quot;{{ report.name|e }}&quot;?');" style="display:inline;">
                     {% include "partials/csrf.html" %}
                     <button type="submit" class="button button--danger">Delete</button>

--- a/changes/bbad02f9-6fd0-4945-bffa-6ddea3e74ee8.json
+++ b/changes/bbad02f9-6fd0-4945-bffa-6ddea3e74ee8.json
@@ -1,0 +1,7 @@
+{
+  "guid": "bbad02f9-6fd0-4945-bffa-6ddea3e74ee8",
+  "occurred_at": "2026-08-04T00:00:00Z",
+  "change_type": "Feature",
+  "summary": "Added a Clone action to saved reports so administrators can copy report settings and permissions into a new, editable report.",
+  "content_hash": "7ce18b38333ca1b07542631ba92f403d34ecafa21fdb28edb917a2943e914943"
+}

--- a/tests/test_reporting_admin_clone.py
+++ b/tests/test_reporting_admin_clone.py
@@ -1,0 +1,91 @@
+"""Regression coverage for cloning saved reports."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from app.features.reporting import handlers as reporting_handlers
+from app.repositories import reporting as reporting_repo
+
+
+def test_admin_reporting_clone_prefills_create_form(monkeypatch):
+    captured: dict[str, object] = {}
+    source = {
+        "id": 12,
+        "name": "User Mailboxes",
+        "slug": "user-mailboxes",
+        "description": "Mailbox storage by user",
+        "sql_query": "SELECT * FROM m365_mailboxes WHERE mailbox_type = 'User'",
+        "is_system": False,
+    }
+
+    async def fake_require_super_admin_page(_request):
+        return {"id": 1, "is_super_admin": True}, None
+
+    async def fake_get_query(report_id):
+        assert report_id == 12
+        return source
+
+    async def fake_list_permissions(report_id):
+        assert report_id == 12
+        return [7, 9]
+
+    async def fake_render_template(template, _request, user, *, extra):
+        captured.update(template=template, user=user, extra=extra)
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(
+        reporting_handlers,
+        "_main",
+        lambda: SimpleNamespace(
+            _require_super_admin_page=fake_require_super_admin_page,
+            _render_template=fake_render_template,
+        ),
+    )
+    monkeypatch.setattr(
+        reporting_handlers,
+        "_list_reporting_eligible_users",
+        lambda: _eligible_users(),
+    )
+    monkeypatch.setattr(reporting_repo, "get_query", fake_get_query)
+    monkeypatch.setattr(reporting_repo, "list_permission_user_ids", fake_list_permissions)
+
+    response = asyncio.run(reporting_handlers.admin_reporting_clone(SimpleNamespace(), 12))
+
+    assert response.status_code == 200
+    assert captured["template"] == "admin/reporting_form.html"
+    extra = captured["extra"]
+    assert extra["form_action"] == "/admin/reporting"
+    assert extra["submit_label"] == "Create cloned report"
+    assert extra["granted_user_ids"] == {7, 9}
+    assert extra["report"] == {
+        **source,
+        "id": None,
+        "name": "User Mailboxes (Copy)",
+        "slug": "user-mailboxes-copy",
+    }
+
+
+def test_admin_reporting_clone_redirects_when_source_is_missing(monkeypatch):
+    async def fake_require_super_admin_page(_request):
+        return {"id": 1, "is_super_admin": True}, None
+
+    async def fake_get_query(_report_id):
+        return None
+
+    monkeypatch.setattr(
+        reporting_handlers,
+        "_main",
+        lambda: SimpleNamespace(_require_super_admin_page=fake_require_super_admin_page),
+    )
+    monkeypatch.setattr(reporting_repo, "get_query", fake_get_query)
+
+    response = asyncio.run(reporting_handlers.admin_reporting_clone(SimpleNamespace(), 404))
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/admin/reporting"
+
+
+async def _eligible_users():
+    return [{"id": 7, "label": "Tech One"}, {"id": 9, "label": "Tech Two"}]

--- a/tests/test_reporting_feature_pack.py
+++ b/tests/test_reporting_feature_pack.py
@@ -17,6 +17,7 @@ EXPECTED = {
     ("GET", "/admin/reporting"),
     ("GET", "/admin/reporting/new"),
     ("GET", "/admin/reporting/{report_id}/edit"),
+    ("GET", "/admin/reporting/{report_id}/clone"),
     ("POST", "/admin/reporting"),
     ("POST", "/admin/reporting/{report_id}"),
     ("POST", "/admin/reporting/{report_id}/delete"),
@@ -62,9 +63,10 @@ def test_reporting_pack_owns_handlers():
     assert reporting_routes.router.routes[2].endpoint == reporting_handlers.admin_reporting
     assert reporting_routes.router.routes[3].endpoint == reporting_handlers.admin_reporting_new
     assert reporting_routes.router.routes[4].endpoint == reporting_handlers.admin_reporting_edit
-    assert reporting_routes.router.routes[5].endpoint == reporting_handlers.admin_reporting_create
-    assert reporting_routes.router.routes[6].endpoint == reporting_handlers.admin_reporting_update
-    assert reporting_routes.router.routes[7].endpoint == reporting_handlers.admin_reporting_delete
+    assert reporting_routes.router.routes[5].endpoint == reporting_handlers.admin_reporting_clone
+    assert reporting_routes.router.routes[6].endpoint == reporting_handlers.admin_reporting_create
+    assert reporting_routes.router.routes[7].endpoint == reporting_handlers.admin_reporting_update
+    assert reporting_routes.router.routes[8].endpoint == reporting_handlers.admin_reporting_delete
 
 
 def test_reporting_pack_loads_and_reloads_cleanly():


### PR DESCRIPTION
### Motivation

- Make it easy for administrators to duplicate an existing saved report so they can quickly create a similar report (for example, copying a User Mailboxes report to create a Shared Mailboxes variant).

### Description

- Add a new handler `admin_reporting_clone` in `app/features/reporting/handlers.py` which loads a source report and renders the existing create form prefilled with the source report's SQL, description and permissions and with a `(Copy)` suffix in name and slug.
- Register the route `GET /admin/reporting/{report_id}/clone` in `app/features/reporting/routes.py` and expose the handler via `__all__` in the handlers module.
- Add a `Clone` action button to the admin listing template at `app/templates/admin/reporting.html` and bump the reporting feature pack version to `1.1.0` in `app/features/reporting/__init__.py`.
- Add regression tests `tests/test_reporting_admin_clone.py` and update `tests/test_reporting_feature_pack.py`, and include a changelog entry in `changes/` describing the feature.

### Testing

- Ran the targeted test set `pytest -q tests/test_reporting_admin_clone.py tests/test_reporting_feature_pack.py tests/test_reporting_slug.py tests/test_reporting_admin_preview.py` which completed successfully (10 tests passed). 
- Fixed an initial assertion mismatch in `tests/test_reporting_admin_clone.py` during development and re-ran the targeted tests to confirm success.
- Ran `git diff --check` to ensure no whitespace/patch issues and committed the changes as `Add report cloning action`.
- A full `pytest -q` run in this environment aborted during collection due to unrelated environment/test dependencies (missing `respx` and some imports), so full-suite verification was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a718cc32e7c833282137abef7e3496c)