### PR TITLE
Pin n8n node dev dependencies

### DIFF
--- a/integrations/n8n-node-myportal/package-lock.json
+++ b/integrations/n8n-node-myportal/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@n8n/node-cli": "*",
+        "@n8n/node-cli": "0.42.0",
         "@types/node": "^20.14.9",
-        "n8n-workflow": "*",
+        "n8n-workflow": "2.33.0",
         "typescript": "^5.5.3"
       }
     },

--- a/integrations/n8n-node-myportal/package.json
+++ b/integrations/n8n-node-myportal/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/node": "^20.14.9",
     "typescript": "^5.5.3",
-    "@n8n/node-cli": "*",
-    "n8n-workflow": "*"
+    "@n8n/node-cli": "0.42.0",
+    "n8n-workflow": "2.33.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Avoid wildcard devDependency ranges that let `npm` resolve newer/broken transitive dependency trees (which caused native build/compatibility failures during installs) by pinning to known-good versions.

### Description
- Update `integrations/n8n-node-myportal/package.json` to pin `@n8n/node-cli` to `0.42.0` and `n8n-workflow` to `2.33.0`, and update the lockfile root metadata in `integrations/n8n-node-myportal/package-lock.json` to match.

### Testing
- Ran `npm ci --ignore-scripts`, `npm run lint`, and `npm run build` in `integrations/n8n-node-myportal` and all succeeded; created a package with `npm pack` and verified installation by installing the generated tarball in a temporary project, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a72a4fe1c388332936565e16e897525)