### PR TITLE
Specify Node/npm engines and document install troubleshooting for n8n MyPortal node

### DIFF
--- a/integrations/n8n-node-myportal/README.md
+++ b/integrations/n8n-node-myportal/README.md
@@ -135,7 +135,27 @@ installing it manually in a running container.
 
 ## Development
 
+Use Node.js 22 or 24 when installing and building this package locally. Current n8n development
+dependencies include native modules that do not build correctly on older Node.js versions.
+
 ```bash
 npm install
 npm run build
 ```
+
+If `npm install` fails with an error like
+`404 Not Found - GET https://registry.npmjs.org/@npmcli%2fdocs`, the missing package is not a
+MyPortal dependency. It is usually caused by a broken or stale npm CLI/cache while npm is resolving
+dependencies. Switch to a supported Node.js release, refresh npm's cache, and reinstall from a clean
+dependency tree:
+
+```bash
+node --version
+npm --version
+npm cache verify
+rm -rf node_modules package-lock.json
+npm install
+```
+
+If the same `@npmcli/docs` 404 continues after the clean install, reinstall Node.js 22 or 24 with a
+fresh bundled npm and run `npm install` again before changing this package's dependencies.

--- a/integrations/n8n-node-myportal/package-lock.json
+++ b/integrations/n8n-node-myportal/package-lock.json
@@ -13,6 +13,10 @@
         "@types/node": "^20.14.9",
         "n8n-workflow": "2.33.0",
         "typescript": "^5.5.3"
+      },
+      "engines": {
+        "node": ">=22 <25",
+        "npm": ">=10"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/integrations/n8n-node-myportal/package.json
+++ b/integrations/n8n-node-myportal/package.json
@@ -7,6 +7,10 @@
     "myportal"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=22 <25",
+    "npm": ">=10"
+  },
   "main": "dist/nodes/MyPortal/MyPortal.node.js",
   "scripts": {
     "build": "tsc && mkdir -p dist/nodes/MyPortal && cp nodes/MyPortal/myportal.svg dist/nodes/MyPortal/myportal.svg",


### PR DESCRIPTION
### Motivation
- Prevent confusing installs on unsupported runtimes by declaring the supported Node and npm engine ranges. 
- Surface that the `@npmcli/docs` 404 is typically an npm CLI/cache or runtime issue rather than a MyPortal package dependency. 
- Help contributors avoid native build failures (e.g. `isolated-vm`) by recommending supported Node versions for local builds. 

### Description
- Add an `engines` block to `integrations/n8n-node-myportal/package.json` requiring `node: >=22 <25` and `npm: >=10`. 
- Add the same `engines` metadata to the package lock (`integrations/n8n-node-myportal/package-lock.json`) so installs acknowledge the runtime constraint. 
- Expand `integrations/n8n-node-myportal/README.md` with a recommendation to use Node.js 22 or 24 and a troubleshooting section that documents a clean-reinstall workflow (`npm cache verify`, remove `node_modules` and `package-lock.json`, then `npm install`) to resolve `@npmcli/docs` 404 errors. 

### Testing
- Ran `cd integrations/n8n-node-myportal && npm install --package-lock-only --ignore-scripts`, which completed successfully. 
- Reproduced a failing build on Node 20 (native `isolated-vm` compile errors), then switched to Node 22 with `nvm use 22.22.2` and ran `npm ci`, which completed successfully. 
- Verified type-checking and compilation by running `npm run lint` and `npm run build` under Node 22, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a72a71b91588332b4cc83c35dd2717c)