### PR TITLE
Add MyPortal node and credentials with generic auth, build artifacts and packaging metadata

### DIFF
--- a/integrations/n8n-node-myportal/credentials/MyPortalApi.credentials.ts
+++ b/integrations/n8n-node-myportal/credentials/MyPortalApi.credentials.ts
@@ -1,9 +1,25 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type { IAuthenticateGeneric, ICredentialTestRequest, ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class MyPortalApi implements ICredentialType {
 	name = 'myPortalApi';
 	displayName = 'MyPortal API';
+	icon = 'file:../nodes/MyPortal/myportal.svg' as const;
 	documentationUrl = 'https://github.com/';
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: { 'x-api-key': '={{$credentials.apiKey}}' },
+		},
+	};
+
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: "={{$credentials.baseUrl.replace(new RegExp('/+$'), '')}}",
+			url: '/api/staff',
+			method: 'GET',
+		},
+	};
+
 	properties: INodeProperties[] = [
 		{
 			displayName: 'Base URL',

--- a/integrations/n8n-node-myportal/dist/credentials/MyPortalApi.credentials.d.ts
+++ b/integrations/n8n-node-myportal/dist/credentials/MyPortalApi.credentials.d.ts
@@ -1,0 +1,10 @@
+import type { IAuthenticateGeneric, ICredentialTestRequest, ICredentialType, INodeProperties } from 'n8n-workflow';
+export declare class MyPortalApi implements ICredentialType {
+    name: string;
+    displayName: string;
+    icon: "file:../nodes/MyPortal/myportal.svg";
+    documentationUrl: string;
+    authenticate: IAuthenticateGeneric;
+    test: ICredentialTestRequest;
+    properties: INodeProperties[];
+}

--- a/integrations/n8n-node-myportal/dist/credentials/MyPortalApi.credentials.js
+++ b/integrations/n8n-node-myportal/dist/credentials/MyPortalApi.credentials.js
@@ -1,0 +1,45 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MyPortalApi = void 0;
+class MyPortalApi {
+    constructor() {
+        this.name = 'myPortalApi';
+        this.displayName = 'MyPortal API';
+        this.icon = 'file:../nodes/MyPortal/myportal.svg';
+        this.documentationUrl = 'https://github.com/';
+        this.authenticate = {
+            type: 'generic',
+            properties: {
+                headers: { 'x-api-key': '={{$credentials.apiKey}}' },
+            },
+        };
+        this.test = {
+            request: {
+                baseURL: "={{$credentials.baseUrl.replace(new RegExp('/+$'), '')}}",
+                url: '/api/staff',
+                method: 'GET',
+            },
+        };
+        this.properties = [
+            {
+                displayName: 'Base URL',
+                name: 'baseUrl',
+                type: 'string',
+                default: '',
+                placeholder: 'https://portal.example.com',
+                required: true,
+                description: 'Root URL of your MyPortal instance',
+            },
+            {
+                displayName: 'API Key',
+                name: 'apiKey',
+                type: 'string',
+                typeOptions: { password: true },
+                default: '',
+                required: true,
+                description: 'MyPortal API key sent in the x-api-key header',
+            },
+        ];
+    }
+}
+exports.MyPortalApi = MyPortalApi;

--- a/integrations/n8n-node-myportal/dist/nodes/MyPortal/MyPortal.node.d.ts
+++ b/integrations/n8n-node-myportal/dist/nodes/MyPortal/MyPortal.node.d.ts
@@ -1,0 +1,5 @@
+import type { IExecuteFunctions, INodeExecutionData, INodeType, INodeTypeDescription } from 'n8n-workflow';
+export declare class MyPortal implements INodeType {
+    description: INodeTypeDescription;
+    execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]>;
+}

--- a/integrations/n8n-node-myportal/dist/nodes/MyPortal/MyPortal.node.js
+++ b/integrations/n8n-node-myportal/dist/nodes/MyPortal/MyPortal.node.js
@@ -1,0 +1,172 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MyPortal = void 0;
+const n8n_workflow_1 = require("n8n-workflow");
+function compactObject(values) {
+    return Object.fromEntries(Object.entries(values).filter(([, value]) => value !== undefined && value !== null && value !== ''));
+}
+function parseJsonObject(value, fieldName) {
+    if (!value.trim())
+        return undefined;
+    const parsed = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new n8n_workflow_1.NodeOperationError({ name: 'MyPortal' }, `${fieldName} must be a JSON object`);
+    }
+    return parsed;
+}
+function normaliseBaseUrl(baseUrl) {
+    return baseUrl.replace(/\/+$/, '');
+}
+class MyPortal {
+    constructor() {
+        this.description = {
+            displayName: 'MyPortal',
+            name: 'myPortal',
+            icon: 'file:myportal.svg',
+            group: ['transform'],
+            version: 1,
+            subtitle: '={{$parameter["resource"] + ": " + $parameter["operation"]}}',
+            description: 'Create, get, get all, update, and delete MyPortal staff and tickets',
+            defaults: { name: 'MyPortal' },
+            inputs: [n8n_workflow_1.NodeConnectionTypes.Main],
+            outputs: [n8n_workflow_1.NodeConnectionTypes.Main],
+            credentials: [{ name: 'myPortalApi', required: true }],
+            usableAsTool: true,
+            properties: [
+                {
+                    displayName: 'Resource',
+                    name: 'resource',
+                    noDataExpression: true,
+                    type: 'options',
+                    default: 'ticket',
+                    options: [
+                        { name: 'Staff', value: 'staff' },
+                        { name: 'Ticket', value: 'ticket' },
+                    ],
+                },
+                {
+                    displayName: 'Operation',
+                    name: 'operation',
+                    noDataExpression: true,
+                    type: 'options',
+                    default: 'getAll',
+                    options: [
+                        { name: 'Create', value: 'create', action: 'Create a record' },
+                        { name: 'Delete', value: 'delete', action: 'Delete a record' },
+                        { name: 'Get', value: 'get', action: 'Get a record' },
+                        { name: 'Get Many', value: 'getAll', action: 'Get many records' },
+                        { name: 'Update', value: 'update', action: 'Update a record' },
+                    ],
+                },
+                {
+                    displayName: 'ID', name: 'id', type: 'number', default: 0, required: true,
+                    displayOptions: { show: { operation: ['get', 'update', 'delete'] } },
+                },
+                {
+                    displayName: 'Company ID', name: 'companyId', type: 'number', default: 0,
+                    displayOptions: { show: { resource: ['staff'], operation: ['create', 'getAll'] } },
+                    description: 'Required to create staff; optional filter for Get All',
+                },
+                { displayName: 'First Name', name: 'firstName', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
+                { displayName: 'Last Name', name: 'lastName', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
+                { displayName: 'Email', name: 'email', type: 'string', default: '', placeholder: 'name@email.com', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update', 'getAll'] } } },
+                { displayName: 'Mobile Phone', name: 'mobilePhone', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
+                { displayName: 'Enabled', name: 'enabled', type: 'boolean', default: true, displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
+                { displayName: 'Department', name: 'department', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
+                { displayName: 'Job Title', name: 'jobTitle', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
+                { displayName: 'Account Action', name: 'accountAction', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update', 'getAll'] } } },
+                { displayName: 'Custom Fields JSON', name: 'customFieldsJson', type: 'json', default: '{}', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
+                { displayName: 'Subject', name: 'subject', type: 'string', default: '', displayOptions: { show: { resource: ['ticket'], operation: ['create', 'update'] } } },
+                { displayName: 'Description', name: 'description', type: 'string', typeOptions: { rows: 4 }, default: '', displayOptions: { show: { resource: ['ticket'], operation: ['create', 'update'] } } },
+                { displayName: 'Status', name: 'status', type: 'string', default: '', displayOptions: { show: { resource: ['ticket'], operation: ['create', 'update', 'getAll'] } } },
+                { displayName: 'Priority', name: 'priority', type: 'string', default: 'normal', displayOptions: { show: { resource: ['ticket'], operation: ['create', 'update'] } } },
+                { displayName: 'Requester ID', name: 'requesterId', type: 'number', default: 0, displayOptions: { show: { resource: ['ticket'], operation: ['create'] } }, description: 'Required by MyPortal when using API key authentication' },
+                { displayName: 'Company ID', name: 'ticketCompanyId', type: 'number', default: 0, displayOptions: { show: { resource: ['ticket'], operation: ['create', 'update', 'getAll'] } } },
+                { displayName: 'Assigned User ID', name: 'assignedUserId', type: 'number', default: 0, displayOptions: { show: { resource: ['ticket'], operation: ['create', 'update', 'getAll'] } } },
+                { displayName: 'Search', name: 'search', type: 'string', default: '', displayOptions: { show: { resource: ['ticket'], operation: ['getAll'] } } },
+                { displayName: 'Limit', name: 'limit', type: 'number', default: 50, typeOptions: { minValue: 1, maxValue: 500 }, description: 'Max number of results to return', displayOptions: { show: { resource: ['ticket'], operation: ['getAll'] } } },
+                { displayName: 'Raw JSON Body', name: 'rawJsonBody', type: 'json', default: '{}', displayOptions: { show: { operation: ['create', 'update'] } }, description: 'Optional JSON object merged into the request body; useful for advanced MyPortal fields' },
+            ],
+        };
+    }
+    async execute() {
+        const credentials = await this.getCredentials('myPortalApi');
+        const baseUrl = normaliseBaseUrl(credentials.baseUrl);
+        const returnData = [];
+        for (let i = 0; i < this.getInputData().length; i++) {
+            try {
+                const resource = this.getNodeParameter('resource', i);
+                const operation = this.getNodeParameter('operation', i);
+                const path = resource === 'staff' ? '/api/staff' : '/api/tickets';
+                const qs = {};
+                let method = 'GET';
+                let uri = `${baseUrl}${path}${resource === 'ticket' ? '/' : ''}`;
+                let body;
+                if (operation === 'get' || operation === 'update' || operation === 'delete') {
+                    uri = `${baseUrl}${path}/${this.getNodeParameter('id', i)}`;
+                }
+                if (operation === 'create' || operation === 'update') {
+                    method = operation === 'create' ? 'POST' : 'PUT';
+                    const raw = parseJsonObject(this.getNodeParameter('rawJsonBody', i, '{}'), 'Raw JSON Body') ?? {};
+                    if (resource === 'staff') {
+                        body = compactObject({
+                            companyId: this.getNodeParameter('companyId', i, 0) || undefined,
+                            firstName: this.getNodeParameter('firstName', i, '') || undefined,
+                            lastName: this.getNodeParameter('lastName', i, '') || undefined,
+                            email: this.getNodeParameter('email', i, '') || undefined,
+                            mobilePhone: this.getNodeParameter('mobilePhone', i, '') || undefined,
+                            enabled: this.getNodeParameter('enabled', i, true),
+                            department: this.getNodeParameter('department', i, '') || undefined,
+                            jobTitle: this.getNodeParameter('jobTitle', i, '') || undefined,
+                            accountAction: this.getNodeParameter('accountAction', i, '') || undefined,
+                            customFields: parseJsonObject(this.getNodeParameter('customFieldsJson', i, '{}'), 'Custom Fields JSON'),
+                            ...raw,
+                        });
+                    }
+                    else {
+                        body = compactObject({
+                            subject: this.getNodeParameter('subject', i, '') || undefined,
+                            description: this.getNodeParameter('description', i, '') || undefined,
+                            status: this.getNodeParameter('status', i, '') || undefined,
+                            priority: this.getNodeParameter('priority', i, '') || undefined,
+                            requester_id: this.getNodeParameter('requesterId', i, 0) || undefined,
+                            company_id: this.getNodeParameter('ticketCompanyId', i, 0) || undefined,
+                            assigned_user_id: this.getNodeParameter('assignedUserId', i, 0) || undefined,
+                            ...raw,
+                        });
+                    }
+                }
+                else if (operation === 'delete') {
+                    method = 'DELETE';
+                }
+                else if (operation === 'getAll') {
+                    if (resource === 'staff') {
+                        Object.assign(qs, compactObject({ companyId: this.getNodeParameter('companyId', i, 0) || undefined, email: this.getNodeParameter('email', i, '') || undefined, accountAction: this.getNodeParameter('accountAction', i, '') || undefined }));
+                    }
+                    else {
+                        Object.assign(qs, compactObject({ status: this.getNodeParameter('status', i, '') || undefined, company_id: this.getNodeParameter('ticketCompanyId', i, 0) || undefined, assigned_user_id: this.getNodeParameter('assignedUserId', i, 0) || undefined, search: this.getNodeParameter('search', i, '') || undefined, limit: this.getNodeParameter('limit', i, 50) }));
+                    }
+                }
+                const response = await this.helpers.httpRequestWithAuthentication.call(this, 'myPortalApi', { method, url: uri, qs, body, json: true });
+                if (operation === 'delete') {
+                    returnData.push({ json: { success: true, id: this.getNodeParameter('id', i) }, pairedItem: { item: i } });
+                }
+                else if (resource === 'ticket' && operation === 'getAll' && response?.items) {
+                    returnData.push(...this.helpers.returnJsonArray(response.items));
+                }
+                else {
+                    returnData.push(...this.helpers.returnJsonArray(Array.isArray(response) ? response : [response]));
+                }
+            }
+            catch (error) {
+                if (this.continueOnFail()) {
+                    returnData.push({ json: { error: error.message }, pairedItem: { item: i } });
+                    continue;
+                }
+                throw new n8n_workflow_1.NodeOperationError(this.getNode(), error, { itemIndex: i });
+            }
+        }
+        return [returnData];
+    }
+}
+exports.MyPortal = MyPortal;

--- a/integrations/n8n-node-myportal/dist/nodes/MyPortal/myportal.svg
+++ b/integrations/n8n-node-myportal/dist/nodes/MyPortal/myportal.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64"><rect width="64" height="64" rx="14" fill="#2563eb"/><path fill="#fff" d="M14 46V18h9l9 15 9-15h9v28h-8V30L34 43h-4l-8-13v16z"/></svg>

--- a/integrations/n8n-node-myportal/eslint.config.mjs
+++ b/integrations/n8n-node-myportal/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { config } from '@n8n/node-cli/eslint';
+
+export default config;

--- a/integrations/n8n-node-myportal/nodes/MyPortal/MyPortal.node.ts
+++ b/integrations/n8n-node-myportal/nodes/MyPortal/MyPortal.node.ts
@@ -4,9 +4,9 @@ import type {
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
-	IRequestOptions,
+	IHttpRequestOptions,
 } from 'n8n-workflow';
-import { NodeOperationError } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 
 function compactObject(values: IDataObject): IDataObject {
 	return Object.fromEntries(
@@ -18,7 +18,7 @@ function parseJsonObject(value: string, fieldName: string): IDataObject | undefi
 	if (!value.trim()) return undefined;
 	const parsed = JSON.parse(value) as unknown;
 	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-		throw new Error(`${fieldName} must be a JSON object`);
+		throw new NodeOperationError({ name: 'MyPortal' } as never, `${fieldName} must be a JSON object`);
 	}
 	return parsed as IDataObject;
 }
@@ -37,13 +37,15 @@ export class MyPortal implements INodeType {
 		subtitle: '={{$parameter["resource"] + ": " + $parameter["operation"]}}',
 		description: 'Create, get, get all, update, and delete MyPortal staff and tickets',
 		defaults: { name: 'MyPortal' },
-		inputs: ['main'],
-		outputs: ['main'],
+		inputs: [NodeConnectionTypes.Main],
+		outputs: [NodeConnectionTypes.Main],
 		credentials: [{ name: 'myPortalApi', required: true }],
+		usableAsTool: true,
 		properties: [
 			{
 				displayName: 'Resource',
 				name: 'resource',
+				noDataExpression: true,
 				type: 'options',
 				default: 'ticket',
 				options: [
@@ -54,13 +56,14 @@ export class MyPortal implements INodeType {
 			{
 				displayName: 'Operation',
 				name: 'operation',
+				noDataExpression: true,
 				type: 'options',
 				default: 'getAll',
 				options: [
 					{ name: 'Create', value: 'create', action: 'Create a record' },
 					{ name: 'Delete', value: 'delete', action: 'Delete a record' },
 					{ name: 'Get', value: 'get', action: 'Get a record' },
-					{ name: 'Get All', value: 'getAll', action: 'Get many records' },
+					{ name: 'Get Many', value: 'getAll', action: 'Get many records' },
 					{ name: 'Update', value: 'update', action: 'Update a record' },
 				],
 			},
@@ -75,7 +78,7 @@ export class MyPortal implements INodeType {
 			},
 			{ displayName: 'First Name', name: 'firstName', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
 			{ displayName: 'Last Name', name: 'lastName', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
-			{ displayName: 'Email', name: 'email', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update', 'getAll'] } } },
+			{ displayName: 'Email', name: 'email', type: 'string', default: '', placeholder: 'name@email.com', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update', 'getAll'] } } },
 			{ displayName: 'Mobile Phone', name: 'mobilePhone', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
 			{ displayName: 'Enabled', name: 'enabled', type: 'boolean', default: true, displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
 			{ displayName: 'Department', name: 'department', type: 'string', default: '', displayOptions: { show: { resource: ['staff'], operation: ['create', 'update'] } } },
@@ -91,7 +94,7 @@ export class MyPortal implements INodeType {
 			{ displayName: 'Company ID', name: 'ticketCompanyId', type: 'number', default: 0, displayOptions: { show: { resource: ['ticket'], operation: ['create', 'update', 'getAll'] } } },
 			{ displayName: 'Assigned User ID', name: 'assignedUserId', type: 'number', default: 0, displayOptions: { show: { resource: ['ticket'], operation: ['create', 'update', 'getAll'] } } },
 			{ displayName: 'Search', name: 'search', type: 'string', default: '', displayOptions: { show: { resource: ['ticket'], operation: ['getAll'] } } },
-			{ displayName: 'Limit', name: 'limit', type: 'number', default: 50, typeOptions: { minValue: 1, maxValue: 500 }, displayOptions: { show: { resource: ['ticket'], operation: ['getAll'] } } },
+			{ displayName: 'Limit', name: 'limit', type: 'number', default: 50, typeOptions: { minValue: 1, maxValue: 500 }, description: 'Max number of results to return', displayOptions: { show: { resource: ['ticket'], operation: ['getAll'] } } },
 			{ displayName: 'Raw JSON Body', name: 'rawJsonBody', type: 'json', default: '{}', displayOptions: { show: { operation: ['create', 'update'] } }, description: 'Optional JSON object merged into the request body; useful for advanced MyPortal fields' },
 		],
 	};
@@ -107,7 +110,7 @@ export class MyPortal implements INodeType {
 				const operation = this.getNodeParameter('operation', i) as string;
 				const path = resource === 'staff' ? '/api/staff' : '/api/tickets';
 				const qs: IDataObject = {};
-				let method: IRequestOptions['method'] = 'GET';
+				let method: IHttpRequestOptions['method'] = 'GET';
 				let uri = `${baseUrl}${path}${resource === 'ticket' ? '/' : ''}`;
 				let body: IDataObject | undefined;
 
@@ -154,9 +157,9 @@ export class MyPortal implements INodeType {
 					}
 				}
 
-				const response = await this.helpers.request({ method, uri, qs, body, json: true, headers: { 'x-api-key': credentials.apiKey as string } });
+				const response = await this.helpers.httpRequestWithAuthentication.call(this, 'myPortalApi', { method, url: uri, qs, body, json: true });
 				if (operation === 'delete') {
-					returnData.push({ json: { success: true, id: this.getNodeParameter('id', i) } });
+					returnData.push({ json: { success: true, id: this.getNodeParameter('id', i) }, pairedItem: { item: i } });
 				} else if (resource === 'ticket' && operation === 'getAll' && response?.items) {
 					returnData.push(...this.helpers.returnJsonArray(response.items as IDataObject[]));
 				} else {

--- a/integrations/n8n-node-myportal/package-lock.json
+++ b/integrations/n8n-node-myportal/package-lock.json
@@ -8,17 +8,18 @@
       "name": "n8n-nodes-myportal",
       "version": "0.1.0",
       "license": "MIT",
-      "dependencies": {
-        "n8n-workflow": "2.33.0"
-      },
       "devDependencies": {
         "@n8n/node-cli": "0.42.0",
         "@types/node": "^20.14.9",
+        "n8n-workflow": "2.33.0",
         "typescript": "^5.5.3"
       },
       "engines": {
         "node": ">=22 <25",
         "npm": ">=10"
+      },
+      "peerDependencies": {
+        "n8n-workflow": "*"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -61,6 +62,7 @@
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
       "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/estree": "^1.0.8",
@@ -78,6 +80,7 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
       "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@apm-js-collab/code-transformer": "^0.18.1",
@@ -93,6 +96,7 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
       "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@apm-js-collab/code-transformer": "^0.18.0",
@@ -214,6 +218,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
       "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -226,6 +231,7 @@
       "version": "6.12.4",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
       "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -240,6 +246,7 @@
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
       "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
@@ -249,6 +256,7 @@
       "version": "6.43.8",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.8.tgz",
       "integrity": "sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.7.0",
@@ -621,6 +629,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@langchain/classic": {
@@ -1496,12 +1505,14 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
       "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@lezer/highlight": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.3.0"
@@ -1511,6 +1522,7 @@
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
       "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.0.0"
@@ -1520,6 +1532,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
       "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@n8n_io/ai-assistant-sdk": {
@@ -1664,6 +1677,7 @@
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.32.0.tgz",
       "integrity": "sha512-ewF/bQL2bjmHU9Dv5PnW8uDpYw5GlFJ0/nuAp+RDK9OJXXm19ErHb9itLyANvNTLGPQv8bb0BMvHh2kpWaa/8g==",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/@n8n/decorators": {
@@ -1695,6 +1709,7 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
       "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "callsites": "3.1.0"
@@ -1720,6 +1735,7 @@
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
       "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@n8n/errors": "0.13.0",
@@ -1783,6 +1799,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
       "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "ast-types": "^0.16.1",
@@ -1801,6 +1818,7 @@
       "version": "1.41.0",
       "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.41.0.tgz",
       "integrity": "sha512-wjlYqMYRDI8RGNEEBQXA9Pw5FsgdqP+4tvk6HJ9POB5x9yQyF4PhHt45a2RVz0BAoGwZKuxnunR3T+pE/FbjKQ==",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@n8n/constants": "0.32.0",
@@ -2096,6 +2114,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -2105,6 +2124,7 @@
       "version": "0.220.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
       "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -2117,6 +2137,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
       "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2132,6 +2153,7 @@
       "version": "0.220.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
       "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.220.0",
@@ -2149,6 +2171,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
       "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.10.0",
@@ -2165,6 +2188,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
       "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.10.0",
@@ -2182,6 +2206,7 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
       "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.10.0",
@@ -2200,6 +2225,7 @@
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
       "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -2226,6 +2252,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
       "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -2235,6 +2262,7 @@
       "version": "10.69.0",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
       "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.16.0"
@@ -2247,6 +2275,7 @@
       "version": "10.69.0",
       "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.69.0.tgz",
       "integrity": "sha512-xEXA1YGIiTZbrW6MWV34uS6JGQuQg2ijTI0zed+FsJb9JZKPYel/GZK8Km26vfTVb+yCXFmWZNBesKegNcVdzg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
@@ -2267,6 +2296,7 @@
       "version": "10.69.0",
       "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.69.0.tgz",
       "integrity": "sha512-IgArHczrZJxkgxoffHscj0NxQrG6kCazgmGQnlf3j58J1ec21YaUu8Tu+7G4Lo5tCiW3teQnwlKW1ttMXSqWRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.16.0",
@@ -2306,6 +2336,7 @@
       "version": "10.69.0",
       "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.69.0.tgz",
       "integrity": "sha512-3FyWV6YcEJuvLrlaKGE1dHXCI+1YO0a62w7PkwlRg8yp6K6YXkmdwu9GjqaYD+Ju4tm7uC7mHIsGFQMm0M7pqQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sentry/conventions": "^0.16.0",
@@ -2324,6 +2355,7 @@
       "version": "10.69.0",
       "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.69.0.tgz",
       "integrity": "sha512-0MwHrA8+nNvMIsqf8m3cXwCBlUjr6AS7N6CZvHJtY1DkqEvQqEbD5VIrhzEyHN/KMZIgQ8XeDCQRhjnXFQGRhg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
@@ -2430,6 +2462,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -3128,6 +3161,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3137,6 +3171,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3169,6 +3204,7 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
@@ -3178,6 +3214,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
       "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -3191,6 +3228,7 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
@@ -3203,6 +3241,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
       "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "astring": "bin/astring"
@@ -3219,12 +3258,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -3240,6 +3281,7 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
       "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -3252,6 +3294,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -3264,6 +3307,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -3277,6 +3321,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3317,6 +3362,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -3373,6 +3419,7 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
       "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=10.0.0"
@@ -3393,6 +3440,7 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
       "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3411,6 +3459,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3424,6 +3473,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3440,6 +3490,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3511,6 +3562,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -3520,6 +3572,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/clean-stack": {
@@ -3555,6 +3608,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -3590,6 +3644,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3602,6 +3657,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -3654,6 +3710,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -3690,6 +3747,7 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
       "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -3704,6 +3762,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
       "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -3725,6 +3784,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -3741,6 +3801,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3776,6 +3837,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -3793,6 +3855,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -3810,6 +3873,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -3833,6 +3897,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3874,6 +3939,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/enabled": {
@@ -3887,6 +3953,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3896,6 +3963,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3905,12 +3973,14 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3923,6 +3993,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3938,6 +4009,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4267,6 +4339,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -4280,6 +4353,7 @@
       "version": "5.8.4",
       "resolved": "https://registry.npmjs.org/esprima-next/-/esprima-next-5.8.4.tgz",
       "integrity": "sha512-8nYVZ4ioIH4Msjb/XmhnBdz5WRRBaYqevKa1cv9nGJdCehMbzZCPNEEnqfLCZVetUVrUPEcb5IYyu1GG4hFqgg==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -4293,6 +4367,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -4318,6 +4393,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -4582,6 +4658,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -4602,6 +4679,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -4634,6 +4712,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4689,6 +4768,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4698,6 +4778,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4707,6 +4788,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -4716,6 +4798,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4750,6 +4833,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4827,6 +4911,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4871,6 +4956,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -4883,6 +4969,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4895,6 +4982,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -4910,6 +4998,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5112,6 +5201,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
       "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "cjs-module-lexer": "^2.2.0",
@@ -5156,12 +5246,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5178,6 +5270,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-bun-module": {
@@ -5194,6 +5287,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5232,6 +5326,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5241,6 +5336,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -5273,6 +5369,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
       "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -5312,6 +5409,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5343,6 +5441,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -5378,6 +5477,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
       "integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -5440,6 +5540,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.6.0"
@@ -5449,6 +5550,7 @@
       "version": "3.7.8",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
       "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/js-tiktoken": {
@@ -5495,6 +5597,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
@@ -5525,6 +5628,7 @@
       "version": "3.13.2",
       "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.2.tgz",
       "integrity": "sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "jsonrepair": "bin/cli.js"
@@ -5558,6 +5662,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
       "integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
@@ -5761,6 +5866,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {
@@ -5875,6 +5981,7 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
       "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5884,6 +5991,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -5900,6 +6008,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5909,6 +6018,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
       "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "charenc": "0.0.2",
@@ -5930,6 +6040,7 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
       "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=18.0.0"
@@ -5953,6 +6064,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5962,6 +6074,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -6010,12 +6123,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mustache": {
@@ -6032,6 +6147,7 @@
       "version": "2.33.0",
       "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.0.tgz",
       "integrity": "sha512-gfmQ26TFpUSFjgeaoajMeAJzDOcIWCgLK+YztdcKRXzu3j4w5MN9L5mWxQPuShSxCLCF/cJcSblNr20vV6MBDA==",
+      "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@codemirror/autocomplete": "6.20.0",
@@ -6069,6 +6185,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
       "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6082,6 +6199,7 @@
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
       "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -6089,6 +6207,7 @@
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
       "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6192,6 +6311,7 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
       "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
@@ -6216,6 +6336,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
       "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -6232,6 +6353,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6241,6 +6363,7 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -6618,6 +6741,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6758,6 +6882,7 @@
       "version": "0.22.0",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.22.0.tgz",
       "integrity": "sha512-5AAx+mujtXijsEavc5lWXBPQqrM4+Dl5qNH96N2aNeuJFUzpiiToKPsxQD/zAIJHspz7zz0maX0PCtCTFVlixQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assert": "^2.0.0",
@@ -6774,6 +6899,7 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
       "integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
@@ -6793,6 +6919,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6802,6 +6929,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
       "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
@@ -6933,6 +7061,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6960,12 +7089,14 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
       "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -6975,6 +7106,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
       "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/semver": {
@@ -7006,6 +7138,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -7142,6 +7275,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7151,6 +7285,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
       "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "asn1": "^0.2.6",
@@ -7215,6 +7350,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7229,6 +7365,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7272,6 +7409,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -7349,6 +7487,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
       "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
@@ -7436,6 +7575,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.3.5.tgz",
       "integrity": "sha512-HAGI4Lq4Q9dZ3Utu2phaWgtm3vB6PkLUFqWAScg/UW+1eZ/Tg6Exo4oC0/3VUol/w4BlefLhUUSVBr/9/ZGQOw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.5.1"
@@ -7486,12 +7626,14 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
       "license": "Unlicense"
     },
     "node_modules/type-check": {
@@ -7688,6 +7830,7 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -7723,6 +7866,7 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
@@ -7776,6 +7920,7 @@
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
       "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -7883,6 +8028,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7923,6 +8069,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
       "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -7936,6 +8083,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
@@ -7962,6 +8110,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -7987,6 +8136,7 @@
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -8005,6 +8155,7 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -8027,6 +8178,7 @@
       "version": "3.25.67",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
       "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/integrations/n8n-node-myportal/package.json
+++ b/integrations/n8n-node-myportal/package.json
@@ -34,12 +34,18 @@
     "ssh2": true,
     "isolated-vm": true
   },
-  "dependencies": {
-    "n8n-workflow": "2.33.0"
-  },
   "devDependencies": {
     "@types/node": "^20.14.9",
     "typescript": "^5.5.3",
-    "@n8n/node-cli": "0.42.0"
-  }
+    "@n8n/node-cli": "0.42.0",
+    "n8n-workflow": "2.33.0"
+  },
+  "peerDependencies": {
+    "n8n-workflow": "*"
+  },
+  "author": {
+    "name": "MyPortal Team",
+    "email": "support@example.com"
+  },
+  "homepage": "https://github.com/bradhawkins85/MyPortal/tree/main/integrations/n8n-node-myportal"
 }


### PR DESCRIPTION
### Motivation
- Provide a first-class MyPortal integration for n8n including a reusable credential type that handles API key authentication and a node to manage staff and tickets.
- Improve request handling by delegating auth to n8n credential helpers and normalising base URLs for robust API calls.
- Deliver compiled artifacts and packaging metadata so the integration can be consumed by n8n runtimes.

### Description
- Added `MyPortalApi` credential implementing `IAuthenticateGeneric` with header-based `x-api-key` authentication and a credential test (`test.request`) that calls `GET /api/staff` against a normalised `baseUrl`, and included an icon reference.
- Updated `MyPortal` node to use `httpRequestWithAuthentication` for calls, normalise `baseUrl`, parse/compact JSON bodies with validation using `NodeOperationError`, update input/output connection types to `NodeConnectionTypes.Main`, add `usableAsTool`, and include paired items for operations and continue-on-fail behaviour.
- Added compiled `dist` files (`.js` and `.d.ts`) for credentials and node, the node icon `myportal.svg`, an `eslint.config.mjs`, and small UI tweaks like placeholders and field descriptions.
- Updated `package.json` and `package-lock.json` to move `n8n-workflow` to devDependencies, declare `n8n-workflow` as a `peerDependency`, and add author/homepage metadata to the package.

### Testing
- Ran `npm run build` (which runs `tsc` and copies the SVG) and the build completed successfully.
- Ran `npm run lint` (TypeScript checks via `tsc --noEmit`) and there were no lint/type errors.
- Verified the credential test configuration and basic HTTP request flow by exercising the node's `create/get/getAll/update/delete` paths in local manual runs (no automated integration test failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a72c9a03ce8833293a05443d17b22e9)