### PR TITLE
Fix in-transit shipment ticket updates

### DIFF
--- a/app/services/ticket_shipment_tracking.py
+++ b/app/services/ticket_shipment_tracking.py
@@ -126,10 +126,18 @@ def _is_missing_scalar(value: Any) -> bool:
     return value in (None, "")
 
 
-def _is_delivered_in_full(snapshot_payload: Mapping[str, Any] | None) -> bool:
+def _normalised_snapshot_status(snapshot_payload: Mapping[str, Any] | None) -> str:
     if not snapshot_payload:
-        return False
-    return str(snapshot_payload.get("status") or "").strip().casefold() == DELIVERED_IN_FULL_STATUS
+        return ""
+    return str(snapshot_payload.get("status") or "").strip().casefold()
+
+
+def _is_delivered_in_full(snapshot_payload: Mapping[str, Any] | None) -> bool:
+    return _normalised_snapshot_status(snapshot_payload) == DELIVERED_IN_FULL_STATUS
+
+
+def _is_in_transit(snapshot_payload: Mapping[str, Any] | None) -> bool:
+    return _normalised_snapshot_status(snapshot_payload) == "in transit"
 
 
 def _snapshot_payload(snapshot: CanonicalShipmentSnapshot | Mapping[str, Any] | None) -> dict[str, Any] | None:
@@ -699,7 +707,8 @@ async def process_due_shipment_watches(*, limit: int = 200) -> dict[str, int]:
                     await shipment_watch_repo.disable_watch(ticket_id)
 
                 first_success = previous_hash is None
-                has_update = changed_now or first_success
+                missing_public_update = refreshed.get("last_posted_update_at") is None
+                has_update = changed_now or first_success or (missing_public_update and _is_in_transit(snapshot_payload))
                 if not has_update:
                     continue
                 # `changed` tracks detected shipment updates, while `posted`

--- a/tests/test_ticket_shipment_tracking.py
+++ b/tests/test_ticket_shipment_tracking.py
@@ -425,6 +425,65 @@ async def test_process_due_shipment_watches_skips_not_due(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_process_due_shipment_watches_posts_unposted_in_transit_snapshot(monkeypatch):
+    now = datetime.now(timezone.utc)
+    previous_snapshot = {
+        "status": "In transit",
+        "eta_date": "2026-07-20",
+        "proof_of_delivery_date": None,
+        "signatory": None,
+        "items_in_transit": 1,
+        "onboard_for_delivery": 0,
+        "items_delivered": 0,
+        "tracking_events": [],
+    }
+    due_watch = {
+        "id": 1,
+        "ticket_id": 10,
+        "provider": "startrack",
+        "tracking_url": "https://www.startrack.com.au/track/ABC123",
+        "poll_interval_seconds": 60,
+        "last_checked_at": now - timedelta(minutes=5),
+        "last_snapshot": previous_snapshot,
+        "last_snapshot_hash": "existing-hash",
+        "last_posted_update_at": None,
+        "active": True,
+        "public_comments_enabled": True,
+    }
+
+    async def fake_list(limit=200):
+        return [due_watch]
+
+    async def fake_get(watch_id):
+        return due_watch
+
+    monkeypatch.setattr(svc.shipment_watch_repo, "list_active_watches", fake_list)
+    monkeypatch.setattr(svc.shipment_watch_repo, "get_watch_by_id", fake_get)
+    monkeypatch.setattr(svc.shipment_watch_repo, "update_watch_check_state", AsyncMock(return_value=None))
+
+    provider = svc.StarTrackProviderAdapter()
+    monkeypatch.setattr(provider, "fetch", AsyncMock(return_value={"url": due_watch["tracking_url"], "html": "", "text": "In transit"}))
+    monkeypatch.setattr(provider, "normalize", AsyncMock(return_value=svc.CanonicalShipmentSnapshot(**previous_snapshot)))
+    monkeypatch.setattr(svc, "detect_provider", lambda url: provider)
+
+    @asynccontextmanager
+    async def fake_lock(name, timeout=1):
+        yield True
+
+    monkeypatch.setattr(svc.db, "acquire_lock", fake_lock)
+    create_reply_mock = AsyncMock(return_value={"id": 100})
+    monkeypatch.setattr(svc.tickets_repo, "create_reply", create_reply_mock)
+    monkeypatch.setattr(svc.tickets_service, "emit_ticket_replied_event", AsyncMock(return_value=None))
+    monkeypatch.setattr(svc.tickets_service, "emit_ticket_updated_event", AsyncMock(return_value=None))
+
+    result = await svc.process_due_shipment_watches(limit=10)
+
+    assert result["changed"] == 1
+    assert result["posted"] == 1
+    create_reply_mock.assert_awaited_once()
+
+
+@pytest.mark.anyio
 async def test_process_due_shipment_watches_skips_public_reply_when_disabled(monkeypatch):
     now = datetime.now(timezone.utc)
     due_watch = {


### PR DESCRIPTION
### Motivation
- Ensure tickets receive a public shipping update when a watch is in-progress (`In transit`) but no public update has yet been posted for the watch.

### Description
- Introduce `_normalised_snapshot_status` helper and reuse it to implement `_is_delivered_in_full` and a new `_is_in_transit` helper in `app/services/ticket_shipment_tracking.py`.
- Change watch-processing logic so `has_update` becomes true when the watch has a missing `last_posted_update_at` and the current snapshot is `In transit`, ensuring an initial in-transit status is posted even if the snapshot hash already exists.
- Add a regression test `test_process_due_shipment_watches_posts_unposted_in_transit_snapshot` to `tests/test_ticket_shipment_tracking.py` that verifies an unposted in-transit snapshot is emitted as a public ticket reply.

### Testing
- Ran `pytest tests/test_ticket_shipment_tracking.py` and all tests passed (`20 passed`).
- Ran `python -m ruff check app/services/ticket_shipment_tracking.py tests/test_ticket_shipment_tracking.py` and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a728b01d04483328d738531f47cf927)