### PR TITLE
Fix n8n node packaging and install docs to prevent TAR_BAD_ARCHIVE and TypeScript build failures

### DIFF
--- a/integrations/n8n-node-myportal/README.md
+++ b/integrations/n8n-node-myportal/README.md
@@ -34,7 +34,10 @@ The workflow:
 5. Runs `npm pack` and uploads the generated `n8n-nodes-myportal-*.tgz` as a workflow artifact.
 
 Download the `n8n-nodes-myportal` artifact from a successful workflow run when you want to install
-the built package without publishing it to npm.
+the built package without publishing it to npm. GitHub downloads workflow artifacts as `.zip` files;
+unzip the artifact first and install the `n8n-nodes-myportal-*.tgz` file inside it. Installing the
+artifact `.zip` directly with npm causes `TAR_BAD_ARCHIVE` / checksum errors because npm expects a
+gzip-compressed npm package tarball, not GitHub's artifact wrapper.
 
 ## Install in n8n
 
@@ -60,16 +63,17 @@ npm install n8n-nodes-myportal
 Use this when the package has not been published to npm yet.
 
 1. Run the **Build n8n MyPortal Node** GitHub Actions workflow.
-2. Download and unzip the `n8n-nodes-myportal` artifact.
-3. Copy or upload the generated `n8n-nodes-myportal-*.tgz` file to your n8n host.
-4. Install it from the n8n user directory:
+2. Download the `n8n-nodes-myportal` artifact `.zip`.
+3. Unzip it and verify that you have the generated `n8n-nodes-myportal-*.tgz` file.
+4. Copy or upload only the `.tgz` file to your n8n host.
+5. Install it from the n8n user directory:
 
 ```bash
 cd ~/.n8n
 npm install /path/to/n8n-nodes-myportal-0.1.0.tgz
 ```
 
-5. Restart n8n, then create a **MyPortal API** credential and add the **MyPortal** node to a workflow.
+6. Restart n8n, then create a **MyPortal API** credential and add the **MyPortal** node to a workflow.
 
 ### Option 3: Install in Docker
 

--- a/integrations/n8n-node-myportal/package.json
+++ b/integrations/n8n-node-myportal/package.json
@@ -2,15 +2,32 @@
   "name": "n8n-nodes-myportal",
   "version": "0.1.0",
   "description": "n8n community node for MyPortal staff and ticket actions.",
-  "keywords": ["n8n-community-node-package", "myportal"],
+  "keywords": [
+    "n8n-community-node-package",
+    "myportal"
+  ],
   "license": "MIT",
   "main": "dist/nodes/MyPortal/MyPortal.node.js",
-  "scripts": {"build": "tsc", "lint": "tsc --noEmit", "prepack": "npm run build"},
-  "files": ["dist"],
+  "scripts": {
+    "build": "tsc && mkdir -p dist/nodes/MyPortal && cp nodes/MyPortal/myportal.svg dist/nodes/MyPortal/myportal.svg",
+    "lint": "tsc --noEmit",
+    "prepack": "npm run build"
+  },
+  "files": [
+    "dist"
+  ],
   "n8n": {
     "n8nNodesApiVersion": 1,
-    "credentials": ["dist/credentials/MyPortalApi.credentials.js"],
-    "nodes": ["dist/nodes/MyPortal/MyPortal.node.js"]
+    "credentials": [
+      "dist/credentials/MyPortalApi.credentials.js"
+    ],
+    "nodes": [
+      "dist/nodes/MyPortal/MyPortal.node.js"
+    ]
   },
-  "devDependencies": {"@types/node": "^20.14.9", "n8n-workflow": "^1.82.0", "typescript": "^5.5.3"}
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "n8n-workflow": "^1.82.0",
+    "typescript": "^5.5.3"
+  }
 }

--- a/integrations/n8n-node-myportal/tsconfig.json
+++ b/integrations/n8n-node-myportal/tsconfig.json
@@ -1,15 +1,20 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
-    "lib": ["es2020"],
+    "module": "Node16",
+    "lib": [
+      "es2020"
+    ],
     "declaration": true,
     "outDir": "dist",
     "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node16"
   },
-  "include": ["credentials/**/*.ts", "nodes/**/*.ts"]
+  "include": [
+    "credentials/**/*.ts",
+    "nodes/**/*.ts"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Prevent users from hitting `TAR_BAD_ARCHIVE` / checksum errors when installing the GitHub Actions artifact zip wrapper instead of the inner `.tgz` package. 
- Ensure the package build includes the compiled icon asset so the published tarball is complete and installable. 
- Resolve TypeScript compilation/deprecation issues caused by mismatched module/moduleResolution settings.

### Description
- Updated `package.json` `build` script to copy `nodes/MyPortal/myportal.svg` into `dist/nodes/MyPortal/` so the packaged tarball contains the node icon. 
- Reformatted `package.json` and adjusted scripts/fields for consistency. 
- Updated `tsconfig.json` to use `"module": "Node16"` and `"moduleResolution": "node16"` to address TypeScript deprecation/build errors. 
- Expanded `README.md` to document that GitHub Actions artifacts download as `.zip` files and to instruct users to unzip and install the enclosed `n8n-nodes-myportal-*.tgz` (avoids `TAR_BAD_ARCHIVE`).

### Testing
- Ran `npm ci --ignore-scripts` in `integrations/n8n-node-myportal` successfully. 
- Ran `npm run lint` (`tsc --noEmit`) successfully. 
- Ran `npm run build` and `npm pack --dry-run` successfully and confirmed the tarball contains `dist/` files including the icon. 
- Ran `npm pack` and verified installation by creating a temp project and installing the produced `n8n-nodes-myportal-0.1.0.tgz`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a727b16efa88332a6afa5eadb6b8d22)