### PR TITLE
Fix last-reply-status column in AJAX-refreshed ticket rows

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1197,6 +1197,30 @@
       return cell;
     }
 
+    function createLastReplyStatusCell(status) {
+      const cell = document.createElement('td');
+      cell.dataset.label = 'Last Reply Status';
+      cell.dataset.column = 'last-reply-status';
+      cell.className = 'tickets-table__cell tickets-table__cell--last-reply-status';
+
+      if (!status) {
+        cell.textContent = '—';
+        return cell;
+      }
+
+      const badgeClasses = {
+        Bounced: 'badge--danger',
+        Read: 'badge--success',
+        Delivered: 'badge--info',
+        Sent: 'badge--muted',
+      };
+      const badge = document.createElement('span');
+      badge.className = `badge ${badgeClasses[status] || 'badge--muted'}`;
+      badge.textContent = String(status);
+      cell.appendChild(badge);
+      return cell;
+    }
+
 
     function applyColumnVisibility() {
       const toggles = Array.from(document.querySelectorAll('[data-ticket-columns] .ticket-column-toggle'));
@@ -1281,6 +1305,7 @@
       appendTextCell('company', 'Company', companyDisplay);
       appendTextCell('assigned', 'Assigned', ticket.assigned_user_email || '—');
       appendTextCell('updated', 'Updated', formatUpdatedAt(ticket.updated_at), { value: ticket.updated_at || '' });
+      row.appendChild(createLastReplyStatusCell(ticket.latest_public_reply_email_status));
       appendTextCell('review-date', 'Review Date', formatReviewDate(ticket.review_date), { value: ticket.review_date || '', className: reviewDateClass(ticket.review_date) });
       appendTextCell('category', 'Category', ticket.category || '—');
       appendTextCell('requester', 'Requester', ticket.requester_label || ticket.requester_email || ticket.requester_id || '—');

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -229,6 +229,25 @@ def test_table_cell_data_column_attributes():
         )
 
 
+def test_ticket_refresh_rows_include_last_reply_status_column():
+    """Refreshed ticket rows must include Last Reply Status to stay aligned with headers."""
+    javascript = (
+        TEMPLATE_PATH.parent.parent.parent / "static" / "js" / "admin.js"
+    ).read_text(encoding="utf-8")
+
+    build_row_start = javascript.index("function buildRow(ticket)")
+    build_row_end = javascript.index("function patchRows(items)", build_row_start)
+    build_row = javascript[build_row_start:build_row_end]
+
+    updated_cell_index = build_row.index("appendTextCell('updated', 'Updated'")
+    last_reply_cell_index = build_row.index(
+        "row.appendChild(createLastReplyStatusCell(ticket.latest_public_reply_email_status))"
+    )
+    review_date_cell_index = build_row.index("appendTextCell('review-date', 'Review Date'")
+
+    assert updated_cell_index < last_reply_cell_index < review_date_cell_index
+    assert "cell.dataset.column = 'last-reply-status'" in javascript
+
 
 def test_ticket_update_actor_type_column_is_available():
     """The automation variable ticket_update.actor_type should be available as a ticket column."""


### PR DESCRIPTION
### Motivation
- The table header includes a "Last Reply Status" column but the client-side row builder omitted that cell, causing columns to shift when rows are refreshed.
- The intent is to preserve header/row alignment for AJAX-updated ticket rows and to display the same badge styling used by server-rendered rows.

### Description
- Added `createLastReplyStatusCell(status)` to `app/static/js/admin.js` which renders a `td` with `data-column='last-reply-status'`, shows `—` when empty, and maps statuses (`Bounced`, `Read`, `Delivered`, `Sent`) to the same badge classes as server HTML.
- Inserted a call to `row.appendChild(createLastReplyStatusCell(ticket.latest_public_reply_email_status))` into the `buildRow(ticket)` function to place the cell between `Updated` and `Review Date` so columns remain aligned.
- Added a regression test `test_ticket_refresh_rows_include_last_reply_status_column` in `tests/test_ticket_column_customisation.py` that verifies the new cell is emitted in the correct position and that the JS contains the `last-reply-status` data-column.

### Testing
- Ran `pytest tests/test_ticket_column_customisation.py` and the suite passed with `27 passed`.
- The new test verifies the `buildRow` implementation and the presence/positioning of the `last-reply-status` cell in `app/static/js/admin.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a72a10ebafc833291678aa5c957f595)