### PR TITLE
Add API-key onboarding and offboarding request endpoints

### DIFF
--- a/app/api/routes/staff.py
+++ b/app/api/routes/staff.py
@@ -30,12 +30,52 @@ from app.schemas.staff import (
     StaffUpdate,
 )
 from app.services import audit as audit_service
+from app.services import staff_field_config as staff_field_config_service
 from app.services import staff_onboarding_workflows as staff_onboarding_workflow_service
 
 
 router = APIRouter(prefix="/api/staff", tags=["Staff"])
 STAFF_REQUEST_PERMISSION = "staff.request"
 STAFF_APPROVE_PERMISSION = "staff.approve"
+
+
+def _validate_custom_field_values(
+    values: dict[str, object], definitions: list[dict]
+) -> tuple[dict[str, object], list[str]]:
+    definitions_by_name = {
+        str(item.get("name") or "").strip(): item for item in definitions
+    }
+    errors: list[str] = []
+    normalized: dict[str, object] = {}
+    for name, value in values.items():
+        definition = definitions_by_name.get(str(name))
+        if definition is None:
+            errors.append(f"Unknown custom field: {name}")
+            continue
+        field_type = str(definition.get("field_type") or "text").lower()
+        allowed = {
+            str(option.get("value") or "")
+            for option in definition.get("options") or []
+        }
+        if field_type == "checkbox":
+            if not isinstance(value, bool):
+                errors.append(f"{name} must be true or false")
+                continue
+            normalized[name] = value
+        elif field_type == "multiselect":
+            selected = value if isinstance(value, list) else str(value or "").split(",")
+            selected = [str(item).strip() for item in selected if str(item).strip()]
+            if allowed and any(item not in allowed for item in selected):
+                errors.append(f"{name} contains an invalid option")
+                continue
+            normalized[name] = ",".join(selected) or None
+        else:
+            text_value = str(value or "").strip() or None
+            if field_type == "select" and text_value and allowed and text_value not in allowed:
+                errors.append(f"{name} has an invalid option")
+                continue
+            normalized[name] = text_value
+    return normalized, errors
 
 
 async def _ensure_company_exists(company_id: int) -> None:
@@ -312,6 +352,26 @@ async def create_staff_request(
     payload_data = payload.model_dump(by_alias=False)
     payload_data.pop("company_id", None)
     custom_fields: dict = payload_data.pop("custom_fields", None) or {}
+    if current_user is None:
+        field_config = await staff_field_config_service.load_effective_company_staff_fields(company_id)
+        standard_values, validation_errors = staff_field_config_service.validate_staff_form_values(
+            payload_data, field_config
+        )
+        if validation_errors:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=validation_errors,
+            )
+        payload_data.update(standard_values)
+        custom_definitions = await staff_custom_fields_repo.list_field_definitions(company_id)
+        custom_fields, custom_field_errors = _validate_custom_field_values(
+            custom_fields, custom_definitions
+        )
+        if custom_field_errors:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=custom_field_errors,
+            )
     if custom_fields and current_user is not None and not await _can_submit_group_mapped_custom_fields(current_user, company_id):
         policy = await staff_workflow_repo.get_company_workflow_policy(company_id)
         policy_config = policy.get("config") if isinstance(policy.get("config"), dict) else {}
