### PR TITLE
Import read messages moved into monitored M365 mailboxes

### DIFF
--- a/app/services/m365_mail.py
+++ b/app/services/m365_mail.py
@@ -89,6 +89,33 @@ def account_auth_status(account: Mapping[str, Any]) -> str:
     return "not_configured"
 
 
+def _parse_graph_datetime(value: Any) -> datetime | None:
+    """Return a timezone-aware UTC datetime for database or Graph values."""
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _message_changed_since(
+    message: Mapping[str, Any], last_synced_at: datetime | None
+) -> bool:
+    """Whether Graph reports that a message changed after the prior sync cursor."""
+    if last_synced_at is None:
+        return False
+    modified_at = _parse_graph_datetime(message.get("lastModifiedDateTime"))
+    return modified_at is not None and modified_at >= last_synced_at
+
+
 def enrich_account_response(account: dict[str, Any]) -> dict[str, Any]:
     """Add computed fields before returning an account to the API/template."""
     account = dict(account)
@@ -986,6 +1013,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
     folder = _normalise_string(account.get("folder"), default="Inbox") or "Inbox"
     process_unread_only = bool(account.get("process_unread_only", True))
     mark_as_read = bool(account.get("mark_as_read", True))
+    last_synced_at = _parse_graph_datetime(account.get("last_synced_at"))
 
     # Per-account delegated tokens take priority over company credentials.
     # When the admin has signed in directly for this mailbox, the account
@@ -1075,7 +1103,7 @@ async def sync_account(account_id: int) -> dict[str, Any]:
             "$select": (
                 "id,subject,body,bodyPreview,from,toRecipients,ccRecipients,bccRecipients,"
                 "replyTo,internetMessageHeaders,internetMessageId,isRead,receivedDateTime,"
-                "hasAttachments,conversationId"
+                "lastModifiedDateTime,hasAttachments,conversationId"
             ),
         }
         using_unread_filter = process_unread_only
@@ -1086,6 +1114,16 @@ async def sync_account(account_id: int) -> dict[str, Any]:
             # page of already-read messages.  Do not combine this with $orderby:
             # some Exchange Online/shared-mailbox configurations reject that shape.
             query_params["$filter"] = "isRead eq false"
+            if last_synced_at is not None:
+                # Outlook commonly marks a message as read while a technician is
+                # moving it into a monitored folder or shared mailbox. Include
+                # messages changed since the previous run so those newly-arrived
+                # read messages are not invisible to an unread-only sync. The
+                # local import record still provides idempotency.
+                changed_since = last_synced_at.isoformat().replace("+00:00", "Z")
+                query_params["$filter"] += (
+                    f" or lastModifiedDateTime ge {changed_since}"
+                )
         else:
             query_params["$orderby"] = "receivedDateTime asc"
         full_url = (
@@ -1241,8 +1279,15 @@ async def sync_account(account_id: int) -> dict[str, Any]:
                     "received_at": msg.get("receivedDateTime"),
                 }
 
