### PR TITLE
Fix staff activation when onboarding requests are approved

### DIFF
--- a/app/api/routes/staff.py
+++ b/app/api/routes/staff.py
@@ -460,6 +460,42 @@ async def approve_staff_request_entry(
 
     if existing_staff:
         staff_id = int(existing_staff["id"])
+        # A request can match an inactive/ex-staff record left by an earlier
+        # lifecycle. Treat approval as a new onboarding decision rather than
+        # merely linking the request to that hidden record.
+        await staff_repo.update_staff(
+            staff_id,
+            company_id=int(staff_request["company_id"]),
+            first_name=str(staff_request.get("first_name") or existing_staff.get("first_name") or ""),
+            last_name=str(staff_request.get("last_name") or existing_staff.get("last_name") or ""),
+            email=staff_request.get("email") or existing_staff.get("email"),
+            mobile_phone=staff_request.get("mobile_phone") or existing_staff.get("mobile_phone"),
+            date_onboarded=staff_request.get("date_onboarded") or existing_staff.get("date_onboarded"),
+            date_offboarded=None,
+            enabled=bool(staff_request.get("enabled", True)),
+            is_ex_staff=False,
+            street=existing_staff.get("street"),
+            city=existing_staff.get("city"),
+            state=existing_staff.get("state"),
+            postcode=existing_staff.get("postcode"),
+            country=existing_staff.get("country"),
+            department=staff_request.get("department") or existing_staff.get("department"),
+            job_title=staff_request.get("job_title") or existing_staff.get("job_title"),
+            org_company=existing_staff.get("org_company"),
+            manager_name=existing_staff.get("manager_name"),
+            account_action=None,
+            syncro_contact_id=existing_staff.get("syncro_contact_id"),
+            onboarding_status="approved",
+            onboarding_complete=False,
+            onboarding_completed_at=None,
+            approval_status="approved",
+            requested_by_user_id=staff_request.get("requested_by_user_id"),
+            requested_at=staff_request.get("requested_at"),
+            approved_by_user_id=approver_id,
+            approved_at=now,
+            request_notes=staff_request.get("request_notes"),
+            approval_notes=approval_comment,
+        )
     else:
         created_staff = await staff_repo.create_staff(
             company_id=int(staff_request["company_id"]),
@@ -481,18 +517,21 @@ async def approve_staff_request_entry(
             requested_at=staff_request.get("requested_at"),
         )
         staff_id = int(created_staff["id"])
-        custom_fields = staff_request.get("custom_fields") or {}
-        if custom_fields:
-            await staff_custom_fields_repo.set_staff_field_values_by_name(
-                company_id=int(staff_request["company_id"]),
-                staff_id=staff_id,
-                values=custom_fields,
-            )
-        await staff_onboarding_workflow_service.enqueue_staff_onboarding_workflow(
+
+    custom_fields = staff_request.get("custom_fields") or {}
+    if custom_fields:
+        await staff_custom_fields_repo.set_staff_field_values_by_name(
             company_id=int(staff_request["company_id"]),
             staff_id=staff_id,
-            initiated_by_user_id=approver_id,
+            values=custom_fields,
         )
+    # Queue for both newly-created and reactivated staff. Previously the
+    # existing-record path skipped workflow execution entirely.
+    await staff_onboarding_workflow_service.enqueue_staff_onboarding_workflow(
+        company_id=int(staff_request["company_id"]),
+        staff_id=staff_id,
+        initiated_by_user_id=approver_id,
+    )
 
     updated_request = await staff_requests_repo.update_request_status(
         request_id,

--- a/tests/test_staff_onboarding_endpoints.py
+++ b/tests/test_staff_onboarding_endpoints.py
@@ -213,3 +213,47 @@ async def test_offboarding_deny_requires_reason(monkeypatch):
 
     assert exc.value.status_code == 400
     assert "reason" in str(exc.value.detail).lower()
+
+
+@pytest.mark.anyio
+async def test_request_approval_reactivates_existing_staff_and_queues_workflow(monkeypatch):
+    from app.api.routes import staff
+    from app.schemas.staff import StaffApprovalDecision
+
+    request_record = {
+        "id": 31, "company_id": 4, "first_name": "Ada", "last_name": "Lovelace",
+        "email": "ada@example.com", "enabled": True, "status": "pending",
+        "custom_fields": {"Office": "London"},
+    }
+    existing_record = {
+        "id": 22, "company_id": 4, "first_name": "Ada", "last_name": "Lovelace",
+        "email": "ada@example.com", "enabled": False, "is_ex_staff": True,
+    }
+    monkeypatch.setattr(staff.staff_requests_repo, "get_request_by_id", AsyncMock(return_value=request_record))
+    monkeypatch.setattr(staff, "_require_staff_approval_access", AsyncMock())
+    monkeypatch.setattr(staff.staff_repo, "list_staff_by_email", AsyncMock(return_value=[existing_record]))
+    update_staff_mock = AsyncMock(return_value=existing_record)
+    monkeypatch.setattr(staff.staff_repo, "update_staff", update_staff_mock)
+    custom_fields_mock = AsyncMock()
+    monkeypatch.setattr(staff.staff_custom_fields_repo, "set_staff_field_values_by_name", custom_fields_mock)
+    enqueue_mock = AsyncMock()
+    monkeypatch.setattr(staff.staff_onboarding_workflow_service, "enqueue_staff_onboarding_workflow", enqueue_mock)
+    monkeypatch.setattr(
+        staff.staff_requests_repo, "update_request_status",
+        AsyncMock(return_value={**request_record, "status": "approved", "staff_id": 22}),
+    )
+    monkeypatch.setattr(staff.audit_service, "log_action", AsyncMock())
+
+    result = await staff.approve_staff_request_entry(
+        request_id=31, payload=StaffApprovalDecision(comment="Approved"),
+        _=None, current_user={"id": 99, "is_super_admin": True},
+    )
+
+    assert result.staff_id == 22
+    updated = update_staff_mock.await_args.kwargs
+    assert updated["enabled"] is True
+    assert updated["is_ex_staff"] is False
+    assert updated["onboarding_status"] == "approved"
+    assert updated["approval_status"] == "approved"
+    custom_fields_mock.assert_awaited_once_with(company_id=4, staff_id=22, values={"Office": "London"})
+    enqueue_mock.assert_awaited_once_with(company_id=4, staff_id=22, initiated_by_user_id=99)


### PR DESCRIPTION
### Motivation
- Approving an onboarding request that matched an existing but inactive/ex-staff record previously linked the request but did not reactivate the staff member or run the onboarding workflow, leaving them absent from the staff list and preventing automated provisioning.

### Description
- Update `approve_staff_request_entry` to reactivate and update an existing `staff` record when a matching email/company is found, applying request fields and approval metadata and setting `enabled=True` and `is_ex_staff=False`.
- Ensure request `custom_fields` are persisted via `staff_custom_fields_repo.set_staff_field_values_by_name` for both newly-created and reactivated staff.
- Always enqueue the onboarding workflow with `staff_onboarding_workflow_service.enqueue_staff_onboarding_workflow` for both newly-created and reactivated staff so configured policies execute.
- Add regression test `test_request_approval_reactivates_existing_staff_and_queues_workflow` in `tests/test_staff_onboarding_endpoints.py` to cover the existing-record approval path.

### Testing
- Ran `python -m pytest -q tests/test_staff_onboarding_endpoints.py`, all tests passed (`6 passed`).
- Ran formatting and lint checks with `python -m black --fast` and `python -m ruff check`, which completed successfully.
- Verified `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7411b17bcc83329e74d38e14d83038)