### PR TITLE
Allow random schedules for bulk task creation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5973,15 +5973,18 @@ async def admin_bulk_create_scheduled_tasks(request: Request):
         return flash_redirect("/admin/scheduled-tasks", "Select a task option to bulk create.", "error")
 
     cron_fields = cron.split()
-    if len(cron_fields) not in {5, 6}:
-        return flash_redirect("/admin/scheduled-tasks", "Enter a valid five- or six-field cron expression.", "error")
-    try:
-        start_minute = int(cron_fields[0])
-        start_hour = int(cron_fields[1])
-    except (TypeError, ValueError):
-        return flash_redirect("/admin/scheduled-tasks", "Bulk create requires numeric minute and hour cron fields.", "error")
-    if start_minute < 0 or start_minute > 59 or start_hour < 0 or start_hour > 23:
-        return flash_redirect("/admin/scheduled-tasks", "Cron start time must be between 00:00 and 23:59 UTC.", "error")
+    start_minute: int | None = None
+    start_hour: int | None = None
+    if cron:
+        if len(cron_fields) not in {5, 6}:
+            return flash_redirect("/admin/scheduled-tasks", "Enter a valid five- or six-field cron expression.", "error")
+        try:
+            start_minute = int(cron_fields[0])
+            start_hour = int(cron_fields[1])
+        except (TypeError, ValueError):
+            return flash_redirect("/admin/scheduled-tasks", "Bulk create requires numeric minute and hour cron fields.", "error")
+        if start_minute < 0 or start_minute > 59 or start_hour < 0 or start_hour > 23:
+            return flash_redirect("/admin/scheduled-tasks", "Cron start time must be between 00:00 and 23:59 UTC.", "error")
 
     company_ids: list[int] = []
     seen: set[int] = set()
@@ -6027,15 +6030,19 @@ async def admin_bulk_create_scheduled_tasks(request: Request):
     exclude_from_calendar = form.get("excludeFromCalendar") is not None
     created_count = 0
     for offset, company_id in enumerate(company_ids):