-                # Skip already-read messages when only processing unread
-                if process_unread_only and msg.get("isRead", False):
+                # Read messages are normally excluded in unread-only mode. A read
+                # message modified since the previous run may have just been moved
+                # into this monitored folder, however, so it must be imported once.
+                recently_changed = _message_changed_since(msg, last_synced_at)
+                if (
+                    process_unread_only
+                    and msg.get("isRead", False)
+                    and not recently_changed
+                ):
                     _remember_message_action(
                         {
                             **message_log_base,
@@ -1756,7 +1801,9 @@ async def sync_account(account_id: int) -> dict[str, Any]:
 
     await mail_repo.update_account(
         int(account_id),
-        last_synced_at=datetime.now(timezone.utc),
+        # Use the start of the run as the next cursor. Changes made while this run
+        # was in progress will therefore remain eligible on the next run.
+        last_synced_at=started_at,
     )
     created_count = sum(
         1 for action in message_actions if action.get("outcome") == "created_new_ticket"

--- a/tests/test_m365_mail_service.py
+++ b/tests/test_m365_mail_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from typing import Any
 from urllib.parse import unquote
 
@@ -106,6 +107,27 @@ def test_build_filter_context_empty_recipients():
     assert context["bcc"] == []
     assert context["is_unread"] is False
     assert context["is_read"] is True
+
+
+def test_message_changed_since_accepts_read_message_moved_after_last_sync():
+    """A recent Graph modification makes a moved, already-read message eligible."""
+    last_sync = datetime(2026, 8, 13, 9, 0, tzinfo=timezone.utc)
+
+    assert m365_mail._message_changed_since(
+        {"isRead": True, "lastModifiedDateTime": "2026-08-13T09:01:00Z"},
+        last_sync,
+    )
+
+
+def test_message_changed_since_rejects_old_or_unparseable_modification():
+    last_sync = datetime(2026, 8, 13, 9, 0, tzinfo=timezone.utc)
+
+    assert not m365_mail._message_changed_since(
+        {"lastModifiedDateTime": "2026-08-13T08:59:59Z"}, last_sync
+    )
+    assert not m365_mail._message_changed_since(
+        {"lastModifiedDateTime": "not-a-date"}, last_sync
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -861,6 +883,7 @@ async def test_sync_account_no_company_resolves_from_email(monkeypatch):
             "mark_as_read": False,
             "filter_query": None,
             "sync_known_only": False,
+            "last_synced_at": datetime(2026, 1, 20, 13, 55, tzinfo=timezone.utc),
         }
 
     async def fake_list_provisioned():
@@ -883,15 +906,21 @@ async def test_sync_account_no_company_resolves_from_email(monkeypatch):
                 "ccRecipients": [],
                 "bccRecipients": [],
                 "replyTo": [],
-                "isRead": False,
+                # Outlook can set this while moving mail into the monitored
+                # mailbox. A modification after the cursor must still import it.
+                "isRead": True,
                 "receivedDateTime": "2026-01-20T14:00:00Z",
+                "lastModifiedDateTime": "2026-01-20T14:01:00Z",
                 "hasAttachments": False,
                 "internetMessageHeaders": [],
             }
         ],
     }
 
+    graph_urls: list[str] = []
+
     async def fake_graph_get(access_token: str, url: str):
+        graph_urls.append(unquote(url))
         return graph_messages
 
     async def fake_get_message(account_id: int, message_uid: str):
@@ -951,6 +980,10 @@ async def test_sync_account_no_company_resolves_from_email(monkeypatch):
     assert len(created_tickets) == 1
     assert created_tickets[0]["company_id"] == 42
     assert created_tickets[0]["requester_id"] == 99
+    assert any(
+        "isRead eq false or lastModifiedDateTime ge 2026-01-20T13:55:00Z" in url
+        for url in graph_urls
+    )
 
 
 async def test_sync_account_skips_already_imported(monkeypatch):


### PR DESCRIPTION
### Motivation

- Fix a bug where messages that a technician moves into a monitored Microsoft 365 mailbox can be marked read by Outlook and then be excluded from an unread-only sync, causing them not to be imported.

### Description

- Add helpers ` _parse_graph_datetime` and `_message_changed_since` to parse Graph timestamps and determine if a message was modified after the prior sync cursor. 
- Request `lastModifiedDateTime` from Microsoft Graph and include it in `$select` so the server can inspect modification times. 
- When an account is configured with `process_unread_only`, extend the Graph `$filter` to include messages with `lastModifiedDateTime` >= the account's `last_synced_at` so recently-changed (moved) messages are still returned even if already read. 
- Change client-side logic to import a read message when `_message_changed_since(...)` indicates the message was modified since the previous run. 
- Save the run cursor as the sync `started_at` to avoid missing changes made while the run is in progress. 
- Add regression tests for timestamp parsing and for the moved-read-message scenario and update the mailbox sync test to assert the modified-time filter is used.

### Testing

- Ran `pytest -q tests/test_m365_mail_service.py` and all tests in that file passed (`43 passed`).
- Verified `python -m py_compile app/services/m365_mail.py tests/test_m365_mail_service.py` succeeded.
- Ran `ruff check app/services/m365_mail.py tests/test_m365_mail_service.py`, which completed but reported pre-existing unused-import / unused-variable issues unrelated to the new logic.
- Verified Graph query URL construction and sync behaviour via updated unit tests that assert the unread filter now includes a `lastModifiedDateTime` clause and that a moved, already-read message is imported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7d253a66b48332818e33d6f16fa7d5)