### PR TITLE
Rebalance admin ticket detail columns for wide screens

### DIFF
--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -5560,6 +5560,11 @@ dialog.modal:not([open]) {
     grid-template-columns: minmax(280px, 320px) minmax(360px, 1fr) minmax(0, 1fr);
   }
 
+  /* Keep reference panels compact so replies and conversation remain the focus. */
+  .management__body--ticket-detail-admin {
+    grid-template-columns: minmax(280px, 320px) minmax(360px, 3fr) minmax(0, 7fr);
+  }
+
   .management__body--ticket-detail-two-column {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }


### PR DESCRIPTION
### Motivation
- Reallocate horizontal space on very wide screens so the main ticket content (description, AI summary, tasks, etc.) becomes ~60% width and the Add a reply / Conversation history area gains the reclaimed space for better usability.

### Description
- Add a scoped wide-screen CSS rule in `app/static/css/app.css` under `@media (min-width: 1800px)` that defines `.management__body--ticket-detail-admin { grid-template-columns: minmax(280px, 320px) minmax(360px, 3fr) minmax(0, 7fr); }`, shifting the previous layout to a 3fr/7fr split while preserving existing responsive behavior.

### Testing
- Ran `pytest -q tests/test_ticket_detail_realtime_refresh.py tests/test_ticket_number_rendering_issue.py` and the test run completed successfully with 10 passed tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7bd9b1ea7c83328889c0b445918b2b)