-        fields = list(cron_fields)
-        total_minutes = start_hour * 60 + start_minute + offset
-        fields[0] = str(total_minutes % 60)
-        fields[1] = str((total_minutes // 60) % 24)
+        if start_hour is None or start_minute is None:
+            task_cron = _random_daily_cron()
+        else:
+            fields = list(cron_fields)
+            total_minutes = start_hour * 60 + start_minute + offset
+            fields[0] = str(total_minutes % 60)
+            fields[1] = str((total_minutes // 60) % 24)
+            task_cron = " ".join(fields)
         company_name = active_company_lookup[company_id]
         await scheduled_tasks_repo.create_task(
             name=f"{company_name} — {command_label}",
             command=command,
-            cron=" ".join(fields),
+            cron=task_cron,
             company_id=company_id,
             description=description,
             active=active,
@@ -6062,7 +6069,11 @@ async def admin_bulk_create_scheduled_tasks(request: Request):
     base_url = "/admin/scheduled-tasks"
     redirect_url = f"{base_url}?show_inactive={show_inactive_param}" if show_inactive_param else base_url
     response = RedirectResponse(url=redirect_url, status_code=status.HTTP_303_SEE_OTHER)
-    set_flash(response, f"Created {created_count} scheduled {noun} from {start_hour:02d}:{start_minute:02d} UTC.", "success")
+    if start_hour is None or start_minute is None:
+        success_message = f"Created {created_count} scheduled {noun} at random daily times."
+    else:
+        success_message = f"Created {created_count} scheduled {noun} from {start_hour:02d}:{start_minute:02d} UTC."
+    set_flash(response, success_message, "success")
     return response
 
 

--- a/app/templates/admin/scheduled_tasks.html
+++ b/app/templates/admin/scheduled_tasks.html
@@ -367,9 +367,9 @@
           <p class="form-help">One scheduled task will be created for each selected company.</p>
         </div>
         <div class="form-field">
-          <label class="form-label" for="bulk-task-cron">Desired start cron expression</label>
-          <input class="form-input" id="bulk-task-cron" name="cron" required placeholder="0 2 * * *" pattern="^[^\s]+(\s+[^\s]+){4,5}$" />
-          <p class="form-help">The minute and hour are auto-incremented by one minute per company, starting from this UTC time.</p>
+          <label class="form-label" for="bulk-task-cron">Desired start cron expression (optional)</label>
+          <input class="form-input" id="bulk-task-cron" name="cron" placeholder="0 2 * * *" pattern="^[^\s]+(\s+[^\s]+){4,5}$" />
+          <p class="form-help">Leave blank to assign each company a random daily time. When provided, the minute and hour are auto-incremented by one minute per company, starting from this UTC time.</p>
         </div>
         <div class="form-field" id="bulk-task-description-field">
           <label class="form-label" for="bulk-task-description">Description</label>

--- a/tests/test_admin_scheduled_tasks_page.py
+++ b/tests/test_admin_scheduled_tasks_page.py
@@ -420,6 +420,61 @@ def test_bulk_delete_scheduled_tasks(super_admin_context, csrf_session, monkeypa
     assert deleted == [[1, 2]]
 
 
+def test_bulk_create_scheduled_tasks_randomises_times_when_cron_is_blank(
+    super_admin_context, csrf_session, monkeypatch
+):
+    """A missing bulk cron assigns an independent random daily time per company."""
+    created = []
+    random_crons = iter(["7 1 * * *", "42 19 * * *"])
+
+    async def fake_list_companies():
+        return [{"id": 1, "name": "Acme"}, {"id": 2, "name": "Globex"}]
+
+    async def fake_create_task(**kwargs):
+        created.append(kwargs)
+
+    async def fake_refresh():
+        return None
+
+    monkeypatch.setattr(main_module.company_repo, "list_companies", fake_list_companies)
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "create_task", fake_create_task)
+    monkeypatch.setattr(main_module.scheduler_service, "refresh", fake_refresh)
+    monkeypatch.setattr(main_module, "_random_daily_cron", lambda: next(random_crons))
+
+    with TestClient(app, follow_redirects=False) as client:
+        response = client.post(
+            "/admin/scheduled-tasks/bulk-create",
+            data={
+                "command": "sync_assets",
+                "cron": "",
+                "companyIds": ["1", "2"],
+                "active": "on",
+                "_csrf": csrf_session.csrf_token,
+            },
+        )
+
+    assert response.status_code == 303
+    assert [task["cron"] for task in created] == ["7 1 * * *", "42 19 * * *"]
+
+
+def test_bulk_create_modal_describes_optional_random_schedule(super_admin_context, monkeypatch):
+    async def fake_list_tasks(include_inactive=False):
+        return []
+
+    async def fake_list_companies():
+        return [{"id": 1, "name": "Acme"}]
+
+    monkeypatch.setattr(main_module.scheduled_tasks_repo, "list_tasks", fake_list_tasks)
+    monkeypatch.setattr(main_module.company_repo, "list_companies", fake_list_companies)
+
+    with TestClient(app) as client:
+        response = client.get("/admin/scheduled-tasks")
+
+    assert response.status_code == 200
+    assert 'id="bulk-task-cron" name="cron" placeholder=' in response.text
+    assert "Leave blank to assign each company a random daily time." in response.text
+
+
 def test_bulk_delete_scheduled_tasks_no_ids(super_admin_context, csrf_session):
     """Bulk delete with no IDs redirects with an error message."""
     with TestClient(app, follow_redirects=False) as client:


### PR DESCRIPTION
### Motivation

- Make bulk scheduled-task creation more convenient by allowing admins to omit a cron expression and have the system assign a randomized daily time per company.
- Preserve the existing behaviour where a provided cron is used as a staggered start time and minute/hour are auto-incremented per company.

### Description

- Update the bulk create handler `admin_bulk_create_scheduled_tasks` to accept an empty `cron` and, when blank, call `_random_daily_cron()` once per company instead of requiring numeric minute/hour parsing. (`app/main.py`)
- When a cron is provided maintain the one-minute-per-company staggering logic, otherwise set each created task's `cron` to the random daily expression; also adjust the success flash message to reflect random scheduling. (`app/main.py`)
- Make the bulk-create form's cron field optional and add explanatory help text about optional random schedules. (`app/templates/admin/scheduled_tasks.html`)
- Add tests covering blank-cron behaviour and the updated modal text: `test_bulk_create_scheduled_tasks_randomises_times_when_cron_is_blank` and `test_bulk_create_modal_describes_optional_random_schedule`. (`tests/test_admin_scheduled_tasks_page.py`)

### Testing

- Ran `pytest -q tests/test_admin_scheduled_tasks_page.py -k 'bulk_create'` and the two new/targeted tests passed. 
- Ran `pytest -q tests/test_admin_scheduled_tasks_page.py` which showed the two new bulk-create tests pass but the file contains a pre-existing unrelated failure (`test_scheduled_tasks_page_renders_tasks`) that is not caused by these changes. 
- Verified repository diff and committed the changes (`Allow random schedules for bulk task creation`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a757f0ff3088332900c698bafd71a8f)