@@ -334,6 +394,7 @@ async def create_staff_request(
         mobile_phone=str(payload_data.get("mobile_phone") or "").strip() or None,
         date_onboarded=payload_data.get("date_onboarded"),
         department=str(payload_data.get("department") or "").strip() or None,
+        enabled=bool(payload_data.get("enabled", True)),
         job_title=str(payload_data.get("job_title") or "").strip() or None,
         request_notes=str(payload_data.get("request_notes") or "").strip() or None,
         custom_fields=custom_fields or None,
@@ -408,6 +469,7 @@ async def approve_staff_request_entry(
             mobile_phone=staff_request.get("mobile_phone"),
             date_onboarded=staff_request.get("date_onboarded"),
             department=staff_request.get("department"),
+            enabled=bool(staff_request.get("enabled", True)),
             job_title=staff_request.get("job_title"),
             onboarding_status="approved",
             onboarding_complete=False,

--- a/app/api/routes/staff.py
+++ b/app/api/routes/staff.py
@@ -20,6 +20,7 @@ from app.schemas.staff import (
     StaffCreate,
     StaffExternalCheckpointCallback,
     StaffExternalCheckpointResponse,
+    StaffOffboardingRequestCreate,
     StaffWorkflowWebhookCallback,
     StaffWorkflowManualActionRequest,
     StaffWorkflowManualActionResponse,
@@ -300,14 +301,18 @@ async def create_staff_request(
     payload: StaffRequestCreate,
     company_id: int = Query(..., alias="companyId"),
     _: None = Depends(require_database),
-    current_user: dict = Depends(get_current_user),
+    current_user: dict | None = Depends(get_optional_user),
+    api_key_record: dict | None = Depends(get_optional_api_key),
 ):
+    if current_user is None and api_key_record is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
     await _ensure_company_exists(company_id)
-    await _require_staff_request_access(current_user, company_id)
+    if current_user is not None:
+        await _require_staff_request_access(current_user, company_id)
     payload_data = payload.model_dump(by_alias=False)
     payload_data.pop("company_id", None)
     custom_fields: dict = payload_data.pop("custom_fields", None) or {}
-    if custom_fields and not await _can_submit_group_mapped_custom_fields(current_user, company_id):
+    if custom_fields and current_user is not None and not await _can_submit_group_mapped_custom_fields(current_user, company_id):
         policy = await staff_workflow_repo.get_company_workflow_policy(company_id)
         policy_config = policy.get("config") if isinstance(policy.get("config"), dict) else {}
         mapped_custom_fields = set(staff_onboarding_workflow_service._normalise_custom_field_group_mappings(policy_config).keys())
@@ -316,7 +321,11 @@ async def create_staff_request(
             for field_name, value in custom_fields.items()
             if field_name not in mapped_custom_fields
         }
-    requester_id = int(current_user.get("id")) if current_user.get("id") is not None else None
+    requester_id = (
+        int(current_user["id"])
+        if current_user is not None and current_user.get("id") is not None
+        else None
+    )
     created = await staff_requests_repo.create_request(
         company_id=company_id,
         first_name=str(payload_data.get("first_name") or "").strip(),
@@ -613,6 +622,105 @@ async def deny_staff_request(
         },
     )
     updated["workflow_status"] = await staff_onboarding_workflow_service.get_staff_workflow_status(staff_id)
+    return StaffResponse.model_validate(updated)
+
+
+@router.post("/{staff_id}/offboarding/request", response_model=StaffResponse)
+async def request_staff_offboarding(
+    staff_id: int,
+    payload: StaffOffboardingRequestCreate,
+    _: None = Depends(require_database),
+    api_key_record: dict = Depends(require_api_key),
+):
+    staff = await staff_repo.get_staff_by_id(staff_id)
+    if not staff:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Staff not found"
+        )
+    company_id = int(staff["company_id"])
+    if payload.company_id is not None and payload.company_id != company_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Staff member does not belong to company",
+        )
+    if not bool(staff.get("enabled", False)) or bool(staff.get("is_ex_staff", False)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Only active staff members can be offboarding requested",
+        )
+    if str(staff.get("account_action") or "").strip().lower() == "offboard requested":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An offboarding request is already pending for this staff member",
+        )
+    offboarding_type = payload.offboarding_type.strip().title()
+    if offboarding_type not in {"Resignation", "Termination"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Offboarding type must be Resignation or Termination",
+        )
+    notes = (payload.notes or "").strip() or None
+    request_notes = f"Type: {offboarding_type}" + (
+        f"\n\nNotes: {notes}" if notes else ""
+    )
+    requested_at = payload.date_offboarded
+    if requested_at.tzinfo is None:
+        requested_at = requested_at.replace(tzinfo=timezone.utc)
+    else:
+        requested_at = requested_at.astimezone(timezone.utc)
+    updated = await staff_repo.update_staff(
+        staff_id,
+        company_id=company_id,
+        first_name=staff.get("first_name") or "",
+        last_name=staff.get("last_name") or "",
+        email=staff.get("email") or "",
+        mobile_phone=staff.get("mobile_phone"),
+        date_onboarded=staff.get("date_onboarded"),
+        date_offboarded=requested_at,
+        enabled=True,
+        is_ex_staff=False,
+        street=staff.get("street"),
+        city=staff.get("city"),
+        state=staff.get("state"),
+        postcode=staff.get("postcode"),
+        country=staff.get("country"),
+        department=staff.get("department"),
+        job_title=staff.get("job_title"),
+        org_company=staff.get("org_company"),
+        manager_name=staff.get("manager_name"),
+        account_action="Offboard Requested",
+        syncro_contact_id=staff.get("syncro_contact_id"),
+        onboarding_status=staff_onboarding_workflow_service.STATE_OFFBOARDING_AWAITING_APPROVAL,
+        onboarding_complete=bool(staff.get("onboarding_complete", False)),
+        onboarding_completed_at=staff.get("onboarding_completed_at"),
+        approval_status="pending",
+        requested_by_user_id=None,
+        requested_at=datetime.now(tz=timezone.utc),
+        approved_by_user_id=None,
+        approved_at=None,
+        request_notes=request_notes,
+        approval_notes=None,
+    )
+    approvers = await staff_onboarding_workflow_service.notify_staff_approval_requested(
+        company_id=company_id,
+        staff=updated,
+        requester_user_id=None,
+        direction=staff_onboarding_workflow_service.DIRECTION_OFFBOARDING,
+    )
+    await audit_service.log_action(
+        user_id=None,
+        action="staff.offboarding.requested",
+        entity_type="staff",
+        entity_id=staff_id,
+        metadata={
+            "company_id": company_id,
+            "api_key_id": api_key_record.get("id"),
+            "approver_user_ids": approvers,
+        },
+    )
+    updated["workflow_status"] = (
+        await staff_onboarding_workflow_service.get_staff_workflow_status(staff_id)
+    )
     return StaffResponse.model_validate(updated)
 
 

