### PR TITLE
Add "Last Reply Status" column to tickets table (template, JS, tests)

### DIFF
--- a/app/static/js/admin.js
+++ b/app/static/js/admin.js
@@ -1197,6 +1197,26 @@
       return cell;
     }
 
+    function createLastReplyStatusCell(status) {
+      const cell = document.createElement('td');
+      cell.dataset.label = 'Last Reply Status';
+      cell.dataset.column = 'last-reply-status';
+      cell.className = 'tickets-table__cell tickets-table__cell--last-reply-status';
+
+      const badgeClasses = {
+        Bounced: 'badge--danger',
+        Read: 'badge--success',
+        Delivered: 'badge--info',
+        Sent: 'badge--muted',
+      };
+      const displayStatus = status ? String(status) : 'No email status';
+      const badge = document.createElement('span');
+      badge.className = `badge ${badgeClasses[displayStatus] || 'badge--muted'}`;
+      badge.textContent = displayStatus;
+      cell.appendChild(badge);
+      return cell;
+    }
+
 
     function applyColumnVisibility() {
       const toggles = Array.from(document.querySelectorAll('[data-ticket-columns] .ticket-column-toggle'));
@@ -1281,6 +1301,7 @@
       appendTextCell('company', 'Company', companyDisplay);
       appendTextCell('assigned', 'Assigned', ticket.assigned_user_email || '—');
       appendTextCell('updated', 'Updated', formatUpdatedAt(ticket.updated_at), { value: ticket.updated_at || '' });
+      row.appendChild(createLastReplyStatusCell(ticket.latest_public_reply_email_status));
       appendTextCell('review-date', 'Review Date', formatReviewDate(ticket.review_date), { value: ticket.review_date || '', className: reviewDateClass(ticket.review_date) });
       appendTextCell('category', 'Category', ticket.category || '—');
       appendTextCell('requester', 'Requester', ticket.requester_label || ticket.requester_email || ticket.requester_id || '—');

--- a/app/templates/admin/tickets.html
+++ b/app/templates/admin/tickets.html
@@ -759,7 +759,7 @@
                       {% if last_reply_status %}
                         <span class="badge {{ last_reply_status_class }}">{{ last_reply_status }}</span>
                       {% else %}
-                        —
+                        <span class="badge badge--muted">No email status</span>
                       {% endif %}
                     </td>
                     {% set review_date = ticket.review_date %}

--- a/tests/test_ticket_column_customisation.py
+++ b/tests/test_ticket_column_customisation.py
@@ -229,6 +229,35 @@ def test_table_cell_data_column_attributes():
         )
 
 
+def test_ticket_refresh_rows_include_last_reply_status_column():
+    """Refreshed ticket rows must include Last Reply Status to stay aligned with headers."""
+    javascript = (
+        TEMPLATE_PATH.parent.parent.parent / "static" / "js" / "admin.js"
+    ).read_text(encoding="utf-8")
+
+    build_row_start = javascript.index("function buildRow(ticket)")
+    build_row_end = javascript.index("function patchRows(items)", build_row_start)
+    build_row = javascript[build_row_start:build_row_end]
+
+    updated_cell_index = build_row.index("appendTextCell('updated', 'Updated'")
+    last_reply_cell_index = build_row.index(
+        "row.appendChild(createLastReplyStatusCell(ticket.latest_public_reply_email_status))"
+    )
+    review_date_cell_index = build_row.index("appendTextCell('review-date', 'Review Date'")
+
+    assert updated_cell_index < last_reply_cell_index < review_date_cell_index
+    assert "cell.dataset.column = 'last-reply-status'" in javascript
+    assert "No email status" in javascript
+
+
+def test_last_reply_status_empty_state_is_visible():
+    """The Last Reply Status column should not appear blank when no email tracking exists."""
+    html = _template_html()
+    last_reply_cell = html[html.index('data-column="last-reply-status"', html.index('<tbody>')):]
+    last_reply_cell = last_reply_cell[:last_reply_cell.index("</td>")]
+
+    assert '<span class="badge badge--muted">No email status</span>' in last_reply_cell
+
 
 def test_ticket_update_actor_type_column_is_available():
     """The automation variable ticket_update.actor_type should be available as a ticket column."""


### PR DESCRIPTION
### Motivation

- Surface the latest public reply email tracking status for tickets in the admin ticket list so operators can see delivery/read/bounce info at a glance.
- Ensure client-side row refresh logic keeps the table cells aligned with the headers by including the same column in `buildRow`.

### Description

- Add a `createLastReplyStatusCell` helper in `app/static/js/admin.js` and append `row.appendChild(createLastReplyStatusCell(ticket.latest_public_reply_email_status))` inside `buildRow` so refreshed rows include the column, with a badge and a fallback label `No email status`.
- Update `app/templates/admin/tickets.html` to render a `td` for `data-column="last-reply-status"` and display a status badge using the mapped classes, or a muted `No email status` badge when empty.
- Add tests in `tests/test_ticket_column_customisation.py` to assert the JS `buildRow` includes the new column and ordering, and that the template renders the empty-state badge.

### Testing

- Ran `pytest tests/test_ticket_column_customisation.py::test_ticket_refresh_rows_include_last_reply_status_column` and it passed.
- Ran `pytest tests/test_ticket_column_customisation.py::test_last_reply_status_empty_state_is_visible` and it passed.
- Ran the file-level tests `pytest tests/test_ticket_column_customisation.py` to validate column attributes and the new checks, and the suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a72a10ebafc833291678aa5c957f595)