### PR TITLE
Add immediate TRMM tray agent sync (API + importer + agent script)

### DIFF
--- a/app/api/routes/tray.py
+++ b/app/api/routes/tray.py
@@ -33,6 +33,7 @@ from app.api.dependencies.auth import (
     get_current_user,
     require_super_admin,
 )
+from app.api.dependencies.api_keys import require_api_key
 from app.core.config import get_settings
 from app.core.logging import log_error, log_info
 from app.repositories import assets as assets_repo
@@ -63,6 +64,8 @@ from app.schemas.tray import (
     TrayTicketSubmitResponse,
     TrayTRMMScriptRunRequest,
     TrayTRMMScriptRunResponse,
+    TrayTRMMSyncRequest,
+    TrayTRMMSyncResponse,
 )
 from app.services import audit as audit_service
 from app.services import chat_ticket_sync
@@ -74,6 +77,7 @@ from app.services import tickets as tickets_service
 from app.services import syncro as syncro_service
 from app.services import tray as tray_service
 from app.services import tray_ticket_questions as tq_service
+from app.services import asset_importer
 from app.services.sanitization import sanitize_rich_text
 from app.security.encryption import decrypt_secret, encrypt_secret
 from app.repositories import tray_ticket_questions as tq_repo
@@ -257,6 +261,57 @@ async def enrol_device(
         auth_token=auth_token,
         company_id=device.get("company_id"),
         asset_id=device.get("asset_id"),
+    )
+
+
+@router.post(
+    "/trmm-sync",
+    response_model=TrayTRMMSyncResponse,
+    summary="Immediately link a Tactical RMM agent to an enrolled tray device",
+)
+async def sync_trmm_agent(
+    payload: TrayTRMMSyncRequest,
+    api_key: dict = Depends(require_api_key),
+) -> TrayTRMMSyncResponse:
+    """Synchronise one agent without waiting for the scheduled TRMM import.
+
+    This endpoint is intended for an agent-side Tactical RMM script.  The
+    MyPortal API key may be restricted to this exact route and POST method.
+    """
+
+    tray_agent_id = payload.tray_agent_id.strip()
+    agent_id = payload.agent_id.strip()
+    device = await tray_repo.get_device_by_uid(tray_agent_id)
+    if not device or device.get("status") == "revoked":
+        raise HTTPException(status_code=404, detail="Tray device not found")
+    company_id = device.get("company_id")
+    if company_id is None:
+        raise HTTPException(
+            status_code=409, detail="Tray device is not assigned to a company"
+        )
+
+    try:
+        asset_id = await asset_importer.sync_tactical_agent(
+            int(company_id), agent_id=agent_id, tray_device_uid=tray_agent_id
+        )
+    except tacticalrmm_service.TacticalRMMConfigurationError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except tacticalrmm_service.TacticalRMMAPIError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    log_info(
+        "Tactical RMM agent pushed tray link",
+        api_key_id=api_key.get("id"),
+        company_id=company_id,
+        device_id=device.get("id"),
+        asset_id=asset_id,
+        trmm_agent_id=agent_id,
+    )
+    return TrayTRMMSyncResponse(
+        status="linked",
+        device_id=int(device["id"]),
+        asset_id=asset_id,
+        agent_id=agent_id,
     )
 
 