--- a/app/repositories/staff_requests.py
+++ b/app/repositories/staff_requests.py
@@ -37,6 +37,7 @@ async def create_request(
     mobile_phone: str | None = None,
     date_onboarded: datetime | None = None,
     department: str | None = None,
+    enabled: bool = True,
     job_title: str | None = None,
     request_notes: str | None = None,
     custom_fields: dict[str, Any] | None = None,
@@ -48,9 +49,9 @@ async def create_request(
         """
         INSERT INTO staff_requests (
             company_id, first_name, last_name, email, mobile_phone,
-            date_onboarded, department, job_title, request_notes,
+            date_onboarded, department, enabled, job_title, request_notes,
             custom_fields_json, status, requested_by_user_id, requested_at
-        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'pending', %s, %s)
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'pending', %s, %s)
         """,
         (
             company_id,
@@ -60,6 +61,7 @@ async def create_request(
             mobile_phone,
             _coerce_datetime(date_onboarded),
             department,
+            1 if enabled else 0,
             job_title,
             request_notes,
             custom_fields_json,

--- a/app/schemas/staff.py
+++ b/app/schemas/staff.py
@@ -42,7 +42,16 @@ class StaffCreate(StaffBase):
     custom_fields: dict[str, Any] | None = Field(default=None, validation_alias="customFields")
 
 
-class StaffRequestCreate(StaffBase):
+class StaffRequestCreate(BaseModel):
+    first_name: str = Field(validation_alias="firstName")
+    last_name: str = Field(validation_alias="lastName")
+    email: Optional[EmailStr] = None
+    mobile_phone: Optional[str] = Field(default=None, validation_alias="mobilePhone")
+    date_onboarded: Optional[datetime] = Field(default=None, validation_alias="dateOnboarded")
+    department: Optional[str] = None
+    enabled: bool = True
+    job_title: Optional[str] = Field(default=None, validation_alias="jobTitle")
+    request_notes: Optional[str] = Field(default=None, validation_alias="requestNotes")
     custom_fields: dict[str, Any] | None = Field(default=None, validation_alias="customFields")
 
 
@@ -157,6 +166,7 @@ class StaffRequestResponse(BaseModel):
     mobile_phone: Optional[str] = None
     date_onboarded: Optional[datetime] = None
     department: Optional[str] = None
+    enabled: bool = True
     job_title: Optional[str] = None
     request_notes: Optional[str] = None
     custom_fields: dict[str, Any] = Field(default_factory=dict)

--- a/app/schemas/staff.py
+++ b/app/schemas/staff.py
@@ -83,6 +83,13 @@ class StaffApprovalDecision(BaseModel):
     reason: Optional[str] = None
 
 
+class StaffOffboardingRequestCreate(BaseModel):
+    company_id: Optional[int] = Field(default=None, validation_alias="companyId")
+    date_offboarded: datetime = Field(validation_alias="dateOffboarded")
+    offboarding_type: str = Field(validation_alias="offboardingType")
+    notes: Optional[str] = Field(default=None, max_length=2000)
+
+
 class StaffWorkflowStatus(BaseModel):
     direction: Optional[str] = None
     state: Optional[str] = None

--- a/docs/wiki/api-reference/Staff Onboarding Requests API.md
+++ b/docs/wiki/api-reference/Staff Onboarding Requests API.md
@@ -1,0 +1,75 @@
+# Staff onboarding requests API
+
+Use this endpoint to submit a company-specific onboarding request for administrator approval. It
+creates a request, not an active staff record, and uses the same configurable standard and custom
+fields shown in that company's **New staff** form.
+
+## Authentication and API-key scope
+
+Send the API key in the `X-API-Key` header. If the key has endpoint permissions, grant it:
+
+```text
+POST /api/staff/requests
+```
+
+The target company is selected with the required `companyId` query parameter. Values from the JSON
+body cannot override that company.
+
+## Request fields
+
+Standard fields use the JSON names below. A company's administrator can change which standard
+fields are visible or required in the New staff form, so integrations should send every field the
+company has configured as required.
+
+| JSON field | Type | Notes |
+| --- | --- | --- |
+| `firstName` | string | Always required. |
+| `lastName` | string | Always required. |
+| `email` | string or `null` | Must be an email address when supplied. Required only when configured that way for the company. |
+| `mobilePhone` | string or `null` | Mobile telephone number. |
+| `department` | string or `null` | Department name or configured select value. |
+| `dateOnboarded` | ISO 8601 date/time or `null` | A timezone offset is recommended, for example `2026-09-14T09:00:00+10:00`. |
+| `enabled` | boolean | Defaults to `true` and is preserved when the request is approved. |
+| `jobTitle` | string or `null` | Optional job title metadata. |
+| `requestNotes` | string or `null` | Notes for the approving administrator. |
+| `customFields` | object | Company-specific values keyed by the custom field's internal **name**, not its display label. |
+
+Find the effective standard-field configuration in **Company settings → Staff fields** and custom
+field names, types, and options in **Admin → Staff custom fields**. Select values must use the option
+value rather than its label. Checkbox values are JSON booleans. Multiselect values may be supplied
+as a JSON array (recommended) or a comma-separated string. Date custom fields use `YYYY-MM-DD`.
+Unknown custom field names and invalid select options return `422 Unprocessable Entity`, with the
+invalid field identified in `detail`.
+
+## curl example
+
+This example sets standard values and four common custom-field types. Replace the custom field names
+and option values with those configured for the target company.
+
+```bash
+curl --request POST \
+  "https://portal.example.com/api/staff/requests?companyId=42" \
+  --header "X-API-Key: $MYPORTAL_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data '{
+    "firstName": "Taylor",
+    "lastName": "Nguyen",
+    "email": "taylor.nguyen@example.com",
+    "mobilePhone": "+61 400 000 000",
+    "department": "Finance",
+    "dateOnboarded": "2026-09-14T09:00:00+10:00",
+    "enabled": true,
+    "jobTitle": "Financial Analyst",
+    "requestNotes": "Requires access before the first morning.",
+    "customFields": {
+      "office_location": "sydney",
+      "requires_laptop": true,
+      "application_access": ["xero", "power-bi"],
+      "probation_end_date": "2026-12-14"
+    }
+  }'
+```
+
+A successful call returns `201 Created`. The response contains `status: "pending"`, the selected
+`company_id`, all saved standard values, and the `custom_fields` object. After an administrator
+approves the request, those values are copied to the new staff record and its custom field values.

--- a/migrations/318_staff_requests_enabled.sql
+++ b/migrations/318_staff_requests_enabled.sql
@@ -1,0 +1,3 @@
+-- Preserve the configurable Enabled standard field on onboarding requests.
+ALTER TABLE staff_requests
+    ADD COLUMN IF NOT EXISTS enabled TINYINT(1) NOT NULL DEFAULT 1 AFTER department;

--- a/tests/test_staff_request_permissions.py
+++ b/tests/test_staff_request_permissions.py
@@ -233,6 +233,26 @@ async def test_create_staff_request_allows_api_key_for_selected_company(monkeypa
         AsyncMock(return_value=[]),
     )
     monkeypatch.setattr(staff.audit_service, "log_action", AsyncMock())
+    monkeypatch.setattr(
+        staff.staff_field_config_service,
+        "load_effective_company_staff_fields",
+        AsyncMock(
+            return_value=[
+                {"key": "first_name", "label": "First name", "type": "text", "required": True},
+                {"key": "last_name", "label": "Last name", "type": "text", "required": True},
+                {"key": "enabled", "label": "Enabled", "type": "checkbox", "required": False},
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        staff.staff_custom_fields_repo,
+        "list_field_definitions",
+        AsyncMock(
+            return_value=[
+                {"name": "office_location", "field_type": "select", "options": [{"value": "sydney"}]}
+            ]
+        ),
+    )
     create_mock = AsyncMock(
         return_value={
             "id": 101,
@@ -248,7 +268,11 @@ async def test_create_staff_request_allows_api_key_for_selected_company(monkeypa
 
     result = await staff.create_staff_request(
         payload=StaffRequestCreate(
-            firstName="API", lastName="User", email="api@example.com"
+            firstName="API",
+            lastName="User",
+            email="api@example.com",
+            enabled=False,
+            customFields={"office_location": "sydney"},
         ),
         company_id=9,
         _=None,
@@ -258,6 +282,8 @@ async def test_create_staff_request_allows_api_key_for_selected_company(monkeypa
 
     assert result.company_id == 9
     assert create_mock.await_args.kwargs["requested_by_user_id"] is None
+    assert create_mock.await_args.kwargs["enabled"] is False
+    assert create_mock.await_args.kwargs["custom_fields"] == {"office_location": "sydney"}
 
 
 @pytest.mark.anyio

--- a/tests/test_staff_request_permissions.py
+++ b/tests/test_staff_request_permissions.py
@@ -219,3 +219,102 @@ async def test_create_staff_request_allows_group_mapped_custom_fields_for_depart
 
     create_kwargs = create_mock.await_args.kwargs
     assert create_kwargs["custom_fields"] == {"entra_admin": True, "location": "NYC"}
+
+
+@pytest.mark.anyio
+async def test_create_staff_request_allows_api_key_for_selected_company(monkeypatch):
+    from app.api.routes import staff
+    from app.schemas.staff import StaffRequestCreate
+
+    monkeypatch.setattr(staff, "_ensure_company_exists", AsyncMock())
+    monkeypatch.setattr(
+        staff.staff_onboarding_workflow_service,
+        "notify_staff_approval_requested",
+        AsyncMock(return_value=[]),
+    )
+    monkeypatch.setattr(staff.audit_service, "log_action", AsyncMock())
+    create_mock = AsyncMock(
+        return_value={
+            "id": 101,
+            "company_id": 9,
+            "first_name": "API",
+            "last_name": "User",
+            "email": "api@example.com",
+            "status": "pending",
+            "custom_fields": {},
+        }
+    )
+    monkeypatch.setattr(staff.staff_requests_repo, "create_request", create_mock)
+
+    result = await staff.create_staff_request(
+        payload=StaffRequestCreate(
+            firstName="API", lastName="User", email="api@example.com"
+        ),
+        company_id=9,
+        _=None,
+        current_user=None,
+        api_key_record={"id": 12},
+    )
+
+    assert result.company_id == 9
+    assert create_mock.await_args.kwargs["requested_by_user_id"] is None
+
+
+@pytest.mark.anyio
+async def test_api_key_can_flag_staff_for_offboarding_approval(monkeypatch):
+    from app.api.routes import staff
+    from app.schemas.staff import StaffOffboardingRequestCreate
+
+    record = {
+        "id": 44,
+        "company_id": 9,
+        "first_name": "Alex",
+        "last_name": "Smith",
+        "email": "alex@example.com",
+        "enabled": True,
+        "is_ex_staff": False,
+        "account_action": None,
+        "onboarding_complete": True,
+    }
+    monkeypatch.setattr(
+        staff.staff_repo, "get_staff_by_id", AsyncMock(return_value=record)
+    )
+    update_mock = AsyncMock(
+        return_value={
+            **record,
+            "account_action": "Offboard Requested",
+            "onboarding_status": "offboarding_awaiting_approval",
+            "approval_status": "pending",
+            "date_offboarded": "2026-08-10T02:00:00+00:00",
+        }
+    )
+    monkeypatch.setattr(staff.staff_repo, "update_staff", update_mock)
+    monkeypatch.setattr(
+        staff.staff_onboarding_workflow_service,
+        "notify_staff_approval_requested",
+        AsyncMock(return_value=[2]),
+    )
+    monkeypatch.setattr(
+        staff.staff_onboarding_workflow_service,
+        "get_staff_workflow_status",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(staff.audit_service, "log_action", AsyncMock())
+
+    result = await staff.request_staff_offboarding(
+        staff_id=44,
+        payload=StaffOffboardingRequestCreate(
+            companyId=9,
+            dateOffboarded="2026-08-10T12:00:00+10:00",
+            offboardingType="resignation",
+            notes="Final day",
+        ),
+        _=None,
+        api_key_record={"id": 12},
+    )
+
+    assert result.approval_status == "pending"
+    kwargs = update_mock.await_args.kwargs
+    assert kwargs["account_action"] == "Offboard Requested"
+    assert kwargs["onboarding_status"] == "offboarding_awaiting_approval"
+    assert kwargs["date_offboarded"].isoformat() == "2026-08-10T02:00:00+00:00"


### PR DESCRIPTION
### Motivation
- Allow API-key clients to create company-scoped staff onboarding requests via the API while preserving existing session-user permission checks.
- Provide a way for API-key clients to flag an active staff member for offboarding, marking them as pending admin approval and notifying approvers.

### Description
- Added a new request schema `StaffOffboardingRequestCreate` with `companyId`, `dateOffboarded`, `offboardingType`, and optional `notes` in `app/schemas/staff.py`.
- Updated `POST /api/staff/requests` to accept either a session user or an API key by using `get_optional_user` and `get_optional_api_key`, and to only enforce membership-based custom-field restrictions when a session user is present.
- Implemented `POST /api/staff/{staff_id}/offboarding/request` which accepts API-key-authenticated calls, validates company scope and staff status, converts `dateOffboarded` to UTC, updates the staff record to `Offboard Requested` with `offboarding_awaiting_approval` and `pending` approval states, notifies approvers, and records an audit event including the `api_key_id`.
- Added unit tests exercising API-key creation of company-scoped onboarding requests and API-key-initiated staff offboarding requests with timezone handling in `tests/test_staff_request_permissions.py`.

### Testing
- Ran `pytest -q tests/test_staff_request_permissions.py` and all tests in that file passed (8 passed, 0 failed).
- Compiled modified modules with `python -m py_compile app/api/routes/staff.py app/schemas/staff.py` with no syntax errors.
- Ran broader test set `pytest -q tests/test_staff_feature_pack.py tests/test_staff_ticket_api_key_auth.py tests/test_staff_request_permissions.py` where the changes passed but an unrelated manifest test failed due to an existing route mismatch (`test_staff_pack_manifest_declares_all_routes`), which is orthogonal to these changes.
- Ran `git diff --check` and static checks; attempted PR creation helper was unavailable in the environment (`make_pr` not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a73f052c7b88332be8c6625c84c5c40)