### PR TITLE
Show company automation and recurring-invoice item counts in admin Companies table and make names clickable

### DIFF
--- a/app/features/companies/handlers.py
+++ b/app/features/companies/handlers.py
@@ -119,8 +119,10 @@ async def _render_companies_dashboard(
     include_archived: bool = False,
     status_code: int = status.HTTP_200_OK,
 ) -> HTMLResponse:
+    from app.repositories import company_recurring_invoice_items as recurring_items_repo
     from app.repositories import m365 as m365_repo
     from app.repositories import roles as role_repo
+    from app.repositories import scheduled_tasks as scheduled_tasks_repo
     from app.repositories import user_companies as user_company_repo
     from app.services import m365 as m365_service
 
@@ -142,14 +144,21 @@ async def _render_companies_dashboard(
         company_ids_with_rows.append((company_id, company))
 
     if company_ids_with_rows:
-        credentials_rows = await asyncio.gather(
-            *(
-                m365_repo.get_credentials(company_id)
-                for company_id, _ in company_ids_with_rows
-            )
+        company_ids = [company_id for company_id, _ in company_ids_with_rows]
+        credentials_rows, automation_counts, recurring_item_counts = await asyncio.gather(
+            asyncio.gather(
+                *(m365_repo.get_credentials(company_id) for company_id in company_ids)
+            ),
+            scheduled_tasks_repo.count_tasks_by_company_ids(company_ids),
+            recurring_items_repo.count_items_by_company_ids(company_ids),
         )
         for (_, company), credentials in zip(company_ids_with_rows, credentials_rows):
             company["m365_tenant_id"] = (credentials or {}).get("tenant_id", "").strip()
+        for company_id, company in company_ids_with_rows:
+            company["automation_count"] = automation_counts.get(company_id, 0)
+            company["recurring_invoice_item_count"] = recurring_item_counts.get(
+                company_id, 0
+            )
 
     # Fetch M365 consent status for companies that have credentials configured.
     m365_company_ids = [

--- a/app/repositories/company_recurring_invoice_items.py
+++ b/app/repositories/company_recurring_invoice_items.py
@@ -27,6 +27,28 @@ async def list_company_recurring_invoice_items(company_id: int) -> Sequence[dict
     return rows
 
 
+async def count_items_by_company_ids(company_ids: Sequence[int]) -> dict[int, int]:
+    """Return recurring invoice item counts grouped by company."""
+    unique_ids = sorted({int(company_id) for company_id in company_ids})
+    if not unique_ids:
+        return {}
+    placeholders = ", ".join(["%s"] * len(unique_ids))
+    rows = await db.fetch_all(
+        f"""
+        SELECT company_id, COUNT(*) AS item_count
+        FROM company_recurring_invoice_items
+        WHERE company_id IN ({placeholders})
+        GROUP BY company_id
+        """,
+        tuple(unique_ids),
+    )
+    return {
+        int(row["company_id"]): int(row["item_count"])
+        for row in rows
+        if row.get("company_id") is not None
+    }
+
+
 async def get_recurring_invoice_item(item_id: int) -> Optional[dict[str, Any]]:
     """Get a single recurring invoice item by ID."""
     row = await db.fetch_one(

--- a/app/repositories/scheduled_tasks.py
+++ b/app/repositories/scheduled_tasks.py
@@ -55,6 +55,28 @@ async def get_commands_for_company(company_id: int) -> set[str]:
     )
     return {row["command"] for row in rows}
 
+
+async def count_tasks_by_company_ids(company_ids: Sequence[int]) -> dict[int, int]:
+    """Return scheduled-task counts grouped by company."""
+    unique_ids = sorted({int(company_id) for company_id in company_ids})
+    if not unique_ids:
+        return {}
+    placeholders = ", ".join(["%s"] * len(unique_ids))
+    rows = await db.fetch_all(
+        f"""
+        SELECT company_id, COUNT(*) AS task_count
+        FROM scheduled_tasks
+        WHERE company_id IN ({placeholders})
+        GROUP BY company_id
+        """,
+        tuple(unique_ids),
+    )
+    return {
+        int(row["company_id"]): int(row["task_count"])
+        for row in rows
+        if row.get("company_id") is not None
+    }
+
 async def get_task_for_company_by_command(company_id: int, command: str) -> dict[str, Any] | None:
     """Return the first task matching *command* for *company_id*, or None."""
     row = await db.fetch_one(

--- a/app/templates/admin/companies.html
+++ b/app/templates/admin/companies.html
@@ -15,6 +15,8 @@
   {"key": "syncro_id", "module": "syncro",     "label": "Syncro ID",     "default_visible": false},
   {"key": "xero_id", "module": "xero",       "label": "Xero ID",       "default_visible": false},
   {"key": "email_domains", "label": "Email domains", "default_visible": false},
+  {"key": "automations", "label": "Company automations", "default_visible": false},
+  {"key": "recurring_invoice_items", "label": "Recurring invoice items", "default_visible": false},
   {"key": "tacticalrmm_client_id", "module": "tacticalrmm",     "label": "Tactical RMM client ID",      "default_visible": false},
   {"key": "hudu_id", "module": "hudu",                   "label": "Hudu ID",                      "default_visible": false},
   {"key": "huntress_organization_id", "module": "huntress",  "label": "Huntress organisation ID",     "default_visible": false},
@@ -67,6 +69,8 @@
                 {% if module_enabled.get('syncro', false) %}<th scope="col" data-sort="string" data-column-key="syncro_id">Syncro ID</th>{% endif %}
                 {% if module_enabled.get('xero', false) %}<th scope="col" data-sort="string" data-column-key="xero_id">Xero ID</th>{% endif %}
                 <th scope="col" data-sort="string" data-column-key="email_domains">Email domains</th>
+                <th scope="col" data-sort="number" data-column-key="automations">Company automations</th>
+                <th scope="col" data-sort="number" data-column-key="recurring_invoice_items">Recurring invoice items</th>
                 {% if module_enabled.get('tacticalrmm', false) %}<th scope="col" data-sort="string" data-column-key="tacticalrmm_client_id">Tactical RMM client ID</th>{% endif %}
                 {% if module_enabled.get('hudu', false) %}<th scope="col" data-sort="string" data-column-key="hudu_id">Hudu ID</th>{% endif %}
                 {% if module_enabled.get('huntress', false) %}<th scope="col" data-sort="string" data-column-key="huntress_organization_id">Huntress organisation ID</th>{% endif %}
@@ -85,7 +89,7 @@
               {% if managed_companies %}
                 {% for company in managed_companies %}
                   <tr>
-                    <td data-label="Name" data-column-key="name">{{ company.name }}</td>
+                    <td data-label="Name" data-column-key="name"><a href="/admin/companies/{{ company.id }}/edit">{{ company.name }}</a></td>
                     {% if module_enabled.get('syncro', false) %}<td data-label="Syncro ID" data-value="{{ company.syncro_company_id or '' }}" data-column-key="syncro_id">
                       {% if company.syncro_company_id %}
                         {{ company.syncro_company_id }}
@@ -107,6 +111,8 @@
                         <span class="text-muted">—</span>
                       {% endif %}
                     </td>
+                    <td data-label="Company automations" data-value="{{ company.automation_count }}" data-column-key="automations">{{ company.automation_count }}</td>
+                    <td data-label="Recurring invoice items" data-value="{{ company.recurring_invoice_item_count }}" data-column-key="recurring_invoice_items">{{ company.recurring_invoice_item_count }}</td>
                     {% if module_enabled.get('tacticalrmm', false) %}<td data-label="Tactical RMM client ID" data-value="{{ company.tacticalrmm_client_id or '' }}" data-column-key="tacticalrmm_client_id">
                       {% if company.tacticalrmm_client_id %}
                         {{ company.tacticalrmm_client_id }}

--- a/tests/test_company_table_counts.py
+++ b/tests/test_company_table_counts.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.repositories import company_recurring_invoice_items, scheduled_tasks
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_scheduled_task_counts_are_grouped_by_company(monkeypatch):
+    fetch_all = AsyncMock(
+        return_value=[
+            {"company_id": 2, "task_count": 3},
+            {"company_id": 7, "task_count": 1},
+        ]
+    )
+    monkeypatch.setattr(scheduled_tasks.db, "fetch_all", fetch_all)
+
+    result = await scheduled_tasks.count_tasks_by_company_ids([7, 2, 7])
+
+    assert result == {2: 3, 7: 1}
+    query, params = fetch_all.await_args.args
+    assert "GROUP BY company_id" in query
+    assert params == (2, 7)
+
+
+@pytest.mark.anyio
+async def test_recurring_item_counts_are_grouped_by_company(monkeypatch):
+    fetch_all = AsyncMock(
+        return_value=[{"company_id": 2, "item_count": 4}]
+    )
+    monkeypatch.setattr(company_recurring_invoice_items.db, "fetch_all", fetch_all)
+
+    result = await company_recurring_invoice_items.count_items_by_company_ids([9, 2])
+
+    assert result == {2: 4}
+    query, params = fetch_all.await_args.args
+    assert "company_recurring_invoice_items" in query
+    assert "GROUP BY company_id" in query
+    assert params == (2, 9)
+
+
+def test_company_table_exposes_optional_counts_and_edit_links():
+    template = open("app/templates/admin/companies.html", encoding="utf-8").read()
+
+    assert '"key": "automations"' in template
+    assert '"key": "recurring_invoice_items"' in template
+    assert template.count('"default_visible": false') >= 2
+    assert 'data-column-key="automations"' in template
+    assert 'data-column-key="recurring_invoice_items"' in template
+    assert (
+        '<a href="/admin/companies/{{ company.id }}/edit">{{ company.name }}</a>'
+        in template
+    )


### PR DESCRIPTION
### Motivation
- Provide admins with quick visibility into how many scheduled automations and recurring invoice items each company has so missing configuration can be detected at a glance. 
- Make the company name link directly to the company edit page to speed up navigation from the list view.

### Description
- Add grouped-count repository helpers `count_tasks_by_company_ids` in `app/repositories/scheduled_tasks.py` and `count_items_by_company_ids` in `app/repositories/company_recurring_invoice_items.py` to efficiently fetch counts via a single grouped query per resource. 
- Update the companies dashboard handler in `app/features/companies/handlers.py` to concurrently load M365 credentials and the two count maps with `asyncio.gather` and attach `automation_count` and `recurring_invoice_item_count` to each company row. 
- Add two optional, sortable table columns (`automations` and `recurring_invoice_items`) and make the company `Name` cell a link to the edit page in `app/templates/admin/companies.html`. 
- Add focused tests `tests/test_company_table_counts.py` that validate the grouped queries and the presence of the new template keys and edit link.

### Testing
- `ruff check app/repositories/scheduled_tasks.py app/repositories/company_recurring_invoice_items.py app/features/companies/handlers.py tests/test_company_table_counts.py` — passed. 
- `python -m pytest -q tests/test_company_table_counts.py` — passed (tests for grouped counts and template expectations all succeeded). 
- `python -m pytest -q tests/test_company_table_counts.py tests/test_companies_feature_pack.py` — the newly added tests passed but the existing `test_companies_feature_pack` failed in this environment due to a pre-existing route manifest mismatch (tray ticket-question routes) unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a758167944c8332ac43d0f7e0f62053)