### PR TITLE
Enable click-to-dial for Outlook contact numbers and add "Attach to contact" action

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5645,6 +5645,29 @@ async def profile_m365_contact_phones(request: Request, name: str = Query(..., m
     return JSONResponse({"phones": phones})
 
 
+@app.post("/api/tickets/{ticket_id}/requester/mobile", response_class=JSONResponse)
+async def attach_ticket_requester_mobile(request: Request, ticket_id: int):
+    _, redirect = await _require_authenticated_user(request)
+    if redirect:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+
+    ticket = await tickets_repo.get_ticket(ticket_id)
+    if not ticket or ticket.get("requester_staff_id") is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket requester contact not found")
+
+    payload = await request.json()
+    phone = str(payload.get("phone") or "").strip() if isinstance(payload, dict) else ""
+    normalized = re.sub(r"[^0-9+]", "", phone)
+    if not re.fullmatch(r"\+?[0-9]{3,15}", normalized):
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid phone number")
+
+    staff_id = int(ticket["requester_staff_id"])
+    if not await staff_repo.get_staff_by_id(staff_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket requester contact not found")
+    await staff_repo.update_mobile_phone(staff_id, phone)
+    return JSONResponse({"ok": True, "staff_id": staff_id, "mobile_phone": phone})
+
+
 @app.get("/api/rag/relationships/metrics", response_class=JSONResponse)
 async def rag_relationship_metrics():
     from app.repositories import rag_relationships as rel_repo

--- a/app/repositories/staff.py
+++ b/app/repositories/staff.py
@@ -516,6 +516,14 @@ async def get_staff_by_id(staff_id: int) -> dict[str, Any] | None:
     return mapped
 
 
+async def update_mobile_phone(staff_id: int, mobile_phone: str) -> None:
+    """Update only the mobile number on an existing staff record."""
+    await db.execute(
+        "UPDATE staff SET mobile_phone = %s WHERE id = %s",
+        (mobile_phone, staff_id),
+    )
+
+
 async def get_staff_by_company_and_email(
     company_id: int, email: str
 ) -> dict[str, Any] | None:

--- a/app/static/js/click_to_call.js
+++ b/app/static/js/click_to_call.js
@@ -48,6 +48,13 @@
     }
   }
 
+  // Phone numbers added after page load (for example, Outlook contact search
+  // results) can use the same configured desk-phone integration.
+  window.__portalClickToCall = {
+    call,
+    isEnabled: () => enabled,
+  };
+
   function linkify(root) {
     if (!enabled || !root || root.nodeType !== Node.ELEMENT_NODE) return;
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);

--- a/app/static/js/ticket_detail.js
+++ b/app/static/js/ticket_detail.js
@@ -25,10 +25,47 @@
         phones.forEach((item) => {
           const line = document.createElement('p');
           line.className = 'form-help';
-          const link = document.createElement('a');
-          link.href = `tel:${item.phone}`;
-          link.textContent = item.phone;
-          line.append(`${item.name}: `, link);
+          const dialButton = document.createElement('button');
+          dialButton.type = 'button';
+          dialButton.className = 'click-to-call';
+          dialButton.textContent = item.phone;
+          dialButton.title = `Call ${item.phone}`;
+          dialButton.addEventListener('click', () => {
+            const clickToCall = window.__portalClickToCall;
+            if (clickToCall && clickToCall.isEnabled()) {
+              clickToCall.call(item.phone);
+              return;
+            }
+            status.textContent = 'Enable click to call in your profile to dial this number.';
+          });
+          line.append(`${item.name}: `, dialButton);
+
+          const staffId = root.dataset.requesterStaffId;
+          const ticketId = root.dataset.ticketId;
+          if (staffId && ticketId) {
+            const attachButton = document.createElement('button');
+            attachButton.type = 'button';
+            attachButton.className = 'button button--ghost button--small';
+            attachButton.textContent = 'Attach to contact';
+            attachButton.addEventListener('click', async () => {
+              attachButton.disabled = true;
+              try {
+                const attachResponse = await fetch(`/api/tickets/${encodeURIComponent(ticketId)}/requester/mobile`, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ phone: item.phone }),
+                });
+                const attachPayload = await attachResponse.json().catch(() => ({}));
+                if (!attachResponse.ok) throw new Error(attachPayload.detail || 'Unable to attach number');
+                attachButton.textContent = 'Attached';
+                status.textContent = 'Mobile number attached to the requester contact.';
+              } catch (error) {
+                attachButton.disabled = false;
+                status.textContent = error.message || 'Unable to attach number.';
+              }
+            });
+            line.append(' ', attachButton);
+          }
           results.appendChild(line);
         });
       } catch (error) {

--- a/app/templates/admin/ticket_detail.html
+++ b/app/templates/admin/ticket_detail.html
@@ -197,7 +197,12 @@
                   <p class="form-help">—</p>
                 {% endif %}
                 {% if ticket_requester_lookup_name %}
-                  <div data-outlook-contact-phones data-requester-name="{{ ticket_requester_lookup_name }}">
+                  <div
+                    data-outlook-contact-phones
+                    data-requester-name="{{ ticket_requester_lookup_name }}"
+                    data-ticket-id="{{ ticket.id }}"
+                    {% if ticket.requester_staff_id %}data-requester-staff-id="{{ ticket.requester_staff_id }}"{% endif %}
+                  >
                     <button type="button" class="button button--ghost button--small" data-outlook-contact-load>Check Outlook contacts</button>
                     <p class="form-help" data-outlook-contact-status hidden></p>
                     <div data-outlook-contact-results></div>

--- a/tests/test_outlook_contact_attachment.py
+++ b/tests/test_outlook_contact_attachment.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from starlette.requests import Request
+
+from app import main
+from app.main import app
+
+
+def _json_request(payload: dict) -> Request:
+    body = json.dumps(payload).encode()
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request({"type": "http", "method": "POST", "path": "/", "headers": []}, receive)
+
+
+def test_requester_mobile_attachment_route_is_available():
+    routes = [
+        route for route in app.routes
+        if getattr(route, "path", None) == "/api/tickets/{ticket_id}/requester/mobile"
+    ]
+
+    assert len(routes) == 1
+    assert "POST" in routes[0].methods
+
+
+@pytest.mark.anyio
+async def test_attach_requester_mobile_updates_the_tickets_staff_record(monkeypatch):
+    monkeypatch.setattr(main, "_require_authenticated_user", AsyncMock(return_value=({"id": 7}, None)))
+    monkeypatch.setattr(main.tickets_repo, "get_ticket", AsyncMock(return_value={"requester_staff_id": 42}))
+    monkeypatch.setattr(main.staff_repo, "get_staff_by_id", AsyncMock(return_value={"id": 42}))
+    update_mobile = AsyncMock()
+    monkeypatch.setattr(main.staff_repo, "update_mobile_phone", update_mobile)
+
+    response = await main.attach_ticket_requester_mobile(
+        _json_request({"phone": "+61 400 111 222"}),
+        123,
+    )
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == {
+        "ok": True,
+        "staff_id": 42,
+        "mobile_phone": "+61 400 111 222",
+    }
+    update_mobile.assert_awaited_once_with(42, "+61 400 111 222")
+
+
+def test_outlook_results_use_portal_click_to_call_and_offer_attachment():
+    script = Path("app/static/js/ticket_detail.js").read_text()
+
+    assert "window.__portalClickToCall" in script
+    assert "Attach to contact" in script
+    assert "link.href = `tel:" not in script


### PR DESCRIPTION
### Motivation
- Outlook contact lookup returned `tel:` links which bypass the portal's configured click-to-call integration and do not support dialing from the configured desk-phone; discovered numbers should use the same click-to-call workflow.
- Technicians need a fast way to save discovered mobile numbers to the requester staff record so the requester has an accurate `mobile_phone` on file.

### Description
- Expose the portal call API for dynamic content by adding `window.__portalClickToCall` with `call` and `isEnabled` in `app/static/js/click_to_call.js` so numbers added after load can use click-to-call.
- Replace `tel:` links in Outlook lookup results with click-to-call buttons in `app/static/js/ticket_detail.js`, and show a helpful message when click-to-call is not enabled.
- Add an `Attach to contact` button for each discovered number which POSTs to a new endpoint to save the number on the requester staff record, and include ticket/requester IDs on the template element in `app/templates/admin/ticket_detail.html`.
- Implement `POST /api/tickets/{ticket_id}/requester/mobile` in `app/main.py` which requires authentication, validates the phone format, confirms the ticket has a staff requester, and updates the staff record via a new `update_mobile_phone` function in `app/repositories/staff.py`.
- Add focused tests in `tests/test_outlook_contact_attachment.py` that assert the route exists, that attaching a number calls the staff update, and that the JS changes include `window.__portalClickToCall` and no `tel:` link generation.

### Testing
- Ran `pytest -q tests/test_user_m365_contacts.py tests/test_outlook_contact_attachment.py` and the test suite passed (10 tests passed).
- Verified the updated client-side behavior by ensuring `ticket_detail.js` contains `window.__portalClickToCall` and no `tel:` link generation as asserted by the new tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a753ec4073c8332b912bc7d4140df0d)