### PR TITLE
Keep shipment checks running with private ticket updates

### DIFF
--- a/app/services/ticket_shipment_tracking.py
+++ b/app/services/ticket_shipment_tracking.py
@@ -712,12 +712,9 @@ async def process_due_shipment_watches(*, limit: int = 200) -> dict[str, int]:
                 if not has_update:
                     continue
                 # `changed` tracks detected shipment updates, while `posted`
-                # only tracks the subset that are emitted as public ticket
-                # comments.
+                # tracks the updates added to the ticket as either public or
+                # private comments.
                 changed += 1
-
-                if not refreshed["public_comments_enabled"]:
-                    continue
 
                 reply_external_ref = f"shipment-watch:{provider.slug}:{current_hash[:32]}"
                 reply_body = _render_ticket_reply(snapshot_payload, refreshed)
@@ -725,7 +722,7 @@ async def process_due_shipment_watches(*, limit: int = 200) -> dict[str, int]:
                     ticket_id=ticket_id,
                     author_id=None,
                     body=reply_body,
-                    is_internal=False,
+                    is_internal=not bool(refreshed["public_comments_enabled"]),
                     external_reference=reply_external_ref[:128],
                 )
                 await shipment_watch_repo.update_watch_check_state(

--- a/tests/test_ticket_shipment_tracking.py
+++ b/tests/test_ticket_shipment_tracking.py
@@ -484,7 +484,7 @@ async def test_process_due_shipment_watches_posts_unposted_in_transit_snapshot(m
 
 
 @pytest.mark.anyio
-async def test_process_due_shipment_watches_skips_public_reply_when_disabled(monkeypatch):
+async def test_process_due_shipment_watches_posts_private_reply_when_public_comments_disabled(monkeypatch):
     now = datetime.now(timezone.utc)
     due_watch = {
         "id": 1,
@@ -551,10 +551,11 @@ async def test_process_due_shipment_watches_skips_public_reply_when_disabled(mon
 
     assert result["checked"] == 1
     assert result["changed"] == 1
-    assert result["posted"] == 0
-    create_reply_mock.assert_not_awaited()
-    emit_replied_mock.assert_not_awaited()
-    emit_updated_mock.assert_not_awaited()
+    assert result["posted"] == 1
+    create_reply_mock.assert_awaited_once()
+    assert create_reply_mock.await_args.kwargs["is_internal"] is True
+    emit_replied_mock.assert_awaited_once()
+    emit_updated_mock.assert_awaited_once()
     assert any(entry["watch_id"] == 1 for entry in updates)
 
 


### PR DESCRIPTION
### Motivation
- Shipment watch processing previously skipped creating ticket replies when the watch had `public_comments_enabled` disabled, which prevented checks and ticket-state updates from being surfaced; the intent is to continue performing checks but post private/internal comments when public comments are disabled.

### Description
- Continue processing due shipment watches and detect meaningful updates regardless of the `public_comments_enabled` flag. 
- Create the ticket reply via `tickets_repo.create_reply` with `is_internal=not bool(refreshed["public_comments_enabled"])` so updates are private when public comments are unticked. 
- Preserve watch-state updates (`update_watch_check_state`) and emit ticket events via `tickets_service.emit_ticket_replied_event` and `tickets_service.emit_ticket_updated_event` for both public and private replies. 
- Update tests in `tests/test_ticket_shipment_tracking.py` to assert that private replies are created and events are emitted when `public_comments_enabled` is false.

### Testing
- ✅ Ran `pytest -q tests/test_ticket_shipment_tracking.py` and all relevant tests passed (20 passed). 
- ✅ Ran `ruff check app/services/ticket_shipment_tracking.py tests/test_ticket_shipment_tracking.py` with no issues. 
- ✅ Ran `git diff --check` and repository checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a73f0d681388332a4db96d0def99d19)