### PR TITLE
Show last reply status on admin tickets list

### DIFF
--- a/app/api/routes/tickets.py
+++ b/app/api/routes/tickets.py
@@ -500,6 +500,9 @@ async def get_ticket_dashboard(
                     else None
                 ),
                 latest_reply_kind=automation_data.get("latest_reply_kind"),
+                latest_public_reply_email_status=automation_data.get(
+                    "latest_public_reply_email_status"
+                ),
                 ticket_update_actor_type=automation_data.get("ticket_update_actor_type"),
             )
         )

--- a/app/repositories/tickets.py
+++ b/app/repositories/tickets.py
@@ -1642,6 +1642,7 @@ async def get_automation_filter_context_by_ticket_ids(
             "latest_reply_at": None,
             "latest_reply_is_internal": None,
             "latest_reply_kind": None,
+            "latest_public_reply_email_status": None,
             "ticket_update_actor_type": None,
         }
         for ticket_id in unique_ids
@@ -1751,6 +1752,44 @@ async def get_automation_filter_context_by_ticket_ids(
         result[ticket_id]["latest_reply_kind"] = row.get("kind")
         result[ticket_id]["ticket_update_actor_type"] = row.get(
             "ticket_update_actor_type"
+        )
+
+    latest_public_reply_rows = await db.fetch_all(
+        f"""
+        SELECT
+            tr.ticket_id,
+            CASE
+                WHEN tr.email_bounced_at IS NOT NULL THEN 'Bounced'
+                WHEN tr.email_opened_at IS NOT NULL THEN 'Read'
+                WHEN tr.email_delivered_at IS NOT NULL THEN 'Delivered'
+                WHEN tr.email_sent_at IS NOT NULL
+                    OR tr.email_tracking_id IS NOT NULL
+                    OR tr.smtp2go_message_id IS NOT NULL THEN 'Sent'
+                ELSE NULL
+            END AS email_status
+        FROM ticket_replies AS tr
+        INNER JOIN (
+            SELECT ticket_id, MAX(id) AS latest_reply_id
+            FROM ticket_replies
+            WHERE ticket_id IN ({placeholders})
+              AND is_internal = 0
+              AND (
+                  email_sent_at IS NOT NULL
+                  OR email_tracking_id IS NOT NULL
+                  OR smtp2go_message_id IS NOT NULL
+                  OR email_delivered_at IS NOT NULL
+                  OR email_opened_at IS NOT NULL
+                  OR email_bounced_at IS NOT NULL
+              )
+            GROUP BY ticket_id
+        ) AS latest_public ON latest_public.latest_reply_id = tr.id
+        """,
+        tuple(unique_ids),
+    )
+    for row in latest_public_reply_rows:
+        ticket_id = int(row["ticket_id"])
+        result[ticket_id]["latest_public_reply_email_status"] = row.get(
+            "email_status"
         )
 
     return result

--- a/app/schemas/tickets.py
+++ b/app/schemas/tickets.py
@@ -201,6 +201,7 @@ class TicketDashboardRow(BaseModel):
     last_reply_age_hours: Optional[int] = None
     latest_reply_is_internal: Optional[bool] = None
     latest_reply_kind: Optional[str] = None
+    latest_public_reply_email_status: Optional[str] = None
     ticket_update_actor_type: Optional[str] = None
 
     class Config:

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -437,6 +437,10 @@
                     <span>Updated</span>
                   </label>
                   <label class="ticket-columns__option">
+                    <input type="checkbox" class="ticket-column-toggle" data-column="last-reply-status" checked />
+                    <span>Last Reply Status</span>
+                  </label>
+                  <label class="ticket-columns__option">
                     <input type="checkbox" class="ticket-column-toggle" data-column="review-date" />
                     <span>Review Date</span>
                   </label>
@@ -661,6 +665,7 @@
                 <th scope="col" data-sort="string" data-column="company" class="tickets-table__column tickets-table__column--company">Company</th>
                 <th scope="col" data-sort="string" data-column="assigned" class="tickets-table__column tickets-table__column--assigned">Assigned</th>
                 <th scope="col" data-sort="string" data-column="updated" class="tickets-table__column tickets-table__column--updated">Updated</th>
+                <th scope="col" data-sort="string" data-column="last-reply-status" class="tickets-table__column tickets-table__column--last-reply-status">Last Reply Status</th>
                 <th scope="col" data-sort="string" data-column="review-date" class="tickets-table__column tickets-table__column--review-date">Review Date</th>
                 <th scope="col" data-sort="string" data-column="category" class="tickets-table__column tickets-table__column--category">Category</th>
                 <th scope="col" data-sort="string" data-column="requester" class="tickets-table__column tickets-table__column--requester">Requester</th>
@@ -742,6 +747,21 @@
                     <td data-label="Company" data-column="company" class="tickets-table__cell tickets-table__cell--company">{{ company.name if company else (ticket.company_id or '—') }}</td>
                     <td data-label="Assigned" data-column="assigned" class="tickets-table__cell tickets-table__cell--assigned">{{ assigned_label }}</td>
                     <td data-label="Updated" data-column="updated" class="tickets-table__cell tickets-table__cell--updated">{{ ticket.updated_at.astimezone().strftime('%Y-%m-%d %H:%M') if ticket.updated_at else '—' }}</td>
+                    {% set automation_data = (ticket_automation_filter_lookup or {}).get(ticket.id, {}) %}
+                    {% set last_reply_status = automation_data.get('latest_public_reply_email_status') %}
+                    {% set last_reply_status_class = {
+                      'Bounced': 'badge--danger',
+                      'Read': 'badge--success',
+                      'Delivered': 'badge--info',
+                      'Sent': 'badge--muted'
+                    }.get(last_reply_status, 'badge--muted') %}
+                    <td data-label="Last Reply Status" data-column="last-reply-status" class="tickets-table__cell tickets-table__cell--last-reply-status">
+                      {% if last_reply_status %}
+                        <span class="badge {{ last_reply_status_class }}">{{ last_reply_status }}</span>
+                      {% else %}
+                        —
+                      {% endif %}
+                    </td>
                     {% set review_date = ticket.review_date %}
                     {% set review_date_class = 'ticket-review-date--past' if review_date and review_date < ticket_dashboard_now.date() else ('ticket-review-date--future' if review_date and review_date > ticket_dashboard_now.date() else '') %}
                     <td data-label="Review Date" data-column="review-date" class="tickets-table__cell tickets-table__cell--review-date {{ review_date_class }}">{{ review_date.isoformat() if review_date else '—' }}</td>
@@ -760,7 +780,6 @@
                     {% set time_data = (ticket_time_lookup or {}).get(ticket.id, {}) %}
                     <td data-label="Billable Mins" data-column="billable-minutes" class="tickets-table__cell tickets-table__cell--billable-minutes">{{ time_data.get('billable_minutes', 0) }}</td>
                     <td data-label="Non-Billable Mins" data-column="non-billable-minutes" class="tickets-table__cell tickets-table__cell--non-billable-minutes">{{ time_data.get('non_billable_minutes', 0) }}</td>
-                    {% set automation_data = (ticket_automation_filter_lookup or {}).get(ticket.id, {}) %}
                     {% set requester_email = ticket.requester_email or (requester.email if requester else '') %}
                     {% set assigned_email = assigned.email if assigned else '' %}
                     {% set created_age_days = ((ticket_dashboard_now - ticket.created_at).total_seconds() // 86400) | int if ticket.created_at else '' %}
@@ -792,7 +811,7 @@
                 {% endfor %}
               {% else %}
                 <tr>
-                  <td colspan="{{ 38 + (1 if can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
+                  <td colspan="{{ 39 + (1 if can_bulk_delete_tickets or can_merge_tickets or can_bulk_edit_tickets else 0) }}" class="table__empty">No tickets found for the selected filters.</td>
                 </tr>
               {% endif %}
             </tbody>

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -11,7 +11,7 @@ TEMPLATE_PATH = (
     / "app" / "templates" / "admin" / "tickets.html"
 )
 
-EXPECTED_COLUMNS = ["id", "status", "priority", "company", "assigned", "updated"]
+EXPECTED_COLUMNS = ["id", "status", "priority", "company", "assigned", "updated", "last-reply-status"]
 ALWAYS_VISIBLE_COLUMNS = ["subject"]
 
 


### PR DESCRIPTION
### Motivation
- Technicians need to see the delivery/read status of the last public reply on the tickets index so they don't have to open each ticket to confirm whether their outgoing reply was Sent/Delivered/Read/Bounced.

### Description
- Add `latest_public_reply_email_status` to the dashboard ticket row model (`app/schemas/tickets.py`) and expose it from the ticket list API rows (`app/api/routes/tickets.py`) via `automation_data` lookup.
- Aggregate the latest tracked public reply status per ticket in `get_automation_filter_context_by_ticket_ids` and populate `latest_public_reply_email_status` with a precedence of Bounced > Read > Delivered > Sent (`app/repositories/tickets.py`).
- Add a default-visible column toggle, table header, and per-row badge rendering for `Last Reply Status` in the admin tickets template, and adjust empty-table colspan to account for the new column (`app/templates/admin/tickets.html`).
- Update the column-customisation unit test to expect the new `last-reply-status` column (`tests/test_ticket_column_customisation.py`).

### Testing
- Ran `python -m pytest tests/test_ticket_column_customisation.py` and the test suite passed (`26 passed`).
- Ran Python bytecode compilation via `python -m compileall app/repositories/tickets.py app/api/routes/tickets.py app/schemas/tickets.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a729ed6e30c83328aa09ec815296c65)