@@ -864,7 +919,7 @@ def _render_ticket_form(
                 option_html.append(
                     f'<option value="{_html.escape(opt_s)}"{selected}>{_html.escape(opt_s)}</option>'
                 )
-            control = f'<select {attrs}>{"".join(option_html)}</select>'
+            control = f"<select {attrs}>{''.join(option_html)}</select>"
         elif field_type == "boolean":
             checked = " checked" if value.lower() in {"yes", "true", "1", "on"} else ""
             control = f'<label class="check"><input type="checkbox" {attrs} value="Yes"{checked}> Yes</label>'
@@ -898,7 +953,7 @@ def _render_ticket_form(
 .actions{{display:flex;justify-content:flex-end;gap:12px;margin-top:24px}}button{{border:0;border-radius:10px;padding:12px 18px;font-weight:700;cursor:pointer}}.primary{{background:var(--primary);color:white}}.secondary{{background:#e5e7eb;color:#111827}}
 .alert{{border-radius:12px;padding:12px 14px;margin-bottom:18px}}.alert-error{{background:#fef2f2;color:#991b1b;border:1px solid #fecaca}}.alert-success{{background:#ecfdf5;color:#065f46;border:1px solid #a7f3d0}}
 @media(max-width:760px){{.shell{{display:block}}.nav{{padding:16px}}.main{{padding:16px}}}}
-</style></head><body><div class="shell"><aside class="nav"><div class="brand"><img src="{_html.escape(branding_icon_url, quote=True)}" alt=""><h1>{_html.escape(brand_name)}</h1></div><p>This secure tray form is authenticated by your enrolled tray device and links the request to this computer.</p></aside><header class="header"><h2>{_html.escape(title)}</h2><p>{_html.escape(intro)}</p></header><main class="main"><form class="card" method="post" action="/api/tray/ticket-form"><input type="hidden" name="token" value="{_html.escape(token)}"><input type="hidden" name="csrf" value="{_html.escape(csrf)}"><input type="hidden" id="question-meta" value="{meta_json}">{notice}{done}{''.join(fields)}<div class="actions"><button type="button" class="secondary" onclick="window.close()">Cancel</button><button class="primary" type="submit"{disabled}>Send Request</button></div></form></main></div>
+</style></head><body><div class="shell"><aside class="nav"><div class="brand"><img src="{_html.escape(branding_icon_url, quote=True)}" alt=""><h1>{_html.escape(brand_name)}</h1></div><p>This secure tray form is authenticated by your enrolled tray device and links the request to this computer.</p></aside><header class="header"><h2>{_html.escape(title)}</h2><p>{_html.escape(intro)}</p></header><main class="main"><form class="card" method="post" action="/api/tray/ticket-form"><input type="hidden" name="token" value="{_html.escape(token)}"><input type="hidden" name="csrf" value="{_html.escape(csrf)}"><input type="hidden" id="question-meta" value="{meta_json}">{notice}{done}{"".join(fields)}<div class="actions"><button type="button" class="secondary" onclick="window.close()">Cancel</button><button class="primary" type="submit"{disabled}>Send Request</button></div></form></main></div>
 <script>
 const meta=JSON.parse(document.getElementById('question-meta').value||'[]');
 function valueFor(id){{const el=document.querySelector(`[data-question-input="${{id}}"]`);if(!el)return'';if(el.type==='checkbox')return el.checked?'Yes':'No';return (el.value||'').trim();}}
@@ -2021,7 +2076,9 @@ async def admin_list_versions(
                 "rollout_start_at": (
                     rollout_start.isoformat()
                     if hasattr(rollout_start, "isoformat")
-                    else str(rollout_start) if rollout_start else None
+                    else str(rollout_start)
+                    if rollout_start
+                    else None
                 ),
                 "devices_on_version": devices_on_version,
                 "total_devices": total_devices,

--- a/app/schemas/tray.py
+++ b/app/schemas/tray.py
@@ -32,6 +32,20 @@ class TrayEnrolResponse(BaseModel):
     poll_interval_seconds: int = 30
 
 
+class TrayTRMMSyncRequest(BaseModel):
+    """Identifiers posted by a Tactical RMM agent-side sync script."""
+
+    agent_id: str = Field(min_length=1, max_length=255)
+    tray_agent_id: str = Field(min_length=1, max_length=255)
+
+
+class TrayTRMMSyncResponse(BaseModel):
+    status: str
+    device_id: int
+    asset_id: int
+    agent_id: str
+
+
 class TrayHeartbeatRequest(BaseModel):
     console_user: Optional[str] = Field(default=None, max_length=255)
     agent_version: Optional[str] = Field(default=None, max_length=32)

--- a/app/services/asset_importer.py
+++ b/app/services/asset_importer.py
@@ -135,7 +135,9 @@ async def _sync_tactical_asset_custom_fields(
         field_type: str = field_def["field_type"]
         field_def_id: int = field_def["id"]
 
-        trmm_field = trmm_fields.get(field_name) or trmm_fields_lower.get(field_name.lower())
+        trmm_field = trmm_fields.get(field_name) or trmm_fields_lower.get(
+            field_name.lower()
+        )
 
         if field_type != "checkbox":
             # Non-checkbox: import value directly from matching TRMM field.
@@ -172,7 +174,9 @@ async def _sync_tactical_asset_custom_fields(
             else:
                 # No matching TRMM custom field -> check installed software.
                 if installed_software_lower is None:
-                    sw_names = await tacticalrmm.fetch_agent_installed_software(trmm_agent_id)
+                    sw_names = await tacticalrmm.fetch_agent_installed_software(
+                        trmm_agent_id
+                    )
                     installed_software_lower = {s.lower() for s in sw_names}
                 bool_val = field_name.lower() in installed_software_lower
 
@@ -243,6 +247,68 @@ async def _sync_tactical_tray_device_link(
     await tray_repo.link_device_to_asset(device_id_int, asset_id)
 
 
+async def sync_tactical_agent(
+    company_id: int, *, agent_id: str, tray_device_uid: str
+) -> int:
+    """Import and link one TRMM agent immediately after tray installation."""
+
+    company = await company_repo.get_company_by_id(company_id)
+    if not company:
+        raise ValueError(f"Company {company_id} not found")
+    if not _clean_string(company.get("tacticalrmm_client_id")):
+        raise tacticalrmm.TacticalRMMConfigurationError(
+            "Company is missing a Tactical RMM mapping"
+        )
+
+    agent = await tacticalrmm.fetch_agent(agent_id)
+    details = tacticalrmm.extract_agent_details(agent)
+    expected_client_id = _clean_string(company.get("tacticalrmm_client_id"))
+    actual_client_id = _clean_string(details.get("client_id"))
+    if actual_client_id and actual_client_id != expected_client_id:
+        raise tacticalrmm.TacticalRMMAPIError(
+            "Tactical RMM agent does not belong to the tray device company"
+        )
+    asset_id = await assets_repo.upsert_asset(
+        company_id=company_id,
+        name=_clean_string(details.get("name")) or "Asset",
+        type=_clean_string(details.get("type")),
+        machine_type=_clean_string(details.get("machine_type")),
+        serial_number=_clean_string(details.get("serial_number")),
+        status=_clean_string(details.get("status")),
+        os_name=_clean_string(details.get("os_name")),
+        cpu_name=_clean_string(details.get("cpu_name")),
+        ram_gb=details.get("ram_gb"),
+        hdd_size=_clean_string(details.get("hdd_size"), max_length=255),
+        last_sync=details.get("last_sync"),
+        motherboard_manufacturer=_clean_string(details.get("motherboard_manufacturer")),
+        form_factor=_clean_string(details.get("form_factor")),
+        last_user=_clean_string(details.get("last_user")),
+        approx_age=details.get("approx_age"),
+        performance_score=details.get("performance_score"),
+        warranty_status=_clean_string(details.get("warranty_status")),
+        warranty_end_date=details.get("warranty_end_date"),
+        tactical_asset_id=agent_id,
+        match_name=True,
+    )
+    if not asset_id:
+        raise tacticalrmm.TacticalRMMAPIError("Unable to create the MyPortal asset")
+
+    device = await tray_repo.get_device_by_uid(tray_device_uid)
+    if not device or int(device.get("company_id") or 0) != int(company_id):
+        raise ValueError("Tray device does not belong to the expected company")
+    await tray_repo.link_device_to_asset(int(device["id"]), asset_id)
+    try:
+        await _sync_tactical_asset_custom_fields(asset_id, agent_id, agent)
+    except Exception as exc:  # noqa: BLE001 - optional fields must not delay linking
+        log_error(
+            "Failed to sync custom fields during immediate Tactical RMM tray link",
+            asset_id=asset_id,
+            tactical_asset_id=agent_id,
+            error=str(exc),
+        )
+    return asset_id
+
+
 async def import_tactical_assets_for_company(
     company_id: int,
     *,
@@ -253,7 +319,9 @@ async def import_tactical_assets_for_company(
         raise ValueError(f"Company {company_id} not found")
     client_identifier = tactical_client_id or company.get("tacticalrmm_client_id")
     if not client_identifier:
-        raise tacticalrmm.TacticalRMMConfigurationError("Company is missing a Tactical RMM mapping")
+        raise tacticalrmm.TacticalRMMConfigurationError(
+            "Company is missing a Tactical RMM mapping"
+        )
 
     client_id = str(client_identifier).strip()
     log_info(
@@ -288,7 +356,9 @@ async def import_tactical_assets_for_company(
             ram_gb=details.get("ram_gb"),
             hdd_size=_clean_string(details.get("hdd_size"), max_length=255),
             last_sync=details.get("last_sync"),
-            motherboard_manufacturer=_clean_string(details.get("motherboard_manufacturer")),
+            motherboard_manufacturer=_clean_string(
+                details.get("motherboard_manufacturer")
+            ),
             form_factor=_clean_string(details.get("form_factor")),
             last_user=_clean_string(details.get("last_user")),
             approx_age=details.get("approx_age"),
@@ -301,7 +371,11 @@ async def import_tactical_assets_for_company(
         if asset_id and tactical_id:
             try:
                 await _sync_tactical_asset_custom_fields(asset_id, tactical_id, agent)
-            except (tacticalrmm.TacticalRMMAPIError, tacticalrmm.TacticalRMMConfigurationError, OSError) as exc:
+            except (
+                tacticalrmm.TacticalRMMAPIError,
+                tacticalrmm.TacticalRMMConfigurationError,
+                OSError,
+            ) as exc:
                 log_error(
                     "Failed to sync custom fields for Tactical RMM asset",
                     asset_id=asset_id,
@@ -359,7 +433,9 @@ async def import_all_tactical_assets() -> dict[str, Any]:
         if not client_identifier:
             company_name = _clean_string(company.get("name"))
             if company_name:
-                matched_client_id = await company_id_lookup._lookup_tactical_client_id(company_name)
+                matched_client_id = await company_id_lookup._lookup_tactical_client_id(
+                    company_name
+                )
                 if matched_client_id:
                     client_identifier = matched_client_id
                     await company_repo.update_company(
@@ -388,9 +464,7 @@ async def import_all_tactical_assets() -> dict[str, Any]:
                 company_id=company_id,
                 error=str(exc),
             )
-            summary["skipped"].append(
-                {"company_id": company_id, "reason": str(exc)}
-            )
+            summary["skipped"].append({"company_id": company_id, "reason": str(exc)})
             continue
         except tacticalrmm.TacticalRMMAPIError as exc:
             log_error(
@@ -398,9 +472,7 @@ async def import_all_tactical_assets() -> dict[str, Any]:
                 company_id=company_id,
                 error=str(exc),
             )
-            summary["skipped"].append(
-                {"company_id": company_id, "reason": str(exc)}
-            )
+            summary["skipped"].append({"company_id": company_id, "reason": str(exc)})
             continue
 
         summary["companies"][company_id] = {"processed": processed}

--- a/app/services/tacticalrmm.py
+++ b/app/services/tacticalrmm.py
@@ -52,9 +52,13 @@ async def _load_settings() -> dict[str, Any]:
         base_url = _clean_text(settings.get("base_url"))
         api_key = _clean_text(settings.get("api_key"))
         if not base_url:
-            raise TacticalRMMConfigurationError("Tactical RMM base URL is not configured")
+            raise TacticalRMMConfigurationError(
+                "Tactical RMM base URL is not configured"
+            )
         if not api_key:
-            raise TacticalRMMConfigurationError("Tactical RMM API key is not configured")
+            raise TacticalRMMConfigurationError(
+                "Tactical RMM API key is not configured"
+            )
         verify_ssl = bool(settings.get("verify_ssl", True))
         cached = {
             "base_url": base_url.rstrip("/"),
@@ -73,7 +77,9 @@ async def _call_endpoint(
     if body is not None:
         payload["body"] = body
     try:
-        result = await modules_service.trigger_module("tacticalrmm", payload, background=False)
+        result = await modules_service.trigger_module(
+            "tacticalrmm", payload, background=False
+        )
     except ValueError as exc:
         raise TacticalRMMConfigurationError(str(exc)) from exc
     status = str(result.get("status") or "").lower()
@@ -100,7 +106,9 @@ def _normalise_next_url(next_value: Any, base_url: str) -> str | None:
             if candidate:
                 next_value = candidate
                 break
-    if isinstance(next_value, Sequence) and not isinstance(next_value, (str, bytes, bytearray)):
+    if isinstance(next_value, Sequence) and not isinstance(
+        next_value, (str, bytes, bytearray)
+    ):
         for candidate in next_value:
             resolved = _normalise_next_url(candidate, base_url)
             if resolved:
@@ -118,20 +126,28 @@ def _normalise_next_url(next_value: Any, base_url: str) -> str | None:
     return next_value.lstrip("/")
 
 
-def _extract_agent_page(response: Any, base_url: str) -> tuple[list[Mapping[str, Any]], str | None]:
+def _extract_agent_page(
+    response: Any, base_url: str
+) -> tuple[list[Mapping[str, Any]], str | None]:
     if isinstance(response, list):
         return [item for item in response if isinstance(item, Mapping)], None
     if isinstance(response, Mapping):
         for key in ("results", "agents", "items", "data"):
             value = response.get(key)
             if isinstance(value, list):
-                next_link = response.get("next") or response.get("next_url") or response.get("nextLink")
+                next_link = (
+                    response.get("next")
+                    or response.get("next_url")
+                    or response.get("nextLink")
+                )
                 if not next_link:
                     pagination = response.get("links") or response.get("pagination")
                     if isinstance(pagination, Mapping):
                         next_link = pagination.get("next") or pagination.get("next_url")
                 next_endpoint = _normalise_next_url(next_link, base_url)
-                return [item for item in value if isinstance(item, Mapping)], next_endpoint
+                return [
+                    item for item in value if isinstance(item, Mapping)
+                ], next_endpoint
         # Some endpoints may return a single agent
         if all(key in response for key in ("id", "hostname", "client")):
             return [response], None
@@ -188,7 +204,7 @@ def _ram_gb_from_wmi_memory(memory: Any) -> float | None:
                 continue
     if total_bytes <= 0:
         return None
-    return round(total_bytes / (1024 ** 3), 2)
+    return round(total_bytes / (1024**3), 2)
 
 
 def _coerce_float(value: Any) -> float | None:
@@ -212,7 +228,11 @@ def _join_list(value: Any, separator: str = ", ") -> str | None:
     if value is None:
         return None
     if isinstance(value, list):
-        parts = [str(item).strip() for item in value if item is not None and str(item).strip()]
+        parts = [
+            str(item).strip()
+            for item in value
+            if item is not None and str(item).strip()
+        ]
         return separator.join(parts) if parts else None
     if isinstance(value, str):
         return value.strip() or None
@@ -299,7 +319,9 @@ def extract_agent_details(agent: Mapping[str, Any]) -> dict[str, Any]:
             "computername",
         )
     )
-    client_info = agent.get("client") if isinstance(agent.get("client"), Mapping) else {}
+    client_info = (
+        agent.get("client") if isinstance(agent.get("client"), Mapping) else {}
+    )
     site_info = agent.get("site") if isinstance(agent.get("site"), Mapping) else {}
 
     # ``logged_username`` is the computed field name in AgentTableSerializer;
@@ -320,19 +342,31 @@ def extract_agent_details(agent: Mapping[str, Any]) -> dict[str, Any]:
         "name": name or "Agent",
         "type": _clean_text(_lookup(agent, "monitoring_type", "agent_type", "type")),
         "machine_type": _machine_type_from_sources(
-            _lookup(agent, "machine_type", "device_machine_type", "virtualization_type"),
-            _lookup(agent, "is_virtual", "is_vm", "virtual_machine", "hypervisor_present"),
+            _lookup(
+                agent, "machine_type", "device_machine_type", "virtualization_type"
+            ),
+            _lookup(
+                agent, "is_virtual", "is_vm", "virtual_machine", "hypervisor_present"
+            ),
             _lookup(hardware, "machine_type", "virtualization_type"),
-            _lookup(hardware, "is_virtual", "is_vm", "virtual_machine", "hypervisor_present"),
+            _lookup(
+                hardware, "is_virtual", "is_vm", "virtual_machine", "hypervisor_present"
+            ),
             _lookup(agent, "make_model", "model", "manufacturer"),
-            _lookup(hardware, "model", "manufacturer", "system_model", "system_manufacturer"),
+            _lookup(
+                hardware, "model", "manufacturer", "system_model", "system_manufacturer"
+            ),
         ),
         "serial_number": _clean_text(
             _lookup(agent, "serial_number", "serial", "bios_serial")
             or _lookup(hardware, "serial", "serial_number")
         ),
-        "status": _clean_text(_lookup(agent, "status", "agent_status", "monitoring_status")),
-        "os_name": _clean_text(_lookup(agent, "os", "operating_system", "os_name", "os_version")),
+        "status": _clean_text(
+            _lookup(agent, "status", "agent_status", "monitoring_status")
+        ),
+        "os_name": _clean_text(
+            _lookup(agent, "os", "operating_system", "os_name", "os_version")
+        ),
         # cpu_model is a list in the real TacticalRMM API – join multiple CPUs
         "cpu_name": _clean_text(
             _join_list(_lookup(agent, "cpu_model", "processor"))
@@ -376,10 +410,10 @@ def extract_agent_details(agent: Mapping[str, Any]) -> dict[str, Any]:
             or _lookup(hardware, "performance_score")
         ),
         "warranty_status": _clean_text(_lookup(agent, "warranty_status")),
-        "warranty_end_date": _lookup(agent, "warranty_expires", "warranty_end", "warranty_expiration"),
-        "tactical_asset_id": _clean_text(
-            _lookup(agent, "agent_id", "id", "pk")
+        "warranty_end_date": _lookup(
+            agent, "warranty_expires", "warranty_end", "warranty_expiration"
         ),
+        "tactical_asset_id": _clean_text(_lookup(agent, "agent_id", "id", "pk")),
         "client_id": _clean_text(
             _lookup(client_info, "id", "pk", "client_id")
             or _lookup(agent, "client_id", "client")
@@ -389,11 +423,14 @@ def extract_agent_details(agent: Mapping[str, Any]) -> dict[str, Any]:
             or _lookup(agent, "client_name", "client")
         ),
         "site_name": _clean_text(
-            _lookup(site_info, "name", "site")
-            or _lookup(agent, "site", "site_name")
+            _lookup(site_info, "name", "site") or _lookup(agent, "site", "site_name")
         ),
     }
-    if not details["tactical_asset_id"] and details.get("client_id") and details.get("name"):
+    if (
+        not details["tactical_asset_id"]
+        and details.get("client_id")
+        and details.get("name")
+    ):
         details["tactical_asset_id"] = f"{details['client_id']}::{details['name']}"
     return details
 
@@ -419,6 +456,22 @@ async def _fetch_agent_detail(agent_id: str) -> Mapping[str, Any] | None:
     return None
 
 
+async def fetch_agent(agent_id: str) -> Mapping[str, Any]:
+    """Fetch one agent for an on-demand integration sync."""
+
+    clean_agent_id = str(agent_id).strip()
+    if not clean_agent_id:
+        raise ValueError("Tactical RMM agent ID is required")
+    result = await _call_endpoint(f"agents/{clean_agent_id}/")
+    if not isinstance(result, Mapping):
+        raise TacticalRMMAPIError("Tactical RMM returned an invalid agent response")
+    # AgentSerializer can omit its database ID, so retain the authoritative ID
+    # supplied by the script for asset matching.
+    agent = dict(result)
+    agent["agent_id"] = clean_agent_id
+    return agent
+
+
 async def fetch_agents(client_id: str | None = None) -> list[Mapping[str, Any]]:
     settings = await _load_settings()
     base_url = settings["base_url"]
@@ -436,7 +489,9 @@ async def fetch_agents(client_id: str | None = None) -> list[Mapping[str, Any]]:
         try:
             response = await _call_endpoint(endpoint)
         except TacticalRMMAPIError as exc:
-            log_error("Failed to fetch Tactical RMM agents", endpoint=endpoint, error=str(exc))
+            log_error(
+                "Failed to fetch Tactical RMM agents", endpoint=endpoint, error=str(exc)
+            )
             continue
         page_items, next_endpoint = _extract_agent_page(response, base_url)
         if page_items:
@@ -447,7 +502,11 @@ async def fetch_agents(client_id: str | None = None) -> list[Mapping[str, Any]]:
             try:
                 response = await _call_endpoint(next_endpoint)
             except TacticalRMMAPIError as exc:
-                log_error("Failed to fetch Tactical RMM agents page", endpoint=next_endpoint, error=str(exc))
+                log_error(
+                    "Failed to fetch Tactical RMM agents page",
+                    endpoint=next_endpoint,
+                    error=str(exc),
+                )
                 break
             page_items, next_endpoint = _extract_agent_page(response, base_url)
             if page_items:
@@ -460,8 +519,7 @@ async def fetch_agents(client_id: str | None = None) -> list[Mapping[str, Any]]:
     # RAM data is available for extract_agent_details().
     if collected:
         agent_ids = [
-            str(a.get("agent_id") or a.get("id") or "").strip()
-            for a in collected
+            str(a.get("agent_id") or a.get("id") or "").strip() for a in collected
         ]
         details: list[Mapping[str, Any] | None] = list(
             await asyncio.gather(
@@ -574,18 +632,20 @@ async def fetch_scripts() -> list[dict[str, Any]]:
         sid = _script_id(item)
         if sid is None:
             continue
-        scripts.append({
-            "id": sid,
-            "name": _script_label(item),
-            "description": _clean_text(item.get("description")),
-            "category": _clean_text(item.get("category")),
-            "script_type": (
-                _clean_text(item.get("shell"))
-                or _clean_text(item.get("script_type"))
-                or _clean_text(item.get("type"))
-            ),
-            "raw": dict(item),
-        })
+        scripts.append(
+            {
+                "id": sid,
+                "name": _script_label(item),
+                "description": _clean_text(item.get("description")),
+                "category": _clean_text(item.get("category")),
+                "script_type": (
+                    _clean_text(item.get("shell"))
+                    or _clean_text(item.get("script_type"))
+                    or _clean_text(item.get("type"))
+                ),
+                "raw": dict(item),
+            }
+        )
     scripts.sort(
         key=lambda s: (str(s.get("name") or "").lower(), int(s.get("id") or 0))
     )
@@ -604,13 +664,17 @@ def _script_default_body(
     timeout = max(1, min(timeout, 86400))
     return {
         "output": script.get("output") or "forget",
-        "emails": script.get("emails") if isinstance(script.get("emails"), list) else [],
+        "emails": script.get("emails")
+        if isinstance(script.get("emails"), list)
+        else [],
         "emailMode": script.get("emailMode") or script.get("email_mode") or "default",
         "custom_field": script.get("custom_field"),
         "save_all_output": bool(script.get("save_all_output", False)),
         "script": script_id,
         "args": script.get("args") if isinstance(script.get("args"), list) else [],
-        "env_vars": script.get("env_vars") if isinstance(script.get("env_vars"), list) else [],
+        "env_vars": script.get("env_vars")
+        if isinstance(script.get("env_vars"), list)
+        else [],
         "run_as_user": bool(script.get("run_as_user", False)),
         "timeout": timeout,
     }
@@ -680,22 +744,24 @@ async def fetch_agent_installed_software(agent_id: str) -> list[str]:
 async def fetch_clients() -> list[Mapping[str, Any]]:
     """
     Fetch all Tactical RMM clients from the /beta/v1/client/ endpoint.
-    
+
     Returns:
         List of client dictionaries with 'id' and 'name' fields
     """
     await _load_settings()
     endpoint = "beta/v1/client/"
-    
+
     collected: list[Mapping[str, Any]] = []
     log_info("Fetching Tactical RMM clients")
-    
+
     try:
         response = await _call_endpoint(endpoint)
     except TacticalRMMAPIError as exc:
-        log_error("Failed to fetch Tactical RMM clients", endpoint=endpoint, error=str(exc))
+        log_error(
+            "Failed to fetch Tactical RMM clients", endpoint=endpoint, error=str(exc)
+        )
         return collected
-    
+
     # The endpoint returns a list of client objects
     if isinstance(response, list):
         for item in response:
@@ -711,5 +777,5 @@ async def fetch_clients() -> list[Mapping[str, Any]]:
         # Handle case where response is a single client
         elif "id" in response and "name" in response:
             collected.append(response)
-    
+
     return collected

--- a/docs/wiki/integrations/Tactical RMM Tray Agent Sync.md
+++ b/docs/wiki/integrations/Tactical RMM Tray Agent Sync.md
@@ -1,0 +1,33 @@
+# Tactical RMM immediate Tray Agent sync
+
+The normal Tactical RMM asset import eventually links an enrolled tray device
+through the `TrayAgentID` custom field. To make tray menu scripts available
+immediately after installation, MyPortal also provides a targeted push endpoint:
+
+```text
+POST /api/tray/trmm-sync
+X-API-Key: <MyPortal API key>
+Content-Type: application/json
+
+{"agent_id":"<TRMM agent ID>","tray_agent_id":"<MyPortal device UID>"}
+```
+
+The endpoint fetches only that Tactical RMM agent, creates or updates its
+MyPortal asset, and links the already-enrolled tray device in the same request.
+It does not wait for or run a full client asset import.
+
+## Tactical RMM setup
+
+1. Ensure the company has a Tactical RMM client mapping and the Tactical RMM
+   integration is enabled in MyPortal.
+2. Create a MyPortal API key. For least privilege, restrict it to `POST` on
+   `/api/tray/trmm-sync` and optionally restrict it to the TRMM server IP.
+3. Add `integrations/tacticalrmm/sync-tray-agent.ps1` to Tactical RMM.
+4. Configure `PortalURL` and `APIKey` as protected script variables. Configure
+   `AgentID` with Tactical RMM's runtime variable for the current agent ID.
+5. Run the script immediately after the tray installation script, or run it on
+   demand for a device that is still waiting to link.
+
+The script waits up to 90 seconds for the tray service to enrol and write
+`%ProgramData%\MyPortal\tray\tray-state.json`, reads `device_uid`, and pushes
+both identifiers to MyPortal. A successful run prints the linked asset ID.

--- a/integrations/tacticalrmm/sync-tray-agent.ps1
+++ b/integrations/tacticalrmm/sync-tray-agent.ps1
@@ -1,0 +1,39 @@
+# MyPortal immediate Tactical RMM / Tray Agent linking script.
+# Configure AgentID with Tactical RMM's agent ID runtime variable and store the
+# API key as a protected script variable. The key only needs POST permission on
+# /api/tray/trmm-sync.
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$PortalURL,
+    [Parameter(Mandatory)][string]$APIKey,
+    [Parameter(Mandatory)][string]$AgentID,
+    [int]$WaitSeconds = 90
+)
+
+$ErrorActionPreference = 'Stop'
+$statePath = Join-Path $env:ProgramData 'MyPortal\tray\tray-state.json'
+$deadline = (Get-Date).AddSeconds($WaitSeconds)
+do {
+    if (Test-Path $statePath) {
+        try {
+            $state = Get-Content $statePath -Raw | ConvertFrom-Json
+            $trayAgentID = [string]$state.device_uid
+            if ($trayAgentID) { break }
+        } catch {
+            # The service may be replacing the state file while we read it.
+        }
+    }
+    Start-Sleep -Seconds 2
+} while ((Get-Date) -lt $deadline)
+
+if (-not $trayAgentID) {
+    throw "Tray Agent did not enrol within $WaitSeconds seconds ($statePath not ready)."
+}
+
+$body = @{ agent_id = $AgentID; tray_agent_id = $trayAgentID } | ConvertTo-Json
+$result = Invoke-RestMethod -Method Post `
+    -Uri "$($PortalURL.TrimEnd('/'))/api/tray/trmm-sync" `
+    -Headers @{ 'X-API-Key' = $APIKey } `
+    -ContentType 'application/json' -Body $body
+
+Write-Host "Linked TRMM agent $AgentID to MyPortal asset $($result.asset_id) and tray device $trayAgentID."

--- a/tests/test_trmm_tray_push_sync.py
+++ b/tests/test_trmm_tray_push_sync.py
@@ -1,0 +1,66 @@
+"""Tests for immediate agent-side Tactical RMM tray synchronisation."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+from app.api.routes import tray as tray_routes
+from app.schemas.tray import TrayTRMMSyncRequest
+from app.services import asset_importer, tacticalrmm
+
+
+def test_sync_tactical_agent_imports_and_links_one_agent(monkeypatch):
+    async def run():
+        monkeypatch.setattr(
+            asset_importer.company_repo,
+            "get_company_by_id",
+            AsyncMock(return_value={"id": 7, "tacticalrmm_client_id": "client-7"}),
+        )
+        monkeypatch.setattr(
+            tacticalrmm,
+            "fetch_agent",
+            AsyncMock(return_value={"agent_id": "agent-1", "hostname": "PC-1"}),
+        )
+        upsert = AsyncMock(return_value=42)
+        monkeypatch.setattr(asset_importer.assets_repo, "upsert_asset", upsert)
+        monkeypatch.setattr(
+            asset_importer.tray_repo,
+            "get_device_by_uid",
+            AsyncMock(return_value={"id": 9, "company_id": 7}),
+        )
+        link = AsyncMock()
+        monkeypatch.setattr(asset_importer.tray_repo, "link_device_to_asset", link)
+        monkeypatch.setattr(
+            asset_importer, "_sync_tactical_asset_custom_fields", AsyncMock()
+        )
+
+        result = await asset_importer.sync_tactical_agent(
+            7, agent_id="agent-1", tray_device_uid="tray-1"
+        )
+
+        assert result == 42
+        assert upsert.await_args.kwargs["tactical_asset_id"] == "agent-1"
+        link.assert_awaited_once_with(9, 42)
+
+    asyncio.run(run())
+
+
+def test_trmm_sync_endpoint_links_enrolled_device(monkeypatch):
+    async def run():
+        monkeypatch.setattr(
+            tray_routes.tray_repo,
+            "get_device_by_uid",
+            AsyncMock(return_value={"id": 9, "company_id": 7, "status": "active"}),
+        )
+        sync = AsyncMock(return_value=42)
+        monkeypatch.setattr(tray_routes.asset_importer, "sync_tactical_agent", sync)
+
+        response = await tray_routes.sync_trmm_agent(
+            TrayTRMMSyncRequest(agent_id=" agent-1 ", tray_agent_id=" tray-1 "),
+            {"id": 3},
+        )
+
+        assert response.status == "linked"
+        assert response.asset_id == 42
+        sync.assert_awaited_once_with(7, agent_id="agent-1", tray_device_uid="tray-1")
+
+    asyncio.run(run())


### PR DESCRIPTION
### Motivation

- Tray installation can be slow to propagate Tactical RMM agent IDs into MyPortal, preventing TRMM scripts from being runnable immediately.
- Provide a lightweight, secure method for an RMM-side script to push a specific TRMM agent → tray device mapping to MyPortal to remove the delay.

### Description

- Add a `POST /api/tray/trmm-sync` endpoint (`app/api/routes/tray.py`) protected by `X-API-Key` (`require_api_key`) that accepts `agent_id` and `tray_agent_id` and triggers a targeted sync. 
- Introduce `TrayTRMMSyncRequest`/`TrayTRMMSyncResponse` schemas in `app/schemas/tray.py` to model the request/response payloads. 
- Implement `asset_importer.sync_tactical_agent` in `app/services/asset_importer.py` to fetch the single TRMM agent, verify company association, upsert the MyPortal asset, link the enrolled tray device, and attempt custom-field sync without blocking the link. 
- Add `tacticalrmm.fetch_agent` in `app/services/tacticalrmm.py` to fetch one agent and preserve the authoritative agent ID for matching. 
- Provide a PowerShell helper `integrations/tacticalrmm/sync-tray-agent.ps1` for use as a TRMM script that waits for the tray enrolment state file, reads `device_uid`, and posts both IDs to MyPortal. 
- Add documentation `docs/wiki/integrations/Tactical RMM Tray Agent Sync.md` describing use and least-privilege API-key guidance. 
- Add unit tests `tests/test_trmm_tray_push_sync.py` covering the importer and the API handler path. 

### Testing

- Linting and formatting checks with `ruff` passed after formatting. 
- Unit tests `tests/test_trmm_tray_push_sync.py`, `tests/test_asset_importer.py`, and `tests/test_tacticalrmm_service.py` were run and succeeded (all tests passed). 
- Automated `pytest` runs for the modified area completed successfully with no failing tests (warnings only from unrelated schema deprecations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a794573dc24833284fab34828a8ac01)