### PR TITLE
Validate n8n package tarball in workflow and clarify artifact installation

### DIFF
--- a/.github/workflows/n8n-node-myportal.yml
+++ b/.github/workflows/n8n-node-myportal.yml
@@ -41,6 +41,13 @@ jobs:
       - name: Package node
         run: npm pack
 
+      - name: Validate package tarball
+        run: |
+          PACKAGE_TARBALL="$(find . -maxdepth 1 -name 'n8n-nodes-myportal-*.tgz' -print -quit)"
+          test -n "$PACKAGE_TARBALL"
+          tar -tzf "$PACKAGE_TARBALL" >/dev/null
+          npm install --dry-run "$PACKAGE_TARBALL"
+
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:

--- a/integrations/n8n-node-myportal/README.md
+++ b/integrations/n8n-node-myportal/README.md
@@ -35,9 +35,10 @@ The workflow:
 
 Download the `n8n-nodes-myportal` artifact from a successful workflow run when you want to install
 the built package without publishing it to npm. GitHub downloads workflow artifacts as `.zip` files;
-unzip the artifact first and install the `n8n-nodes-myportal-*.tgz` file inside it. Installing the
-artifact `.zip` directly with npm causes `TAR_BAD_ARCHIVE` / checksum errors because npm expects a
-gzip-compressed npm package tarball, not GitHub's artifact wrapper.
+unzip the artifact first and install the `n8n-nodes-myportal-*.tgz` file inside it. Do not rename
+the downloaded `.zip` to `.tgz`: that still leaves a ZIP file on disk, and `npm install` will fail
+with `TAR_BAD_ARCHIVE` because npm expects a gzip-compressed npm package tarball, not GitHub's
+artifact wrapper.
 
 ## Install in n8n
 
@@ -64,8 +65,18 @@ Use this when the package has not been published to npm yet.
 
 1. Run the **Build n8n MyPortal Node** GitHub Actions workflow.
 2. Download the `n8n-nodes-myportal` artifact `.zip`.
-3. Unzip it and verify that you have the generated `n8n-nodes-myportal-*.tgz` file.
-4. Copy or upload only the `.tgz` file to your n8n host.
+3. Unzip it and verify that you have the generated `n8n-nodes-myportal-*.tgz` file:
+
+   ```bash
+   unzip n8n-nodes-myportal.zip
+   file n8n-nodes-myportal-0.1.0.tgz
+   tar -tzf n8n-nodes-myportal-0.1.0.tgz >/dev/null
+   ```
+
+   The `file` command should report gzip-compressed data. If it reports Zip archive data, you are
+   still pointing npm at the GitHub artifact wrapper and need to unzip it first.
+
+4. Copy or upload only the extracted `.tgz` file to your n8n host.
 5. Install it from the n8n user directory:
 
 ```bash
@@ -81,6 +92,8 @@ For Docker-based n8n deployments, mount or copy the tarball into the container a
 n8n user directory. One common pattern is:
 
 ```bash
+# If you downloaded the GitHub Actions artifact, unzip it on your host first.
+unzip n8n-nodes-myportal.zip
 docker cp n8n-nodes-myportal-0.1.0.tgz <n8n-container>:/tmp/
 docker exec -it <n8n-container> sh -lc 'cd ~/.n8n && npm install /tmp/n8n-nodes-myportal-0.1.0.tgz'
 docker restart <n8n-container>


### PR DESCRIPTION
### Motivation
- Prevent `TAR_BAD_ARCHIVE` and checksum errors when consumers attempt to `npm install` the GitHub Actions artifact by verifying the produced `.tgz` is a valid gzip tarball before upload.
- Fail fast in CI if packaging produced a broken artifact so consumers don't download an unusable archive.
- Make README guidance explicit to avoid users renaming the artifact `.zip` to `.tgz` and provide simple local checks to diagnose problems.

### Description
- Added a `Validate package tarball` step to `.github/workflows/n8n-node-myportal.yml` that locates the generated `n8n-nodes-myportal-*.tgz`, asserts it exists, runs `tar -tzf` to verify gzip integrity, and runs `npm install --dry-run` against the tarball.
- Updated `integrations/n8n-node-myportal/README.md` to clarify that GitHub Actions artifacts download as ZIP wrappers and that renaming the ZIP to `.tgz` will still fail, and added explicit verification commands (`unzip`, `file`, `tar -tzf`) to check the extracted `.tgz`.
- Updated the Docker install example to recommend unzipping the artifact on the host before copying the extracted `.tgz` into the container.

### Testing
- Ran `cd integrations/n8n-node-myportal && npm ci` locally, which failed because `isolated-vm@6.1.2` requires Node `>=22` while the local environment is Node `v20`, so dependencies could not be built.
- Ran `cd integrations/n8n-node-myportal && npm run lint` locally, which failed because dependencies were not installed (TypeScript cannot resolve `n8n-workflow`), and this is expected to succeed in CI where the workflow uses Node `22` and runs `npm ci` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a727e84c04083328ba2a8b45fbb3a51)